### PR TITLE
Update pending in-person profile queries to consider enrollment expiration

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -184,7 +184,7 @@ class Profile < ApplicationRecord
   end
 
   def in_person_verification_pending?
-    in_person_verification_pending_at.present?
+    in_person_verification_pending_at.present? && !in_person_enrollment.expired?
   end
 
   def deactivate_due_to_gpo_expiration

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -64,7 +64,7 @@ class Profile < ApplicationRecord
 
   def self.in_person_verification_pending
     where.not(in_person_verification_pending_at: nil).
-      joins(:in_person_enrollment).where.not(in_person_enrollment: { status: :expired })
+      left_outer_joins(:in_person_enrollment).where.not(in_person_enrollment: { status: :expired })
   end
 
   # Instance methods

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -63,7 +63,8 @@ class Profile < ApplicationRecord
   end
 
   def self.in_person_verification_pending
-    where.not(in_person_verification_pending_at: nil)
+    where.not(in_person_verification_pending_at: nil).
+      joins(:in_person_enrollment).where.not(in_person_enrollment: { status: :expired })
   end
 
   # Instance methods

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -185,7 +185,7 @@ class Profile < ApplicationRecord
   end
 
   def in_person_verification_pending?
-    in_person_verification_pending_at.present? && !in_person_enrollment.expired?
+    in_person_verification_pending_at.present? && !in_person_enrollment&.expired?
   end
 
   def deactivate_due_to_gpo_expiration

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -64,7 +64,7 @@ class Profile < ApplicationRecord
 
   def self.in_person_verification_pending
     where.not(in_person_verification_pending_at: nil).
-      left_outer_joins(:in_person_enrollment).where.not(in_person_enrollment: { status: :expired })
+      left_outer_joins(:in_person_enrollment).where(in_person_enrollment: { status: :pending })
   end
 
   # Instance methods
@@ -185,7 +185,7 @@ class Profile < ApplicationRecord
   end
 
   def in_person_verification_pending?
-    in_person_verification_pending_at.present? && !in_person_enrollment&.expired?
+    in_person_verification_pending_at.present? && in_person_enrollment&.pending?
   end
 
   def deactivate_due_to_gpo_expiration

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -185,7 +185,7 @@ class Profile < ApplicationRecord
   end
 
   def in_person_verification_pending?
-    in_person_verification_pending_at.present? && in_person_enrollment&.pending?
+    in_person_verification_pending_at.present? && in_person_enrollment&.pending? != false
   end
 
   def deactivate_due_to_gpo_expiration

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe 'IdvStepConcern' do
     end
 
     context 'with pending in person enrollment' do
-      let(:user) { create(:user, :with_pending_in_person_enrollment, :fully_registered) }
+      let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
       before do
         allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Idv::CancellationsController do
       end
 
       context 'with in person enrollment' do
-        let(:user) { build(:user, :with_pending_in_person_enrollment) }
+        let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
         before do
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Idv::SessionsController do
     end
 
     context 'with in person enrollment' do
-      let(:user) { build(:user, :with_pending_in_person_enrollment) }
+      let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
       it 'logs idv_start_over event with extra analytics attributes for barcode step' do
         delete :destroy, params: { step: 'barcode', location: '' }
@@ -101,7 +101,7 @@ RSpec.describe Idv::SessionsController do
     end
 
     context 'with in person enrollment' do
-      let(:user) { build(:user, :with_pending_in_person_enrollment) }
+      let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
       before do
         allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -38,6 +38,10 @@ FactoryBot.define do
     trait :in_person_verification_pending do
       in_person_verification_pending_at { 15.days.ago }
       idv_level { :legacy_in_person }
+
+      after(:build) do |profile|
+        build(:in_person_enrollment, :pending, profile:)
+      end
     end
 
     trait :fraud_pending_reason do

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -38,10 +38,7 @@ FactoryBot.define do
     trait :in_person_verification_pending do
       in_person_verification_pending_at { 15.days.ago }
       idv_level { :legacy_in_person }
-
-      after(:build) do |profile|
-        build(:in_person_enrollment, :pending, profile:)
-      end
+      in_person_enrollment { association :in_person_enrollment, :pending, user: }
     end
 
     trait :fraud_pending_reason do

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -38,7 +38,9 @@ FactoryBot.define do
     trait :in_person_verification_pending do
       in_person_verification_pending_at { 15.days.ago }
       idv_level { :legacy_in_person }
-      in_person_enrollment { association :in_person_enrollment, :pending, user: }
+      in_person_enrollment do
+        association(:in_person_enrollment, :pending, user:, profile: instance)
+      end
     end
 
     trait :fraud_pending_reason do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -215,8 +215,7 @@ FactoryBot.define do
 
     trait :with_pending_in_person_enrollment do
       after :build do |user|
-        profile = create(:profile, :with_pii, :in_person_verification_pending, user: user)
-        create(:in_person_enrollment, :pending, user: user, profile: profile)
+        create(:profile, :with_pii, :in_person_verification_pending, user:)
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -214,9 +214,8 @@ FactoryBot.define do
     end
 
     trait :with_pending_in_person_enrollment do
-      after :build do |user|
-        create(:profile, :with_pii, :in_person_verification_pending, user:)
-      end
+      fully_registered
+      profiles { [association(:profile, :in_person_verification_pending, user: instance)] }
     end
 
     trait :with_pending_gpo_profile do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -215,7 +215,9 @@ FactoryBot.define do
 
     trait :with_pending_in_person_enrollment do
       fully_registered
-      profiles { [association(:profile, :in_person_verification_pending, user: instance)] }
+      profiles do
+        [association(:profile, :with_pii, :in_person_verification_pending, user: instance)]
+      end
     end
 
     trait :with_pending_gpo_profile do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -64,7 +64,20 @@ RSpec.describe Profile do
       expect(profile.verified_at).to be_nil
     end
 
-    context 'enrollment expired' do
+    context 'with unlinked establishing enrollment' do
+      # When marking profile as pending in-person proofing, the enrollment hasn't yet been linked to
+      # the profile.
+      #
+      # See: Idv::Session#create_profile_from_applicant_with_password
+
+      before do
+        profile.in_person_enrollment.update(status: :establishing, profile: nil)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with expired enrollment' do
       before do
         profile.in_person_enrollment.update(status: :expired)
       end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1145,9 +1145,17 @@ RSpec.describe Profile do
     end
 
     describe '.in_person_verification_pending' do
-      it 'returns only in_person_verification_pending Profiles' do
-        user.profiles.create(in_person_verification_pending_at: Time.zone.now)
-        user.profiles.create(in_person_verification_pending_at: nil)
+      it 'returns only profiles pending in person verification with unexpired enrollment' do
+        user.profiles << [
+          create(:profile, :in_person_verification_pending),
+          create(:profile),
+          create(
+            :profile,
+            :in_person_verification_pending,
+            in_person_enrollment: create(:in_person_enrollment, :expired, user:),
+          ),
+        ]
+
         expect(user.profiles.in_person_verification_pending.count).to eq 1
       end
     end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -47,13 +47,10 @@ RSpec.describe Profile do
   end
 
   describe '#in_person_verification_pending?' do
-    it 'returns true if the in_person_verification_pending_at is present' do
-      profile = create(
-        :profile,
-        :in_person_verification_pending,
-        user: user,
-      )
+    let(:profile) { create(:profile, :in_person_verification_pending, user:) }
+    subject(:result) { profile.in_person_verification_pending? }
 
+    it 'returns true if the in_person_verification_pending_at is present' do
       allow(profile).to receive(:update!).and_raise(RuntimeError)
 
       expect(profile.activated_at).to be_nil
@@ -65,6 +62,14 @@ RSpec.describe Profile do
       expect(profile.gpo_verification_pending_at).to be_nil
       expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_nil
+    end
+
+    context 'enrollment expired' do
+      before do
+        profile.in_person_enrollment.update(status: :expired)
+      end
+
+      it { is_expected.to eq(false) }
     end
   end
 

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe AccountShowPresenter do
     it { is_expected.to eq(false) }
 
     context 'with user pending ipp verification' do
-      let(:user) { build(:user, :with_pending_in_person_enrollment) }
+      let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
       it { is_expected.to eq(true) }
     end
@@ -232,7 +232,7 @@ RSpec.describe AccountShowPresenter do
     end
 
     context 'with user pending ipp verification' do
-      let(:user) { build(:user, :with_pending_in_person_enrollment) }
+      let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
       it { is_expected.to eq(true) }
     end
@@ -245,7 +245,7 @@ RSpec.describe AccountShowPresenter do
   end
 
   describe '#formatted_ipp_due_date' do
-    let(:user) { build(:user, :with_pending_in_person_enrollment) }
+    let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
     subject(:formatted_ipp_due_date) { presenter.formatted_ipp_due_date }
 

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
     let(:ipp_sp_name) { 'IPP SP' }
     let(:ipp_sp_issuer) { 'urn:gov:gsa:openidconnect:sp:ipp_sp' }
     let(:ipp_sp) { create(:service_provider, issuer: ipp_sp_issuer, friendly_name: ipp_sp_name) }
-    let(:user) { build(:user, :with_pending_in_person_enrollment) }
+    let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
     before do
       ipp_sp
@@ -82,7 +82,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
     end
 
     context 'with user pending ipp verification' do
-      let(:user) { build(:user, :with_pending_in_person_enrollment) }
+      let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
       it 'shows pending badge' do
         expect(rendered).to have_content(t('account.index.verification.pending_badge'))

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -111,6 +111,38 @@ RSpec.describe 'accounts/show.html.erb' do
     end
   end
 
+  context 'when current user has an in_person_enrollment that was failed' do
+    let(:vtr) { ['Pe'] }
+    let(:sp_name) { 'sinatra-test-app' }
+    let(:user) { create(:user, :with_pending_in_person_enrollment, :with_multiple_emails) }
+
+    before do
+      # Make the in_person_enrollment and associated profile failed
+      in_person_enrollment = user.in_person_enrollments.first
+      in_person_enrollment.update!(status: :failed, status_check_completed_at: Time.zone.now)
+    end
+
+    it 'renders the idv partial' do
+      expect(render).to render_template(partial: 'accounts/_identity_verification')
+    end
+  end
+
+  context 'when current user has an in_person_enrollment that was cancelled' do
+    let(:vtr) { ['Pe'] }
+    let(:sp_name) { 'sinatra-test-app' }
+    let(:user) { build(:user, :with_pending_in_person_enrollment) }
+
+    before do
+      # Make the in_person_enrollment and associated profile cancelled
+      in_person_enrollment = user.in_person_enrollments.first
+      in_person_enrollment.update!(status: :cancelled, status_check_completed_at: Time.zone.now)
+    end
+
+    it 'renders the idv partial' do
+      expect(render).to render_template(partial: 'accounts/_identity_verification')
+    end
+  end
+
   context 'when current user has an in_person_enrollment that expired' do
     let(:vtr) { ['Pe'] }
     let(:sp_name) { 'sinatra-test-app' }

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'accounts/show.html.erb' do
   end
 
   context 'when current user has ipp pending profile' do
-    let(:user) { build(:user, :with_pending_in_person_enrollment) }
+    let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
     it 'renders idv partial' do
       expect(render).to render_template(partial: 'accounts/_identity_verification')
@@ -114,7 +114,7 @@ RSpec.describe 'accounts/show.html.erb' do
   context 'when current user has an in_person_enrollment that expired' do
     let(:vtr) { ['Pe'] }
     let(:sp_name) { 'sinatra-test-app' }
-    let(:user) { build(:user, :with_pending_in_person_enrollment) }
+    let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
     before do
       # Expire the in_person_enrollment and associated profile

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'accounts/show.html.erb' do
   context 'when current user has an in_person_enrollment that was cancelled' do
     let(:vtr) { ['Pe'] }
     let(:sp_name) { 'sinatra-test-app' }
-    let(:user) { build(:user, :with_pending_in_person_enrollment) }
+    let(:user) { create(:user, :with_pending_in_person_enrollment) }
 
     before do
       # Make the in_person_enrollment and associated profile cancelled


### PR DESCRIPTION
## 🛠 Summary of changes

Updates queries for pending in-person profiles profiles to consider whether the associated enrollment is expired.

This follows #11105 (LG-14231), which updated the proofing results job to reset the profile pending timestamp for an expired enrollment. The intent with these changes is to accommodate both new and old profiles which may or may not have this value reset.

This is a (temporary?) alternative to a solution which would involve updating database records to reset the timestamp for profiles associated with expired enrollments: #11130

## 📜 Testing Plan

Override `config/application.yml` to prevent results job from automatically marking pending profiles as successful in local development:

```
in_person_enrollments_ready_job_cron: 0 0 29 2 1
```

1. Have both the IdP and [sample application](https://github.com/18f/identity-oidc-sinatra) running simultaneously
2. In a private browsing window, go to http://localhost:9292
3. Change "Level of Service" to "Identity-verified"
4. Click "Sign in"
5. Create a new account
6. Complete identity verification using in-person proofing
7. Once you reach the barcode step, close your browser
8. Open a rails console: `rails console`
9. Manually mark the enrollment as expired, without updating associated profile (simulate behavior prior to #11105): `InPersonEnrollment.last.update(status: :expired)`
10. Repeat Steps 2-4
11. Sign in with the account you created previously

**Before:** You'd be redirected to the account page (wrong), and the account page would raise an exception when trying to access `due_date` property on the pending enrollment
**After:** You're redirected into the identity verification flow