### PR TITLE
Backfill reset pending timestamp on profiles with expired IPP enrollment

### DIFF
--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -75,4 +75,62 @@ namespace :profiles do
 
     warn "backfill_in_person_verification_pending_at left #{profiles.count} rows"
   end
+
+  ##
+  # Usage:
+  #
+  # Print pending updates
+  # bundle exec rake profiles:backfill_expired_in_person_verification_pending_at
+  #
+  # Commit updates
+  # bundle exec rake profiles:backfill_expired_in_person_verification_pending_at UPDATE_PROFILES=true
+  #
+  task backfill_expired_in_person_verification_pending_at: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    update_profiles = ENV['UPDATE_PROFILES'] == 'true'
+
+    profiles = InPersonEnrollment.where(status: :expired).
+      includes(:profile).
+      where.not(profile: { in_person_verification_pending_at: nil }).
+      map { |enrollment| enrollment.profile }
+
+    profiles.each do |profile|
+      timestamp = profile.in_person_verification_pending_at
+
+      warn "#{profile.id},#{profile.deactivation_reason},#{timestamp}"
+      if update_profiles
+        profile.update!(
+          deactivation_reason: :verification_cancelled,
+          in_person_verification_pending_at: nil,
+        )
+      end
+    end
+  end
+
+  ##
+  # Usage:
+  #
+  # Rollback the above:
+  #
+  # export BACKFILL_OUTPUT='<backfill_output>'
+  # bundle exec rake profiles:rollback_backfill_expired_in_person_verification_pending_at
+  #
+  task rollback_backfill_expired_in_person_verification_pending_at: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    profile_data = ENV['BACKFILL_OUTPUT'].split("\n").map do |profile_row|
+      profile_row.split(',')
+    end
+
+    warn "Updating #{profile_data.count} records"
+    profile_data.each do |profile_datum|
+      profile_id, deactivation_reason, timestamp = profile_datum
+      Profile.where(id: profile_id).update!(
+        deactivation_reason: deactivation_reason,
+        in_person_verification_pending_at: timestamp,
+      )
+      warn profile_id
+    end
+  end
 end

--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -80,12 +80,12 @@ namespace :profiles do
   # Usage:
   #
   # Print pending updates
-  # bundle exec rake profiles:backfill_expired_in_person_verification_pending_at
+  # bundle exec rake profiles:backfill_expired_pending_in_person_verification
   #
   # Commit updates
-  # bundle exec rake profiles:backfill_expired_in_person_verification_pending_at UPDATE_PROFILES=true
+  # bundle exec rake profiles:backfill_expired_pending_in_person_verification UPDATE_PROFILES=true
   #
-  task backfill_expired_in_person_verification_pending_at: :environment do |_task, _args|
+  task backfill_expired_pending_in_person_verification: :environment do |_task, _args|
     ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
 
     update_profiles = ENV['UPDATE_PROFILES'] == 'true'
@@ -114,9 +114,9 @@ namespace :profiles do
   # Rollback the above:
   #
   # export BACKFILL_OUTPUT='<backfill_output>'
-  # bundle exec rake profiles:rollback_backfill_expired_in_person_verification_pending_at
+  # bundle exec rake profiles:rollback_backfill_expired_pending_in_person_verification
   #
-  task rollback_backfill_expired_in_person_verification_pending_at: :environment do |_task, _args|
+  task rollback_backfill_expired_pending_in_person_verification: :environment do |_task, _args|
     ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
 
     profile_data = ENV['BACKFILL_OUTPUT'].split("\n").map do |profile_row|


### PR DESCRIPTION
## 🛠 Summary of changes

Creates a Rake task to update profiles associated with expired in-person proofing enrollments, to reset the value of the profile's pending status and timestamp.

This is an alternative to a solution which involves updating queries to accommodate this mixed state: #11129 

## 📜 Testing Plan

Override `config/application.yml` to prevent results job from automatically marking pending profiles as successful in local development:

```
in_person_enrollments_ready_job_cron: 0 0 29 2 1
```

1. Have both the IdP and [sample application](https://github.com/18f/identity-oidc-sinatra) running simultaneously
2. In a private browsing window, go to http://localhost:9292
3. Change "Level of Service" to "Identity-verified"
4. Click "Sign in"
5. Create a new account
6. Complete identity verification using in-person proofing
7. Once you reach the barcode step, close your browser
8. Open a rails console: `rails console`
9. Manually mark the enrollment as expired, without updating associated profile (simulate behavior prior to #11105): `InPersonEnrollment.last.update(status: :expired)`
10. Run the Rake task to update profiles: `rake profiles:backfill_expired_pending_in_person_verification UPDATE_PROFILES=true`
11. Observe at least one line of output from the previous command
12. Repeat Steps 2-4
13. Sign in with the account you created previously

**Before:** You'd be redirected to the account page (wrong), and the account page would raise an exception when trying to access `due_date` property on the pending enrollment
**After:** You're redirected into the identity verification flow