### PR TITLE
LG-13082: Handle phone submission with CloudFront blocklist match header

### DIFF
--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -38,7 +38,11 @@ module Users
       if result.success?
         handle_create_success(@new_phone_form.phone)
       else
-        flash.now[:error] = result.first_error_message(:recaptcha_token)
+        flash.now[:error] = result.first_error_message(
+          :cloudfront_matched_automated_request,
+          :recaptcha_token,
+        )
+
         render :index
       end
     end
@@ -130,6 +134,8 @@ module Users
         :otp_make_default_number,
         :recaptcha_token,
         :recaptcha_mock_score,
+      ).merge(
+        cloudfront_matched_automated_request: request.headers['CloudFront-Matched-Automated'],
       )
     end
   end

--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -15,6 +15,7 @@ class NewPhoneForm
   validate :validate_not_voip
   validate :validate_not_duplicate
   validate :validate_not_premium_rate
+  validate :validate_cloudfront_matched_automated_request
   validate :validate_recaptcha_token
   validate :validate_allowed_carrier
 
@@ -23,6 +24,7 @@ class NewPhoneForm
               :otp_delivery_preference,
               :otp_make_default_number,
               :setup_voice_preference,
+              :cloudfront_matched_automated_request,
               :recaptcha_token,
               :recaptcha_mock_score,
               :recaptcha_assessment_id
@@ -130,6 +132,15 @@ class NewPhoneForm
     end
   end
 
+  def validate_cloudfront_matched_automated_request
+    return if cloudfront_matched_automated_request.blank?
+    errors.add(
+      :cloudfront_matched_automated_request,
+      :invalid,
+      message: I18n.t('errors.messages.automated_request'),
+    )
+  end
+
   def validate_recaptcha_token
     return if !validate_recaptcha_token?
     _response, assessment_id = recaptcha_form.submit(recaptcha_token)
@@ -171,6 +182,7 @@ class NewPhoneForm
     @otp_make_default_number = true if default_prefs
     @recaptcha_token = params[:recaptcha_token]
     @recaptcha_mock_score = params[:recaptcha_mock_score].to_f if params.key?(:recaptcha_mock_score)
+    @cloudfront_matched_automated_request = params[:cloudfront_matched_automated_request]
   end
 
   def confirmed_phone?

--- a/app/forms/recaptcha_form.rb
+++ b/app/forms/recaptcha_form.rb
@@ -66,12 +66,12 @@ class RecaptchaForm
 
   def validate_token_exists
     return if exempt? || recaptcha_token.present?
-    errors.add(:recaptcha_token, :blank, message: t('errors.messages.invalid_recaptcha_token'))
+    errors.add(:recaptcha_token, :blank, message: t('errors.messages.automated_request'))
   end
 
   def validate_recaptcha_result
     return if @recaptcha_result.blank? || recaptcha_result_valid?(@recaptcha_result)
-    errors.add(:recaptcha_token, :invalid, message: t('errors.messages.invalid_recaptcha_token'))
+    errors.add(:recaptcha_token, :invalid, message: t('errors.messages.automated_request'))
   end
 
   def recaptcha_result

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -39,10 +39,13 @@ class FormResponse
     end
   end
 
-  def first_error_message(key = nil)
+  def first_error_message(*keys)
     return if errors.blank?
-    key ||= errors.keys.first
-    errors[key].first
+    keys = errors.keys if keys.blank?
+    keys.each do |key|
+      return errors[key].first if errors[key].present?
+    end
+    nil
   end
 
   def ==(other)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -722,6 +722,7 @@ errors.manage_authenticator.remove_only_method_error: You cannot remove your onl
 errors.manage_authenticator.unique_name_error: Name already in use. Please use a different name.
 errors.max_password_attempts_reached: You’ve entered too many incorrect passwords. You can reset your password using the “Forgot your password?” link.
 errors.messages.already_confirmed: was already confirmed, please try signing in
+errors.messages.automated_request: We’re sorry, but your computer or network may be sending automated queries. To protect our users, we can’t process your request right now.
 errors.messages.backup_code_limited: You tried too many times, please try again in %{timeout}.
 errors.messages.blank: Please fill in this field.
 errors.messages.blank_cert_element_req: We cannot detect a certificate in your request.
@@ -737,7 +738,6 @@ errors.messages.inclusion: is not included in the list
 errors.messages.invalid_calling_area: Calls to that phone number are not supported. Please try SMS if you have an SMS-capable phone.
 errors.messages.invalid_phone_number.international: Enter a phone number with the correct number of digits.
 errors.messages.invalid_phone_number.us: Enter a 10 digit phone number.
-errors.messages.invalid_recaptcha_token: We’re sorry, but your computer or network may be sending automated queries. To protect our users, we can’t process your request right now.
 errors.messages.invalid_sms_number: The phone number entered doesn’t support text messaging. Try the Phone call option.
 errors.messages.invalid_voice_number: Invalid phone number. Check that you’ve entered the correct country code or area code.
 errors.messages.missing_field: Please fill in this field.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -733,6 +733,7 @@ errors.manage_authenticator.remove_only_method_error: No puede eliminar su únic
 errors.manage_authenticator.unique_name_error: Ese nombre ya está en uso. Use un nombre diferente.
 errors.max_password_attempts_reached: Ingresó demasiadas contraseñas incorrectas. Puede restablecer su contraseña usando el vínculo “¿Olvidó su contraseña?”.
 errors.messages.already_confirmed: ya estaba confirmado, intente iniciar una sesión
+errors.messages.automated_request: Lo sentimos, pero es posible que tu computadora o red te estén enviando consultas automáticas. Para proteger a nuestros usuarios, no podemos procesar tu solicitud en este momento.
 errors.messages.backup_code_limited: Lo intentó demasiadas veces; vuelva a intentarlo en %{timeout}.
 errors.messages.blank: Llene este campo.
 errors.messages.blank_cert_element_req: No podemos detectar un certificado en su solicitud.
@@ -748,7 +749,6 @@ errors.messages.inclusion: no figura en la lista
 errors.messages.invalid_calling_area: No se admiten llamadas a ese número de teléfono. Intente enviar un SMS si tiene un teléfono compatible con SMS.
 errors.messages.invalid_phone_number.international: Ingrese un número de teléfono con el número correcto de dígitos.
 errors.messages.invalid_phone_number.us: Ingrese un número de teléfono de 10 dígitos.
-errors.messages.invalid_recaptcha_token: Lo sentimos, pero es posible que tu computadora o red te estén enviando consultas automáticas. Para proteger a nuestros usuarios, no podemos procesar tu solicitud en este momento.
 errors.messages.invalid_sms_number: El número de teléfono ingresado no admite mensajes de texto. Intente la opción de llamada telefónica.
 errors.messages.invalid_voice_number: Número de teléfono no válido. Verifique haber ingresado el código de país o de área correcto.
 errors.messages.missing_field: Llene este campo.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -722,6 +722,7 @@ errors.manage_authenticator.remove_only_method_error: Vous ne pouvez pas supprim
 errors.manage_authenticator.unique_name_error: Ce nom est déjà pris. Veuillez utiliser un nom différent.
 errors.max_password_attempts_reached: Vous avez saisi des mots de passe inexacts à trop de reprises. Vous pouvez réinitialiser votre mot de passe en utilisant le lien « Mot de passe oublié ? »
 errors.messages.already_confirmed: a déjà été confirmé, veuillez essayer de vous connecter
+errors.messages.automated_request: Désolé, il est possible que votre ordinateur ou votre réseau envoie des requêtes automatiques. Pour protéger nos utilisateurs, nous ne pouvons pas traiter votre demande pour le moment.
 errors.messages.backup_code_limited: Vous avez essayé trop de fois, veuillez réessayer dans %{timeout}.
 errors.messages.blank: Veuillez remplir ce champ.
 errors.messages.blank_cert_element_req: Nous ne pouvons pas détecter un certificat sur votre demande.
@@ -737,7 +738,6 @@ errors.messages.inclusion: n’est pas inclus dans la liste
 errors.messages.invalid_calling_area: Les appels vers ce numéro de téléphone ne sont pas pris en charge. Veuillez essayer par SMS si vous possédez un téléphone disposant de cette fonction.
 errors.messages.invalid_phone_number.international: Saisissez un numéro de téléphone avec le nombre correct de chiffres.
 errors.messages.invalid_phone_number.us: Saisissez un numéro de téléphone à 10 chiffres.
-errors.messages.invalid_recaptcha_token: Désolé, il est possible que votre ordinateur ou votre réseau envoie des requêtes automatiques. Pour protéger nos utilisateurs, nous ne pouvons pas traiter votre demande pour le moment.
 errors.messages.invalid_sms_number: Le numéro de téléphone saisi ne prend pas en charge les messages texte. Veuillez essayer l’option d’appel téléphonique.
 errors.messages.invalid_voice_number: Numéro de téléphone non valide. Vérifiez que vous avez entré le bon indicatif international ou régional.
 errors.messages.missing_field: Veuillez remplir ce champ.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -733,6 +733,7 @@ errors.manage_authenticator.remove_only_method_error: 你不能去掉自己唯�
 errors.manage_authenticator.unique_name_error: 名字已在使用。请使用一个不同的名字。
 errors.max_password_attempts_reached: 你输入了太多不正确的密码。你可以使用“忘了密码？”链接来重设密码。
 errors.messages.already_confirmed: 已确认，请尝试登录
+errors.messages.automated_request: 你必须完成预防滥发邮件测验。
 errors.messages.backup_code_limited: 你尝试了太多次。请在 %{timeout}后再试。
 errors.messages.blank: 请填写这一字段。
 errors.messages.blank_cert_element_req: 我们在你的请求中探查不到证书。
@@ -748,7 +749,6 @@ errors.messages.inclusion: 没有在清单中
 errors.messages.invalid_calling_area: 不支持给那个号码打的电话。如果你有一个可接受短信（SMS）的电话，请尝试用短信。
 errors.messages.invalid_phone_number.international: 输入一个位数正确的电话号码。
 errors.messages.invalid_phone_number.us: 输入 10 位的电话号码。
-errors.messages.invalid_recaptcha_token: 你必须完成预防滥发邮件测验。
 errors.messages.invalid_sms_number: 输入的电话号码不支持短信。尝试接听电话选项。
 errors.messages.invalid_voice_number: 电话号码有误。检查一下你是否输入了正确的国家代码或区域代码。
 errors.messages.missing_field: 请填写这一字段。

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe 'Add a new phone number' do
     fill_in t('components.captcha_submit_button.mock_score_label'), with: '0.5'
     click_send_one_time_code
     expect(page).to have_current_path(phone_setup_path, wait: 5)
-    expect(page).to have_content(t('errors.messages.invalid_recaptcha_token'))
+    expect(page).to have_content(t('errors.messages.automated_request'))
     expect(fake_analytics).to have_logged_event(
       'reCAPTCHA verify result received',
       recaptcha_result: {

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -179,7 +179,7 @@ RSpec.feature 'Sign Up' do
     fill_in t('components.captcha_submit_button.mock_score_label'), with: '0.5'
     click_send_one_time_code
     expect(page).to have_current_path(phone_setup_path, wait: 5)
-    expect(page).to have_content(t('errors.messages.invalid_recaptcha_token'))
+    expect(page).to have_content(t('errors.messages.automated_request'))
   end
 
   context 'with js', js: true do


### PR DESCRIPTION
## 🎫 Ticket

[LG-13082](https://cm-jira.usa.gov/browse/LG-13082)

## 🛠 Summary of changes

Updates phone submission handling to interpret CloudFront header as implying that the request was matched as being automated to display an error message for the user to understand what happened.

## 📜 Testing Plan

This is rather difficult to test, since it requires request headers assumed to be included at the network level.

The best way I found to test this locally is using [Firefox's "Edit and Resend" feature](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/request_details/index.html#headers-toolbar) of its developer tools Network tab.

1. In Firefox, go to http://localhost:3000
2. Create an account
3. At MFA selection, pick phone
4. Open your developer tools and change to the Network tab
5. Submit a valid phone number
6. Right click the "POST" request submission and click "Edit and Resend"
7. Add a request header "CloudFront-Matched-Automated" with any value (e.g. "1") ([see screenshot](https://github.com/user-attachments/assets/a6c451b7-f1ce-47f7-8f8e-72664873b3d4))
8. Click "Send"
9. Click the new request in the list of Network requests
10. Click "Response" tab on the right-hand panel
11. Observe in the plaintext an error text "We’re sorry, but your computer or network may be sending automated queries."

## 👀 Screenshots

![image](https://github.com/user-attachments/assets/fed0ed16-84c6-4c2e-8c69-4501b6902a9d)
