### PR TITLE
LG 14123 Include associated user_id in event disavowal CloudWatch logs

### DIFF
--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -10,13 +10,13 @@ class EventDisavowalController < ApplicationController
       success: true,
       extra: EventDisavowal::BuildDisavowedEventAnalyticsAttributes.call(disavowed_event),
     )
-    analytics.event_disavowal(user_id: disavowed_event.user.id, **result.to_h)
+    analytics.event_disavowal(user_id: disavowed_event.user_id, **result.to_h)
     @forbidden_passwords = forbidden_passwords
   end
 
   def create
     result = password_reset_from_disavowal_form.submit(password_reset_params)
-    analytics.event_disavowal_password_reset(user_id: disavowed_event.user.id, **result.to_h)
+    analytics.event_disavowal_password_reset(user_id: disavowed_event.user_id, **result.to_h)
     if result.success?
       handle_successful_password_reset
     else

--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -10,7 +10,7 @@ class EventDisavowalController < ApplicationController
       success: true,
       extra: EventDisavowal::BuildDisavowedEventAnalyticsAttributes.call(disavowed_event),
     )
-    analytics.event_disavowal(user_id: disavowed_event.user_id, **result.to_h)
+    analytics.event_disavowal(**result.to_h)
     @forbidden_passwords = forbidden_passwords
   end
 

--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -16,7 +16,7 @@ class EventDisavowalController < ApplicationController
 
   def create
     result = password_reset_from_disavowal_form.submit(password_reset_params)
-    analytics.event_disavowal_password_reset(user_id: disavowed_event.user_id, **result.to_h)
+    analytics.event_disavowal_password_reset(**result.to_h)
     if result.success?
       handle_successful_password_reset
     else

--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -10,13 +10,13 @@ class EventDisavowalController < ApplicationController
       success: true,
       extra: EventDisavowal::BuildDisavowedEventAnalyticsAttributes.call(disavowed_event),
     )
-    analytics.event_disavowal(**result.to_h)
+    analytics.event_disavowal(user_id: disavowed_event.user.id, **result.to_h)
     @forbidden_passwords = forbidden_passwords
   end
 
   def create
     result = password_reset_from_disavowal_form.submit(password_reset_params)
-    analytics.event_disavowal_password_reset(**result.to_h)
+    analytics.event_disavowal_password_reset(user_id: disavowed_event.user.id, **result.to_h)
     if result.success?
       handle_successful_password_reset
     else

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -521,6 +521,7 @@ module AnalyticsEvents
   # @param [Integer, nil] event_id events table id
   # @param [String, nil] event_type (see Event#event_type)
   # @param [String, nil] event_ip ip address for the event
+  # @param [Int, nil] user_id id address for the user
   # Tracks disavowed event
   def event_disavowal(
     success:,
@@ -561,6 +562,7 @@ module AnalyticsEvents
   # @param [Integer, nil] event_id events table id
   # @param [String, nil] event_type (see Event#event_type)
   # @param [String, nil] event_ip ip address for the event
+  # @param [Int, nil] user_id id address for the user
   # Event disavowal password reset was performed
   def event_disavowal_password_reset(
     success:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -534,6 +534,7 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
+    user_id: nil,
     **extra
   )
     track_event(
@@ -548,6 +549,7 @@ module AnalyticsEvents
       event_id:,
       event_type:,
       event_ip:,
+      user_id:,
       **extra,
     )
   end
@@ -575,6 +577,7 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
+    user_id: nil,
     **extra
   )
     track_event(
@@ -589,6 +592,7 @@ module AnalyticsEvents
       event_id:,
       event_type:,
       event_ip:,
+      user_id:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -521,7 +521,7 @@ module AnalyticsEvents
   # @param [Integer, nil] event_id events table id
   # @param [String, nil] event_type (see Event#event_type)
   # @param [String, nil] event_ip ip address for the event
-  # @param [Int, nil] user_id id address for the user
+  # @param [String, nil] user_id UUID of the user
   # Tracks disavowed event
   def event_disavowal(
     success:,
@@ -564,7 +564,7 @@ module AnalyticsEvents
   # @param [Integer, nil] event_id events table id
   # @param [String, nil] event_type (see Event#event_type)
   # @param [String, nil] event_ip ip address for the event
-  # @param [Int, nil] user_id id address for the user
+  # @param [String, nil] user_id UUID of the user
   # Event disavowal password reset was performed
   def event_disavowal_password_reset(
     success:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -521,6 +521,7 @@ module AnalyticsEvents
   # @param [Integer, nil] event_id events table id
   # @param [String, nil] event_type (see Event#event_type)
   # @param [String, nil] event_ip ip address for the event
+  # @param [Int, nil] user_id id address for the user
   # Tracks disavowed event
   def event_disavowal(
     success:,
@@ -533,6 +534,7 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
+    user_id: nil,
     **extra
   )
     track_event(
@@ -547,6 +549,7 @@ module AnalyticsEvents
       event_id:,
       event_type:,
       event_ip:,
+      user_id:,
       **extra,
     )
   end
@@ -561,6 +564,7 @@ module AnalyticsEvents
   # @param [Integer, nil] event_id events table id
   # @param [String, nil] event_type (see Event#event_type)
   # @param [String, nil] event_ip ip address for the event
+  # @param [Int, nil] user_id id address for the user
   # Event disavowal password reset was performed
   def event_disavowal_password_reset(
     success:,
@@ -573,6 +577,7 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
+    user_id: nil,
     **extra
   )
     track_event(
@@ -587,6 +592,7 @@ module AnalyticsEvents
       event_id:,
       event_type:,
       event_ip:,
+      user_id:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -534,7 +534,7 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
-    user_id: nil,
+    user_id:,
     **extra
   )
     track_event(
@@ -577,7 +577,7 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
-    user_id: nil,
+    user_id:,
     **extra
   )
     track_event(

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -521,7 +521,6 @@ module AnalyticsEvents
   # @param [Integer, nil] event_id events table id
   # @param [String, nil] event_type (see Event#event_type)
   # @param [String, nil] event_ip ip address for the event
-  # @param [Int, nil] user_id id address for the user
   # Tracks disavowed event
   def event_disavowal(
     success:,
@@ -534,7 +533,6 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
-    user_id: nil,
     **extra
   )
     track_event(
@@ -549,7 +547,6 @@ module AnalyticsEvents
       event_id:,
       event_type:,
       event_ip:,
-      user_id:,
       **extra,
     )
   end
@@ -564,7 +561,6 @@ module AnalyticsEvents
   # @param [Integer, nil] event_id events table id
   # @param [String, nil] event_type (see Event#event_type)
   # @param [String, nil] event_ip ip address for the event
-  # @param [Int, nil] user_id id address for the user
   # Event disavowal password reset was performed
   def event_disavowal_password_reset(
     success:,
@@ -577,7 +573,6 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
-    user_id: nil,
     **extra
   )
     track_event(
@@ -592,7 +587,6 @@ module AnalyticsEvents
       event_id:,
       event_type:,
       event_ip:,
-      user_id:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -526,6 +526,7 @@ module AnalyticsEvents
   def event_disavowal(
     success:,
     errors:,
+    user_id:,
     error_details: nil,
     event_created_at: nil,
     disavowed_device_last_used_at: nil,
@@ -534,7 +535,6 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
-    user_id:,
     **extra
   )
     track_event(
@@ -569,6 +569,7 @@ module AnalyticsEvents
   def event_disavowal_password_reset(
     success:,
     errors:,
+    user_id:,
     error_details: nil,
     event_created_at: nil,
     disavowed_device_last_used_at: nil,
@@ -577,7 +578,6 @@ module AnalyticsEvents
     event_id: nil,
     event_type: nil,
     event_ip: nil,
-    user_id:,
     **extra
   )
     track_event(

--- a/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
+++ b/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
@@ -11,7 +11,7 @@ module EventDisavowal
         event_type: event.event_type,
         event_created_at: event.created_at,
         event_ip: event.ip,
-        user_id: event.user_id,
+        user_id: event.user.uuid,
         disavowed_device_user_agent: device&.user_agent,
         disavowed_device_last_ip: device&.last_ip,
         disavowed_device_last_used_at: device&.last_used_at,

--- a/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
+++ b/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
@@ -11,6 +11,7 @@ module EventDisavowal
         event_type: event.event_type,
         event_created_at: event.created_at,
         event_ip: event.ip,
+        user_id: event.user_id,
         disavowed_device_user_agent: device&.user_agent,
         disavowed_device_last_ip: device&.last_ip,
         disavowed_device_last_used_at: device&.last_used_at,

--- a/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
+++ b/app/services/event_disavowal/build_disavowed_event_analytics_attributes.rb
@@ -11,7 +11,7 @@ module EventDisavowal
         event_type: event.event_type,
         event_created_at: event.created_at,
         event_ip: event.ip,
-        user_id: event.user.uuid,
+        user_id: event.user&.uuid,
         disavowed_device_user_agent: device&.user_agent,
         disavowed_device_last_ip: device&.last_ip,
         disavowed_device_last_used_at: device&.last_used_at,

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe EventDisavowalController do
 
         expect(@analytics).to have_logged_event(
           'Event disavowal visited',
-          build_analytics_hash,
+          build_analytics_hash(user_id: event.user_id),
         )
       end
 
@@ -31,7 +31,7 @@ RSpec.describe EventDisavowalController do
 
         expect(@analytics).to have_logged_event(
           'Event disavowal visited',
-          build_analytics_hash,
+          build_analytics_hash(user_id: event.user_id),
         )
         expect(assigns(:forbidden_passwords)).to all(be_a(String))
       end
@@ -79,7 +79,7 @@ RSpec.describe EventDisavowalController do
 
         expect(@analytics).to have_logged_event(
           'Event disavowal password reset',
-          build_analytics_hash,
+          build_analytics_hash(user_id: event.user_id),
         )
       end
     end
@@ -172,7 +172,7 @@ RSpec.describe EventDisavowalController do
     end
   end
 
-  def build_analytics_hash(success: true, errors: {})
+  def build_analytics_hash(success: true, errors: {}, user_id: nil)
     hash_including(
       {
         event_created_at: event.created_at,
@@ -184,6 +184,7 @@ RSpec.describe EventDisavowalController do
         event_ip: event.ip,
         disavowed_device_user_agent: event.device.user_agent,
         disavowed_device_last_ip: event.device.last_ip,
+        user_id: user_id,
       }.compact,
     )
   end

--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe EventDisavowalController do
 
         expect(@analytics).to have_logged_event(
           'Event disavowal visited',
-          build_analytics_hash(user_id: event.user_id),
+          build_analytics_hash(user_id: event.user.uuid),
         )
       end
 
@@ -31,7 +31,7 @@ RSpec.describe EventDisavowalController do
 
         expect(@analytics).to have_logged_event(
           'Event disavowal visited',
-          build_analytics_hash(user_id: event.user_id),
+          build_analytics_hash(user_id: event.user.uuid),
         )
         expect(assigns(:forbidden_passwords)).to all(be_a(String))
       end
@@ -79,7 +79,7 @@ RSpec.describe EventDisavowalController do
 
         expect(@analytics).to have_logged_event(
           'Event disavowal password reset',
-          build_analytics_hash(user_id: event.user_id),
+          build_analytics_hash(user_id: event.user.uuid),
         )
       end
     end


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14123](https://cm-jira.usa.gov/browse/LG-14123)



## 🛠 Summary of changes

Passes the `disavowed_event.user.id` value along to the respective Analytics events.


## 📜 Testing Plan

- [ ] In a console run make watch_events
- [ ] Login and MFA as a user in a private browser window to trigger the New Device email
- [ ] After receiving the new device notification click to reset password there
- [ ] Observe in the watch_events feed "Event disavowal visited" and "Event disavowal password reset" will show the user_id



## 👀 Screenshots

![Screenshot 2024-08-23 at 9 28 52 AM (2)](https://github.com/user-attachments/assets/b5d0d72f-2714-43c0-bc38-b542f518a717)
![Screenshot 2024-08-23 at 9 28 07 AM (2)](https://github.com/user-attachments/assets/d47688a4-329e-419f-af7a-169c2be23fc2)


