### PR TITLE
Use Rubocop to enforce consistent collection methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1081,6 +1081,9 @@ Style/ClassEqualityComparison:
 Style/ClassMethods:
   Enabled: true
 
+Style/CollectionMethods:
+  Enabled: true
+
 Style/ColonMethodCall:
   Enabled: true
 

--- a/app/jobs/reports/monthly_gpo_letter_requests_report.rb
+++ b/app/jobs/reports/monthly_gpo_letter_requests_report.rb
@@ -24,7 +24,7 @@ module Reports
     private
 
     def calculate_totals(daily_results)
-      daily_results.inject(0) { |sum, rec| sum + rec['letter_requests_count'].to_i }
+      daily_results.reduce(0) { |sum, rec| sum + rec['letter_requests_count'].to_i }
     end
   end
 end

--- a/app/services/doc_auth/lexis_nexis/image_metrics_reader.rb
+++ b/app/services/doc_auth/lexis_nexis/image_metrics_reader.rb
@@ -11,7 +11,7 @@ module DocAuth
         true_id_product[:ParameterDetails].each do |detail|
           next unless detail[:Group] == 'IMAGE_METRICS_RESULT'
 
-          inner_val = detail.dig(:Values).collect { |value| value.dig(:Value) }
+          inner_val = detail.dig(:Values).map { |value| value.dig(:Value) }
           image_metrics[detail[:Name]] = inner_val
         end
 

--- a/app/services/encryption/encryptors/attribute_encryptor.rb
+++ b/app/services/encryption/encryptors/attribute_encryptor.rb
@@ -50,7 +50,7 @@ module Encryption
       end
 
       def all_keys
-        [current_key].concat(old_keys.collect { |hash| hash['key'] })
+        [current_key].concat(old_keys.map { |hash| hash['key'] })
       end
 
       def old_keys

--- a/app/services/flow/base_flow.rb
+++ b/app/services/flow/base_flow.rb
@@ -19,7 +19,7 @@ module Flow
 
     def next_step
       return @redirect if @redirect
-      step, _klass = steps.detect do |_step, klass|
+      step, _klass = steps.find do |_step, klass|
         !@flow_session[klass.to_s]
       end
       step

--- a/lib/reporting/mfa_report.rb
+++ b/lib/reporting/mfa_report.rb
@@ -135,7 +135,7 @@ module Reporting
     end
 
     def totals(key)
-      data.inject(0) { |sum, slice| slice[key].to_i + sum }
+      data.reduce(0) { |sum, slice| slice[key].to_i + sum }
     end
 
     def multi_factor_auth_table

--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'phone otp confirmation' do
   end
 
   def phone_configuration
-    user.reload.phone_configurations.detect do |phone_configuration|
+    user.reload.phone_configurations.find do |phone_configuration|
       phone_configuration.phone == formatted_phone
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1315,7 +1315,7 @@ RSpec.describe User do
 
   describe '#visible_email_addresses' do
     let(:user) { create(:user) }
-    let(:confirmed_email_address) { user.email_addresses.detect(&:confirmed?) }
+    let(:confirmed_email_address) { user.email_addresses.find(&:confirmed?) }
     let!(:unconfirmed_expired_email_address) do
       create(
         :email_address,

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -182,7 +182,7 @@ RSpec::Matchers.define :have_unique_ids do
 
   failure_message do |page|
     page_ids = ids(page)
-    duplicate = page_ids.detect { |id| page_ids.count(id) > 1 }
+    duplicate = page_ids.find { |id| page_ids.count(id) > 1 }
     "Expected no duplicate element IDs. Found duplicate: #{duplicate}"
   end
 end

--- a/spec/support/shared_examples_for_email_validation.rb
+++ b/spec/support/shared_examples_for_email_validation.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples 'email validation' do
   it 'uses the valid_email gem with mx and ban_disposable options' do
     email_validator = subject._validators.values.flatten.
-      detect { |v| v.instance_of?(EmailValidator) }
+      find { |v| v.instance_of?(EmailValidator) }
 
     expect(email_validator.options).
       to eq(mx_with_fallback: true, ban_disposable_email: true, partial: true)


### PR DESCRIPTION
[Based on an observation in another PR](https://github.com/18F/identity-idp/pull/11142/files#r1731375804), I realized we were 99% consistent on `#map` over `#collect`, and that Rubocop could easily help us stay at 100% consistency

Basically: it discourages all of the `#*ect` methods (except `#select`, that's much clearer than `#find_all`)
[Docs link](https://docs.rubocop.org/rubocop/cops_style.html)