### PR TITLE
LG-14128 Stop that the TMx response body is empty on errored transactions

### DIFF
--- a/app/services/proofing/ddp_result.rb
+++ b/app/services/proofing/ddp_result.rb
@@ -70,8 +70,16 @@ module Proofing
         timed_out: timed_out?,
         transaction_id: transaction_id,
         review_status: review_status,
-        response_body: Proofing::LexisNexis::Ddp::ResponseRedacter.redact(response_body),
+        response_body: redacted_response_body,
       }
+    end
+
+    private
+
+    def redacted_response_body
+      return if response_body.nil?
+
+      Proofing::LexisNexis::Ddp::ResponseRedacter.redact(response_body)
     end
   end
 end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -771,7 +771,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: { error: 'TMx response body was empty' } }
+          response_body: nil }
       end
 
       it 'records all of the events' do
@@ -847,7 +847,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: { error: 'TMx response body was empty' } }
+          response_body: nil }
       end
 
       it 'records all of the events' do
@@ -892,7 +892,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: { error: 'TMx response body was empty' } }
+          response_body: nil }
       end
 
       it 'records all of the events' do
@@ -949,7 +949,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: { error: 'TMx response body was empty' } }
+          response_body: nil }
       end
 
       it 'records all of the events', allow_browser_log: true do
@@ -1019,7 +1019,7 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: { error: 'TMx response body was empty' } }
+          response_body: nil }
       end
 
       it 'records all of the events' do

--- a/spec/services/proofing/ddp_result_spec.rb
+++ b/spec/services/proofing/ddp_result_spec.rb
@@ -117,4 +117,23 @@ RSpec.describe Proofing::DdpResult do
       end
     end
   end
+
+  describe '#to_h' do
+    context 'when response_body is present' do
+      it 'is redacted' do
+        response_body = { first_name: 'Jonny Proofs' }
+        result = Proofing::DdpResult.new(response_body:)
+
+        expect(result.to_h[:response_body]).to eq({ first_name: '[redacted]' })
+      end
+    end
+
+    context 'when response_body is not present' do
+      it 'is nil' do
+        result = Proofing::DdpResult.new(response_body: nil)
+
+        expect(result.to_h[:response_body]).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
We use ThreatMetrix as part of our proofing process. When we get a response from ThreatMetrix we log the response body along with some other metadata about the response. The response body contains sensitive PII that cannot be logged so before logging the response body is passed through the `ResponseRedacter` which redacts sensitive info.

The `ResponseRedacter` gaurds against nil response bodies by returning returning a response with an error with the description `TMx response body was empty'. As a result, any time there is no response body to be logged we see that error in our logs. This can be confusing when other errors occur, for example network timeouts or connection failures. It makes it appear as though the issue is a missing response body.

This commit modifies the `DdpResult` to only redact the response body when it is present. When it is absent a nil value is returned. This will cause the empty response body to quit being logged and appearing in cloudwatch when exceptions occur.
