### PR TITLE
LG-14220: Standardize and simplify content for consent screen

### DIFF
--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -2,6 +2,7 @@
 
 class CompletionsPresenter
   include ActionView::Helpers::TranslationHelper
+  include ActionView::Helpers::TagHelper
 
   attr_reader :current_user, :current_sp, :decrypted_pii, :requested_attributes, :completion_context
 
@@ -77,15 +78,21 @@ class CompletionsPresenter
     if consent_has_expired?
       safe_join(
         [
-          t('help_text.requested_attributes.consent_reminder_html', sp: sp_name),
-          t('help_text.requested_attributes.intro_html', sp: sp_name),
+          t(
+            'help_text.requested_attributes.consent_reminder_html',
+            sp_html: content_tag(:strong, sp_name),
+          ),
+          t('help_text.requested_attributes.intro_html', sp_html: content_tag(:strong, sp_name)),
         ],
         ' ',
       )
     elsif ial2_requested? && reverified_after_consent?
-      t('help_text.requested_attributes.ial2_reverified_consent_info', sp: sp_name)
+      t(
+        'help_text.requested_attributes.ial2_reverified_consent_info_html',
+        sp_html: content_tag(:strong, sp_name),
+      )
     else
-      t('help_text.requested_attributes.intro_html', sp: sp_name)
+      t('help_text.requested_attributes.intro_html', sp_html: content_tag(:strong, sp_name))
     end
   end
 

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CompletionsPresenter
+  include ActionView::Helpers::TranslationHelper
+
   attr_reader :current_user, :current_sp, :decrypted_pii, :requested_attributes, :completion_context
 
   SORTED_IAL2_ATTRIBUTE_MAPPING = [
@@ -72,33 +74,18 @@ class CompletionsPresenter
   end
 
   def intro
-    if ial2_requested?
-      if consent_has_expired?
-        I18n.t(
-          'help_text.requested_attributes.ial2_consent_reminder_html',
-          sp: sp_name,
-        )
-      elsif reverified_after_consent?
-        I18n.t(
-          'help_text.requested_attributes.ial2_reverified_consent_info',
-          sp: sp_name,
-        )
-      else
-        I18n.t(
-          'help_text.requested_attributes.ial2_intro_html',
-          sp: sp_name,
-        )
-      end
-    elsif consent_has_expired?
-      I18n.t(
-        'help_text.requested_attributes.ial1_consent_reminder_html',
-        sp: sp_name,
+    if consent_has_expired?
+      safe_join(
+        [
+          t('help_text.requested_attributes.consent_reminder_html', sp: sp_name),
+          t('help_text.requested_attributes.intro_html', sp: sp_name),
+        ],
+        ' ',
       )
+    elsif ial2_requested? && reverified_after_consent?
+      t('help_text.requested_attributes.ial2_reverified_consent_info', sp: sp_name)
     else
-      I18n.t(
-        'help_text.requested_attributes.ial1_intro_html',
-        sp: sp_name,
-      )
+      t('help_text.requested_attributes.intro_html', sp: sp_name)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -958,11 +958,11 @@ headings.webauthn_setup.new: Insert your security key
 help_text.requested_attributes.address: Address
 help_text.requested_attributes.all_emails: Email addresses on your account
 help_text.requested_attributes.birthdate: Date of birth
-help_text.requested_attributes.consent_reminder_html: You must consent each year to share your information with <strong>%{sp}</strong>.
+help_text.requested_attributes.consent_reminder_html: You must consent each year to share your information with %{sp_html}.
 help_text.requested_attributes.email: Email address
 help_text.requested_attributes.full_name: Full name
-help_text.requested_attributes.ial2_reverified_consent_info: 'Because you verified your identity again, we need your permission to share this information with %{sp}:'
-help_text.requested_attributes.intro_html: 'We’ll share this information with <strong>%{sp}</strong>:'
+help_text.requested_attributes.ial2_reverified_consent_info_html: 'Because you verified your identity again, we need your permission to share this information with %{sp_html}:'
+help_text.requested_attributes.intro_html: 'We’ll share this information with %{sp_html}:'
 help_text.requested_attributes.phone: Phone number
 help_text.requested_attributes.social_security_number: Social Security number
 help_text.requested_attributes.verified_at: Updated on

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -958,13 +958,11 @@ headings.webauthn_setup.new: Insert your security key
 help_text.requested_attributes.address: Address
 help_text.requested_attributes.all_emails: Email addresses on your account
 help_text.requested_attributes.birthdate: Date of birth
+help_text.requested_attributes.consent_reminder_html: You must consent each year to share your information with <strong>%{sp}</strong>.
 help_text.requested_attributes.email: Email address
 help_text.requested_attributes.full_name: Full name
-help_text.requested_attributes.ial1_consent_reminder_html: You must consent each year to share your information with <strong>%{sp}</strong>. We’ll share your information with <strong>%{sp}</strong> to connect your account.
-help_text.requested_attributes.ial1_intro_html: We’ll share your information with <strong>%{sp}</strong> to connect your account.
-help_text.requested_attributes.ial2_consent_reminder_html: '<strong>%{sp}</strong> needs to know who you are to connect to your account. You must consent each year to share your verified information with <strong>%{sp}</strong>. We’ll share this information:'
-help_text.requested_attributes.ial2_intro_html: '<strong>%{sp}</strong> needs to know who you are to connect your account. We’ll share this information with %{sp}:'
 help_text.requested_attributes.ial2_reverified_consent_info: 'Because you verified your identity again, we need your permission to share this information with %{sp}:'
+help_text.requested_attributes.intro_html: 'We’ll share this information with <strong>%{sp}</strong>:'
 help_text.requested_attributes.phone: Phone number
 help_text.requested_attributes.social_security_number: Social Security number
 help_text.requested_attributes.verified_at: Updated on

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -969,11 +969,11 @@ headings.webauthn_setup.new: Inserte su clave de seguridad
 help_text.requested_attributes.address: Dirección
 help_text.requested_attributes.all_emails: Direcciones de correo electrónico en su cuenta
 help_text.requested_attributes.birthdate: Fecha de nacimiento
-help_text.requested_attributes.consent_reminder_html: Debe dar su consentimiento cada año para divulgar su información a <strong>%{sp}</strong>.
+help_text.requested_attributes.consent_reminder_html: Debe dar su consentimiento cada año para divulgar su información a %{sp_html}.
 help_text.requested_attributes.email: Dirección de correo electrónico
 help_text.requested_attributes.full_name: Nombre completo
-help_text.requested_attributes.ial2_reverified_consent_info: 'Como volvió a verificar su identidad, necesitamos su permiso para divulgar esta información a %{sp}:'
-help_text.requested_attributes.intro_html: 'Divulgaremos esta información a <strong>%{sp}</strong>:'
+help_text.requested_attributes.ial2_reverified_consent_info_html: 'Como volvió a verificar su identidad, necesitamos su permiso para divulgar esta información a %{sp_html}:'
+help_text.requested_attributes.intro_html: 'Divulgaremos esta información a %{sp_html}:'
 help_text.requested_attributes.phone: Número de teléfono
 help_text.requested_attributes.social_security_number: Número de Seguro Social
 help_text.requested_attributes.verified_at: Actualizado en

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -969,13 +969,11 @@ headings.webauthn_setup.new: Inserte su clave de seguridad
 help_text.requested_attributes.address: Dirección
 help_text.requested_attributes.all_emails: Direcciones de correo electrónico en su cuenta
 help_text.requested_attributes.birthdate: Fecha de nacimiento
+help_text.requested_attributes.consent_reminder_html: Debe dar su consentimiento cada año para divulgar su información a <strong>%{sp}</strong>.
 help_text.requested_attributes.email: Dirección de correo electrónico
 help_text.requested_attributes.full_name: Nombre completo
-help_text.requested_attributes.ial1_consent_reminder_html: Debe dar su consentimiento cada año para divulgar su información a <strong>%{sp}</strong>. Divulgaremos su información a <strong>%{sp}</strong> para conectar su cuenta.
-help_text.requested_attributes.ial1_intro_html: Divulgaremos su información a <strong>%{sp}</strong> para conectar su cuenta.
-help_text.requested_attributes.ial2_consent_reminder_html: 'Para conectar su cuenta, <strong>%{sp}</strong> necesita saber quién es usted. Debe dar su consentimiento cada año para divulgar su información verificada a <strong>%{sp}</strong>. Divulgaremos esta información:'
-help_text.requested_attributes.ial2_intro_html: 'Para conectar su cuenta, <strong>%{sp}</strong> necesita saber quién es usted. Divulgaremos esta información a %{sp}:'
 help_text.requested_attributes.ial2_reverified_consent_info: 'Como volvió a verificar su identidad, necesitamos su permiso para divulgar esta información a %{sp}:'
+help_text.requested_attributes.intro_html: 'Divulgaremos esta información a <strong>%{sp}</strong>:'
 help_text.requested_attributes.phone: Número de teléfono
 help_text.requested_attributes.social_security_number: Número de Seguro Social
 help_text.requested_attributes.verified_at: Actualizado en

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -958,11 +958,11 @@ headings.webauthn_setup.new: Insérer votre clé de sécurité
 help_text.requested_attributes.address: Adresse
 help_text.requested_attributes.all_emails: Adresses e-mail sur votre compte
 help_text.requested_attributes.birthdate: Date de naissance
-help_text.requested_attributes.consent_reminder_html: Vous devez consentir chaque année au partage de vos informations avec <strong>%{sp}</strong>.
+help_text.requested_attributes.consent_reminder_html: Vous devez consentir chaque année au partage de vos informations avec %{sp_html}.
 help_text.requested_attributes.email: Adresse e-mail
 help_text.requested_attributes.full_name: Nom complet
-help_text.requested_attributes.ial2_reverified_consent_info: 'Étant donné que vous avez revérifié votre identité, nous avons besoin de votre autorisation pour partager ces informations avec %{sp} :'
-help_text.requested_attributes.intro_html: 'Nous partagerons ces informations avec <strong>%{sp}</strong>:'
+help_text.requested_attributes.ial2_reverified_consent_info_html: 'Étant donné que vous avez revérifié votre identité, nous avons besoin de votre autorisation pour partager ces informations avec %{sp_html} :'
+help_text.requested_attributes.intro_html: 'Nous partagerons ces informations avec %{sp_html}:'
 help_text.requested_attributes.phone: Numéro de téléphone
 help_text.requested_attributes.social_security_number: Numéro de sécurité sociale
 help_text.requested_attributes.verified_at: Mis à jour le

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -958,13 +958,11 @@ headings.webauthn_setup.new: Insérer votre clé de sécurité
 help_text.requested_attributes.address: Adresse
 help_text.requested_attributes.all_emails: Adresses e-mail sur votre compte
 help_text.requested_attributes.birthdate: Date de naissance
+help_text.requested_attributes.consent_reminder_html: Vous devez consentir chaque année au partage de vos informations avec <strong>%{sp}</strong>.
 help_text.requested_attributes.email: Adresse e-mail
 help_text.requested_attributes.full_name: Nom complet
-help_text.requested_attributes.ial1_consent_reminder_html: Vous devez consentir chaque année au partage de vos informations avec <strong>%{sp}</strong>. Nous partagerons vos informations avec <strong>%{sp}</strong> pour connecter votre compte.
-help_text.requested_attributes.ial1_intro_html: Nous partagerons vos informations avec <strong>%{sp}</strong> pour connecter votre compte.
-help_text.requested_attributes.ial2_consent_reminder_html: '<strong>%{sp}</strong> a besoin de savoir qui vous êtes pour se connecter à votre compte. Vous devez consentir chaque année à partager vos informations vérifiées avec <strong>%{sp}</strong>. Nous partagerons ces informations :'
-help_text.requested_attributes.ial2_intro_html: '<strong>%{sp}</strong> a besoin de savoir qui vous êtes pour connecter votre compte. Nous partagerons ces informations avec %{sp} :'
 help_text.requested_attributes.ial2_reverified_consent_info: 'Étant donné que vous avez revérifié votre identité, nous avons besoin de votre autorisation pour partager ces informations avec %{sp} :'
+help_text.requested_attributes.intro_html: 'Nous partagerons ces informations avec <strong>%{sp}</strong>:'
 help_text.requested_attributes.phone: Numéro de téléphone
 help_text.requested_attributes.social_security_number: Numéro de sécurité sociale
 help_text.requested_attributes.verified_at: Mis à jour le

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -971,13 +971,11 @@ headings.webauthn_setup.new: 插入您的安全密钥
 help_text.requested_attributes.address: 地址
 help_text.requested_attributes.all_emails: 你账户上的电邮地址
 help_text.requested_attributes.birthdate: 生日
+help_text.requested_attributes.consent_reminder_html: 你每年都必须授权同意与 <strong>%{sp}</strong> 分享信息。
 help_text.requested_attributes.email: 电邮地址
 help_text.requested_attributes.full_name: 姓名
-help_text.requested_attributes.ial1_consent_reminder_html: 你每年都必须授权同意与 <strong>%{sp}</strong> 分享信息。我们将与 <strong>%{sp}</strong> 分享你的信息来连接你账户。
-help_text.requested_attributes.ial1_intro_html: 我们将与 <strong>%{sp}</strong> 分享你的信息来连接你账户。
-help_text.requested_attributes.ial2_consent_reminder_html: '<strong>%{sp}</strong> 需要知道你是谁才能连接你的账户。你每年都必须授权同意与 <strong>%{sp}</strong> 分享已验证过的你的信息。我们会分享这些信息：'
-help_text.requested_attributes.ial2_intro_html: '<strong>%{sp}</strong> 需要知道你是谁才能连接你的账户。我们会与 %{sp} 分享这些信息：'
 help_text.requested_attributes.ial2_reverified_consent_info: '因为你重新验证了身份，我们需要得到你的许可才能与 %{sp} 分享该信息。'
+help_text.requested_attributes.intro_html: 我们会与 <strong>%{sp}</strong> 分享这些信息：
 help_text.requested_attributes.phone: 电话号码
 help_text.requested_attributes.social_security_number: 社会保障号码
 help_text.requested_attributes.verified_at: 更新是在

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -971,11 +971,11 @@ headings.webauthn_setup.new: 插入您的安全密钥
 help_text.requested_attributes.address: 地址
 help_text.requested_attributes.all_emails: 你账户上的电邮地址
 help_text.requested_attributes.birthdate: 生日
-help_text.requested_attributes.consent_reminder_html: 你每年都必须授权同意与 <strong>%{sp}</strong> 分享信息。
+help_text.requested_attributes.consent_reminder_html: 你每年都必须授权同意与 %{sp_html} 分享信息。
 help_text.requested_attributes.email: 电邮地址
 help_text.requested_attributes.full_name: 姓名
-help_text.requested_attributes.ial2_reverified_consent_info: '因为你重新验证了身份，我们需要得到你的许可才能与 %{sp} 分享该信息。'
-help_text.requested_attributes.intro_html: 我们会与 <strong>%{sp}</strong> 分享这些信息：
+help_text.requested_attributes.ial2_reverified_consent_info_html: '因为你重新验证了身份，我们需要得到你的许可才能与 %{sp_html} 分享该信息。'
+help_text.requested_attributes.intro_html: 我们会与 %{sp_html} 分享这些信息：
 help_text.requested_attributes.phone: 电话号码
 help_text.requested_attributes.social_security_number: 社会保障号码
 help_text.requested_attributes.verified_at: 更新是在

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CompletionsPresenter do
+  include ActionView::Helpers::OutputSafetyHelper
+
   let(:identities) do
     [
       build(
@@ -147,43 +149,46 @@ RSpec.describe CompletionsPresenter do
   end
 
   describe '#intro' do
-    describe 'ial1' do
-      context 'consent has expired since the last sign in' do
-        let(:identities) do
-          [
-            build(
-              :service_provider_identity,
-              service_provider: current_sp.issuer,
-              last_consented_at: 2.years.ago,
-            ),
-          ]
-        end
-        let(:completion_context) { :consent_expired }
+    it 'renders the standard intro message' do
+      expect(presenter.intro).to eq(
+        t('help_text.requested_attributes.intro_html', sp: current_sp.friendly_name),
+      )
+    end
 
-        it 'renders the expired IAL1 consent intro message' do
-          expect(presenter.intro).to eq(
-            I18n.t(
-              'help_text.requested_attributes.ial1_consent_reminder_html',
-              sp: current_sp.friendly_name,
-            ),
-          )
-        end
+    context 'consent has expired since the last sign in' do
+      let(:identities) do
+        [
+          build(
+            :service_provider_identity,
+            service_provider: current_sp.issuer,
+            last_consented_at: 2.years.ago,
+          ),
+        ]
       end
+      let(:completion_context) { :consent_expired }
 
-      context 'when consent has not expired' do
-        it 'renders the standard intro message' do
-          expect(presenter.intro).to eq(
-            I18n.t(
-              'help_text.requested_attributes.ial1_intro_html',
-              sp: current_sp.friendly_name,
-            ),
-          )
-        end
+      it 'renders the expired consent intro message' do
+        expect(presenter.intro).to eq(
+          safe_join(
+            [
+              t(
+                'help_text.requested_attributes.consent_reminder_html',
+                sp: current_sp.friendly_name,
+              ),
+              t(
+                'help_text.requested_attributes.intro_html',
+                sp: current_sp.friendly_name,
+              ),
+            ],
+            ' ',
+          ),
+        )
       end
     end
 
     describe 'ial2' do
       let(:ial2_requested) { true }
+
       context 'consent has expired since the last sign in' do
         let(:identities) do
           [
@@ -196,11 +201,20 @@ RSpec.describe CompletionsPresenter do
         end
         let(:completion_context) { :consent_expired }
 
-        it 'renders the expired IAL2 consent intro message' do
+        it 'renders the expired consent intro message' do
           expect(presenter.intro).to eq(
-            I18n.t(
-              'help_text.requested_attributes.ial2_consent_reminder_html',
-              sp: current_sp.friendly_name,
+            safe_join(
+              [
+                t(
+                  'help_text.requested_attributes.consent_reminder_html',
+                  sp: current_sp.friendly_name,
+                ),
+                t(
+                  'help_text.requested_attributes.intro_html',
+                  sp: current_sp.friendly_name,
+                ),
+              ],
+              ' ',
             ),
           )
         end
@@ -217,21 +231,11 @@ RSpec.describe CompletionsPresenter do
           ]
         end
         let(:completion_context) { :reverified_after_consent }
+
         it 'renders the reverified IAL2 consent intro message' do
           expect(presenter.intro).to eq(
-            I18n.t(
+            t(
               'help_text.requested_attributes.ial2_reverified_consent_info',
-              sp: current_sp.friendly_name,
-            ),
-          )
-        end
-      end
-
-      context 'when consent has not expired' do
-        it 'renders the standard intro message' do
-          expect(presenter.intro).to eq(
-            I18n.t(
-              'help_text.requested_attributes.ial2_intro_html',
               sp: current_sp.friendly_name,
             ),
           )

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CompletionsPresenter do
   include ActionView::Helpers::OutputSafetyHelper
+  include ActionView::Helpers::TagHelper
 
   let(:identities) do
     [
@@ -151,7 +152,10 @@ RSpec.describe CompletionsPresenter do
   describe '#intro' do
     it 'renders the standard intro message' do
       expect(presenter.intro).to eq(
-        t('help_text.requested_attributes.intro_html', sp: current_sp.friendly_name),
+        t(
+          'help_text.requested_attributes.intro_html',
+          sp_html: content_tag(:strong, current_sp.friendly_name),
+        ),
       )
     end
 
@@ -173,11 +177,11 @@ RSpec.describe CompletionsPresenter do
             [
               t(
                 'help_text.requested_attributes.consent_reminder_html',
-                sp: current_sp.friendly_name,
+                sp_html: content_tag(:strong, current_sp.friendly_name),
               ),
               t(
                 'help_text.requested_attributes.intro_html',
-                sp: current_sp.friendly_name,
+                sp_html: content_tag(:strong, current_sp.friendly_name),
               ),
             ],
             ' ',
@@ -207,11 +211,11 @@ RSpec.describe CompletionsPresenter do
               [
                 t(
                   'help_text.requested_attributes.consent_reminder_html',
-                  sp: current_sp.friendly_name,
+                  sp_html: content_tag(:strong, current_sp.friendly_name),
                 ),
                 t(
                   'help_text.requested_attributes.intro_html',
-                  sp: current_sp.friendly_name,
+                  sp_html: content_tag(:strong, current_sp.friendly_name),
                 ),
               ],
               ' ',
@@ -235,8 +239,8 @@ RSpec.describe CompletionsPresenter do
         it 'renders the reverified IAL2 consent intro message' do
           expect(presenter.intro).to eq(
             t(
-              'help_text.requested_attributes.ial2_reverified_consent_info',
-              sp: current_sp.friendly_name,
+              'help_text.requested_attributes.ial2_reverified_consent_info_html',
+              sp_html: content_tag(:strong, current_sp.friendly_name),
             ),
           )
         end

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
     expect(text).to_not include(service_provider.agency.name)
     expect(text).to include(
       view_context.strip_tags(
-        I18n.t(
-          'help_text.requested_attributes.ial1_intro_html',
+        t(
+          'help_text.requested_attributes.intro_html',
           sp: service_provider.friendly_name,
         ),
       ),

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
       view_context.strip_tags(
         t(
           'help_text.requested_attributes.intro_html',
-          sp: service_provider.friendly_name,
+          sp_html: content_tag(:strong, service_provider.friendly_name),
         ),
       ),
     )


### PR DESCRIPTION
## 🎫 Ticket

[LG-14220](https://cm-jira.usa.gov/browse/LG-14220)

## 🛠 Summary of changes

Updates content logic for the consent screen to be simplified and standardized across IAL1 and IdV consent.

## 📜 Testing Plan

1. Have the IdP and [sample application](https://github.com/18f/identity-oidc-sinatra) running simultaneously
2. Go to http://localhost:9292
3. (Optional) Set "Level of Service" to "Identity-verified"
4. Click "Sign in"
5. Proceed to sign in
6. (If not prompted to consent, visit http://localhost:3000/account/connected_accounts , "Disconnect" on the listed applications, and start over)
7. When prompted to consent, observe consistent language "We’ll share this information with %{sp}:"
8. Simulate yearly re-consent by applying diff:
```diff
diff --git a/app/presenters/completions_presenter.rb b/app/presenters/completions_presenter.rb
index 911246f83f..28e8641515 100644
--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -111,2 +111,3 @@ class CompletionsPresenter
   def consent_has_expired?
+    return true
     completion_context == :consent_expired
```
9. Refresh page
10. Observe same content as before, but with leading sentence "You must consent each year to share your information with %{sp}."

## 👀 Screenshots

State|Before|After
---|---|---
IAL1|![before-ial1-en](https://github.com/user-attachments/assets/29c797ec-879e-4f8e-8b37-d02242275f43)|![after-ial1-en](https://github.com/user-attachments/assets/f8a78a77-a5e6-4f31-95c2-a4bdaa8fd5e7)
IAL1 Re-Consent|![before-ial1-reconsent-en](https://github.com/user-attachments/assets/c7de0fdd-d6e0-4328-b936-3d6c23794a98)|![after-ial1-reconsent-en](https://github.com/user-attachments/assets/7d0b5c8a-b166-49ce-aca5-aff8ddf410df)
IdV|![before-ial2-en](https://github.com/user-attachments/assets/0f6e601d-175d-404a-ba23-16f1b7da38b1)|![after-ial2-en](https://github.com/user-attachments/assets/f4a6933e-b0ff-48c6-8dfd-7600954edf2f)
IdV Re-Consent|![before-ial2-reconsent-en](https://github.com/user-attachments/assets/cdc7a542-04da-476d-8fc8-9c9be6f00f97)|![after-ial2-reconsent-en](https://github.com/user-attachments/assets/2aa30931-0b75-45a7-85a4-cf8f5aadcf08)