### PR TITLE
revert back to sending mock client metadata only when using the mock doc auth vendor

### DIFF
--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -7,7 +7,7 @@
 <%= tag.div id: 'document-capture-form', data: {
       app_name: APP_NAME,
       liveness_required: nil,
-      mock_client: mock_client,
+      mock_client: mock_client.presence,
       help_center_redirect_url: help_center_redirect_url(
         flow: :idv,
         step: :document_capture,

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       it 'contains mock-client-data in metadata' do
         render_partial
         expect(rendered).not_to have_css(
-          "#document-capture-form[data-mock-client]",
+          '#document-capture-form[data-mock-client]',
         )
       end
     end
@@ -145,7 +145,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       it 'contains mock-client-data in metadata' do
         render_partial
         expect(rendered).to have_css(
-          "#document-capture-form[data-mock-client]",
+          '#document-capture-form[data-mock-client]',
         )
       end
     end

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -135,10 +135,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       it 'contains mock-client-data in metadata' do
         render_partial
         expect(rendered).not_to have_css(
-          "#document-capture-form[data-mock-client='false']",
-        )
-        expect(rendered).not_to have_css(
-          "#document-capture-form[data-mock-client='true']",
+          "#document-capture-form[data-mock-client]",
         )
       end
     end
@@ -148,7 +145,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       it 'contains mock-client-data in metadata' do
         render_partial
         expect(rendered).to have_css(
-          "#document-capture-form[data-mock-client='true']",
+          "#document-capture-form[data-mock-client]",
         )
       end
     end

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
   let(:skip_doc_auth_from_handoff) { false }
   let(:opted_in_to_in_person_proofing) { false }
   let(:presenter) { Idv::InPerson::UspsFormPresenter.new }
+  let(:mock_client) { false }
 
   before do
     decorated_sp_session = instance_double(
@@ -55,7 +56,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       skip_doc_auth_from_how_to_verify: skip_doc_auth_from_how_to_verify,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
-      mock_client: nil,
+      mock_client: mock_client,
     }
   end
 
@@ -126,6 +127,28 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
         render_partial
         expect(rendered).to have_css(
           "#document-capture-form[data-doc-auth-selfie-capture='false']",
+        )
+      end
+    end
+
+    context 'when not using doc auth mock client' do
+      it 'contains mock-client-data in metadata' do
+        render_partial
+        expect(rendered).not_to have_css(
+          "#document-capture-form[data-mock-client='false']",
+        )
+        expect(rendered).not_to have_css(
+          "#document-capture-form[data-mock-client='true']",
+        )
+      end
+    end
+
+    context 'when using doc auth mock client' do
+      let(:mock_client) { true }
+      it 'contains mock-client-data in metadata' do
+        render_partial
+        expect(rendered).to have_css(
+          "#document-capture-form[data-mock-client='true']",
         )
       end
     end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14314](https://cm-jira.usa.gov/browse/LG-14314)

## 🛠 Summary of changes
- the mock-client meta data is defined only when the mock-client attribute is true

## 📜 Testing Plan

See video recording below or follow steps

- [ ] in application.yml, set: `doc_auth_vendor: 'mock'`
- [ ] attempt to upload a file for doc auth
- [ ] confirm file picker allows all file types
- [ ] in application.yml, set: `doc_auth_vendor: 'not-mock'`
- [ ] attempt to upload a file for doc auth
- [ ] confirm file picker allows jpg and png files only

## 👀 Video Recording
https://gsa-tts.slack.com/archives/C0751MB0CAV/p1724762294302399?thread_ts=1724762259.730499&cid=C0751MB0CAV

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
