### PR TITLE
Allow for extra arguments to `idv_doc_auth_verify_polling_wait_visited` event

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1648,8 +1648,8 @@ module AnalyticsEvents
 
   # User visits IdV verify step waiting on a resolution proofing job result
   # @identity.idp.previous_event_name IdV: doc auth verify visited
-  def idv_doc_auth_verify_polling_wait_visited
-    track_event(:idv_doc_auth_verify_polling_wait_visited)
+  def idv_doc_auth_verify_polling_wait_visited(**extra)
+    track_event(:idv_doc_auth_verify_polling_wait_visited, **extra)
   end
 
   # rubocop:disable Layout/LineLength


### PR DESCRIPTION
The `idv_doc_auth_verify_polling_wait_visited` gets logged when a polling event occurs on the verify info step. This event does not have any extra attributes that it needs to log. As a result we left off the extra arguments when adding it.

Leaving off the extra arguments led to an issue with the `AnalyticsEventsEnhancer`. This adds attributes to the events that are prefixed with `idv_` when they are called. A result of this was a `ArgumentError` for this event since it did not have the extra arguments for these attributes.
