### PR TITLE
Refactor ial/aal determination

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -125,13 +125,9 @@ module SamlIdpAuthConcern
     if saml_request.requested_vtr_authn_contexts.present?
       resolved_authn_context_result.expanded_component_values
     else
-      saml_request.requested_aal_authn_context ||
+      FederatedProtocols::Saml.new(saml_request).aal ||
         default_aal_context
     end
-  end
-
-  def requested_ial_authn_context
-    saml_request.requested_ial_authn_context || default_ial_context
   end
 
   def link_identity_from_session_data

--- a/app/models/federated_protocols/oidc.rb
+++ b/app/models/federated_protocols/oidc.rb
@@ -30,10 +30,6 @@ module FederatedProtocols
       OpenidConnectAttributeScoper.new(request.scope).requested_attributes
     end
 
-    def biometric_comparison_required?
-      request.biometric_comparison_required?
-    end
-
     def service_provider
       request.service_provider
     end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5845,7 +5845,7 @@ module AnalyticsEvents
   # @param [String] endpoint
   # @param [Boolean] idv
   # @param [Boolean] finish_profile
-  # @param [Integer] requested_ial
+  # @param [String] requested_ial
   # @param [Boolean] request_signed
   # @param [String] matching_cert_serial
   # matches the request certificate in a successful, signed request
@@ -5890,7 +5890,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Integer] requested_ial
+  # @param [String] requested_ial
   # @param [Array] authn_context
   # @param [String, nil] requested_aal_authn_context
   # @param [String, nil] requested_vtr_authn_contexts

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -42,7 +42,7 @@ class AttributeAsserter
       add_vot(attrs)
     else
       add_aal(attrs)
-      add_ial(attrs) if authn_request.requested_ial_authn_context || !service_provider.ial.nil?
+      add_ial(attrs)
     end
 
     add_x509(attrs) if bundle.include?(:x509_presented) && x509_data
@@ -145,7 +145,7 @@ class AttributeAsserter
   end
 
   def add_aal(attrs)
-    requested_context = authn_request.requested_aal_authn_context
+    requested_context = requested_aal_authn_context
     requested_aal_level = Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_AAL[requested_context]
     aal_level = requested_aal_level || service_provider.default_aal || ::Idp::Constants::DEFAULT_AAL
     context = Saml::Idp::Constants::AUTHN_CONTEXT_AAL_TO_CLASSREF[aal_level]
@@ -220,12 +220,16 @@ class AttributeAsserter
     ).map(&:to_sym)
   end
 
-  def authn_request_bundle
-    SamlRequestParser.new(authn_request).requested_attributes
+  def requested_ial_authn_context
+    FederatedProtocols::Saml.new(authn_request).requested_ial_authn_context
   end
 
-  def authn_context
-    authn_request.requested_ial_authn_context
+  def requested_aal_authn_context
+    FederatedProtocols::Saml.new(authn_request).aal
+  end
+
+  def authn_request_bundle
+    SamlRequestParser.new(authn_request).requested_attributes
   end
 
   def x509_data

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -979,9 +979,6 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
 
   context 'Happy selfie path' do
     before do
-      allow_any_instance_of(FederatedProtocols::Oidc).
-        to receive(:biometric_comparison_required?).
-        and_return(true)
       allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:success)
 
       perform_in_browser(:desktop) do

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -362,10 +362,6 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analyti
   end
 
   context 'barcode read error on desktop, redo document capture on mobile' do
-    before do
-      allow_any_instance_of(FederatedProtocols::Oidc).
-        to receive(:biometric_comparison_required?).and_return(true)
-    end
     it 'continues to ssn on desktop when user selects Continue', js: true do
       user = nil
 

--- a/spec/models/federated_protocols/saml_spec.rb
+++ b/spec/models/federated_protocols/saml_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+module FederatedProtocols
+  RSpec.describe Saml do
+    let(:authn_contexts) { [] }
+    let(:saml_request) { instance_double(SamlIdp::Request) }
+
+    subject { FederatedProtocols::Saml.new saml_request }
+
+    before do
+      allow(saml_request).to receive(:requested_authn_contexts).and_return(authn_contexts)
+    end
+
+    describe '#aal' do
+      context 'when no aal context is requested' do
+        it 'returns nil' do
+          expect(subject.aal).to be_nil
+        end
+      end
+
+      context 'when the only context requested is aal' do
+        let(:aal) { 'http://idmanagement.gov/ns/assurance/aal/2' }
+        let(:authn_contexts) { [aal] }
+
+        it 'returns the requested aal' do
+          expect(subject.aal).to eq(aal)
+        end
+      end
+
+      context 'when multiple contexts are requested including aal' do
+        let(:aal) { 'http://idmanagement.gov/ns/assurance/aal/2' }
+        let(:ial) { 'http://idmanagement.gov/ns/assurance/ial/1' }
+        let(:authn_contexts) { [ial, aal] }
+
+        it 'returns the requested aal' do
+          expect(subject.aal).to eq(aal)
+        end
+      end
+    end
+
+    describe '#requested_ial_authn_context' do
+      context 'when no ial context is requested' do
+        it 'returns nil' do
+          expect(subject.requested_ial_authn_context).to be_nil
+        end
+      end
+
+      context 'when the only context requested is ial' do
+        let(:ial) { 'http://idmanagement.gov/ns/assurance/ial/2' }
+        let(:authn_contexts) { [ial] }
+
+        it 'returns the requested ial' do
+          expect(subject.requested_ial_authn_context).to eq(ial)
+        end
+      end
+
+      context 'when multiple contexts are requested including ial' do
+        let(:aal) { 'http://idmanagement.gov/ns/assurance/aal/2' }
+        let(:ial) { 'http://idmanagement.gov/ns/assurance/ial/1' }
+        let(:authn_contexts) { [ial, aal] }
+
+        it 'returns the requested ial' do
+          expect(subject.requested_ial_authn_context).to eq(ial)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Restrict ial and aal determination to the idp app.

This was unnecessarily leaking into the saml_idp gem. A subsequent PR in
that repo will remove these concerns there.

As part of the move to semantic ACR values, we will also replace the regex prefix matching for IALs and AALs with explicit enumerations.

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
