### PR TITLE
LG-14095: make the default doc_auth vendor `mock`

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -97,6 +97,8 @@ doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_selfie_desktop_test_mode: false
 doc_auth_separate_pages_enabled: false
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'
+doc_auth_vendor: 'mock'
+doc_auth_vendor_default: 'mock'
 doc_auth_vendor_lexis_nexis_percent: 100 # note, LN is currently the default vendor
 doc_auth_vendor_socure_percent: 0
 doc_auth_vendor_switching_enabled: false
@@ -400,8 +402,6 @@ development:
   dashboard_api_token: test_token
   dashboard_url: http://localhost:3001/api/service_providers
   doc_auth_selfie_desktop_test_mode: true
-  doc_auth_vendor: 'mock'
-  doc_auth_vendor_default: 'mock'
   domain_name: localhost:3000
   enable_rate_limiting: false
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
@@ -461,8 +461,6 @@ production:
   dashboard_url: https://dashboard.demo.login.gov
   disable_email_sending: false
   disable_logout_get_request: false
-  doc_auth_vendor: 'lexisnexis'
-  doc_auth_vendor_default: 'lexisnexis'
   domain_name: login.gov
   email_registrations_per_ip_track_only_mode: true
   enable_test_routes: false
@@ -517,8 +515,6 @@ test:
   dashboard_url: https://dashboard.demo.login.gov
   doc_auth_max_attempts: 4
   doc_auth_selfie_desktop_test_mode: true
-  doc_auth_vendor: 'mock'
-  doc_auth_vendor_default: 'mock'
   doc_capture_polling_enabled: false
   domain_name: www.example.com
   email_registrations_per_ip_limit: 3


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14095](https://cm-jira.usa.gov/browse/LG-14095)

## 🛠 Summary of changes

Previously, the default in the Rails production environment was lexisnexis. This PR makes it mock everywhere, and forces us to explicitly set an overriding default in the S3 configs for each env.
