### PR TITLE
Lg 13316 add selfie attempt num to idv event

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -354,8 +354,9 @@ module Idv
       zip_code = client_response.pii_from_doc&.zipcode&.to_s&.strip&.slice(0, 5)
       issue_year = client_response.pii_from_doc&.state_id_issued&.to_date&.year
       captured_result = document_capture_session&.load_result
-      selfie_image_fingerprint_add_count = (selfie_image_fingerprint ? 1 : 0)
-      selfie_attempts = (captured_result&.failed_selfie_image_fingerprints || []).length + selfie_image_fingerprint_add_count
+      processed_selfie_count = (selfie_image_fingerprint ? 1 : 0)
+      past_selfie_count = (captured_result&.failed_selfie_image_fingerprints || []).length
+      selfie_attempts = past_selfie_count + processed_selfie_count
       analytics.idv_doc_auth_submitted_image_upload_vendor(
         **client_response.to_h.merge(
           birth_year: birth_year,

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -354,7 +354,7 @@ module Idv
       zip_code = client_response.pii_from_doc&.zipcode&.to_s&.strip&.slice(0, 5)
       issue_year = client_response.pii_from_doc&.state_id_issued&.to_date&.year
       captured_result = document_capture_session&.load_result
-      selfie_attempts = (captured_result&.failed_selfie_image_fingerprints || []).length() + 1 # TODO: check logic
+      selfie_attempts = (captured_result&.failed_selfie_image_fingerprints || []).length() + 1
       analytics.idv_doc_auth_submitted_image_upload_vendor(
         **client_response.to_h.merge(
           birth_year: birth_year,

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -205,13 +205,13 @@ module Idv
       rate_limiter.attempts if document_capture_session
     end
 
-    def processed_selfie_attempts
-      return 0 if document_capture_session.nil?
+    def processed_selfie_attempts_data
+      return {} if document_capture_session.nil? || !liveness_checking_required
 
       captured_result = document_capture_session&.load_result
       processed_selfie_count = (selfie_image_fingerprint ? 1 : 0)
       past_selfie_count = (captured_result&.failed_selfie_image_fingerprints || []).length
-      past_selfie_count + processed_selfie_count
+      { selfie_attempts: past_selfie_count + processed_selfie_count }
     end
 
     def determine_response(form_response:, client_response:, doc_pii_response:)
@@ -371,9 +371,9 @@ module Idv
           vendor_request_time_in_ms: vendor_request_time_in_ms,
           zip_code: zip_code,
           issue_year: issue_year,
-          selfie_attempts: processed_selfie_attempts,
         ).except(:classification_info).
-        merge(acuant_sdk_upgrade_ab_test_data),
+        merge(acuant_sdk_upgrade_ab_test_data).
+        merge(processed_selfie_attempts_data),
       )
     end
 

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -354,7 +354,8 @@ module Idv
       zip_code = client_response.pii_from_doc&.zipcode&.to_s&.strip&.slice(0, 5)
       issue_year = client_response.pii_from_doc&.state_id_issued&.to_date&.year
       captured_result = document_capture_session&.load_result
-      selfie_attempts = (captured_result&.failed_selfie_image_fingerprints || []).length + 1
+      selfie_image_fingerprint_add_count = (selfie_image_fingerprint ? 1 : 0)
+      selfie_attempts = (captured_result&.failed_selfie_image_fingerprints || []).length + selfie_image_fingerprint_add_count
       analytics.idv_doc_auth_submitted_image_upload_vendor(
         **client_response.to_h.merge(
           birth_year: birth_year,

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -353,6 +353,8 @@ module Idv
       birth_year = client_response.pii_from_doc&.dob&.to_date&.year
       zip_code = client_response.pii_from_doc&.zipcode&.to_s&.strip&.slice(0, 5)
       issue_year = client_response.pii_from_doc&.state_id_issued&.to_date&.year
+      captured_result = document_capture_session&.load_result
+      selfie_attempts = (captured_result&.failed_selfie_image_fingerprints || []).length() + 1 # TODO: check logic
       analytics.idv_doc_auth_submitted_image_upload_vendor(
         **client_response.to_h.merge(
           birth_year: birth_year,
@@ -362,6 +364,7 @@ module Idv
           vendor_request_time_in_ms: vendor_request_time_in_ms,
           zip_code: zip_code,
           issue_year: issue_year,
+          selfie_attempts: selfie_attempts,
         ).except(:classification_info).
         merge(acuant_sdk_upgrade_ab_test_data),
       )

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -209,7 +209,7 @@ module Idv
       return {} if document_capture_session.nil? || !liveness_checking_required
 
       captured_result = document_capture_session&.load_result
-      processed_selfie_count = (selfie_image_fingerprint ? 1 : 0)
+      processed_selfie_count = selfie_image_fingerprint ? 1 : 0
       past_selfie_count = (captured_result&.failed_selfie_image_fingerprints || []).length
       { selfie_attempts: past_selfie_count + processed_selfie_count }
     end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -354,7 +354,7 @@ module Idv
       zip_code = client_response.pii_from_doc&.zipcode&.to_s&.strip&.slice(0, 5)
       issue_year = client_response.pii_from_doc&.state_id_issued&.to_date&.year
       captured_result = document_capture_session&.load_result
-      selfie_attempts = (captured_result&.failed_selfie_image_fingerprints || []).length() + 1
+      selfie_attempts = (captured_result&.failed_selfie_image_fingerprints || []).length + 1
       analytics.idv_doc_auth_submitted_image_upload_vendor(
         **client_response.to_h.merge(
           birth_year: birth_year,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1536,6 +1536,7 @@ module AnalyticsEvents
     selfie_quality_good: nil,
     workflow: nil,
     birth_year: nil,
+    selfie_attempts: nil,
     **extra
   )
     track_event(
@@ -1581,6 +1582,7 @@ module AnalyticsEvents
       workflow:,
       birth_year:,
       issue_year:,
+      selfie_attempts:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1479,6 +1479,7 @@ module AnalyticsEvents
   # @param [String] workflow LexisNexis TrueID workflow
   # @param [String] birth_year Birth year from document
   # @param [Integer] issue_year Year document was issued
+  # @param [Integer] selfie_attempts number of selfie attempts the user currently has processed
   # @option extra [String] 'DocumentName'
   # @option extra [String] 'DocAuthResult'
   # @option extra [String] 'DocIssuerCode'

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -385,7 +385,6 @@ RSpec.describe Idv::ImageUploadsController do
           birth_year: 1938,
           zip_code: '59010',
           issue_year: 2019,
-          selfie_attempts: 0,
         )
 
         expect(@analytics).to have_logged_event(
@@ -512,7 +511,6 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
-              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -592,7 +590,6 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
-              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -672,7 +669,6 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
-              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -748,7 +744,6 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_live: true,
               selfie_quality_good: true,
               zip_code: '12345',
-              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -825,7 +820,6 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
-              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -924,7 +918,6 @@ RSpec.describe Idv::ImageUploadsController do
           liveness_checking_required: boolean,
           selfie_live: true,
           selfie_quality_good: true,
-          selfie_attempts: 0,
         )
 
         expect_funnel_update_counts(user, 1)
@@ -997,7 +990,6 @@ RSpec.describe Idv::ImageUploadsController do
           selfie_live: boolean,
           selfie_quality_good: boolean,
           workflow: an_instance_of(String),
-          selfie_attempts: 0,
         )
 
         expect_funnel_update_counts(user, 1)

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -385,6 +385,7 @@ RSpec.describe Idv::ImageUploadsController do
           birth_year: 1938,
           zip_code: '59010',
           issue_year: 2019,
+          selfie_attempts: 1,
         )
 
         expect(@analytics).to have_logged_event(
@@ -511,6 +512,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
+              selfie_attempts: 1,
             )
 
             expect(@analytics).to have_logged_event(
@@ -590,6 +592,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
+              selfie_attempts: 1,
             )
 
             expect(@analytics).to have_logged_event(
@@ -669,6 +672,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
+              selfie_attempts: 1,
             )
 
             expect(@analytics).to have_logged_event(
@@ -744,6 +748,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_live: true,
               selfie_quality_good: true,
               zip_code: '12345',
+              selfie_attempts: 1,
             )
 
             expect(@analytics).to have_logged_event(
@@ -820,6 +825,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
+              selfie_attempts: 1,
             )
 
             expect(@analytics).to have_logged_event(
@@ -918,6 +924,7 @@ RSpec.describe Idv::ImageUploadsController do
           liveness_checking_required: boolean,
           selfie_live: true,
           selfie_quality_good: true,
+          selfie_attempts: 1,
         )
 
         expect_funnel_update_counts(user, 1)
@@ -990,6 +997,7 @@ RSpec.describe Idv::ImageUploadsController do
           selfie_live: boolean,
           selfie_quality_good: boolean,
           workflow: an_instance_of(String),
+          selfie_attempts: 1,
         )
 
         expect_funnel_update_counts(user, 1)

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe Idv::ImageUploadsController do
           birth_year: 1938,
           zip_code: '59010',
           issue_year: 2019,
-          selfie_attempts: 1,
+          selfie_attempts: 0,
         )
 
         expect(@analytics).to have_logged_event(
@@ -512,7 +512,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
-              selfie_attempts: 1,
+              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -592,7 +592,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
-              selfie_attempts: 1,
+              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -672,7 +672,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
-              selfie_attempts: 1,
+              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -748,7 +748,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_live: true,
               selfie_quality_good: true,
               zip_code: '12345',
-              selfie_attempts: 1,
+              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -825,7 +825,7 @@ RSpec.describe Idv::ImageUploadsController do
               selfie_quality_good: true,
               birth_year: 1938,
               zip_code: '12345',
-              selfie_attempts: 1,
+              selfie_attempts: 0,
             )
 
             expect(@analytics).to have_logged_event(
@@ -924,7 +924,7 @@ RSpec.describe Idv::ImageUploadsController do
           liveness_checking_required: boolean,
           selfie_live: true,
           selfie_quality_good: true,
-          selfie_attempts: 1,
+          selfie_attempts: 0,
         )
 
         expect_funnel_update_counts(user, 1)
@@ -997,7 +997,7 @@ RSpec.describe Idv::ImageUploadsController do
           selfie_live: boolean,
           selfie_quality_good: boolean,
           workflow: an_instance_of(String),
-          selfie_attempts: 1,
+          selfie_attempts: 0,
         )
 
         expect_funnel_update_counts(user, 1)

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -222,6 +222,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
           birth_year: 1938,
           zip_code: '59010',
           issue_year: 2019,
+          selfie_attempts: 1,
         )
       end
 
@@ -311,6 +312,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
             birth_year: 1938,
             zip_code: '59010',
             issue_year: 2019,
+            selfie_attempts: 1,
           )
         end
 

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
           birth_year: 1938,
           zip_code: '59010',
           issue_year: 2019,
-          selfie_attempts: 1,
+          selfie_attempts: 0,
         )
       end
 

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -222,7 +222,6 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
           birth_year: 1938,
           zip_code: '59010',
           issue_year: 2019,
-          selfie_attempts: 0,
         )
       end
 
@@ -312,7 +311,7 @@ RSpec.describe Idv::ApiImageUploadForm, allowed_extra_analytics: [:*] do
             birth_year: 1938,
             zip_code: '59010',
             issue_year: 2019,
-            selfie_attempts: 1,
+            selfie_attempts: a_kind_of(Numeric),
           )
         end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-13316](https://cm-jira.usa.gov/browse/LG-13316)


## 🛠 Summary of changes

Added selfie_attempts as a metric in existing log event named 'doc auth image upload vendor submitted'.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - Boot up local test app and local app using the config to use selfies (doc_auth_selfie_capture_enabled: true in application.yml), also boot up identity-oidc sinatra and choose 'biometric comparison' to trigger selfie workflow. 
- [ ] Step 2 - Create an account and go to the verify link
- [ ] Step 3 - Submit selfies multiple times and look to the log/events.log file to check if selfie_attempts is incrementing/changing appropriately. 


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
