### PR TITLE
LG-14196 | Set idv_consent_given_at timestamp

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -37,6 +37,7 @@ module Idv
 
       if result.success?
         idv_session.idv_consent_given = true
+        idv_session.idv_consent_given_at = Time.zone.now
 
         if IdentityConfig.store.in_person_proofing_opt_in_enabled &&
            IdentityConfig.store.in_person_proofing_enabled

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -13,6 +13,7 @@ module Idv
       had_barcode_attention_error
       had_barcode_read_failure
       idv_consent_given
+      idv_consent_given_at
       idv_phone_step_document_capture_session_uuid
       mail_only_warning_shown
       opted_in_to_in_person_proofing

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -161,6 +161,12 @@ RSpec.describe Idv::AgreementController, allowed_extra_analytics: [:*] do
 
           expect(response).to redirect_to(idv_hybrid_handoff_url)
         end
+
+        it 'sets an idv_consent_given_at timestamp' do
+          put :update, params: params
+
+          expect(subject.idv_session.idv_consent_given_at).to be_within(3.seconds).of(Time.zone.now)
+        end
       end
 
       context 'when both ipp and opt-in ipp are enabled' do
@@ -227,6 +233,13 @@ RSpec.describe Idv::AgreementController, allowed_extra_analytics: [:*] do
       it 'renders the form again' do
         put :update, params: params
         expect(response).to render_template('idv/agreement/show')
+      end
+
+      it 'does not set IDV consent flags' do
+        put :update, params: params
+
+        expect(subject.idv_session.idv_consent_given).to be_nil
+        expect(subject.idv_session.idv_consent_given_at).to be_nil
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14196](https://cm-jira.usa.gov/browse/LG-14196)


## 🛠 Summary of changes

This is the first of a two-part series; part 1 needs to be released before part 2.

Socure's API requires us to pass the time when a user consented to IdV. We currently store a boolean, `idv_consent_given`, on the user session, tracking whether they have agreed to sharing their data for IdV. This moves to storing a timestamp, `idv_consent_given_at`, so that we can stop answering "When did the user consent?" with "Yes." (Pragmatically, because it's stored on the session, we know they consented very recently. But we should store the actual timestamp.)

N.B. also that we are not currently sending any data to Socure in production environments; it is all feature-flagged off.

I am currently leaving the old `idv_consent_given` logic intact. We can release this and start setting `idv_consent_given_at` in sessions.

The second PR, after it's being set on new sessions, will replace the existing `idv_consent_given` boolean logic with checking the timestamp instead.

I expanded the AgreementController test to assert that it was set correctly. The not-nil `idv_consent_given` assertion will be short-lived, but it's correct for now.
