### PR TITLE
Jmax/lg 13092 delete duplicate tests in document capture spec.rb

### DIFF
--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -266,10 +266,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_rate_limited_sub_header_not_present
                 expect_review_issues_body_message('doc_auth.errors.general.no_liveness')
                 expect_rate_limit_warning(max_attempts - 1)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.no_liveness')
                 expect_resubmit_page_inline_error_messages(2)
@@ -302,8 +299,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(detail_message)
                 expect(page).to have_content(warning_message)
                 expect(page).to have_current_path(idv_document_capture_path)
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
+                expect_to_try_again
+
                 inline_error = strip_tags(t('doc_auth.errors.card_type'))
                 expect(page).to have_content(inline_error)
 
@@ -328,10 +325,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_rate_limited_sub_header_not_present
                 expect_review_issues_body_message('doc_auth.errors.general.multiple_front_id_failures')
                 expect_rate_limit_warning(max_attempts - 3)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.multiple_front_id_failures')
                 expect_resubmit_page_inline_error_messages(1)
@@ -358,10 +352,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_rate_limited_sub_header_not_present
                 expect_review_issues_body_message('doc_auth.errors.general.multiple_back_id_failures')
                 expect_rate_limit_warning(max_attempts - 4)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.multiple_back_id_failures')
                 expect_resubmit_page_inline_error_messages(1)
@@ -427,9 +418,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
                 expect(page).to have_content(review_page_body_copy)
                 expect_rate_limit_warning(max_attempts - 1)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
+                expect_to_try_again
 
                 inline_error_message = strip_tags(t('doc_auth.errors.dpi.failed_short'))
                 expect(page).to have_content(inline_error_message)
@@ -467,10 +456,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 2)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
                 expect_resubmit_page_inline_selfie_error_message(true)
@@ -499,10 +485,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 3)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.dpi.top_msg')
 
@@ -534,10 +517,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 4)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.dpi.top_msg')
 
@@ -569,10 +549,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 5)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.selfie_failure')
 
@@ -608,10 +585,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 6)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.alerts.barcode_content_check')
 
@@ -645,10 +619,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 7)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.alerts.barcode_content_check')
 
@@ -680,10 +651,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 8)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.no_liveness')
 
@@ -719,10 +687,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 9)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
                 expect_resubmit_page_inline_selfie_error_message(true)
@@ -751,10 +716,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 10)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.alerts.address_check')
 
@@ -788,10 +750,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(review_page_body_copy)
 
                 expect_rate_limit_warning(max_attempts - 11)
-
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
-
+                expect_to_try_again
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.selfie_failure')
 
@@ -834,8 +793,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 )
                 expect(page).to have_content(review_issues_header)
                 expect(page).to have_current_path(idv_document_capture_path)
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
+                expect_to_try_again
+
                 inline_error = strip_tags(t('doc_auth.errors.general.selfie_failure'))
                 expect(page).to have_content(inline_error)
 
@@ -868,8 +827,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 )
                 expect(page).to have_content(review_issues_header)
                 expect(page).to have_current_path(idv_document_capture_path)
-                click_try_again
-                expect(page).to have_current_path(idv_document_capture_path)
+                expect_to_try_again
+
                 inline_error = strip_tags(t('doc_auth.errors.general.selfie_failure'))
                 expect(page).to have_content(inline_error)
               end
@@ -1059,6 +1018,11 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
     else
       expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
     end
+  end
+
+  def expect_to_try_again
+    click_try_again
+    expect(page).to have_current_path(idv_document_capture_path)
   end
 
   def expect_costing_for_document

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -270,8 +270,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(t('doc_auth.errors.general.no_liveness'))
                 expect(page).to have_content(resubmit_page_body_copy)
@@ -343,8 +342,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(
                   t('doc_auth.errors.general.multiple_front_id_failures'),
@@ -386,8 +384,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(
                   t('doc_auth.errors.general.multiple_back_id_failures'),
@@ -471,8 +468,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 inline_error_message = strip_tags(t('doc_auth.errors.dpi.failed_short'))
                 expect(page).to have_content(inline_error_message)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
                 expect(page).to have_content(resubmit_page_body_copy)
@@ -515,8 +511,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(
                   t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'),
@@ -556,8 +551,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
                 expect(page).to have_content(resubmit_page_body_copy)
@@ -597,8 +591,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
                 expect(page).to have_content(resubmit_page_body_copy)
@@ -638,8 +631,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
                 expect(page).to have_content(resubmit_page_body_copy)
@@ -683,8 +675,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_nbsp(
                   t('doc_auth.errors.alerts.barcode_content_check'),
@@ -728,8 +719,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_nbsp(
                   t('doc_auth.errors.alerts.barcode_content_check'),
@@ -771,8 +761,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(t('doc_auth.errors.general.no_liveness'))
                 expect(page).to have_content(resubmit_page_body_copy)
@@ -816,8 +805,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(
                   t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'),
@@ -857,8 +845,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(t('doc_auth.errors.alerts.address_check'))
                 expect(page).to have_content(resubmit_page_body_copy)
@@ -900,8 +887,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
 
-                resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
-                expect(page).to have_content(resubmit_page_h1_copy)
+                expect_resubmit_page_h1_copy
 
                 resubmit_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
                 expect(page).to have_content(resubmit_page_body_copy)
@@ -1145,6 +1131,11 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
       ),
     )
     expect(page).to have_content(review_issues_rate_limit_warning)
+  end
+
+  def expect_resubmit_page_h1_copy
+    resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
+    expect(page).to have_content(resubmit_page_h1_copy)
   end
 
   def expect_costing_for_document

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
   include ActionView::Helpers::DateHelper
 
   let(:max_attempts) { IdentityConfig.store.doc_auth_max_attempts }
+
   before(:each) do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(@fake_analytics)
     allow_any_instance_of(ServiceProviderSession).to receive(:sp_name).and_return(@sp_name)
@@ -61,11 +62,13 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
     context 'attention barcode with invalid pii is uploaded', allow_browser_log: true do
       let(:desktop_selfie_mode) { false }
+
       # test disabled desktop selfie mode allows upload for doc auth w/o selfie
       before do
         allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
           and_return(desktop_selfie_mode)
       end
+
       it 'try again and page show doc type inline error message' do
         attach_images(
           Rails.root.join(
@@ -1211,6 +1214,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
         describe 'when desktop selfie is allowed' do
           let(:desktop_selfie_mode) { true }
+
           it 'proceed to the next page with valid info, including a selfie image' do
             perform_in_browser(:desktop) do
               visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -245,8 +245,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 use_selfie_image('ial2_test_credential_multiple_doc_auth_failures_both_sides.yml')
                 submit_images
 
-                expect_rate_limited_header
-                expect_rate_limited_sub_header_not_present
+                expect_rate_limited_header(true)
+                expect_rate_limited_sub_header_present(false)
                 expect_review_issues_body_message('doc_auth.errors.general.no_liveness')
                 expect_rate_limit_warning(max_attempts - 1)
                 expect_to_try_again
@@ -261,12 +261,16 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 use_selfie_image('ial2_test_portrait_match_success.yml')
                 submit_images
 
+                expect_rate_limited_header(false)
+                expect_rate_limited_sub_header_present(true)
                 expect_review_issues_body_message('doc_auth.errors.doc_type_not_supported_heading')
                 expect_review_issues_body_message('doc_auth.errors.doc.doc_type_check')
                 expect_rate_limit_warning(max_attempts - 2)
                 expect_to_try_again
 
+                expect_resubmit_page_h1_copy
                 expect_review_issues_body_message('doc_auth.errors.card_type')
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when there are multiple front doc auth errors
                 use_id_image('ial2_test_credential_multiple_doc_auth_failures_front_side_only.yml')
@@ -275,8 +279,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 )
                 submit_images
 
-                expect_rate_limited_header
-                expect_rate_limited_sub_header_not_present
+                expect_rate_limited_header(true)
+                expect_rate_limited_sub_header_present(false)
                 expect_review_issues_body_message(
                   'doc_auth.errors.general.multiple_front_id_failures',
                 )
@@ -295,8 +299,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 )
                 submit_images
 
-                expect_rate_limited_header
-                expect_rate_limited_sub_header_not_present
+                expect_rate_limited_header(true)
+                expect_rate_limited_sub_header_present(false)
                 expect_review_issues_body_message(
                   'doc_auth.errors.general.multiple_back_id_failures',
                 )
@@ -728,14 +732,22 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
     end
   end
 
-  def expect_rate_limited_header
+  def expect_rate_limited_header(expected_to_be_present)
     review_issues_h1_heading = strip_tags(t('doc_auth.errors.rate_limited_heading'))
-    expect(page).to have_content(review_issues_h1_heading)
+    if expected_to_be_present
+      expect(page).to have_content(review_issues_h1_heading)
+    else
+      expect(page).not_to have_content(review_issues_h1_heading)
+    end
   end
 
-  def expect_rate_limited_sub_header_not_present
+  def expect_rate_limited_sub_header_present(expected_to_be_present)
     review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
-    expect(page).not_to have_selector('h2', text: review_issues_subheading)
+    if expected_to_be_present
+      expect(page).to have_selector('h2', text: review_issues_subheading)
+    else
+      expect(page).not_to have_selector('h2', text: review_issues_subheading)
+    end
   end
 
   def expect_review_issues_body_message(translation_key)

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -271,9 +271,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(t('doc_auth.errors.general.no_liveness'))
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.general.no_liveness')
 
                 resubmit_page_inline_error_messages = strip_tags(
                   t('doc_auth.errors.general.fallback_field_level'),
@@ -343,11 +341,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(
-                  t('doc_auth.errors.general.multiple_front_id_failures'),
-                )
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.general.multiple_front_id_failures')
 
                 resubmit_page_inline_error_messages = strip_tags(
                   t('doc_auth.errors.general.fallback_field_level'),
@@ -385,11 +379,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(
-                  t('doc_auth.errors.general.multiple_back_id_failures'),
-                )
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.general.multiple_back_id_failures')
 
                 resubmit_page_inline_error_messages = strip_tags(
                   t('doc_auth.errors.general.fallback_field_level'),
@@ -469,9 +459,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(inline_error_message)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.dpi.top_msg')
 
                 resubmit_page_inline_selfie_error_message = strip_tags(
                   t('doc_auth.errors.general.selfie_failure'),
@@ -512,11 +500,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(
-                  t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'),
-                )
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
 
                 resubmit_page_inline_selfie_error_message = strip_tags(
                   t('doc_auth.errors.general.selfie_failure'),
@@ -552,9 +536,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.dpi.top_msg')
 
                 inline_error_message = strip_tags(t('doc_auth.errors.dpi.failed_short'))
                 expect(page).to have_content(inline_error_message)
@@ -592,9 +574,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.dpi.top_msg')
 
                 inline_error_message = strip_tags(t('doc_auth.errors.dpi.failed_short'))
                 expect(page).to have_content(inline_error_message)
@@ -632,9 +612,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.general.selfie_failure')
 
                 inline_error_message = strip_tags(
                   t('doc_auth.errors.general.multiple_front_id_failures'),
@@ -676,11 +654,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_nbsp(
-                  t('doc_auth.errors.alerts.barcode_content_check'),
-                )
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.alerts.barcode_content_check')
 
                 inline_error_message = strip_tags(t('doc_auth.errors.general.fallback_field_level'))
                 expect(page).to have_content(inline_error_message)
@@ -720,11 +694,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_nbsp(
-                  t('doc_auth.errors.alerts.barcode_content_check'),
-                )
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.alerts.barcode_content_check')
 
                 inline_error_message = strip_tags(t('doc_auth.errors.general.fallback_field_level'))
                 expect(page).to have_content(inline_error_message)
@@ -762,9 +732,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(t('doc_auth.errors.general.no_liveness'))
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.general.no_liveness')
 
                 inline_error_message = strip_tags(t('doc_auth.errors.general.fallback_field_level'))
                 expect(page).to have_content(inline_error_message)
@@ -806,11 +774,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(
-                  t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'),
-                )
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
 
                 resubmit_page_inline_selfie_error_message = strip_tags(
                   t('doc_auth.errors.general.selfie_failure'),
@@ -846,9 +810,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(t('doc_auth.errors.alerts.address_check'))
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.alerts.address_check')
 
                 inline_error_message = strip_tags(
                   t('doc_auth.errors.general.multiple_front_id_failures'),
@@ -888,9 +850,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 expect_resubmit_page_h1_copy
-
-                resubmit_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
-                expect(page).to have_content(resubmit_page_body_copy)
+                expect_resubmit_page_body_copy('doc_auth.errors.general.selfie_failure')
 
                 inline_error_message = strip_tags(
                   t('doc_auth.errors.general.multiple_front_id_failures'),
@@ -1136,6 +1096,11 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
   def expect_resubmit_page_h1_copy
     resubmit_page_h1_copy = strip_tags(t('doc_auth.headings.review_issues'))
     expect(page).to have_content(resubmit_page_h1_copy)
+  end
+
+  def expect_resubmit_page_body_copy(translation_key)
+    resubmit_page_body_copy = strip_tags(t(translation_key))
+    expect(page).to have_content(resubmit_page_body_copy)
   end
 
   def expect_costing_for_document

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
   let(:fake_analytics) { FakeAnalytics.new }
 
   before(:each) do
-    stub_analytics
+    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow_any_instance_of(ServiceProviderSession).to receive(:sp_name).and_return(@sp_name)
   end
 
@@ -123,7 +123,6 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
         expect_costing_for_document
         expect(DocAuthLog.find_by(user_id: @user.id).state).to eq('NY')
 
-        expect(page).to have_current_path(idv_ssn_url)
         fill_out_ssn_form_ok
         click_idv_continue
         complete_verify_step
@@ -210,7 +209,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
         end
 
         context 'documents or selfie with error is uploaded' do
-          shared_examples 'it has correct error display' do
+          shared_examples 'it has correct error displays' do
             # when there are multiple doc auth errors on front and back
             it 'shows the correct error message for the given error' do
               perform_in_browser(:mobile) do
@@ -331,7 +330,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               end
             end
 
-            it_should_behave_like 'it has correct error display'
+            it_should_behave_like 'it has correct error displays'
           end
 
           context 'IPP not enabled' do
@@ -344,7 +343,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
               end
             end
 
-            it_should_behave_like 'it has correct error display'
+            it_should_behave_like 'it has correct error displays'
           end
         end
 

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -264,17 +264,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 expect_rate_limited_header
                 expect_rate_limited_sub_header_not_present
-
-                review_issues_body_message = strip_tags(t('doc_auth.errors.general.no_liveness'))
-                expect(page).to have_content(review_issues_body_message)
-
-                review_issues_rate_limit_warning = strip_tags(
-                  t(
-                    'idv.failure.attempts_html',
-                    count: max_attempts - 1,
-                  ),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_review_issues_body_message('doc_auth.errors.general.no_liveness')
+                expect_rate_limit_warning(max_attempts - 1)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -346,16 +337,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 expect_rate_limited_header
                 expect_rate_limited_sub_header_not_present
-
-                review_issues_body_message = strip_tags(
-                  t('doc_auth.errors.general.multiple_front_id_failures'),
-                )
-                expect(page).to have_content(review_issues_body_message)
-
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 3),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_review_issues_body_message('doc_auth.errors.general.multiple_front_id_failures')
+                expect_rate_limit_warning(max_attempts - 3)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -397,16 +380,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 expect_rate_limited_header
                 expect_rate_limited_sub_header_not_present
-
-                review_issues_body_message = strip_tags(
-                  t('doc_auth.errors.general.multiple_back_id_failures'),
-                )
-                expect(page).to have_content(review_issues_body_message)
-
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 4),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_review_issues_body_message('doc_auth.errors.general.multiple_back_id_failures')
+                expect_rate_limit_warning(max_attempts - 4)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -488,14 +463,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
                 expect(page).to have_content(review_page_body_copy)
-
-                review_issues_rate_limit_warning = strip_tags(
-                  t(
-                    'idv.failure.attempts_html',
-                    count: max_attempts - 1,
-                  ),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 1)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -542,10 +510,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 )
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 2),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 2)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -586,10 +551,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 3),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 3)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -630,10 +592,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 4),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 4)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -674,10 +633,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 review_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 5),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 5)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -722,10 +678,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 )
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 6),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 6)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -770,10 +723,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 )
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 7),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 7)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -816,10 +766,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 review_page_body_copy = strip_tags(t('doc_auth.errors.general.no_liveness'))
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 8),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning).once
+                expect_rate_limit_warning(max_attempts - 8)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -864,10 +811,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 )
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 9),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 9)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -908,10 +852,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 review_page_body_copy = strip_tags(t('doc_auth.errors.alerts.address_check'))
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 10),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 10)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -954,10 +895,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 review_page_body_copy = strip_tags(t('doc_auth.errors.general.selfie_failure'))
                 expect(page).to have_content(review_page_body_copy)
 
-                review_issues_rate_limit_warning = strip_tags(
-                  t('idv.failure.attempts_html', count: max_attempts - 11),
-                )
-                expect(page).to have_content(review_issues_rate_limit_warning)
+                expect_rate_limit_warning(max_attempts - 11)
 
                 click_try_again
                 expect(page).to have_current_path(idv_document_capture_path)
@@ -1189,9 +1127,24 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
     expect(page).to have_content(review_issues_h1_heading)
   end
 
-  def expect_rate_limited_header_not_present
+  def expect_rate_limited_sub_header_not_present
     review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
     expect(page).not_to have_selector('h2', text: review_issues_subheading)
+  end
+
+  def expect_review_issues_body_message(translation_key)
+    review_issues_body_message = strip_tags(t(translation_key))
+    expect(page).to have_content(review_issues_body_message)
+  end
+
+  def expect_rate_limit_warning(expected_remaining_attempts)
+    review_issues_rate_limit_warning = strip_tags(
+      t(
+        'idv.failure.attempts_html',
+        count: expected_remaining_attempts,
+      ),
+    )
+    expect(page).to have_content(review_issues_rate_limit_warning)
   end
 
   def expect_costing_for_document

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -116,12 +116,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
         expect(page).not_to have_content(t('doc_auth.headings.document_capture_selfie'))
 
         # doc auth is successful while liveness is not req'd
-        attach_images(
-          Rails.root.join(
-            'spec', 'fixtures',
-            'ial2_test_credential_no_liveness.yml'
-          ),
-        )
+        use_id_image('ial2_test_credential_no_liveness.yml')
         submit_images
 
         expect(page).to have_current_path(idv_ssn_url)
@@ -223,11 +218,11 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             before do
               allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
               allow(IdentityConfig.store).to receive(
-                                               :in_person_proofing_opt_in_enabled,
-                                             ).and_return(true)
+                :in_person_proofing_opt_in_enabled,
+              ).and_return(true)
               allow_any_instance_of(ServiceProvider).to receive(
-                                                          :in_person_proofing_enabled,
-                                                        ).and_return(true)
+                :in_person_proofing_enabled,
+              ).and_return(true)
               allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(99)
               perform_in_browser(:mobile) do
                 visit_idp_from_sp_with_ial2(
@@ -245,21 +240,9 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
             it 'shows the correct error message for the given error' do
               # when there are multiple doc auth errors on front and back
-
               perform_in_browser(:mobile) do
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_multiple_doc_auth_failures_both_sides.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_multiple_doc_auth_failures_both_sides.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_multiple_doc_auth_failures_both_sides.yml')
+                use_selfie_image('ial2_test_credential_multiple_doc_auth_failures_both_sides.yml')
                 submit_images
 
                 expect_rate_limited_header
@@ -267,63 +250,36 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_review_issues_body_message('doc_auth.errors.general.no_liveness')
                 expect_rate_limit_warning(max_attempts - 1)
                 expect_to_try_again
+
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.no_liveness')
                 expect_resubmit_page_inline_error_messages(2)
                 expect_resubmit_page_inline_selfie_error_message(false)
 
                 # Wrong doc type is uploaded
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_wrong_doc_type.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_portrait_match_success.yml'
-                  ),
-                )
+                use_id_image('ial2_test_credential_wrong_doc_type.yml')
+                use_selfie_image('ial2_test_portrait_match_success.yml')
                 submit_images
-                message = strip_tags(t('doc_auth.errors.doc_type_not_supported_heading'))
-                expect(page).to have_content(message)
-                detail_message = strip_tags(t('doc_auth.errors.doc.doc_type_check'))
 
-                warning_message = strip_tags(
-                  t(
-                    'idv.failure.attempts_html',
-                    count: IdentityConfig.store.doc_auth_max_attempts - 2,
-                  ),
-                )
-                expect(page).to have_content(detail_message)
-                expect(page).to have_content(warning_message)
-                expect(page).to have_current_path(idv_document_capture_path)
+                expect_review_issues_body_message('doc_auth.errors.doc_type_not_supported_heading')
+                expect_review_issues_body_message('doc_auth.errors.doc.doc_type_check')
+                expect_rate_limit_warning(max_attempts - 2)
                 expect_to_try_again
 
-                inline_error = strip_tags(t('doc_auth.errors.card_type'))
-                expect(page).to have_content(inline_error)
+                expect_review_issues_body_message('doc_auth.errors.card_type')
 
                 # when there are multiple front doc auth errors
-
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_multiple_doc_auth_failures_front_side_only.yml'
-                  ),
+                use_id_image('ial2_test_credential_multiple_doc_auth_failures_front_side_only.yml')
+                use_selfie_image(
+                  'ial2_test_credential_multiple_doc_auth_failures_front_side_only.yml',
                 )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_multiple_doc_auth_failures_front_side_only.yml'
-                  ),
-                )
-
                 submit_images
 
                 expect_rate_limited_header
                 expect_rate_limited_sub_header_not_present
-                expect_review_issues_body_message('doc_auth.errors.general.multiple_front_id_failures')
+                expect_review_issues_body_message(
+                  'doc_auth.errors.general.multiple_front_id_failures',
+                )
                 expect_rate_limit_warning(max_attempts - 3)
                 expect_to_try_again
                 expect_resubmit_page_h1_copy
@@ -333,24 +289,17 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 # when there are multiple back doc auth errors
 
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_multiple_doc_auth_failures_back_side_only.yml'
-                  ),
+                use_id_image('ial2_test_credential_multiple_doc_auth_failures_back_side_only.yml')
+                use_selfie_image(
+                  'ial2_test_credential_multiple_doc_auth_failures_back_side_only.yml',
                 )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_multiple_doc_auth_failures_back_side_only.yml'
-                  ),
-                )
-
                 submit_images
 
                 expect_rate_limited_header
                 expect_rate_limited_sub_header_not_present
-                expect_review_issues_body_message('doc_auth.errors.general.multiple_back_id_failures')
+                expect_review_issues_body_message(
+                  'doc_auth.errors.general.multiple_back_id_failures',
+                )
                 expect_rate_limit_warning(max_attempts - 4)
                 expect_to_try_again
                 expect_resubmit_page_h1_copy
@@ -359,26 +308,19 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_resubmit_page_inline_selfie_error_message(false)
 
                 # attention barcode with invalid pii is uploaded
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_barcode_attention_no_address.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_portrait_match_success.yml'
-                  ),
-                )
+                use_id_image('ial2_test_credential_barcode_attention_no_address.yml')
+                use_selfie_image('ial2_test_portrait_match_success.yml')
                 submit_images
 
                 expect(page).to have_content(t('doc_auth.errors.alerts.address_check'))
                 expect(page).to have_current_path(idv_document_capture_path)
 
                 click_try_again
+
+                # And finally, after lots of errors, we can still succeed
                 attach_images
                 submit_images
+
                 expect(page).to have_current_path(idv_ssn_path)
               end
             end
@@ -397,26 +339,10 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             it 'shows the correct error message for the given error' do
               perform_in_browser(:mobile) do
                 # when the only error is a doc auth error
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_fail_selfie_pass.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_fail_selfie_pass.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_doc_auth_fail_selfie_pass.yml')
+                use_selfie_image('ial2_test_credential_doc_auth_fail_selfie_pass.yml')
                 submit_images
 
-                review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
-                expect(page).to have_content(review_page_h1_copy)
-
-                review_page_body_copy = strip_tags(t('doc_auth.errors.dpi.top_msg'))
-                expect(page).to have_content(review_page_body_copy)
                 expect_rate_limit_warning(max_attempts - 1)
                 expect_to_try_again
 
@@ -430,19 +356,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_current_path(idv_document_capture_url)
 
                 # when doc auth result passes but liveness fails
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_no_liveness.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_no_liveness.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_no_liveness.yml')
+                use_selfie_image('ial2_test_credential_no_liveness.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(
@@ -458,24 +373,15 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_rate_limit_warning(max_attempts - 2)
                 expect_to_try_again
                 expect_resubmit_page_h1_copy
-                expect_resubmit_page_body_copy('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
+                expect_resubmit_page_body_copy(
+                  'doc_auth.errors.alerts.selfie_not_live_or_poor_quality',
+                )
                 expect_resubmit_page_inline_selfie_error_message(true)
 
                 # when there are both doc auth errors and liveness errors
 
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_fail_and_no_liveness.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_fail_and_no_liveness.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_doc_auth_fail_and_no_liveness.yml')
+                use_selfie_image('ial2_test_credential_doc_auth_fail_and_no_liveness.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
@@ -494,20 +400,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when there are both doc auth errors and face match errors
-
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_fail_face_match_fail.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_fail_face_match_fail.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_doc_auth_fail_face_match_fail.yml')
+                use_selfie_image('ial2_test_credential_doc_auth_fail_face_match_fail.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
@@ -526,20 +420,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when doc auth result and liveness pass but face match fails
-
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_portrait_match_failure.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_portrait_match_failure.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_portrait_match_failure.yml')
+                use_selfie_image('ial2_test_portrait_match_failure.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(t('doc_auth.errors.selfie_fail_heading'))
@@ -560,20 +442,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_resubmit_page_inline_selfie_error_message(true)
 
                 # when there is a doc auth error on one side of the ID and face match errors
-
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_back_fail_doc_auth_face_match_errors.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_back_fail_doc_auth_face_match_errors.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_back_fail_doc_auth_face_match_errors.yml')
+                use_selfie_image('ial2_test_credential_back_fail_doc_auth_face_match_errors.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
@@ -595,19 +465,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 # when there is a doc auth error on one side of the ID and a liveness error
 
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_back_fail_doc_auth_liveness_errors.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_back_fail_doc_auth_liveness_errors.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_back_fail_doc_auth_liveness_errors.yml')
+                use_selfie_image('ial2_test_credential_back_fail_doc_auth_liveness_errors.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
@@ -628,20 +487,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when doc auth result is "attention" and face match errors
-
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_attention_face_match_fail.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_attention_face_match_fail.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_doc_auth_attention_face_match_fail.yml')
+                use_selfie_image('ial2_test_credential_doc_auth_attention_face_match_fail.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
@@ -660,20 +507,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when doc auth passes but there are both liveness errors and face match errors
-
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_liveness_fail_face_match_fail.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_liveness_fail_face_match_fail.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_liveness_fail_face_match_fail.yml')
+                use_selfie_image('ial2_test_credential_liveness_fail_face_match_fail.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(
@@ -689,24 +524,14 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_rate_limit_warning(max_attempts - 9)
                 expect_to_try_again
                 expect_resubmit_page_h1_copy
-                expect_resubmit_page_body_copy('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
+                expect_resubmit_page_body_copy(
+                  'doc_auth.errors.alerts.selfie_not_live_or_poor_quality',
+                )
                 expect_resubmit_page_inline_selfie_error_message(true)
 
                 # when doc auth, liveness, and face match pass but PII validation fails
-
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_selfie_pass_pii_fail.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_doc_auth_selfie_pass_pii_fail.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_doc_auth_selfie_pass_pii_fail.yml')
+                use_selfie_image('ial2_test_credential_doc_auth_selfie_pass_pii_fail.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(t('doc_auth.errors.rate_limited_heading'))
@@ -727,20 +552,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when there are both face match errors and pii errors
-
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_face_match_fail_and_pii_fail.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_face_match_fail_and_pii_fail.yml'
-                  ),
-                )
-
+                use_id_image('ial2_test_credential_face_match_fail_and_pii_fail.yml')
+                use_selfie_image('ial2_test_credential_face_match_fail_and_pii_fail.yml')
                 submit_images
 
                 review_page_h1_copy = strip_tags(t('doc_auth.errors.selfie_fail_heading'))
@@ -760,68 +573,16 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 expect(page).to have_content(inline_error_message)
                 expect_resubmit_page_inline_selfie_error_message(true)
 
-                # selfie match failure
-                visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
-                sign_in_and_2fa_user(@user)
-                complete_doc_auth_steps_before_document_capture_step
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_portrait_match_failure.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_portrait_match_failure.yml'
-                  ),
-                )
-                submit_images
-                message = strip_tags(t('doc_auth.errors.selfie_fail_heading'))
-                expect(page).to have_content(message)
-                detail_message = strip_tags(t('doc_auth.errors.general.selfie_failure'))
-                warning_message = strip_tags(
-                  t(
-                    'idv.failure.attempts_html',
-                    count: max_attempts - 12,
-                  ),
-                )
-
-                expect(page).to have_content("#{detail_message}\n#{warning_message}")
-                review_issues_header = strip_tags(
-                  t('doc_auth.errors.selfie_fail_heading'),
-                )
-                expect(page).to have_content(review_issues_header)
-                expect(page).to have_current_path(idv_document_capture_path)
-                expect_to_try_again
-
-                inline_error = strip_tags(t('doc_auth.errors.general.selfie_failure'))
-                expect(page).to have_content(inline_error)
-
                 # with Attention with Barcode
-                attach_images(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_barcode_attention_liveness_fail.yml'
-                  ),
-                )
-                attach_selfie(
-                  Rails.root.join(
-                    'spec', 'fixtures',
-                    'ial2_test_credential_barcode_attention_liveness_fail.yml'
-                  ),
-                )
+                use_id_image('ial2_test_credential_barcode_attention_liveness_fail.yml')
+                use_selfie_image('ial2_test_credential_barcode_attention_liveness_fail.yml')
                 submit_images
-                message = strip_tags(t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'))
-                expect(page).to have_content(message)
-                detail_message = strip_tags(t('doc_auth.errors.alerts.selfie_not_live_or_poor_quality'))
-                warning_message = strip_tags(
-                  t(
-                    'idv.failure.attempts_html',
-                    count: max_attempts - 13,
-                  ),
+
+                expect_review_issues_body_message(
+                  'doc_auth.errors.alerts.selfie_not_live_or_poor_quality',
                 )
-                expect(page).to have_content("#{detail_message}\n#{warning_message}")
+                expect_rate_limit_warning(max_attempts - 12)
+
                 review_issues_header = strip_tags(
                   t('doc_auth.errors.selfie_not_live_or_poor_quality_heading'),
                 )
@@ -1023,6 +784,14 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
   def expect_to_try_again
     click_try_again
     expect(page).to have_current_path(idv_document_capture_path)
+  end
+
+  def use_id_image(filename)
+    attach_images Rails.root.join('spec', 'fixtures', filename)
+  end
+
+  def use_selfie_image(filename)
+    attach_selfie Rails.root.join('spec', 'fixtures', filename)
   end
 
   def expect_costing_for_document

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -272,16 +272,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.no_liveness')
-
-                resubmit_page_inline_error_messages = strip_tags(
-                  t('doc_auth.errors.general.fallback_field_level'),
-                )
-                expect(page).to have_content(resubmit_page_inline_error_messages).twice
-
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_error_messages(2)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # Wrong doc type is uploaded
                 attach_images(
@@ -342,16 +334,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.multiple_front_id_failures')
-
-                resubmit_page_inline_error_messages = strip_tags(
-                  t('doc_auth.errors.general.fallback_field_level'),
-                )
-                expect(page).to have_content(resubmit_page_inline_error_messages).once
-
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_error_messages(1)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when there are multiple back doc auth errors
 
@@ -380,16 +364,8 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.general.multiple_back_id_failures')
-
-                resubmit_page_inline_error_messages = strip_tags(
-                  t('doc_auth.errors.general.fallback_field_level'),
-                )
-                expect(page).to have_content(resubmit_page_inline_error_messages).once
-
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_error_messages(1)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # attention barcode with invalid pii is uploaded
                 attach_images(
@@ -460,11 +436,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.dpi.top_msg')
-
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 expect(page).to have_current_path(idv_document_capture_url)
 
@@ -501,11 +473,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
-
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(true)
 
                 # when there are both doc auth errors and liveness errors
 
@@ -540,10 +508,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 inline_error_message = strip_tags(t('doc_auth.errors.dpi.failed_short'))
                 expect(page).to have_content(inline_error_message)
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when there are both doc auth errors and face match errors
 
@@ -578,10 +543,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 inline_error_message = strip_tags(t('doc_auth.errors.dpi.failed_short'))
                 expect(page).to have_content(inline_error_message)
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when doc auth result and liveness pass but face match fails
 
@@ -618,10 +580,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                   t('doc_auth.errors.general.multiple_front_id_failures'),
                 )
                 expect(page).to have_content(inline_error_message)
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(true)
 
                 # when there is a doc auth error on one side of the ID and face match errors
 
@@ -658,10 +617,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 inline_error_message = strip_tags(t('doc_auth.errors.general.fallback_field_level'))
                 expect(page).to have_content(inline_error_message)
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when there is a doc auth error on one side of the ID and a liveness error
 
@@ -698,10 +654,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 inline_error_message = strip_tags(t('doc_auth.errors.general.fallback_field_level'))
                 expect(page).to have_content(inline_error_message)
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when doc auth result is "attention" and face match errors
 
@@ -736,10 +689,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 inline_error_message = strip_tags(t('doc_auth.errors.general.fallback_field_level'))
                 expect(page).to have_content(inline_error_message)
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when doc auth passes but there are both liveness errors and face match errors
 
@@ -775,11 +725,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
                 expect_resubmit_page_h1_copy
                 expect_resubmit_page_body_copy('doc_auth.errors.alerts.selfie_not_live_or_poor_quality')
-
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(true)
 
                 # when doc auth, liveness, and face match pass but PII validation fails
 
@@ -816,10 +762,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                   t('doc_auth.errors.general.multiple_front_id_failures'),
                 )
                 expect(page).to have_content(inline_error_message)
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(false)
 
                 # when there are both face match errors and pii errors
 
@@ -856,10 +799,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                   t('doc_auth.errors.general.multiple_front_id_failures'),
                 )
                 expect(page).to have_content(inline_error_message)
-                resubmit_page_inline_selfie_error_message = strip_tags(
-                  t('doc_auth.errors.general.selfie_failure'),
-                )
-                expect(page).to have_content(resubmit_page_inline_selfie_error_message)
+                expect_resubmit_page_inline_selfie_error_message(true)
 
                 # selfie match failure
                 visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
@@ -1101,6 +1041,24 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
   def expect_resubmit_page_body_copy(translation_key)
     resubmit_page_body_copy = strip_tags(t(translation_key))
     expect(page).to have_content(resubmit_page_body_copy)
+  end
+
+  def expect_resubmit_page_inline_error_messages(expected_count)
+    resubmit_page_inline_error_messages = strip_tags(
+      t('doc_auth.errors.general.fallback_field_level'),
+    )
+    expect(page).to have_content(resubmit_page_inline_error_messages).exactly(expected_count)
+  end
+
+  def expect_resubmit_page_inline_selfie_error_message(should_be_present)
+    resubmit_page_inline_selfie_error_message = strip_tags(
+      t('doc_auth.errors.general.selfie_failure'),
+    )
+    if should_be_present
+      expect(page).to have_content(resubmit_page_inline_selfie_error_message)
+    else
+      expect(page).not_to have_content(resubmit_page_inline_selfie_error_message)
+    end
   end
 
   def expect_costing_for_document

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
   let(:fake_analytics) { FakeAnalytics.new }
 
   before(:each) do
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+    stub_analytics
     allow_any_instance_of(ServiceProviderSession).to receive(:sp_name).and_return(@sp_name)
   end
 

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -198,6 +198,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
 
   context 'selfie check' do
     let(:selfie_check_enabled) { true }
+
     before do
       allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
     end
@@ -1108,6 +1109,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             expect(page).to have_content(inline_error)
           end
         end
+
         context 'with Attention with Barcode' do
           it 'try again and page show selfie fail inline error message' do
             visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
@@ -1181,12 +1183,15 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
           end
         end
       end
+
       context 'on desktop' do
         let(:desktop_selfie_mode) { false }
+
         before do
           allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
             and_return(desktop_selfie_mode)
         end
+
         describe 'when desktop selfie not allowed' do
           it 'can only proceed to link sent page' do
             perform_in_browser(:desktop) do
@@ -1203,6 +1208,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
             end
           end
         end
+
         describe 'when desktop selfie is allowed' do
           let(:desktop_selfie_mode) { true }
           it 'proceed to the next page with valid info, including a selfie image' do
@@ -1239,12 +1245,14 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
           context 'when ipp is enabled' do
             let(:in_person_doc_auth_button_enabled) { true }
             let(:sp_ipp_enabled) { true }
+
             before do
               allow(IdentityConfig.store).to receive(:in_person_doc_auth_button_enabled).
                 and_return(in_person_doc_auth_button_enabled)
               allow(Idv::InPersonConfig).to receive(:enabled_for_issuer?).with(anything).
                 and_return(sp_ipp_enabled)
             end
+
             describe 'when ipp is selected' do
               it 'proceed to the next page and start ipp' do
                 perform_in_browser(:desktop) do
@@ -1285,6 +1293,7 @@ end
 RSpec.feature 'direct access to IPP on desktop', :js, allowed_extra_analytics: [:*] do
   include IdvStepHelper
   include DocAuthHelper
+
   context 'direct access to IPP before handoff page' do
     let(:in_person_proofing_enabled) { true }
     let(:sp_ipp_enabled) { true }
@@ -1322,11 +1331,14 @@ RSpec.feature 'direct access to IPP on desktop', :js, allowed_extra_analytics: [
         expect(page).to have_current_path(idv_agreement_path)
       end
     end
+
     context 'when selfie is enabled' do
       it_behaves_like 'does not allow direct ipp access'
     end
+
     context 'when selfie is disabled' do
       let(:biometric_comparison_required) { false }
+
       it_behaves_like 'does not allow direct ipp access'
     end
   end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -263,9 +263,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 submit_images
 
                 expect_rate_limited_header
-
-                review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
-                expect(page).not_to have_selector('h2', text: review_issues_subheading)
+                expect_rate_limited_sub_header_not_present
 
                 review_issues_body_message = strip_tags(t('doc_auth.errors.general.no_liveness'))
                 expect(page).to have_content(review_issues_body_message)
@@ -347,9 +345,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 submit_images
 
                 expect_rate_limited_header
-
-                review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
-                expect(page).not_to have_selector('h2', text: review_issues_subheading)
+                expect_rate_limited_sub_header_not_present
 
                 review_issues_body_message = strip_tags(
                   t('doc_auth.errors.general.multiple_front_id_failures'),
@@ -400,9 +396,7 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
                 submit_images
 
                 expect_rate_limited_header
-
-                review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
-                expect(page).not_to have_selector('h2', text: review_issues_subheading)
+                expect_rate_limited_sub_header_not_present
 
                 review_issues_body_message = strip_tags(
                   t('doc_auth.errors.general.multiple_back_id_failures'),
@@ -1193,6 +1187,11 @@ RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
   def expect_rate_limited_header
     review_issues_h1_heading = strip_tags(t('doc_auth.errors.rate_limited_heading'))
     expect(page).to have_content(review_issues_h1_heading)
+  end
+
+  def expect_rate_limited_header_not_present
+    review_issues_subheading = strip_tags(t('doc_auth.errors.rate_limited_subheading'))
+    expect(page).not_to have_selector('h2', text: review_issues_subheading)
   end
 
   def expect_costing_for_document


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13092](https://cm-jira.usa.gov/browse/LG-13092)

## 🛠 Summary of changes

Consolidated a bunch of test cases in `features/idv/doc_auth/document_capture_spec.rb` for speed and eliminated some test duplication.

All of the doc capture error handling except rate limiting is now tested in a single inline test (that bumps the rate limits so that we don't trip over them) that retries with different error conditions to check the messages shown for each. This is much faster than restarting IdV from scratch for each error.

## 📜 Testing Plan

- [ ] Ensure that all tests pass without errors, especially the changed feature spec.
- [ ] Verify by inspection that the old test conditions are all still covered by the consolidated specs.