### PR TITLE
Update fast-glob (micromatch) to resolve security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cleave.js": "^1.6.0",
     "concurrently": "^8.2.2",
     "core-js": "^3.21.1",
-    "fast-glob": "^3.2.7",
+    "fast-glob": "^3.3.2",
     "foundation-emails": "^2.3.1",
     "intl-tel-input": "^17.0.19",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3612,7 +3612,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^3.2.7, fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.2:
+fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -4951,9 +4951,9 @@ methods@~1.1.2:
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
 micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.7.tgz#33e8190d9fe474a9895525f5618eee136d46c2e5"
-  integrity sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `micromatch` to the latest version to resolve a security advisory.

Advisory: GHSA-952p-6rrq-rcjv

`micromatch` is a subdependency of `fast-glob`. While not strictly necessary to update `fast-glob` as part of this, I did so for good measure ([bug fixes and performance improvements](https://github.com/mrmlnc/fast-glob/releases)).

Approach was to manually remove the top-level entry for `micromatch` in `yarn.lock` and re-run `yarn install`.

## 📜 Testing Plan

`make audit` produces no vulnerabilities.