### PR TITLE
Log context of contextless kms

### DIFF
--- a/app/services/encryption/contextless_kms_client.rb
+++ b/app/services/encryption/contextless_kms_client.rb
@@ -18,14 +18,14 @@ module Encryption
       KMS: 'KMSx',
     }.freeze
 
-    def encrypt(plaintext)
-      KmsLogger.log(:encrypt, key_id: IdentityConfig.store.aws_kms_key_id)
+    def encrypt(plaintext, log_context: nil)
+      KmsLogger.log(:encrypt, key_id: IdentityConfig.store.aws_kms_key_id, log_context: log_context)
       return encrypt_kms(plaintext) if FeatureManagement.use_kms?
       encrypt_local(plaintext)
     end
 
-    def decrypt(ciphertext)
-      KmsLogger.log(:decrypt, key_id: IdentityConfig.store.aws_kms_key_id)
+    def decrypt(ciphertext, log_context: nil)
+      KmsLogger.log(:decrypt, key_id: IdentityConfig.store.aws_kms_key_id, log_context: log_context)
       return decrypt_kms(ciphertext) if use_kms?(ciphertext)
       decrypt_local(ciphertext)
     end

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -38,7 +38,9 @@ module Encryption
     end
 
     def decrypt(ciphertext, encryption_context)
-      return decrypt_contextless_kms(ciphertext) if self.class.looks_like_contextless?(ciphertext)
+      if self.class.looks_like_contextless?(ciphertext)
+        return decrypt_contextless_kms(ciphertext, encryption_context)
+      end
       KmsLogger.log(:decrypt, context: encryption_context, key_id: kms_key_id)
       return decrypt_kms(ciphertext, encryption_context) if use_kms?(ciphertext)
       decrypt_local(ciphertext, encryption_context)
@@ -135,8 +137,8 @@ module Encryption
       )
     end
 
-    def decrypt_contextless_kms(ciphertext)
-      ContextlessKmsClient.new.decrypt(ciphertext)
+    def decrypt_contextless_kms(ciphertext, encryption_context)
+      ContextlessKmsClient.new.decrypt(ciphertext, log_context: encryption_context)
     end
 
     # chunk plaintext into ~4096 byte chunks, but not less than 1024 bytes in a chunk if chunking.

--- a/app/services/encryption/kms_logger.rb
+++ b/app/services/encryption/kms_logger.rb
@@ -2,11 +2,12 @@
 
 module Encryption
   class KmsLogger
-    def self.log(action, key_id:, context: nil)
+    def self.log(action, key_id:, context: nil, log_context: nil)
       output = {
         kms: {
           action: action,
           encryption_context: context,
+          log_context: log_context,
           key_id: key_id,
         },
         log_filename: Idp::Constants::KMS_LOG_FILENAME,

--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -73,7 +73,7 @@ module Encryption
     def verify(password:, digest_pair:, user_uuid:)
       digest = digest_pair.multi_or_single_region_ciphertext
       password_digest = PasswordDigest.parse_from_string(digest)
-      return verify_uak_digest(password, digest) if stale_digest?(digest)
+      return verify_uak_digest(password, digest) if password_digest.uak_password_digest?
 
       verify_password_against_digest(
         password: password,

--- a/app/services/encryption/user_access_key.rb
+++ b/app/services/encryption/user_access_key.rb
@@ -45,7 +45,7 @@ module Encryption
       self.masked_ciphertext = Base64.strict_decode64(encryption_key_arg)
       z1_padded = z1.dup.rjust(masked_ciphertext.length, '0')
       encrypted_random_r = xor(z1_padded, masked_ciphertext)
-      self.random_r = kms_client.decrypt(encrypted_random_r)
+      self.random_r = kms_client.decrypt(encrypted_random_r, log_context: 'user-access-key')
       self.cek = OpenSSL::Digest::SHA256.hexdigest(z2 + random_r)
       self
     end

--- a/spec/services/encryption/contextless_kms_client_spec.rb
+++ b/spec/services/encryption/contextless_kms_client_spec.rb
@@ -150,10 +150,11 @@ RSpec.describe Encryption::ContextlessKmsClient do
       it 'logs the encryption' do
         expect(Encryption::KmsLogger).to receive(:log).with(
           :encrypt,
+          log_context: { context: 'abc' },
           key_id: IdentityConfig.store.aws_kms_key_id,
         )
 
-        subject.encrypt(long_kms_plaintext)
+        subject.encrypt(long_kms_plaintext, log_context: { context: 'abc' })
       end
     end
 
@@ -185,10 +186,11 @@ RSpec.describe Encryption::ContextlessKmsClient do
       it 'logs the decryption' do
         expect(Encryption::KmsLogger).to receive(:log).with(
           :decrypt,
+          log_context: { context: 'abc' },
           key_id: IdentityConfig.store.aws_kms_key_id,
         )
 
-        subject.decrypt('KMSx' + kms_ciphertext)
+        subject.decrypt('KMSx' + kms_ciphertext, log_context: { context: 'abc' })
       end
     end
 

--- a/spec/services/encryption/kms_client_spec.rb
+++ b/spec/services/encryption/kms_client_spec.rb
@@ -141,10 +141,10 @@ RSpec.describe Encryption::KmsClient do
       before do
         contextless_client = Encryption::ContextlessKmsClient.new
         allow(contextless_client).to receive(:decrypt).
-          with('KMSx123abc').
+          with('KMSx123abc', log_context: encryption_context).
           and_return('plaintext')
         allow(contextless_client).to receive(:decrypt).
-          with('123abc').
+          with('123abc', log_context: encryption_context).
           and_return('plaintext')
         allow(Encryption::ContextlessKmsClient).to receive(:new).and_return(contextless_client)
       end

--- a/spec/services/encryption/kms_logger_spec.rb
+++ b/spec/services/encryption/kms_logger_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Encryption::KmsLogger do
           kms: {
             action: 'encrypt',
             encryption_context: { context: 'pii-encryption', user_uuid: '1234-abc' },
+            log_context: 'log_context',
             key_id: 'super-duper-aws-kms-key-id',
           },
           log_filename: Idp::Constants::KMS_LOG_FILENAME,
@@ -18,6 +19,7 @@ RSpec.describe Encryption::KmsLogger do
         described_class.log(
           :encrypt,
           context: { context: 'pii-encryption', user_uuid: '1234-abc' },
+          log_context: 'log_context',
           key_id: 'super-duper-aws-kms-key-id',
         )
       end
@@ -29,6 +31,7 @@ RSpec.describe Encryption::KmsLogger do
           kms: {
             action: 'decrypt',
             encryption_context: nil,
+            log_context: nil,
             key_id: 'super-duper-aws-kms-key-id',
           },
           log_filename: Idp::Constants::KMS_LOG_FILENAME,


### PR DESCRIPTION
## 🛠 Summary of changes

To better understand the usage of the older single-region KMS key, this adds the context that would have been used in the KMS API call to the KMS log.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
