### PR TITLE
Remove wide card styles

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -5,24 +5,9 @@
   background-color: color('white');
   max-width: $container-skinny-width;
 
-  &-wide {
-    max-width: 100%;
-    padding-bottom: 0;
-    padding-left: 0;
-    padding-right: 0;
-  }
-
   @include at-media('tablet') {
     @include u-padding-x(10);
     @include u-margin-bottom(8);
     border-radius: 5px;
-
-    &-wide {
-      margin-top: units(6);
-      max-width: 100%;
-      padding-bottom: 0;
-      padding-left: 0;
-      padding-right: 0;
-    }
   }
 }

--- a/app/views/test/telephony/index.html.erb
+++ b/app/views/test/telephony/index.html.erb
@@ -4,16 +4,16 @@
 
 <h1>Outbound calls and messages</h1>
 
+<%= button_to 'Clear messages and calls', test_telephony_path, method: :delete, class: 'usa-button' %>
 
-<div class="card card-wide">
-  <div class="padding-4">
-    <%= button_to 'Clear messages and calls', test_telephony_path, method: :delete, class: 'usa-button' %>
-    <div class="grid-row grid-gap margin-top-2">
-      <div class="tablet:grid-col-6">
-        <h2>Messages</h2>
+<div class="grid-row grid-gap margin-top-2 flex-align-stretch">
+  <% [['Messages', @messages], ['Calls', @calls]].each do |title, messages| %>
+    <div class="tablet:grid-col-6">
+      <div class="card padding-4 height-full">
+        <h2 class="margin-0"><%= title %></h2>
 
-        <% @messages.each do |message| %>
-          <div class="lg-card margin-bottom-4">
+        <% messages.each do |message| %>
+          <div class="margin-top-4">
             <p class="margin-y-05">
             <strong>To:</strong> <%= message.to %>
             </p>
@@ -26,24 +26,6 @@
           </div>
         <% end %>
       </div>
-
-      <div class="tablet:grid-col-6">
-        <h2>Calls</h2>
-
-        <% @calls.each do |call| %>
-          <div class="lg-card margin-bottom-4">
-            <p class="margin-y-05">
-            <strong>To:</strong> <%= call.to %>
-            </p>
-            <p class="margin-y-05">
-            <strong>Body:</strong> <%= call.body %>
-            </p>
-            <p class="margin-y-05">
-            <strong>Sent at:</strong> <%= call.sent_at.strftime(t('time.formats.event_timestamp')) %>
-            </p>
-          </div>
-        <% end %>
-      </div>
     </div>
-  </div>
+  <% end %>
 </div>


### PR DESCRIPTION
## 🛠 Summary of changes

Removes styles for the "wide" variation of the `card` CSS class, and re-layouts the telephony test page as a two-column grid of individual cards.

These styles are only used on the telephony testing screen in internal development. Removing them avoids additional ad-hoc (non-design-system-standard) styling and reduces the size of the end-user application stylesheet.

Easier to review with whitespace changes hidden: https://github.com/18F/identity-idp/pull/11176/files?w=1

## 📜 Testing Plan

1. Go to http://localhost:3000/test/telephony
2. Observe updated layout

## 👀 Screenshots

Before|After
---|---
![Screenshot 2024-08-30 at 10 31 47 AM](https://github.com/user-attachments/assets/ac19b259-4c21-4dfb-8a36-edfc223fe32d)|![Screenshot 2024-08-30 at 10 31 39 AM](https://github.com/user-attachments/assets/d449779f-ecd7-4b92-bf31-155b669980d1)

