### PR TITLE
Simplify and standardize card styling

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -2,12 +2,15 @@
 @use '../variables/app' as *;
 
 .card {
+  @include u-padding(4);
   background-color: color('white');
   max-width: $container-skinny-width;
 
+  & + & {
+    @include u-margin-top(4);
+  }
+
   @include at-media('tablet') {
-    @include u-padding-x(10);
-    @include u-margin-bottom(8);
     border-radius: 5px;
   }
 }

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -14,7 +14,6 @@
 @forward 'link';
 @forward 'header';
 @forward 'page-heading';
-@forward 'profile-section';
 @forward 'personal-key';
 @forward 'radio-button';
 @forward 'spinner-button';

--- a/app/assets/stylesheets/components/_profile-section.scss
+++ b/app/assets/stylesheets/components/_profile-section.scss
@@ -1,5 +1,0 @@
-@use 'uswds-core' as *;
-
-.profile-info-box {
-  padding: units(4);
-}

--- a/app/views/accounts/connected_accounts/show.html.erb
+++ b/app/views/accounts/connected_accounts/show.html.erb
@@ -6,7 +6,7 @@
   <%= t('account.connected_apps.description', app_name: APP_NAME) %>
 </p>
 
-<div class="margin-bottom-4 card profile-info-box border-bottom border-primary-light">
+<div class="card border-bottom border-primary-light">
   <ul class="add-list-reset border-bottom border-primary-light">
     <% @presenter.connected_apps.each do |identity| %>
       <li><%= render 'accounts/connected_app', identity: identity %></li>

--- a/app/views/accounts/history/show.html.erb
+++ b/app/views/accounts/history/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('account.navigation.history')) %>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <div class="margin-top-0 border-bottom border-primary-light">
     <h2 class="margin-top-0 margin-bottom-2">
       <%= t('headings.account.devices') %>
@@ -13,7 +13,7 @@
   </div>
 </div>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <div class="margin-top-0 border-bottom border-primary-light">
     <h2 class="margin-top-0 margin-bottom-2">
       <%= t('headings.account.activity') %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -14,12 +14,12 @@
 <% end %>
 
 <% if @presenter.show_idv_partial? %>
-  <div class="margin-bottom-4 card profile-info-box">
+  <div class="card">
     <%= render 'accounts/identity_verification' %>
   </div>
 <% end %>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <h2 class="margin-top-0 margin-bottom-4"><%= t('account.index.email_preferences') %></h2>
 
   <%= render 'emails' %>
@@ -35,7 +35,7 @@
   </div>
 </div>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <h2 class="margin-bottom-1 margin-top-0">
     <%= t('account.index.password') %>
   </h2>
@@ -50,43 +50,43 @@
 </div>
 
 <% if @presenter.show_manage_personal_key_partial? %>
-  <div class="margin-bottom-4 card profile-info-box">
+  <div class="card">
     <%= render 'accounts/manage_personal_key' %>
   </div>
 <% end %>
 
 <% if TwoFactorAuthentication::PhonePolicy.new(current_user).configured? %>
-  <div class="margin-bottom-4 card profile-info-box">
+  <div class="card">
     <%= render 'phone' %>
   </div>
 <% end %>
 
 <% if TwoFactorAuthentication::AuthAppPolicy.new(current_user).configured? %>
-  <div class="margin-bottom-4 card profile-info-box">
+  <div class="card">
     <%= render 'accounts/auth_apps' %>
   </div>
 <% end %>
 
 <% if TwoFactorAuthentication::WebauthnPolicy.new(current_user).platform_configured? %>
-  <div class="margin-bottom-4 card profile-info-box">
+  <div class="card">
     <%= render 'accounts/webauthn_platform' %>
   </div>
 <% end %>
 
 <% if TwoFactorAuthentication::WebauthnPolicy.new(current_user).roaming_configured? %>
-  <div class="margin-bottom-4 card profile-info-box">
+  <div class="card">
     <%= render 'accounts/webauthn_roaming' %>
   </div>
 <% end %>
 
 <% if TwoFactorAuthentication::PivCacPolicy.new(current_user).configured? %>
-  <div class="margin-bottom-4 card profile-info-box">
+  <div class="card">
     <%= render 'accounts/piv_cac' %>
   </div>
 <% end %>
 
 <% if TwoFactorAuthentication::BackupCodePolicy.new(current_user).configured? %>
-  <div class="margin-bottom-4 card profile-info-box">
+  <div class="card">
     <%= render 'accounts/backup_codes' %>
   </div>
 <% end %>

--- a/app/views/accounts/two_factor_authentication/show.html.erb
+++ b/app/views/accounts/two_factor_authentication/show.html.erb
@@ -2,34 +2,34 @@
 
 <%= render PageHeadingComponent.new.with_content(t('headings.account.two_factor')) %>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <% if TwoFactorAuthentication::PhonePolicy.new(current_user).visible? %>
     <%= render 'accounts/phone' %>
   <% end %>
 </div>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <%= render 'accounts/auth_apps' %>
 </div>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <%= render 'accounts/webauthn_platform' %>
 </div>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <%= render 'accounts/webauthn_roaming' %>
 </div>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <%= render 'accounts/piv_cac' %>
 </div>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <%= render 'accounts/backup_codes' %>
 </div>
 
 <% if @presenter.show_manage_personal_key_partial? %>
-  <div class="margin-bottom-4 card profile-info-box">
+  <div class="card">
     <%= render 'accounts/manage_personal_key' %>
   </div>
 <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,7 +6,7 @@
 
 <%= render PageHeadingComponent.new.with_content(t('headings.account.activity')) %>
 
-<div class="margin-bottom-4 card profile-info-box">
+<div class="card">
   <div class="border-bottom border-primary-light">
     <h2 class="margin-top-0">
       <%= @device.nice_name %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
         class: 'site-wrap bg-primary-lighter',
         id: local_assigns[:user_main_tag] == false ? nil : 'main-content',
       ) do %>
-    <div class="grid-container padding-y-4 tablet:padding-y-8 <%= local_assigns[:disable_card].present? ? '' : 'card' %>">
+    <div class="grid-container padding-y-4 tablet:padding-y-8 <%= local_assigns[:disable_card].present? ? '' : 'card padding-x-2 tablet:padding-x-10 tablet:margin-bottom-8' %>">
       <%= yield(:pre_flash_content) if content_for?(:pre_flash_content) %>
       <%= render FlashComponent.new(flash: flash) %>
       <%= yield %>

--- a/app/views/test/telephony/index.html.erb
+++ b/app/views/test/telephony/index.html.erb
@@ -9,7 +9,7 @@
 <div class="grid-row grid-gap margin-top-2 flex-align-stretch">
   <% [['Messages', @messages], ['Calls', @calls]].each do |title, messages| %>
     <div class="tablet:grid-col-6">
-      <div class="card padding-4 height-full">
+      <div class="card height-full">
         <h2 class="margin-0"><%= title %></h2>
 
         <% messages.each do |message| %>

--- a/spec/features/account_email_language_spec.rb
+++ b/spec/features/account_email_language_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Account email language' do
     end
 
     it 'lets them view their current email language' do
-      within(page.find('.profile-info-box', text: t('i18n.language'))) do
+      within(page.find('.card', text: t('i18n.language'))) do
         expect(page).to have_content(t("account.email_language.name.#{original_email_language}"))
       end
     end
@@ -24,7 +24,7 @@ RSpec.describe 'Account email language' do
     context 'changing their email language' do
       let('chosen_email_language') { 'fr' }
       before do
-        within(page.find('.profile-info-box', text: t('i18n.language'))) do
+        within(page.find('.card', text: t('i18n.language'))) do
           click_link(t('forms.buttons.edit'))
         end
 
@@ -33,13 +33,13 @@ RSpec.describe 'Account email language' do
       end
 
       it 'reflects the updated language preference' do
-        within(page.find('.profile-info-box', text: t('i18n.language'))) do
+        within(page.find('.card', text: t('i18n.language'))) do
           expect(page).to have_content(t("account.email_language.name.#{chosen_email_language}"))
         end
       end
 
       it 'respects the language preference in emails, such as password reset emails' do
-        within(page.find('.profile-info-box', text: 'Password')) do
+        within(page.find('.card', text: 'Password')) do
           click_link(t('forms.buttons.edit'))
         end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates card styling to standardize around the usage of cards as stackable elements, as used in the account page and elsewhere (e.g. telephony test screen). This inverts previous assumptions of the base layout card styling as the default, which has much wider padding by default, now implementing those styles in the base layout specifically as the outlier.

In doing so, it eliminates the need for a special `profile-info-box` CSS class, since those styles are now the baseline card styling.

## 📜 Testing Plan

Verify no visual regressions on wide and narrow viewport sizes, particularly for the base layout and account page card stylings.