### PR TITLE
Return user to connected accounts when cancelling revocation

### DIFF
--- a/app/views/users/service_provider_revoke/show.html.erb
+++ b/app/views/users/service_provider_revoke/show.html.erb
@@ -11,8 +11,6 @@
 
 <%= button_to(service_provider_revoke_url(@service_provider.id), method: 'delete', class: 'usa-button usa-button--wide usa-button--big margin-top-4') { t('forms.buttons.continue') } %>
 
-<div class="margin-top-4 border-top border-primary-light">
-  <div class="margin-top-1">
-    <%= link_to(t('links.cancel'), account_url) %>
-  </div>
-</div>
+<%= render PageFooterComponent.new do %>
+  <%= link_to(t('links.cancel'), account_connected_accounts_path) %>
+<% end %>

--- a/spec/support/features/navigation_helper.rb
+++ b/spec/support/features/navigation_helper.rb
@@ -5,10 +5,14 @@ module NavigationHelper
   # sidenav links.
 
   def find_sidenav_delete_account_link
-    find('.sidenav').find_link(t('account.links.delete_account'), href: account_delete_path)
+    within_sidenav { find_link(t('account.links.delete_account'), href: account_delete_path) }
   end
 
   def find_sidenav_forget_browsers_link
-    find('.sidenav').find_link(t('account.navigation.forget_browsers'))
+    within_sidenav { find_link(t('account.navigation.forget_browsers')) }
+  end
+
+  def within_sidenav(&block)
+    within('.sidenav', &block)
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the connected accounts revocation screen to return a user to their connected accounts (where they came from) if they choose to cancel revocation, rather than the root accounts dashboard.

It also includes a handful of general code quality improvements:

- Use standard PageFooterComponent
- Update feature specs to interact with the page as a user would be expected to, rather than visiting URLs directly
- Avoid redundant navigation in feature specs
- Avoid redundant assertions (e.g. checking history path in revocation scenario, when already asserted in preceding scenario)

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in
3. From accounts dashboard, click "Your connected accounts"
4. Click "Disconnect" on one of  your connected accounts
   a. If you don't have a connected account, run and sign in through [sample application](https://github.com/18f/identity-oidc-sinatra)
5. When prompted to confirm revocation, click "Cancel"

Before: You'd be returned to the root account dashboard screen
After: You're returned to the "Your connected accounts" page (where you came from)