### PR TITLE
LG-14320 Add deactivate IPP cancelled profiles task

### DIFF
--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -75,4 +75,67 @@ namespace :profiles do
 
     warn "backfill_in_person_verification_pending_at left #{profiles.count} rows"
   end
+
+  ##
+  # Usage:
+  #
+  # Print pending updates
+  # bundle exec rake profiles:backfill_deactivated_ipp_verification_cancelled
+  #
+  # Commit updates
+  # bundle exec rake profiles:backfill_deactivated_ipp_verification_cancelled UPDATE_PROFILES=true
+  #
+  task backfill_deactivated_ipp_verification_cancelled: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    update_profiles = ENV['UPDATE_PROFILES'] == 'true'
+
+    InPersonEnrollment.where(status: [:expired, :cancelled, :failed]).
+      includes(:profile).
+      where.not(profile: { in_person_verification_pending_at: nil }).
+      find_in_batches do |batch|
+        batch.each do |enrollment|
+          profile = enrollment.profile
+          timestamp = profile.in_person_verification_pending_at
+
+          warn "#{profile.id},#{profile.deactivation_reason},#{timestamp}"
+          if update_profiles
+            profile.update!(
+              deactivation_reason: :verification_cancelled,
+              in_person_verification_pending_at: nil,
+            )
+          end
+        end
+        sleep(0.5)
+      end
+  end
+
+  ##
+  # Usage:
+  #
+  # Rollback the above:
+  #
+  # export BACKFILL_OUTPUT='<backfill_output>'
+  # bundle exec rake profiles:rollback_backfill_deactivated_ipp_verification_cancelled
+  #
+  task rollback_backfill_deactivated_ipp_verification_cancelled: :environment do |_task, _args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 60000')
+
+    profile_data = ENV['BACKFILL_OUTPUT'].split("\n").map do |profile_row|
+      profile_row.split(',')
+    end
+
+    warn "Updating #{profile_data.count} records"
+    profile_data.in_groups_of(1000, false) do |batch|
+      batch.each do |profile_datum|
+        profile_id, deactivation_reason, timestamp = profile_datum
+        Profile.where(id: profile_id).update!(
+          deactivation_reason: deactivation_reason,
+          in_person_verification_pending_at: timestamp,
+        )
+        warn profile_id
+      end
+      sleep(0.5)
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14320](https://cm-jira.usa.gov/browse/LG-14320)

## 🛠 Summary of changes

Added a script to deactivate profiles that are considered to be IPP verification cancelled state.

## 📜 Testing Plan

Scenario: Running backfill script

- [x] Create data using the `seed_users_with_profiles.rb` seed file
```bash
bundle exec rake seed:broken_profiles
```
- [x] Check that number of profile in broken state is greater than 0 using rails console
```ruby
    InPersonEnrollment.where(status: [:expired, :cancelled, :failed]).
      includes(:profile).
      where.not(profile: { in_person_verification_pending_at: nil }).
      count
```

**Note: It might be good to setup the seeder to create a few pending profiles for testing to ensure those do not get updated.**

- [x] Run the backfill script to backup data without updating profiles
```bash
bundle exec rake profiles:backfill_deactivated_ipp_verification_cancelled UPDATE_PROFILES=false
```
- [x] Verify that log output contains the expected profiles information (id, deactivation_reason, in_person_verification_pending_at) is contained in it
- [x] Copy the log output and save it to a file
- [x] Run the backfill script data updating profiles
```bash
bundle exec rake profiles:backfill_deactivated_ipp_verification_cancelled UPDATE_PROFILES=true
```
- [x] Check the number of profile in broken state is 0 using rails console
```ruby
    InPersonEnrollment.where(status: [:expired, :cancelled, :failed]).
      includes(:profile).
      where.not(profile: { in_person_verification_pending_at: nil }).
      count
```

Scenario: Running rollback script

- [x] Run the rollback script
```bash
bundle exec rake profiles:rollback_backfill_deactivated_ipp_verification_cancelled BACKFILL_OUTPUT="$(cat output)"
```
- [x] Check the number of profile in broken state is back to the original count before the backfill script ran using rails console
```ruby
    InPersonEnrollment.where(status: [:expired, :cancelled, :failed]).
      includes(:profile).
      where.not(profile: { in_person_verification_pending_at: nil }).
      count
```

