### PR TITLE
Rearrange connected accounts in stacked layout

### DIFF
--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -1,26 +1,21 @@
 <div class="padding-1 border-top border-left border-right border-primary-light">
-  <div class="grid-row grid-gap-2">
-    <div class="grid-col-fill">
-      <div class="text-bold truncate">
-        <% if identity.return_to_sp_url.present? %>
-          <%= link_to(identity.display_name, identity.return_to_sp_url) %>
-        <% else %>
-          <%= identity.display_name %>
-        <% end %>
-      </div>
-
-      <%= t(
-            'account.connected_apps.associated',
-            timestamp: render(TimeComponent.new(time: identity.created_at)),
-          ).html_safe %>
-    </div>
-    <% if identity.service_provider_id %>
-      <div class="grid-col-12 tablet:grid-col-auto">
-        <%= link_to(
-              t('account.revoke_consent.link_title'),
-              service_provider_revoke_url(identity.service_provider_id),
-            ) %>
-      </div>
+  <h2 class="h3 margin-top-0 margin-bottom-1">
+    <% if identity.return_to_sp_url.present? %>
+      <%= link_to(identity.display_name, identity.return_to_sp_url) %>
+    <% else %>
+      <%= identity.display_name %>
     <% end %>
+  </h2>
+
+  <%= t(
+        'account.connected_apps.associated_html',
+        timestamp: render(TimeComponent.new(time: identity.created_at)),
+      ) %>
+
+  <div class="margin-y-1">
+    <%= render ButtonComponent.new(
+          url: service_provider_revoke_url(identity.service_provider_id),
+          outline: true,
+        ).with_content(t('account.revoke_consent.link_title')) %>
   </div>
 </div>

--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -9,7 +9,7 @@
 
   <%= t(
         'account.connected_apps.associated_html',
-        timestamp: render(TimeComponent.new(time: identity.created_at)),
+        timestamp_html: render(TimeComponent.new(time: identity.created_at)),
       ) %>
 
   <div class="margin-y-1">

--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -12,10 +12,12 @@
         timestamp_html: render(TimeComponent.new(time: identity.created_at)),
       ) %>
 
-  <div class="margin-y-1">
-    <%= render ButtonComponent.new(
-          url: service_provider_revoke_url(identity.service_provider_id),
-          outline: true,
-        ).with_content(t('account.revoke_consent.link_title')) %>
-  </div>
+  <% if identity.service_provider_id %>
+    <div class="margin-y-1">
+      <%= render ButtonComponent.new(
+            url: service_provider_revoke_url(identity.service_provider_id),
+            outline: true,
+          ).with_content(t('account.revoke_consent.link_title')) %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/accounts/connected_accounts/show.html.erb
+++ b/app/views/accounts/connected_accounts/show.html.erb
@@ -7,10 +7,10 @@
 </p>
 
 <div class="margin-bottom-4 card profile-info-box border-bottom border-primary-light">
-  <div class="border-bottom border-primary-light">
+  <ul class="add-list-reset border-bottom border-primary-light">
     <% @presenter.connected_apps.each do |identity| %>
-      <%= render 'accounts/connected_app', identity: identity %>
+      <li><%= render 'accounts/connected_app', identity: identity %></li>
     <% end %>
-  </div>
+  </ul>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ account_reset.request.info:
 account_reset.request.no_cancel: Cancel
 account_reset.request.title: Account deletion and reset
 account_reset.request.yes_continue: Yes, continue deletion
-account.connected_apps.associated: Connected %{timestamp}
+account.connected_apps.associated_html: Connected %{timestamp}
 account.connected_apps.description: With your %{app_name} account, you can securely connect to multiple government accounts online. Below is a list of all the accounts you currently have connected.
 account.email_language.default: '%{language} (default)'
 account.email_language.edit_title: Edit email language preference

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ account_reset.request.info:
 account_reset.request.no_cancel: Cancel
 account_reset.request.title: Account deletion and reset
 account_reset.request.yes_continue: Yes, continue deletion
-account.connected_apps.associated_html: Connected %{timestamp}
+account.connected_apps.associated_html: Connected %{timestamp_html}
 account.connected_apps.description: With your %{app_name} account, you can securely connect to multiple government accounts online. Below is a list of all the accounts you currently have connected.
 account.email_language.default: '%{language} (default)'
 account.email_language.edit_title: Edit email language preference

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -38,7 +38,7 @@ account_reset.request.info:
 account_reset.request.no_cancel: Cancelar
 account_reset.request.title: Eliminación y restablecimiento de cuenta
 account_reset.request.yes_continue: Sí, continuar con la eliminación
-account.connected_apps.associated_html: 'Conectado: %{timestamp}'
+account.connected_apps.associated_html: 'Conectado: %{timestamp_html}'
 account.connected_apps.description: Con su cuenta de %{app_name}, puede conectarse de manera segura a muchas cuentas del gobierno en línea. Esta es una lista de todas las cuentas que tiene conectadas actualmente.
 account.email_language.default: '%{language} (predeterminado)'
 account.email_language.edit_title: Editar la preferencia de idioma del correo electrónico

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -38,7 +38,7 @@ account_reset.request.info:
 account_reset.request.no_cancel: Cancelar
 account_reset.request.title: Eliminación y restablecimiento de cuenta
 account_reset.request.yes_continue: Sí, continuar con la eliminación
-account.connected_apps.associated: 'Conectado: %{timestamp}'
+account.connected_apps.associated_html: 'Conectado: %{timestamp}'
 account.connected_apps.description: Con su cuenta de %{app_name}, puede conectarse de manera segura a muchas cuentas del gobierno en línea. Esta es una lista de todas las cuentas que tiene conectadas actualmente.
 account.email_language.default: '%{language} (predeterminado)'
 account.email_language.edit_title: Editar la preferencia de idioma del correo electrónico

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -38,7 +38,7 @@ account_reset.request.info:
 account_reset.request.no_cancel: Annuler
 account_reset.request.title: Suppression et réinitialisation de compte
 account_reset.request.yes_continue: Oui, continuer la suppression
-account.connected_apps.associated_html: Connecté %{timestamp}
+account.connected_apps.associated_html: Connecté %{timestamp_html}
 account.connected_apps.description: Avec votre compte %{app_name}, vous pouvez vous connecter en toute sécurité à plusieurs comptes de l’administration en ligne. Vous trouverez ci-dessous une liste de tous vos comptes actuellement connectés.
 account.email_language.default: '%{language} (par défaut)'
 account.email_language.edit_title: Modifier la langue dans laquelle vous préférez recevoir les e-mails

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -38,7 +38,7 @@ account_reset.request.info:
 account_reset.request.no_cancel: Annuler
 account_reset.request.title: Suppression et réinitialisation de compte
 account_reset.request.yes_continue: Oui, continuer la suppression
-account.connected_apps.associated: Connecté %{timestamp}
+account.connected_apps.associated_html: Connecté %{timestamp}
 account.connected_apps.description: Avec votre compte %{app_name}, vous pouvez vous connecter en toute sécurité à plusieurs comptes de l’administration en ligne. Vous trouverez ci-dessous une liste de tous vos comptes actuellement connectés.
 account.email_language.default: '%{language} (par défaut)'
 account.email_language.edit_title: Modifier la langue dans laquelle vous préférez recevoir les e-mails

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -38,7 +38,7 @@ account_reset.request.info:
 account_reset.request.no_cancel: 取消
 account_reset.request.title: 账户删除和重设
 account_reset.request.yes_continue: 是的，继续删除
-account.connected_apps.associated: 已连接 %{timestamp}
+account.connected_apps.associated_html: 已连接 %{timestamp}
 account.connected_apps.description: 使用你的 %{app_name} 账户，你可以安全地连接到网上多个政府账户。以下列出了你目前已连接的所有账户。
 account.email_language.default: '%{language} （默认）'
 account.email_language.edit_title: 编辑电邮语言选择

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -38,7 +38,7 @@ account_reset.request.info:
 account_reset.request.no_cancel: 取消
 account_reset.request.title: 账户删除和重设
 account_reset.request.yes_continue: 是的，继续删除
-account.connected_apps.associated_html: 已连接 %{timestamp}
+account.connected_apps.associated_html: 已连接 %{timestamp_html}
 account.connected_apps.description: 使用你的 %{app_name} 账户，你可以安全地连接到网上多个政府账户。以下列出了你目前已连接的所有账户。
 account.email_language.default: '%{language} （默认）'
 account.email_language.edit_title: 编辑电邮语言选择

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Account connected applications' do
   scenario 'revoking consent from an SP' do
     identity_to_revoke = identity_with_link
 
-    within('.profile-info-box .grid-row', text: identity_to_revoke.display_name) do
+    within('li', text: identity_to_revoke.display_name) do
       click_link(t('account.revoke_consent.link_title'))
     end
 
@@ -71,7 +71,7 @@ RSpec.describe 'Account connected applications' do
     expect(page).to have_current_path(account_connected_accounts_path)
 
     # Revoke again and confirm revocation
-    within('.profile-info-box .grid-row', text: identity_to_revoke.display_name) do
+    within('li', text: identity_to_revoke.display_name) do
       click_link(t('account.revoke_consent.link_title'))
     end
     click_on t('forms.buttons.continue')


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-13665](https://cm-jira.usa.gov/browse/LG-13665)

## 🛠 Summary of changes

Updates the layout of the connected accounts page to show the content of individual accounts in a stacking arrangement, with a "Disconnect" button.

This incrementally works toward [LG-13665](https://cm-jira.usa.gov/browse/LG-13665), [pending clarification about identities without linked emails](https://gsa-tts.slack.com/archives/C05R6BLVAQG/p1725033025669399).

It also includes a bit of general clean-up:

- Avoid `String#html_safe` in favor of `_html` suffix for locale string
- Use semantic HTML markup (headings for each item, `<ul>` for list of accounts)

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in
3. Click "Your connected accounts"
4. Observe that accounts are rendered as shown in "After" screenshot

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/8c490a4b-e053-4147-9fab-75ccaba66dee)|![image](https://github.com/user-attachments/assets/487c2393-2b1b-4da2-a874-e7ee2187bc23)
