### PR TITLE
Use picture element to avoid unnecessary image load

### DIFF
--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -2,7 +2,7 @@
   <%= new_tab_link_to('https://www.gsa.gov', class: 'footer__agency-logo') do %>
     <%= picture_tag(aria: { hidden: true }, class: 'margin-right-05') do %>
       <%= tag.source(media: '(min-width: 1024px)', srcset: asset_url('sp-logos/square-gsa.svg')) %>
-      <%= image_tag(asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: '') %>
+      <%= image_tag(asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: '', aria: { hidden: true }) %>
     <% end %>
     <%= t('shared.footer_lite.gsa') %>
   <% end %>
@@ -17,7 +17,7 @@
     <%= new_tab_link_to('https://www.gsa.gov', class: 'footer__agency-logo') do %>
       <%= picture_tag(aria: { hidden: true }, class: 'margin-right-05') do %>
         <%= tag.source(media: '(max-width: 1023px)', srcset: asset_url('sp-logos/square-gsa-dark.svg')) %>
-        <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '') %>
+        <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', aria: { hidden: true }) %>
       <% end %>
       <%= t('shared.footer_lite.gsa') %>
     <% end %>

--- a/app/views/shared/_footer_lite.html.erb
+++ b/app/views/shared/_footer_lite.html.erb
@@ -1,6 +1,9 @@
 <footer class="footer">
   <%= new_tab_link_to('https://www.gsa.gov', class: 'footer__agency-logo') do %>
-    <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '', class: 'margin-right-05', aria: { hidden: true }) %>
+    <%= picture_tag(aria: { hidden: true }, class: 'margin-right-05') do %>
+      <%= tag.source(media: '(min-width: 1024px)', srcset: asset_url('sp-logos/square-gsa.svg')) %>
+      <%= image_tag(asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: '') %>
+    <% end %>
     <%= t('shared.footer_lite.gsa') %>
   <% end %>
   <%= render LanguagePickerComponent.new(class: 'footer__language-picker') %>
@@ -12,7 +15,10 @@
   </div>
   <div class="footer__links">
     <%= new_tab_link_to('https://www.gsa.gov', class: 'footer__agency-logo') do %>
-      <%= image_tag(asset_url('sp-logos/square-gsa-dark.svg'), size: 20, alt: '', class: 'margin-right-05', aria: { hidden: true }) %>
+      <%= picture_tag(aria: { hidden: true }, class: 'margin-right-05') do %>
+        <%= tag.source(media: '(max-width: 1023px)', srcset: asset_url('sp-logos/square-gsa-dark.svg')) %>
+        <%= image_tag(asset_url('sp-logos/square-gsa.svg'), size: 20, alt: '') %>
+      <% end %>
       <%= t('shared.footer_lite.gsa') %>
     <% end %>
   </div>


### PR DESCRIPTION
## 🛠 Summary of changes

Updates footer markup to use [`<picture>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture) to avoid loading an unnecessary image.

The GSA logo rendered the footer is either light or dark depending on the viewport size. In the previous implementation, both images would be downloaded, despite the fact that only one would ever be visible.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Verify no visual regression of the "GSA" logo in the footer, at both large and small viewport size
3. Open browser developer tools Network tab
4. Reload the page
5. Verify that only one variation of the "square-gsa" logo is loaded

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/ef762157-7f00-4e44-bfd5-c9c362ef6f01)|![image](https://github.com/user-attachments/assets/d41c7acd-f5db-4b53-9d79-cd6251ea318f)
