### PR TITLE
LG-13990: log an event on receipt of Socure webhooks

### DIFF
--- a/app/controllers/socure_webhook_controller.rb
+++ b/app/controllers/socure_webhook_controller.rb
@@ -9,6 +9,7 @@ class SocureWebhookController < ApplicationController
 
   def create
     if token_valid?
+      log_webhook_receipt
       render json: { message: 'Secret token is valid.' }
     else
       render status: :unauthorized, json: { message: 'Invalid secret token.' }
@@ -40,5 +41,17 @@ class SocureWebhookController < ApplicationController
         key,
       )
     end
+  end
+
+  def log_webhook_receipt
+    event = socure_params[:event]
+    analytics.idv_doc_auth_socure_webhook_received(
+      event_type: event[:eventType],
+      reference_id: event[:referenceId],
+    )
+  end
+
+  def socure_params
+    params.permit(event: [:eventType, :referenceId])
   end
 end

--- a/app/controllers/socure_webhook_controller.rb
+++ b/app/controllers/socure_webhook_controller.rb
@@ -53,7 +53,6 @@ class SocureWebhookController < ApplicationController
 
   def log_webhook_receipt
     event = socure_params[:event]
-    return if event.blank?
 
     analytics.idv_doc_auth_socure_webhook_received(
       created_at: event[:created],

--- a/app/controllers/socure_webhook_controller.rb
+++ b/app/controllers/socure_webhook_controller.rb
@@ -8,12 +8,15 @@ class SocureWebhookController < ApplicationController
   check_or_render_not_found -> { IdentityConfig.store.socure_webhook_enabled }
 
   def create
-    if token_valid?
-      log_webhook_receipt
-      render json: { message: 'Secret token is valid.' }
-    else
-      render status: :unauthorized, json: { message: 'Invalid secret token.' }
+    unless token_valid?
+      return render(status: :unauthorized, json: { message: 'Invalid secret token.' })
     end
+    if socure_params[:event].blank?
+      return render(status: :bad_request, json: { message: 'Invalid event.' })
+    end
+
+    log_webhook_receipt
+    render json: { message: 'Secret token is valid.' }
   end
 
   private
@@ -45,13 +48,18 @@ class SocureWebhookController < ApplicationController
 
   def log_webhook_receipt
     event = socure_params[:event]
+    return if event.blank?
+
     analytics.idv_doc_auth_socure_webhook_received(
+      created_at: event[:created],
+      customer_user_id: event[:customerUserId],
       event_type: event[:eventType],
       reference_id: event[:referenceId],
+      user_id: event[:customerUserId],
     )
   end
 
   def socure_params
-    params.permit(event: [:eventType, :referenceId])
+    params.permit(event: [:created, :customerUserId, :eventType, :referenceId])
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1333,10 +1333,28 @@ module AnalyticsEvents
     track_event('IdV: doc auth redo_ssn submitted', **extra)
   end
 
+  # @param [String] created_at The created timestamp received from Socure
+  # @param [String] customer_user_id The customerUserId received from Socure
   # @param [String] event_type The eventType received from Socure
   # @param [String] reference_id The referenceId received from Socure
-  def idv_doc_auth_socure_webhook_received(event_type:, reference_id:, **extra)
-    track_event(:idv_doc_auth_socure_webhook_received, event_type:, reference_id:, **extra)
+  # @param [String] user_id The customerUserId, repackaged as user_id
+  def idv_doc_auth_socure_webhook_received(
+    created_at:,
+    customer_user_id:,
+    event_type:,
+    reference_id:,
+    user_id:,
+    **extra
+  )
+    track_event(
+      :idv_doc_auth_socure_webhook_received,
+      created_at:,
+      customer_user_id:,
+      event_type:,
+      reference_id:,
+      user_id:,
+      **extra,
+    )
   end
 
   # User submits IdV Social Security number step

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1333,6 +1333,12 @@ module AnalyticsEvents
     track_event('IdV: doc auth redo_ssn submitted', **extra)
   end
 
+  # @param [String] event_type The eventType received from Socure
+  # @param [String] reference_id The referenceId received from Socure
+  def idv_doc_auth_socure_webhook_received(event_type:, reference_id:, **extra)
+    track_event(:idv_doc_auth_socure_webhook_received, event_type:, reference_id:, **extra)
+  end
+
   # User submits IdV Social Security number step
   # @identity.idp.previous_event_name IdV: in person proofing ssn submitted
   # @param [Boolean] success Whether form validation was successful

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -26,6 +26,7 @@ module Idv
       idv_doc_auth_link_sent_submitted
       idv_doc_auth_link_sent_visited
       idv_doc_auth_redo_ssn_submitted
+      idv_doc_auth_socure_webhook_received
       idv_doc_auth_ssn_submitted
       idv_doc_auth_ssn_visited
       idv_doc_auth_submitted_image_upload_form

--- a/spec/controllers/socure_webhook_controller_spec.rb
+++ b/spec/controllers/socure_webhook_controller_spec.rb
@@ -7,6 +7,24 @@ RSpec.describe SocureWebhookController do
     let(:socure_secret_key) { 'this-is-a-secret' }
     let(:socure_secret_key_queue) { ['this-is-an-old-secret', 'this-is-an-older-secret'] }
     let(:socure_webhook_enabled) { true }
+    let(:webhook_body) do
+      {
+        event: {
+          created: '2020-01-01T00:00:00Z',
+          customerUserId: '123',
+          eventType: 'TEST_WEBHOOK',
+          referenceId: 'abc',
+          data: {
+            documentData: {
+              dob: '2000-01-01',
+              firstName: 'First',
+              lastName: 'Last',
+              address: '123 Main St, Baltimore, MD',
+            },
+          },
+        },
+      }
+    end
 
     before do
       allow(IdentityConfig.store).to receive(:socure_webhook_secret_key).
@@ -15,40 +33,56 @@ RSpec.describe SocureWebhookController do
         and_return(socure_secret_key_queue)
       allow(IdentityConfig.store).to receive(:socure_webhook_enabled).
         and_return(socure_webhook_enabled)
+      stub_analytics
     end
 
-    it 'returns OK with a correct secret key' do
+    it 'returns OK and logs an event with a correct secret key and body' do
       request.headers['Authorization'] = socure_secret_key
-      post :create
+      post :create, params: webhook_body
 
       expect(response).to have_http_status(:ok)
+      expect(@analytics).to have_logged_event(
+        :idv_doc_auth_socure_webhook_received,
+        created_at: '2020-01-01T00:00:00Z',
+        customer_user_id: '123',
+        event_type: 'TEST_WEBHOOK',
+        reference_id: 'abc',
+        user_id: '123',
+      )
     end
 
     it 'returns OK with an older secret key' do
       request.headers['Authorization'] = socure_secret_key_queue.last
-      post :create
+      post :create, params: webhook_body
 
       expect(response).to have_http_status(:ok)
     end
 
     it 'returns unauthorized with a bad secret key' do
       request.headers['Authorization'] = 'ABC123'
-      post :create
+      post :create, params: webhook_body
 
       expect(response).to have_http_status(:unauthorized)
     end
 
     it 'returns unauthorized with no secret key' do
-      post :create
+      post :create, params: webhook_body
 
       expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns bad request with no event in the body' do
+      request.headers['Authorization'] = socure_secret_key
+      post :create, params: {}
+
+      expect(response).to have_http_status(:bad_request)
     end
 
     context 'when socure webhook disabled' do
       let(:socure_webhook_enabled) { false }
       it 'the webhook route does not exist' do
         request.headers['Authorization'] = socure_secret_key
-        post :create
+        post :create, params: webhook_body
 
         expect(response).to be_not_found
       end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13990](https://cm-jira.usa.gov/browse/LG-13990)

## 🛠 Summary of changes

Logs a new event upon authorized receipt of a correctly formatted webhook event from Socure. Will log only the following data:
- `created` => `created_at`
- `customerUserId` => `customer_user_id`
- `eventType` => `event_type`
- `referenceId` => `reference_id`
- `customerUserId` => `user_id`

## 📜 Testing Plan

Run the following :
```
curl -X POST -H "Authorization: this-is-a-secret" -H "Content-Type: application/json" -d '{"event":{ "referenceId": "REF_ID","eventType": "TESTING","pii":"PII","customerUserId":"123","harmless_data":"kitten"}}'  http://127.0.0.1:3000/api/webhooks/socure/event
```

look in your event log and expect to see similar to:
```
{"name":"idv_doc_auth_socure_webhook_received","properties":{"event_properties":{"created_at":"2020-01-01T00:00:00Z","customer_user_id":"123","event_type":"TEST_WEBHOOK","reference_id":"abc"},"new_event":true,"path":"/api/webhooks/socure/event","session_duration":0.000573,"user_id":"123","locale":"en","user_ip":"0.0.0.0","hostname":"www.example.com","pid":94033,"service_provider":null,"trace_id":null,"git_sha":"b62bd94d","git_branch":"stages/solipet","user_agent":"Rails Testing","browser_name":"Unknown Browser","browser_version":"0.0","browser_platform_name":"Unknown","browser_platform_version":"0","browser_device_name":"Unknown","browser_mobile":false,"browser_bot":false},"time":"2024-08-31T03:17:21.514+08:00","id":"0a8f97e4-29b5-43ae-b87d-c1c13588a970","visitor_id":"37f6e917-1ec6-4e24-82ad-5cabb54a82eb","visit_id":"5b278985-061e-4cb5-9553-39e87bd5086b","log_filename":"events.log"}
```