### PR TITLE
LG-13824 Rename state id form as workaround to aggressive browser autofill behavior

### DIFF
--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -148,11 +148,24 @@ module Idv
 
       def pii
         data = pii_from_user
-        data = data.merge(flow_params) if params.has_key?(:state_id)
+        if params.has_key?(:identity_doc) || params.has_key?(:state_id)
+          data = data.merge(flow_params)
+        end
         data.deep_symbolize_keys
       end
 
       def flow_params
+        if params.dig(:identity_doc).present?
+          # Transform the top-level params key to accept the renamed form
+          # for autofill handling workaround
+          params[:state_id] = params.delete(:identity_doc)
+
+          # Rename nested id_number to state_id_number
+          if params[:state_id][:id_number].present?
+            params[:state_id][:state_id_number] = params[:state_id].delete(:id_number)
+          end
+        end
+
         params.require(:state_id).permit(
           *Idv::StateIdForm::ATTRIBUTES,
           dob: [

--- a/app/views/idv/in_person/state_id.html.erb
+++ b/app/views/idv/in_person/state_id.html.erb
@@ -38,6 +38,7 @@
 <% end %>
 
 <%= simple_form_for form,
+                    as: 'identity_doc', # Renaming form as a workaround for aggressive browser autofill assumptions
                     url: url_for,
                     method: 'put',
                     html: { class: 'margin-y-5' } do |f| %>
@@ -140,7 +141,7 @@
     <% end %>
 
     <%= render ValidatedFieldComponent.new(
-          name: :state_id_number,
+          name: :id_number, # Renaming field as a workaround for aggressive browser autofill assumptions
           form: f,
           hint: state_id_number_hint,
           hint_html: { class: ['jurisdiction-extras'] },

--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -45,6 +45,7 @@
 </p>
 <% end %>
 <%= simple_form_for form,
+                    as: 'identity_doc', # Renaming form as a workaround for aggressive browser autofill assumptions
                     url: url_for,
                     method: 'put',
                     html: { class: 'margin-y-5' } do |f| %>
@@ -145,7 +146,7 @@
       <% end %>
     <% end %>
     <%= render ValidatedFieldComponent.new(
-          name: :state_id_number,
+          name: :id_number, # Renaming field as a workaround for aggressive browser autofill assumptions
           form: f,
           hint: state_id_number_hint,
           hint_html: { class: ['tablet:grid-col-10', 'jurisdiction-extras'] },

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -133,8 +133,7 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
     let(:city) { InPersonHelper::GOOD_CITY }
     let(:state) { InPersonHelper::GOOD_STATE }
     let(:zipcode) { InPersonHelper::GOOD_ZIPCODE }
-    # identity_doc_
-    let(:state_id_number) { 'ABC123234' }
+    let(:id_number) { 'ABC123234' }
     let(:state_id_jurisdiction) { 'AL' }
     let(:identity_doc_address1) { InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1 }
     let(:identity_doc_address2) { InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2 }
@@ -143,7 +142,7 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
     let(:identity_doc_zipcode) { InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE }
     context 'with values submitted' do
       let(:invalid_params) do
-        { state_id: {
+        { identity_doc: {
           first_name: 'S@ndy!',
           last_name:,
           same_address_as_id: 'true', # value on submission
@@ -151,14 +150,14 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
           identity_doc_address2:,
           identity_doc_city:,
           state_id_jurisdiction:,
-          state_id_number:,
+          id_number:,
           identity_doc_address_state:,
           identity_doc_zipcode:,
           dob:,
         } }
       end
       let(:params) do
-        { state_id: {
+        { identity_doc: {
           first_name:,
           last_name:,
           same_address_as_id: 'true', # value on submission
@@ -166,7 +165,7 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
           identity_doc_address2:,
           identity_doc_city:,
           state_id_jurisdiction:,
-          state_id_number:,
+          id_number:,
           identity_doc_address_state:,
           identity_doc_zipcode:,
           dob:,
@@ -228,7 +227,8 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
         expect(pii_from_user[:dob]).to eq formatted_dob
         expect(pii_from_user[:identity_doc_zipcode]).to eq identity_doc_zipcode
         expect(pii_from_user[:identity_doc_address_state]).to eq identity_doc_address_state
-        expect(pii_from_user[:state_id_number]).to eq state_id_number
+        # param from form as id_number but is renamed to state_id_number on update
+        expect(pii_from_user[:state_id_number]).to eq id_number
       end
     end
 
@@ -238,7 +238,7 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
       context 'changed from "true" to "false"' do
         let(:params) do
           {
-            state_id: {
+            identity_doc: {
               first_name:,
               last_name:,
               same_address_as_id: 'false', # value on submission
@@ -246,7 +246,7 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
               identity_doc_address2:,
               identity_doc_city:,
               state_id_jurisdiction:,
-              state_id_number:,
+              id_number:,
               identity_doc_address_state:,
               identity_doc_zipcode:,
               dob:,
@@ -296,7 +296,7 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
 
       context 'changed from "false" to "true"' do
         let(:params) do
-          { state_id: {
+          { identity_doc: {
             first_name:,
             last_name:,
             same_address_as_id: 'true', # value on submission
@@ -304,7 +304,7 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
             identity_doc_address2:,
             identity_doc_city:,
             state_id_jurisdiction:,
-            state_id_number:,
+            id_number:,
             identity_doc_address_state:,
             identity_doc_zipcode:,
             dob:,
@@ -335,7 +335,7 @@ RSpec.describe Idv::InPerson::StateIdController, allowed_extra_analytics: [:*] d
 
       context 'not changed from "false"' do
         let(:params) do
-          { state_id: {
+          { identity_doc: {
             dob:,
             same_address_as_id: 'false',
             address1:,

--- a/spec/services/idv/steps/in_person/state_id_step_spec.rb
+++ b/spec/services/idv/steps/in_person/state_id_step_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Idv::Steps::InPerson::StateIdStep do
   include InPersonHelper
   let(:submitted_values) { {} }
-  let(:params) { ActionController::Parameters.new({ state_id: submitted_values }) }
+  let(:params) { ActionController::Parameters.new({ identity_doc: submitted_values }) }
   let(:user) { build(:user) }
   let(:formatted_dob) { InPersonHelper::GOOD_DOB }
   let(:dob) do
@@ -37,7 +37,7 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
       let(:first_name) { 'Natalya' }
       let(:last_name) { 'Rostova' }
       let(:identity_doc_address_state) { 'Nevada' }
-      let(:state_id_number) { 'ABC123234' }
+      let(:id_number) { 'ABC123234' }
       let(:identity_doc_zipcode) { InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE }
       let(:submitted_values) do
         {
@@ -45,7 +45,7 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
           last_name: last_name,
           dob: dob,
           identity_doc_address_state: identity_doc_address_state,
-          state_id_number: state_id_number,
+          id_number: id_number,
           identity_doc_zipcode: identity_doc_zipcode,
         }
       end
@@ -67,14 +67,15 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
         expect(pii_from_user[:last_name]).to eq last_name
         expect(pii_from_user[:dob]).to eq formatted_dob
         expect(pii_from_user[:identity_doc_address_state]).to eq identity_doc_address_state
-        expect(pii_from_user[:state_id_number]).to eq state_id_number
+        # param from form as id_number but is renamed to state_id_number on update
+        expect(pii_from_user[:state_id_number]).to eq id_number
         expect(pii_from_user[:identity_doc_zipcode]).to eq identity_doc_zipcode
       end
     end
 
     context 'when same_address_as_id is...' do
       let(:pii_from_user) { flow.flow_session[:pii_from_user] }
-      let(:params) { ActionController::Parameters.new({ state_id: submitted_values }) }
+      let(:params) { ActionController::Parameters.new({ identity_doc: submitted_values }) }
       # residential
       let(:address1) { InPersonHelper::GOOD_ADDRESS1 }
       let(:address2) { InPersonHelper::GOOD_ADDRESS2 }
@@ -241,7 +242,7 @@ RSpec.describe Idv::Steps::InPerson::StateIdStep do
 
     context 'skip address step?' do
       let(:pii_from_user) { flow.flow_session[:pii_from_user] }
-      let(:params) { ActionController::Parameters.new({ state_id: submitted_values }) }
+      let(:params) { ActionController::Parameters.new({ identity_doc: submitted_values }) }
       let(:enrollment) { InPersonEnrollment.new }
       let(:identity_doc_address_state) { 'Nevada' }
       let(:identity_doc_city) { 'Twin Peaks' }


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13824](https://cm-jira.usa.gov/browse/LG-13824)


## 🛠 Summary of changes

This renames the state ID form name `"state_id"`, and the field `"state_id_number"`, to `"identity_doc"` and `"id_number"` so that the fields do not start with the word "state" - The fields starting with the word "state" causes Chrome and Firefox to make incorrect assumptions that some fields can be autofilled with geographical state, if a user has such an autofill entry saved, when those fields should not be autofilled as such. <sub><sup>This behavior is also a pain for developer testing...</sup></sub>

Notes: 

- This change translates the data back to their original param names in the controller, so this doesn't affect how the data is named throughout the application. The name state_id only has an adverse effect in the form, so this workaround only alters the form name.

- Autocomplete is turned off in this form already [#10604]. 
    - However, the browser's Auto*fill* functionality [doesn't always respect this ](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#off). This solution takes into consideration the browser's tendencies, while still not using Autocomplete. 
    - Adding `autocomplete="given-name"` to the First Name field, for example, would override the browser's presumptive behavior, but it would also utilize Autocomplete which we don't want to do.



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Flow state machine (FSM) version:
    - [x] Set the `in_person_state_id_controller_enabled` flag to **false** in your application.yml and restart the application.
    - [x] Enter through Sinatra, choose identity-verified, and navigate through the IPP flow to /verify/in_person/state_id
    - [x] Trigger the autofill feature with a sample address that includes a state. If you don't have autofill address saved, you can add them in your browser settings. ([Chrome instructions](https://support.google.com/chrome/answer/142893?hl=en&co=GENIE.Platform%3DAndroid))
    - [x] Observe that the first name, last name, date of birth, and ID number fields are **not** populated with the geographical state. 

- [x] Controller version:
    - [x] Set the `in_person_state_id_controller_enabled` flag to **true** in your application.yml and restart the application.
    - [x] Enter through Sinatra, choose identity-verified, and navigate through the IPP flow to verify/in_person_proofing/state_id
    - [x] Trigger the autofill feature with a sample address that includes a state. If you don't have autofill address saved, you can add them in your browser settings. ([Chrome instructions](https://support.google.com/chrome/answer/142893?hl=en&co=GENIE.Platform%3DAndroid))
    - [x] Observe that the first name, last name, date of birth, and ID number fields are **not** populated with the geographical state. 

Test this behavior in Chrome and Firefox. Safari's autofill behavior is very different, but it is worth verifying the page is acceptable in Safari too. 

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

![image](https://github.com/user-attachments/assets/03f48800-c677-4dab-aa9a-3ae147ee6e29)

</details>

<details>
<summary>After:</summary>
<img width="847" alt="image" src="https://github.com/user-attachments/assets/5d0b0804-d04e-4701-87bb-f7e3c0d318b8">

</details>

