### PR TITLE
Run all relevant Axe accessibility test groups

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,11 +197,11 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.9.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    axe-core-api (4.9.1)
+    axe-core-api (4.10.0)
       dumb_delegator
       virtus
-    axe-core-rspec (4.9.1)
-      axe-core-api (= 4.9.1)
+    axe-core-rspec (4.10.0)
+      axe-core-api (= 4.10.0)
       dumb_delegator
       virtus
     axiom-types (0.1.1)

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -337,7 +337,15 @@ class AccessibleName
 end
 
 def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
-  expect(page).to be_axe_clean.according_to(:wcag22aa, :"best-practice")
+  expect(page).to be_axe_clean.according_to(
+    :wcag2a,
+    :wcag2aa,
+    :wcag21a,
+    :wcag21aa,
+    :wcag22a,
+    :wcag22aa,
+    :"best-practice",
+  )
   expect(page).to have_unique_ids
   expect(page).to have_valid_idrefs
   expect(page).to label_required_fields

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -345,6 +345,8 @@ def expect_page_to_have_no_accessibility_violations(page, validate_markup: true)
     :wcag22a,
     :wcag22aa,
     :"best-practice",
+  ).excluding(
+    '.iti__selected-flag', # See: LG-14382
   )
   expect(page).to have_unique_ids
   expect(page).to have_valid_idrefs


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue with our accessibility page testing where applying `:wcag22aa` runs _only_ [tests for rules specific to WCAG 2.2 AA](https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md#wcag-22-level-a--aa-rules), and does not inherit from rules below that.

I noticed this when trying to fix an existing issue which hadn't been flagged by the tests. I'll plan to open a separate pull request for that, since it involves writing new tests, but the scope of this pull request is addressing existing issues within the current tests.

There are existing issues with the phone input component. These are addressed in newer versions of the library, and while I have an in-progress branch to implement the upgrade, there are some incompatibilities with the newer version and content security policies (see upstream pull request https://github.com/jackocnr/intl-tel-input/pull/1778 ). Instead, the changes here exempt those violations and a corresponding ticket for upgrade is tracked at [LG-14382](https://cm-jira.usa.gov/browse/LG-14382).

## 📜 Testing Plan

Verify build passes.