### PR TITLE
Run automated accessibility tests for account pages, fix issues

### DIFF
--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -14,7 +14,7 @@
             renamed: t('two_factor_authentication.auth_app.renamed'),
             manage_accessible_label: t('two_factor_authentication.auth_app.manage_accessible_label'),
           },
-          role: 'list-item',
+          role: 'listitem',
         ) %>
   <% end %>
 </div>

--- a/app/views/accounts/_pii.html.erb
+++ b/app/views/accounts/_pii.html.erb
@@ -60,7 +60,7 @@
 <% unless locked_for_session %>
   <div class="grid-row bg-base-lightest padding-x-2 padding-y-1 fs-12p">
     <div class="grid-col-12">
-      <%= image_tag asset_url('lock.svg'), width: 8, height: 10, class: 'margin-right-1' %>
+      <%= image_tag asset_url('lock.svg'), width: 8, height: 10, class: 'margin-right-1', alt: '', aria: { hidden: true } %>
       <%= t('account.security.text') %>
     </div>
     <%= link_to t('account.security.link'), help_center_redirect_url %>

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -14,7 +14,7 @@
             renamed: t('two_factor_authentication.piv_cac.renamed'),
             manage_accessible_label: t('two_factor_authentication.piv_cac.manage_accessible_label'),
           },
-          role: 'list-item',
+          role: 'listitem',
         ) %>
   <% end %>
 </div>

--- a/app/views/accounts/_webauthn_platform.html.erb
+++ b/app/views/accounts/_webauthn_platform.html.erb
@@ -14,7 +14,7 @@
             renamed: t('two_factor_authentication.webauthn_platform.renamed'),
             manage_accessible_label: t('two_factor_authentication.webauthn_platform.manage_accessible_label'),
           },
-          role: 'list-item',
+          role: 'listitem',
         ) %>
   <% end %>
 </div>

--- a/app/views/accounts/_webauthn_roaming.html.erb
+++ b/app/views/accounts/_webauthn_roaming.html.erb
@@ -19,7 +19,7 @@
             renamed: t('two_factor_authentication.webauthn_roaming.renamed'),
             manage_accessible_label: t('two_factor_authentication.webauthn_roaming.manage_accessible_label'),
           },
-          role: 'list-item',
+          role: 'listitem',
         ) %>
   <% end %>
 </div>

--- a/spec/features/accessibility/account_pages_spec.rb
+++ b/spec/features/accessibility/account_pages_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+require 'axe-rspec'
+
+RSpec.feature 'Accessibility on account pages', :js do
+  let(:user) do
+    # Create an interesting user with various states that affect content shown on account pages
+    create(
+      :user,
+      :with_multiple_emails,
+      :with_webauthn,
+      :with_webauthn_platform,
+      :with_phone,
+      :with_piv_or_cac,
+      :with_personal_key,
+      :with_backup_code,
+      :with_authentication_app,
+      :proofed,
+    )
+  end
+
+  before do
+    visit root_path
+    sign_in_and_2fa_user(user)
+  end
+
+  scenario '"Your account" path' do
+    visit account_path
+
+    expect_page_to_have_no_accessibility_violations(page)
+  end
+
+  scenario '"Your authentication methods" path' do
+    visit account_two_factor_authentication_path
+
+    expect_page_to_have_no_accessibility_violations(page)
+  end
+
+  scenario '"Your connected accounts" path' do
+    visit account_connected_accounts_path
+
+    expect_page_to_have_no_accessibility_violations(page)
+  end
+
+  scenario '"History" path' do
+    visit account_history_path
+
+    expect_page_to_have_no_accessibility_violations(page)
+  end
+end

--- a/spec/features/accessibility/account_pages_spec.rb
+++ b/spec/features/accessibility/account_pages_spec.rb
@@ -6,15 +6,16 @@ RSpec.feature 'Accessibility on account pages', :js do
     # Create an interesting user with various states that affect content shown on account pages
     create(
       :user,
+      :proofed,
       :with_multiple_emails,
-      :with_webauthn,
-      :with_webauthn_platform,
+      # all mfas
+      :with_authentication_app,
+      :with_backup_code,
+      :with_personal_key,
       :with_phone,
       :with_piv_or_cac,
-      :with_personal_key,
-      :with_backup_code,
-      :with_authentication_app,
-      :proofed,
+      :with_webauthn,
+      :with_webauthn_platform,
     )
   end
 

--- a/spec/views/accounts/_auth_apps.html.erb_spec.rb
+++ b/spec/views/accounts/_auth_apps.html.erb_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe 'accounts/_auth_apps.html.erb' do
   end
 
   it 'renders a list of auth apps' do
-    expect(rendered).to have_selector('[role="list"] [role="list-item"]', count: 2)
+    expect(rendered).to have_selector('[role="list"] [role="listitem"]', count: 2)
   end
 end

--- a/spec/views/accounts/_piv_cac.html.erb_spec.rb
+++ b/spec/views/accounts/_piv_cac.html.erb_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe 'accounts/_piv_cac.html.erb' do
   end
 
   it 'renders a list of piv cac configurations' do
-    expect(rendered).to have_selector('[role="list"] [role="list-item"]', count: 2)
+    expect(rendered).to have_selector('[role="list"] [role="listitem"]', count: 2)
   end
 end

--- a/spec/views/accounts/_webauthn_platform.html.erb_spec.rb
+++ b/spec/views/accounts/_webauthn_platform.html.erb_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe 'accounts/_webauthn_platform.html.erb' do
   end
 
   it 'renders a list of platform authenticators' do
-    expect(rendered).to have_selector('[role="list"] [role="list-item"]', count: 2)
+    expect(rendered).to have_selector('[role="list"] [role="listitem"]', count: 2)
   end
 end

--- a/spec/views/accounts/_webauthn_roaming.html.erb_spec.rb
+++ b/spec/views/accounts/_webauthn_roaming.html.erb_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe 'accounts/_webauthn_roaming.html.erb' do
   end
 
   it 'renders a list of roaming authenticators' do
-    expect(rendered).to have_selector('[role="list"] [role="list-item"]', count: 2)
+    expect(rendered).to have_selector('[role="list"] [role="listitem"]', count: 2)
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds feature tests to run automated accessibility tests against account pages.

This was motivated by observing issues when running Axe browser extension on account pages, then realizing we had no coverage for these screens.

It also includes changes to fix existing issues, further reinforcing the value of these tests.

## 📜 Testing Plan

Verify build passes.