### PR TITLE
Log that an in-person enrollment is updated when canceled for invalid enrollment or applicant ID

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -158,11 +158,9 @@ class GetUspsProofingResultsJob < ApplicationJob
         handle_incomplete_status_update(enrollment, response_message)
       end
     elsif response_message == IPP_INVALID_ENROLLMENT_CODE_MESSAGE % enrollment.enrollment_code
-      handle_unexpected_response(enrollment, response_message, reason: 'Invalid enrollment code')
+      handle_invalid_enrollment_code(enrollment, err.response, response_message)
     elsif response_message == IPP_INVALID_APPLICANT_MESSAGE % enrollment.unique_id
-      handle_unexpected_response(
-        enrollment, response_message, reason: 'Invalid applicant unique id'
-      )
+      handle_invalid_applicant_unique_id(enrollment, err.response, response_message)
     else
       handle_client_or_server_error(err, enrollment)
     end
@@ -313,6 +311,28 @@ class GetUspsProofingResultsJob < ApplicationJob
         cancel: false,
       )
     end
+  end
+
+  def handle_invalid_enrollment_code(enrollment, response, response_message)
+    log_enrollment_updated_analytics(
+      enrollment: enrollment,
+      enrollment_passed: false,
+      enrollment_completed: false,
+      response: response[:body],
+      reason: 'Invalid enrollment code',
+    )
+    handle_unexpected_response(enrollment, response_message, reason: 'Invalid enrollment code')
+  end
+
+  def handle_invalid_applicant_unique_id(enrollment, response, response_message)
+    log_enrollment_updated_analytics(
+      enrollment: enrollment,
+      enrollment_passed: false,
+      enrollment_completed: false,
+      response: response[:body],
+      reason: 'Invalid applicant unique id',
+    )
+    handle_unexpected_response(enrollment, response_message, reason: 'Invalid applicant unique id')
   end
 
   def handle_fraud_review_pending(enrollment)

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -986,6 +986,13 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
 
                 expect(pending_enrollment.reload.cancelled?).to be_truthy
                 expect(job_analytics).to have_logged_event(
+                  'GetUspsProofingResultsJob: Enrollment status updated',
+                  hash_including(
+                    passed: false,
+                    reason: 'Invalid enrollment code',
+                  ),
+                )
+                expect(job_analytics).to have_logged_event(
                   'GetUspsProofingResultsJob: Unexpected response received',
                   hash_including(
                     reason: 'Invalid enrollment code',
@@ -1023,6 +1030,13 @@ RSpec.describe GetUspsProofingResultsJob, allowed_extra_analytics: [:*] do
                 job.perform(Time.zone.now)
 
                 expect(pending_enrollment.reload.cancelled?).to be_truthy
+                expect(job_analytics).to have_logged_event(
+                  'GetUspsProofingResultsJob: Enrollment status updated',
+                  hash_including(
+                    passed: false,
+                    reason: 'Invalid applicant unique id',
+                  ),
+                )
                 expect(job_analytics).to have_logged_event(
                   'GetUspsProofingResultsJob: Unexpected response received',
                   hash_including(


### PR DESCRIPTION
The `GetUspsProofingResultsJob` fetches the results of USPS enrollments and updates the status of the enrollment and the profile based on the response.

When the job updates an enrollment (and associated profile) it is expected to log a `GetUspsProofingResultsJob: Enrollment status updated` event. This is done by calling `#log_enrollment_updated_analytics`. As part of the change in #11186 we identified that `#handle_unexpected_response` response did not log an enrollment update analytics event.

This commit adds logging for the cases where `#handle_unexpected_response` is called and enrollments are updated. There are 2 cases where this occurs:

- When the enrollment ID is invalid. A `#handle_invalid_enrollment_code` method was added to account for this.
- When the applicant unique ID is invalid. A `#handle_invalid_applicant_unique_id` method was added to account for this.

I opted to add new methods in this change to match the pattern that is used by other caller of `handle_unexpected_response`: the `handle_expired_status_update` method. All of these methods are called by `handle_bad_request_error` under some condition.
