### PR TITLE
LG-13665: Add option to change selected email shared with partner

### DIFF
--- a/app/components/status_page_component.html.erb
+++ b/app/components/status_page_component.html.erb
@@ -18,3 +18,5 @@
     <%= troubleshooting_options %>
   </div>
 <% end %>
+
+<%= footer if footer? %>

--- a/app/components/status_page_component.html.erb
+++ b/app/components/status_page_component.html.erb
@@ -19,4 +19,4 @@
   </div>
 <% end %>
 
-<%= footer if footer? %>
+<%= footer %>

--- a/app/components/status_page_component.rb
+++ b/app/components/status_page_component.rb
@@ -12,6 +12,7 @@ class StatusPageComponent < BaseComponent
     ButtonComponent.new(**button_options, big: true, wide: true)
   end
   renders_one :troubleshooting_options, TroubleshootingOptionsComponent
+  renders_one :footer, PageFooterComponent
 
   attr_reader :status, :icon
 

--- a/app/controllers/accounts/connected_accounts/selected_email_controller.rb
+++ b/app/controllers/accounts/connected_accounts/selected_email_controller.rb
@@ -3,6 +3,9 @@
 module Accounts
   module ConnectedAccounts
     class SelectedEmailController < ApplicationController
+      include RenderConditionConcern
+
+      check_or_render_not_found -> { IdentityConfig.store.feature_select_email_to_share_enabled }
       before_action :confirm_two_factor_authenticated
       before_action :validate_identity
 

--- a/app/controllers/accounts/connected_accounts/selected_email_controller.rb
+++ b/app/controllers/accounts/connected_accounts/selected_email_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Accounts
+  module ConnectedAccounts
+    class SelectedEmailController < ApplicationController
+      before_action :confirm_two_factor_authenticated
+      before_action :validate_identity
+
+      def edit
+        @identity = identity
+        @select_email_form = build_select_email_form
+        analytics.sp_select_email_visited
+      end
+
+      def update
+        @select_email_form = build_select_email_form
+
+        result = @select_email_form.submit(form_params)
+
+        analytics.sp_select_email_submitted(**result.to_h)
+
+        if result.success?
+          redirect_to account_connected_accounts_path
+        else
+          flash[:error] = result.first_error_message
+          redirect_to edit_connected_account_selected_email_path(identity.id)
+        end
+      end
+
+      private
+
+      def form_params
+        params.require(:select_email_form).permit(:selected_email_id)
+      end
+
+      def build_select_email_form
+        SelectEmailForm.new(user: current_user, identity:)
+      end
+
+      def validate_identity
+        render_not_found if identity.blank?
+      end
+
+      def identity
+        return @identity if defined?(@identity)
+        @identity = current_user.identities.find_by(id: params[:identity_id])
+      end
+    end
+  end
+end

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -32,7 +32,7 @@ module SignUp
     private
 
     def build_select_email_form
-      SelectEmailForm.new(current_user)
+      SelectEmailForm.new(user: current_user)
     end
 
     def form_params

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -2,6 +2,9 @@
 
 module SignUp
   class SelectEmailController < ApplicationController
+    include RenderConditionConcern
+
+    check_or_render_not_found -> { IdentityConfig.store.feature_select_email_to_share_enabled }
     before_action :confirm_two_factor_authenticated
     before_action :verify_needs_completions_screen
 

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -4,28 +4,28 @@ class SelectEmailForm
   include ActiveModel::Model
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :user, :selected_email_id
+  attr_reader :user, :identity, :selected_email_id
 
   validate :validate_owns_selected_email
 
-  def initialize(user)
+  def initialize(user:, identity: nil)
     @user = user
+    @identity = identity
   end
 
   def submit(params)
     @selected_email_id = params[:selected_email_id]
 
     success = valid?
-    FormResponse.new(success:, errors:)
+    identity.update(email_address_id: selected_email_id) if success && identity
+
+    FormResponse.new(success:, errors:, serialize_error_details_only: true)
   end
 
   private
 
   def validate_owns_selected_email
     return if user.confirmed_email_addresses.exists?(id: selected_email_id)
-
-    errors.add :email, I18n.t(
-      'email_address.not_found',
-    ), type: :selected_email_id
+    errors.add(:selected_email_id, :not_found, message: t('email_address.not_found'))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -453,7 +453,7 @@ class User < ApplicationRecord
   end
 
   def connected_apps
-    identities.not_deleted.includes(:service_provider_record).order('created_at DESC')
+    identities.not_deleted.order('created_at DESC')
   end
 
   def delete_account_bullet_key

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -116,7 +116,11 @@ class AccountShowPresenter
     end
   end
 
-  delegate :recent_events, :recent_devices, :connected_apps, to: :user
+  def connected_apps
+    user.connected_apps.includes([:service_provider_record, :email_address])
+  end
+
+  delegate :recent_events, :recent_devices, to: :user
 
   private
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6135,13 +6135,6 @@ module AnalyticsEvents
     )
   end
 
-  # User visited form to change email shared with service provider
-  # @param [String, nil] needs_completion_screen_reason Reason for the consent screen being shown,
-  # if user is changing email in consent flow
-  def sp_select_email_visited(needs_completion_screen_reason: nil, **extra)
-    track_event(:sp_select_email_visited, needs_completion_screen_reason:, **extra)
-  end
-
   # User submitted form to change email shared with service provider
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
@@ -6160,6 +6153,13 @@ module AnalyticsEvents
       needs_completion_screen_reason:,
       **extra,
     )
+  end
+
+  # User visited form to change email shared with service provider
+  # @param [String, nil] needs_completion_screen_reason Reason for the consent screen being shown,
+  # if user is changing email in consent flow
+  def sp_select_email_visited(needs_completion_screen_reason: nil, **extra)
+    track_event(:sp_select_email_visited, needs_completion_screen_reason:, **extra)
   end
 
   # @param [String] area_code Area code of phone number

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6115,6 +6115,33 @@ module AnalyticsEvents
     )
   end
 
+  # User visited form to change email shared with service provider
+  # @param [String, nil] needs_completion_screen_reason Reason for the consent screen being shown,
+  # if user is changing email in consent flow
+  def sp_select_email_visited(needs_completion_screen_reason: nil, **extra)
+    track_event(:sp_select_email_visited, needs_completion_screen_reason:, **extra)
+  end
+
+  # User submitted form to change email shared with service provider
+  # @param [Boolean] success Whether form validation was successful
+  # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
+  # @param [String, nil] needs_completion_screen_reason Reason for the consent screen being shown,
+  # if user is changing email in consent flow
+  def sp_select_email_submitted(
+    success:,
+    error_details: nil,
+    needs_completion_screen_reason: nil,
+    **extra
+  )
+    track_event(
+      :sp_select_email_submitted,
+      success:,
+      error_details:,
+      needs_completion_screen_reason:,
+      **extra,
+    )
+  end
+
   # Tracks when service provider consent is revoked
   # @param [String] issuer issuer of the service provider consent to be revoked
   def sp_revoke_consent_revoked(issuer:, **extra)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6115,6 +6115,26 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when service provider consent is revoked
+  # @param [String] issuer issuer of the service provider consent to be revoked
+  def sp_revoke_consent_revoked(issuer:, **extra)
+    track_event(
+      'SP Revoke Consent: Revoked',
+      issuer: issuer,
+      **extra,
+    )
+  end
+
+  # Tracks when the page to revoke consent (unlink from) a service provider visited
+  # @param [String] issuer which issuer
+  def sp_revoke_consent_visited(issuer:, **extra)
+    track_event(
+      'SP Revoke Consent: Visited',
+      issuer: issuer,
+      **extra,
+    )
+  end
+
   # User visited form to change email shared with service provider
   # @param [String, nil] needs_completion_screen_reason Reason for the consent screen being shown,
   # if user is changing email in consent flow
@@ -6138,26 +6158,6 @@ module AnalyticsEvents
       success:,
       error_details:,
       needs_completion_screen_reason:,
-      **extra,
-    )
-  end
-
-  # Tracks when service provider consent is revoked
-  # @param [String] issuer issuer of the service provider consent to be revoked
-  def sp_revoke_consent_revoked(issuer:, **extra)
-    track_event(
-      'SP Revoke Consent: Revoked',
-      issuer: issuer,
-      **extra,
-    )
-  end
-
-  # Tracks when the page to revoke consent (unlink from) a service provider visited
-  # @param [String] issuer which issuer
-  def sp_revoke_consent_visited(issuer:, **extra)
-    track_event(
-      'SP Revoke Consent: Visited',
-      issuer: issuer,
       **extra,
     )
   end

--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -7,10 +7,29 @@
     <% end %>
   </h2>
 
-  <%= t(
-        'account.connected_apps.associated_html',
-        timestamp_html: render(TimeComponent.new(time: identity.created_at)),
-      ) %>
+  <% if IdentityConfig.store.feature_select_email_to_share_enabled %>
+    <%= t(
+          'account.connected_apps.associated_attributes_html',
+          timestamp_html: render(TimeComponent.new(time: identity.created_at)),
+        ) %>
+    <br />
+    <strong>
+      <% if identity.email_address_id %>
+        <%= identity.email_address.email %>
+      <% else %>
+        <%= t('account.connected_apps.email_not_selected') %>
+      <% end %>
+    </strong>
+    <%= link_to(
+          t('help_text.requested_attributes.change_email_link'),
+          edit_connected_account_selected_email_path(identity_id: identity.id),
+        ) %>
+  <% else %>
+    <%= t(
+          'account.connected_apps.associated_html',
+          timestamp_html: render(TimeComponent.new(time: identity.created_at)),
+        ) %>
+  <% end %>
 
   <% if identity.service_provider_id %>
     <div class="margin-y-1">

--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -14,11 +14,7 @@
         ) %>
     <br />
     <strong>
-      <% if identity.email_address_id %>
-        <%= identity.email_address.email %>
-      <% else %>
-        <%= t('account.connected_apps.email_not_selected') %>
-      <% end %>
+      <%= identity.email_address&.email || t('account.connected_apps.email_not_selected') %>
     </strong>
     <%= link_to(
           t('help_text.requested_attributes.change_email_link'),

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -1,0 +1,40 @@
+<% self.title = t('titles.select_email') %>
+
+<%= render StatusPageComponent.new(status: :info, icon: :question) do |c| %>
+  <% c.with_header { t('titles.select_email') } %>
+
+  <p id="select-email-intro">
+    <%= t('help_text.select_preferred_email', sp: @identity.display_name, app_name: APP_NAME) %>
+  </p>
+
+  <%= simple_form_for(
+        @select_email_form,
+        url: connected_account_selected_email_path(@identity.id),
+        method: :patch,
+      ) do |f| %>
+    <%= f.input(
+          :selected_email_id,
+          as: :radio_buttons,
+          label: false,
+          wrapper_html: { aria: { labelledby: 'select-email-intro' } },
+          collection: current_user.confirmed_email_addresses.map do |email|
+            [
+              email.email,
+              email.id,
+              checked: email.id == @identity.email_address_id,
+            ]
+          end,
+        ) %>
+    <%= f.submit t('help_text.requested_attributes.change_email_link'), class: 'margin-top-1' %>
+  <% end %>
+
+  <%= render ButtonComponent.new(
+        url: add_email_path,
+        outline: true,
+        big: true,
+        wide: true,
+        class: 'margin-top-2',
+      ).with_content(t('account.index.email_add')) %>
+
+  <% c.with_footer { link_to t('forms.buttons.back'), account_connected_accounts_path } %>
+<% end %>

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -1,7 +1,7 @@
 <% self.title = t('titles.select_email') %>
 
 <%= render StatusPageComponent.new(status: :info, icon: :question) do |c| %>
-  <% c.with_header { t('titles.select_email') } %>
+  <% c.with_header(id: 'select-email-heading') { t('titles.select_email') } %>
 
   <p id="select-email-intro">
     <%= t('help_text.select_preferred_email', sp: @identity.display_name, app_name: APP_NAME) %>
@@ -9,14 +9,19 @@
 
   <%= simple_form_for(
         @select_email_form,
-        url: connected_account_selected_email_path(@identity.id),
+        url: connected_account_selected_email_path(identity_id: @identity.id),
         method: :patch,
       ) do |f| %>
     <%= f.input(
           :selected_email_id,
           as: :radio_buttons,
           label: false,
-          wrapper_html: { aria: { labelledby: 'select-email-intro' } },
+          wrapper_html: {
+            aria: {
+              labelledby: 'select-email-heading',
+              describedby: 'select-email-intro',
+            },
+          },
           collection: current_user.confirmed_email_addresses.map do |email|
             [
               email.email,

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -30,7 +30,7 @@
             ]
           end,
         ) %>
-    <%= f.submit t('help_text.requested_attributes.change_email_link'), class: 'margin-top-1' %>
+    <%= f.submit(t('help_text.requested_attributes.change_email_link'), class: 'margin-top-1') %>
   <% end %>
 
   <%= render ButtonComponent.new(

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -92,7 +92,7 @@ SimpleForm.setup do |config|
                     item_wrapper_tag: nil,
                     item_label_class: item_label_class do |b|
       b.use :html5_no_aria_required
-      b.optional :label_text, wrap_with: { tag: 'legend', class: legend_class }
+      b.optional :label, wrap_with: { tag: 'legend', class: legend_class }
       b.optional :hint, wrap_with: { tag: 'div', class: 'usa-hint margin-bottom-05' }
       b.wrapper :grid_row, tag: :div, class: 'grid-row margin-bottom-neg-1' do |gr|
         gr.wrapper :grid_column_radios, tag: :div, class: 'grid-col-fill' do |gc|

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -92,9 +92,7 @@ SimpleForm.setup do |config|
                     item_wrapper_tag: nil,
                     item_label_class: item_label_class do |b|
       b.use :html5_no_aria_required
-      b.wrapper :legend, tag: 'legend', class: legend_class do |ba|
-        ba.use :label_text
-      end
+      b.optional :label_text, wrap_with: { tag: 'legend', class: legend_class }
       b.optional :hint, wrap_with: { tag: 'div', class: 'usa-hint margin-bottom-05' }
       b.wrapper :grid_row, tag: :div, class: 'grid-row margin-bottom-neg-1' do |gr|
         gr.wrapper :grid_column_radios, tag: :div, class: 'grid-col-fill' do |gc|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,8 +38,10 @@ account_reset.request.info:
 account_reset.request.no_cancel: Cancel
 account_reset.request.title: Account deletion and reset
 account_reset.request.yes_continue: Yes, continue deletion
+account.connected_apps.associated_attributes_html: 'Connected %{timestamp_html} with:'
 account.connected_apps.associated_html: Connected %{timestamp_html}
 account.connected_apps.description: With your %{app_name} account, you can securely connect to multiple government accounts online. Below is a list of all the accounts you currently have connected.
+account.connected_apps.email_not_selected: Email not yet selected
 account.email_language.default: '%{language} (default)'
 account.email_language.edit_title: Edit email language preference
 account.email_language.languages_list: You will receive emails from %{app_name} in the language you choose.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -38,8 +38,10 @@ account_reset.request.info:
 account_reset.request.no_cancel: Cancelar
 account_reset.request.title: Eliminación y restablecimiento de cuenta
 account_reset.request.yes_continue: Sí, continuar con la eliminación
+account.connected_apps.associated_attributes_html: 'Conectado el %{timestamp_html} con:'
 account.connected_apps.associated_html: 'Conectado: %{timestamp_html}'
 account.connected_apps.description: Con su cuenta de %{app_name}, puede conectarse de manera segura a muchas cuentas del gobierno en línea. Esta es una lista de todas las cuentas que tiene conectadas actualmente.
+account.connected_apps.email_not_selected: Email not yet selected
 account.email_language.default: '%{language} (predeterminado)'
 account.email_language.edit_title: Editar la preferencia de idioma del correo electrónico
 account.email_language.languages_list: Recibirá mensajes de correo electrónico de %{app_name} en el idioma que elija.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -38,8 +38,10 @@ account_reset.request.info:
 account_reset.request.no_cancel: Annuler
 account_reset.request.title: Suppression et réinitialisation de compte
 account_reset.request.yes_continue: Oui, continuer la suppression
+account.connected_apps.associated_attributes_html: 'Connecté %{timestamp_html} avec :'
 account.connected_apps.associated_html: Connecté %{timestamp_html}
 account.connected_apps.description: Avec votre compte %{app_name}, vous pouvez vous connecter en toute sécurité à plusieurs comptes de l’administration en ligne. Vous trouverez ci-dessous une liste de tous vos comptes actuellement connectés.
+account.connected_apps.email_not_selected: Email not yet selected
 account.email_language.default: '%{language} (par défaut)'
 account.email_language.edit_title: Modifier la langue dans laquelle vous préférez recevoir les e-mails
 account.email_language.languages_list: Vous recevrez des e-mails de %{app_name} dans la langue de votre choix.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -38,8 +38,10 @@ account_reset.request.info:
 account_reset.request.no_cancel: 取消
 account_reset.request.title: 账户删除和重设
 account_reset.request.yes_continue: 是的，继续删除
+account.connected_apps.associated_attributes_html: '在 %{timestamp_html} 用以下电邮做的连接：'
 account.connected_apps.associated_html: 已连接 %{timestamp_html}
 account.connected_apps.description: 使用你的 %{app_name} 账户，你可以安全地连接到网上多个政府账户。以下列出了你目前已连接的所有账户。
+account.connected_apps.email_not_selected: Email not yet selected
 account.email_language.default: '%{language} （默认）'
 account.email_language.edit_title: 编辑电邮语言选择
 account.email_language.languages_list: 您将收到%{app_name}用您选择的语言发送的电子邮件。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,6 +198,10 @@ Rails.application.routes.draw do
 
     get '/account' => 'accounts#show'
     get '/account/connected_accounts' => 'accounts/connected_accounts#show'
+    get '/account/connected_accounts/:identity_id/selected_email' => 'accounts/connected_accounts/selected_email#edit',
+        as: :edit_connected_account_selected_email
+    patch '/account/connected_accounts/:identity_id/selected_email' => 'accounts/connected_accounts/selected_email#update',
+          as: :connected_account_selected_email
     post '/account/reauthentication' => 'accounts#reauthentication'
     get '/account/devices/:id/events' => 'events#show', as: :account_events
     get '/account/delete' => 'users/delete#show', as: :account_delete

--- a/spec/components/status_page_component_spec.rb
+++ b/spec/components/status_page_component_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe StatusPageComponent, type: :component do
     expect(rendered).to have_link('Option', href: '/')
   end
 
+  it 'renders page footer' do
+    rendered = render_inline(StatusPageComponent.new) do |c|
+      c.with_footer.with_content('Footer')
+    end
+
+    expect(rendered).to have_content('Footer')
+  end
+
   it 'validates status' do
     expect do
       render_inline StatusPageComponent.new(status: :foo)

--- a/spec/components/status_page_component_spec.rb
+++ b/spec/components/status_page_component_spec.rb
@@ -59,12 +59,10 @@ RSpec.describe StatusPageComponent, type: :component do
     expect(rendered).to have_link('Option', href: '/')
   end
 
-  it 'renders page footer' do
-    rendered = render_inline(StatusPageComponent.new) do |c|
-      c.with_footer.with_content('Footer')
-    end
+  it 'does not render page footer' do
+    rendered = render_inline(StatusPageComponent.new)
 
-    expect(rendered).to have_content('Footer')
+    expect(rendered).not_to have_css('.page-footer')
   end
 
   it 'validates status' do
@@ -83,5 +81,15 @@ RSpec.describe StatusPageComponent, type: :component do
     expect do
       render_inline StatusPageComponent.new(status: :info)
     end.to raise_error(ActiveModel::ValidationError)
+  end
+
+  context 'with footer' do
+    it 'renders page footer' do
+      rendered = render_inline(StatusPageComponent.new) do |c|
+        c.with_footer.with_content('Footer')
+      end
+
+      expect(rendered).to have_css('.page-footer', text: 'Footer')
+    end
   end
 end

--- a/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
+++ b/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
         expect(response).to redirect_to new_user_session_path
       end
     end
+
+    context 'with selected email to share feature disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:feature_select_email_to_share_enabled).
+          and_return(false)
+      end
+
+      it 'renders 404' do
+        expect(response).to be_not_found
+      end
+    end
   end
 
   describe '#update' do
@@ -97,6 +108,17 @@ RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
 
       it 'redirects to sign in' do
         expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    context 'with selected email to share feature disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:feature_select_email_to_share_enabled).
+          and_return(false)
+      end
+
+      it 'renders 404' do
+        expect(response).to be_not_found
       end
     end
   end

--- a/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
+++ b/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
+  let(:identity) { create(:service_provider_identity, :active) }
+  let(:user) { create(:user, :with_multiple_emails, identities: [identity]) }
+
+  before do
+    stub_sign_in(user) if user
+  end
+
+  describe '#edit' do
+    let(:identity_id) { user.identities.take.id }
+    let(:params) { { identity_id: } }
+    subject(:response) { get :edit, params: }
+
+    it 'logs analytics event' do
+      stub_analytics
+
+      response
+
+      expect(@analytics).to have_logged_event(:sp_select_email_visited)
+    end
+
+    it 'assigns view variables' do
+      response
+
+      expect(assigns(:identity)).to be_kind_of(ServiceProviderIdentity)
+      expect(assigns(:select_email_form)).to be_kind_of(SelectEmailForm)
+    end
+
+    context 'with an identity parameter not associated with the user' do
+      let(:other_user) { create(:user, identities: [create(:service_provider_identity, :active)]) }
+      let(:identity_id) { other_user.identities.take.id }
+
+      it 'renders 404' do
+        expect(response).to be_not_found
+      end
+    end
+
+    context 'signed out' do
+      let(:other_user) { create(:user, identities: [create(:service_provider_identity, :active)]) }
+      let(:identity_id) { other_user.identities.take.id }
+      let(:user) { nil }
+
+      it 'redirects to sign in' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:identity_id) { user.identities.take.id }
+    let(:selected_email) { user.confirmed_email_addresses.sample }
+    let(:params) { { identity_id:, select_email_form: { selected_email_id: selected_email.id } } }
+    subject(:response) { patch :update, params: }
+
+    it 'redirects to connected accounts path' do
+      expect(response).to redirect_to(account_connected_accounts_path)
+    end
+
+    it 'logs analytics event' do
+      stub_analytics
+
+      response
+
+      expect(@analytics).to have_logged_event(:sp_select_email_submitted, success: true)
+    end
+
+    context 'with invalid submission' do
+      let(:params) { super().merge(select_email_form: { selected_email_id: nil }) }
+
+      it 'redirects to form with flash' do
+        expect(response).to redirect_to(edit_connected_account_selected_email_path(identity.id))
+        expect(flash[:error]).to eq(t('email_address.not_found'))
+      end
+
+      it 'logs analytics event' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(
+          :sp_select_email_submitted,
+          success: false,
+          error_details: { selected_email_id: { not_found: true } },
+        )
+      end
+    end
+
+    context 'signed out' do
+      let(:other_user) { create(:user, identities: [create(:service_provider_identity, :active)]) }
+      let(:selected_email) { other_user.confirmed_email_addresses.sample }
+      let(:identity_id) { other_user.identities.take.id }
+      let(:user) { nil }
+
+      it 'redirects to sign in' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+end

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe SignUp::SelectEmailController do
+  let(:user) { create(:user) }
+  let(:sp) { create(:service_provider) }
+
+  before do
+    stub_sign_in(user)
+    allow(controller).to receive(:current_sp).and_return(sp)
+    allow(controller).to receive(:needs_completion_screen_reason).and_return(:new_attributes)
+  end
+
   describe 'before_actions' do
     it 'requires the user be logged in and authenticated' do
       expect(subject).to have_actions(
@@ -17,36 +26,68 @@ RSpec.describe SignUp::SelectEmailController do
     end
   end
 
+  describe '#show' do
+    subject(:response) { get :show }
+
+    it 'assigns view variables' do
+      response
+
+      expect(assigns(:sp_name)).to be_kind_of(String)
+      expect(assigns(:user_emails)).to all be_kind_of(EmailAddress)
+      expect(assigns(:last_sign_in_email_address)).to be_kind_of(String)
+      expect(assigns(:select_email_form)).to be_kind_of(SelectEmailForm)
+    end
+
+    context 'with selected email to share feature disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:feature_select_email_to_share_enabled).
+          and_return(false)
+      end
+
+      it 'renders 404' do
+        expect(response).to be_not_found
+      end
+    end
+  end
+
   describe '#create' do
     let(:email) { 'michael.motorist@email.com' }
     let(:email2) { 'michael.motorist2@email.com' }
     let(:email3) { 'david.motorist@email.com' }
-    let(:user) { create(:user) }
+    let(:params) { { selected_email_id: email2 } }
+
+    subject(:response) { post :create, params: params }
 
     before do
-      user.email_addresses = []
       create(:email_address, user:, email: email)
       create(:email_address, user:, email: email2)
     end
 
     it 'updates selected email address' do
-      post :create, params: { selected_email_id: email2 }
+      response
 
       expect(user.email_addresses.last.email).
         to include('michael.motorist2@email.com')
     end
 
     context 'with a corrupted email selected_email_id form' do
-      render_views
-      it 'rejects email not belonging to the user' do
-        stub_sign_in(user)
-        allow(controller).to receive(:needs_completion_screen_reason).and_return(true)
-        post :create, params: { selected_email_id: email3 }
+      let(:params) { { selected_email_id: email3 } }
 
+      it 'rejects email not belonging to the user' do
+        expect(response).to redirect_to(sign_up_select_email_path)
         expect(user.email_addresses.last.email).
           to include('michael.motorist2@email.com')
+      end
+    end
 
-        expect(response).to redirect_to(sign_up_select_email_path)
+    context 'with selected email to share feature disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:feature_select_email_to_share_enabled).
+          and_return(false)
+      end
+
+      it 'renders 404' do
+        expect(response).to be_not_found
       end
     end
   end

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Account connected applications' do
   include NavigationHelper
 
   let(:user) { create(:user, :fully_registered, created_at: Time.zone.now - 100.days) }
-  let(:identity_with_link) do
+  let(:identity) do
     create(
       :service_provider_identity,
       :active,
@@ -22,8 +22,8 @@ RSpec.describe 'Account connected applications' do
       service_provider: 'https://rp2.serviceprovider.com/auth/saml/metadata',
     )
   end
-  let(:identity_with_link_timestamp) do
-    identity_with_link.created_at.utc.strftime(t('time.formats.event_timestamp'))
+  let(:identity_timestamp) do
+    identity.created_at.utc.strftime(t('time.formats.event_timestamp'))
   end
   let(:identity_without_link_timestamp) do
     identity_without_link.created_at.utc.strftime(t('time.formats.event_timestamp'))
@@ -38,7 +38,7 @@ RSpec.describe 'Account connected applications' do
   scenario 'viewing account connected applications' do
     expect(page).to have_content(t('headings.account.connected_accounts'))
 
-    expect(identity_without_link_timestamp).to appear_before(identity_with_link_timestamp)
+    expect(identity_without_link_timestamp).to appear_before(identity_timestamp)
 
     within_sidenav { click_on t('account.navigation.history') }
     expect(page).to have_content(
@@ -49,39 +49,57 @@ RSpec.describe 'Account connected applications' do
     expect(page).to have_content(
       t(
         'event_types.authenticated_at_html',
-        service_provider_link_html: identity_with_link.display_name,
+        service_provider_link_html: identity.display_name,
       ),
     )
     expect(page).to have_link(
-      identity_with_link.display_name, href: 'http://localhost:3000'
+      identity.display_name, href: 'http://localhost:3000'
     )
   end
 
   scenario 'revoking consent from an SP' do
-    identity_to_revoke = identity_with_link
-
-    within('li', text: identity_to_revoke.display_name) do
+    within('li', text: identity.display_name) do
       click_link(t('account.revoke_consent.link_title'))
     end
 
-    expect(page).to have_content(identity_to_revoke.display_name)
+    expect(page).to have_content(identity.display_name)
 
     # Canceling should return to the Connected Accounts page
     click_on t('links.cancel')
     expect(page).to have_current_path(account_connected_accounts_path)
 
     # Revoke again and confirm revocation
-    within('li', text: identity_to_revoke.display_name) do
+    within('li', text: identity.display_name) do
       click_link(t('account.revoke_consent.link_title'))
     end
     click_on t('forms.buttons.continue')
 
     # Accounts page should no longer list this app in the applications section
-    expect(page).to_not have_content(identity_to_revoke.display_name)
+    expect(page).to_not have_content(identity.display_name)
+  end
+
+  scenario 'changing email shared with SP' do
+    within('li', text: identity.display_name) do
+      expect(page).to have_content(t('account.connected_apps.email_not_selected'))
+      click_link(t('help_text.requested_attributes.change_email_link'))
+    end
+
+    expect(page).to have_field(user.email) { |field| !field[:checked] }
+
+    choose user.email
+    click_on t('help_text.requested_attributes.change_email_link')
+
+    within('li', text: identity.display_name) do
+      expect(page).not_to have_content(t('account.connected_apps.email_not_selected'))
+      expect(page).to have_content(user.email)
+      click_link(t('help_text.requested_attributes.change_email_link'))
+    end
+
+    expect(page).to have_field(user.email) { |field| field[:checked] }
   end
 
   def build_account_connected_apps
-    identity_with_link
+    identity
     identity_without_link
   end
 end

--- a/spec/features/visitors/email_language_preference_spec.rb
+++ b/spec/features/visitors/email_language_preference_spec.rb
@@ -9,11 +9,14 @@ RSpec.describe 'visitor signs up with email language preference' do
     )
     expect(field).to be_present
     expect(field[:lang]).to eq(I18n.default_locale.to_s)
+    fields = [field]
     (I18n.available_locales - [I18n.default_locale]).each do |locale|
       field = page.find_field(t("i18n.locale.#{locale}"))
       expect(field).to be_present
       expect(field[:lang]).to eq(locale.to_s)
+      fields << field
     end
+    expect(fields).to be_logically_grouped(t('forms.registration.labels.email_language'))
 
     visit sign_up_email_path(:es)
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -76,6 +76,7 @@ module I18n
         { key: 'time.formats.event_timestamp', locales: %i[zh] },
         { key: 'time.formats.full_date', locales: %i[es] }, # format is the same in Spanish and English
         { key: 'time.formats.sms_date' }, # for us date format
+        { key: 'account.connected_apps.email_not_selected' }, # See: LG-?????
       ].freeze
       # rubocop:enable Layout/LineLength
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -76,7 +76,7 @@ module I18n
         { key: 'time.formats.event_timestamp', locales: %i[zh] },
         { key: 'time.formats.full_date', locales: %i[es] }, # format is the same in Spanish and English
         { key: 'time.formats.sms_date' }, # for us date format
-        { key: 'account.connected_apps.email_not_selected' }, # See: LG-?????
+        { key: 'account.connected_apps.email_not_selected' }, # See: LG-14398
       ].freeze
       # rubocop:enable Layout/LineLength
 

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -348,6 +348,22 @@ RSpec.describe AccountShowPresenter do
     end
   end
 
+  describe '#connected_apps' do
+    let(:user) { create(:user, identities: [create(:service_provider_identity)]) }
+    subject(:connected_apps) { presenter.connected_apps }
+
+    it 'delegates to user, eager-loading view-specific relations' do
+      expect(connected_apps).to be_present.
+        and eq(user.connected_apps).
+        and all(
+          satisfy do |app|
+            app.association(:service_provider_record).loaded? &&
+              app.association(:email_address).loaded?
+          end,
+        )
+    end
+  end
+
   describe '#backup_codes_generated_at' do
     it 'returns the created_at date of the oldest backup code' do
       user = create(:user)

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -119,7 +119,9 @@ RSpec::Matchers.define :have_description do |description|
       map { |descriptor_id| page.find("##{descriptor_id}")&.text }
   end
 
-  match { |element| descriptors(element)&.include?(description) }
+  match do |element|
+    descriptors(element)&.any? { |descriptor| descriptor.strip == description }
+  end
 
   failure_message do |element|
     <<-STR.squish

--- a/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
+  let(:identity) { create(:service_provider_identity, :active) }
+  let(:user) do
+    create(
+      :user,
+      email_addresses: [
+        create(:email_address),
+        create(:email_address),
+        create(:email_address, :unconfirmed),
+      ],
+      identities: [identity],
+    )
+  end
+
+  subject(:rendered) { render }
+
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+    @identity = identity
+    @select_email_form = SelectEmailForm.new(user:, identity:)
+  end
+
+  it 'renders a list of the users email addresses as radio options' do
+    allow(self).to receive(:page).and_return(Capybara.string(rendered))
+    inputs = page.find_all('[type="radio"]')
+    expect(inputs.count).to eq(2)
+    expect(inputs).to be_logically_grouped(t('titles.select_email'))
+    fieldset = page.find('fieldset')
+    expect(fieldset).to have_description(
+      t('help_text.select_preferred_email', sp: identity.display_name, app_name: APP_NAME),
+    )
+  end
+end

--- a/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
+
 RSpec.describe 'accounts/connected_accounts/show.html.erb' do
   let(:user) { create(:user, :fully_registered, :with_personal_key) }
+  let(:feature_select_email_to_share_enabled) { true }
 
   before do
     allow(view).to receive(:current_user).and_return(user)
+    allow(IdentityConfig.store).to receive(:feature_select_email_to_share_enabled).
+      and_return(feature_select_email_to_share_enabled)
     assign(
       :presenter,
       AccountShowPresenter.new(
@@ -17,10 +21,79 @@ RSpec.describe 'accounts/connected_accounts/show.html.erb' do
     )
   end
 
-  it 'contains connected applications' do
+  it 'renders a blank page' do
+    # Blank page may not be the ideal behavior, but it's the expected one.
+    # See: LG-3504
     render
 
-    expect(rendered).to have_content t('headings.account.connected_accounts')
+    expect(rendered).to have_content(t('headings.account.connected_accounts'))
+    expect(rendered).to have_css('ul:not(:has(li))')
+  end
+
+  context 'with a connected app' do
+    let!(:identity) { create(:service_provider_identity, user:) }
+
+    it 'lists applications with link to revoke' do
+      render
+
+      expect(rendered).to have_css('li', count: user.identities.count)
+
+      page = Capybara.string(rendered.html)
+      within page.find_css('li', text: user.identities.first.display_name) do
+        expect(rendered).to have_link(t('account.revoke_consent.link_title'))
+      end
+    end
+
+    it 'renders option to change email' do
+      render
+
+      expect(rendered).to have_content(t('account.connected_apps.email_not_selected'))
+      expect(rendered).to have_link(
+        t('help_text.requested_attributes.change_email_link'),
+        href: edit_connected_account_selected_email_path(identity_id: identity.id),
+      )
+    end
+
+    context 'with selected email to share feature disabled' do
+      let(:feature_select_email_to_share_enabled) { false }
+
+      it 'does not render option to change email' do
+        render
+
+        expect(rendered).not_to have_content(t('account.connected_apps.email_not_selected'))
+        expect(rendered).not_to have_link(
+          t('help_text.requested_attributes.change_email_link'),
+          href: edit_connected_account_selected_email_path(identity_id: identity.id),
+        )
+      end
+    end
+
+    context 'with connected app having linked email' do
+      let(:email_address) { user.confirmed_email_addresses.take }
+      let!(:identity) do
+        create(:service_provider_identity, user:, email_address_id: email_address.id)
+      end
+
+      it 'renders associated email with option to change' do
+        render
+
+        expect(rendered).to have_content(email_address.email)
+        expect(rendered).to have_link(
+          t('help_text.requested_attributes.change_email_link'),
+          href: edit_connected_account_selected_email_path(identity_id: identity.id),
+        )
+      end
+
+      context 'with selected email to share feature disabled' do
+        let(:feature_select_email_to_share_enabled) { false }
+
+        it 'does not render associated email' do
+          render
+
+          expect(rendered).not_to have_content(email_address.email)
+        end
+      end
+    end
   end
 
   context 'with a connected app that is an invalid service provider' do

--- a/spec/views/sign_up/select_email/show.html.erb_spec.rb
+++ b/spec/views/sign_up/select_email/show.html.erb_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe 'sign_up/select_email/show.html.erb' do
   let(:user) { create(:user) }
 
   before do
-    user.email_addresses.create(email: email, confirmed_at: Time.zone.now)
-    user.email_addresses.create(email: email2, confirmed_at: Time.zone.now)
-    user.reload
-    @user_emails = user.email_addresses
-    @select_email_form = SelectEmailForm.new(user)
+    create(:email_address, email: email, user:)
+    create(:email_address, email: email2, user:)
+    @user_emails = user.confirmed_email_addresses
+    @select_email_form = SelectEmailForm.new(user:)
   end
 
   it 'shows all of the user\'s emails' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-13665](https://cm-jira.usa.gov/browse/LG-13665)

## 🛠 Summary of changes

Adds a new flow to allow a user to change their selected email shared with a partner from their Connected Accounts dashboard screen.

## 📜 Testing Plan

1. Go http://localhost:3000
2. Sign in
3. From account dashboard, click "Connected Accounts" in sidebar
4. (If you don't have any connected accounts, sign in and consent using [sample application](https://github.com/18f/identity-oidc-sinatra))
5. Observe:
   1. If you have selected a specific email to be changed (either from consent screen or from the following steps), it is shown
   2. Otherwise, you see "Email not yet selected"
7. Click "Change"
8. Change your selected email (you may need to _add_ a second email first, unless you have "Not yet selected")
9. Click "Submit"
10. Repeat Step 5

## 👀 Screenshots

![image](https://github.com/user-attachments/assets/5d7d1141-883a-4f4e-a959-be3a0edcbbeb)
