### PR TITLE
Rearrange conditions to short-circuit before database queries

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -363,7 +363,7 @@ class ApplicationController < ActionController::Base
   def sp_required_mfa_verification_url
     return login_two_factor_piv_cac_url if service_provider_mfa_policy.piv_cac_required?
 
-    if TwoFactorAuthentication::PivCacPolicy.new(current_user).enabled? && !mobile?
+    if !mobile? && TwoFactorAuthentication::PivCacPolicy.new(current_user).enabled?
       login_two_factor_piv_cac_url
     elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user).platform_enabled?
       login_two_factor_webauthn_url(platform: true)

--- a/app/controllers/concerns/mfa_setup_concern.rb
+++ b/app/controllers/concerns/mfa_setup_concern.rb
@@ -82,7 +82,7 @@ module MfaSetupConcern
   end
 
   def check_if_possible_piv_user
-    if current_user.has_fed_or_mil_email? && current_user.piv_cac_recommended_dismissed_at.nil?
+    if current_user.piv_cac_recommended_dismissed_at.nil? && current_user.has_fed_or_mil_email?
       redirect_to login_piv_cac_recommended_path
     end
   end

--- a/app/forms/recaptcha_form.rb
+++ b/app/forms/recaptcha_form.rb
@@ -51,7 +51,7 @@ class RecaptchaForm
   # @return [Array(Boolean, String), Array(Boolean, nil)]
   def submit(recaptcha_token)
     @recaptcha_token = recaptcha_token
-    @recaptcha_result = recaptcha_result if !exempt? && recaptcha_token.present?
+    @recaptcha_result = recaptcha_result if recaptcha_token.present? && !exempt?
 
     log_analytics(result: @recaptcha_result) if @recaptcha_result
     response = FormResponse.new(success: valid?, errors:, serialize_error_details_only: true)

--- a/app/forms/webauthn_visit_form.rb
+++ b/app/forms/webauthn_visit_form.rb
@@ -27,7 +27,7 @@ class WebauthnVisitForm
   end
 
   def current_mfa_setup_path
-    if mfa_user.two_factor_enabled? && !in_mfa_selection_flow
+    if !in_mfa_selection_flow && mfa_user.two_factor_enabled?
       account_path
     else
       authentication_methods_setup_path

--- a/app/presenters/two_factor_options_presenter.rb
+++ b/app/presenters/two_factor_options_presenter.rb
@@ -94,7 +94,7 @@ class TwoFactorOptionsPresenter
   def skip_path
     if show_cancel_return_to_sp?
       return_to_sp_cancel_path
-    elsif two_factor_enabled? && show_skip_additional_mfa_link?
+    elsif show_skip_additional_mfa_link? && two_factor_enabled?
       after_mfa_setup_path
     end
   end

--- a/app/services/user_event_creator.rb
+++ b/app/services/user_event_creator.rb
@@ -78,7 +78,7 @@ class UserEventCreator
 
   # @return [Array(Event, String)] an (event, disavowal_token) tuple
   def create_event_for_new_device(event_type:, user:, disavowal_token:)
-    if user.fully_registered? && user.has_devices? && disavowal_token.nil?
+    if disavowal_token.nil? && user.fully_registered? && user.has_devices?
       device, event, disavowal_token = Device.transaction do
         device = create_device_for_user(user)
         event, disavowal_token = create_user_event_with_disavowal(event_type, user, device)


### PR DESCRIPTION
## 🛠 Summary of changes

Rearranges a handful of `&&` conditions to move trivial-cost checks to earlier in the condition, leveraging boolean short-circuiting to avoid more costly checks.

These were discovered by searching ` && ` in `app/**/*.rb` files and manually reviewing each instance.

## 📜 Testing Plan

Verify build passes.

It's not expected this should have a meaningful impact, but there may be scenarios where a condition was already written with short-circuiting in mind, where the latter part of a condition relies on a dependency established in an earlier part. Those have been considered as part of these changes, but a secondary review is appreciated.