### PR TITLE
Touch up code related to "account_verified" email

### DIFF
--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -109,7 +109,7 @@ module Idv
             sp_name: decorated_sp_session.sp_name,
           )
           flash[:success] = t('account.index.verification.success')
-      end
+        end
 
         idv_session.address_verification_mechanism = 'gpo'
         idv_session.address_confirmed!

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -242,8 +242,7 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  # remove disavowal_token after next deploy
-  def account_verified(date_time:, sp_name:, disavowal_token: nil) # rubocop:disable Lint/UnusedMethodArgument
+  def account_verified(date_time:, sp_name:)
     with_user_locale(user) do
       @date = I18n.l(date_time, format: :event_date)
       @sp_name = sp_name

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -147,7 +147,6 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.with(user: user, email_address: email_address_record).account_verified(
       date_time: DateTime.now,
       sp_name: 'Example App',
-      disavowal_token: SecureRandom.hex,
     )
   end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -517,15 +517,11 @@ RSpec.describe UserMailer, type: :mailer do
   end
 
   describe '#account_verified' do
-    disavowal_token = 'i_am_disavowal_token'
     let(:sp_name) { '' }
     let(:date_time) { Time.zone.now }
     let(:mail) do
       UserMailer.with(user: user, email_address: email_address).
-        account_verified(
-          date_time: date_time, sp_name: sp_name,
-          disavowal_token: disavowal_token
-        )
+        account_verified(date_time: date_time, sp_name: sp_name)
     end
 
     it_behaves_like 'a system email'


### PR DESCRIPTION
I noticed these 2 cleanup opportunities while working on a new account verified email:

- There is some out-of-place indentation in `EnterCodeController`
- There is a comment saying to remove an argument in the next deploy. The next deploy after that comment was added was ~150 deploys ago.

This commit cleans up both
