### PR TITLE
Log more context of contextless KMS

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -14,6 +14,7 @@ module UserAccessKeyOverrides
       password: password,
       digest_pair: password_regional_digest_pair,
       user_uuid: uuid,
+      log_context: 'password-digest',
     )
     @password = password if result
     result
@@ -41,6 +42,7 @@ module UserAccessKeyOverrides
       password: normalized_personal_key,
       digest_pair: recovery_code_regional_digest_pair,
       user_uuid: uuid,
+      log_context: 'personal-key',
     )
   end
 

--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -70,10 +70,12 @@ module Encryption
       )
     end
 
-    def verify(password:, digest_pair:, user_uuid:)
+    def verify(password:, digest_pair:, user_uuid:, log_context:)
       digest = digest_pair.multi_or_single_region_ciphertext
       password_digest = PasswordDigest.parse_from_string(digest)
-      return verify_uak_digest(password, digest) if password_digest.uak_password_digest?
+      if password_digest.uak_password_digest?
+        return verify_uak_digest(password, digest, user_uuid, log_context)
+      end
 
       verify_password_against_digest(
         password: password,
@@ -122,8 +124,13 @@ module Encryption
       }
     end
 
-    def verify_uak_digest(password, digest)
-      UakPasswordVerifier.verify(password: password, digest: digest)
+    def verify_uak_digest(password, digest, user_uuid, log_context)
+      UakPasswordVerifier.verify(
+        password: password,
+        digest: digest,
+        user_uuid: user_uuid,
+        log_context: log_context,
+      )
     end
 
     add_method_tracer :create_digest_pair, "Custom/#{name}/create_digest_pair"

--- a/app/services/encryption/uak_password_verifier.rb
+++ b/app/services/encryption/uak_password_verifier.rb
@@ -42,13 +42,15 @@ module Encryption
       ).to_s
     end
 
-    def self.verify(password:, digest:)
+    def self.verify(password:, digest:, user_uuid:, log_context:)
       return false if password.blank?
       parsed_digest = PasswordDigest.parse_from_string(digest)
       uak = UserAccessKey.new(
         password: password,
         salt: parsed_digest.password_salt,
         cost: parsed_digest.password_cost,
+        user_uuid: user_uuid,
+        log_context: log_context,
       )
       uak.unlock(parsed_digest.encryption_key)
       Devise.secure_compare(uak.encrypted_password, parsed_digest.encrypted_password)

--- a/app/services/encryption/user_access_key.rb
+++ b/app/services/encryption/user_access_key.rb
@@ -16,7 +16,8 @@ module Encryption
 
     attr_reader :cost, :salt, :z1, :z2, :random_r, :masked_ciphertext, :cek
 
-    def initialize(password: nil, salt: nil, cost: nil, scrypt_hash: nil)
+    # rubocop:disable Layout/LineLength
+    def initialize(password: nil, salt: nil, cost: nil, scrypt_hash: nil, user_uuid: nil, log_context: nil)
       cost ||= IdentityConfig.store.scrypt_cost
       scrypt_password = if scrypt_hash.present?
                           SCrypt::Password.new(scrypt_hash)
@@ -26,7 +27,10 @@ module Encryption
       self.cost = scrypt_password.cost
       self.salt = scrypt_password.salt
       self.z1, self.z2 = split_scrypt_digest(scrypt_password.digest)
+      @user_uuid = user_uuid
+      @log_context = log_context
     end
+    # rubocop:enable Layout/LineLength
 
     def as_scrypt_hash
       "#{cost}#{salt}$#{z1}#{z2}"
@@ -45,7 +49,13 @@ module Encryption
       self.masked_ciphertext = Base64.strict_decode64(encryption_key_arg)
       z1_padded = z1.dup.rjust(masked_ciphertext.length, '0')
       encrypted_random_r = xor(z1_padded, masked_ciphertext)
-      self.random_r = kms_client.decrypt(encrypted_random_r, log_context: 'user-access-key')
+      self.random_r = kms_client.decrypt(
+        encrypted_random_r,
+        log_context: {
+          context: @log_context,
+          user_uuid: @user_uuid,
+        },
+      )
       self.cek = OpenSSL::Digest::SHA256.hexdigest(z2 + random_r)
       self
     end

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -81,7 +81,10 @@ RSpec.describe Encryption::PasswordVerifier do
     it 'returns true if the password does match' do
       digest_pair = subject.create_digest_pair(password: password, user_uuid: user_uuid)
 
-      result = subject.verify(digest_pair: digest_pair, password: password, user_uuid: user_uuid)
+      result = subject.verify(
+        digest_pair: digest_pair, password: password, user_uuid: user_uuid,
+        log_context: nil
+      )
 
       expect(result).to eq(true)
     end
@@ -89,7 +92,10 @@ RSpec.describe Encryption::PasswordVerifier do
     it 'returns false if the password does not match' do
       digest_pair = subject.create_digest_pair(password: password, user_uuid: user_uuid)
 
-      result = subject.verify(digest_pair: digest_pair, password: 'qwerty', user_uuid: user_uuid)
+      result = subject.verify(
+        digest_pair: digest_pair, password: 'qwerty', user_uuid: user_uuid,
+        log_context: nil
+      )
 
       expect(result).to eq(false)
     end
@@ -102,6 +108,7 @@ RSpec.describe Encryption::PasswordVerifier do
         ),
         password: password,
         user_uuid: user_uuid,
+        log_context: nil,
       )
 
       expect(result).to eq(false)
@@ -117,6 +124,7 @@ RSpec.describe Encryption::PasswordVerifier do
         digest_pair: legacy_digest_pair,
         password: password,
         user_uuid: user_uuid,
+        log_context: nil,
       )
 
       expect(good_match_result).to eq(true)
@@ -125,6 +133,7 @@ RSpec.describe Encryption::PasswordVerifier do
         digest_pair: legacy_digest_pair,
         password: 'fake news',
         user_uuid: user_uuid,
+        log_context: nil,
       )
 
       expect(bad_match_result).to eq(false)
@@ -141,11 +150,13 @@ RSpec.describe Encryption::PasswordVerifier do
         password: password,
         digest_pair: test_digest_pair,
         user_uuid: user_uuid,
+        log_context: nil,
       )
       incorrect_password_result = subject.verify(
         password: 'this is a fake password lol',
         digest_pair: test_digest_pair,
         user_uuid: user_uuid,
+        log_context: nil,
       )
 
       expect(correct_password_result).to eq(true)

--- a/spec/services/encryption/uak_password_verifier_spec.rb
+++ b/spec/services/encryption/uak_password_verifier_spec.rb
@@ -47,20 +47,35 @@ RSpec.describe Encryption::UakPasswordVerifier do
       password = 'saltypickles'
 
       digest = described_class.digest(password)
-      result = described_class.verify(password: password, digest: digest)
+      result = described_class.verify(
+        password: password,
+        digest: digest,
+        user_uuid: nil,
+        log_context: nil,
+      )
 
       expect(result).to eq(true)
     end
 
     it 'returns false if the password does not match' do
       digest = described_class.digest('saltypickles')
-      result = described_class.verify(password: 'pepperpickles', digest: digest)
+      result = described_class.verify(
+        password: 'pepperpickles',
+        digest: digest,
+        user_uuid: nil,
+        log_context: nil,
+      )
 
       expect(result).to eq(false)
     end
 
     it 'returns false for nonsese' do
-      result = described_class.verify(password: 'saltypickles', digest: 'this is fake')
+      result = described_class.verify(
+        password: 'saltypickles',
+        digest: 'this is fake',
+        user_uuid: nil,
+        log_context: nil,
+      )
 
       expect(result).to eq(false)
     end
@@ -85,7 +100,12 @@ RSpec.describe Encryption::UakPasswordVerifier do
         password_cost: '4000$8$4$',
       }.to_json
 
-      result = described_class.verify(password: password, digest: legacy_password_digest)
+      result = described_class.verify(
+        password: password,
+        digest: legacy_password_digest,
+        user_uuid: nil,
+        log_context: nil,
+      )
 
       expect(result).to eq(true)
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Follow up to #11174 to add even more context to our logging. The depths of the calls are pretty far removed, so it unfortunately requires passing it from pretty far up.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
