### PR TITLE
WIP:  update aws-sdk-ses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,14 +164,14 @@ GEM
     ast (2.4.2)
     awrence (1.2.1)
     aws-eventstream (1.3.0)
-    aws-partitions (1.963.0)
+    aws-partitions (1.971.0)
     aws-sdk-cloudwatchlogs (1.49.0)
       aws-sdk-core (~> 3, >= 3.122.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.201.4)
+    aws-sdk-core (3.203.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.8)
+      aws-sigv4 (~> 1.9)
       jmespath (~> 1, >= 1.6.1)
     aws-sdk-kms (1.71.0)
       aws-sdk-core (~> 3, >= 3.177.0)
@@ -186,9 +186,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.179.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.6)
-    aws-sdk-ses (1.44.0)
-      aws-sdk-core (~> 3, >= 3.122.0)
-      aws-sigv4 (~> 1.1)
+    aws-sdk-ses (1.70.0)
+      aws-sdk-core (~> 3, >= 3.203.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-sns (1.82.0)
       aws-sdk-core (~> 3, >= 3.201.0)
       aws-sigv4 (~> 1.5)
@@ -881,4 +881,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.6
+   2.5.11


### PR DESCRIPTION
## 🛠 Summary of changes

It appears as if the old version of aws-sdk-ses is not able to handle Pod Identity(https://aws.amazon.com/blogs/containers/amazon-eks-pod-identity-a-new-way-for-applications-on-eks-to-obtain-iam-credentials/).  This updates the gem so that it will work.
