### PR TITLE
Add CSP allowlisting for reCAPTCHA at sign in

### DIFF
--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -7,6 +7,48 @@ RSpec.describe Users::SessionsController, devise: true do
 
   let(:mock_valid_site) { 'http://example.com' }
 
+  describe 'before_actions' do
+    describe 'recaptcha csp' do
+      it 'does not allow recaptcha in the csp' do
+        expect(subject).not_to receive(:allow_csp_recaptcha_src)
+
+        get :new
+      end
+
+      context 'recaptcha enabled' do
+        before do
+          allow(FeatureManagement).to receive(:sign_in_recaptcha_enabled?).and_return(true)
+        end
+
+        it 'allows recaptcha in the csp' do
+          expect(subject).to receive(:allow_csp_recaptcha_src)
+
+          get :new
+        end
+      end
+    end
+  end
+
+  describe 'after actions' do
+    it 'does not add recaptcha resource hints' do
+      expect(subject).not_to receive(:add_recaptcha_resource_hints)
+
+      get :new
+    end
+
+    context 'recaptcha enabled' do
+      before do
+        allow(FeatureManagement).to receive(:sign_in_recaptcha_enabled?).and_return(true)
+      end
+
+      it 'adds recaptcha resource hints' do
+        expect(subject).to receive(:add_recaptcha_resource_hints)
+
+        get :new
+      end
+    end
+  end
+
   describe 'GET /logout' do
     it 'does not log user out and redirects to root' do
       sign_in_as_user


### PR DESCRIPTION
## 🛠 Summary of changes

Adds necessary CSP exceptions to allow reCAPTCHA to be loaded when performed at sign-in.

## 📜 Testing Plan

You need to add configuration values for reCAPTCHA credentials, but they don't have to be valid.

In `config/application.yml`:

```
recaptcha_enterprise_api_key: 'test'
recaptcha_enterprise_project_id: 'test'
recaptcha_site_key: 'test'
```

Verify that the header values are present on the sign-in screen:

1. Start `make run`
2. In a terminal console: `curl -I --silent http://localhost:3000 | grep content-security-policy`
3. Observe "google.com" and "gstatic.com" domains in the resulting header value