### PR TITLE
Proof-of-Concept: Add persistence option for A/B tests

### DIFF
--- a/app/jobs/outdated_ab_test_assignment_cleanup_job.rb
+++ b/app/jobs/outdated_ab_test_assignment_cleanup_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class OutdatedAbTestAssignmentCleanupJob < ApplicationJob
+  queue_as :low
+
+  def perform
+    AbTestAssignment.where.not(experiment: active_experiments).destroy_all
+  end
+
+  private
+
+  def active_experiments
+    AbTests.all.values.map(&:experiment_name)
+  end
+end

--- a/app/models/ab_test_assignment.rb
+++ b/app/models/ab_test_assignment.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AbTestAssignment < ApplicationRecord
+  class << self
+    def bucket(**)
+      find_by(**)&.bucket&.to_sym
+    end
+  end
+end

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -83,6 +83,7 @@ class Analytics
         session:,
         user:,
         user_session:,
+        persisted_read_only: true,
       )
       if !bucket.blank?
         obj[test_id.downcase] = {

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -65,6 +65,7 @@ module AbTests
 
   RECAPTCHA_SIGN_IN = AbTest.new(
     experiment_name: 'reCAPTCHA at Sign-In',
+    persist: true,
     should_log: [
       'Email and Password Authentication',
       'IdV: doc auth verify proofing results',
@@ -72,11 +73,5 @@ module AbTests
       :idv_enter_password_submitted,
     ].to_set,
     buckets: { sign_in_recaptcha: IdentityConfig.store.sign_in_recaptcha_percent_tested },
-  ) do |user:, user_session:, **|
-    if user_session&.[](:captcha_validation_performed_at_sign_in) == false
-      nil
-    else
-      user&.uuid
-    end
-  end.freeze
+  ).freeze
 end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -235,6 +235,11 @@ else
         cron: cron_every_monday_2am,
         args: -> { [Time.zone.yesterday.end_of_day] },
       },
+      # Outdated A/B test assignment clean-up
+      outdated_ab_test_assignment_cleanup: {
+        class: 'OutdatedAbTestAssignmentCleanupJob',
+        cron: cron_every_monday,
+      },
     }.compact
   end
   # rubocop:enable Metrics/BlockLength

--- a/db/primary_migrate/20240905125027_create_ab_test_assignments.rb
+++ b/db/primary_migrate/20240905125027_create_ab_test_assignments.rb
@@ -1,0 +1,10 @@
+class CreateAbTestAssignments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :ab_test_assignments do |t|
+      t.string :experiment, null: false
+      t.string :discriminator, null: false
+      t.string :bucket, null: false
+      t.index [:experiment, :discriminator], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_28_182041) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_05_125027) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "ab_test_assignments", force: :cascade do |t|
+    t.string "experiment", null: false
+    t.string "discriminator", null: false
+    t.string "bucket", null: false
+    t.index ["experiment", "discriminator"], name: "index_ab_test_assignments_on_experiment_and_discriminator", unique: true
+  end
 
   create_table "account_reset_requests", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -664,7 +672,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_28_182041) do
   add_foreign_key "iaa_gtcs", "partner_accounts"
   add_foreign_key "iaa_orders", "iaa_gtcs"
   add_foreign_key "in_person_enrollments", "profiles"
-  add_foreign_key "in_person_enrollments", "service_providers", column: "issuer", primary_key: "issuer", validate: false
+  add_foreign_key "in_person_enrollments", "service_providers", column: "issuer", primary_key: "issuer"
   add_foreign_key "in_person_enrollments", "users"
   add_foreign_key "integration_usages", "iaa_orders"
   add_foreign_key "integration_usages", "integrations"

--- a/lib/ab_test.rb
+++ b/lib/ab_test.rb
@@ -49,8 +49,6 @@ class AbTest
     user_session:,
     persisted_read_only: false
   )
-    return nil if no_percentages?
-
     discriminator = resolve_discriminator(
       request:, service_provider:, session:, user:,
       user_session:
@@ -59,6 +57,8 @@ class AbTest
 
     persisted_value = AbTestAssignment.bucket(experiment:, discriminator:) if persist
     return persisted_value if persisted_value || (persist && persisted_read_only)
+
+    return nil if no_percentages?
 
     user_value = percent(discriminator)
 

--- a/lib/ab_test.rb
+++ b/lib/ab_test.rb
@@ -39,7 +39,16 @@ class AbTest
   # @params [Hash] session
   # @param [User] user
   # @param [Hash] user_session
-  def bucket(request:, service_provider:, session:, user:, user_session:)
+  # @param [Boolean] persisted_read_only Avoid new bucket assignment if test is configured to be
+  # persisted but there is no persisted value.
+  def bucket(
+    request:,
+    service_provider:,
+    session:,
+    user:,
+    user_session:,
+    persisted_read_only: false
+  )
     return nil if no_percentages?
 
     discriminator = resolve_discriminator(
@@ -49,7 +58,7 @@ class AbTest
     return nil if discriminator.blank?
 
     persisted_value = AbTestAssignment.bucket(experiment:, discriminator:) if persist
-    return persisted_value if persisted_value
+    return persisted_value if persisted_value || (persist && persisted_read_only)
 
     user_value = percent(discriminator)
 


### PR DESCRIPTION
## 🛠 Summary of changes

Adds support for an A/B test to persist its bucket assignment to the database, useful in scenarios where relevant metrics of a test may be logged at a different point in time than the enrollment itself.

Discussed in [2024-09-04 Engineering Huddle](https://docs.google.com/document/d/1g_V2vlT79tScBKIVw7M4UXf15TrG69iUrLHE0yE1GGI/edit#heading=h.yr5fiscgveu6)

General use-cases:

- Avoid consider a user as part of a bucket if they did not complete some earlier action while the test was active (e.g. account creation)
- Allow logging to continue even after the test itself has ended (percentages reset to 0)

Specific examples:

- If a user is subjected to reCAPTCHA assessment at sign-in, we want to log this test assignment if the user is later suspended for fraudulent activity
- If we allow some users to register Face or Touch Unlock as an MFA method on desktop computers, we want to know how successful these users are when they later authenticate with that method. We also want the ability to stop enrolling new users into the test while continuing to monitor success rates for those who had been previously enrolled.

## 📜 Testing Plan

Verify that bucket assignment for reCAPTCHA at sign-in sticks, even after the test is configured to not enroll new users.

1. In a Private Browsing tab, go to http://localhost:3000
2. Sign in
3. Edit `config/application.yml` to effectively disable test:

```yaml
development:
  sign_in_recaptcha_percent_tested: 0
```

4. Restart server
5. Run `make watch_events` in a separate terminal process
6. Repeat Steps 1 & 2
7. Observe "Email and Password Authentication" event includes `ab_tests.recaptcha_sign_in.bucket` value (`sign_in_recaptcha`)