### PR TITLE
Upgrade Faker to latest major version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,8 +321,8 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
-    faker (2.19.0)
-      i18n (>= 1.6, < 2)
+    faker (3.4.2)
+      i18n (>= 1.8.11, < 2)
     faraday (2.10.0)
       faraday-net_http (>= 2.0, < 3.2)
       logger

--- a/spec/controllers/users/email_confirmations_controller_spec.rb
+++ b/spec/controllers/users/email_confirmations_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Users::EmailConfirmationsController do
     describe 'Valid email confirmation tokens' do
       it 'tracks a valid email confirmation token event' do
         user = create(:user)
-        new_email = Faker::Internet.safe_email
+        new_email = Faker::Internet.email
 
         expect(PushNotification::HttpPush).to receive(:deliver).once.
           with(PushNotification::EmailChangedEvent.new(
@@ -27,7 +27,7 @@ RSpec.describe Users::EmailConfirmationsController do
 
       it 'rejects an otherwise valid token for unconfirmed users' do
         user = create(:user, :unconfirmed, email_addresses: [])
-        new_email = Faker::Internet.safe_email
+        new_email = Faker::Internet.email
 
         add_email_form = AddUserEmailForm.new
         add_email_form.submit(user, email: new_email)
@@ -41,7 +41,7 @@ RSpec.describe Users::EmailConfirmationsController do
 
       it 'rejects expired tokens' do
         user = create(:user)
-        new_email = Faker::Internet.safe_email
+        new_email = Faker::Internet.email
 
         add_email_form = AddUserEmailForm.new
         add_email_form.submit(user, email: new_email)

--- a/spec/controllers/users/emails_controller_spec.rb
+++ b/spec/controllers/users/emails_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Users::EmailsController do
         stub_sign_in(user)
 
         while EmailPolicy.new(user).can_add_email?
-          email = Faker::Internet.safe_email
+          email = Faker::Internet.email
           user.email_addresses.create(email: email, confirmed_at: Time.zone.now)
         end
       end
@@ -53,7 +53,7 @@ RSpec.describe Users::EmailsController do
 
     context 'valid email exists in session' do
       it 'sends email' do
-        email = Faker::Internet.safe_email
+        email = Faker::Internet.email
 
         post :add, params: { user: { email: email } }
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -906,7 +906,7 @@ RSpec.describe Users::SessionsController, devise: true do
       render_views
 
       it 'does not prefill the form' do
-        email = Faker::Internet.safe_email
+        email = Faker::Internet.email
         password = SecureRandom.uuid
 
         get :new, params: { user: { email: email, password: password } }

--- a/spec/factories/email_addresses.rb
+++ b/spec/factories/email_addresses.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :email_address do
     confirmed_at { Time.zone.now }
     confirmation_sent_at { Time.zone.now - 5.minutes }
-    email { Faker::Internet.safe_email }
+    email { Faker::Internet.email }
     user { association :user }
 
     trait :unconfirmed do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
         until user.email_addresses.many?
           user.email_addresses << build(
             :email_address,
-            email: Faker::Internet.safe_email,
+            email: Faker::Internet.email,
             confirmed_at: user.confirmed_at,
             user_id: -1,
           )
@@ -57,7 +57,7 @@ FactoryBot.define do
         until user.email_addresses.many?
           user.email_addresses << build(
             :email_address,
-            email: Faker::Internet.safe_email,
+            email: Faker::Internet.email,
             confirmed_at: user.confirmed_at,
             user_id: -1,
           )

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Sign Up' do
   end
 
   context 'picking a preferred email language on signup' do
-    let(:email) { Faker::Internet.safe_email }
+    let(:email) { Faker::Internet.email }
 
     it 'allows a user to pick a language when entering email' do
       visit sign_up_email_path

--- a/spec/services/push_notification/email_changed_event_spec.rb
+++ b/spec/services/push_notification/email_changed_event_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PushNotification::EmailChangedEvent do
   end
 
   let(:user) { build(:user) }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
 
   describe '#event_type' do
     it 'is the RISC event type' do

--- a/spec/services/push_notification/http_push_spec.rb
+++ b/spec/services/push_notification/http_push_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe PushNotification::HttpPush do
   let(:event) do
     PushNotification::IdentifierRecycledEvent.new(
       user: user,
-      email: Faker::Internet.safe_email,
+      email: Faker::Internet.email,
     )
   end
   let(:now) { Time.zone.now }

--- a/spec/services/push_notification/identifier_recycled_event_spec.rb
+++ b/spec/services/push_notification/identifier_recycled_event_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PushNotification::IdentifierRecycledEvent do
   end
 
   let(:user) { build(:user) }
-  let(:email) { Faker::Internet.safe_email }
+  let(:email) { Faker::Internet.email }
 
   describe '#event_type' do
     it 'is the RISC event type' do

--- a/spec/services/reset_user_password_spec.rb
+++ b/spec/services/reset_user_password_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ResetUserPassword do
     end
 
     it 'notifies the user via email to each of their confirmed email addresses' do
-      create(:email_address, user:, email: Faker::Internet.safe_email, confirmed_at: nil)
+      create(:email_address, user:, email: Faker::Internet.email, confirmed_at: nil)
       expect { call }.
         to(change { ActionMailer::Base.deliveries.count }.by(2))
 

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe UspsInPersonProofing::Proofer do
           zip_code: Faker::Address.zip_code,
           first_name: Faker::Name.first_name,
           last_name: Faker::Name.last_name,
-          email: Faker::Internet.safe_email,
+          email: Faker::Internet.email,
           unique_id: '123456789',
         )
         stub_request_token
@@ -291,7 +291,7 @@ RSpec.describe UspsInPersonProofing::Proofer do
         zip_code: Faker::Address.zip_code,
         first_name: Faker::Name.first_name,
         last_name: Faker::Name.last_name,
-        email: Faker::Internet.safe_email,
+        email: Faker::Internet.email,
         unique_id: '123456789',
       )
     end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -122,7 +122,7 @@ module Features
     end
 
     def sign_up
-      email = Faker::Internet.safe_email
+      email = Faker::Internet.email
       sign_up_with(email)
       confirm_last_user
     end


### PR DESCRIPTION
Upgrade Faker to latest major version (2.19 -> 3.4.2)

* Includes API fixes (i.e., `Faker::Internet.safe_email` is now `Faker::Internet.email`)