### PR TITLE
Support changing error strings after ValidatedFieldElement connected

### DIFF
--- a/app/javascript/packages/memorable-date/index.spec.ts
+++ b/app/javascript/packages/memorable-date/index.spec.ts
@@ -71,7 +71,6 @@ describe('MemorableDateElement', () => {
             <lg-memorable-date id="test-memorable-date">
                 <script id="test-md-error-mappings" type="application/json" class="memorable-date__error-strings"></script>
                 <lg-validated-field error-id="test-md-error-message">
-                    <script type="application/json" class="validated-field__error-strings">{}</script>
                     <input type="text"
                         id="test-md-month"
                         required="required"
@@ -82,7 +81,6 @@ describe('MemorableDateElement', () => {
                         maxlength="2" />
                 </lg-validated-field>
                 <lg-validated-field error-id="test-md-error-message">
-                    <script type="application/json" class="validated-field__error-strings">{}</script>
                     <input type="text"
                         id="test-md-day"
                         required="required"
@@ -93,7 +91,6 @@ describe('MemorableDateElement', () => {
                         maxlength="2" />
                 </lg-validated-field>
                 <lg-validated-field error-id="test-md-error-message">
-                    <script type="application/json" class="validated-field__error-strings">{}</script>
                     <input type="text"
                         id="test-md-year"
                         required="required"

--- a/app/javascript/packages/memorable-date/index.spec.ts
+++ b/app/javascript/packages/memorable-date/index.spec.ts
@@ -71,6 +71,7 @@ describe('MemorableDateElement', () => {
             <lg-memorable-date id="test-memorable-date">
                 <script id="test-md-error-mappings" type="application/json" class="memorable-date__error-strings"></script>
                 <lg-validated-field error-id="test-md-error-message">
+                    <script type="application/json" class="validated-field__error-strings">{}</script>
                     <input type="text"
                         id="test-md-month"
                         required="required"
@@ -81,6 +82,7 @@ describe('MemorableDateElement', () => {
                         maxlength="2" />
                 </lg-validated-field>
                 <lg-validated-field error-id="test-md-error-message">
+                    <script type="application/json" class="validated-field__error-strings">{}</script>
                     <input type="text"
                         id="test-md-day"
                         required="required"
@@ -91,6 +93,7 @@ describe('MemorableDateElement', () => {
                         maxlength="2" />
                 </lg-validated-field>
                 <lg-validated-field error-id="test-md-error-message">
+                    <script type="application/json" class="validated-field__error-strings">{}</script>
                     <input type="text"
                         id="test-md-year"
                         required="required"

--- a/app/javascript/packages/validated-field/validated-field-element.ts
+++ b/app/javascript/packages/validated-field/validated-field-element.ts
@@ -1,6 +1,4 @@
 class ValidatedFieldElement extends HTMLElement {
-  errorStrings: Partial<ValidityState> = {};
-
   input: HTMLInputElement | null;
 
   inputWrapper: HTMLElement | null;
@@ -11,16 +9,13 @@ class ValidatedFieldElement extends HTMLElement {
     this.input = this.querySelector('.validated-field__input');
     this.inputWrapper = this.querySelector('.validated-field__input-wrapper');
     this.errorMessage = this.ownerDocument.getElementById(this.errorId);
-    try {
-      Object.assign(
-        this.errorStrings,
-        JSON.parse(this.querySelector('.validated-field__error-strings')?.textContent || ''),
-      );
-    } catch {}
-
     this.input?.addEventListener('input', () => this.setErrorMessage());
     this.input?.addEventListener('input', () => this.setInputIsValid(true));
     this.input?.addEventListener('invalid', (event) => this.toggleErrorMessage(event));
+  }
+
+  get errorStrings(): Partial<ValidityState> {
+    return JSON.parse(this.querySelector('.validated-field__error-strings')?.textContent || '');
   }
 
   get errorId(): string {

--- a/app/javascript/packages/validated-field/validated-field-element.ts
+++ b/app/javascript/packages/validated-field/validated-field-element.ts
@@ -15,7 +15,11 @@ class ValidatedFieldElement extends HTMLElement {
   }
 
   get errorStrings(): Partial<ValidityState> {
-    return JSON.parse(this.querySelector('.validated-field__error-strings')?.textContent || '');
+    try {
+      return JSON.parse(this.querySelector('.validated-field__error-strings')?.textContent || '');
+    } catch {
+      return {};
+    }
   }
 
   get errorId(): string {

--- a/app/javascript/packages/validated-field/validated-field.spec.tsx
+++ b/app/javascript/packages/validated-field/validated-field.spec.tsx
@@ -133,6 +133,20 @@ describe('ValidatedField', () => {
     expect(input.classList.contains('my-custom-class')).to.be.true();
   });
 
+  it('renders updated error message on re-render', () => {
+    const { getByRole, getByText, rerender } = render(
+      <ValidatedField required messages={{ valueMissing: 'foo' }} />,
+    );
+
+    rerender(<ValidatedField required messages={{ valueMissing: 'bar' }} />);
+
+    const input = getByRole('textbox') as HTMLInputElement;
+
+    input.reportValidity();
+
+    expect(getByText('bar')).to.exist();
+  });
+
   it('exposes the function reportValidity', () => {
     const { getByRole } = render(<ValidatedField />);
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where React `<ValidatedFieldElement />` changes to error messages after creating an element would not be reflected (not kept in sync). This happens because the error messages were previously assigned when the element is connected to the page, and never updated after that. Because React will often try to reuse an existing element rather than recreating one, this creates issues if we want to change the error messages after the element is mounted.

The solution is to compute the error messages on-demand, each time an error message is shown.

## 📜 Testing Plan

Verify that the included test passes:

```
yarn mocha app/javascript/packages/validated-field/validated-field.spec.tsx
```

Optionally, verify that the included test fails on `main`:

```
git checkout main
git checkout aduth-validated-field-updated-error-strings -- app/javascript/packages/validated-field/validated-field.spec.tsx
yarn mocha app/javascript/packages/validated-field/validated-field.spec.tsx
```