### PR TITLE
LG-14216: Assign reCAPTCHA A/B test bucket for missing user

### DIFF
--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -75,8 +75,10 @@ module AbTests
   ) do |user:, user_session:, **|
     if user_session&.[](:captcha_validation_performed_at_sign_in) == false
       nil
+    elsif user
+      user.uuid
     else
-      user&.uuid
+      SecureRandom.gen_random(1)
     end
   end.freeze
 end

--- a/spec/config/initializers/ab_tests_spec.rb
+++ b/spec/config/initializers/ab_tests_spec.rb
@@ -197,8 +197,8 @@ RSpec.describe AbTests do
       context 'with no associated user' do
         let(:user) { nil }
 
-        it 'does not return a bucket' do
-          expect(bucket).to be_nil
+        it 'returns a bucket' do
+          expect(bucket).not_to be_nil
         end
       end
 


### PR DESCRIPTION
## 🎫 Ticket

Addendum for [LG-14216](https://cm-jira.usa.gov/browse/LG-14216) (implemented in #11148)

## 🛠 Summary of changes

Updates the discriminator evaluation for reCAPTCHA at sign-in to randomly assign requests which aren't associated with a user. This provides some resiliency against user existence probing, though there are other mitigations which already provide protection (ping me on Slack if interested).

This test is not currently live in production.

This would likely be very incompatible with #11202 since it would result in persisting records for many random values (although only within the domain of 1 bytes worth of random data), so I'd plan to avoid opting-in reCAPTCHA for persistence if moving forward with these changes.

## 📜 Testing Plan

Verify that reCAPTCHA is performed based on percent tested when trying to authenticate with a user that doesn't exist:

1. Configure in `config/application.yml`:
    ```
    development:
      sign_in_recaptcha_percent_tested: 50
    ```
2. Restart server, if running
3. In a fresh private browsing window, go to http://localhost:3000
4. Sign in to an account that doesn't exist, e.g. `abc@example.com`, assigning a failing reCAPTCHA score (e.g. `0.1`)
5. Repeat Steps 3 & 4 until you encounter the "Security check failed" screen
6. Observe that you see the screen on about 50% of attempts