### PR TITLE
LG-14390 No longer cancel pending enrollments on logout from cancel page

### DIFF
--- a/app/controllers/idv/cancellations_controller.rb
+++ b/app/controllers/idv/cancellations_controller.rb
@@ -66,7 +66,7 @@ module Idv
       if hybrid_session?
         cancel_document_capture_session
       else
-        cancel_in_person_enrollment_if_exists
+        cancel_establishing_in_person_enrollments
         idv_session = user_session[:idv]
         idv_session&.clear
         user_session['idv/in_person'] = {}
@@ -113,9 +113,8 @@ module Idv
       end
     end
 
-    def cancel_in_person_enrollment_if_exists
+    def cancel_establishing_in_person_enrollments
       return if !IdentityConfig.store.in_person_proofing_enabled
-      current_user.pending_in_person_enrollment&.update(status: :cancelled)
       UspsInPersonProofing::EnrollmentHelper.
         cancel_stale_establishing_enrollments_for_user(current_user)
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -220,6 +220,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_establishing_in_person_enrollment do
+      after :build do |user|
+        create(:in_person_enrollment, :establishing, user: user)
+      end
+    end
+
     trait :with_pending_gpo_profile do
       transient do
         code_sent_at { created_at }


### PR DESCRIPTION
changelog: Internal, In-person proofing, The "Exit Login.gov" button on the cancel page from the barcode step will no longer cancel user's pending enrollments.

## 🎫 Ticket

Link to the relevant ticket:
[LG-14390](https://cm-jira.usa.gov/browse/LG-14390)

## 🛠 Summary of changes

The "Exit Login.gov" button on the cancel page from the barcode step will no longer cancel user's pending enrollments.

## 📜 Testing Plan

Scenario: Barcode Page: "exit login.gov" button from cancel page 
- [x] Login through the oidc sinatra application selecting the Enhanced In-person Proofing level of service
- [x] Use an existing account or create an account
- [x] Follow the flow for creating an ID-IPP enrollment until reaching the barcode page
- [x] From the barcode page click on the "cancel your barcode" link at the bottom of the page
- [x] From the cancel page click on the "Exit Login.gov" button
- [x] Login from oidc sinatra application
- [x] Verify you still land on the barcode page

Scenario: During Identity Verification: "exit login.gov" button from cancel page 
- [x] Login through the oidc sinatra application selecting the Enhanced In-person Proofing level of service
- [x] Use an existing account or create an account
- [x] Follow the flow for creating an ID-IPP enrollment
- [x] During the flow click on the "cancel" link before a barcode is created
- [x] From the cancel page click on the "Exit Login.gov" button
- [x] Login from oidc sinatra application
- [x] Verify you land on the welcome page `/verify/welcome`
