### PR TITLE
Improve accessibility labeling for partner email select

### DIFF
--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -1,50 +1,43 @@
 <% self.title = t('titles.select_email') %>
 
 <%= render StatusPageComponent.new(status: :info, icon: :question) do |c| %>
-  <% c.with_header { t('titles.select_email') } %>
+  <% c.with_header(id: 'select-email-heading') { t('titles.select_email') } %>
+
   <p id="select-email-intro">
     <%= I18n.t('help_text.select_preferred_email', sp: @sp_name, app_name: APP_NAME) %>
   </p>
 
-  <%= simple_form_for('', url: sign_up_select_email_path) do |f| %>
-    <fieldset class="usa-fieldset" aria-labelledby="select-email-intro">
-      <div class="grid-row margin-bottom-neg-1">
-        <div class="grid-col-fill">
-          <div class="display-inline-block minw-full">
-            <% @user_emails.each do |email, index| %>
-              <div class="usa-radio">
-                <%= radio_button_tag(
-                      'select_email_form[selected_email_id]',
-                      email.id,
-                      email.email == @last_sign_in_email_address,
-                      class: 'usa-radio__input usa-radio__input--bordered',
-                    ) %>
-                    <%= label_tag(
-                          "select_email_form_selected_email_id_#{email.id}",
-                          class: 'usa-radio__label width-full',
-                        ) do %>
-                      <%= email.email %>
-                    <% end %>
-              </div>
-            <% end %>
-          </div>
-        </div>
-        <div class="grid-col-4 tablet:grid-col-6"></div>
-      </div>
-    </fieldset>
-    <%= f.submit t('help_text.requested_attributes.change_email_link'), class: 'margin-top-4' %>
+  <%= simple_form_for(@select_email_form, url: sign_up_select_email_path) do |f| %>
+    <%= f.input(
+          :selected_email_id,
+          as: :radio_buttons,
+          label: false,
+          wrapper_html: {
+            aria: {
+              labelledby: 'select-email-heading',
+              describedby: 'select-email-intro',
+            },
+          },
+          collection: @user_emails.map do |email|
+            [
+              email.email,
+              email.id,
+              checked: email.email == @last_sign_in_email_address,
+            ]
+          end,
+        ) %>
+    <%= f.submit t('help_text.requested_attributes.change_email_link'), class: 'margin-top-1' %>
   <% end %>
 
-    <%= render ButtonComponent.new(
-          url: add_email_path,
-          outline: true,
-          big: true,
-          wide: true,
-          class: 'margin-top-2',
-        ).with_content(t('account.index.email_add')) %>
-        
+  <%= render ButtonComponent.new(
+        url: add_email_path,
+        outline: true,
+        big: true,
+        wide: true,
+        class: 'margin-top-2',
+      ).with_content(t('account.index.email_add')) %>
+
   <%= render PageFooterComponent.new do %>
     <%= link_to t('forms.buttons.back'), sign_up_completed_path %>
   <% end %>
-
 <% end %>


### PR DESCRIPTION
## 🎫 Ticket

Relates to [LG-13665](https://cm-jira.usa.gov/browse/LG-13665) and [LG-13001](https://cm-jira.usa.gov/browse/LG-13001) (brings implementations in sync)

## 🛠 Summary of changes

Updates partner email selection during sign-up completions to use accessibility labeling from similar view in #11196.

Specifically, revises the radio button "label" to use the heading ("Select your preferred email") rather than the paragraph description ("You may change which email you share with Example Sinatra App since you have multiple emails associated with your Login.gov account."), and provides the paragraph description as an additional `aria-describedby` resource.

## 📜 Testing Plan

1. (Prerequisite: Revoke consent for OIDC sample application if already consented)
2. Run [OIDC sample application](https://github.com/18f/identity-oidc-sinatra) in a separate terminal process
3. Go to http://localhost:9292
4. Click "Sign in"
5. Sign in
6. At completions screen, click "Change" next to email
   1. If you see "Add new email", go through this process and pick up again at completions screen after adding email. This experience is imperfect and is slated for improvement in [LG-14404](https://cm-jira.usa.gov/browse/LG-14404)
7. Activate screen reader on "Select your preferred email"  screen
8. Shift focus to radio button
9. Observe label "Select your preferred email" for radio field

## 👀 Screenshots

Announcement|Before|After
---|---|---
Label|![Screenshot 2024-09-06 at 12 19 26 PM](https://github.com/user-attachments/assets/330a4d89-27c6-4747-8cc7-404d80015ddf)|![Screenshot 2024-09-06 at 12 28 48 PM](https://github.com/user-attachments/assets/f94b3474-06a6-4ddd-aad3-8546864c642f)
Description|N/A|![Screenshot 2024-09-06 at 12 19 05 PM](https://github.com/user-attachments/assets/def32d5c-7dc6-401a-a25a-3bc951315cb5)



