### PR TITLE
Remove redundant Hash#compact for extra analytics events

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -380,7 +380,7 @@ module Idv
     def acuant_sdk_upgrade_ab_test_data
       {
         acuant_sdk_upgrade_ab_test_bucket:,
-      }.compact
+      }
     end
 
     def acuant_sdk_captured?

--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -175,6 +175,6 @@ class WebauthnSetupForm
       authenticator_data_flags: authenticator_data_flags,
       unknown_transports: invalid_transports.presence,
       aaguid: aaguid,
-    }.compact
+    }
   end
 end

--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -167,6 +167,6 @@ class WebauthnVerificationForm
       webauthn_configuration_id: webauthn_configuration&.id,
       frontend_error: webauthn_error.presence,
       webauthn_aaguid: webauthn_configuration&.aaguid,
-    }.compact
+    }
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1436,6 +1436,8 @@ module AnalyticsEvents
   # @param [String] front_image_fingerprint Fingerprint of front image data
   # @param [String] back_image_fingerprint Fingerprint of back image data
   # @param [String] selfie_image_fingerprint Fingerprint of selfie image data
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
   # The document capture image uploaded was locally validated during the IDV process
   def idv_doc_auth_submitted_image_upload_form(
     success:,
@@ -1449,6 +1451,7 @@ module AnalyticsEvents
     front_image_fingerprint: nil,
     back_image_fingerprint: nil,
     selfie_image_fingerprint: nil,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     **extra
   )
     track_event(
@@ -1464,6 +1467,7 @@ module AnalyticsEvents
       back_image_fingerprint:,
       liveness_checking_required:,
       selfie_image_fingerprint:,
+      acuant_sdk_upgrade_ab_test_bucket:,
       **extra,
     )
   end
@@ -1511,6 +1515,8 @@ module AnalyticsEvents
   # @param [String] birth_year Birth year from document
   # @param [Integer] issue_year Year document was issued
   # @param [Integer] selfie_attempts number of selfie attempts the user currently has processed
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
   # @option extra [String] 'DocumentName'
   # @option extra [String] 'DocAuthResult'
   # @option extra [String] 'DocIssuerCode'
@@ -1569,6 +1575,7 @@ module AnalyticsEvents
     workflow: nil,
     birth_year: nil,
     selfie_attempts: nil,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
     **extra
   )
     track_event(
@@ -1615,6 +1622,7 @@ module AnalyticsEvents
       birth_year:,
       issue_year:,
       selfie_attempts:,
+      acuant_sdk_upgrade_ab_test_bucket:,
       **extra,
     )
   end
@@ -4544,6 +4552,7 @@ module AnalyticsEvents
   # @param [String] piv_cac_configuration_dn_uuid PIV/CAC X509 distinguished name UUID
   # @param [String, nil] key_id PIV/CAC key_id from PKI service
   # @param [Integer] webauthn_configuration_id Database ID of WebAuthn configuration
+  # @param [String] webauthn_aaguid AAGUID valule of WebAuthn configuration
   # @param [Integer] phone_configuration_id Database ID of phone configuration
   # @param [Boolean] confirmation_for_add_phone Whether authenticating while adding phone
   # @param [String] area_code Area code of phone number
@@ -4567,6 +4576,7 @@ module AnalyticsEvents
     piv_cac_configuration_dn_uuid: nil,
     key_id: nil,
     webauthn_configuration_id: nil,
+    webauthn_aaguid: nil,
     confirmation_for_add_phone: nil,
     phone_configuration_id: nil,
     area_code: nil,
@@ -4590,6 +4600,7 @@ module AnalyticsEvents
       piv_cac_configuration_dn_uuid:,
       key_id:,
       webauthn_configuration_id:,
+      webauthn_aaguid:,
       confirmation_for_add_phone:,
       phone_configuration_id:,
       area_code:,
@@ -4878,6 +4889,9 @@ module AnalyticsEvents
   # @param [String, nil] key_id PIV/CAC key_id from PKI service
   # @param [Hash] mfa_method_counts Hash of MFA method with the number of that method on the account
   # @param [Hash] authenticator_data_flags WebAuthn authenticator data flags
+  # @param [String, nil] aaguid AAGUID value of WebAuthn device
+  # @param [String[], nil] unknown_transports Array of unrecognized WebAuthn transports, intended to
+  # be used in case of future specification changes.
   def multi_factor_auth_setup(
     success:,
     multi_factor_auth_method:,
@@ -4898,6 +4912,8 @@ module AnalyticsEvents
     key_id: nil,
     mfa_method_counts: nil,
     authenticator_data_flags: nil,
+    aaguid: nil,
+    unknown_transports: nil,
     **extra
   )
     track_event(
@@ -4921,6 +4937,8 @@ module AnalyticsEvents
       key_id:,
       mfa_method_counts:,
       authenticator_data_flags:,
+      aaguid:,
+      unknown_transports:,
       **extra,
     )
   end

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe WebauthnSetupForm do
               at: false,
               ed: true,
             },
+            unknown_transports: nil,
+            aaguid: nil,
             pii_like_keypaths: [[:mfa_method_counts, :phone]],
           }
 
@@ -161,6 +163,7 @@ RSpec.describe WebauthnSetupForm do
             },
             pii_like_keypaths: [[:mfa_method_counts, :phone]],
             unknown_transports: ['wrong'],
+            aaguid: nil,
           )
         end
       end
@@ -182,6 +185,8 @@ RSpec.describe WebauthnSetupForm do
             at: false,
             ed: true,
           },
+          unknown_transports: nil,
+          aaguid: nil,
           pii_like_keypaths: [[:mfa_method_counts, :phone]],
         }
 
@@ -231,6 +236,8 @@ RSpec.describe WebauthnSetupForm do
             at: false,
             ed: true,
           },
+          unknown_transports: nil,
+          aaguid: nil,
           pii_like_keypaths: [[:mfa_method_counts, :phone]],
         }
 

--- a/spec/forms/webauthn_verification_form_spec.rb
+++ b/spec/forms/webauthn_verification_form_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe WebauthnVerificationForm do
           expect(result.to_h).to eq(
             success: true,
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: nil,
+            webauthn_aaguid: nil,
           )
         end
       end
@@ -64,6 +66,7 @@ RSpec.describe WebauthnVerificationForm do
           expect(result.to_h).to eq(
             success: true,
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: nil,
             webauthn_aaguid: aaguid,
           )
         end
@@ -76,6 +79,8 @@ RSpec.describe WebauthnVerificationForm do
           expect(result.to_h).to eq(
             success: true,
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: nil,
+            webauthn_aaguid: nil,
           )
         end
       end
@@ -93,6 +98,8 @@ RSpec.describe WebauthnVerificationForm do
               authenticator_data: { invalid_authenticator_data: true },
             },
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: nil,
+            webauthn_aaguid: nil,
           )
         end
       end
@@ -107,6 +114,8 @@ RSpec.describe WebauthnVerificationForm do
               authenticator_data: { blank: true, invalid_authenticator_data: true },
             },
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: nil,
+            webauthn_aaguid: nil,
           )
         end
       end
@@ -122,6 +131,8 @@ RSpec.describe WebauthnVerificationForm do
               authenticator_data: { invalid_authenticator_data: true },
             },
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: nil,
+            webauthn_aaguid: nil,
           )
         end
       end
@@ -137,6 +148,8 @@ RSpec.describe WebauthnVerificationForm do
               authenticator_data: { invalid_authenticator_data: true },
             },
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: nil,
+            webauthn_aaguid: nil,
           )
         end
       end
@@ -148,6 +161,9 @@ RSpec.describe WebauthnVerificationForm do
           expect(result.to_h).to eq(
             success: false,
             error_details: { webauthn_configuration: { blank: true } },
+            webauthn_configuration_id: nil,
+            frontend_error: nil,
+            webauthn_aaguid: nil,
           )
         end
       end
@@ -161,6 +177,7 @@ RSpec.describe WebauthnVerificationForm do
             error_details: { webauthn_error: { present: true } },
             webauthn_configuration_id: webauthn_configuration.id,
             frontend_error: webauthn_error,
+            webauthn_aaguid: nil,
           )
         end
       end
@@ -176,6 +193,8 @@ RSpec.describe WebauthnVerificationForm do
                 screen_lock_error: { present: true },
               },
               webauthn_configuration_id: webauthn_configuration.id,
+              frontend_error: nil,
+              webauthn_aaguid: nil,
             )
           end
 
@@ -202,6 +221,8 @@ RSpec.describe WebauthnVerificationForm do
                   screen_lock_error: { present: true },
                 },
                 webauthn_configuration_id: webauthn_configuration.id,
+                frontend_error: nil,
+                webauthn_aaguid: nil,
               )
             end
 
@@ -227,6 +248,8 @@ RSpec.describe WebauthnVerificationForm do
                   screen_lock_error: { present: true },
                 },
                 webauthn_configuration_id: webauthn_configuration.id,
+                frontend_error: nil,
+                webauthn_aaguid: nil,
               )
             end
 
@@ -251,6 +274,8 @@ RSpec.describe WebauthnVerificationForm do
                   screen_lock_error: { present: true },
                 },
                 webauthn_configuration_id: webauthn_configuration.id,
+                frontend_error: nil,
+                webauthn_aaguid: nil,
               )
             end
 
@@ -277,6 +302,8 @@ RSpec.describe WebauthnVerificationForm do
             success: false,
             error_details: { authenticator_data: { invalid_authenticator_data: true } },
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: nil,
+            webauthn_aaguid: nil,
           )
         end
       end
@@ -292,6 +319,8 @@ RSpec.describe WebauthnVerificationForm do
             success: false,
             error_details: { authenticator_data: { invalid_authenticator_data: true } },
             webauthn_configuration_id: webauthn_configuration.id,
+            frontend_error: nil,
+            webauthn_aaguid: nil,
           )
         end
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Removes `.compact` from form `extra_analytics_attributes`, since this is handled by the `Analytics` class as of #10987.

The extra compacting also hid parameters from the `UndocumentedParamsChecker`, evidenced by the additional changes to document these parameters after removing the `.compact`.

## 📜 Testing Plan

Verify build passes.