### PR TITLE
Remove unused analytics events

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6327,14 +6327,6 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks when the user is notified their password is compromised
-  def user_password_compromised_visited(**extra)
-    track_event(
-      :user_password_compromised_visited,
-      **extra,
-    )
-  end
-
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission


### PR DESCRIPTION
## 🛠 Summary of changes

Removes an unused analytics event method.

Discovered using a little bash script combined with manual review:

```bash
for i in `rails runner 'puts AnalyticsEvents.instance_methods.join(" ")'`
do
  if ! grep -q -R 'app' --exclude app/services/analytics_events.rb -e $i
  then
    echo $i;
  fi
done
```

The removed method was added in #10392 and its last reference removed in #10861.

## 📜 Testing Plan

Verify there are no code references to the removed method.