### PR TITLE
LG-13657 Remove IPP FSM - set controller feature flag in test and update tests

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -526,6 +526,7 @@ test:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
   identity_pki_disabled: true
+  in_person_state_id_controller_enabled: true
   lexisnexis_trueid_account_id: 'test_account'
   lockout_period_in_minutes: 5
   logins_per_email_and_ip_limit: 2

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe Idv::InPerson::AddressController, allowed_extra_analytics: [:*] d
       end
 
       context 'in_person_state_id_controller_enabled is not enabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).
+            and_return(false)
+        end
+
         it 'redirects to state id page if not complete' do
           subject.user_session['idv/in_person'][:pii_from_user].delete(:identity_doc_address1)
           get :show

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Idv::InPersonController do
           it 'redirects to the first step' do
             get :index
 
-            expect(response).to redirect_to idv_in_person_step_url(step: :state_id)
+            expect(response).to redirect_to idv_in_person_proofing_state_id_path
           end
 
           it 'has non-nil presenter' do
@@ -82,7 +82,7 @@ RSpec.describe Idv::InPersonController do
               it 'redirects to the first step' do
                 get :index
 
-                expect(response).to redirect_to idv_in_person_step_url(step: :state_id)
+                expect(response).to redirect_to idv_in_person_proofing_state_id_path
               end
             end
           end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -509,10 +509,10 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
         flow_path: 'standard', opted_in_to_in_person_proofing: false
       },
       'IdV: in person proofing state_id visited' => {
-        step: 'state_id', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing'
+        step: 'state_id', flow_path: 'standard', analytics_id: 'In Person Proofing'
       },
       'IdV: in person proofing state_id submitted' => {
-        success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', errors: {}, same_address_as_id: false, birth_year: '1938', document_zip_code: '12345'
+        success: true, flow_path: 'standard', step: 'state_id', analytics_id: 'In Person Proofing', errors: {}, same_address_as_id: false, birth_year: '1938', document_zip_code: '12345'
       },
       'IdV: in person proofing address visited' => {
         step: 'address', flow_path: 'standard', analytics_id: 'In Person Proofing', same_address_as_id: false

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
 
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).and_return(true)
   end
 
   it 'works for a happy path', allow_browser_log: true do
@@ -38,7 +39,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
         ),
       ),
     )
-    complete_state_id_step(user)
+    complete_state_id_controller(user)
 
     # ssn page
     expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
@@ -290,7 +291,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     end
 
     it 'shows the address page' do
-      complete_state_id_step(user, same_address_as_id: false)
+      complete_state_id_controller(user, same_address_as_id: false)
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
       expect(page).to have_content(t('in_person_proofing.headings.address'))
 
@@ -303,7 +304,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     end
 
     it 'can update the address page form' do
-      complete_state_id_step(user, same_address_as_id: false)
+      complete_state_id_controller(user, same_address_as_id: false)
       complete_address_step(user, same_address_as_id: false)
       complete_ssn_step(user)
       # click update address link on the verify page
@@ -328,7 +329,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     end
 
     it 'allows user to update their residential address as different from their state id' do
-      complete_state_id_step(user, same_address_as_id: true)
+      complete_state_id_controller(user, same_address_as_id: true)
       # skip address step b/c residential address is same as state id address
       complete_ssn_step(user)
 
@@ -367,6 +368,8 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
 
     before do
       allow(IdentityConfig.store).to receive(:in_person_outage_message_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).
+        and_return(true)
     end
 
     it 'allows the user to generate a barcode despite outage', allow_browser_log: true do
@@ -410,7 +413,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
       complete_location_step
 
       # state ID page
-      complete_state_id_step(user, same_address_as_id: false)
+      complete_state_id_controller(user, same_address_as_id: false)
 
       # address page
       complete_address_step(user, same_address_as_id: false)
@@ -506,7 +509,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
       complete_prepare_step(user)
       complete_location_step
       # Causes the schedule USPS enrollment request to throw a bad request error
-      complete_state_id_step(user, first_name: 'usps client error')
+      complete_state_id_controller(user, first_name: 'usps client error')
       complete_ssn_step(user)
       complete_verify_step(user)
       fill_out_phone_form_ok(MfaContext.new(user).phone_configurations.first.phone)

--- a/spec/features/idv/in_person_threatmetrix_spec.rb
+++ b/spec/features/idv/in_person_threatmetrix_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'In Person Proofing Threatmetrix', js: true, allowed_extra_analyt
       complete_location_step(user)
 
       # state ID page
-      complete_state_id_step(user)
+      complete_state_id_controller(user)
 
       # ssn page
       complete_ssn_step(user, 'Reject')
@@ -170,7 +170,7 @@ RSpec.describe 'In Person Proofing Threatmetrix', js: true, allowed_extra_analyt
       begin_in_person_proofing(user)
       complete_prepare_step(user)
       complete_location_step
-      complete_state_id_step(user)
+      complete_state_id_controller(user)
 
       # ssn page
       complete_ssn_step(user, tmx_status)

--- a/spec/features/idv/steps/in_person/verify_info_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_info_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true, allowed_extra_analytics: [:*
 
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).and_return(false)
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow(user).to receive(:enrollment).
       and_return(enrollment)

--- a/spec/features/idv/steps/in_person/verify_info_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_info_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true, allowed_extra_analytics: [:*
   context 'when in_person_state_id_controller_enabled is false' do
     before do
       allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-      allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).and_return(false)
+      allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).
+        and_return(false)
       allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
       allow(user).to receive(:enrollment).
         and_return(enrollment)

--- a/spec/features/idv/steps/in_person/verify_info_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_info_spec.rb
@@ -9,165 +9,341 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true, allowed_extra_analytics: [:*
   let(:fake_analytics) { FakeAnalytics.new(user: user) }
   let(:enrollment) { InPersonEnrollment.new }
 
-  before do
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-    allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).and_return(false)
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
-    allow(user).to receive(:enrollment).
-      and_return(enrollment)
+  context 'when in_person_state_id_controller_enabled is false' do
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).and_return(false)
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+      allow(user).to receive(:enrollment).
+        and_return(enrollment)
+    end
+
+    it 'provides back buttons for address, state ID, and SSN that discard changes',
+       allow_browser_log: true do
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_step(user)
+      complete_ssn_step(user)
+
+      # verify page
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
+      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
+      expect(page).to have_text(
+        Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        count: 3,
+      )
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+
+      # click update state ID button
+      click_button t('idv.buttons.change_state_id_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
+      fill_in t('in_person_proofing.form.state_id.first_name'), with: 'bad first name'
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).not_to have_text('bad first name')
+
+      # click update address link
+      click_link t('idv.buttons.change_address_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_address'))
+      fill_in t('idv.form.address1'), with: 'bad address'
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1)
+      expect(page).not_to have_text('bad address')
+
+      # click update ssn button
+      click_on t('idv.buttons.change_ssn_label')
+      expect(page).to have_content(t('doc_auth.headings.ssn_update'))
+      fill_out_ssn_form_fail
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+
+      complete_verify_step(user)
+
+      # phone page
+      expect(page).to have_content(t('titles.idv.phone'))
+    end
+
+    it 'returns the user to the verify info page when updates are made',
+       allow_browser_log: true do
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_step(user)
+      complete_ssn_step(user)
+
+      # verify page
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
+      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
+      expect(page).to have_text(
+        Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        count: 3,
+      )
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+
+      # click update state ID button
+      click_button t('idv.buttons.change_state_id_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
+      fill_in t('in_person_proofing.form.state_id.first_name'), with: 'Natalya'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('Natalya')
+      expect(page).not_to have_text('bad first name')
+
+      # click update address link
+      click_link t('idv.buttons.change_address_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_address'))
+      fill_in t('idv.form.address1'), with: '987 Fake St.'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('987 Fake St.')
+      expect(page).not_to have_text('bad address')
+
+      # click update ssn button
+      click_on t('idv.buttons.change_ssn_label')
+      expect(page).to have_content(t('doc_auth.headings.ssn_update'))
+      fill_in t('idv.form.ssn_label'), with: '900-12-2345'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('9**-**-***5')
+
+      complete_verify_step(user)
+
+      # phone page
+      expect(page).to have_content(t('titles.idv.phone'))
+    end
+
+    it 'does not proceed to the next page if resolution fails',
+       allow_browser_log: true do
+      sign_in_and_2fa_user
+
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_step(user)
+      fill_out_ssn_form_with_ssn_that_fails_resolution
+      click_idv_continue
+      complete_verify_step(user)
+
+      expect(page).to have_current_path(idv_session_errors_warning_path(flow: 'in_person'))
+      click_on t('idv.failure.button.warning')
+
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+    end
+
+    it 'proceeds to the next page if resolution passes',
+       allow_browser_log: true do
+      sign_in_and_2fa_user
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_step(user)
+      complete_ssn_step(user)
+      complete_verify_step(user)
+
+      expect(page).to have_content(t('titles.idv.phone'))
+      expect(fake_analytics).to have_logged_event(
+        'IdV: doc auth verify proofing results',
+        hash_including(analytics_id: 'In Person Proofing'),
+      )
+    end
   end
+  context 'when in_person_state_id_controller_enabled is true' do
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+      allow(user).to receive(:enrollment).
+        and_return(enrollment)
+    end
 
-  it 'provides back buttons for address, state ID, and SSN that discard changes',
-     allow_browser_log: true do
-    sign_in_and_2fa_user(user)
-    begin_in_person_proofing(user)
-    complete_prepare_step(user)
-    complete_location_step(user)
-    complete_state_id_step(user)
-    complete_ssn_step(user)
+    it 'provides back buttons for address, state ID, and SSN that discard changes',
+       allow_browser_log: true do
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_controller(user)
+      complete_ssn_step(user)
 
-    # verify page
-    expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
-    expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
-    expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
-    expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
-    expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction], count: 3)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
-    expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+      # verify page
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
+      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
+      expect(page).to have_text(
+        Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        count: 3,
+      )
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
 
-    # click update state ID button
-    click_button t('idv.buttons.change_state_id_label')
-    expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
-    fill_in t('in_person_proofing.form.state_id.first_name'), with: 'bad first name'
-    click_doc_auth_back_link
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
-    expect(page).not_to have_text('bad first name')
+      # click update state ID button
+      click_button t('idv.buttons.change_state_id_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
+      fill_in t('in_person_proofing.form.state_id.first_name'), with: 'bad first name'
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).not_to have_text('bad first name')
 
-    # click update address link
-    click_link t('idv.buttons.change_address_label')
-    expect(page).to have_content(t('in_person_proofing.headings.update_address'))
-    fill_in t('idv.form.address1'), with: 'bad address'
-    click_doc_auth_back_link
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1)
-    expect(page).not_to have_text('bad address')
+      # click update address link
+      click_link t('idv.buttons.change_address_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_address'))
+      fill_in t('idv.form.address1'), with: 'bad address'
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1)
+      expect(page).not_to have_text('bad address')
 
-    # click update ssn button
-    click_on t('idv.buttons.change_ssn_label')
-    expect(page).to have_content(t('doc_auth.headings.ssn_update'))
-    fill_out_ssn_form_fail
-    click_doc_auth_back_link
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+      # click update ssn button
+      click_on t('idv.buttons.change_ssn_label')
+      expect(page).to have_content(t('doc_auth.headings.ssn_update'))
+      fill_out_ssn_form_fail
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
 
-    complete_verify_step(user)
+      complete_verify_step(user)
 
-    # phone page
-    expect(page).to have_content(t('titles.idv.phone'))
-  end
+      # phone page
+      expect(page).to have_content(t('titles.idv.phone'))
+    end
 
-  it 'returns the user to the verify info page when updates are made',
-     allow_browser_log: true do
-    sign_in_and_2fa_user(user)
-    begin_in_person_proofing(user)
-    complete_prepare_step(user)
-    complete_location_step(user)
-    complete_state_id_step(user)
-    complete_ssn_step(user)
+    it 'returns the user to the verify info page when updates are made',
+       allow_browser_log: true do
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_controller(user)
+      complete_ssn_step(user)
 
-    # verify page
-    expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
-    expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
-    expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
-    expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
-    expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction], count: 3)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
-    expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+      # verify page
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
+      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
+      expect(page).to have_text(
+        Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        count: 3,
+      )
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
 
-    # click update state ID button
-    click_button t('idv.buttons.change_state_id_label')
-    expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
-    fill_in t('in_person_proofing.form.state_id.first_name'), with: 'Natalya'
-    click_button t('forms.buttons.submit.update')
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text('Natalya')
-    expect(page).not_to have_text('bad first name')
+      # click update state ID button
+      click_button t('idv.buttons.change_state_id_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
+      fill_in t('in_person_proofing.form.state_id.first_name'), with: 'Natalya'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('Natalya')
+      expect(page).not_to have_text('bad first name')
 
-    # click update address link
-    click_link t('idv.buttons.change_address_label')
-    expect(page).to have_content(t('in_person_proofing.headings.update_address'))
-    fill_in t('idv.form.address1'), with: '987 Fake St.'
-    click_button t('forms.buttons.submit.update')
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text('987 Fake St.')
-    expect(page).not_to have_text('bad address')
+      # click update address link
+      click_link t('idv.buttons.change_address_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_address'))
+      fill_in t('idv.form.address1'), with: '987 Fake St.'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('987 Fake St.')
+      expect(page).not_to have_text('bad address')
 
-    # click update ssn button
-    click_on t('idv.buttons.change_ssn_label')
-    expect(page).to have_content(t('doc_auth.headings.ssn_update'))
-    fill_in t('idv.form.ssn_label'), with: '900-12-2345'
-    click_button t('forms.buttons.submit.update')
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text('9**-**-***5')
+      # click update ssn button
+      click_on t('idv.buttons.change_ssn_label')
+      expect(page).to have_content(t('doc_auth.headings.ssn_update'))
+      fill_in t('idv.form.ssn_label'), with: '900-12-2345'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('9**-**-***5')
 
-    complete_verify_step(user)
+      complete_verify_step(user)
 
-    # phone page
-    expect(page).to have_content(t('titles.idv.phone'))
-  end
+      # phone page
+      expect(page).to have_content(t('titles.idv.phone'))
+    end
 
-  it 'does not proceed to the next page if resolution fails',
-     allow_browser_log: true do
-    sign_in_and_2fa_user
+    it 'does not proceed to the next page if resolution fails',
+       allow_browser_log: true do
+      sign_in_and_2fa_user
 
-    begin_in_person_proofing(user)
-    complete_prepare_step(user)
-    complete_location_step(user)
-    complete_state_id_step(user)
-    fill_out_ssn_form_with_ssn_that_fails_resolution
-    click_idv_continue
-    complete_verify_step(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_controller(user)
+      fill_out_ssn_form_with_ssn_that_fails_resolution
+      click_idv_continue
+      complete_verify_step(user)
 
-    expect(page).to have_current_path(idv_session_errors_warning_path(flow: 'in_person'))
-    click_on t('idv.failure.button.warning')
+      expect(page).to have_current_path(idv_session_errors_warning_path(flow: 'in_person'))
+      click_on t('idv.failure.button.warning')
 
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-  end
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+    end
 
-  it 'proceeds to the next page if resolution passes',
-     allow_browser_log: true do
-    sign_in_and_2fa_user
-    begin_in_person_proofing(user)
-    complete_prepare_step(user)
-    complete_location_step(user)
-    complete_state_id_step(user)
-    complete_ssn_step(user)
-    complete_verify_step(user)
+    it 'proceeds to the next page if resolution passes',
+       allow_browser_log: true do
+      sign_in_and_2fa_user
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_controller(user)
+      complete_ssn_step(user)
+      complete_verify_step(user)
 
-    expect(page).to have_content(t('titles.idv.phone'))
-    expect(fake_analytics).to have_logged_event(
-      'IdV: doc auth verify proofing results',
-      hash_including(analytics_id: 'In Person Proofing'),
-    )
+      expect(page).to have_content(t('titles.idv.phone'))
+      expect(fake_analytics).to have_logged_event(
+        'IdV: doc auth verify proofing results',
+        hash_including(analytics_id: 'In Person Proofing'),
+      )
+    end
   end
 end

--- a/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
+++ b/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true, allowed_extra_analy
         complete_location_step
 
         # state ID page
-        complete_state_id_step(user)
+        complete_state_id_controller(user)
 
         # ssn page
         select 'Reject', from: :mock_profiling_result
@@ -156,7 +156,7 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true, allowed_extra_analy
           ),
         ),
       )
-      complete_state_id_step(user)
+      complete_state_id_controller(user)
 
       # ssn page
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
@@ -341,7 +341,7 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true, allowed_extra_analy
           ),
         ),
       )
-      complete_state_id_step(user)
+      complete_state_id_controller(user)
 
       # ssn page
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -109,7 +109,7 @@ module InPersonHelper
 
     # pause for the location list to disappear
     wait_for_content_to_disappear do
-      expect(page).to have_no_css('.location-collection-item')
+      expect(page).to have_no_css('.location-collection-item', wait: 1)
     end
   end
 
@@ -163,7 +163,6 @@ module InPersonHelper
     begin_in_person_proofing
     complete_prepare_step
     complete_location_step
-
     expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
   end
 
@@ -180,7 +179,7 @@ module InPersonHelper
                                             same_address_as_id: true)
     complete_prepare_step(user)
     complete_location_step(user)
-    complete_state_id_step(user, same_address_as_id: same_address_as_id)
+    complete_state_id_controller(user, same_address_as_id: same_address_as_id)
     complete_address_step(user, same_address_as_id: same_address_as_id) unless same_address_as_id
     complete_ssn_step(user, tmx_status)
     complete_verify_step(user)
@@ -256,9 +255,9 @@ module InPersonHelper
 
   def perform_desktop_hybrid_steps(user = user_with_2fa, same_address_as_id: true)
     perform_in_browser(:desktop) do
-      expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
+      expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
 
-      complete_state_id_step(user, same_address_as_id: same_address_as_id)
+      complete_state_id_controller(user, same_address_as_id: same_address_as_id)
       complete_address_step(user, same_address_as_id: same_address_as_id) unless same_address_as_id
       complete_ssn_step(user)
       complete_verify_step(user)


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-13657](https://cm-jira.usa.gov/browse/LG-13657)



## 🛠 Summary of changes

In preparation for turning on the `in_person_state_id_controller_enabled` flag in other environments, this PR turns it on in `test` and updates tests accordingly.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify that tests pass


