### PR TITLE
LG-13135: rename `submit_attempts_remaining`

### DIFF
--- a/app/controllers/idv/session_errors_controller.rb
+++ b/app/controllers/idv/session_errors_controller.rb
@@ -95,7 +95,7 @@ module Idv
         type: params[:action],
       }
 
-      options[:submit_attempts_remaining] = based_on_limiter.remaining_count if based_on_limiter
+      options[:remaining_submit_attempts] = based_on_limiter.remaining_count if based_on_limiter
 
       analytics.idv_session_error_visited(**options)
     end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4237,16 +4237,17 @@ module AnalyticsEvents
 
   # Tracks when the user visits one of the the session error pages.
   # @param [String] type
-  # @param [Integer,nil] submit_attempts_remaining (previously called "attempts_remaining")
+  # @param [Integer,nil] remaining_submit_attempts
+  #   (previously called "attempts_remaining" and "submit_attempts_remaining")
   def idv_session_error_visited(
     type:,
-    submit_attempts_remaining: nil,
+    remaining_submit_attempts: nil,
     **extra
   )
     track_event(
       'IdV: session error visited',
-      type: type,
-      submit_attempts_remaining: submit_attempts_remaining,
+      type:,
+      remaining_submit_attempts:,
       **extra,
     )
   end

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Idv::SessionErrorsController do
           'IdV: session error visited',
           hash_including(
             type: action.to_s,
-            submit_attempts_remaining: IdentityConfig.store.idv_max_attempts - 1,
+            remaining_submit_attempts: IdentityConfig.store.idv_max_attempts - 1,
           ),
         )
       end
@@ -271,7 +271,7 @@ RSpec.describe Idv::SessionErrorsController do
           'IdV: session error visited',
           hash_including(
             type: action.to_s,
-            submit_attempts_remaining: 0,
+            remaining_submit_attempts: 0,
           ),
         )
       end
@@ -313,7 +313,7 @@ RSpec.describe Idv::SessionErrorsController do
           'IdV: session error visited',
           hash_including(
             type: 'ssn_failure',
-            submit_attempts_remaining: 0,
+            remaining_submit_attempts: 0,
           ),
         )
       end
@@ -347,7 +347,7 @@ RSpec.describe Idv::SessionErrorsController do
           'IdV: session error visited',
           hash_including(
             type: action.to_s,
-            submit_attempts_remaining: 0,
+            remaining_submit_attempts: 0,
           ),
         )
       end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-13135](https://cm-jira.usa.gov/browse/LG-13135)

## 🛠 Summary of changes

Renames the symbol `:submit_attempts_remaining` to `remaining_submit_attempts` for consistency with the rest of the codebase.
