### PR TITLE
Fix expected analytics logging for DocAuth result

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1602,7 +1602,8 @@ module AnalyticsEvents
   # @param [Boolean] attention_with_barcode Whether result was attention with barcode
   # @param [Boolean] doc_type_supported
   # @param [Boolean] doc_auth_success
-  # @param [String] liveness_checking_required Whether or not the selfie is required
+  # @param [Boolean] liveness_checking_required Whether or not the selfie is required
+  # @param [Boolean] liveness_enabled Whether or not the selfie result is included in response
   # @param [String] selfie_status
   # @param [String] vendor
   # @param [String] conversation_id
@@ -1686,6 +1687,7 @@ module AnalyticsEvents
     birth_year: nil,
     selfie_attempts: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
+    liveness_enabled: nil,
     **extra
   )
     track_event(
@@ -1733,6 +1735,7 @@ module AnalyticsEvents
       issue_year:,
       selfie_attempts:,
       acuant_sdk_upgrade_ab_test_bucket:,
+      liveness_enabled:,
       **extra,
     )
   end
@@ -2857,20 +2860,23 @@ module AnalyticsEvents
   # @param [String] step
   # @param [String] analytics_id
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  # @param [Boolean] same_address_as_id
   # State id page visited
   def idv_in_person_proofing_state_id_visited(
     flow_path: nil,
     step: nil,
     analytics_id: nil,
     opted_in_to_in_person_proofing: nil,
+    same_address_as_id: nil,
     **extra
   )
     track_event(
       'IdV: in person proofing state_id visited',
-      flow_path: flow_path,
-      step: step,
-      analytics_id: analytics_id,
-      opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
+      flow_path:,
+      step:,
+      analytics_id:,
+      opted_in_to_in_person_proofing:,
+      same_address_as_id:,
       **extra,
     )
   end

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -28,7 +28,8 @@ module DocAuth
             classification_info: classification_info,
             workflow: workflow,
             liveness_checking_required: @selfie_required,
-          }.compact,
+            **@response_info.to_h,
+          },
         )
       end
 
@@ -69,8 +70,8 @@ module DocAuth
               mock_args[:passed] = passed.map!(&:symbolize_keys) if passed.present?
               mock_args[:liveness_enabled] = face_match_result ? true : false
               mock_args[:classification_info] = classification_info if classification_info.present?
-              fake_response_info = create_response_info(**mock_args)
-              ErrorGenerator.new(config).generate_doc_auth_errors(fake_response_info)
+              @response_info = create_response_info(**mock_args)
+              ErrorGenerator.new(config).generate_doc_auth_errors(@response_info)
             elsif file_data.include?(:general) # general is the key for errors from parsing
               file_data
             end
@@ -232,8 +233,7 @@ module DocAuth
           liveness_enabled: liveness_enabled,
           classification_info: classification_info,
           portrait_match_results: selfie_check_performed? ? portrait_match_results : nil,
-          extra: { liveness_checking_required: liveness_enabled },
-        }.compact
+        }
       end
     end
   end

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -45,7 +45,7 @@ module DocAuth
             failed = file_data.dig('failed_alerts')&.dup
             passed = file_data.dig('passed_alerts')
             face_match_result = file_data.dig('portrait_match_results', 'FaceMatchResult')
-            classification_info = file_data.dig('classification_info')
+            classification_info = file_data.dig('classification_info')&.symbolize_keys
             # Pass and doc type is ok
             has_fields = [
               doc_auth_result,

--- a/app/services/flow/flow_state_machine.rb
+++ b/app/services/flow/flow_state_machine.rb
@@ -28,7 +28,6 @@ module Flow
 
       result = flow.handle(step)
 
-      increment_step_name_counts
       analytics.public_send(
         flow.step_handler_instance(step).analytics_submitted_event,
         **result.to_h.merge(analytics_properties),
@@ -54,7 +53,6 @@ module Flow
     end
 
     def track_step_visited
-      increment_step_name_counts
       analytics.public_send(
         flow.step_handler(current_step).analytics_visited_event,
         **analytics_properties,
@@ -188,7 +186,6 @@ module Flow
       {
         flow_path: flow.flow_path,
         step: current_step,
-        step_count: current_flow_step_counts[current_step_name],
         analytics_id: @analytics_id,
       }.merge(flow.extra_analytics_properties).
         merge(**opt_in_analytics_properties)
@@ -196,16 +193,6 @@ module Flow
 
     def current_step_name
       "#{current_step}_#{action_name}"
-    end
-
-    def current_flow_step_counts
-      current_session["#{@name}_flow_step_counts"] ||= {}
-      current_session["#{@name}_flow_step_counts"].default = 0
-      current_session["#{@name}_flow_step_counts"]
-    end
-
-    def increment_step_name_counts
-      current_flow_step_counts[current_step_name] += 1
     end
 
     def next_step

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -971,7 +971,7 @@ RSpec.describe Idv::ImageUploadsController do
           attention_with_barcode: false,
           async: false,
           billed: true,
-          doc_auth_result: 'Caution',
+          doc_auth_result: 'Failed',
           user_id: user.uuid,
           submit_attempts: 1,
           remaining_submit_attempts: IdentityConfig.store.doc_auth_max_attempts - 1,
@@ -990,6 +990,27 @@ RSpec.describe Idv::ImageUploadsController do
           selfie_live: boolean,
           selfie_quality_good: boolean,
           workflow: an_instance_of(String),
+          alert_failure_count: 1,
+          liveness_enabled: false,
+          vendor: 'Mock',
+          processed_alerts: {
+            failed: [{ name: '2D Barcode Content', result: 'Attention' }],
+            passed: [],
+          },
+          image_metrics: {
+            back: {
+              'GlareMetric' => 100,
+              'HorizontalResolution' => 600,
+              'SharpnessMetric' => 100,
+              'VerticalResolution' => 600,
+            },
+            front: {
+              'GlareMetric' => 100,
+              'HorizontalResolution' => 600,
+              'SharpnessMetric' => 100,
+              'VerticalResolution' => 600,
+            },
+          },
         )
 
         expect_funnel_update_counts(user, 1)

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -509,10 +509,10 @@ RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
         flow_path: 'standard', opted_in_to_in_person_proofing: false
       },
       'IdV: in person proofing state_id visited' => {
-        step: 'state_id', flow_path: 'standard', step_count: 1, analytics_id: 'In Person Proofing'
+        step: 'state_id', flow_path: 'standard', analytics_id: 'In Person Proofing'
       },
       'IdV: in person proofing state_id submitted' => {
-        success: true, flow_path: 'standard', step: 'state_id', step_count: 1, analytics_id: 'In Person Proofing', errors: {}, same_address_as_id: false, birth_year: '1938', document_zip_code: '12345'
+        success: true, flow_path: 'standard', step: 'state_id', analytics_id: 'In Person Proofing', errors: {}, same_address_as_id: false, birth_year: '1938', document_zip_code: '12345'
       },
       'IdV: in person proofing address visited' => {
         step: 'address', flow_path: 'standard', analytics_id: 'In Person Proofing', same_address_as_id: false

--- a/spec/features/idv/in_person_threatmetrix_spec.rb
+++ b/spec/features/idv/in_person_threatmetrix_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'action_account'
 require 'axe-rspec'
 
-RSpec.describe 'In Person Proofing Threatmetrix', js: true, allowed_extra_analytics: [:*] do
+RSpec.describe 'In Person Proofing Threatmetrix', js: true do
   include InPersonHelper
 
   let(:sp) { :oidc }

--- a/spec/features/idv/steps/in_person/address_spec.rb
+++ b/spec/features/idv/steps/in_person/address_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'doc auth In person proofing residential address step',
-               js: true,
-               allowed_extra_analytics: [:*] do
+RSpec.describe 'doc auth In person proofing residential address step', :js do
   include IdvStepHelper
   include InPersonHelper
 

--- a/spec/features/idv/steps/in_person/state_id_step_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'doc auth IPP state ID step', js: true, allowed_extra_analytics: [:*] do
+RSpec.describe 'doc auth IPP state ID step', js: true do
   include IdvStepHelper
   include InPersonHelper
 

--- a/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
+++ b/spec/services/doc_auth/mock/doc_auth_mock_client_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
         )
 
         expect(response.selfie_check_performed?).to be(true)
-        expect(response.extra).to have_key(:portrait_match_results)
+        expect(response.extra[:portrait_match_results]).to be_present
       end
 
       it 'returns selfie status with default setting' do
@@ -271,7 +271,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
 
         expect(response.selfie_check_performed?).to be(true)
         expect(response.selfie_status).to eq(:success)
-        expect(response.extra).to_not have_key(:portrait_match_results)
+        expect(response.extra[:portrait_match_results]).to be_nil
       end
     end
 
@@ -291,7 +291,7 @@ RSpec.describe DocAuth::Mock::DocAuthMockClient do
         )
 
         expect(response.selfie_check_performed?).to be(false)
-        expect(response.extra).not_to have_key(:portrait_match_results)
+        expect(response.extra[:portrait_match_results]).to be_nil
       end
     end
   end

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -323,6 +323,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         classification_info: {},
         workflow: 'test_non_liveness_workflow',
         liveness_checking_required: false,
+        portrait_match_results: nil,
       )
       expect(response.doc_auth_success?).to eq(true)
       expect(response.selfie_status).to eq(:not_processed)
@@ -392,11 +393,33 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.pii_from_doc).to eq(nil)
       expect(response.attention_with_barcode?).to eq(false)
       expect(response.extra).to eq(
-        doc_auth_result: DocAuth::LexisNexis::ResultCodes::CAUTION.name,
+        doc_auth_result: DocAuth::LexisNexis::ResultCodes::FAILED.name,
         billed: true,
-        classification_info: {},
+        classification_info: nil,
         liveness_checking_required: false,
         workflow: 'test_non_liveness_workflow',
+        portrait_match_results: nil,
+        alert_failure_count: 1,
+        liveness_enabled: false,
+        vendor: 'Mock',
+        processed_alerts: {
+          failed: [{ name: '2D Barcode Read', result: 'Failed' }],
+          passed: [],
+        },
+        image_metrics: {
+          back: {
+            'GlareMetric' => 100,
+            'HorizontalResolution' => 100,
+            'SharpnessMetric' => 100,
+            'VerticalResolution' => 600,
+          },
+          front: {
+            'GlareMetric' => 100,
+            'HorizontalResolution' => 600,
+            'SharpnessMetric' => 100,
+            'VerticalResolution' => 600,
+          },
+        },
       )
     end
   end
@@ -421,9 +444,31 @@ RSpec.describe DocAuth::Mock::ResultResponse do
       expect(response.extra).to eq(
         doc_auth_result: DocAuth::LexisNexis::ResultCodes::FAILED.name,
         billed: true,
-        classification_info: {},
+        classification_info: nil,
         liveness_checking_required: false,
         workflow: 'test_non_liveness_workflow',
+        portrait_match_results: nil,
+        alert_failure_count: 1,
+        liveness_enabled: false,
+        vendor: 'Mock',
+        processed_alerts: {
+          failed: [{ name: '2D Barcode Read', result: 'Failed' }],
+          passed: [],
+        },
+        image_metrics: {
+          back: {
+            'GlareMetric' => 100,
+            'HorizontalResolution' => 600,
+            'SharpnessMetric' => 100,
+            'VerticalResolution' => 600,
+          },
+          front: {
+            'GlareMetric' => 100,
+            'HorizontalResolution' => 600,
+            'SharpnessMetric' => 100,
+            'VerticalResolution' => 600,
+          },
+        },
       )
     end
   end
@@ -480,6 +525,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
         classification_info: {},
         liveness_checking_required: false,
         workflow: 'test_non_liveness_workflow',
+        portrait_match_results: nil,
       )
     end
   end
@@ -788,7 +834,7 @@ RSpec.describe DocAuth::Mock::ResultResponse do
 
     it 'returns the expected values' do
       expect(response.selfie_check_performed?).to eq(false)
-      expect(response.extra).not_to have_key(:portrait_match_results)
+      expect(response.extra[:portrait_match_results]).to be_nil
       expect(response.doc_auth_success?).to eq(true)
       expect(response.selfie_status).to eq(:not_processed)
       expect(response.extra[:liveness_checking_required]).to eq(false)


### PR DESCRIPTION
## 🛠 Summary of changes

Implements suggestion from https://github.com/18F/identity-idp/pull/11220#discussion_r1751995660 to unexempt `state_id_step_spec.rb` allowed extra analytics, fixing issues exposed:

- Doc auth mock proofing vendor didn't include all expected analytics properties
   - Fix: Include expected analytics property
- `step_count` is only included for FSM implementation, but is being removed in non-FSM approach
   - Fix: Remove `step_count` from FSM with expectation that it's no longer needed

## 📜 Testing Plan

Verify build passes.