### PR TITLE
Add erroneous character checking to address search field

### DIFF
--- a/app/javascript/packages/address-search/components/full-address-search-input.tsx
+++ b/app/javascript/packages/address-search/components/full-address-search-input.tsx
@@ -4,7 +4,7 @@ import type { RegisterFieldCallback } from '@18f/identity-form-steps';
 import { useDidUpdateEffect } from '@18f/identity-react-hooks';
 import { SpinnerButtonRefHandle, SpinnerButton } from '@18f/identity-spinner-button';
 import { ValidatedField } from '@18f/identity-validated-field';
-import { t } from '@18f/identity-i18n';
+import { useI18n } from '@18f/identity-react-i18n';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import useValidatedUspsLocations from '../hooks/use-validated-usps-locations';
 
@@ -30,6 +30,7 @@ export default function FullAddressSearchInput({
   registerField = () => undefined,
   usStatesTerritories,
 }: FullAddressSearchInputProps) {
+  const { t } = useI18n();
   const spinnerButtonRef = useRef<SpinnerButtonRefHandle>(null);
   const [addressValue, setAddressValue] = useState('');
   const [cityValue, setCityValue] = useState('');
@@ -82,12 +83,27 @@ export default function FullAddressSearchInput({
     [addressValue, cityValue, stateValue, zipCodeValue],
   );
 
+  const getErroneousAddressChars = () => {
+    const addressReStr = validatedAddressFieldRef.current?.pattern;
+
+    if (!addressReStr) {
+      return;
+    }
+
+    const addressRegex = new RegExp(addressReStr, 'g');
+    const errChars = addressValue.replace(addressRegex, '');
+    const uniqErrChars = [...new Set(errChars.split(''))].join('');
+    return uniqErrChars;
+  };
+
   return (
     <>
       <ValidatedField
         ref={validatedAddressFieldRef}
         messages={{
-          patternMismatch: t('simple_form.required.text'),
+          patternMismatch: t('in_person_proofing.form.address.errors.unsupported_chars', {
+            char_list: getErroneousAddressChars(),
+          }),
         }}
       >
         <TextInput
@@ -98,7 +114,7 @@ export default function FullAddressSearchInput({
           label={t('in_person_proofing.body.location.po_search.address_label')}
           disabled={disabled}
           maxLength={255}
-          pattern=".*\S.*$"
+          pattern="[A-Za-z0-9\-' .\/#]*"
         />
       </ValidatedField>
       <ValidatedField

--- a/app/javascript/packages/address-search/hooks/use-validated-usps-locations.ts
+++ b/app/javascript/packages/address-search/hooks/use-validated-usps-locations.ts
@@ -6,10 +6,10 @@ import { t } from '@18f/identity-i18n';
 
 export default function useValidatedUspsLocations(locationsURL: string) {
   const [locationQuery, setLocationQuery] = useState<LocationQuery | null>(null);
-  const validatedAddressFieldRef = useRef<HTMLFormElement>(null);
-  const validatedCityFieldRef = useRef<HTMLFormElement>(null);
-  const validatedStateFieldRef = useRef<HTMLFormElement>(null);
-  const validatedZipCodeFieldRef = useRef<HTMLFormElement>(null);
+  const validatedAddressFieldRef = useRef<HTMLInputElement>(null);
+  const validatedCityFieldRef = useRef<HTMLInputElement>(null);
+  const validatedStateFieldRef = useRef<HTMLInputElement>(null);
+  const validatedZipCodeFieldRef = useRef<HTMLInputElement>(null);
 
   const checkValidityAndDisplayErrors = (address, city, state, zipCode) => {
     let formIsValid = true;
@@ -48,7 +48,14 @@ export default function useValidatedUspsLocations(locationsURL: string) {
     validatedStateFieldRef.current?.reportValidity();
     validatedZipCodeFieldRef.current?.reportValidity();
 
-    return formIsValid && zipCodeIsValid;
+    const hasInvalidFields = [
+      validatedAddressFieldRef,
+      validatedCityFieldRef,
+      validatedStateFieldRef,
+      validatedZipCodeFieldRef,
+    ].some((fieldRef) => fieldRef.current?.validity?.valid === false);
+
+    return formIsValid && zipCodeIsValid && !hasInvalidFields;
   };
 
   const handleLocationSearch = useCallback(

--- a/app/services/usps_in_person_proofing/applicant.rb
+++ b/app/services/usps_in_person_proofing/applicant.rb
@@ -4,5 +4,9 @@ module UspsInPersonProofing
   Applicant = Struct.new(
     :unique_id, :first_name, :last_name, :address, :city, :state, :zip_code,
     :email, keyword_init: true
-  )
+  ) do
+    def has_valid_address?
+      (address =~ /[^A-Za-z0-9\-' .\/#]/).nil?
+    end
+  end
 end

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -133,6 +133,21 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
       end
     end
 
+    context 'address has unsupported characters' do
+      subject(:response) do
+        post :index, params: { locale: locale,
+                               address: { street_address: '1600, Pennsylvania Ave',
+                                          city: 'Washington',
+                                          state: 'DC',
+                                          zip_code: '20500' } }
+      end
+
+      it 'returns unprocessable entity' do
+        subject
+        expect(response.status).to eq 422
+      end
+    end
+
     context 'no addresses found by usps' do
       before do
         allow(proofer).to receive(:request_facilities).with(address, false).


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14071](https://cm-jira.usa.gov/browse/LG-14071)


## 🛠 Summary of changes

Added client side character checking to PO search address field so that it aligns with other address field validations such as the ones associated with the state ID form. 

Also added a validation function server side in case someone disables JS and submits. (It will fail as it used to instead of showing the new unsupported characters message since this is not how users ~should~ be interacting with the form, but it's technically possible.)

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Step 1: Create or login to an account that is at the starting step of the IPP flow.
- [x] Step 2: When on the PO search page add a comma and a hash/pound sign to the address field.
- [ ] Step 3: On submission, an error should show regarding unsupported errors and specifically the comma. Allowed characters: alpha-numerics, spaces and the following: - ' . / #

(To see the dynamism of the error message you can also throw in a dollar sign and resubmit)
