### PR TITLE
LG-13863 Add automatic retry logic to the USPS proofer client

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3480,6 +3480,34 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks USPS in-person proofing request retries
+  # @param [String] context The context request the retry was executed.
+  # @param [Integer] retry_attempt The current retry attempt.
+  # @param [Integer] retry_max The max number of retries that could occur.
+  # @param [Integer] status_code The status code received before retry.
+  # @param [String] exception_class The class name of the exception.
+  # @param [String] exception_message The exception message.
+  def idv_in_person_usps_request_retry(
+    context:,
+    retry_attempt:,
+    retry_max:,
+    status_code:,
+    exception_class:,
+    exception_message:,
+    **extra
+  )
+    track_event(
+      :idv_in_person_usps_request_retry,
+      context: context,
+      retry_attempt: retry_attempt,
+      retry_max: retry_max,
+      status_code: status_code,
+      expection_class: exception_class,
+      expection_message: exception_message,
+      **extra,
+    )
+  end
+
   # User visits IdV
   # @param [Hash,nil] proofing_components User's proofing components.
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -85,6 +85,7 @@ module Idv
       idv_in_person_usps_proofing_results_job_unexpected_response
       idv_in_person_usps_proofing_results_job_user_sent_to_fraud_review
       idv_in_person_usps_request_enroll_exception
+      idv_in_person_usps_request_retry
       idv_ipp_deactivated_for_never_visiting_post_office
       idv_link_sent_capture_doc_polling_complete
       idv_link_sent_capture_doc_polling_started

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -141,8 +141,8 @@ module UspsInPersonProofing
     def faraday_retry
       Faraday.new(headers: request_headers) do |conn|
         conn.request :retry, {
-          max: 3,
-          interval: 0.5,
+          max: 2,
+          interval: 1,
           backoff_factor: 2,
           exceptions: Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [Faraday::ServerError,
                                                                         Faraday::ConnectionFailed],

--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe 'dev rake tasks', allowed_extra_analytics: [:*] do
       stub_request(
         :post,
         %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant},
-      ).to_raise(Faraday::TimeoutError).times(8).then.
+      ).to_raise(Faraday::TimeoutError).times(6).then.
         to_return(
           status: 200,
           body: UspsInPersonProofing::Mock::Fixtures.request_enroll_response,
@@ -431,7 +431,7 @@ RSpec.describe 'dev rake tasks', allowed_extra_analytics: [:*] do
       stub_request(
         :post,
         %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant},
-      ).to_raise(Faraday::TimeoutError).times(8).then.
+      ).to_raise(Faraday::TimeoutError).times(6).then.
         to_return(
           status: 200,
           body: UspsInPersonProofing::Mock::Fixtures.request_enroll_response,

--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe 'dev rake tasks', allowed_extra_analytics: [:*] do
       stub_request(
         :post,
         %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant},
-      ).to_raise(Faraday::TimeoutError).times(2).then.
+      ).to_raise(Faraday::TimeoutError).times(8).then.
         to_return(
           status: 200,
           body: UspsInPersonProofing::Mock::Fixtures.request_enroll_response,
@@ -431,7 +431,7 @@ RSpec.describe 'dev rake tasks', allowed_extra_analytics: [:*] do
       stub_request(
         :post,
         %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant},
-      ).to_raise(Faraday::TimeoutError).times(2).then.
+      ).to_raise(Faraday::TimeoutError).times(8).then.
         to_return(
           status: 200,
           body: UspsInPersonProofing::Mock::Fixtures.request_enroll_response,

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -349,6 +349,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
     let(:enrollment) { create(:in_person_enrollment, :with_service_provider) }
     let(:usps_eipp_sponsor_id) { '314159265359' }
     let(:is_enhanced_ipp) { true }
+    let(:analytics) { instance_double(Analytics) }
     let(:pii) do
       Pii::Attributes.new_from_hash(
         Idp::Constants::MOCK_IDV_APPLICANT,
@@ -386,7 +387,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
 
       it 'creates an enhanced ipp enrollment' do
         expect(proofer).to receive(:request_enroll).with(applicant, is_enhanced_ipp)
-        subject.create_usps_enrollment(enrollment, pii, is_enhanced_ipp)
+        subject.create_usps_enrollment(enrollment, pii, is_enhanced_ipp, analytics)
       end
 
       it 'saves sponsor_id on the enrollment to the usps_eipp_sponsor_id' do

--- a/spec/services/usps_in_person_proofing/proofer_spec.rb
+++ b/spec/services/usps_in_person_proofing/proofer_spec.rb
@@ -432,8 +432,8 @@ RSpec.describe UspsInPersonProofing::Proofer do
           @response = err
         end
 
-        it 'retries the USPS optInIPPApplicant request 4 times' do
-          expect(@mock).to have_been_made.times(4)
+        it 'retries the USPS optInIPPApplicant request' do
+          expect(@mock).to have_been_made.times(3)
         end
 
         it 'throws a Faraday::ServerError' do

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -121,6 +121,18 @@ module UspsIppHelper
     )
   end
 
+  def stub_request_enroll_server_down_time_response
+    stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant}).to_return(
+      status: 500,
+      body: UspsInPersonProofing::Mock::Fixtures.internal_server_error_response,
+      headers: { 'content-type' => 'application/json' },
+    ).times(2).to_return(
+      status: 200,
+      body: UspsInPersonProofing::Mock::Fixtures.request_enroll_response,
+      headers: { 'content-type' => 'application/json' },
+    )
+  end
+
   def stub_request_enroll_invalid_response
     stub_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant}).to_return(
       status: 200,

--- a/spec/support/usps_ipp_helper.rb
+++ b/spec/support/usps_ipp_helper.rb
@@ -126,7 +126,7 @@ module UspsIppHelper
       status: 500,
       body: UspsInPersonProofing::Mock::Fixtures.internal_server_error_response,
       headers: { 'content-type' => 'application/json' },
-    ).times(2).to_return(
+    ).times(1).to_return(
       status: 200,
       body: UspsInPersonProofing::Mock::Fixtures.request_enroll_response,
       headers: { 'content-type' => 'application/json' },


### PR DESCRIPTION
changelog: Internal, In-person proofing, Add automatic retry logic to the USPS proofer client enroll requests.

## 🎫 Ticket

Link to the relevant ticket:
[LG-13863](https://cm-jira.usa.gov/browse/LG-13863)

## 🛠 Summary of changes

Add automatic retry logic to the USPS proofer client enroll requests.

## 📜 Testing Plan

todo!
