### PR TITLE
Remove ab_test_args stub analytics properties

### DIFF
--- a/app/helpers/opt_in_helper.rb
+++ b/app/helpers/opt_in_helper.rb
@@ -4,8 +4,8 @@ module OptInHelper
   def opt_in_analytics_properties
     if IdentityConfig.store.in_person_proofing_opt_in_enabled
       { opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing }
-      else
-        {}
-      end
+    else
+      { opted_in_to_in_person_proofing: nil }
+    end
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1720,7 +1720,7 @@ module AnalyticsEvents
     flow_path:,
     liveness_checking_required:,
     issue_year:,
-    failed_image_fingerprints:,
+    failed_image_fingerprints: nil,
     billed: nil,
     doc_auth_result: nil,
     vendor_request_time_in_ms: nil,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1687,6 +1687,8 @@ module AnalyticsEvents
   # @param [String] workflow LexisNexis TrueID workflow
   # @param [String] birth_year Birth year from document
   # @param [Integer] issue_year Year document was issued
+  # @param [Hash] failed_image_fingerprints Hash of document field with an array of failed image
+  # fingerprints for that field.
   # @param [Integer] selfie_attempts number of selfie attempts the user currently has processed
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
@@ -1718,6 +1720,7 @@ module AnalyticsEvents
     flow_path:,
     liveness_checking_required:,
     issue_year:,
+    failed_image_fingerprints:,
     billed: nil,
     doc_auth_result: nil,
     vendor_request_time_in_ms: nil,
@@ -1795,6 +1798,7 @@ module AnalyticsEvents
       workflow:,
       birth_year:,
       issue_year:,
+      failed_image_fingerprints:,
       selfie_attempts:,
       acuant_sdk_upgrade_ab_test_bucket:,
       liveness_enabled:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1098,11 +1098,13 @@ module AnalyticsEvents
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_agreement_submitted(
     success:,
     errors:,
     step:,
     analytics_id:,
+    opted_in_to_in_person_proofing: nil,
     error_details: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
@@ -1117,6 +1119,7 @@ module AnalyticsEvents
       analytics_id:,
       acuant_sdk_upgrade_ab_test_bucket:,
       skip_hybrid_handoff:,
+      opted_in_to_in_person_proofing:,
       **extra,
     )
   end
@@ -1127,9 +1130,11 @@ module AnalyticsEvents
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_agreement_visited(
     step:,
     analytics_id:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
@@ -1140,6 +1145,7 @@ module AnalyticsEvents
       analytics_id:,
       acuant_sdk_upgrade_ab_test_bucket:,
       skip_hybrid_handoff:,
+      opted_in_to_in_person_proofing:,
       **extra,
     )
   end
@@ -1179,6 +1185,7 @@ module AnalyticsEvents
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
   # @param [Boolean] stored_result_present Whether a stored result was present
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_document_capture_submitted(
     success:,
     errors:,
@@ -1187,6 +1194,7 @@ module AnalyticsEvents
     liveness_checking_required:,
     selfie_check_required:,
     flow_path:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     redo_document_capture: nil,
     skip_hybrid_handoff: nil,
@@ -1205,6 +1213,7 @@ module AnalyticsEvents
       selfie_check_required:,
       acuant_sdk_upgrade_ab_test_bucket:,
       flow_path:,
+      opted_in_to_in_person_proofing:,
       stored_result_present:,
       **extra,
     )
@@ -1221,12 +1230,14 @@ module AnalyticsEvents
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_document_capture_visited(
     step:,
     analytics_id:,
     liveness_checking_required:,
     selfie_check_required:,
     flow_path:,
+    opted_in_to_in_person_proofing: nil,
     redo_document_capture: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
@@ -1241,6 +1252,7 @@ module AnalyticsEvents
       skip_hybrid_handoff:,
       liveness_checking_required:,
       selfie_check_required:,
+      opted_in_to_in_person_proofing:,
       acuant_sdk_upgrade_ab_test_bucket:,
       **extra,
     )
@@ -1275,12 +1287,14 @@ module AnalyticsEvents
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] selection Selection form parameter
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_how_to_verify_submitted(
     success:,
     errors:,
     step:,
     analytics_id:,
     skip_hybrid_handoff:,
+    opted_in_to_in_person_proofing: nil,
     selection: nil,
     error_details: nil,
     **extra
@@ -1294,6 +1308,7 @@ module AnalyticsEvents
       analytics_id:,
       skip_hybrid_handoff:,
       selection:,
+      opted_in_to_in_person_proofing:,
       **extra,
     )
   end
@@ -1301,10 +1316,12 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_how_to_verify_visited(
     step:,
     analytics_id:,
     skip_hybrid_handoff:,
+    opted_in_to_in_person_proofing: nil,
     **extra
   )
     track_event(
@@ -1312,6 +1329,7 @@ module AnalyticsEvents
       step:,
       analytics_id:,
       skip_hybrid_handoff:,
+      opted_in_to_in_person_proofing:,
       **extra,
     )
   end
@@ -1333,6 +1351,7 @@ module AnalyticsEvents
   # SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Hash] telephony_response Response from Telephony gem
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_hybrid_handoff_submitted(
     success:,
     errors:,
@@ -1342,6 +1361,7 @@ module AnalyticsEvents
     selfie_check_required:,
     destination:,
     flow_path:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     telephony_response: nil,
@@ -1357,6 +1377,7 @@ module AnalyticsEvents
       skip_hybrid_handoff:,
       selfie_check_required:,
       acuant_sdk_upgrade_ab_test_bucket:,
+      opted_in_to_in_person_proofing:,
       destination:,
       flow_path:,
       telephony_response:,
@@ -1374,11 +1395,13 @@ module AnalyticsEvents
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_hybrid_handoff_visited(
     step:,
     analytics_id:,
     redo_document_capture:,
     selfie_check_required:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     **extra
@@ -1389,6 +1412,7 @@ module AnalyticsEvents
       analytics_id:,
       redo_document_capture:,
       skip_hybrid_handoff:,
+      opted_in_to_in_person_proofing:,
       selfie_check_required:,
       acuant_sdk_upgrade_ab_test_bucket:,
       **extra,
@@ -1398,13 +1422,24 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # @identity.idp.previous_event_name IdV: doc auth send_link submitted
-  def idv_doc_auth_link_sent_submitted(step:, analytics_id:, flow_path:, **extra)
+  def idv_doc_auth_link_sent_submitted(
+    step:,
+    analytics_id:,
+    flow_path:,
+    opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
+    **extra
+  )
     track_event(
       'IdV: doc auth link_sent submitted',
       step:,
       analytics_id:,
       flow_path:,
+      opted_in_to_in_person_proofing:,
+      skip_hybrid_handoff:,
       **extra,
     )
   end
@@ -1412,12 +1447,23 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param ["hybrid","standard"] flow_path Document capture user flow
-  def idv_doc_auth_link_sent_visited(step:, analytics_id:, flow_path:, **extra)
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  def idv_doc_auth_link_sent_visited(
+    step:,
+    analytics_id:,
+    flow_path:,
+    opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
+    **extra
+  )
     track_event(
       'IdV: doc auth link_sent visited',
       step:,
       analytics_id:,
       flow_path:,
+      opted_in_to_in_person_proofing:,
+      skip_hybrid_handoff:,
       **extra,
     )
   end
@@ -1426,10 +1472,14 @@ module AnalyticsEvents
   # @param [String] analytics_id Current IdV flow identifier
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] same_address_as_id
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_redo_ssn_submitted(
     step:,
     analytics_id:,
     flow_path:,
+    opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
     same_address_as_id: nil,
     **extra
   )
@@ -1438,6 +1488,8 @@ module AnalyticsEvents
       step:,
       analytics_id:,
       flow_path:,
+      opted_in_to_in_person_proofing:,
+      skip_hybrid_handoff:,
       same_address_as_id:,
       **extra,
     )
@@ -1478,12 +1530,14 @@ module AnalyticsEvents
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] same_address_as_id
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_ssn_submitted(
     success:,
     errors:,
     step:,
     analytics_id:,
     flow_path:,
+    opted_in_to_in_person_proofing: nil,
     error_details: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
@@ -1500,6 +1554,7 @@ module AnalyticsEvents
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
       flow_path:,
+      opted_in_to_in_person_proofing:,
       same_address_as_id:,
       **extra,
     )
@@ -1513,10 +1568,12 @@ module AnalyticsEvents
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] same_address_as_id
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_ssn_visited(
     step:,
     analytics_id:,
     flow_path:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     same_address_as_id: nil,
@@ -1529,6 +1586,7 @@ module AnalyticsEvents
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
       flow_path:,
+      opted_in_to_in_person_proofing:,
       same_address_as_id:,
       **extra,
     )
@@ -1915,10 +1973,12 @@ module AnalyticsEvents
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] same_address_as_id
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_verify_submitted(
     step:,
     analytics_id:,
     flow_path:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     same_address_as_id: nil,
@@ -1931,6 +1991,7 @@ module AnalyticsEvents
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
       flow_path:,
+      opted_in_to_in_person_proofing:,
       same_address_as_id:,
       **extra,
     )
@@ -1944,10 +2005,12 @@ module AnalyticsEvents
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] same_address_as_id
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_verify_visited(
     step:,
     analytics_id:,
     flow_path:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     same_address_as_id: nil,
@@ -1960,6 +2023,7 @@ module AnalyticsEvents
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
       flow_path:,
+      opted_in_to_in_person_proofing:,
       same_address_as_id:,
       **extra,
     )
@@ -1981,11 +2045,19 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
-  def idv_doc_auth_welcome_submitted(step:, analytics_id:, skip_hybrid_handoff: nil, **extra)
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  def idv_doc_auth_welcome_submitted(
+    step:,
+    analytics_id:,
+    opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
+    **extra
+  )
     track_event(
       'IdV: doc auth welcome submitted',
       step:,
       analytics_id:,
+      opted_in_to_in_person_proofing:,
       skip_hybrid_handoff:,
       **extra,
     )
@@ -1995,12 +2067,20 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
-  def idv_doc_auth_welcome_visited(step:, analytics_id:, skip_hybrid_handoff: nil, **extra)
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  def idv_doc_auth_welcome_visited(
+    step:,
+    analytics_id:,
+    opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
+    **extra
+  )
     track_event(
       'IdV: doc auth welcome visited',
       step:,
       analytics_id:,
       skip_hybrid_handoff:,
+      opted_in_to_in_person_proofing:,
       **extra,
     )
   end
@@ -2025,6 +2105,7 @@ module AnalyticsEvents
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # @param [Integer,nil] proofing_workflow_time_in_seconds The time since starting proofing
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # @identity.idp.previous_event_name  IdV: review info visited
   def idv_enter_password_submitted(
     success:,
@@ -2032,6 +2113,7 @@ module AnalyticsEvents
     fraud_rejection:,
     gpo_verification_pending:,
     in_person_verification_pending:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     deactivation_reason: nil,
@@ -2050,6 +2132,7 @@ module AnalyticsEvents
       in_person_verification_pending:,
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
+      opted_in_to_in_person_proofing:,
       fraud_rejection:,
       proofing_components:,
       active_profile_idv_level:,
@@ -2073,9 +2156,11 @@ module AnalyticsEvents
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   #        used to verify the user's identity
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # User visited IDV password confirm page
   # @identity.idp.previous_event_name  IdV: review info visited
   def idv_enter_password_visited(
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     proofing_components: nil,
@@ -2086,6 +2171,7 @@ module AnalyticsEvents
   )
     track_event(
       :idv_enter_password_visited,
+      opted_in_to_in_person_proofing:,
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
       address_verification_method:,
@@ -2116,6 +2202,7 @@ module AnalyticsEvents
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
   # @param [Array,nil] profile_history Array of user's profiles (oldest to newest).
   # @param [Integer,nil] proofing_workflow_time_in_seconds The time since starting proofing
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # @see Reporting::IdentityVerificationReport#query This event is used by the identity verification
   #       report. Changes here should be reflected there.
   # Tracks the last step of IDV, indicates the user successfully proofed
@@ -2125,6 +2212,7 @@ module AnalyticsEvents
     fraud_rejection:,
     gpo_verification_pending:,
     in_person_verification_pending:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     deactivation_reason: nil,
@@ -2142,6 +2230,7 @@ module AnalyticsEvents
       fraud_rejection:,
       gpo_verification_pending:,
       in_person_verification_pending:,
+      opted_in_to_in_person_proofing:,
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
       deactivation_reason:,
@@ -2343,6 +2432,8 @@ module AnalyticsEvents
   # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # GPO letter was enqueued and the time at which it was enqueued
   def idv_gpo_address_letter_enqueued(
     enqueued_at:,
@@ -2350,6 +2441,8 @@ module AnalyticsEvents
     first_letter_requested_at:,
     hours_since_first_letter:,
     phone_step_attempts:,
+    opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
     pending_profile_idv_level: nil,
@@ -2357,14 +2450,16 @@ module AnalyticsEvents
   )
     track_event(
       'IdV: USPS address letter enqueued',
-      enqueued_at: enqueued_at,
-      resend: resend,
-      first_letter_requested_at: first_letter_requested_at,
-      hours_since_first_letter: hours_since_first_letter,
-      phone_step_attempts: phone_step_attempts,
-      proofing_components: proofing_components,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
+      enqueued_at:,
+      resend:,
+      first_letter_requested_at:,
+      hours_since_first_letter:,
+      phone_step_attempts:,
+      opted_in_to_in_person_proofing:,
+      skip_hybrid_handoff:,
+      proofing_components:,
+      active_profile_idv_level:,
+      pending_profile_idv_level:,
       **extra,
     )
   end
@@ -2384,12 +2479,16 @@ module AnalyticsEvents
   # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # GPO letter was requested
   def idv_gpo_address_letter_requested(
     resend:,
     first_letter_requested_at:,
     hours_since_first_letter:,
     phone_step_attempts:,
+    opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
     pending_profile_idv_level: nil,
@@ -2397,13 +2496,15 @@ module AnalyticsEvents
   )
     track_event(
       'IdV: USPS address letter requested',
-      resend: resend,
+      resend:,
       first_letter_requested_at:,
       hours_since_first_letter:,
       phone_step_attempts:,
-      proofing_components: proofing_components,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
+      opted_in_to_in_person_proofing:,
+      skip_hybrid_handoff:,
+      proofing_components:,
+      active_profile_idv_level:,
+      pending_profile_idv_level:,
       **extra,
     )
   end
@@ -2520,7 +2621,7 @@ module AnalyticsEvents
   def idv_in_person_location_submitted(
     selected_location:,
     flow_path:,
-    opted_in_to_in_person_proofing:,
+    opted_in_to_in_person_proofing: nil,
     **extra
   )
     track_event(
@@ -2826,6 +2927,7 @@ module AnalyticsEvents
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # @param [String] birth_year Birth year from document
   # @param [String] document_zip_code ZIP code from document
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # User submitted state id
   def idv_in_person_proofing_state_id_submitted(
     success:,
@@ -2835,6 +2937,7 @@ module AnalyticsEvents
     analytics_id:,
     birth_year:,
     document_zip_code:,
+    skip_hybrid_handoff: nil,
     error_details: nil,
     same_address_as_id: nil,
     opted_in_to_in_person_proofing: nil,
@@ -2850,6 +2953,7 @@ module AnalyticsEvents
       error_details:,
       birth_year:,
       document_zip_code:,
+      skip_hybrid_handoff:,
       same_address_as_id:,
       opted_in_to_in_person_proofing:,
       **extra,
@@ -2861,12 +2965,14 @@ module AnalyticsEvents
   # @param [String] analytics_id
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # @param [Boolean] same_address_as_id
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # State id page visited
   def idv_in_person_proofing_state_id_visited(
     flow_path: nil,
     step: nil,
     analytics_id: nil,
     opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
     same_address_as_id: nil,
     **extra
   )
@@ -2876,6 +2982,7 @@ module AnalyticsEvents
       step:,
       analytics_id:,
       opted_in_to_in_person_proofing:,
+      skip_hybrid_handoff:,
       same_address_as_id:,
       **extra,
     )
@@ -3589,8 +3696,10 @@ module AnalyticsEvents
   # @param [Boolean] encrypted_profiles_missing True if user's session had no encrypted pii
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # User visited IDV personal key page
   def idv_personal_key_visited(
+    opted_in_to_in_person_proofing: nil,
     proofing_components: nil,
     address_verification_method: nil,
     in_person_verification_pending: nil,
@@ -3601,12 +3710,13 @@ module AnalyticsEvents
   )
     track_event(
       'IdV: personal key visited',
-      proofing_components: proofing_components,
-      address_verification_method: address_verification_method,
-      in_person_verification_pending: in_person_verification_pending,
-      encrypted_profiles_missing: encrypted_profiles_missing,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
+      opted_in_to_in_person_proofing:,
+      proofing_components:,
+      address_verification_method:,
+      in_person_verification_pending:,
+      encrypted_profiles_missing:,
+      active_profile_idv_level:,
+      pending_profile_idv_level:,
       **extra,
     )
   end
@@ -3632,6 +3742,7 @@ module AnalyticsEvents
   # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # The user submitted their phone on the phone confirmation page
   def idv_phone_confirmation_form_submitted(
     success:,
@@ -3642,6 +3753,7 @@ module AnalyticsEvents
     carrier:,
     country_code:,
     area_code:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     error_details: nil,
@@ -3660,6 +3772,7 @@ module AnalyticsEvents
       carrier:,
       country_code:,
       area_code:,
+      opted_in_to_in_person_proofing:,
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
       otp_delivery_preference:,
@@ -3880,6 +3993,7 @@ module AnalyticsEvents
   # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # When a user attempts to confirm possession of a new phone number during the IDV process
   def idv_phone_confirmation_otp_submitted(
     success:,
@@ -3889,6 +4003,7 @@ module AnalyticsEvents
     otp_delivery_preference:,
     second_factor_attempts_count:,
     second_factor_locked_at:,
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     error_details: nil,
@@ -3907,6 +4022,7 @@ module AnalyticsEvents
       otp_delivery_preference:,
       second_factor_attempts_count:,
       second_factor_locked_at:,
+      opted_in_to_in_person_proofing:,
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
       proofing_components:,
@@ -3962,6 +4078,7 @@ module AnalyticsEvents
   # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # The vendor finished the process of confirming the users phone
   def idv_phone_confirmation_vendor_submitted(
     success:,
@@ -3972,6 +4089,7 @@ module AnalyticsEvents
     phone_fingerprint:,
     new_phone_added:,
     hybrid_handoff_phone_used:,
+    opted_in_to_in_person_proofing: nil,
     error_details: nil,
     proofing_components: nil,
     active_profile_idv_level: nil,
@@ -3989,6 +4107,7 @@ module AnalyticsEvents
       phone_fingerprint:,
       new_phone_added:,
       hybrid_handoff_phone_used:,
+      opted_in_to_in_person_proofing:,
       proofing_components:,
       active_profile_idv_level:,
       pending_profile_idv_level:,
@@ -4010,9 +4129,13 @@ module AnalyticsEvents
   # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # When a user gets an error during the phone finder flow of IDV
   def idv_phone_error_visited(
     type:,
+    opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
     proofing_components: nil,
     limiter_expires_at: nil,
     remaining_submit_attempts: nil,
@@ -4023,6 +4146,8 @@ module AnalyticsEvents
     track_event(
       'IdV: phone error visited',
       type:,
+      opted_in_to_in_person_proofing:,
+      skip_hybrid_handoff:,
       proofing_components:,
       limiter_expires_at:,
       remaining_submit_attempts:,
@@ -4044,8 +4169,10 @@ module AnalyticsEvents
   # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # User visited idv phone of record
   def idv_phone_of_record_visited(
+    opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     proofing_components: nil,
@@ -4055,6 +4182,7 @@ module AnalyticsEvents
   )
     track_event(
       'IdV: phone of record visited',
+      opted_in_to_in_person_proofing:,
       skip_hybrid_handoff:,
       acuant_sdk_upgrade_ab_test_bucket:,
       proofing_components:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -406,12 +406,16 @@ module AnalyticsEvents
   end
 
   # @param [String] message the warning
+  # @param [Array<String>] unknown_alerts Names of alerts not recognized by our code
+  # @param [Hash] response_info Response payload
   # Logged when there is a non-user-facing error in the doc auth process, such as an unrecognized
   # field from a vendor
-  def doc_auth_warning(message: nil, **extra)
+  def doc_auth_warning(message: nil, unknown_alerts: nil, response_info: nil, **extra)
     track_event(
       'Doc Auth Warning',
-      message: message,
+      message:,
+      unknown_alerts:,
+      response_info:,
       **extra,
     )
   end
@@ -2730,11 +2734,13 @@ module AnalyticsEvents
   # @param [String] analytics_id
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] same_address_as_id
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # address page visited
   def idv_in_person_proofing_address_visited(
     flow_path:,
     step:,
     analytics_id:,
+    opted_in_to_in_person_proofing: nil,
     skip_hybrid_handoff: nil,
     same_address_as_id: nil,
     **extra
@@ -2744,6 +2750,7 @@ module AnalyticsEvents
       flow_path:,
       step:,
       analytics_id:,
+      opted_in_to_in_person_proofing:,
       skip_hybrid_handoff:,
       same_address_as_id:,
       **extra,
@@ -2890,6 +2897,7 @@ module AnalyticsEvents
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean, nil] same_address_as_id
   # @param [String] current_address_zip_code ZIP code of given address
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_in_person_proofing_residential_address_submitted(
     success:,
     errors:,
@@ -2897,6 +2905,7 @@ module AnalyticsEvents
     step:,
     analytics_id:,
     current_address_zip_code:,
+    opted_in_to_in_person_proofing: nil,
     error_details: nil,
     skip_hybrid_handoff: nil,
     same_address_as_id: nil,
@@ -2910,6 +2919,7 @@ module AnalyticsEvents
       step:,
       analytics_id:,
       current_address_zip_code:,
+      opted_in_to_in_person_proofing:,
       error_details:,
       skip_hybrid_handoff:,
       same_address_as_id:,
@@ -3006,16 +3016,21 @@ module AnalyticsEvents
   # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [String,nil] active_profile_idv_level ID verification level of user's active profile.
   # @param [String,nil] pending_profile_idv_level ID verification level of user's pending profile.
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # The user visited the "ready to verify" page for the in person proofing flow
-  def idv_in_person_ready_to_verify_visit(proofing_components: nil,
-                                          active_profile_idv_level: nil,
-                                          pending_profile_idv_level: nil,
-                                          **extra)
+  def idv_in_person_ready_to_verify_visit(
+    opted_in_to_in_person_proofing: nil,
+    proofing_components: nil,
+    active_profile_idv_level: nil,
+    pending_profile_idv_level: nil,
+    **extra
+  )
     track_event(
       'IdV: in person ready to verify visited',
-      proofing_components: proofing_components,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
+      opted_in_to_in_person_proofing:,
+      proofing_components:,
+      active_profile_idv_level:,
+      pending_profile_idv_level:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2864,6 +2864,7 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Boolean] same_address_as_id
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # User submitted state id on redo state id page
   def idv_in_person_proofing_redo_state_id_submitted(
     success:,
@@ -2873,6 +2874,7 @@ module AnalyticsEvents
     step: nil,
     analytics_id: nil,
     same_address_as_id: nil,
+    opted_in_to_in_person_proofing: nil,
     **extra
   )
     track_event(
@@ -2884,6 +2886,7 @@ module AnalyticsEvents
       errors:,
       error_details:,
       same_address_as_id:,
+      opted_in_to_in_person_proofing:,
       **extra,
     )
   end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -1,20 +1,14 @@
 require 'rails_helper'
 
-RSpec.describe Idv::AgreementController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::AgreementController do
   include FlowPolicyHelper
 
   let(:user) { create(:user) }
-
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
 
   before do
     stub_sign_in(user)
     stub_up_to(:welcome, idv_session: subject.idv_session)
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe '#step_info' do
@@ -45,7 +39,7 @@ RSpec.describe Idv::AgreementController,
       {
         step: 'agreement',
         analytics_id: 'Doc Auth',
-      }.merge(ab_test_args)
+      }
     end
 
     it 'renders the show template' do
@@ -109,7 +103,7 @@ RSpec.describe Idv::AgreementController,
         errors: {},
         step: 'agreement',
         analytics_id: 'Doc Auth',
-      }.merge(ab_test_args)
+      }
     end
 
     let(:skip_hybrid_handoff) { nil }

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -1,16 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe Idv::ByMail::RequestLetterController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::ByMail::RequestLetterController do
   let(:user) { create(:user) }
-
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
 
   before do
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe '#step_info' do
@@ -104,7 +98,6 @@ RSpec.describe Idv::ByMail::RequestLetterController,
           resend: false,
           phone_step_attempts: 1,
           hours_since_first_letter: 0,
-          **ab_test_args,
         ),
       )
     end

--- a/spec/controllers/idv/by_mail/resend_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/resend_letter_controller_spec.rb
@@ -1,17 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe Idv::ByMail::ResendLetterController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::ByMail::ResendLetterController do
   let(:user) { create(:user) }
-
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
 
   before do
     stub_sign_in(user)
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe '#new' do

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::DocumentCaptureController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::DocumentCaptureController do
   include FlowPolicyHelper
 
   let(:document_capture_session_requested_at) { Time.zone.now }
@@ -16,10 +15,6 @@ RSpec.describe Idv::DocumentCaptureController,
   let(:document_capture_session_uuid) { document_capture_session&.uuid }
 
   let(:user) { create(:user) }
-
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
 
   # selfie related test flags
   let(:sp_selfie_enabled) { false }
@@ -37,7 +32,6 @@ RSpec.describe Idv::DocumentCaptureController,
     allow(controller).to receive(:resolved_authn_context_result).
       and_return(resolved_authn_context)
     subject.idv_session.flow_path = flow_path
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe '#step_info' do
@@ -110,7 +104,7 @@ RSpec.describe Idv::DocumentCaptureController,
         step: 'document_capture',
         liveness_checking_required: false,
         selfie_check_required: sp_selfie_enabled,
-      }.merge(ab_test_args)
+      }
     end
 
     it 'has non-nil presenter' do
@@ -302,7 +296,7 @@ RSpec.describe Idv::DocumentCaptureController,
         step: 'document_capture',
         liveness_checking_required: false,
         selfie_check_required: sp_selfie_enabled,
-      }.merge(ab_test_args)
+      }
     end
     let(:result) { { success: true, errors: {} } }
 

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::EnterPasswordController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::EnterPasswordController do
   include UspsIppHelper
 
   let(:user) do
@@ -18,15 +17,10 @@ RSpec.describe Idv::EnterPasswordController,
     subject.idv_session
   end
 
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
-
   before do
     stub_analytics
     stub_sign_in(user)
     allow(IdentityConfig.store).to receive(:usps_mock_fallback).and_return(false)
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
     subject.idv_session.welcome_visited = true
     subject.idv_session.idv_consent_given_at = Time.zone.now
     subject.idv_session.proofing_started_at = 5.minutes.ago.iso8601
@@ -279,7 +273,6 @@ RSpec.describe Idv::EnterPasswordController,
             fraud_rejection: false,
             gpo_verification_pending: false,
             in_person_verification_pending: false,
-            **ab_test_args,
           ),
         )
       end
@@ -297,7 +290,6 @@ RSpec.describe Idv::EnterPasswordController,
           gpo_verification_pending: false,
           in_person_verification_pending: false,
           proofing_workflow_time_in_seconds: 5.minutes.to_i,
-          **ab_test_args,
         ),
       )
       expect(@analytics).to have_logged_event(
@@ -848,7 +840,6 @@ RSpec.describe Idv::EnterPasswordController,
                       fraud_rejection: false,
                       gpo_verification_pending: false,
                       in_person_verification_pending: false,
-                      **ab_test_args,
                     ),
                   )
                   expect(@analytics).to have_logged_event(
@@ -859,7 +850,6 @@ RSpec.describe Idv::EnterPasswordController,
                       fraud_rejection: false,
                       gpo_verification_pending: false,
                       in_person_verification_pending: false,
-                      **ab_test_args,
                     ),
                   )
                 end
@@ -916,7 +906,6 @@ RSpec.describe Idv::EnterPasswordController,
             phone_step_attempts: 1,
             first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
             hours_since_first_letter: 0,
-            **ab_test_args,
           ),
         )
       end
@@ -936,7 +925,6 @@ RSpec.describe Idv::EnterPasswordController,
               phone_step_attempts: RateLimiter.max_attempts(rate_limit_type),
               first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
               hours_since_first_letter: 0,
-              **ab_test_args,
             ),
           )
         end

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -1,12 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe Idv::HowToVerifyController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::HowToVerifyController do
   let(:user) { create(:user) }
   let(:enabled) { true }
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
   let(:service_provider) do
     create(:service_provider, :active, :in_person_proofing_enabled)
   end
@@ -16,7 +12,6 @@ RSpec.describe Idv::HowToVerifyController,
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled) { true }
     stub_sign_in(user)
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
     allow(subject.idv_session).to receive(:service_provider).and_return(service_provider)
     subject.idv_session.welcome_visited = true
     subject.idv_session.idv_consent_given_at = Time.zone.now
@@ -115,7 +110,7 @@ RSpec.describe Idv::HowToVerifyController,
       {
         step: 'how_to_verify',
         analytics_id: 'Doc Auth',
-      }.merge(ab_test_args)
+      }
     end
 
     it 'renders the show template' do
@@ -184,7 +179,7 @@ RSpec.describe Idv::HowToVerifyController,
           error_details: { selection: { blank: true } },
           errors: { selection: ['Select a way to verify your identity.'] },
           success: false,
-        }.merge(ab_test_args)
+        }
       end
 
       let(:params) { nil }
@@ -204,7 +199,7 @@ RSpec.describe Idv::HowToVerifyController,
           error_details: { selection: { inclusion: true } },
           errors: { selection: ['Select a way to verify your identity.'] },
           success: false,
-        }.merge(ab_test_args)
+        }
       end
 
       it_behaves_like 'invalid form submissions'
@@ -219,7 +214,7 @@ RSpec.describe Idv::HowToVerifyController,
           errors: {},
           success: true,
           selection:,
-        }.merge(ab_test_args)
+        }
       end
       it 'sets skip doc auth on idv session to false and redirects to hybrid handoff' do
         put :update, params: params
@@ -245,7 +240,7 @@ RSpec.describe Idv::HowToVerifyController,
           errors: {},
           success: true,
           selection:,
-        }.merge(ab_test_args)
+        }
       end
       it 'sets skip doc auth on idv session to true and redirects to document capture' do
         put :update, params: params

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -1,14 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe Idv::HybridHandoffController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::HybridHandoffController do
   include FlowPolicyHelper
 
   let(:user) { create(:user) }
 
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
   let(:service_provider) do
     create(:service_provider, :active, :in_person_proofing_enabled)
   end
@@ -22,7 +18,6 @@ RSpec.describe Idv::HybridHandoffController,
     stub_sign_in(user)
     stub_up_to(:agreement, idv_session: subject.idv_session)
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
     allow(subject.idv_session).to receive(:service_provider).and_return(service_provider)
 
     resolved_authn_context_result = sp_selfie_enabled ?
@@ -67,7 +62,7 @@ RSpec.describe Idv::HybridHandoffController,
         step: 'hybrid_handoff',
         analytics_id: 'Doc Auth',
         selfie_check_required: sp_selfie_enabled,
-      }.merge(ab_test_args)
+      }
     end
 
     it 'renders the show template' do
@@ -306,7 +301,7 @@ RSpec.describe Idv::HybridHandoffController,
             request_id: 'fake-message-request-id',
             success: true,
           },
-        }.merge(ab_test_args)
+        }
       end
 
       let(:params) do
@@ -356,7 +351,7 @@ RSpec.describe Idv::HybridHandoffController,
           step: 'hybrid_handoff',
           analytics_id: 'Doc Auth',
           selfie_check_required: sp_selfie_enabled,
-        }.merge(ab_test_args)
+        }
       end
 
       let(:params) do

--- a/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/capture_complete_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::HybridMobile::CaptureCompleteController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::HybridMobile::CaptureCompleteController do
   let(:user) { create(:user) }
 
   let!(:document_capture_session) do
@@ -21,17 +20,12 @@ RSpec.describe Idv::HybridMobile::CaptureCompleteController,
     )
   end
 
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
-
   before do
     session[:doc_capture_user_id] = user&.id
     session[:document_capture_session_uuid] = document_capture_session_uuid
     stub_analytics
     allow(subject).to receive(:confirm_document_capture_session_complete).
       and_return(true)
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe 'before_actions' do
@@ -51,7 +45,7 @@ RSpec.describe Idv::HybridMobile::CaptureCompleteController,
         flow_path: 'hybrid',
         step: 'capture_complete',
         liveness_checking_required: false,
-      }.merge(ab_test_args)
+      }
     end
 
     it 'renders the show template' do

--- a/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::HybridMobile::DocumentCaptureController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::HybridMobile::DocumentCaptureController do
   let(:user) { create(:user) }
 
   let!(:document_capture_session) do
@@ -17,17 +16,11 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController,
   let(:document_capture_session_result_captured_at) { Time.zone.now + 1.second }
   let(:document_capture_session_result_success) { true }
 
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
-
   before do
     stub_analytics
 
     session[:doc_capture_user_id] = user&.id
     session[:document_capture_session_uuid] = document_capture_session_uuid
-
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe 'before_actions' do
@@ -59,7 +52,7 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController,
           step: 'document_capture',
           selfie_check_required: false,
           liveness_checking_required: boolean,
-        }.merge(ab_test_args)
+        }
       end
 
       it 'renders the show template' do
@@ -182,7 +175,7 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController,
           step: 'document_capture',
           liveness_checking_required: false,
           selfie_check_required: boolean,
-        }.merge(ab_test_args)
+        }
       end
 
       before do

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::InPerson::SsnController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::InPerson::SsnController do
   let(:pii_from_user) { Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID_WITH_NO_SSN.dup }
 
   let(:flow_session) do
@@ -12,15 +11,10 @@ RSpec.describe Idv::InPerson::SsnController,
 
   let(:user) { create(:user) }
 
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
-
   before do
     stub_sign_in(user)
     subject.user_session['idv/in_person'] = flow_session
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
     subject.idv_session.flow_path = 'standard'
   end
 
@@ -49,7 +43,7 @@ RSpec.describe Idv::InPerson::SsnController,
         flow_path: 'standard',
         step: 'ssn',
         same_address_as_id: true,
-      }.merge(ab_test_args)
+      }
     end
 
     it 'renders the show template' do
@@ -119,7 +113,7 @@ RSpec.describe Idv::InPerson::SsnController,
           success: true,
           errors: {},
           same_address_as_id: true,
-        }.merge(ab_test_args)
+        }
       end
 
       it 'sends analytics_submitted event' do
@@ -163,7 +157,7 @@ RSpec.describe Idv::InPerson::SsnController,
           },
           error_details: { ssn: { invalid: true } },
           same_address_as_id: true,
-        }.merge(ab_test_args)
+        }
       end
 
       render_views

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -1,16 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe Idv::InPerson::StateIdController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::InPerson::StateIdController do
   include FlowPolicyHelper
   include InPersonHelper
 
   let(:user) { build(:user) }
   let(:enrollment) { InPersonEnrollment.new }
-
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
 
   before do
     allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).
@@ -23,7 +18,6 @@ RSpec.describe Idv::InPerson::StateIdController,
     subject.user_session['idv/in_person'] = { pii_from_user: {} }
     subject.idv_session.ssn = nil # This made specs pass. Might need more investigation.
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe 'before_actions' do
@@ -77,7 +71,7 @@ RSpec.describe Idv::InPerson::StateIdController,
         analytics_id: 'In Person Proofing',
         flow_path: 'standard',
         step: 'state_id',
-      }.merge(ab_test_args)
+      }
     end
 
     it 'has non-nil presenter' do
@@ -183,7 +177,7 @@ RSpec.describe Idv::InPerson::StateIdController,
           same_address_as_id: true,
           birth_year: dob[:year],
           document_zip_code: identity_doc_zipcode&.slice(0, 5),
-        }.merge(ab_test_args)
+        }
       end
 
       it 'logs idv_in_person_proofing_state_id_submitted' do

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::InPerson::VerifyInfoController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::InPerson::VerifyInfoController do
   let(:pii_from_user) { Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup }
   let(:flow_session) do
     { pii_from_user: pii_from_user }
@@ -10,16 +9,11 @@ RSpec.describe Idv::InPerson::VerifyInfoController,
   let(:user) { create(:user, :with_phone, with: { phone: '+1 (415) 555-0130' }) }
   let(:service_provider) { create(:service_provider) }
 
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
-
   before do
     stub_sign_in(user)
     subject.idv_session.flow_path = 'standard'
     subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID[:ssn]
     subject.user_session['idv/in_person'] = flow_session
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe '#step_info' do
@@ -79,7 +73,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController,
           flow_path: 'standard',
           step: 'verify',
           same_address_as_id: true,
-        }.merge(ab_test_args),
+        },
       )
     end
 
@@ -139,7 +133,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController,
               flow_path: 'standard',
               step: 'verify',
               same_address_as_id: true,
-            }.merge(ab_test_args),
+            },
           ),
         )
       end

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -1,12 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe Idv::LinkSentController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::LinkSentController do
   let(:user) { create(:user) }
-
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
 
   before do
     stub_sign_in(user)
@@ -14,7 +9,6 @@ RSpec.describe Idv::LinkSentController,
     subject.idv_session.idv_consent_given_at = Time.zone.now
     subject.idv_session.flow_path = 'hybrid'
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe '#step_info' do
@@ -53,7 +47,7 @@ RSpec.describe Idv::LinkSentController,
         analytics_id: 'Doc Auth',
         flow_path: 'hybrid',
         step: 'link_sent',
-      }.merge(ab_test_args)
+      }
     end
 
     it 'renders the show template' do
@@ -115,7 +109,7 @@ RSpec.describe Idv::LinkSentController,
         analytics_id: 'Doc Auth',
         flow_path: 'hybrid',
         step: 'link_sent',
-      }.merge(ab_test_args)
+      }
     end
 
     it 'invalidates future steps' do

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::OtpVerificationController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::OtpVerificationController do
   let(:user) { create(:user) }
 
   let(:phone) { '2255555000' }
@@ -19,13 +18,9 @@ RSpec.describe Idv::OtpVerificationController,
       sent_at: phone_confirmation_otp_sent_at,
     )
   end
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
 
   before do
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
 
     sign_in(user)
     stub_verify_steps_one_and_two(user)
@@ -169,7 +164,6 @@ RSpec.describe Idv::OtpVerificationController,
           code_matches: true,
           otp_delivery_preference: :sms,
           second_factor_attempts_count: 0,
-          **ab_test_args,
         ),
       )
     end

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::PhoneController do
   include FlowPolicyHelper
 
   let(:max_attempts) { RateLimiter.max_attempts(:proof_address) }
@@ -241,13 +241,7 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:sample_bucket1, 
         with: { phone: '+1 (415) 555-0130' }
       )
     end
-    let(:ab_test_args) do
-      { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-    end
 
-    before do
-      allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
-    end
     context 'when form is invalid' do
       let(:improbable_phone_message) { t('errors.messages.improbable_phone') }
       let(:improbable_otp_message) { 'is not included in the list' }
@@ -309,7 +303,6 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:sample_bucket1, 
             phone_type: :mobile,
             otp_delivery_preference: '🎷',
             types: [],
-            **ab_test_args,
           ),
         )
 
@@ -351,7 +344,6 @@ RSpec.describe Idv::PhoneController, allowed_extra_analytics: [:sample_bucket1, 
             phone_type: :mobile,
             otp_delivery_preference: 'sms',
             types: [:fixed_or_mobile],
-            **ab_test_args,
           ),
         )
       end

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -1,11 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::PhoneErrorsController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
-
+RSpec.describe Idv::PhoneErrorsController do
   describe '#step_info' do
     it 'returns a valid StepInfo object' do
       expect(Idv::PhoneErrorsController.step_info).to be_valid
@@ -15,7 +10,6 @@ RSpec.describe Idv::PhoneErrorsController,
   before do
     allow(subject).to receive(:remaining_submit_attempts).and_return(5)
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
 
     if user
       stub_sign_in(user)
@@ -159,7 +153,6 @@ RSpec.describe Idv::PhoneErrorsController,
           'IdV: phone error visited',
           type: action,
           remaining_submit_attempts: 4,
-          **ab_test_args,
         )
       end
     end
@@ -212,7 +205,6 @@ RSpec.describe Idv::PhoneErrorsController,
           'IdV: phone error visited',
           type: action,
           remaining_submit_attempts: 4,
-          **ab_test_args,
         )
       end
     end
@@ -244,7 +236,6 @@ RSpec.describe Idv::PhoneErrorsController,
             'IdV: phone error visited',
             type: action,
             limiter_expires_at: attempted_at + rate_limit_window,
-            **ab_test_args,
           )
         end
       end

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -1,21 +1,16 @@
 require 'rails_helper'
 
-RSpec.describe Idv::SsnController, allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::SsnController do
   include FlowPolicyHelper
 
   let(:ssn) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn] }
 
   let(:user) { create(:user) }
 
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
-
   before do
     stub_sign_in(user)
     stub_up_to(:document_capture, idv_session: subject.idv_session)
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe '#step_info' do
@@ -54,7 +49,7 @@ RSpec.describe Idv::SsnController, allowed_extra_analytics: [:sample_bucket1, :s
         analytics_id: 'Doc Auth',
         flow_path: 'standard',
         step: 'ssn',
-      }.merge(ab_test_args)
+      }
     end
 
     it 'renders the show template' do
@@ -131,7 +126,7 @@ RSpec.describe Idv::SsnController, allowed_extra_analytics: [:sample_bucket1, :s
           step: 'ssn',
           success: true,
           errors: {},
-        }.merge(ab_test_args)
+        }
       end
 
       it 'updates idv_session.ssn' do
@@ -189,7 +184,7 @@ RSpec.describe Idv::SsnController, allowed_extra_analytics: [:sample_bucket1, :s
             ssn: [t('idv.errors.pattern_mismatch.ssn')],
           },
           error_details: { ssn: { invalid: true } },
-        }.merge(ab_test_args)
+        }
       end
 
       render_views

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Idv::VerifyInfoController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::VerifyInfoController do
   include FlowPolicyHelper
 
   let(:user) { create(:user) }
@@ -10,18 +9,13 @@ RSpec.describe Idv::VerifyInfoController,
       analytics_id: 'Doc Auth',
       flow_path: 'standard',
       step: 'verify',
-    }.merge(ab_test_args)
-  end
-
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
+    }
   end
 
   before do
     stub_sign_in(user)
     stub_up_to(:ssn, idv_session: subject.idv_session)
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe '#step_info' do
@@ -62,7 +56,7 @@ RSpec.describe Idv::VerifyInfoController,
           analytics_id: 'Doc Auth',
           flow_path: 'standard',
           step: 'verify',
-        }.merge(ab_test_args),
+        },
       )
     end
 
@@ -300,7 +294,7 @@ RSpec.describe Idv::VerifyInfoController,
                 analytics_id: 'Doc Auth',
                 flow_path: 'standard',
                 step: 'verify',
-              }.merge(ab_test_args),
+              },
             ),
           )
         end

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -1,17 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe Idv::WelcomeController,
-               allowed_extra_analytics: [:sample_bucket1, :sample_bucket2] do
+RSpec.describe Idv::WelcomeController do
   let(:user) { create(:user) }
-
-  let(:ab_test_args) do
-    { sample_bucket1: :sample_value1, sample_bucket2: :sample_value2 }
-  end
 
   before do
     stub_sign_in(user)
     stub_analytics
-    allow(subject).to receive(:ab_test_analytics_buckets).and_return(ab_test_args)
   end
 
   describe '#step_info' do
@@ -42,7 +36,7 @@ RSpec.describe Idv::WelcomeController,
       {
         step: 'welcome',
         analytics_id: 'Doc Auth',
-      }.merge(ab_test_args)
+      }
     end
 
     it 'renders the show template' do
@@ -122,7 +116,7 @@ RSpec.describe Idv::WelcomeController,
       {
         step: 'welcome',
         analytics_id: 'Doc Auth',
-      }.merge(ab_test_args)
+      }
     end
 
     it 'sends analytics_submitted event' do

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'axe-rspec'
 
-RSpec.feature 'Accessibility on IDV pages', :js, allowed_extra_analytics: [:*] do
+RSpec.feature 'Accessibility on IDV pages', :js do
   describe 'IDV pages' do
     include IdvStepHelper
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'csv'
 
-RSpec.feature 'Analytics Regression', js: true, allowed_extra_analytics: [:*] do
+RSpec.feature 'Analytics Regression', :js do
   include IdvStepHelper
   include InPersonHelper
 

--- a/spec/features/idv/clearing_and_restarting_spec.rb
+++ b/spec/features/idv/clearing_and_restarting_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'clearing IdV and restarting', allowed_extra_analytics: [:*] do
+RSpec.describe 'clearing IdV and restarting' do
   include IdvStepHelper
 
   let(:user) { user_with_2fa }

--- a/spec/features/idv/doc_auth/address_step_spec.rb
+++ b/spec/features/idv/doc_auth/address_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'doc auth verify step', :js, allowed_extra_analytics: [:*] do
+RSpec.feature 'doc auth verify step', :js do
   include IdvStepHelper
   include DocAuthHelper
 

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -1282,7 +1282,7 @@ RSpec.feature 'document capture step', :js do
   end
 end
 
-RSpec.feature 'direct access to IPP on desktop', :js, allowed_extra_analytics: [:*] do
+RSpec.feature 'direct access to IPP on desktop', :js do
   include IdvStepHelper
   include DocAuthHelper
   context 'direct access to IPP before handoff page' do

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'document capture step', :js, allowed_extra_analytics: [:*] do
+RSpec.feature 'document capture step', :js do
   include IdvStepHelper
   include DocAuthHelper
   include DocCaptureHelper

--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'how to verify step', js: true, allowed_extra_analytics: [:*] do
+RSpec.feature 'how to verify step', js: true do
   include IdvHelper
   include DocAuthHelper
 

--- a/spec/features/idv/doc_auth/link_sent_spec.rb
+++ b/spec/features/idv/doc_auth/link_sent_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'doc auth link sent step', allowed_extra_analytics: [:*] do
+RSpec.feature 'doc auth link sent step' do
   include IdvStepHelper
   include DocAuthHelper
   include DocCaptureHelper

--- a/spec/features/idv/hybrid_mobile/entry_spec.rb
+++ b/spec/features/idv/hybrid_mobile/entry_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'mobile hybrid flow entry', js: true, allowed_extra_analytics: [:*] do
+RSpec.feature 'mobile hybrid flow entry', :js do
   include IdvStepHelper
 
   let(:link_sent_via_sms) do

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start, allowed_extra_analytics: [:*] do
+RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
   include IdvHelper
   include IdvStepHelper
   include DocAuthHelper

--- a/spec/features/idv/phone_errors_spec.rb
+++ b/spec/features/idv/phone_errors_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
-RSpec.feature 'phone errors', :js, allowed_extra_analytics: [:*] do
+
+RSpec.feature 'phone errors', :js do
   include IdvStepHelper
   include IdvHelper
 

--- a/spec/features/idv/proof_address_rate_limit_spec.rb
+++ b/spec/features/idv/proof_address_rate_limit_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'address proofing rate limit', allowed_extra_analytics: [:*] do
+RSpec.feature 'address proofing rate limit' do
   include IdvStepHelper
   include IdvHelper
 

--- a/spec/features/idv/puerto_rican_address_spec.rb
+++ b/spec/features/idv/puerto_rican_address_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'proofing flow with a Puerto Rican document', :js, allowed_extra_analytics: [:*] do
+RSpec.describe 'proofing flow with a Puerto Rican document', :js do
   include DocAuthHelper
   include IdvStepHelper
 

--- a/spec/features/idv/steps/in_person/ssn_spec.rb
+++ b/spec/features/idv/steps/in_person/ssn_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'doc auth IPP ssn step', js: true, allowed_extra_analytics: [:*] do
+RSpec.describe 'doc auth IPP ssn step', :js do
   include IdvStepHelper
   include InPersonHelper
 

--- a/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'state id 50/50 state', js: true, allowed_extra_analytics: [:*],
-                                       allow_browser_log: true do
+RSpec.describe 'state id 50/50 state', :js, allow_browser_log: true do
   include IdvStepHelper
   include InPersonHelper
 

--- a/spec/features/idv/steps/in_person/state_id_controller_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'state id controller enabled', js: true, allowed_extra_analytics: [:*] do
+RSpec.describe 'state id controller enabled', :js do
   include IdvStepHelper
   include InPersonHelper
 

--- a/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
+++ b/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'axe-rspec'
 
-RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true, allowed_extra_analytics: [:*] do
+RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true do
   include IdvStepHelper
   include SpAuthHelper
   include InPersonHelper

--- a/spec/features/idv/steps/phone_step_spec.rb
+++ b/spec/features/idv/steps/phone_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'idv phone step', :js, allowed_extra_analytics: [:*] do
+RSpec.feature 'idv phone step', :js do
   include IdvStepHelper
   include IdvHelper
 

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'idv request letter step', allowed_extra_analytics: [:*] do
+RSpec.feature 'idv request letter step' do
   include IdvStepHelper
   include OidcAuthHelper
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates controller specs to remove `ab_test_args` method stubbing.

**Why?**

- We should want to know exactly what's logged, including both the value and the keyword argument being part of affected analytics event method signatures
   - Documenting the keyword arguments will cause them to be visible on [Analytics Events internal handbook page](https://lg-public.pages.production.gitlab.login.gov/identity-internal-handbook/articles/analytics-events.html)
- These aren't really A/B tests, they're just properties controlled by a feature flag
- This will simplify the effort to remove the in-person proofing opt-in feature flag, which has already been live in production for many months now
- The properties are already documented for many analytics events where we're not stubbing the result, so this brings consistency
- Allows for removing `allowed_extra_analytics` exceptions, particularly in feature specs, where the logged output would match more what's in the real-world, and wouldn't benefit from the stubbing implemented in controller specs

**Draft until verified if CI builds reveal any unnecessary `allowed_extra_analytics` to be removed.**

## 📜 Testing Plan

Verify build passes.