### PR TITLE
LG-14498 Fix backfill deactive IPP cancelled profiles

### DIFF
--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -100,10 +100,11 @@ namespace :profiles do
 
           warn "#{profile.id},#{profile.deactivation_reason},#{timestamp}"
           if update_profiles
-            profile.update!(
-              deactivation_reason: :verification_cancelled,
-              in_person_verification_pending_at: nil,
-            )
+            unless profile.deactivation_reason.present?
+              profile.deactivation_reason = :verification_cancelled
+            end
+            profile.in_person_verification_pending_at = nil
+            profile.save!
           end
         end
         sleep(0.5)


### PR DESCRIPTION
The backfill script will no longer overwrite existing deactivation reasons on IPP cancelled profiles.

[skip changelog]

## 🎫 Ticket

Link to the relevant ticket:
[LG-14498](https://cm-jira.usa.gov/browse/LG-14498)

## 🛠 Summary of changes

The backfill script will no longer overwrite existing deactivation reasons on IPP cancelled profiles.

## 📜 Testing Plan

Ensure a profile exists with deactivation reason `encryption_error`:
- [x] Login through the oidc sinatra application selecting the Enhanced In-person Proofing level of service
- [x] Use an existing account or create an account
- [x] Follow the flow for creating an ID-IPP enrollment until reaching the barcode page
- [x] From the barcode page click on the "cancel your barcode" link at the bottom of the page
- [x] Navigate to the account page and logout
- [x] Login through the oidc sinatra application selecting the Enhanced In-person Proofing level of service
- [x] Use the reset password link from the login.gov login page
- [x] Re-login with new password
- [x] Verify that a profile exists with deactivation reason `encryption_error`
- [x] Update the InPersonEnrollment to be status `expired`

**Note: With default config this will be time sensitive make sure InPersonEnrollment status isn't `passed` when you go to update the enrollment status. The profile cannot be active during this test plan**

Scenario: Running Backfill script
- [x] Check that number of profile in broken state is greater than 0 using rails console
```ruby
    InPersonEnrollment.where(status: [:expired, :cancelled, :failed]).
      includes(:profile).
      where.not(profile: { in_person_verification_pending_at: nil }).
      count
```

- [x] Run the backfill script to backup data without updating profiles
```bash
bundle exec rake profiles:backfill_deactivated_ipp_verification_cancelled UPDATE_PROFILES=false
```
- [x] Verify that log output contains the expected profiles information (id, deactivation_reason, in_person_verification_pending_at) is contained in it **(Note that the profile with the `encryption_error` deactivation reason exists in the output data)**
- [x] Copy the log output and save it to a file
- [x] Run the backfill script data updating profiles
```bash
bundle exec rake profiles:backfill_deactivated_ipp_verification_cancelled UPDATE_PROFILES=true
```
- [x] Check the number of profile in broken state is 0 using rails console
```ruby
    InPersonEnrollment.where(status: [:expired, :cancelled, :failed]).
      includes(:profile).
      where.not(profile: { in_person_verification_pending_at: nil }).
      count
```
- [x] Verify that the `encryption_error` profile deactivation reason has not changed.

Scenario: Running rollback script

- [x] Run the rollback script
```bash
bundle exec rake profiles:rollback_backfill_deactivated_ipp_verification_cancelled BACKFILL_OUTPUT="$(cat output)"
```
- [x] Check the number of profile in broken state is back to the original count before the backfill script ran using rails console
```ruby
    InPersonEnrollment.where(status: [:expired, :cancelled, :failed]).
      includes(:profile).
      where.not(profile: { in_person_verification_pending_at: nil }).
      count
```