### PR TITLE
LG-14432 Log `fraud_pending_reason` on `idv_final` event

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -49,6 +49,7 @@ module Idv
         success: true,
         fraud_review_pending: idv_session.profile.fraud_review_pending?,
         fraud_rejection: idv_session.profile.fraud_rejection?,
+        fraud_pending_reason: idv_session.profile.fraud_pending_reason,
         gpo_verification_pending: idv_session.profile.gpo_verification_pending?,
         in_person_verification_pending: idv_session.profile.in_person_verification_pending?,
         deactivation_reason: idv_session.profile.deactivation_reason,
@@ -61,6 +62,7 @@ module Idv
         success: true,
         fraud_review_pending: idv_session.profile.fraud_review_pending?,
         fraud_rejection: idv_session.profile.fraud_rejection?,
+        fraud_pending_reason: idv_session.profile.fraud_pending_reason,
         gpo_verification_pending: idv_session.profile.gpo_verification_pending?,
         in_person_verification_pending: idv_session.profile.in_person_verification_pending?,
         deactivation_reason: idv_session.profile.deactivation_reason,
@@ -116,6 +118,7 @@ module Idv
         in_person_verification_pending: current_user.in_person_pending_profile?,
         fraud_review_pending: fraud_review_pending?,
         fraud_rejection: fraud_rejection?,
+        fraud_pending_reason: nil,
         **ab_test_analytics_buckets,
       )
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2097,6 +2097,7 @@ module AnalyticsEvents
   # @param [Boolean] success
   # @param [Boolean] fraud_review_pending
   # @param [Boolean] fraud_rejection
+  # @param [String,nil] fraud_pending_reason The reason this profile is eligible for fraud review
   # @param [Boolean] gpo_verification_pending
   # @param [Boolean] in_person_verification_pending
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
@@ -2119,6 +2120,7 @@ module AnalyticsEvents
     success:,
     fraud_review_pending:,
     fraud_rejection:,
+    fraud_pending_reason:,
     gpo_verification_pending:,
     in_person_verification_pending:,
     opted_in_to_in_person_proofing: nil,
@@ -2136,6 +2138,7 @@ module AnalyticsEvents
       success:,
       deactivation_reason:,
       fraud_review_pending:,
+      fraud_pending_reason:,
       gpo_verification_pending:,
       in_person_verification_pending:,
       skip_hybrid_handoff:,
@@ -2194,6 +2197,7 @@ module AnalyticsEvents
   # @param [String, nil] deactivation_reason Reason user's profile was deactivated, if any.
   # @param [Boolean] fraud_review_pending Profile is under review for fraud
   # @param [Boolean] fraud_rejection Profile is rejected due to fraud
+  # @param [String,nil] fraud_pending_reason The reason this profile is eligible for fraud review
   # @param [Boolean] gpo_verification_pending Profile is awaiting gpo verification
   # @param [Boolean] in_person_verification_pending Profile is awaiting in person verification
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
@@ -2218,6 +2222,7 @@ module AnalyticsEvents
     success:,
     fraud_review_pending:,
     fraud_rejection:,
+    fraud_pending_reason:,
     gpo_verification_pending:,
     in_person_verification_pending:,
     opted_in_to_in_person_proofing: nil,
@@ -2236,6 +2241,7 @@ module AnalyticsEvents
       success:,
       fraud_review_pending:,
       fraud_rejection:,
+      fraud_pending_reason:,
       gpo_verification_pending:,
       in_person_verification_pending:,
       opted_in_to_in_person_proofing:,

--- a/lib/reporting/identity_verification_report.rb
+++ b/lib/reporting/identity_verification_report.rb
@@ -353,7 +353,7 @@ module Reporting
         | filter (name = %{fraud_review_passed} and properties.event_properties.success = 1)
                  or (name != %{fraud_review_passed})
         | fields
-            coalesce(properties.event_properties.fraud_review_pending, 0) AS fraud_review_pending
+            coalesce(properties.event_properties.fraud_review_pending, properties.event_properties.fraud_pending_reason, 0) AS fraud_review_pending
           , coalesce(properties.event_properties.gpo_verification_pending, 0) AS gpo_verification_pending
           , coalesce(properties.event_properties.in_person_verification_pending, 0) AS in_person_verification_pending
           , ispresent(properties.event_properties.deactivation_reason) AS has_other_deactivation_reason

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -815,6 +815,11 @@ RSpec.describe Idv::EnterPasswordController do
                     !review_status.nil? && review_status != 'pass'
                 end
                 let(:review_status) { review_status }
+                let(:fraud_pending_reason) do
+                  if fraud_review_pending?
+                    "threatmetrix_#{review_status}"
+                  end
+                end
                 let(:proofing_device_profiling_state) { proofing_device_profiling_state }
 
                 before do
@@ -835,21 +840,27 @@ RSpec.describe Idv::EnterPasswordController do
                   expect(@analytics).to have_logged_event(
                     :idv_enter_password_submitted,
                     hash_including(
-                      success: true,
-                      fraud_review_pending: fraud_review_pending?,
-                      fraud_rejection: false,
-                      gpo_verification_pending: false,
-                      in_person_verification_pending: false,
+                      {
+                        success: true,
+                        fraud_review_pending: fraud_review_pending?,
+                        fraud_pending_reason: fraud_pending_reason,
+                        fraud_rejection: false,
+                        gpo_verification_pending: false,
+                        in_person_verification_pending: false,
+                      }.compact,
                     ),
                   )
                   expect(@analytics).to have_logged_event(
                     'IdV: final resolution',
                     hash_including(
-                      success: true,
-                      fraud_review_pending: fraud_review_pending?,
-                      fraud_rejection: false,
-                      gpo_verification_pending: false,
-                      in_person_verification_pending: false,
+                      {
+                        success: true,
+                        fraud_review_pending: fraud_review_pending?,
+                        fraud_pending_reason: fraud_pending_reason,
+                        fraud_rejection: false,
+                        gpo_verification_pending: false,
+                        in_person_verification_pending: false,
+                      }.compact,
                     ),
                   )
                 end


### PR DESCRIPTION
Users are marked `fraud_review_pending` on the last step of the IdV process. For users who go through document capture and verify by phone that means that they are marked `fraud_review_pending` at enter password. However, users doing verify-by-mail or in-person-proofing are not marked `fraud_review_pending` until they complete those flows. This is done so that users do not get marked `fraud_review_pending` if we have disabled device profiling by the time they get to those later steps.

This is an issue with logging at the enter-password step since those users in in-person and verify-by-mail that will eventually be marked fraud review pending are not when we log those properties. This is especially problematic since we use the `idv_final` event at the password step for the Identity Verification Report.

If a user has a device profiling result that will lead them to be fraud-review pending we store that on the profile as `fraud_pending_reason` and use it downstream to make the determination to move verify-by-mail and in-person users into the fraud review flow.

This commit logs the `fraud_pending_reason` value on the profile at enter-password so that we have visibility into users the will be eventually marked `fraud_review_pending`. It also uses this new property in the Identity Verification Report.

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
