### PR TITLE
Hotfix: fix exclamation mark for authentication setup success page in French

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1592,7 +1592,7 @@ titles.idv.phone: Vérifier votre numéro de téléphone
 titles.idv.reset_password: Réinitialiser le mot de passe
 titles.idv.verify_info: Vérifier vos informations
 titles.mfa_setup.face_touch_unlock_confirmation: Déverrouillage facial ou tactile ajouté
-titles.mfa_setup.suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification ! Ajoutez-en une deuxième en guise de sauvegarde.
+titles.mfa_setup.suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification! Ajoutez-en une deuxième en guise de sauvegarde.
 titles.no_auth_option: Aucune méthode de connexion trouvée
 titles.openid_connect.authorization: Autorisation OpenID Connect
 titles.openid_connect.logout: Déconnexion OpenID Connect


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Summary of changes

This PR removes an extraneous space on authentication setup success screen in French

## 📜 Testing Plan

Pre-requisite

- [ ] Create new account
- [ ] Select one authentication method for setup
- [ ] Complete steps to set up auth method
- [ ] Observe page with new change

## 👀 Screenshots
| Before | After |
|--------|--------|
|  <img width="729" alt="Screenshot 2024-09-13 at 9 01 09 AM" src="https://github.com/user-attachments/assets/5b61f4d8-0296-4a04-a4b9-6f4e0db97022"> | <img width="846" alt="image" src="https://github.com/user-attachments/assets/57d70c82-07f6-4be6-a5b1-b61038eb7180"> |

