### PR TITLE
LG-14100 Include identity-verified status in account reset delete event

### DIFF
--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -61,7 +61,7 @@ class AnonymousUser
     false
   end
 
-  def active_profile?
-    false
+  def active_profile
+    nil
   end
 end

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -60,4 +60,8 @@ class AnonymousUser
   def identity_verified?
     false
   end
+
+  def active_profile?
+    false
+  end
 end

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -66,10 +66,6 @@ module AccountReset
     end
     # rubocop:enable IdentityIdp/MailLaterLinter
 
-    def profile_components
-      user.active_profile.proofing_components if user.active_profile?
-    end
-
     def extra_analytics_attributes
       {
         user_id: user.uuid,
@@ -77,7 +73,7 @@ module AccountReset
         account_age_in_days: account_age,
         account_confirmed_at: user.confirmed_at,
         mfa_method_counts: mfa_method_counts,
-        proofing_components: profile_components,
+        profile_idv_level: user.active_profile&.idv_level,
         identity_verified: user.identity_verified?,
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
       }

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -16,8 +16,6 @@ module AccountReset
 
       track_account_age
       track_mfa_method_counts
-      track_identity_verified_status
-      track_identity_verification_pending
 
       extra = extra_analytics_attributes
 
@@ -28,8 +26,7 @@ module AccountReset
 
     private
 
-    attr_reader :success, :account_age, :mfa_method_counts, :request, :analytics, :verified_status,
-                :verification_method
+    attr_reader :success, :account_age, :mfa_method_counts, :request, :analytics
 
     # @return [Integer, nil] number of days since the account was confirmed (rounded) or nil if
     # the account was not confirmed
@@ -42,15 +39,15 @@ module AccountReset
       @mfa_method_counts = MfaContext.new(user).enabled_two_factor_configuration_counts_hash
     end
 
-    def track_identity_verified_status
-      @verified_status = user.identity_verified?
-    end
-
-    def track_identity_verification_pending
-      return false unless success
-      @verification_method = user.pending_in_person_enrollment.present? && 'IPP' ||
-                             user.gpo_verification_pending_profile.present? && 'GPO' ||
-                             user.identity_verified_with_biometric_comparison? && 'Biometric' || nil
+    def verification_method
+      return nil if user.uuid == 'anonymous-uuid'
+      if user.pending_in_person_enrollment.present?
+        :in_person_proofing
+      elsif user.gpo_verification_pending_profile.present?
+        :verify_by_mail
+      elsif user.identity_verified_with_biometric_comparison?
+        :biometric_comparison
+      end
     end
 
     def handle_successful_submission
@@ -87,7 +84,7 @@ module AccountReset
         account_age_in_days: account_age,
         account_confirmed_at: user.confirmed_at,
         mfa_method_counts: mfa_method_counts,
-        identity_verified: verified_status,
+        identity_verified: user.identity_verified?,
         identity_verification_method: verification_method,
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
       }

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -67,8 +67,7 @@ module AccountReset
     # rubocop:enable IdentityIdp/MailLaterLinter
 
     def profile_components
-      return nil if !user.identity_verified?
-      user.active_profile.proofing_components if user.active_profile?
+      user.active_profile.proofing_components if user.identity_verified? && user.active_profile?
     end
 
     def extra_analytics_attributes

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -40,10 +40,10 @@ module AccountReset
     end
 
     def verification_method
-      return nil if user.uuid == 'anonymous-uuid'
-      if user.pending_in_person_enrollment.present?
+      return nil if !user.identity_verified?
+      if user.in_person_enrollments.present?
         :in_person_proofing
-      elsif user.gpo_verification_pending_profile.present?
+      elsif user.active_profile.gpo_confirmation_codes.present?
         :verify_by_mail
       elsif user.identity_verified_with_biometric_comparison?
         :biometric_comparison

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -67,7 +67,7 @@ module AccountReset
     # rubocop:enable IdentityIdp/MailLaterLinter
 
     def profile_components
-      user.active_profile.proofing_components if user.identity_verified? && user.active_profile?
+      user.active_profile.proofing_components if user.active_profile?
     end
 
     def extra_analytics_attributes

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -16,6 +16,8 @@ module AccountReset
 
       track_account_age
       track_mfa_method_counts
+      track_identity_verified_status
+      track_identity_verification_pending
 
       extra = extra_analytics_attributes
 
@@ -26,7 +28,8 @@ module AccountReset
 
     private
 
-    attr_reader :success, :account_age, :mfa_method_counts, :request, :analytics
+    attr_reader :success, :account_age, :mfa_method_counts, :request, :analytics, :verified_status,
+                :verification_method
 
     # @return [Integer, nil] number of days since the account was confirmed (rounded) or nil if
     # the account was not confirmed
@@ -37,6 +40,17 @@ module AccountReset
 
     def track_mfa_method_counts
       @mfa_method_counts = MfaContext.new(user).enabled_two_factor_configuration_counts_hash
+    end
+
+    def track_identity_verified_status
+      @verified_status = user.identity_verified?
+    end
+
+    def track_identity_verification_pending
+      return false unless success
+      @verification_method = user.pending_in_person_enrollment.present? && 'IPP' ||
+                             user.gpo_verification_pending_profile.present? && 'GPO' ||
+                             user.identity_verified_with_biometric_comparison? && 'Biometric' || nil
     end
 
     def handle_successful_submission
@@ -73,6 +87,8 @@ module AccountReset
         account_age_in_days: account_age,
         account_confirmed_at: user.confirmed_at,
         mfa_method_counts: mfa_method_counts,
+        identity_verified: verified_status,
+        identity_verification_method: verification_method,
         pii_like_keypaths: [[:mfa_method_counts, :phone]],
       }
     end

--- a/app/services/account_reset/delete_account.rb
+++ b/app/services/account_reset/delete_account.rb
@@ -68,7 +68,7 @@ module AccountReset
 
     def profile_components
       return nil if !user.identity_verified?
-      ProofingComponent.create_or_find_by(user: user)
+      user.active_profile.proofing_components if user.active_profile?
     end
 
     def extra_analytics_attributes

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -86,9 +86,16 @@ module AnalyticsEvents
   # @param [Integer, nil] account_age_in_days number of days since the account was confirmed
   # @param [Time] account_confirmed_at date that account creation was confirmed
   # (rounded) or nil if the account was not confirmed
+  # @param [Hash,nil] proofing_components User's current proofing components
+  # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
+  # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
+  # @option proofing_components [String,nil] 'source_check' Source used to verify user's PII
+  # @option proofing_components [String,nil] 'resolution_check' Vendor for identity resolution check
+  # @option proofing_components [String,nil] 'address_check' Method used to verify user's address
+  # @option proofing_components [Boolean,nil] 'threatmetrix' Whether ThreatMetrix check was done
+  # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [Hash] mfa_method_counts Hash of MFA method with the number of that method on the account
   # @param [Boolean] identity_verified if the deletion occurs on a verified account
-  # @param [String, nil] identity_verification_method verification method used if applicable
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # An account has been deleted through the account reset flow
@@ -99,8 +106,8 @@ module AnalyticsEvents
     account_confirmed_at:,
     mfa_method_counts:,
     identity_verified:,
-    identity_verification_method:,
     errors:,
+    proofing_components: nil,
     error_details: nil,
     **extra
   )
@@ -111,8 +118,8 @@ module AnalyticsEvents
       account_age_in_days:,
       account_confirmed_at:,
       mfa_method_counts:,
+      proofing_components: proofing_components,
       identity_verified:,
-      identity_verification_method:,
       errors:,
       error_details:,
       **extra,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -86,17 +86,10 @@ module AnalyticsEvents
   # @param [Integer, nil] account_age_in_days number of days since the account was confirmed
   # @param [Time] account_confirmed_at date that account creation was confirmed
   # (rounded) or nil if the account was not confirmed
-  # @param [Hash,nil] proofing_components User's current proofing components
-  # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
-  # @option proofing_components [String,nil] 'document_type' Type of ID used to verify
-  # @option proofing_components [String,nil] 'source_check' Source used to verify user's PII
-  # @option proofing_components [String,nil] 'resolution_check' Vendor for identity resolution check
-  # @option proofing_components [String,nil] 'address_check' Method used to verify user's address
-  # @option proofing_components [Boolean,nil] 'threatmetrix' Whether ThreatMetrix check was done
-  # @option proofing_components [String,nil] 'threatmetrix_review_status' TMX decision on the user
   # @param [Hash] mfa_method_counts Hash of MFA method with the number of that method on the account
   # @param [Boolean] identity_verified if the deletion occurs on a verified account
   # @param [Hash] errors Errors resulting from form validation
+  # @param [String, nil] profile_idv_level shows how verified the user is
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # An account has been deleted through the account reset flow
   def account_reset_delete(
@@ -107,7 +100,7 @@ module AnalyticsEvents
     mfa_method_counts:,
     identity_verified:,
     errors:,
-    proofing_components: nil,
+    profile_idv_level: nil,
     error_details: nil,
     **extra
   )
@@ -118,7 +111,7 @@ module AnalyticsEvents
       account_age_in_days:,
       account_confirmed_at:,
       mfa_method_counts:,
-      proofing_components:,
+      profile_idv_level:,
       identity_verified:,
       errors:,
       error_details:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -87,6 +87,8 @@ module AnalyticsEvents
   # @param [Time] account_confirmed_at date that account creation was confirmed
   # (rounded) or nil if the account was not confirmed
   # @param [Hash] mfa_method_counts Hash of MFA method with the number of that method on the account
+  # @param [Boolean] identity_verified if the deletion occurs on a verified account
+  # @param [String, nil] identity_verification_method verification method used if applicable
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # An account has been deleted through the account reset flow
@@ -96,6 +98,8 @@ module AnalyticsEvents
     account_age_in_days:,
     account_confirmed_at:,
     mfa_method_counts:,
+    identity_verified:,
+    identity_verification_method:,
     errors:,
     error_details: nil,
     **extra
@@ -107,6 +111,8 @@ module AnalyticsEvents
       account_age_in_days:,
       account_confirmed_at:,
       mfa_method_counts:,
+      identity_verified:,
+      identity_verification_method:,
       errors:,
       error_details:,
       **extra,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -118,7 +118,7 @@ module AnalyticsEvents
       account_age_in_days:,
       account_confirmed_at:,
       mfa_method_counts:,
-      proofing_components: proofing_components,
+      proofing_components:,
       identity_verified:,
       errors:,
       error_details:,

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -149,27 +149,6 @@ RSpec.describe AccountReset::DeleteAccountController do
       )
     end
 
-    it 'logs info about user with a verified by mail account' do
-      user = create(:user, :proofed_with_gpo)
-      create_account_reset_request_for(user)
-      grant_request(user)
-      session[:granted_token] = AccountResetRequest.first.granted_token
-
-      delete :delete
-
-      expect(@analytics).to have_logged_event(
-        'Account Reset: delete',
-        user_id: user.uuid,
-        success: true,
-        errors: {},
-        mfa_method_counts: { phone: 1 },
-        profile_idv_level: 'legacy_unsupervised',
-        identity_verified: true,
-        account_age_in_days: 0,
-        account_confirmed_at: user.confirmed_at,
-      )
-    end
-
     it 'logs info about user verified in person proofed account' do
       user = create(
         :user,

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe AccountReset::DeleteAccountController do
 
     it 'logs info about user verified account' do
       user = create(:user, :proofed)
+      proofing_components = ProofingComponent.create_or_find_by(user: user)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -119,6 +120,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
+        proofing_components: proofing_components,
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
@@ -128,6 +130,7 @@ RSpec.describe AccountReset::DeleteAccountController do
 
     it 'logs info about user biometrically verified account' do
       user = create(:user, :proofed_with_selfie, :with_phone)
+      proofing_components = ProofingComponent.create_or_find_by(user: user)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -140,8 +143,8 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
+        proofing_components: proofing_components,
         identity_verified: true,
-        identity_verification_method: :biometric_comparison,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )
@@ -150,6 +153,7 @@ RSpec.describe AccountReset::DeleteAccountController do
 
     it 'logs info about user with a verified by mail account' do
       user = create(:user, :proofed_with_gpo)
+      proofing_components = ProofingComponent.create_or_find_by(user: user)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -162,8 +166,8 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
+        proofing_components: proofing_components,
         identity_verified: true,
-        identity_verification_method: :verify_by_mail,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )
@@ -176,6 +180,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         :proofed_in_person_enrollment,
         :with_phone,
       )
+      proofing_components = ProofingComponent.create_or_find_by(user: user)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -188,8 +193,8 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
+        proofing_components: proofing_components,
         identity_verified: true,
-        identity_verification_method: :in_person_proofing,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -106,14 +106,7 @@ RSpec.describe AccountReset::DeleteAccountController do
     end
 
     it 'logs info about user verified account' do
-      user = create(
-        :user,
-        :fully_registered,
-        confirmed_at: Time.zone.now.round,
-        profiles: [build(:profile, :active, :verified, pii: { first_name: 'Jane' })],
-      )
-
-      create_list(:webauthn_configuration, 2, user: user)
+      user = create(:user, :proofed)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -125,10 +118,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         user_id: user.uuid,
         success: true,
         errors: {},
-        mfa_method_counts: {
-          phone: 1,
-          webauthn: 2,
-        },
+        mfa_method_counts: { phone: 1 },
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
@@ -137,17 +127,7 @@ RSpec.describe AccountReset::DeleteAccountController do
     end
 
     it 'logs info about user biometrically verified account' do
-      user = create(
-        :user,
-        :fully_registered,
-        confirmed_at: Time.zone.now.round,
-        profiles: [build(
-          :profile, :active, :verified, pii: { first_name: 'Jane' },
-                                        idv_level: :unsupervised_with_selfie
-        )],
-      )
-
-      create_list(:webauthn_configuration, 2, user: user)
+      user = create(:user, :proofed_with_selfie, :with_phone)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -159,10 +139,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         user_id: user.uuid,
         success: true,
         errors: {},
-        mfa_method_counts: {
-          phone: 1,
-          webauthn: 2,
-        },
+        mfa_method_counts: { phone: 1 },
         identity_verified: true,
         identity_verification_method: :biometric_comparison,
         account_age_in_days: 0,
@@ -172,14 +149,7 @@ RSpec.describe AccountReset::DeleteAccountController do
     end
 
     it 'logs info about user pending verify by mail account' do
-      user = create(
-        :user,
-        :fully_registered,
-        confirmed_at: Time.zone.now.round,
-        profiles: [build(:profile, :verify_by_mail_pending, pii: { first_name: 'Jane' })],
-      )
-
-      create_list(:webauthn_configuration, 2, user: user)
+      user = create(:user, :with_pending_gpo_profile, :with_phone)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -191,10 +161,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         user_id: user.uuid,
         success: true,
         errors: {},
-        mfa_method_counts: {
-          phone: 1,
-          webauthn: 2,
-        },
+        mfa_method_counts: { phone: 1 },
         identity_verified: false,
         identity_verification_method: :verify_by_mail,
         account_age_in_days: 0,
@@ -206,12 +173,9 @@ RSpec.describe AccountReset::DeleteAccountController do
     it 'logs info about user pending in person verification account' do
       user = create(
         :user,
-        :fully_registered,
         :with_pending_in_person_enrollment,
-        confirmed_at: Time.zone.now.round,
+        :with_phone,
       )
-
-      create_list(:webauthn_configuration, 2, user: user)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -223,10 +187,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         user_id: user.uuid,
         success: true,
         errors: {},
-        mfa_method_counts: {
-          phone: 1,
-          webauthn: 2,
-        },
+        mfa_method_counts: { phone: 1 },
         identity_verified: false,
         identity_verification_method: :in_person_proofing,
         account_age_in_days: 0,

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe AccountReset::DeleteAccountController do
     end
 
     it 'logs info about user verified account' do
-      user = create(:user, :proofed, confirmed_at: Time.zone.now.round)
+      user = create(:user, :proofed)
+      proofing_components = user.active_profile.proofing_components
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -119,15 +120,18 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
+        proofing_components: proofing_components,
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )
-      expect(response).to redirect_to account_reset_confirm_delete_account_url
     end
 
     it 'logs info about user biometrically verified account' do
-      user = create(:user, :proofed_with_selfie, :with_phone)
+      user = create(
+        :user, :proofed_with_selfie, :with_phone
+      )
+      proofing_components = user.active_profile.proofing_components
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -140,15 +144,16 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
+        proofing_components: proofing_components,
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )
-      expect(response).to redirect_to account_reset_confirm_delete_account_url
     end
 
     it 'logs info about user with a verified by mail account' do
       user = create(:user, :proofed_with_gpo)
+      proofing_components = user.active_profile.proofing_components
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -161,19 +166,20 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
+        proofing_components: proofing_components,
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )
-      expect(response).to redirect_to account_reset_confirm_delete_account_url
     end
 
-    it 'logs info about user pending in person verification account' do
+    it 'logs info about user verified in person proofed account' do
       user = create(
         :user,
         :proofed_in_person_enrollment,
         :with_phone,
       )
+      proofing_components = user.active_profile.proofing_components
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -186,11 +192,11 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
+        proofing_components: proofing_components,
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )
-      expect(response).to redirect_to account_reset_confirm_delete_account_url
     end
   end
 

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -148,8 +148,8 @@ RSpec.describe AccountReset::DeleteAccountController do
       expect(response).to redirect_to account_reset_confirm_delete_account_url
     end
 
-    it 'logs info about user pending verify by mail account' do
-      user = create(:user, :with_pending_gpo_profile, :with_phone)
+    it 'logs info about user with a verified by mail account' do
+      user = create(:user, :proofed_with_gpo)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -162,7 +162,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        identity_verified: false,
+        identity_verified: true,
         identity_verification_method: :verify_by_mail,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
@@ -173,7 +173,7 @@ RSpec.describe AccountReset::DeleteAccountController do
     it 'logs info about user pending in person verification account' do
       user = create(
         :user,
-        :with_pending_in_person_enrollment,
+        :proofed_in_person_enrollment,
         :with_phone,
       )
       create_account_reset_request_for(user)
@@ -188,7 +188,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        identity_verified: false,
+        identity_verified: true,
         identity_verification_method: :in_person_proofing,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe AccountReset::DeleteAccountController do
           webauthn: 2,
         },
         identity_verified: true,
-        identity_verification_method: 'Biometric',
+        identity_verification_method: :biometric_comparison,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )
@@ -196,7 +196,7 @@ RSpec.describe AccountReset::DeleteAccountController do
           webauthn: 2,
         },
         identity_verified: false,
-        identity_verification_method: 'GPO',
+        identity_verification_method: :verify_by_mail,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )
@@ -228,7 +228,7 @@ RSpec.describe AccountReset::DeleteAccountController do
           webauthn: 2,
         },
         identity_verified: false,
-        identity_verification_method: 'IPP',
+        identity_verification_method: :in_person_proofing,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
       )

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe AccountReset::DeleteAccountController do
     end
 
     it 'logs info about user verified account' do
-      user = create(:user, :proofed)
+      user = create(:user, :proofed, confirmed_at: Time.zone.now.round)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -107,7 +107,6 @@ RSpec.describe AccountReset::DeleteAccountController do
 
     it 'logs info about user verified account' do
       user = create(:user, :proofed)
-      proofing_components = ProofingComponent.create_or_find_by(user: user)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -120,7 +119,6 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        proofing_components: proofing_components,
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
@@ -130,7 +128,6 @@ RSpec.describe AccountReset::DeleteAccountController do
 
     it 'logs info about user biometrically verified account' do
       user = create(:user, :proofed_with_selfie, :with_phone)
-      proofing_components = ProofingComponent.create_or_find_by(user: user)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -143,7 +140,6 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        proofing_components: proofing_components,
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
@@ -153,7 +149,6 @@ RSpec.describe AccountReset::DeleteAccountController do
 
     it 'logs info about user with a verified by mail account' do
       user = create(:user, :proofed_with_gpo)
-      proofing_components = ProofingComponent.create_or_find_by(user: user)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -166,7 +161,6 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        proofing_components: proofing_components,
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
@@ -180,7 +174,6 @@ RSpec.describe AccountReset::DeleteAccountController do
         :proofed_in_person_enrollment,
         :with_phone,
       )
-      proofing_components = ProofingComponent.create_or_find_by(user: user)
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -193,7 +186,6 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        proofing_components: proofing_components,
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,

--- a/spec/controllers/account_reset/delete_account_controller_spec.rb
+++ b/spec/controllers/account_reset/delete_account_controller_spec.rb
@@ -107,7 +107,6 @@ RSpec.describe AccountReset::DeleteAccountController do
 
     it 'logs info about user verified account' do
       user = create(:user, :proofed)
-      proofing_components = user.active_profile.proofing_components
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -120,7 +119,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        proofing_components: proofing_components,
+        profile_idv_level: 'legacy_unsupervised',
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
@@ -131,7 +130,6 @@ RSpec.describe AccountReset::DeleteAccountController do
       user = create(
         :user, :proofed_with_selfie, :with_phone
       )
-      proofing_components = user.active_profile.proofing_components
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -144,7 +142,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        proofing_components: proofing_components,
+        profile_idv_level: 'unsupervised_with_selfie',
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
@@ -153,7 +151,6 @@ RSpec.describe AccountReset::DeleteAccountController do
 
     it 'logs info about user with a verified by mail account' do
       user = create(:user, :proofed_with_gpo)
-      proofing_components = user.active_profile.proofing_components
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -166,7 +163,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        proofing_components: proofing_components,
+        profile_idv_level: 'legacy_unsupervised',
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,
@@ -179,7 +176,6 @@ RSpec.describe AccountReset::DeleteAccountController do
         :proofed_in_person_enrollment,
         :with_phone,
       )
-      proofing_components = user.active_profile.proofing_components
       create_account_reset_request_for(user)
       grant_request(user)
       session[:granted_token] = AccountResetRequest.first.granted_token
@@ -192,7 +188,7 @@ RSpec.describe AccountReset::DeleteAccountController do
         success: true,
         errors: {},
         mfa_method_counts: { phone: 1 },
-        proofing_components: proofing_components,
+        profile_idv_level: 'legacy_in_person',
         identity_verified: true,
         account_age_in_days: 0,
         account_confirmed_at: user.confirmed_at,

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -200,7 +200,6 @@ FactoryBot.define do
           :active,
           :with_pii,
           user: user,
-          proofing_components: { document_check: 'mock', document_type: 'state_id' },
         )
       end
     end
@@ -217,7 +216,6 @@ FactoryBot.define do
           :with_pii,
           idv_level: :unsupervised_with_selfie,
           user: user,
-          proofing_components: { document_check: 'mock', document_type: 'biometric' },
         )
       end
     end
@@ -272,14 +270,15 @@ FactoryBot.define do
       confirmed_at { Time.zone.now.round }
 
       after :build do |user|
-        create(
+        profile = create(
           :profile,
-          :active,
           :with_pii,
+          :active,
+          :verified,
+          :in_person_verification_pending,
           user: user,
-          proofing_components: { document_check: 'mock', document_type: 'ipp' },
         )
-        create(:in_person_enrollment, status: 'passed', user: user)
+        create(:in_person_enrollment, :passed, user: user, profile: profile)
       end
     end
 
@@ -293,7 +292,6 @@ FactoryBot.define do
           :active,
           :with_pii,
           user: user,
-          proofing_components: { document_check: 'mock', document_type: 'gpo' },
         )
         gpo_code = create(:gpo_confirmation_code)
         profile.gpo_confirmation_codes << gpo_code

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -192,14 +192,22 @@ FactoryBot.define do
 
     trait :proofed do
       fully_registered
+      confirmed_at { Time.zone.now.round }
 
       after :build do |user|
-        create(:profile, :active, :verified, :with_pii, user: user)
+        create(
+          :profile,
+          :active,
+          :with_pii,
+          user: user,
+          proofing_components: { document_check: 'mock', document_type: 'state_id' },
+        )
       end
     end
 
     trait :proofed_with_selfie do
       fully_registered
+      confirmed_at { Time.zone.now.round }
 
       after :build do |user|
         create(
@@ -209,6 +217,7 @@ FactoryBot.define do
           :with_pii,
           idv_level: :unsupervised_with_selfie,
           user: user,
+          proofing_components: { document_check: 'mock', document_type: 'biometric' },
         )
       end
     end
@@ -223,13 +232,6 @@ FactoryBot.define do
     trait :with_establishing_in_person_enrollment do
       after :build do |user|
         create(:in_person_enrollment, :establishing, user: user)
-      end
-    end
-
-    trait :proofed_in_person_enrollment do
-      proofed
-      after :build do |user|
-        create(:in_person_enrollment, status: 'passed', user: user)
       end
     end
 
@@ -265,10 +267,34 @@ FactoryBot.define do
       end
     end
 
-    trait :proofed_with_gpo do
-      proofed
+    trait :proofed_in_person_enrollment do
+      fully_registered
+      confirmed_at { Time.zone.now.round }
+
       after :build do |user|
-        profile = user.active_profile
+        create(
+          :profile,
+          :active,
+          :with_pii,
+          user: user,
+          proofing_components: { document_check: 'mock', document_type: 'ipp' },
+        )
+        create(:in_person_enrollment, status: 'passed', user: user)
+      end
+    end
+
+    trait :proofed_with_gpo do
+      fully_registered
+      confirmed_at { Time.zone.now.round }
+
+      after :build do |user|
+        profile = create(
+          :profile,
+          :active,
+          :with_pii,
+          user: user,
+          proofing_components: { document_check: 'mock', document_type: 'gpo' },
+        )
         gpo_code = create(:gpo_confirmation_code)
         profile.gpo_confirmation_codes << gpo_code
         device = create(:device, user: user)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -226,6 +226,13 @@ FactoryBot.define do
       end
     end
 
+    trait :proofed_in_person_enrollment do
+      proofed
+      after :build do |user|
+        create(:in_person_enrollment, status: 'passed', user: user)
+      end
+    end
+
     trait :with_pending_gpo_profile do
       transient do
         code_sent_at { created_at }


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-14100](https://cm-jira.usa.gov/browse/LG-14100)


## 🛠 Summary of changes

Add Identity Verified details to 'Account Reset: delete' event.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

Reduce wait time for Account Reset: delete by setting in your local application.yml
`account_reset_wait_period_days: 0`

- [ ] In a console window run make watch_events
- [ ] With an unverified, verified, pending account go through the process to delete an account by way of the link on the Select your authentication method screen in sign in.
- [ ] When the deletion process completes observe relevant values are posted to the event_properties block.
identity_verified:
profile_idv_level: (if applicable)


## 👀 Screenshots
![Screenshot 2024-09-19 at 10 50 19 AM (2)](https://github.com/user-attachments/assets/893ab923-7130-40f8-835a-9c7d9a18071e)


