### PR TITLE
LG-14392 Add doc_auth.headings.selfie_capture

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -62,12 +62,12 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
   const documentFormStep: FormStep = {
     name: 'documents',
     form: DocumentsStep,
-    title: t('doc_auth.headings.document_capture'), // might want to change title to isolated doc capture heading
+    title: t('doc_auth.headings.document_capture'),
   };
   const selfieFormStep: FormStep = {
     name: 'selfie',
     form: SelfieStep,
-    title: '', // TODO: replace with yml selfie_capture (Ticket LG-14392)
+    title: t('doc_auth.headings.selfie_capture'),
   };
   const documentsFormSteps: FormStep[] =
     isSelfieCaptureEnabled && docAuthSeparatePagesEnabled && submissionError === undefined

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -591,6 +591,7 @@ doc_auth.headings.no_ssn: Don’t have a Social Security number?
 doc_auth.headings.review_issues: Check your images and try again
 doc_auth.headings.secure_account: Secure your account
 doc_auth.headings.selfie: Photo of your face
+doc_auth.headings.selfie_capture: Capture photo of yourself
 doc_auth.headings.ssn: Enter your Social Security number
 doc_auth.headings.ssn_update: Update your Social Security number
 doc_auth.headings.text_message: We sent a message to your phone

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -602,6 +602,7 @@ doc_auth.headings.no_ssn: '¿No tiene un número de Seguro Social?'
 doc_auth.headings.review_issues: Revise sus imágenes e inténtelo de nuevo
 doc_auth.headings.secure_account: Proteja su cuenta
 doc_auth.headings.selfie: Fotografía de su cara
+doc_auth.headings.selfie_capture: Capture una foto de usted
 doc_auth.headings.ssn: Ingrese su número de Seguro Social
 doc_auth.headings.ssn_update: Actualice su número de Seguro Social
 doc_auth.headings.text_message: Enviamos un mensaje a su teléfono

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -591,6 +591,7 @@ doc_auth.headings.no_ssn: Vous n’avez pas de numéro de sécurité sociale ?
 doc_auth.headings.review_issues: Vérifiez vos images et essayez à nouveau
 doc_auth.headings.secure_account: Sécuriser votre compte
 doc_auth.headings.selfie: Photo de votre visage
+doc_auth.headings.selfie_capture: Prenez-vous en photo
 doc_auth.headings.ssn: Saisir votre numéro de sécurité sociale
 doc_auth.headings.ssn_update: Mettre à jour votre numéro de sécurité sociale
 doc_auth.headings.text_message: Nous avons envoyé un message à votre téléphone

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -602,6 +602,7 @@ doc_auth.headings.no_ssn: 没有社会保障号码？
 doc_auth.headings.review_issues: 检查一下你的图片并再试一次
 doc_auth.headings.secure_account: 保护你的账户安全
 doc_auth.headings.selfie: 照片
+doc_auth.headings.selfie_capture: 拍你本人照片
 doc_auth.headings.ssn: 输入你的社会保障号码
 doc_auth.headings.ssn_update: 更新你的社会保障号码
 doc_auth.headings.text_message: 我们给你的手机发了短信

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -498,6 +498,7 @@ RSpec.feature 'document capture step', :js do
       expect(page).not_to have_content(t('doc_auth.tips.document_capture_selfie_text1'))
       attach_images
       continue_doc_auth_form
+      expect(page).to have_title(t('doc_auth.headings.selfie_capture'))
       expect(page).to have_content(t('doc_auth.tips.document_capture_selfie_text1'))
       attach_selfie
       submit_images


### PR DESCRIPTION
update capture heading to selfie step in for split doc auth

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14392](https://cm-jira.usa.gov/browse/LG-14392)


## 🛠 Summary of changes

Added selfie capture heading translations and added title to selfie step for split doc auth


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - Ensure your version of the app has doc_auth_separate_pages_enabled: true (application.yml)
- [ ] Step 2 - Start with an oidc instance and select biometric vot (to go through doc auth flow with selfie)
- [ ] Step 3 - Go through normal login doc auth flow until the selfie step
- [ ] Step 4 - Ensure that the title on the tab (HTML <title>) is updated from "Add your ID" to "Capture photo of yourself"



## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="1512" alt="Old Selfie Title" src="https://github.com/user-attachments/assets/a8dd0bd8-58d1-472f-9259-eb06286a7dfe">

</details>

<details>
<summary>After:</summary>
<img width="1512" alt="New Selfie Title" src="https://github.com/user-attachments/assets/ddacda59-1709-4fff-986a-e88cc7226f5f">

</details>

