### PR TITLE
LG-14260 Send the actual timestamp that consent was submitted in Socure request

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -36,7 +36,6 @@ module Idv
       )
 
       if result.success?
-        idv_session.idv_consent_given = true
         idv_session.idv_consent_given_at = Time.zone.now
 
         if IdentityConfig.store.in_person_proofing_opt_in_enabled &&

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -75,7 +75,10 @@ module Idv
 
       def pii
         pii_from_user = user_session.dig('idv/in_person', :pii_from_user) || {}
-        pii_from_user.merge(ssn: idv_session.ssn)
+        pii_from_user.merge(
+          consent_given_at: idv_session.idv_consent_given_at,
+          ssn: idv_session.ssn,
+        )
       end
 
       # override IdvSessionConcern

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -79,6 +79,7 @@ module Idv
     def pii
       idv_session.pii_from_doc.to_h.merge(
         ssn: idv_session.ssn,
+        consent_given_at: idv_session.idv_consent_given_at,
         **idv_session.updated_user_address.to_h,
       ).with_indifferent_access
     end

--- a/app/jobs/socure_shadow_mode_proofing_job.rb
+++ b/app/jobs/socure_shadow_mode_proofing_job.rb
@@ -100,6 +100,7 @@ class SocureShadowModeProofingJob < ApplicationJob
         :phone,
         :dob,
         :ssn,
+        :consent_given_at,
       ),
       email: user_email,
     }

--- a/app/services/proofing/socure/id_plus/input.rb
+++ b/app/services/proofing/socure/id_plus/input.rb
@@ -16,7 +16,9 @@ module Proofing
         :phone,
         :email,
         :ssn,
+        :consent_given_at,
         keyword_init: true,
+        allowed_members: [:consent_given_at],
       ).freeze
     end
   end

--- a/app/services/proofing/socure/id_plus/request.rb
+++ b/app/services/proofing/socure/id_plus/request.rb
@@ -98,7 +98,7 @@ module Proofing
             dob: input.dob&.to_date&.to_s,
 
             userConsent: true,
-            consentTimestamp: 5.minutes.ago.iso8601,
+            consentTimestamp: input.consent_given_at&.to_time&.iso8601,
 
             email: input.email,
             mobileNumber: input.phone,

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
     stub_sign_in(user)
     subject.idv_session.flow_path = 'standard'
     subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID[:ssn]
+    subject.idv_session.idv_consent_given_at = Time.zone.now.to_s
     subject.user_session['idv/in_person'] = flow_session
   end
 
@@ -216,6 +217,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
         hash_including(
           state_id_type: 'drivers_license',
           ssn: Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID[:ssn],
+          consent_given_at: subject.idv_session.idv_consent_given_at,
         ),
       ).and_call_original
 
@@ -264,7 +266,9 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
 
       it 'captures state id address fields in the pii' do
         expect(Idv::Agent).to receive(:new).with(
-          Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS,
+          Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS.merge(
+            consent_given_at: subject.idv_session.idv_consent_given_at,
+          ),
         ).and_call_original
         put :update
       end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -397,6 +397,7 @@ RSpec.describe Idv::VerifyInfoController do
       expect(Idv::Agent).to receive(:new).with(
         hash_including(
           ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
+          consent_given_at: controller.idv_session.idv_consent_given_at,
           **Idp::Constants::MOCK_IDV_APPLICANT,
         ),
       ).and_call_original

--- a/spec/services/proofing/socure/id_plus/input_spec.rb
+++ b/spec/services/proofing/socure/id_plus/input_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Proofing::Socure::IdPlus::Input do
   let(:user) { build(:user) }
 
   let(:state_id) do
-    Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE
+    Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.merge(consent_given_at: '2024-09-01T00:00:00Z')
   end
 
   subject do
@@ -32,6 +32,8 @@ RSpec.describe Proofing::Socure::IdPlus::Input do
         phone: '12025551212',
         ssn: '900-66-1234',
         email: user.email,
+
+        consent_given_at: '2024-09-01T00:00:00Z',
       },
     )
   end

--- a/spec/services/proofing/socure/id_plus/request_spec.rb
+++ b/spec/services/proofing/socure/id_plus/request_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Proofing::Socure::IdPlus::Request do
           mobileNumber: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:phone],
 
           userConsent: true,
-          consentTimestamp: '2024-09-01T00:00:00Z'.to_time.iso8601,
+          consentTimestamp: '2024-09-01T00:00:00+00:00',
         },
       )
     end

--- a/spec/services/proofing/socure/id_plus/request_spec.rb
+++ b/spec/services/proofing/socure/id_plus/request_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe Proofing::Socure::IdPlus::Request do
   let(:input) do
     Proofing::Socure::IdPlus::Input.new(
       email: user.email,
-      **Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.slice(
+      **Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.merge(
+        consent_given_at: '2024-09-01T00:00:00Z',
+      ).slice(
         *Proofing::Socure::IdPlus::Input.members,
       ),
     )
@@ -27,37 +29,30 @@ RSpec.describe Proofing::Socure::IdPlus::Request do
 
   describe '#body' do
     it 'contains all expected values' do
-      freeze_time do
-        expect(JSON.parse(request.body, symbolize_names: true)).to eql(
-          {
-            modules: [
-              'kyc',
-            ],
-            firstName: 'FAKEY',
-            surName: 'MCFAKERSON',
-            dob: '1938-10-06',
-            physicalAddress: '1 FAKE RD',
-            physicalAddress2: nil,
-            city: 'GREAT FALLS',
-            state: 'MT',
-            zip: '59010-1234',
-            country: 'US',
-            nationalId: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn],
-            countryOfOrigin: 'US',
+      expect(JSON.parse(request.body, symbolize_names: true)).to eql(
+        {
+          modules: [
+            'kyc',
+          ],
+          firstName: 'FAKEY',
+          surName: 'MCFAKERSON',
+          dob: '1938-10-06',
+          physicalAddress: '1 FAKE RD',
+          physicalAddress2: nil,
+          city: 'GREAT FALLS',
+          state: 'MT',
+          zip: '59010-1234',
+          country: 'US',
+          nationalId: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn],
+          countryOfOrigin: 'US',
 
-            email: user.email,
-            mobileNumber: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:phone],
+          email: user.email,
+          mobileNumber: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:phone],
 
-            userConsent: true,
-
-            # XXX: This should be set to the time the user submitted agreement,
-            #      which we are not currently tracking. The "5.minutes.ago" is
-            #      because Socure will reject times "in the future", so we avoid
-            #      our clocks being out of sync with theirs.
-            consentTimestamp: 5.minutes.ago.iso8601,
-          },
-        )
-      end
+          userConsent: true,
+          consentTimestamp: '2024-09-01T00:00:00Z'.to_time.iso8601,
+        },
+      )
     end
   end
 

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -12,7 +12,7 @@ module FlowPolicyHelper
     when :welcome
       idv_session.welcome_visited = true
     when :agreement
-      idv_session.idv_consent_given_at = Time.zone.now
+      idv_session.idv_consent_given_at = Time.zone.now.to_s
     when :how_to_verify
       idv_session.skip_doc_auth = false
       idv_session.skip_doc_auth_from_how_to_verify = false


### PR DESCRIPTION
Socure requires that we send them the timestamp that the user submitted consent to share their info. A previous commit started recording the timestamp in the `Idv::AgreementController`. This commit does the work to start passing to timestamp to Socure in the applicant hash.
