### PR TITLE
LG-12377 Remove 404 action for State ID Controller/FSM removal

### DIFF
--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -6,7 +6,6 @@ module Idv
       include Idv::AvailabilityConcern
       include IdvStepConcern
 
-      before_action :render_404_if_controller_not_enabled
       before_action :redirect_unless_enrollment # confirm previous step is complete
       before_action :set_usps_form_presenter
 
@@ -91,11 +90,6 @@ module Idv
       end
 
       private
-
-      def render_404_if_controller_not_enabled
-        render_not_found unless
-            IdentityConfig.store.in_person_state_id_controller_enabled
-      end
 
       def redirect_unless_enrollment
         redirect_to idv_document_capture_url unless current_user.establishing_in_person_enrollment

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -28,32 +28,6 @@ RSpec.describe Idv::InPerson::StateIdController do
       )
     end
 
-    context '#render_404_if_controller_not_enabled' do
-      context 'flag not set' do
-        before do
-          allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).
-            and_return(nil)
-        end
-        it 'renders a 404' do
-          get :show
-
-          expect(response).to be_not_found
-        end
-      end
-
-      context 'flag not enabled' do
-        before do
-          allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).
-            and_return(false)
-        end
-        it 'renders a 404' do
-          get :show
-
-          expect(response).to be_not_found
-        end
-      end
-    end
-
     context '#confirm_establishing_enrollment' do
       let(:enrollment) { nil }
       it 'redirects to document capture if not complete' do

--- a/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
@@ -71,11 +71,8 @@ RSpec.describe 'state id 50/50 state', :js, allow_browser_log: true do
         page.refresh
       end
 
-      it 'renders the 404 page' do
-        expect(page).to have_content(
-          "The page you were looking for doesn’t exist.\nYou might want to double-check your link" \
-          " and try again. (404)",
-        )
+      it 'renders the state ID controller page without error' do
+        expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12377](https://cm-jira.usa.gov/browse/LG-12377)

## 🛠 Summary of changes

This removes the before action that causes the State ID controller to show a 404 when the `in_person_state_id_controller_enabled` feature flag is turned off.

 ## 📜 Testing Plan

Both URLs work with the controller state enabled:
- [x] Ensure the environment variable `in_person_state_id_controller_enabled` is set to false in your application.yml and restart the application.
- [x] Go through the IPP flow
- [x] At the state ID page, change the url from `/verify/in_person/state_id` to `/verify/in_person_proofing/state_id`
- [x] Observe the state ID page loads and doesn't show a 404 error.

Disabling the controller variable to simulate 50/50 state:
- [x] Ensure the environment variable `in_person_state_id_controller_enabled` is set to true in your application.yml and restart the application.
- [x] Go through the IPP flow
- [x] At the state ID page go back to application.yml and change the `in_person_state_id_controller_enabled` to false, and restart the application.
- [x] Refresh the state ID page.
- [x] Observe the state ID page loads and doesn't show a 404 error.

Enabling the controller variable to simulate 50/50 state:
- [x] Ensure the environment variable `in_person_state_id_controller_enabled` is set to false in your application.yml and restart the application.
- [x] Go through the IPP flow
- [x] At the state ID page go back to application.yml and change the `in_person_state_id_controller_enabled` to true, and restart the application.
- [x] Refresh the state ID page.
- [x] Observe the state ID page loads and doesn't show a 404 error.

## 👀 Screenshots

<details>
<summary>Before:</summary>
<img width="1337" alt="Screenshot 2024-09-16 at 3 26 20 PM" src="https://github.com/user-attachments/assets/478beb4a-1958-47f2-bb3d-c32deb9c7358">

</details>

<details>
<summary>After:</summary>
<img width="1300" alt="Screenshot 2024-09-16 at 3 27 15 PM" src="https://github.com/user-attachments/assets/11398bd8-872b-4ff8-950f-e05bb91e3489">

</details>

