### PR TITLE
Remove dependency on saml_idp instance variable

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -129,7 +129,7 @@ class SamlIdpController < ApplicationController
       finish_profile: user_has_pending_profile?,
       requested_ial: requested_ial,
       request_signed: saml_request.signed?,
-      matching_cert_serial: saml_request.service_provider.matching_cert&.serial&.to_s,
+      matching_cert_serial:,
       requested_nameid_format: saml_request.name_id_format,
     )
 
@@ -138,6 +138,12 @@ class SamlIdpController < ApplicationController
     end
 
     analytics.saml_auth(**analytics_payload)
+  end
+
+  def matching_cert_serial
+    saml_request.matching_cert&.serial&.to_s
+  rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
+    nil
   end
 
   def log_external_saml_auth_request

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6289,7 +6289,7 @@ module AnalyticsEvents
     finish_profile:,
     requested_ial:,
     request_signed:,
-    matching_cert_serial: nil,
+    matching_cert_serial:,
     error_details: nil,
     cert_error_details: nil,
     **extra

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6289,7 +6289,7 @@ module AnalyticsEvents
     finish_profile:,
     requested_ial:,
     request_signed:,
-    matching_cert_serial:,
+    matching_cert_serial: nil,
     error_details: nil,
     cert_error_details: nil,
     **extra


### PR DESCRIPTION
changelog: Internal, Protocols, Removes dependency on service provider instance variable

## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/2 and
[LG-4875](https://cm-jira.usa.gov/browse/LG-4875)

## 🛠 Summary of changes
This is the penultimate step to clear out this old ticket :)
The matching_cert method has been pulled into the request object, rather than the service_provider object. There's one more bit of cleanup to be done on the saml_idp to remove that instance variable, but since all the pieces are in place to remove the IdP's dependency on it, I thought I would do that first.

Updating the IdP code will possibly allow us to remove this ValidationError, which is catching the edge case we've seen in the past where a request that is signed will have an X509 Certificate element in the XML, with no actual certificate embedded in it. 