### PR TITLE
LG-12213: Fix redirect when selecting Face/Touch on unsupported device

### DIFF
--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -7,7 +7,6 @@ module TwoFactorAuthentication
     include NewDeviceConcern
 
     before_action :check_sp_required_mfa
-    before_action :check_if_device_supports_platform_auth, only: :show
     before_action :confirm_webauthn_enabled, only: :show
 
     def show
@@ -22,17 +21,6 @@ module TwoFactorAuthentication
     end
 
     private
-
-    def check_if_device_supports_platform_auth
-      return unless user_session.has_key?(:platform_authenticator_available)
-      if platform_authenticator? && !device_supports_webauthn_platform?
-        redirect_to login_two_factor_options_url
-      end
-    end
-
-    def device_supports_webauthn_platform?
-      user_session.delete(:platform_authenticator_available) == true
-    end
 
     def handle_webauthn_result(result)
       handle_verification_for_authentication_context(

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -338,15 +338,17 @@ module Users
     def redirect_url
       if !mobile? && TwoFactorAuthentication::PivCacPolicy.new(current_user).enabled?
         login_two_factor_piv_cac_url
+      elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user).platform_enabled?
+        if user_session[:platform_authenticator_available] == false
+          login_two_factor_options_url
+        else
+          login_two_factor_webauthn_url(platform: true)
+        end
       elsif TwoFactorAuthentication::WebauthnPolicy.new(current_user).enabled?
-        login_two_factor_webauthn_url(webauthn_params)
+        login_two_factor_webauthn_url
       elsif TwoFactorAuthentication::AuthAppPolicy.new(current_user).enabled?
         login_two_factor_authenticator_url
       end
-    end
-
-    def webauthn_params
-      { platform: current_user.webauthn_configurations.platform_authenticators.present? }
     end
 
     def handle_too_many_short_term_otp_sends(method:, default:)

--- a/spec/features/remember_device/revocation_spec.rb
+++ b/spec/features/remember_device/revocation_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature 'taking an action that revokes remember device' do
                     elsif TwoFactorAuthentication::WebauthnPolicy.new(user).platform_enabled?
                       login_two_factor_webauthn_path(platform: true)
                     elsif TwoFactorAuthentication::WebauthnPolicy.new(user).enabled?
-                      login_two_factor_webauthn_path(platform: false)
+                      login_two_factor_webauthn_path
                     elsif TwoFactorAuthentication::AuthAppPolicy.new(user).enabled?
                       login_two_factor_authenticator_path
                     elsif TwoFactorAuthentication::PhonePolicy.new(user).enabled?

--- a/spec/features/webauthn/hidden_spec.rb
+++ b/spec/features/webauthn/hidden_spec.rb
@@ -99,7 +99,6 @@ RSpec.describe 'webauthn hide' do
             visit new_user_session_path
             set_hidden_field('platform_authenticator_available', 'false')
             fill_in_credentials_and_submit(email, user.password)
-            continue_as(email, user.password)
 
             # Redirected to options page
             expect(current_path).to eq(login_two_factor_options_path)
@@ -122,7 +121,6 @@ RSpec.describe 'webauthn hide' do
               visit new_user_session_path
               set_hidden_field('platform_authenticator_available', 'false')
               fill_in_credentials_and_submit(email, user.password)
-              continue_as(email, user.password)
 
               # Redirected to default MFA method
               expect(current_path).to eq(login_two_factor_piv_cac_path)

--- a/spec/features/webauthn/hidden_spec.rb
+++ b/spec/features/webauthn/hidden_spec.rb
@@ -94,11 +94,9 @@ RSpec.describe 'webauthn hide' do
 
         context 'with device that doesnt support authenticator' do
           it 'redirects to options page and allows them to choose authenticator' do
-            email = user.email_addresses.first.email
-
             visit new_user_session_path
             set_hidden_field('platform_authenticator_available', 'false')
-            fill_in_credentials_and_submit(email, user.password)
+            fill_in_credentials_and_submit(user.email, user.password)
 
             # Redirected to options page
             expect(current_path).to eq(login_two_factor_options_path)
@@ -116,11 +114,9 @@ RSpec.describe 'webauthn hide' do
             end
 
             it 'allows them to choose authenticator if they change from their default method' do
-              email = user.email_addresses.first.email
-
               visit new_user_session_path
               set_hidden_field('platform_authenticator_available', 'false')
-              fill_in_credentials_and_submit(email, user.password)
+              fill_in_credentials_and_submit(user.email, user.password)
 
               # Redirected to default MFA method
               expect(current_path).to eq(login_two_factor_piv_cac_path)

--- a/spec/support/shared_examples/remember_device.rb
+++ b/spec/support/shared_examples/remember_device.rb
@@ -70,7 +70,7 @@ RSpec.shared_examples 'remember device' do
                     elsif TwoFactorAuthentication::WebauthnPolicy.new(user).platform_enabled?
                       login_two_factor_webauthn_path(platform: true)
                     elsif TwoFactorAuthentication::WebauthnPolicy.new(user).enabled?
-                      login_two_factor_webauthn_path(platform: false)
+                      login_two_factor_webauthn_path
                     elsif TwoFactorAuthentication::AuthAppPolicy.new(user).enabled?
                       login_two_factor_authenticator_path
                     elsif TwoFactorAuthentication::PhonePolicy.new(user).enabled?


### PR DESCRIPTION
## 🎫 Ticket

[LG-12213](https://cm-jira.usa.gov/browse/LG-12213)

## 🛠 Summary of changes

Fixes an issue where a user may be redirected away from authenticating with Face or Touch Unlock if they are on an unsupported device, and if they have a stronger authenticator available.

For context, we detect if the current device has a platform authenticator available when signing in, and if they're on a "supported" device for enrolling Face or Touch Unlock (iOS 16+, Android 9+). If they are not on a supported device, but the user has a platform authenticator credential associated with their device, we redirect them to their list of MFA options. They can choose to still authenticator with Face or Touch Unlock if they want.

The problem is that the check was performed when the user arrives at the Face or Touch Unlock verification screen, assuming they'd be redirected their above other methods since it's a strong authentication method. However, there is a stronger authentication method (PIV), and so the user wouldn't necessarily always be directed to verify with Face or Touch Unlock. If the user has both a PIV and Face or Touch Unlock, and chose to switch to use their Face or Touch Unlock, they'd be confusingly bounced out of the Face or Touch Unlock verification screen.

## 📜 Testing Plan

1. Prerequisite: Have an account with both PIV and Face or Touch Unlock
2. Go to https://localhost:3000 on a device that is "unsupported". A desktop computer is your best bet.
3. Sign in
4. (If not prompted for MFA, click "Forget all browsers" from Account sidebar, confirm, sign out, and start over)
5. When prompted for PIV authenticator, click "Choose another authentication method"
6. Choose "Face or Touch Unlock"
7. Click "Continue"

**Before:** It would appear that nothing happened, that the page listing MFA methods reloaded. It would work on a second submission.
**After:** You arrive at the Face or Touch Unlock verification screen.

## 👀 Screenshots

_Before_:

https://github.com/user-attachments/assets/d1cb779f-b80d-4a36-a007-60c201cb8a42

_After_:

https://github.com/user-attachments/assets/b82f0395-2d51-4919-96bd-391efab4d49d