### PR TITLE
LG-13462 Move `account_lex_id` and `session_id` into `DdpResult`

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1925,9 +1925,9 @@ module AnalyticsEvents
   # @option proofing_results [String,nil] context.stages.threatmetrix.exception If an exception was encountered making the request to the vendor, its message is provided here.
   # @option proofing_results [Boolean] context.stages.threatmetrix.timed_out Whether the request to the vendor timed out.
   # @option proofing_results [String] context.stages.threatmetrix.transaction_id Vendor-specific transaction ID for the request.
+  # @option proofing_results [String] context.stages.threatmetrix.session_id Session ID associated with the response.
+  # @option proofing_results [String] context.stages.threatmetrix.account_lex_id LexID associated with the response.
   # @option proofing_results [Hash] context.stages.threatmetrix.response_body JSON body of the response returned from the vendor. PII has been redacted.
-  # @option proofing_results [String] context.stages.threatmetrix.response_body.account_lex_id LexID associated with the response.
-  # @option proofing_results [String] context.stages.threatmetrix.response_body.session_id Session ID associated with the response.
   # @option proofing_results [String] context.stages.threatmetrix.review_status One of "pass", "review", "reject".
   # @param skip_hybrid_handoff [Boolean] Whether the user should skip hybrid handoff (i.e. because they are already on a mobile device)
   # @param ssn_is_unique [Boolean] Whether another Profile existed with the same SSN at the time the profile associated with the current IdV session was minted.

--- a/app/services/proofing/ddp_result.rb
+++ b/app/services/proofing/ddp_result.rb
@@ -7,6 +7,8 @@ module Proofing
                   :success,
                   :transaction_id,
                   :review_status,
+                  :account_lex_id,
+                  :session_id,
                   :response_body,
                   :client
 
@@ -16,6 +18,8 @@ module Proofing
         context: {},
         exception: nil,
         transaction_id: nil,
+        account_lex_id: nil,
+        session_id: nil,
         review_status: nil,
         response_body: nil,
         client: nil
@@ -25,6 +29,8 @@ module Proofing
       @context = context
       @exception = exception
       @transaction_id = transaction_id
+      @account_lex_id = account_lex_id
+      @session_id = session_id
       @response_body = response_body
       @review_status = review_status
       @client = client
@@ -70,6 +76,8 @@ module Proofing
         timed_out: timed_out?,
         transaction_id: transaction_id,
         review_status: review_status,
+        account_lex_id: account_lex_id,
+        session_id: session_id,
         response_body: redacted_response_body,
       }
     end

--- a/app/services/proofing/lexis_nexis/ddp/proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofer.rb
@@ -36,6 +36,8 @@ module Proofing
           result.review_status = review_status
           result.add_error(:request_result, request_result) unless request_result == 'success'
           result.add_error(:review_status, review_status) unless review_status == 'pass'
+          result.account_lex_id = body['account_lex_id']
+          result.session_id = body['session_id']
 
           result.success = !result.errors?
           result.client = 'lexisnexis'

--- a/app/services/proofing/mock/ddp_mock_client.rb
+++ b/app/services/proofing/mock/ddp_mock_client.rb
@@ -39,6 +39,8 @@ module Proofing
         'ddp',
       ).freeze
       TRANSACTION_ID = 'ddp-mock-transaction-id-123'
+      ACCOUNT_LEX_ID = 'super-cool-test-lex-id'
+      SESSION_ID = 'super-cool-test-session-id'
 
       def initialize(response_fixture_file: 'successful_response.json')
         @response_fixture_file = File.expand_path(response_fixture_file, FIXTURES_DIR)
@@ -55,6 +57,8 @@ module Proofing
         return exception_result if review_status.nil?
 
         result.review_status = review_status
+        result.account_lex_id = ACCOUNT_LEX_ID
+        result.session_id = SESSION_ID
         result.response_body = response_body
 
         result.add_error(:review_status, review_status) unless review_status == 'pass'

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -11,21 +11,27 @@ RSpec.feature 'Analytics Regression', :js do
   let(:threatmetrix) { true }
   let(:idv_level) { 'in_person' }
   let(:threatmetrix_response) do
-    { client: nil,
+    {
+      client: nil,
       errors: {},
       exception: nil,
       response_body: { "fraudpoint.score": '500',
                        request_id: '1234',
                        request_result: 'success',
+                       account_lex_id: 'super-cool-test-lex-id',
+                       session_id: 'super-cool-test-session-id',
                        review_status: 'pass',
                        risk_rating: 'trusted',
                        summary_risk_score: '-6',
                        tmx_risk_rating: 'neutral',
                        tmx_summary_reason_code: ['Identity_Negative_History'] },
       review_status: 'pass',
+      account_lex_id: 'super-cool-test-lex-id',
+      session_id: 'super-cool-test-session-id',
       success: true,
       timed_out: false,
-      transaction_id: 'ddp-mock-transaction-id-123' }
+      transaction_id: 'ddp-mock-transaction-id-123',
+    }
   end
   let(:base_proofing_components) do
     {
@@ -767,14 +773,18 @@ RSpec.feature 'Analytics Regression', :js do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
       let(:threatmetrix_response) do
-        { client: 'tmx_disabled',
+        {
+          client: 'tmx_disabled',
           success: true,
           errors: {},
           exception: nil,
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: nil }
+          account_lex_id: nil,
+          session_id: nil,
+          response_body: nil,
+        }
       end
 
       it 'records all of the events' do
@@ -843,14 +853,18 @@ RSpec.feature 'Analytics Regression', :js do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
       let(:threatmetrix_response) do
-        { client: 'tmx_disabled',
+        {
+          client: 'tmx_disabled',
           success: true,
           errors: {},
           exception: nil,
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: nil }
+          account_lex_id: nil,
+          session_id: nil,
+          response_body: nil,
+        }
       end
 
       it 'records all of the events' do
@@ -888,14 +902,18 @@ RSpec.feature 'Analytics Regression', :js do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
       let(:threatmetrix_response) do
-        { client: 'tmx_disabled',
+        {
+          client: 'tmx_disabled',
           success: true,
           errors: {},
           exception: nil,
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: nil }
+          account_lex_id: nil,
+          session_id: nil,
+          response_body: nil,
+        }
       end
 
       it 'records all of the events' do
@@ -945,14 +963,18 @@ RSpec.feature 'Analytics Regression', :js do
       let(:idv_level) { 'legacy_in_person' }
       let(:threatmetrix) { false }
       let(:threatmetrix_response) do
-        { client: 'tmx_disabled',
+        {
+          client: 'tmx_disabled',
           success: true,
           errors: {},
           exception: nil,
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: nil }
+          account_lex_id: nil,
+          session_id: nil,
+          response_body: nil,
+        }
       end
 
       it 'records all of the events', allow_browser_log: true do
@@ -1012,14 +1034,18 @@ RSpec.feature 'Analytics Regression', :js do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
       let(:threatmetrix_response) do
-        { client: 'tmx_disabled',
+        {
+          client: 'tmx_disabled',
           success: true,
           errors: {},
           exception: nil,
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: nil }
+          account_lex_id: nil,
+          session_id: nil,
+          response_body: nil,
+        }
       end
 
       it 'records all of the events' do
@@ -1069,14 +1095,18 @@ RSpec.feature 'Analytics Regression', :js do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
       let(:threatmetrix_response) do
-        { client: 'tmx_disabled',
+        {
+          client: 'tmx_disabled',
           success: true,
           errors: {},
           exception: nil,
           timed_out: false,
           transaction_id: nil,
           review_status: 'pass',
-          response_body: nil }
+          account_lex_id: nil,
+          session_id: nil,
+          response_body: nil,
+        }
       end
 
       it 'records all of the events' do

--- a/spec/fixtures/proofing/lexis_nexis/ddp/successful_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/successful_response.json
@@ -7,5 +7,7 @@
   "tmx_risk_rating": "neutral",
   "fraudpoint.score": "500",
   "first_name": "WARNING! YOU SHOULD NEVER SEE THIS PII FIELD IN THE LOGS",
-  "tmx_summary_reason_code": ["Identity_Negative_History"]
+  "tmx_summary_reason_code": ["Identity_Negative_History"],
+  "session_id": "super-cool-test-session-id",
+  "account_lex_id": "super-cool-test-lex-id"
 }

--- a/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofing_spec.rb
@@ -99,6 +99,9 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofer do
 
         expect(result.success?).to eq(true)
         expect(result.errors).to be_empty
+        expect(result.review_status).to eq('pass')
+        expect(result.session_id).to eq('super-cool-test-session-id')
+        expect(result.account_lex_id).to eq('super-cool-test-lex-id')
       end
     end
 


### PR DESCRIPTION
We use the `Ddp::Proofer` to communicate with Threatmetrix for device profiling. This returns a `DdpResult` which includes a large hash representing the redacted Threatmetrix response body. This result is eventually logged in the `IdV: doc auth verify proofing results` event.

The Threatmetrix response body is large and we are working to move it into its own analytics event.

The `account_lex_id` and `session_id` have been identified as especially helpful fields from the response body. Before we move the response body into its own event we are moving these fields onto `DdpResult`. This will cause them to be logged a level above the response body so they are present after we move the response body to its own event.
