### PR TITLE
Deploy RC 415 to Production

### DIFF
--- a/app/controllers/concerns/personal_key_concern.rb
+++ b/app/controllers/concerns/personal_key_concern.rb
@@ -14,7 +14,7 @@ module PersonalKeyConcern
       Pii::ReEncryptor.new(user: current_user, user_session: user_session).perform
       active_profile.personal_key
     else
-      PersonalKeyGenerator.new(current_user).create
+      PersonalKeyGenerator.new(current_user).generate!
     end
   end
 

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -66,8 +66,7 @@ module TwoFactorAuthentication
 
     def remove_personal_key
       # for now we will regenerate a key and not show it to them so retire personal key page shows
-      current_user.personal_key = PersonalKeyGenerator.new(current_user).create
-      current_user.save!
+      PersonalKeyGenerator.new(current_user).generate!
       user_session.delete(:personal_key)
     end
 

--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -7,11 +7,9 @@ import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import GeneralError from './general-error';
 import TipList from './tip-list';
 import { SelfieCaptureContext } from '../context';
-import {
-  DocumentCaptureSubheaderOne,
-  SelfieCaptureWithHeader,
-  DocumentFrontAndBackCapture,
-} from './documents-and-selfie-step';
+import { DocumentCaptureSubheaderOne } from './documents-and-selfie-step';
+import { DocumentsCaptureStep } from './documents-step';
+import { SelfieCaptureStep } from './selfie-step';
 import type { ReviewIssuesStepValue } from './review-issues-step';
 
 interface DocumentCaptureReviewIssuesProps extends FormStepComponentProps<ReviewIssuesStepValue> {
@@ -79,9 +77,9 @@ function DocumentCaptureReviewIssues({
           ]}
         />
       )}
-      <DocumentFrontAndBackCapture defaultSideProps={defaultSideProps} value={value} />
+      <DocumentsCaptureStep defaultSideProps={defaultSideProps} value={value} />
       {isSelfieCaptureEnabled && (
-        <SelfieCaptureWithHeader defaultSideProps={defaultSideProps} selfieValue={value.selfie} />
+        <SelfieCaptureStep defaultSideProps={defaultSideProps} selfieValue={value.selfie} />
       )}
       <FormStepsButton.Submit />
       <Cancel />

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -55,9 +55,10 @@ function DocumentSideAcuantCapture({
 }: DocumentSideAcuantCaptureProps) {
   const error = errors.find(({ field }) => field === side)?.error;
   const { changeStepCanComplete } = useContext(FormStepsContext);
-  const { isSelfieCaptureEnabled, isSelfieDesktopTestMode } = useContext(SelfieCaptureContext);
+  const { isSelfieCaptureEnabled, isSelfieDesktopTestMode, docAuthSeparatePagesEnabled } =
+    useContext(SelfieCaptureContext);
   const isUploadAllowed = isSelfieDesktopTestMode || !isSelfieCaptureEnabled;
-
+  const stepCanComplete = docAuthSeparatePagesEnabled ? undefined : true;
   return (
     <AcuantCapture
       ref={registerField(side, { isRequired: true })}
@@ -79,7 +80,7 @@ function DocumentSideAcuantCapture({
           onError(new Error(t('doc_auth.errors.doc.resubmit_failed_image')), { field: side });
           changeStepCanComplete(false);
         } else {
-          changeStepCanComplete(true);
+          changeStepCanComplete(stepCanComplete);
         }
       }}
       onCameraAccessDeclined={() => {

--- a/app/javascript/packages/document-capture/components/documents-step.tsx
+++ b/app/javascript/packages/document-capture/components/documents-step.tsx
@@ -1,37 +1,53 @@
 import { useContext } from 'react';
 import { useI18n } from '@18f/identity-react-i18n';
-import {
-  FormStepComponentProps,
-  FormStepsButton,
-  FormStepsContext,
-} from '@18f/identity-form-steps';
+import { FormStepComponentProps, FormStepsButton } from '@18f/identity-form-steps';
 import { PageHeading } from '@18f/identity-components';
 import { Cancel } from '@18f/identity-verify-flow';
 import HybridDocCaptureWarning from './hybrid-doc-capture-warning';
-import { SelfieCaptureStep } from './selfie-step';
-import { DocumentsCaptureStep } from './documents-step';
 import TipList from './tip-list';
+import { DeviceContext, SelfieCaptureContext, UploadContext } from '../context';
 import {
+  ImageValue,
   DefaultSideProps,
   DocumentsAndSelfieStepValue,
 } from '../interface/documents-image-selfie-value';
-import { DeviceContext, SelfieCaptureContext, UploadContext } from '../context';
+import DocumentSideAcuantCapture from './document-side-acuant-capture';
 
-export function DocumentCaptureSubheaderOne({
-  isSelfieCaptureEnabled,
+export function DocumentsCaptureStep({
+  defaultSideProps,
+  value,
 }: {
-  isSelfieCaptureEnabled: boolean;
+  defaultSideProps: DefaultSideProps;
+  value: Record<string, ImageValue>;
 }) {
+  type DocumentSide = 'front' | 'back';
+  const documentsSides: DocumentSide[] = ['front', 'back'];
+  return (
+    <>
+      {documentsSides.map((side) => (
+        <DocumentSideAcuantCapture
+          {...defaultSideProps}
+          key={side}
+          side={side}
+          value={value[side]}
+        />
+      ))}
+    </>
+  );
+}
+
+export function DocumentCaptureSubheaderOne() {
   const { t } = useI18n();
   return (
     <h2>
       <hr className="margin-y-5" />
-      {isSelfieCaptureEnabled && '1. '}
+      {'1. '}
       {t('doc_auth.headings.document_capture_subheader_id')}
     </h2>
   );
 }
-export default function DocumentsAndSelfieStep({
+
+export default function DocumentsStep({
   value = {},
   onChange = () => {},
   errors = [],
@@ -40,7 +56,6 @@ export default function DocumentsAndSelfieStep({
 }: FormStepComponentProps<DocumentsAndSelfieStepValue>) {
   const { t } = useI18n();
   const { isMobile } = useContext(DeviceContext);
-  const { isLastStep } = useContext(FormStepsContext);
   const { flowPath } = useContext(UploadContext);
   const { isSelfieCaptureEnabled } = useContext(SelfieCaptureContext);
   const pageHeaderText = isSelfieCaptureEnabled
@@ -56,9 +71,7 @@ export default function DocumentsAndSelfieStep({
     <>
       {flowPath === 'hybrid' && <HybridDocCaptureWarning className="margin-bottom-4" />}
       <PageHeading>{pageHeaderText}</PageHeading>
-      {isSelfieCaptureEnabled && (
-        <DocumentCaptureSubheaderOne isSelfieCaptureEnabled={isSelfieCaptureEnabled} />
-      )}
+      <DocumentCaptureSubheaderOne />
       <TipList
         titleClassName="margin-bottom-0 text-bold"
         title={t('doc_auth.tips.document_capture_selfie_id_header_text')}
@@ -69,10 +82,7 @@ export default function DocumentsAndSelfieStep({
         ].concat(!isMobile ? [t('doc_auth.tips.document_capture_id_text4')] : [])}
       />
       <DocumentsCaptureStep defaultSideProps={defaultSideProps} value={value} />
-      {isSelfieCaptureEnabled && (
-        <SelfieCaptureStep defaultSideProps={defaultSideProps} selfieValue={value.selfie} />
-      )}
-      {isLastStep ? <FormStepsButton.Submit /> : <FormStepsButton.Continue />}
+      <FormStepsButton.Continue />
       <Cancel />
     </>
   );

--- a/app/javascript/packages/document-capture/components/selfie-step.tsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.tsx
@@ -1,0 +1,80 @@
+import { useContext } from 'react';
+import { useI18n } from '@18f/identity-react-i18n';
+import {
+  FormStepComponentProps,
+  FormStepsButton,
+  FormStepsContext,
+} from '@18f/identity-form-steps';
+import { PageHeading } from '@18f/identity-components';
+import { Cancel } from '@18f/identity-verify-flow';
+import HybridDocCaptureWarning from './hybrid-doc-capture-warning';
+import DocumentSideAcuantCapture from './document-side-acuant-capture';
+import TipList from './tip-list';
+import { UploadContext } from '../context';
+import {
+  ImageValue,
+  DefaultSideProps,
+  DocumentsAndSelfieStepValue,
+} from '../interface/documents-image-selfie-value';
+
+export function SelfieCaptureStep({
+  defaultSideProps,
+  selfieValue,
+}: {
+  defaultSideProps: DefaultSideProps;
+  selfieValue: ImageValue;
+}) {
+  const { t } = useI18n();
+  return (
+    <>
+      <hr className="margin-y-5" />
+      <h2>2. {t('doc_auth.headings.document_capture_subheader_selfie')}</h2>
+      <p>{t('doc_auth.info.selfie_capture_content')}</p>
+      <TipList
+        title={t('doc_auth.tips.document_capture_selfie_selfie_text')}
+        titleClassName="margin-bottom-0 text-bold"
+        items={[
+          t('doc_auth.tips.document_capture_selfie_text1'),
+          t('doc_auth.tips.document_capture_selfie_text2'),
+          t('doc_auth.tips.document_capture_selfie_text3'),
+          t('doc_auth.tips.document_capture_selfie_text4'),
+        ]}
+      />
+      <DocumentSideAcuantCapture
+        {...defaultSideProps}
+        key="selfie"
+        side="selfie"
+        value={selfieValue}
+      />
+    </>
+  );
+}
+
+export default function SelfieStep({
+  value = {},
+  onChange = () => {},
+  errors = [],
+  onError = () => {},
+  registerField = () => undefined,
+}: FormStepComponentProps<DocumentsAndSelfieStepValue>) {
+  const { t } = useI18n();
+  const { isLastStep } = useContext(FormStepsContext);
+  const { flowPath } = useContext(UploadContext);
+  const pageHeaderText = t('doc_auth.headings.document_capture_with_selfie');
+
+  const defaultSideProps: DefaultSideProps = {
+    registerField,
+    onChange,
+    errors,
+    onError,
+  };
+  return (
+    <>
+      {flowPath === 'hybrid' && <HybridDocCaptureWarning className="margin-bottom-4" />}
+      <PageHeading>{pageHeaderText}</PageHeading>
+      <SelfieCaptureStep defaultSideProps={defaultSideProps} selfieValue={value.selfie} />
+      {isLastStep ? <FormStepsButton.Submit /> : <FormStepsButton.Continue />}
+      <Cancel />
+    </>
+  );
+}

--- a/app/javascript/packages/document-capture/context/selfie-capture.tsx
+++ b/app/javascript/packages/document-capture/context/selfie-capture.tsx
@@ -9,11 +9,16 @@ interface SelfieCaptureProps {
    * Specify whether to allow uploads for selfie when in test mode.
    */
   isSelfieDesktopTestMode: boolean;
+  /**
+   * Specify whether to seperate seflie upload and document upload into seperate form steps/pages
+   */
+  docAuthSeparatePagesEnabled: boolean;
 }
 
 const SelfieCaptureContext = createContext<SelfieCaptureProps>({
   isSelfieCaptureEnabled: false,
   isSelfieDesktopTestMode: false,
+  docAuthSeparatePagesEnabled: false,
 });
 
 SelfieCaptureContext.displayName = 'SelfieCaptureContext';

--- a/app/javascript/packages/document-capture/interface/documents-image-selfie-value.tsx
+++ b/app/javascript/packages/document-capture/interface/documents-image-selfie-value.tsx
@@ -1,0 +1,14 @@
+import { FormStepComponentProps } from '@18f/identity-form-steps';
+
+export type ImageValue = Blob | string | null | undefined;
+export interface DocumentsAndSelfieStepValue {
+  front: ImageValue;
+  back: ImageValue;
+  selfie: ImageValue;
+  front_image_metadata?: string;
+  back_image_metadata?: string;
+}
+export type DefaultSideProps = Pick<
+  FormStepComponentProps<DocumentsAndSelfieStepValue>,
+  'registerField' | 'onChange' | 'errors' | 'onError'
+>;

--- a/app/javascript/packages/form-steps/form-steps-context.tsx
+++ b/app/javascript/packages/form-steps/form-steps-context.tsx
@@ -10,7 +10,7 @@ interface FormStepsContextValue {
   /**
    * Allow a step to tell FormSteps it can complete the flow
    */
-  changeStepCanComplete: (isComplete: boolean) => void;
+  changeStepCanComplete: (isComplete?: boolean) => void;
 
   /**
    * Whether the current step is pending submission.

--- a/app/javascript/packages/form-steps/form-steps.tsx
+++ b/app/javascript/packages/form-steps/form-steps.tsx
@@ -269,7 +269,6 @@ function FormSteps({
 
     didSubmitWithErrors.current = false;
   }, [activeErrors]);
-
   useEffect(() => {
     // reset stepName if it doesn't correspond to an existing step
     const stepsCheck = steps.map((step) => step?.name).filter(Boolean);
@@ -432,7 +431,7 @@ function FormSteps({
   };
 
   // wrap setter in a function to pass to FormStepsContext
-  const changeStepCanComplete = (isComplete: boolean) => {
+  const changeStepCanComplete = (isComplete?: boolean) => {
     setStepCanComplete(isComplete);
   };
 

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -41,6 +41,7 @@ interface AppRootData {
   docAuthSelfieDesktopTestMode: string;
   locationsUrl: string;
   addressSearchUrl: string;
+  docAuthSeparatePagesEnabled: string;
 }
 
 const appRoot = document.getElementById('document-capture-form')!;
@@ -109,6 +110,7 @@ const {
   howToVerifyUrl,
   previousStepUrl,
   docAuthSelfieDesktopTestMode,
+  docAuthSeparatePagesEnabled,
   locationsUrl: locationsURL,
   addressSearchUrl: addressSearchURL,
 } = appRoot.dataset as DOMStringMap & AppRootData;
@@ -189,6 +191,7 @@ const App = composeComponents(
       value: {
         isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
         isSelfieDesktopTestMode: String(docAuthSelfieDesktopTestMode) === 'true',
+        docAuthSeparatePagesEnabled: String(docAuthSeparatePagesEnabled) === 'true',
       },
     },
   ],

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -279,7 +279,7 @@ class Profile < ApplicationRecord
 
   # @param [Pii::Attributes] pii
   def encrypt_recovery_pii(pii, personal_key: nil)
-    personal_key ||= personal_key_generator.create
+    personal_key ||= personal_key_generator.generate!
     encryptor = Encryption::Encryptors::PiiEncryptor.new(
       personal_key_generator.normalize(personal_key),
     )

--- a/app/services/personal_key_generator.rb
+++ b/app/services/personal_key_generator.rb
@@ -10,7 +10,7 @@ class PersonalKeyGenerator
     @length = length
   end
 
-  def create
+  def generate!
     user.personal_key = raw_personal_key
     user.save!
     raw_personal_key.tr(' ', '-')

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -43,6 +43,7 @@
       how_to_verify_url: idv_how_to_verify_url,
       previous_step_url: @previous_step_url,
       locations_url: idv_in_person_usps_locations_url,
+      doc_auth_separate_pages_enabled: IdentityConfig.store.doc_auth_separate_pages_enabled,
       address_search_url: '',
     } %>
   <%= simple_form_for(

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -530,6 +530,7 @@ test:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
   identity_pki_disabled: true
+  in_person_state_id_controller_enabled: true
   lexisnexis_trueid_account_id: 'test_account'
   lockout_period_in_minutes: 5
   logins_per_email_and_ip_limit: 2

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1592,7 +1592,7 @@ titles.idv.phone: Vérifier votre numéro de téléphone
 titles.idv.reset_password: Réinitialiser le mot de passe
 titles.idv.verify_info: Vérifier vos informations
 titles.mfa_setup.face_touch_unlock_confirmation: Déverrouillage facial ou tactile ajouté
-titles.mfa_setup.suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification ! Ajoutez-en une deuxième en guise de sauvegarde.
+titles.mfa_setup.suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification! Ajoutez-en une deuxième en guise de sauvegarde.
 titles.no_auth_option: Aucune méthode de connexion trouvée
 titles.openid_connect.authorization: Autorisation OpenID Connect
 titles.openid_connect.logout: Déconnexion OpenID Connect

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1592,7 +1592,7 @@ titles.idv.phone: Vérifier votre numéro de téléphone
 titles.idv.reset_password: Réinitialiser le mot de passe
 titles.idv.verify_info: Vérifier vos informations
 titles.mfa_setup.face_touch_unlock_confirmation: Déverrouillage facial ou tactile ajouté
-titles.mfa_setup.suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification! Ajoutez-en une deuxième en guise de sauvegarde.
+titles.mfa_setup.suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification ! Ajoutez-en une deuxième en guise de sauvegarde.
 titles.no_auth_option: Aucune méthode de connexion trouvée
 titles.openid_connect.authorization: Autorisation OpenID Connect
 titles.openid_connect.logout: Déconnexion OpenID Connect

--- a/lib/reporting/drop_off_report.rb
+++ b/lib/reporting/drop_off_report.rb
@@ -47,7 +47,6 @@ module Reporting
       IDV_PENDING_GPO = 'IdV: USPS address letter enqueued'
       IDV_ENTER_PASSWORD_SUBMITTED = 'idv_enter_password_submitted'
       OLD_IDV_ENTER_PASSWORD_SUBMITTED = 'IdV: review complete'
-      IDV_PERSONAL_KEY_SUBMITTED = 'IdV: personal key submitted'
       IDV_FINAL_RESOLUTION = 'IdV: final resolution'
       IPP_ENROLLMENT_UPDATE = 'GetUspsProofingResultsJob: Enrollment status updated'
 
@@ -223,15 +222,15 @@ module Reporting
         ],
         [
           'Verified (event)',
-          idv_personal_key_submitted,
+          idv_final_resolution_verified,
           dropoff = idv_enter_password_submitted -
-                    idv_personal_key_submitted,
+                    idv_final_resolution_verified,
           percent(
             numerator: dropoff,
             denominator: idv_enter_password_submitted,
           ),
           percent(
-            numerator: idv_personal_key_submitted,
+            numerator: idv_final_resolution_verified,
             denominator: idv_started,
           ),
         ],
@@ -262,15 +261,15 @@ module Reporting
     STEP_DEFINITIONS = [
       ['Step', 'Definition'],
       [
-        'Welcome (page viewed)',
+        'Welcome (page view)',
         'Start of proofing process',
       ],
       [
-        'User agreement (page viewer)',
+        'User agreement (page view)',
         'Users who clicked "Continue" on the welcome page',
       ],
       [
-        'Capture Document (page viewed)',
+        'Capture Document (page view)',
         'Users who check the consent checkbox and click "Continue"',
       ],
       [
@@ -303,7 +302,7 @@ module Reporting
       ],
       [
         'Verified (event)',
-        'Users who confirm their personal key and complete setting up their verified account',
+        'Users who completed identity verification in a single, unsupervised session',
       ],
       [
         'Workflow Complete - Total Pending',
@@ -355,10 +354,6 @@ module Reporting
     def idv_enter_password_submitted
       (data[Events::IDV_ENTER_PASSWORD_SUBMITTED] +
         data[Events::OLD_IDV_ENTER_PASSWORD_SUBMITTED]).count
-    end
-
-    def idv_personal_key_submitted
-      data[Events::IDV_PERSONAL_KEY_SUBMITTED].count
     end
 
     def idv_pending_gpo

--- a/lib/tasks/backfill_in_person_pending_at.rake
+++ b/lib/tasks/backfill_in_person_pending_at.rake
@@ -100,10 +100,11 @@ namespace :profiles do
 
           warn "#{profile.id},#{profile.deactivation_reason},#{timestamp}"
           if update_profiles
-            profile.update!(
-              deactivation_reason: :verification_cancelled,
-              in_person_verification_pending_at: nil,
-            )
+            unless profile.deactivation_reason.present?
+              profile.deactivation_reason = :verification_cancelled
+            end
+            profile.in_person_verification_pending_at = nil
+            profile.save!
           end
         end
         sleep(0.5)

--- a/spec/controllers/accounts/personal_keys_controller_spec.rb
+++ b/spec/controllers/accounts/personal_keys_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Accounts::PersonalKeysController do
       allow(PersonalKeyGenerator).to receive(:new).
         with(subject.current_user).and_return(generator)
 
-      expect(generator).to receive(:create)
+      expect(generator).to receive(:generate!)
 
       post :create
 

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe Idv::InPerson::AddressController do
       end
 
       context 'in_person_state_id_controller_enabled is not enabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).
+            and_return(false)
+        end
+
         it 'redirects to state id page if not complete' do
           subject.user_session['idv/in_person'][:pii_from_user].delete(:identity_doc_address1)
           get :show

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Idv::InPersonController do
           it 'redirects to the first step' do
             get :index
 
-            expect(response).to redirect_to idv_in_person_step_url(step: :state_id)
+            expect(response).to redirect_to idv_in_person_proofing_state_id_path
           end
 
           it 'has non-nil presenter' do
@@ -82,7 +82,7 @@ RSpec.describe Idv::InPersonController do
               it 'redirects to the first step' do
                 get :index
 
-                expect(response).to redirect_to idv_in_person_step_url(step: :state_id)
+                expect(response).to redirect_to idv_in_person_proofing_state_id_path
               end
             end
           end

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
     it 'redirects to the two_factor_options page if user is IAL2' do
       profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
       user = profile.user
-      PersonalKeyGenerator.new(user).create
+      PersonalKeyGenerator.new(user).generate!
       stub_sign_in_before_2fa(user)
       get :show
 
@@ -43,7 +43,7 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
   describe '#create' do
     context 'when the user enters a valid personal key' do
       let(:user) { create(:user, :with_phone) }
-      let(:personal_key) { { personal_key: PersonalKeyGenerator.new(user).create } }
+      let(:personal_key) { { personal_key: PersonalKeyGenerator.new(user).generate! } }
       let(:payload) { { personal_key_form: personal_key } }
       it 'tracks the valid authentication event' do
         personal_key
@@ -134,7 +134,7 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
 
     it 'does generate a new personal key after the user signs in with their old one' do
       user = create(:user)
-      raw_key = PersonalKeyGenerator.new(user).create
+      raw_key = PersonalKeyGenerator.new(user).generate!
       old_key = user.reload.encrypted_recovery_code_digest
       stub_sign_in_before_2fa(user)
       post :create, params: { personal_key_form: { personal_key: raw_key } }
@@ -147,7 +147,7 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
     it 'redirects to the two_factor_options page if user is IAL2' do
       profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
       user = profile.user
-      raw_key = PersonalKeyGenerator.new(user).create
+      raw_key = PersonalKeyGenerator.new(user).generate!
       stub_sign_in_before_2fa(user)
       post :create, params: { personal_key_form: { personal_key: raw_key } }
 

--- a/spec/controllers/users/personal_keys_controller_spec.rb
+++ b/spec/controllers/users/personal_keys_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Users::PersonalKeysController do
       allow(PersonalKeyGenerator).to receive(:new).
         with(subject.current_user).and_return(generator)
 
-      expect(generator).to_not receive(:create)
+      expect(generator).to_not receive(:generate!)
 
       get :show
     end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -1031,4 +1031,61 @@ RSpec.feature 'Analytics Regression', :js do
       end
     end
   end
+  context 'Happy split doc auth path' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_separate_pages_enabled).and_return(true)
+      allow_any_instance_of(FederatedProtocols::Oidc).
+        to receive(:biometric_comparison_required?).
+        and_return(true)
+      allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:success)
+
+      perform_in_browser(:desktop) do
+        sign_in_and_2fa_user(user)
+        visit_idp_from_sp_with_ial2(:oidc, biometric_comparison_required: true)
+        complete_doc_auth_steps_before_document_capture_step
+        attach_images
+        continue_doc_auth_form
+        attach_selfie
+        submit_images
+
+        click_idv_continue
+        visit idv_ssn_url
+        complete_ssn_step
+        complete_verify_step
+        fill_out_phone_form_ok('202-555-1212')
+        verify_phone_otp
+        complete_enter_password_step(user)
+        acknowledge_and_confirm_personal_key
+      end
+    end
+
+    it 'records all of the events' do
+      happy_mobile_selfie_path_events.each do |event, attributes|
+        expect(fake_analytics).to have_logged_event(event, attributes)
+      end
+    end
+
+    context 'proofing_device_profiling disabled' do
+      let(:proofing_device_profiling) { :disabled }
+      let(:threatmetrix) { false }
+      let(:threatmetrix_response) do
+        { client: 'tmx_disabled',
+          success: true,
+          errors: {},
+          exception: nil,
+          timed_out: false,
+          transaction_id: nil,
+          review_status: 'pass',
+          response_body: nil }
+      end
+
+      it 'records all of the events' do
+        aggregate_failures 'analytics events' do
+          happy_mobile_selfie_path_events.each do |event, attributes|
+            expect(fake_analytics).to have_logged_event(event, attributes)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -484,6 +484,49 @@ RSpec.feature 'document capture step', :js do
     end
   end
 
+  context 'split doc auth flow', allow_browser_log: true do
+    before do
+      allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:doc_auth_separate_pages_enabled).and_return(true)
+      visit_idp_from_oidc_sp_with_ial2(biometric_comparison_required: true)
+      sign_in_and_2fa_user(@user)
+      complete_doc_auth_steps_before_document_capture_step
+    end
+    it 'user can go through verification uploading ID and selfie on seprerate pages' do
+      expect(page).to have_current_path(idv_document_capture_url)
+      expect(page).not_to have_content(t('doc_auth.tips.document_capture_selfie_text1'))
+      attach_images
+      continue_doc_auth_form
+      expect(page).to have_content(t('doc_auth.tips.document_capture_selfie_text1'))
+      attach_selfie
+      submit_images
+      expect(page).to have_content(t('doc_auth.headings.capture_complete'))
+    end
+    it 'initial verification failure allows user to resubmit all images in 1 page' do
+      attach_images(
+        Rails.root.join(
+          'spec', 'fixtures',
+          'ial2_test_credential_multiple_doc_auth_failures_both_sides.yml'
+        ),
+      )
+      continue_doc_auth_form
+      attach_selfie(
+        Rails.root.join(
+          'spec', 'fixtures',
+          'ial2_test_credential_forces_error.yml'
+        ),
+      )
+      submit_images
+      expect(page).to have_content(t('doc_auth.errors.rate_limited_heading'))
+      click_try_again
+      expect(page).to have_content(t('doc_auth.headings.review_issues'))
+      attach_liveness_images
+      submit_images
+      expect(page).to have_content(t('doc_auth.headings.capture_complete'))
+    end
+  end
+
   def expect_rate_limited_header(expected_to_be_present)
     review_issues_h1_heading = strip_tags(t('doc_auth.errors.rate_limited_heading'))
     if expected_to_be_present

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
 
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).and_return(true)
   end
 
   it 'works for a happy path', allow_browser_log: true do
@@ -38,7 +39,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
         ),
       ),
     )
-    complete_state_id_step(user)
+    complete_state_id_controller(user)
 
     # ssn page
     expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
@@ -290,7 +291,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     end
 
     it 'shows the address page' do
-      complete_state_id_step(user, same_address_as_id: false)
+      complete_state_id_controller(user, same_address_as_id: false)
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
       expect(page).to have_content(t('in_person_proofing.headings.address'))
 
@@ -303,7 +304,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     end
 
     it 'can update the address page form' do
-      complete_state_id_step(user, same_address_as_id: false)
+      complete_state_id_controller(user, same_address_as_id: false)
       complete_address_step(user, same_address_as_id: false)
       complete_ssn_step(user)
       # click update address link on the verify page
@@ -328,7 +329,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     end
 
     it 'allows user to update their residential address as different from their state id' do
-      complete_state_id_step(user, same_address_as_id: true)
+      complete_state_id_controller(user, same_address_as_id: true)
       # skip address step b/c residential address is same as state id address
       complete_ssn_step(user)
 
@@ -367,6 +368,8 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
 
     before do
       allow(IdentityConfig.store).to receive(:in_person_outage_message_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).
+        and_return(true)
     end
 
     it 'allows the user to generate a barcode despite outage', allow_browser_log: true do
@@ -410,7 +413,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
       complete_location_step
 
       # state ID page
-      complete_state_id_step(user, same_address_as_id: false)
+      complete_state_id_controller(user, same_address_as_id: false)
 
       # address page
       complete_address_step(user, same_address_as_id: false)
@@ -506,7 +509,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
       complete_prepare_step(user)
       complete_location_step
       # Causes the schedule USPS enrollment request to throw a bad request error
-      complete_state_id_step(user, first_name: 'usps client error')
+      complete_state_id_controller(user, first_name: 'usps client error')
       complete_ssn_step(user)
       complete_verify_step(user)
       fill_out_phone_form_ok(MfaContext.new(user).phone_configurations.first.phone)

--- a/spec/features/idv/in_person_threatmetrix_spec.rb
+++ b/spec/features/idv/in_person_threatmetrix_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'In Person Proofing Threatmetrix', js: true do
       complete_location_step(user)
 
       # state ID page
-      complete_state_id_step(user)
+      complete_state_id_controller(user)
 
       # ssn page
       complete_ssn_step(user, 'Reject')
@@ -170,7 +170,7 @@ RSpec.describe 'In Person Proofing Threatmetrix', js: true do
       begin_in_person_proofing(user)
       complete_prepare_step(user)
       complete_location_step
-      complete_state_id_step(user)
+      complete_state_id_controller(user)
 
       # ssn page
       complete_ssn_step(user, tmx_status)

--- a/spec/features/idv/steps/in_person/verify_info_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_info_spec.rb
@@ -9,164 +9,342 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true, allowed_extra_analytics: [:*
   let(:fake_analytics) { FakeAnalytics.new(user: user) }
   let(:enrollment) { InPersonEnrollment.new }
 
-  before do
-    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-    allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
-    allow(user).to receive(:enrollment).
-      and_return(enrollment)
+  context 'when in_person_state_id_controller_enabled is false' do
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:in_person_state_id_controller_enabled).
+        and_return(false)
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+      allow(user).to receive(:enrollment).
+        and_return(enrollment)
+    end
+
+    it 'provides back buttons for address, state ID, and SSN that discard changes',
+       allow_browser_log: true do
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_step(user)
+      complete_ssn_step(user)
+
+      # verify page
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
+      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
+      expect(page).to have_text(
+        Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        count: 3,
+      )
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+
+      # click update state ID button
+      click_button t('idv.buttons.change_state_id_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
+      fill_in t('in_person_proofing.form.state_id.first_name'), with: 'bad first name'
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).not_to have_text('bad first name')
+
+      # click update address link
+      click_link t('idv.buttons.change_address_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_address'))
+      fill_in t('idv.form.address1'), with: 'bad address'
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1)
+      expect(page).not_to have_text('bad address')
+
+      # click update ssn button
+      click_on t('idv.buttons.change_ssn_label')
+      expect(page).to have_content(t('doc_auth.headings.ssn_update'))
+      fill_out_ssn_form_fail
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+
+      complete_verify_step(user)
+
+      # phone page
+      expect(page).to have_content(t('titles.idv.phone'))
+    end
+
+    it 'returns the user to the verify info page when updates are made',
+       allow_browser_log: true do
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_step(user)
+      complete_ssn_step(user)
+
+      # verify page
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
+      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
+      expect(page).to have_text(
+        Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        count: 3,
+      )
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+
+      # click update state ID button
+      click_button t('idv.buttons.change_state_id_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
+      fill_in t('in_person_proofing.form.state_id.first_name'), with: 'Natalya'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('Natalya')
+      expect(page).not_to have_text('bad first name')
+
+      # click update address link
+      click_link t('idv.buttons.change_address_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_address'))
+      fill_in t('idv.form.address1'), with: '987 Fake St.'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('987 Fake St.')
+      expect(page).not_to have_text('bad address')
+
+      # click update ssn button
+      click_on t('idv.buttons.change_ssn_label')
+      expect(page).to have_content(t('doc_auth.headings.ssn_update'))
+      fill_in t('idv.form.ssn_label'), with: '900-12-2345'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('9**-**-***5')
+
+      complete_verify_step(user)
+
+      # phone page
+      expect(page).to have_content(t('titles.idv.phone'))
+    end
+
+    it 'does not proceed to the next page if resolution fails',
+       allow_browser_log: true do
+      sign_in_and_2fa_user
+
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_step(user)
+      fill_out_ssn_form_with_ssn_that_fails_resolution
+      click_idv_continue
+      complete_verify_step(user)
+
+      expect(page).to have_current_path(idv_session_errors_warning_path(flow: 'in_person'))
+      click_on t('idv.failure.button.warning')
+
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+    end
+
+    it 'proceeds to the next page if resolution passes',
+       allow_browser_log: true do
+      sign_in_and_2fa_user
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_step(user)
+      complete_ssn_step(user)
+      complete_verify_step(user)
+
+      expect(page).to have_content(t('titles.idv.phone'))
+      expect(fake_analytics).to have_logged_event(
+        'IdV: doc auth verify proofing results',
+        hash_including(analytics_id: 'In Person Proofing'),
+      )
+    end
   end
+  context 'when in_person_state_id_controller_enabled is true' do
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+      allow(user).to receive(:enrollment).
+        and_return(enrollment)
+    end
 
-  it 'provides back buttons for address, state ID, and SSN that discard changes',
-     allow_browser_log: true do
-    sign_in_and_2fa_user(user)
-    begin_in_person_proofing(user)
-    complete_prepare_step(user)
-    complete_location_step(user)
-    complete_state_id_step(user)
-    complete_ssn_step(user)
+    it 'provides back buttons for address, state ID, and SSN that discard changes',
+       allow_browser_log: true do
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_controller(user)
+      complete_ssn_step(user)
 
-    # verify page
-    expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
-    expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
-    expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
-    expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
-    expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction], count: 3)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
-    expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+      # verify page
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
+      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
+      expect(page).to have_text(
+        Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        count: 3,
+      )
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
 
-    # click update state ID button
-    click_button t('idv.buttons.change_state_id_label')
-    expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
-    fill_in t('in_person_proofing.form.state_id.first_name'), with: 'bad first name'
-    click_doc_auth_back_link
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
-    expect(page).not_to have_text('bad first name')
+      # click update state ID button
+      click_button t('idv.buttons.change_state_id_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
+      fill_in t('in_person_proofing.form.state_id.first_name'), with: 'bad first name'
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).not_to have_text('bad first name')
 
-    # click update address link
-    click_link t('idv.buttons.change_address_label')
-    expect(page).to have_content(t('in_person_proofing.headings.update_address'))
-    fill_in t('idv.form.address1'), with: 'bad address'
-    click_doc_auth_back_link
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1)
-    expect(page).not_to have_text('bad address')
+      # click update address link
+      click_link t('idv.buttons.change_address_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_address'))
+      fill_in t('idv.form.address1'), with: 'bad address'
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1)
+      expect(page).not_to have_text('bad address')
 
-    # click update ssn button
-    click_on t('idv.buttons.change_ssn_label')
-    expect(page).to have_content(t('doc_auth.headings.ssn_update'))
-    fill_out_ssn_form_fail
-    click_doc_auth_back_link
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+      # click update ssn button
+      click_on t('idv.buttons.change_ssn_label')
+      expect(page).to have_content(t('doc_auth.headings.ssn_update'))
+      fill_out_ssn_form_fail
+      click_doc_auth_back_link
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
 
-    complete_verify_step(user)
+      complete_verify_step(user)
 
-    # phone page
-    expect(page).to have_content(t('titles.idv.phone'))
-  end
+      # phone page
+      expect(page).to have_content(t('titles.idv.phone'))
+    end
 
-  it 'returns the user to the verify info page when updates are made',
-     allow_browser_log: true do
-    sign_in_and_2fa_user(user)
-    begin_in_person_proofing(user)
-    complete_prepare_step(user)
-    complete_location_step(user)
-    complete_state_id_step(user)
-    complete_ssn_step(user)
+    it 'returns the user to the verify info page when updates are made',
+       allow_browser_log: true do
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_controller(user)
+      complete_ssn_step(user)
 
-    # verify page
-    expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
-    expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
-    expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
-    expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
-    expect(page).to have_text(Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction], count: 3)
-    expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
-    expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
+      # verify page
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text(InPersonHelper::GOOD_FIRST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
+      expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
+      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice
+      expect(page).to have_text(
+        Idp::Constants::MOCK_IDV_APPLICANT[:state_id_jurisdiction],
+        count: 3,
+      )
+      expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE).twice
+      expect(page).to have_text(DocAuthHelper::GOOD_SSN_MASKED)
 
-    # click update state ID button
-    click_button t('idv.buttons.change_state_id_label')
-    expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
-    fill_in t('in_person_proofing.form.state_id.first_name'), with: 'Natalya'
-    click_button t('forms.buttons.submit.update')
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text('Natalya')
-    expect(page).not_to have_text('bad first name')
+      # click update state ID button
+      click_button t('idv.buttons.change_state_id_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_state_id'))
+      fill_in t('in_person_proofing.form.state_id.first_name'), with: 'Natalya'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('Natalya')
+      expect(page).not_to have_text('bad first name')
 
-    # click update address link
-    click_link t('idv.buttons.change_address_label')
-    expect(page).to have_content(t('in_person_proofing.headings.update_address'))
-    fill_in t('idv.form.address1'), with: '987 Fake St.'
-    click_button t('forms.buttons.submit.update')
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text('987 Fake St.')
-    expect(page).not_to have_text('bad address')
+      # click update address link
+      click_link t('idv.buttons.change_address_label')
+      expect(page).to have_content(t('in_person_proofing.headings.update_address'))
+      fill_in t('idv.form.address1'), with: '987 Fake St.'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('987 Fake St.')
+      expect(page).not_to have_text('bad address')
 
-    # click update ssn button
-    click_on t('idv.buttons.change_ssn_label')
-    expect(page).to have_content(t('doc_auth.headings.ssn_update'))
-    fill_in t('idv.form.ssn_label'), with: '900-12-2345'
-    click_button t('forms.buttons.submit.update')
-    expect(page).to have_content(t('headings.verify'))
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-    expect(page).to have_text('9**-**-***5')
+      # click update ssn button
+      click_on t('idv.buttons.change_ssn_label')
+      expect(page).to have_content(t('doc_auth.headings.ssn_update'))
+      fill_in t('idv.form.ssn_label'), with: '900-12-2345'
+      click_button t('forms.buttons.submit.update')
+      expect(page).to have_content(t('headings.verify'))
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+      expect(page).to have_text('9**-**-***5')
 
-    complete_verify_step(user)
+      complete_verify_step(user)
 
-    # phone page
-    expect(page).to have_content(t('titles.idv.phone'))
-  end
+      # phone page
+      expect(page).to have_content(t('titles.idv.phone'))
+    end
 
-  it 'does not proceed to the next page if resolution fails',
-     allow_browser_log: true do
-    sign_in_and_2fa_user
+    it 'does not proceed to the next page if resolution fails',
+       allow_browser_log: true do
+      sign_in_and_2fa_user
 
-    begin_in_person_proofing(user)
-    complete_prepare_step(user)
-    complete_location_step(user)
-    complete_state_id_step(user)
-    fill_out_ssn_form_with_ssn_that_fails_resolution
-    click_idv_continue
-    complete_verify_step(user)
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_controller(user)
+      fill_out_ssn_form_with_ssn_that_fails_resolution
+      click_idv_continue
+      complete_verify_step(user)
 
-    expect(page).to have_current_path(idv_session_errors_warning_path(flow: 'in_person'))
-    click_on t('idv.failure.button.warning')
+      expect(page).to have_current_path(idv_session_errors_warning_path(flow: 'in_person'))
+      click_on t('idv.failure.button.warning')
 
-    expect(page).to have_current_path(idv_in_person_verify_info_path)
-  end
+      expect(page).to have_current_path(idv_in_person_verify_info_path)
+    end
 
-  it 'proceeds to the next page if resolution passes',
-     allow_browser_log: true do
-    sign_in_and_2fa_user
-    begin_in_person_proofing(user)
-    complete_prepare_step(user)
-    complete_location_step(user)
-    complete_state_id_step(user)
-    complete_ssn_step(user)
-    complete_verify_step(user)
+    it 'proceeds to the next page if resolution passes',
+       allow_browser_log: true do
+      sign_in_and_2fa_user
+      begin_in_person_proofing(user)
+      complete_prepare_step(user)
+      complete_location_step(user)
+      complete_state_id_controller(user)
+      complete_ssn_step(user)
+      complete_verify_step(user)
 
-    expect(page).to have_content(t('titles.idv.phone'))
-    expect(fake_analytics).to have_logged_event(
-      'IdV: doc auth verify proofing results',
-      hash_including(analytics_id: 'In Person Proofing'),
-    )
+      expect(page).to have_content(t('titles.idv.phone'))
+      expect(fake_analytics).to have_logged_event(
+        'IdV: doc auth verify proofing results',
+        hash_including(analytics_id: 'In Person Proofing'),
+      )
+    end
   end
 end

--- a/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
+++ b/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true do
         complete_location_step
 
         # state ID page
-        complete_state_id_step(user)
+        complete_state_id_controller(user)
 
         # ssn page
         select 'Reject', from: :mock_profiling_result
@@ -156,7 +156,7 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true do
           ),
         ),
       )
-      complete_state_id_step(user)
+      complete_state_id_controller(user)
 
       # ssn page
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
@@ -341,7 +341,7 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true do
           ),
         ),
       )
-      complete_state_id_step(user)
+      complete_state_id_controller(user)
 
       # ssn page
       expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Signing in via one-time use personal key' do
       :user, :fully_registered, :with_phone, :with_personal_key,
       with: { phone: '+1 (202) 345-6789' }
     )
-    raw_key = PersonalKeyGenerator.new(user).create
+    raw_key = PersonalKeyGenerator.new(user).generate!
     old_key = user.reload.encrypted_recovery_code_digest
 
     sign_in_before_2fa(user)
@@ -39,7 +39,7 @@ RSpec.feature 'Signing in via one-time use personal key' do
         second_factor_attempts_count: IdentityConfig.store.login_otp_confirmation_max_attempts - 1,
       )
       sign_in_before_2fa(user)
-      personal_key = PersonalKeyGenerator.new(user).create
+      personal_key = PersonalKeyGenerator.new(user).generate!
       wrong_personal_key = personal_key.split('-').reverse.join
 
       choose_another_security_option('personal_key')

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -665,7 +665,7 @@ RSpec.feature 'Sign in' do
     # this can happen if you submit the personal key form multiple times quickly
     it 'does not redirect to the personal key page' do
       user = create(:user, :fully_registered)
-      old_personal_key = PersonalKeyGenerator.new(user).create
+      old_personal_key = PersonalKeyGenerator.new(user).generate!
       signin(user.email, user.password)
       choose_another_security_option('personal_key')
       enter_personal_key(personal_key: old_personal_key)

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PersonalKeyForm do
     context 'when the form is valid' do
       it 'returns FormResponse with success: true' do
         user = create(:user)
-        raw_code = PersonalKeyGenerator.new(user).create
+        raw_code = PersonalKeyGenerator.new(user).generate!
         old_code = user.reload.encrypted_recovery_code_digest
 
         form = PersonalKeyForm.new(user, raw_code)

--- a/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
@@ -11,6 +11,7 @@ import {
   AcuantContextProvider,
   DeviceContext,
   InPersonContext,
+  SelfieCaptureContext,
 } from '@18f/identity-document-capture';
 import DocumentCapture from '@18f/identity-document-capture/components/document-capture';
 import { FlowContext } from '@18f/identity-verify-flow';
@@ -365,5 +366,18 @@ describe('document-capture/components/document-capture', () => {
         expect(step.closest('.step-indicator__step--current')).to.exist();
       });
     });
+  });
+
+  it('does not show selfie on first page when doc auth seperated pages enabled', () => {
+    const { queryByText } = render(
+      <SelfieCaptureContext.Provider
+        value={{ isSelfieCaptureEnabled: true, docAuthSeparatePagesEnabled: true }}
+      >
+        <DocumentCapture />
+      </SelfieCaptureContext.Provider>,
+    );
+
+    const selfie = queryByText('doc_auth.headings.document_capture_selfie');
+    expect(selfie).not.to.exist();
   });
 });

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
@@ -19,7 +19,11 @@ describe('DocumentSideAcuantCapture', () => {
           const { queryAllByText } = render(
             <DeviceContext.Provider value={{ isMobile: true }}>
               <SelfieCaptureContext.Provider
-                value={{ isSelfieCaptureEnabled: false, isSelfieDesktopTestMode: false }}
+                value={{
+                  isSelfieCaptureEnabled: false,
+                  isSelfieDesktopTestMode: false,
+                  docAuthSeparatePagesEnabled: false,
+                }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
@@ -39,7 +43,11 @@ describe('DocumentSideAcuantCapture', () => {
           const { queryAllByText } = render(
             <DeviceContext.Provider value={{ isMobile: true }}>
               <SelfieCaptureContext.Provider
-                value={{ isSelfieCaptureEnabled: false, isSelfieDesktopTestMode: true }}
+                value={{
+                  isSelfieCaptureEnabled: false,
+                  isSelfieDesktopTestMode: true,
+                  docAuthSeparatePagesEnabled: false,
+                }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
@@ -61,7 +69,11 @@ describe('DocumentSideAcuantCapture', () => {
           const { queryAllByText } = render(
             <DeviceContext.Provider value={{ isMobile: false }}>
               <SelfieCaptureContext.Provider
-                value={{ isSelfieCaptureEnabled: false, isSelfieDesktopTestMode: false }}
+                value={{
+                  isSelfieCaptureEnabled: false,
+                  isSelfieDesktopTestMode: false,
+                  docAuthSeparatePagesEnabled: false,
+                }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
@@ -79,7 +91,11 @@ describe('DocumentSideAcuantCapture', () => {
           const { queryAllByText } = render(
             <DeviceContext.Provider value={{ isMobile: false }}>
               <SelfieCaptureContext.Provider
-                value={{ isSelfieCaptureEnabled: false, isSelfieDesktopTestMode: true }}
+                value={{
+                  isSelfieCaptureEnabled: false,
+                  isSelfieDesktopTestMode: true,
+                  docAuthSeparatePagesEnabled: false,
+                }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
@@ -101,7 +117,11 @@ describe('DocumentSideAcuantCapture', () => {
           const { queryAllByText } = render(
             <DeviceContext.Provider value={{ isMobile: true }}>
               <SelfieCaptureContext.Provider
-                value={{ isSelfieCaptureEnabled: true, isSelfieDesktopTestMode: false }}
+                value={{
+                  isSelfieCaptureEnabled: true,
+                  isSelfieDesktopTestMode: false,
+                  docAuthSeparatePagesEnabled: false,
+                }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
@@ -125,7 +145,11 @@ describe('DocumentSideAcuantCapture', () => {
           const { queryAllByText } = render(
             <DeviceContext.Provider value={{ isMobile: true }}>
               <SelfieCaptureContext.Provider
-                value={{ isSelfieCaptureEnabled: true, isSelfieDesktopTestMode: true }}
+                value={{
+                  isSelfieCaptureEnabled: true,
+                  isSelfieDesktopTestMode: true,
+                  docAuthSeparatePagesEnabled: false,
+                }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
@@ -157,7 +181,11 @@ describe('DocumentSideAcuantCapture', () => {
           const { queryAllByText } = render(
             <DeviceContext.Provider value={{ isMobile: false }}>
               <SelfieCaptureContext.Provider
-                value={{ isSelfieCaptureEnabled: true, isSelfieDesktopTestMode: true }}
+                value={{
+                  isSelfieCaptureEnabled: true,
+                  isSelfieDesktopTestMode: true,
+                  docAuthSeparatePagesEnabled: false,
+                }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />

--- a/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
@@ -6,7 +6,11 @@ describe('document-capture/context/selfie-capture', () => {
   it('has expected default properties', () => {
     const { result } = renderHook(() => useContext(SelfieCaptureContext));
 
-    expect(result.current).to.have.keys(['isSelfieCaptureEnabled', 'isSelfieDesktopTestMode']);
+    expect(result.current).to.have.keys([
+      'isSelfieCaptureEnabled',
+      'isSelfieDesktopTestMode',
+      'docAuthSeparatePagesEnabled',
+    ]);
     expect(result.current.isSelfieCaptureEnabled).to.be.a('boolean');
   });
 });

--- a/spec/lib/reporting/drop_off_report_spec.rb
+++ b/spec/lib/reporting/drop_off_report_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Reporting::DropOffReport do
         ),
         ['Verified (event)'] + string_or_num(
           strings,
-          *(values ? iterator.next : [4, 0, 0.0, 0.5]),
+          *(values ? iterator.next : [1, 3, 0.75, 0.125]),
         ),
         ['Workflow Complete - Total Pending'] + string_or_num(
           strings,

--- a/spec/services/personal_key_generator_spec.rb
+++ b/spec/services/personal_key_generator_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe PersonalKeyGenerator do
     allow(RandomPhrase).to receive(:new).and_return(random_phrase)
   end
 
-  describe '#create' do
+  describe '#generate!' do
     it 'returns the raw personal key' do
       stub_random_phrase
 
-      expect(generator.create).to eq personal_key.tr(' ', '-')
+      expect(generator.generate!).to eq personal_key.tr(' ', '-')
     end
 
     it 'hashes the raw personal key' do
@@ -25,26 +25,26 @@ RSpec.describe PersonalKeyGenerator do
 
       stub_random_phrase
 
-      generator.create
+      generator.generate!
 
       expect(user.encrypted_recovery_code_digest).to_not eq personal_key
     end
 
     it 'generates a phrase of 4 words by default' do
-      expect(generator.create).to match(/\A\w\w\w\w-\w\w\w\w-\w\w\w\w-\w\w\w\w\z/)
+      expect(generator.generate!).to match(/\A\w\w\w\w-\w\w\w\w-\w\w\w\w-\w\w\w\w\z/)
     end
 
     it 'allows length to be configured via ENV var' do
       allow(IdentityConfig.store).to receive(:recovery_code_length).and_return(14)
 
       fourteen_letters_and_spaces_start_end_with_letter = /\A(\w+-){13}\w+\z/
-      expect(generator.create).to match(fourteen_letters_and_spaces_start_end_with_letter)
+      expect(generator.generate!).to match(fourteen_letters_and_spaces_start_end_with_letter)
     end
 
     it 'sets the encrypted recovery code digest' do
       user = create(:user)
       generator = PersonalKeyGenerator.new(user)
-      key = generator.create
+      key = generator.generate!
 
       expect(user.encrypted_recovery_code_digest).to_not be_empty
       expect(generator.verify(key)).to eq(true)
@@ -54,7 +54,7 @@ RSpec.describe PersonalKeyGenerator do
   describe '#verify' do
     before do
       stub_random_phrase
-      generator.create
+      generator.generate!
     end
 
     it 'returns false for the wrong code' do

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -8,6 +8,15 @@ module DocumentCaptureStepHelper
     end
   end
 
+  def continue_doc_auth_form
+    click_on 'Continue'
+
+    # Wait for the the loading interstitial to disappear before continuing
+    wait_for_content_to_disappear do
+      expect(page).not_to have_content(t('doc_auth.headings.interstitial'), wait: 10)
+    end
+  end
+
   def attach_and_submit_images
     attach_images
     submit_images

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -109,7 +109,7 @@ module InPersonHelper
 
     # pause for the location list to disappear
     wait_for_content_to_disappear do
-      expect(page).to have_no_css('.location-collection-item')
+      expect(page).to have_no_css('.location-collection-item', wait: 1)
     end
   end
 
@@ -163,7 +163,6 @@ module InPersonHelper
     begin_in_person_proofing
     complete_prepare_step
     complete_location_step
-
     expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
   end
 
@@ -180,7 +179,7 @@ module InPersonHelper
                                             same_address_as_id: true)
     complete_prepare_step(user)
     complete_location_step(user)
-    complete_state_id_step(user, same_address_as_id: same_address_as_id)
+    complete_state_id_controller(user, same_address_as_id: same_address_as_id)
     complete_address_step(user, same_address_as_id: same_address_as_id) unless same_address_as_id
     complete_ssn_step(user, tmx_status)
     complete_verify_step(user)
@@ -256,9 +255,9 @@ module InPersonHelper
 
   def perform_desktop_hybrid_steps(user = user_with_2fa, same_address_as_id: true)
     perform_in_browser(:desktop) do
-      expect(page).to have_current_path(idv_in_person_step_path(step: :state_id), wait: 10)
+      expect(page).to have_current_path(idv_in_person_proofing_state_id_path, wait: 10)
 
-      complete_state_id_step(user, same_address_as_id: same_address_as_id)
+      complete_state_id_controller(user, same_address_as_id: same_address_as_id)
       complete_address_step(user, same_address_as_id: same_address_as_id) unless same_address_as_id
       complete_ssn_step(user)
       complete_verify_step(user)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -128,7 +128,7 @@ RSpec.shared_examples 'signing in as IAL1 with personal key after resetting pass
 
     set_new_browser_session
 
-    old_personal_key = PersonalKeyGenerator.new(user).create
+    old_personal_key = PersonalKeyGenerator.new(user).generate!
     visit_idp_from_sp_with_ial1(sp)
     trigger_reset_password_and_click_email_link(user.confirmed_email_addresses.first.email)
     fill_in t('forms.passwords.edit.labels.password'), with: new_password
@@ -318,7 +318,7 @@ end
 
 def ial1_sign_in_with_personal_key_goes_to_sp(sp)
   user = create_ial1_account_go_back_to_sp_and_sign_out(sp)
-  old_personal_key = PersonalKeyGenerator.new(user).create
+  old_personal_key = PersonalKeyGenerator.new(user).generate!
 
   Capybara.reset_sessions!
 


### PR DESCRIPTION
## User-Facing Improvements
- Reports: Verified (event) field in Drop Off report description and calculation updated for accuracy ([#11234](https://github.com/18F/identity-idp/pull/11234))

## Bug Fixes
- Personal Keys: Fix double personal key generation when using personal key as second factor ([#11227](https://github.com/18F/identity-idp/pull/11227))

## Internal
- In-person proofing: Set state id controller feature flag to true in test ([#11217](https://github.com/18F/identity-idp/pull/11217))

## Upcoming Features
- doc auth: Seperate selfie and doc capture into seperate form pages (steps) based on FF ([#11194](https://github.com/18F/identity-idp/pull/11194))
