### PR TITLE
LG-14327: Remove registration hints for Face or Touch Unlock

### DIFF
--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -61,8 +61,6 @@ describe('enrollWebauthnDevice', () => {
         user,
         challenge,
         excludeCredentials,
-        authenticatorAttachment: 'cross-platform',
-        hints: ['security-key'],
       });
 
       expect(navigator.credentials.create).to.have.been.calledWith({
@@ -130,16 +128,15 @@ describe('enrollWebauthnDevice', () => {
     context('platform authenticator', () => {
       it('enrolls a device with correct authenticatorAttachment', async () => {
         await enrollWebauthnDevice({
+          platformAuthenticator: true,
           user,
           challenge,
           excludeCredentials,
-          authenticatorAttachment: 'platform',
-          hints: ['client-device'],
         });
 
         expect(navigator.credentials.create).to.have.been.calledWithMatch({
           publicKey: {
-            hints: ['client-device'],
+            hints: ['client-device', 'hybrid'],
             authenticatorSelection: {
               authenticatorAttachment: 'platform',
             },
@@ -162,7 +159,6 @@ describe('enrollWebauthnDevice', () => {
         user,
         challenge,
         excludeCredentials,
-        authenticatorAttachment: 'cross-platform',
       });
 
       expect(result.transports).to.equal(undefined);
@@ -182,7 +178,6 @@ describe('enrollWebauthnDevice', () => {
         user,
         challenge,
         excludeCredentials,
-        authenticatorAttachment: 'cross-platform',
       });
 
       expect(result.authenticatorDataFlagsValue).to.equal(undefined);

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -136,7 +136,7 @@ describe('enrollWebauthnDevice', () => {
 
         expect(navigator.credentials.create).to.have.been.calledWithMatch({
           publicKey: {
-            hints: ['client-device', 'hybrid'],
+            hints: undefined,
             authenticatorSelection: {
               authenticatorAttachment: 'platform',
             },

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -91,7 +91,7 @@ async function enrollWebauthnDevice({
       pubKeyCredParams: SUPPORTED_ALGORITHMS.map((alg) => ({ alg, type: 'public-key' })),
       timeout: 800000,
       attestation: 'none',
-      hints: platformAuthenticator ? ['client-device', 'hybrid'] : ['security-key'],
+      hints: platformAuthenticator ? undefined : ['security-key'],
       authenticatorSelection: {
         // A user is assumed to be AAL2 recently authenticated before being permitted to add an
         // authentication method to their account. Additionally, unless explicitly discouraged,

--- a/app/javascript/packs/webauthn-setup.ts
+++ b/app/javascript/packs/webauthn-setup.ts
@@ -42,6 +42,7 @@ function webauthn() {
       (document.getElementById('platform_authenticator') as HTMLInputElement).value === 'true';
 
     enrollWebauthnDevice({
+      platformAuthenticator,
       user: {
         id: longToByteArray(Number((document.getElementById('user_id') as HTMLInputElement).value)),
         name: (document.getElementById('user_email') as HTMLInputElement).value,
@@ -55,8 +56,6 @@ function webauthn() {
           .split(',')
           .filter(Boolean),
       ),
-      authenticatorAttachment: platformAuthenticator ? 'platform' : 'cross-platform',
-      hints: platformAuthenticator ? ['client-device', 'hybrid'] : ['security-key'],
     })
       .then((result) => {
         (document.getElementById('webauthn_id') as HTMLInputElement).value = result.webauthnId;


### PR DESCRIPTION
## 🎫 Ticket

[LG-14327](https://cm-jira.usa.gov/browse/LG-14327)

## 🛠 Summary of changes

Updates WebAuthn registration to avoid passing `hints` for platform authenticators.

This was introduced in LG-12571 (#10382), specifically aimed at improving the experience of registering security keys. While the hints provided for platform authenticators weren't intended or expected to have an impact, it was discovered that providing these hints can cause browsers to impose additional constraints for registration (see [related Slack discussion](https://gsa-tts.slack.com/archives/C01710KMYUB/p1724761159588019)). Specifically, Chrome on macOS prevents the user from registering their device if iCloud Keychain syncing is not available.

## 📜 Testing Plan

1. On a macOS device without iCloud Keychain (e.g. GFE), visit http://localhost:3000
2. Sign in
3. On account dashboard, click "Add Face or Touch Unlock" in sidebar
4. Add a Face or Touch Unlock device

Before: You'd be unable.
After: You can save a device-bound credential.

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/202ad312-c5bb-49bb-a96b-ef9bd4e91553)|![image](https://github.com/user-attachments/assets/9d68036d-ac6d-442d-b316-eb26a535ec2d)
