### PR TITLE
LG-14400 add recaptcha disclaimer text on sign-in

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -98,7 +98,7 @@
   <% if FeatureManagement.sign_in_recaptcha_enabled? %>
     <p class="margin-top-4">
       <%= t(
-            'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
+            'notices.sign_in.recaptcha.disclosure_statement_html',
             google_policy_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_policy_link'), GooglePolicySite.privacy_url),
             google_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url),
           ) %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -95,7 +95,7 @@
           ),
         ) %>
   </p>
-  <% if FeatureManagement.sign_in_recaptcha_enabled? || true %>
+  <% if FeatureManagement.sign_in_recaptcha_enabled? %>
     <p class="margin-top-4">
       <%= t(
             'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -97,13 +97,13 @@
   </p>
   <% if FeatureManagement.sign_in_recaptcha_enabled? %>
     <p class="margin-top-4">
-    <%= t(
-          'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
-          app_name: APP_NAME,
-          google_policy_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_policy_link'), GooglePolicySite.privacy_url),
-          google_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url),
-        ) %>
-  </p>
+      <%= t(
+            'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
+            app_name: APP_NAME,
+            google_policy_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_policy_link'), GooglePolicySite.privacy_url),
+            google_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url),
+          ) %>
+    </p>
   <% end %>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -98,11 +98,10 @@
   <% if FeatureManagement.sign_in_recaptcha_enabled? %>
     <p class="margin-top-4">
     <%= t(
-          'two_factor_authentication.recaptcha.disclosure_statement_html',
+          'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
           app_name: APP_NAME,
           google_policy_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_policy_link'), GooglePolicySite.privacy_url),
           google_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url),
-          login_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
         ) %>
   </p>
   <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -95,11 +95,10 @@
           ),
         ) %>
   </p>
-  <% if FeatureManagement.sign_in_recaptcha_enabled? %>
+  <% if FeatureManagement.sign_in_recaptcha_enabled? || true %>
     <p class="margin-top-4">
       <%= t(
             'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
-            app_name: APP_NAME,
             google_policy_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_policy_link'), GooglePolicySite.privacy_url),
             google_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url),
           ) %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -95,6 +95,17 @@
           ),
         ) %>
   </p>
+  <% if FeatureManagement.sign_in_recaptcha_enabled? %>
+    <p class="margin-top-4">
+    <%= t(
+          'two_factor_authentication.recaptcha.disclosure_statement_html',
+          app_name: APP_NAME,
+          google_policy_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_policy_link'), GooglePolicySite.privacy_url),
+          google_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url),
+          login_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
+        ) %>
+  </p>
+  <% end %>
 <% end %>
 
 <%= javascript_packs_tag_once('platform-authenticator-available', preload_links_header: false) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1428,6 +1428,7 @@ notices.privacy.security_and_privacy_practices: Security Practices and Privacy A
 notices.resend_confirmation_email.success: We sent another confirmation email.
 notices.session_cleared: For your security, we clear what you entered if you don’t move to a new page within %{minutes} minutes.
 notices.session_timedout: We signed you out. For your security, %{app_name} ends your session when you haven’t moved to a new page for %{minutes} minutes.
+notices.sign_in.recaptcha.disclosure_statement_html: This site is protected by reCAPTCHA and the Google %{google_policy_link_html} and %{google_tos_link_html} apply.
 notices.signed_up_and_confirmed.first_paragraph_end: with a link to confirm your email address. Follow the link to continue adding this email to your account.
 notices.signed_up_and_confirmed.first_paragraph_start: We sent an email to
 notices.signed_up_and_confirmed.no_email_sent_explanation_start: Didn’t receive an email?
@@ -1733,7 +1734,6 @@ two_factor_authentication.recaptcha.google_policy_link: Privacy Policy
 two_factor_authentication.recaptcha.google_tos_link: Terms of Service
 two_factor_authentication.recaptcha.login_tos_link: Mobile Terms of Use
 two_factor_authentication.recommended: Recommended
-two_factor_authentication.sign_in.recaptcha.disclosure_statement_html: This site is protected by reCAPTCHA and the Google %{google_policy_link_html} and %{google_tos_link_html} apply.
 two_factor_authentication.totp_header_text: Enter your authentication app code
 two_factor_authentication.two_factor_aal3_choice: Additional authentication required
 two_factor_authentication.two_factor_aal3_choice_intro: This app requires a higher level of security. You need to verify your identity using a physical device such as a security key or government employee ID (PIV or CAC) to access your information.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1733,6 +1733,7 @@ two_factor_authentication.recaptcha.google_policy_link: Privacy Policy
 two_factor_authentication.recaptcha.google_tos_link: Terms of Service
 two_factor_authentication.recaptcha.login_tos_link: Mobile Terms of Use
 two_factor_authentication.recommended: Recommended
+two_factor_authentication.sign_in.recaptcha.disclosure_statement_html: This site is protected by reCAPTCHA and the Google %{google_policy_link_html} and %{google_tos_link_html} apply.
 two_factor_authentication.totp_header_text: Enter your authentication app code
 two_factor_authentication.two_factor_aal3_choice: Additional authentication required
 two_factor_authentication.two_factor_aal3_choice_intro: This app requires a higher level of security. You need to verify your identity using a physical device such as a security key or government employee ID (PIV or CAC) to access your information.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1745,6 +1745,7 @@ two_factor_authentication.recaptcha.google_policy_link: Política de privacidad
 two_factor_authentication.recaptcha.google_tos_link: Condiciones de servicio
 two_factor_authentication.recaptcha.login_tos_link: Condiciones de uso del servicio móvil
 two_factor_authentication.recommended: Recomendado
+two_factor_authentication.sign_in.recaptcha.disclosure_statement_html: Este sitio está protegido por reCAPTCHA y se aplican %{google_policy_link_html} y %{google_tos_link_html} de Google.
 two_factor_authentication.totp_header_text: Ingrese su código de la aplicación de autenticación
 two_factor_authentication.two_factor_aal3_choice: Se requiere autenticación adicional
 two_factor_authentication.two_factor_aal3_choice_intro: Esta aplicación requiere un nivel más alto de seguridad. Debe verificar su identidad con un dispositivo físico, como una clave de seguridad o una identificación de empleado de gobierno (tarjeta PIV o CAC), para acceder a su información.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1439,6 +1439,7 @@ notices.privacy.security_and_privacy_practices: Prácticas de seguridad y declar
 notices.resend_confirmation_email.success: Enviamos otro correo electrónico de confirmación.
 notices.session_cleared: Por su seguridad, borramos lo que usted ingresó si usted no pasa a una página nueva en %{minutes} minutos.
 notices.session_timedout: Cerramos su sesión. Por su seguridad, %{app_name} cierra su sesión cuando usted no pasa a una página nueva en %{minutes} minutos.
+notices.sign_in.recaptcha.disclosure_statement_html: Este sitio está protegido por reCAPTCHA y se aplican %{google_policy_link_html} y %{google_tos_link_html} de Google.
 notices.signed_up_and_confirmed.first_paragraph_end: con un vínculo para confirmar su dirección de correo electrónico. Siga el vínculo para continuar agregando este correo electrónico a su cuenta.
 notices.signed_up_and_confirmed.first_paragraph_start: Enviamos un correo electrónico a
 notices.signed_up_and_confirmed.no_email_sent_explanation_start: '¿No recibió un correo electrónico?'
@@ -1745,7 +1746,6 @@ two_factor_authentication.recaptcha.google_policy_link: Política de privacidad
 two_factor_authentication.recaptcha.google_tos_link: Condiciones de servicio
 two_factor_authentication.recaptcha.login_tos_link: Condiciones de uso del servicio móvil
 two_factor_authentication.recommended: Recomendado
-two_factor_authentication.sign_in.recaptcha.disclosure_statement_html: Este sitio está protegido por reCAPTCHA y se aplican %{google_policy_link_html} y %{google_tos_link_html} de Google.
 two_factor_authentication.totp_header_text: Ingrese su código de la aplicación de autenticación
 two_factor_authentication.two_factor_aal3_choice: Se requiere autenticación adicional
 two_factor_authentication.two_factor_aal3_choice_intro: Esta aplicación requiere un nivel más alto de seguridad. Debe verificar su identidad con un dispositivo físico, como una clave de seguridad o una identificación de empleado de gobierno (tarjeta PIV o CAC), para acceder a su información.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1428,6 +1428,7 @@ notices.privacy.security_and_privacy_practices: Déclaration relatives à la loi
 notices.resend_confirmation_email.success: Nous avons envoyé un autre e-mail de confirmation.
 notices.session_cleared: Pour votre sécurité, nous effaçons les informations que vous avez saisies si vous ne passez pas à une nouvelle page dans les %{minutes} minutes.
 notices.session_timedout: Nous vous avons déconnecté. Pour votre sécurité, %{app_name} désactive votre session si vous n’êtes pas passé à une nouvelle page après %{minutes} minutes.
+notices.sign_in.recaptcha.disclosure_statement_html: Ce site est protégé par reCAPTCHA. Les %{google_policy_link_html} et %{google_tos_link_html} de Google s’appliquent.
 notices.signed_up_and_confirmed.first_paragraph_end: avec un lien pour confirmer votre adresse e-mail. Suivez le lien pour continuer à ajouter cet adresse e-mail à votre compte.
 notices.signed_up_and_confirmed.first_paragraph_start: Nous avons envoyé un e-mail à
 notices.signed_up_and_confirmed.no_email_sent_explanation_start: Vous n’avez pas reçu d’e-mail ?
@@ -1733,7 +1734,6 @@ two_factor_authentication.recaptcha.google_policy_link: politique de confidentia
 two_factor_authentication.recaptcha.google_tos_link: conditions de service
 two_factor_authentication.recaptcha.login_tos_link: conditions d’utilisation mobile
 two_factor_authentication.recommended: Recommandation
-two_factor_authentication.sign_in.recaptcha.disclosure_statement_html: Ce site est protégé par reCAPTCHA. Les %{google_policy_link_html} et %{google_tos_link_html} de Google s’appliquent.
 two_factor_authentication.totp_header_text: Saisir votre code d’appli d’authentification
 two_factor_authentication.two_factor_aal3_choice: Authentification supplémentaire requise
 two_factor_authentication.two_factor_aal3_choice_intro: Cette appli nécessite un niveau de sécurité plus élevé. Vous devez vérifier votre identité à l’aide d’un dispositif physique tel qu’une clé de sécurité ou une carte d’employé fédéral (PIV ou CAC) pour accéder à vos informations.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1733,6 +1733,7 @@ two_factor_authentication.recaptcha.google_policy_link: politique de confidentia
 two_factor_authentication.recaptcha.google_tos_link: conditions de service
 two_factor_authentication.recaptcha.login_tos_link: conditions d’utilisation mobile
 two_factor_authentication.recommended: Recommandation
+two_factor_authentication.sign_in.recaptcha.disclosure_statement_html: Ce site est protégé par reCAPTCHA. Les %{google_policy_link_html} et %{google_tos_link_html} de Google s’appliquent.
 two_factor_authentication.totp_header_text: Saisir votre code d’appli d’authentification
 two_factor_authentication.two_factor_aal3_choice: Authentification supplémentaire requise
 two_factor_authentication.two_factor_aal3_choice_intro: Cette appli nécessite un niveau de sécurité plus élevé. Vous devez vérifier votre identité à l’aide d’un dispositif physique tel qu’une clé de sécurité ou une carte d’employé fédéral (PIV ou CAC) pour accéder à vos informations.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1441,6 +1441,7 @@ notices.privacy.security_and_privacy_practices: 安全实践和隐私法声明
 notices.resend_confirmation_email.success: 我们发送了另外一个确认电邮。
 notices.session_cleared: 为了你的安全，如果你在 %{minutes} 分钟内不移动到一个新页面，我们会清除你输入的内容。
 notices.session_timedout: 我们已将你登出。为了你的安全，如果你在 %{minutes} 分钟内不移动到一个新页面，%{app_name} 会结束你此次访问。
+notices.sign_in.recaptcha.disclosure_statement_html: 该网站由 reCAPTCHA 保护而且谷歌的 %{google_policy_link_html} 和 %{google_tos_link_html} 都适用。
 notices.signed_up_and_confirmed.first_paragraph_end: 带有确认你的电邮地址的链接。点击链接去继续把这个电邮添加到你的账户。
 notices.signed_up_and_confirmed.first_paragraph_start: 我们已发电邮到
 notices.signed_up_and_confirmed.no_email_sent_explanation_start: 没有收到电邮？
@@ -1746,7 +1747,6 @@ two_factor_authentication.recaptcha.google_policy_link: 隐私政策
 two_factor_authentication.recaptcha.google_tos_link: 服务条款
 two_factor_authentication.recaptcha.login_tos_link: 移动使用条款
 two_factor_authentication.recommended: 建议
-two_factor_authentication.sign_in.recaptcha.disclosure_statement_html: 该网站由 reCAPTCHA 保护而且谷歌的 %{google_policy_link_html} 和 %{google_tos_link_html} 都适用。
 two_factor_authentication.totp_header_text: 输入你的身份证实应用程序代码
 two_factor_authentication.two_factor_aal3_choice: 要求额外的身份证实
 two_factor_authentication.two_factor_aal3_choice_intro: 该应用程序要求更高的安全级别。要访问你信息，你需要使用一个实体设备 - 比如安全密钥或政府雇员身份证件(PIV 或 CAC) - 来验证你的身份。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1746,6 +1746,7 @@ two_factor_authentication.recaptcha.google_policy_link: 隐私政策
 two_factor_authentication.recaptcha.google_tos_link: 服务条款
 two_factor_authentication.recaptcha.login_tos_link: 移动使用条款
 two_factor_authentication.recommended: 建议
+two_factor_authentication.sign_in.recaptcha.disclosure_statement_html: 该网站由 reCAPTCHA 保护而且谷歌的 %{google_policy_link_html} 和 %{google_tos_link_html} 都适用。
 two_factor_authentication.totp_header_text: 输入你的身份证实应用程序代码
 two_factor_authentication.two_factor_aal3_choice: 要求额外的身份证实
 two_factor_authentication.two_factor_aal3_choice_intro: 该应用程序要求更高的安全级别。要访问你信息，你需要使用一个实体设备 - 比如安全密钥或政府雇员身份证件(PIV 或 CAC) - 来验证你的身份。

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'devise/sessions/new.html.erb' do
   include UserAgentHelper
-  include Rails.application.routes.url_helpers
+  include LinkHelper
 
   before do
     allow(view).to receive(:resource).and_return(build_stubbed(:user))
@@ -246,22 +246,21 @@ RSpec.describe 'devise/sessions/new.html.erb' do
         expect(rendered).to have_css('lg-captcha-submit-button')
       end
 
+      before do
+        allow(FeatureManagement).to receive(:sign_in_recaptcha_enabled?).and_return(true)
+      end
+
       it 'renders recaptcha disclaimer text' do
         expect(rendered).to have_content(
           t(
-            'two_factor_authentication.recaptcha.disclosure_statement_html',
+            'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
             app_name: APP_NAME,
             google_policy_link_html: new_tab_link_to(
               t('two_factor_authentication.recaptcha.google_policy_link'),
               GooglePolicySite.privacy_url,
             ),
             google_tos_link_html: new_tab_link_to(
-              t('two_factor_authentication.recaptcha.google_tos_link'),
-              GooglePolicySite.terms_url,
-            ),
-            login_tos_link_html: new_tab_link_to(
-              t('two_factor_authentication.recaptcha.login_tos_link'),
-              MarketingSite.rules_of_use_url,
+              t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url
             ),
           ),
         )

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -248,15 +248,16 @@ RSpec.describe 'devise/sessions/new.html.erb' do
 
       it 'renders recaptcha disclaimer text' do
         expect(rendered).to have_content(
-          t(
-            'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
-            app_name: APP_NAME,
-            google_policy_link_html: new_tab_link_to(
-              t('two_factor_authentication.recaptcha.google_policy_link'),
-              GooglePolicySite.privacy_url,
-            ),
-            google_tos_link_html: new_tab_link_to(
-              t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url
+          strip_tags(
+            t(
+              'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
+              google_policy_link_html: new_tab_link_to(
+                t('two_factor_authentication.recaptcha.google_policy_link'),
+                GooglePolicySite.privacy_url,
+              ),
+              google_tos_link_html: new_tab_link_to(
+                t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url
+              ),
             ),
           ),
         )

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'devise/sessions/new.html.erb' do
   include UserAgentHelper
+  include Rails.application.routes.url_helpers
 
   before do
     allow(view).to receive(:resource).and_return(build_stubbed(:user))
@@ -243,6 +244,27 @@ RSpec.describe 'devise/sessions/new.html.erb' do
       it 'renders captcha sign-in submit button' do
         expect(rendered).to have_button(t('links.sign_in'))
         expect(rendered).to have_css('lg-captcha-submit-button')
+      end
+
+      it 'renders recaptcha disclaimer text' do
+        expect(rendered).to have_content(
+          t(
+            'two_factor_authentication.recaptcha.disclosure_statement_html',
+            app_name: APP_NAME,
+            google_policy_link_html: new_tab_link_to(
+              t('two_factor_authentication.recaptcha.google_policy_link'),
+              GooglePolicySite.privacy_url,
+            ),
+            google_tos_link_html: new_tab_link_to(
+              t('two_factor_authentication.recaptcha.google_tos_link'),
+              GooglePolicySite.terms_url,
+            ),
+            login_tos_link_html: new_tab_link_to(
+              t('two_factor_authentication.recaptcha.login_tos_link'),
+              MarketingSite.rules_of_use_url,
+            ),
+          ),
+        )
       end
     end
   end

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -246,10 +246,6 @@ RSpec.describe 'devise/sessions/new.html.erb' do
         expect(rendered).to have_css('lg-captcha-submit-button')
       end
 
-      before do
-        allow(FeatureManagement).to receive(:sign_in_recaptcha_enabled?).and_return(true)
-      end
-
       it 'renders recaptcha disclaimer text' do
         expect(rendered).to have_content(
           t(

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -228,6 +228,23 @@ RSpec.describe 'devise/sessions/new.html.erb' do
         expect(rendered).not_to have_css('lg-captcha-submit-button')
       end
 
+      it 'does not render the recaptcha disclaimer text' do
+        expect(rendered).not_to have_content(
+          strip_tags(
+            t(
+              'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
+              google_policy_link_html: new_tab_link_to(
+                t('two_factor_authentication.recaptcha.google_policy_link'),
+                GooglePolicySite.privacy_url,
+              ),
+              google_tos_link_html: new_tab_link_to(
+                t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url
+              ),
+            ),
+          ),
+        )
+      end
+
       context 'recaptcha mock validator is enabled' do
         let(:recaptcha_mock_validator) { true }
 

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
         expect(rendered).to have_content(
           strip_tags(
             t(
-              'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
+              'notices.sign_in.recaptcha.disclosure_statement_html',
               google_policy_link_html: new_tab_link_to(
                 t('two_factor_authentication.recaptcha.google_policy_link'),
                 GooglePolicySite.privacy_url,

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
         expect(rendered).not_to have_content(
           strip_tags(
             t(
-              'two_factor_authentication.sign_in.recaptcha.disclosure_statement_html',
+              'notices.sign_in.recaptcha.disclosure_statement_html',
               google_policy_link_html: new_tab_link_to(
                 t('two_factor_authentication.recaptcha.google_policy_link'),
                 GooglePolicySite.privacy_url,


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14400](https://cm-jira.usa.gov/browse/LG-14400)



## 🛠 Summary of changes

Adds a disclaimer text block in the sign in view that will show if recaptcha is enabled.


## 📜 Testing Plan

Checklist of steps to confirm the changes.

- [ ] Enable reCAPTCHA locally in your development environment (recaptcha_enterprise_api_key, recaptcha_enterprise_project_id, recaptcha_secret_key, sign_in_recaptcha_score_threshold)
- [ ] Visit http://localhost:3000
- [ ] Observe the newly added text at the bottom of the sign in page that it matches what is in the Figma.



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
