### PR TITLE
LG-14393: Require threatmetrix_session_id for verify info step

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -43,6 +43,11 @@ module Idv
       return true
     end
 
+    def log_event_for_missing_threatmetrix_session_id
+      return if self.class.threatmetrix_session_id_present_or_not_required?(idv_session:)
+      analytics.idv_verify_info_missing_threatmetrix_session_id if idv_session.ssn_step_complete?
+    end
+
     private
 
     def ipp_enrollment_in_progress?

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -6,6 +6,13 @@ module Idv
 
     STEP_NAME = 'verify_info'
 
+    class_methods do
+      def threatmetrix_session_id_present_or_not_required?(idv_session:)
+        return true unless FeatureManagement.proofing_device_profiling_decisioning_enabled?
+        idv_session.threatmetrix_session_id.present?
+      end
+    end
+
     def shared_update
       return if idv_session.verify_info_step_document_capture_session_uuid
       analytics.idv_doc_auth_verify_submitted(**analytics_arguments)

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -45,7 +45,9 @@ module Idv
         controller: self,
         next_steps: [:phone, :request_letter],
         preconditions: ->(idv_session:, user:) do
-          idv_session.ssn && idv_session.remote_document_capture_complete?
+          idv_session.remote_document_capture_complete? &&
+            idv_session.ssn_step_complete? &&
+              threatmetrix_session_id_present_or_not_required?(idv_session:)
         end,
         undo_step: ->(idv_session:, user:) do
           idv_session.resolution_successful = nil

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -9,6 +9,7 @@ module Idv
     include Steps::ThreatMetrixStepHelper
 
     before_action :confirm_not_rate_limited_after_doc_auth, except: [:show]
+    before_action :log_event_for_missing_threatmetrix_session_id
     before_action :confirm_step_allowed
 
     def show

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4758,6 +4758,11 @@ module AnalyticsEvents
     )
   end
 
+  # The user ended up at the "Verify info" screen without a Threatmetrix session id.
+  def idv_verify_info_missing_threatmetrix_session_id(**extra)
+    track_event(:idv_verify_info_missing_threatmetrix_session_id, **extra)
+  end
+
   # @param [Boolean] acuant_sdk_upgrade_a_b_testing_enabled
   # @param [String] acuant_version
   # @param ["hybrid","standard"] flow_path Document capture user flow

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -240,6 +240,10 @@ module Idv
         user_session['idv/in_person'][:pii_from_user].has_key?(:identity_doc_address1)
     end
 
+    def ssn_step_complete?
+      ssn.present?
+    end
+
     def verify_info_step_complete?
       resolution_successful
     end

--- a/app/services/idv/steps/threat_metrix_step_helper.rb
+++ b/app/services/idv/steps/threat_metrix_step_helper.rb
@@ -14,8 +14,19 @@ module Idv
       end
 
       def generate_threatmetrix_session_id(updating_ssn)
-        idv_session.threatmetrix_session_id = SecureRandom.uuid if !updating_ssn
+        if should_generate_new_threatmetrix_session_id?(updating_ssn)
+          idv_session.threatmetrix_session_id = SecureRandom.uuid
+        end
+
         idv_session.threatmetrix_session_id
+      end
+
+      def should_generate_new_threatmetrix_session_id?(updating_ssn)
+        if updating_ssn
+          idv_session.threatmetrix_session_id.blank?
+        else
+          true
+        end
       end
 
       # @return [Array<String>]

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Idv::EnterPasswordController do
     subject.idv_session.flow_path = 'standard'
     subject.idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
     subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn]
+    subject.idv_session.threatmetrix_session_id = 'random-session-id'
     subject.idv_session.resolution_successful = true
     subject.idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE
     subject.idv_session.resolution_successful = true

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Idv::OtpVerificationController do
     subject.idv_session.idv_consent_given_at = Time.zone.now
     subject.idv_session.flow_path = 'standard'
     subject.idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
+    subject.idv_session.threatmetrix_session_id = 'random-session-id'
     subject.idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE[:ssn]
     subject.idv_session.resolution_successful = true
     subject.idv_session.applicant[:phone] = phone

--- a/spec/controllers/idv/phone_errors_controller_spec.rb
+++ b/spec/controllers/idv/phone_errors_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Idv::PhoneErrorsController do
       subject.idv_session.idv_consent_given_at = Time.zone.now
       subject.idv_session.flow_path = 'standard'
       subject.idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
+      subject.idv_session.threatmetrix_session_id = 'random-session-id'
       subject.idv_session.ssn = '123-45-6789'
       subject.idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE
       subject.idv_session.resolution_successful = true

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -181,11 +181,30 @@ RSpec.describe Idv::VerifyInfoController do
       context 'when idv_session is missing threatmetrix_session_id' do
         before do
           controller.idv_session.threatmetrix_session_id = nil
-          get :show
         end
 
         it 'redirects back to the SSN step' do
+          get :show
           expect(response).to redirect_to(idv_ssn_url)
+        end
+
+        it 'logs an idv_verify_info_missing_threatmetrix_session_id event' do
+          get :show
+          expect(@analytics).to have_logged_event(
+            :idv_verify_info_missing_threatmetrix_session_id,
+          )
+        end
+
+        context 'when ssn is not present in idv_session' do
+          before do
+            controller.idv_session.ssn = nil
+          end
+          it 'does not log an idv_verify_info_missing_threatmetrix_session_id event' do
+            get :show
+            expect(@analytics).not_to have_logged_event(
+              :idv_verify_info_missing_threatmetrix_session_id,
+            )
+          end
         end
       end
 

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Idv::VerifyInfoController do
 
     context 'when proofing_device_profiling is enabled' do
       let(:threatmetrix_client_id) { 'threatmetrix_client' }
-
+      let(:review_status) { 'pass' }
       let(:idv_result) do
         {
           context: {
@@ -178,9 +178,18 @@ RSpec.describe Idv::VerifyInfoController do
         allow(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(:enabled)
       end
 
-      context 'when threatmetrix response is Pass' do
-        let(:review_status) { 'pass' }
+      context 'when idv_session is missing threatmetrix_session_id' do
+        before do
+          controller.idv_session.threatmetrix_session_id = nil
+          get :show
+        end
 
+        it 'redirects back to the SSN step' do
+          expect(response).to redirect_to(idv_ssn_url)
+        end
+      end
+
+      context 'when threatmetrix response is Pass' do
         it 'sets the review status in the idv session' do
           get :show
           expect(controller.idv_session.threatmetrix_review_status).to eq('pass')
@@ -234,6 +243,23 @@ RSpec.describe Idv::VerifyInfoController do
         it 'sets the review status in the idv session' do
           get :show
           expect(controller.idv_session.threatmetrix_review_status).to eq('review')
+        end
+      end
+    end
+
+    context 'when proofing_device_profiling is disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(:disabled)
+      end
+
+      context 'when idv_session is missing threatmetrix_session_id' do
+        before do
+          controller.idv_session.threatmetrix_session_id = nil
+          get :show
+        end
+
+        it 'does not redirect back to the SSN step' do
+          expect(response).not_to redirect_to(idv_ssn_url)
         end
       end
     end

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -25,6 +25,7 @@ module FlowPolicyHelper
       idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
     when :ssn
       idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
+      idv_session.threatmetrix_session_id = 'a-random-session-id'
     when :ipp_ssn
       idv_session.send(:user_session)['idv/in_person'] = {
         pii_from_user: Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup,


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14393](https://cm-jira.usa.gov/browse/LG-14393)

## 🛠 Summary of changes

This PR updates the `preconditions` of `VerifyInfoController` (both remote + IPP variants) to require the presence of a `threatmetrix_session_id`. This is to work around a **rare** case where a user might end up on the verify info screen with no session id present. This is not an ideal fix, but rather an attempt to prevent a condition where a user will have no chance of passing identity verification.

## 📜 Testing Plan

1. Apply the patch below (hit copy, then `pbpaste | git apply`) to ensure no threatmetrix_session_id is written to your session
2. Go through IdV up to the SSN screen
3. When you click the **Continue** button, you should not see the Verify info screen, but rather the "Update your SSN" screen
4. Verify that clicking the **Update** button does not advance you to the verify info screen.
5. Revert the change made in step 1, click **Update**, and you should advance to the Verify Info screen.

### The patch

```diff
diff --git a/app/services/idv/steps/threat_metrix_step_helper.rb b/app/services/idv/steps/threat_metrix_step_helper.rb
index a17d45813..f748ad328 100644
--- a/app/services/idv/steps/threat_metrix_step_helper.rb
+++ b/app/services/idv/steps/threat_metrix_step_helper.rb
@@ -15,7 +15,7 @@ module Idv

       def generate_threatmetrix_session_id(updating_ssn)
         if should_generate_new_threatmetrix_session_id?(updating_ssn)
-          idv_session.threatmetrix_session_id = SecureRandom.uuid
+          return SecureRandom.uuid
         end

         idv_session.threatmetrix_session_id

```
