### PR TITLE
Remove lingering reference to outdated F/T setup feature flag

### DIFF
--- a/spec/presenters/two_factor_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_options_presenter_spec.rb
@@ -116,23 +116,6 @@ RSpec.describe TwoFactorOptionsPresenter do
         ]
       end
     end
-    context 'when platform_auth_set_up_enabled is enabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:platform_auth_set_up_enabled).
-          and_return(true)
-      end
-
-      it 'supplies all the options except webauthn' do
-        expect(presenter.options.map(&:class)).to eq [
-          TwoFactorAuthentication::SetUpWebauthnPlatformSelectionPresenter,
-          TwoFactorAuthentication::SetUpAuthAppSelectionPresenter,
-          TwoFactorAuthentication::SetUpPhoneSelectionPresenter,
-          TwoFactorAuthentication::SetUpWebauthnSelectionPresenter,
-          TwoFactorAuthentication::SetUpPivCacSelectionPresenter,
-          TwoFactorAuthentication::SetUpBackupCodeSelectionPresenter,
-        ]
-      end
-    end
   end
 
   describe '#all_options_sorted' do


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a spec testing expected behavior for the `platform_auth_set_up_enabled` feature flag.

This feature flag was removed in #9485, but the tests were accidentally added back in #9532, likely due to merge conflict handling since they were merged around the same time.

## 📜 Testing Plan

Verify build passes.