### PR TITLE
Remove unnecessary quibble loader registration

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -4,6 +4,5 @@ module.exports = /** @type {import('mocha').MochaOptions} */ ({
   require: ['./spec/javascript/support/mocha.js'],
   file: 'spec/javascript/spec_helper.js',
   extension: ['js', 'jsx', 'ts', 'tsx'],
-  loader: ['quibble'],
   conditions: ['source'],
 });


### PR DESCRIPTION
## 🛠 Summary of changes

Updates how we use [`quibble`](https://github.com/testdouble/quibble) for JavaScript module substitution in tests to avoid explicitly passing `loader` option to Mocha.

This resolves a warning that's logged when running tests, and will likely help avoid a future incompatibility when Node.js removes the `--loader` flag:

```
(node:34551) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:
--import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("quibble", pathToFileURL("./"));'
(Use `node --trace-warnings ...` to show where the warning was created)
```

It's no longer necessary to pass the loader option in newer versions of Node.js, because Quibble ✨ automagically ✨ registers the hooks behind the scenes.

>For versions larger or equal to v20.6.0, there is no need to specify a `--loader`, as registering the loader happens automatically once you use the API.

https://github.com/testdouble/quibble#es-modules-support

## 📜 Testing Plan

Verify build passes.

Verify `yarn test` passes, and doesn't log the warning shown above.