### PR TITLE
LG-14370 Add biographical info to proofing result

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -173,6 +173,9 @@ module Idv
             [:proofing_results, :context, :stages, :threatmetrix, :response_body, :first_name],
             [:same_address_as_id],
             [:proofing_results, :context, :stages, :state_id, :state_id_jurisdiction],
+            [:proofing_results, :biographical_info, :identity_doc_address_state],
+            [:proofing_results, :biographical_info, :state_id_jurisdiction],
+            [:proofing_results, :biographical_info, :same_address_as_id],
           ],
         },
       )

--- a/app/jobs/socure_shadow_mode_proofing_job.rb
+++ b/app/jobs/socure_shadow_mode_proofing_job.rb
@@ -49,6 +49,10 @@ class SocureShadowModeProofingJob < ApplicationJob
         [:resolution_result, :context, :stages, :residential_address, :errors, :ssn],
         [:resolution_result, :context, :stages, :threatmetrix, :response_body, :first_name],
         [:resolution_result, :context, :stages, :state_id, :state_id_jurisdiction],
+        [:resolution_result, :context, :stages, :state_id, :state_id_jurisdiction],
+        [:resolution_result, :biographical_info, :identity_doc_address_state],
+        [:resolution_result, :biographical_info, :state_id_jurisdiction],
+        [:resolution_result, :biographical_info, :same_address_as_id],
       ],
     )
   end

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -53,6 +53,7 @@ module Proofing
           state_id_result: state_id_result,
           residential_resolution_result: residential_instant_verify_result,
           same_address_as_id: applicant_pii[:same_address_as_id],
+          applicant_pii: applicant_pii,
         )
       end
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -107,6 +107,14 @@ RSpec.feature 'Analytics Regression', :js do
           threatmetrix: threatmetrix_response,
         },
       },
+      biographical_info: {
+        birth_year: 1938,
+        identity_doc_address_state: nil,
+        same_address_as_id: nil,
+        state: 'MT',
+        state_id_jurisdiction: 'ND',
+        state_id_number: '#############',
+      },
     }
   end
 
@@ -136,6 +144,14 @@ RSpec.feature 'Analytics Regression', :js do
           state_id: state_id_resolution,
           threatmetrix: threatmetrix_response,
         },
+      },
+      biographical_info: {
+        birth_year: 1938,
+        identity_doc_address_state: 'ND',
+        same_address_as_id: 'false',
+        state: 'MT',
+        state_id_jurisdiction: 'ND',
+        state_id_number: '#############',
       },
     }
   end

--- a/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
+++ b/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe SocureShadowModeProofingJob do
             },
           },
         },
+        biographical_info: {
+          birth_year: 1938,
+          identity_doc_address_state: nil,
+          same_address_as_id: nil,
+          state: 'MT',
+          state_id_jurisdiction: 'ND',
+          state_id_number: '#############',
+        },
         ssn_is_unique: true,
       },
     )
@@ -250,6 +258,14 @@ RSpec.describe SocureShadowModeProofingJob do
             ssn_is_unique: true,
             threatmetrix_review_status: 'pass',
             timed_out: false,
+            biographical_info: {
+              birth_year: 1938,
+              identity_doc_address_state: nil,
+              same_address_as_id: nil,
+              state: 'MT',
+              state_id_jurisdiction: 'ND',
+              state_id_number: '#############',
+            },
           },
           socure_result: {
             attributes_requiring_additional_verification: [],

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
     )
   end
 
+  let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
+
   subject do
     described_class.new(
       resolution_result: resolution_result,
@@ -53,6 +55,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
       ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       device_profiling_result: device_profiling_result,
       same_address_as_id: same_address_as_id,
+      applicant_pii: applicant_pii,
     )
   end
 
@@ -89,6 +92,40 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
           expect(result.success?).to eq(false)
           resolution_adjudication_reason = result.extra[:context][:resolution_adjudication_reason]
           expect(resolution_adjudication_reason).to eq(:fail_state_id)
+        end
+      end
+    end
+
+    describe 'biographical_info' do
+      context 'the applicant PII contains one address' do
+        it 'includes formatted PII' do
+          result = subject.adjudicated_result
+
+          expect(result.extra[:biographical_info]).to eq(
+            birth_year: 1938,
+            state: 'MT',
+            identity_doc_address_state: nil,
+            state_id_jurisdiction: 'ND',
+            state_id_number: '#############',
+            same_address_as_id: nil,
+          )
+        end
+      end
+
+      context 'the applicant PII contains a residential address and document address' do
+        let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID }
+
+        it 'includes formatted PII' do
+          result = subject.adjudicated_result
+
+          expect(result.extra[:biographical_info]).to eq(
+            birth_year: 1938,
+            state: 'MT',
+            identity_doc_address_state: 'MT',
+            state_id_jurisdiction: 'ND',
+            state_id_number: '#############',
+            same_address_as_id: 'true',
+          )
         end
       end
     end


### PR DESCRIPTION
Currently we log PII or redacted PII related to the resolution proofing job in the `IdV: doc auth verify proofing results` event. This primarily includes state ID information which is added to the logs in `VerifyInfoConcern#idv_result_to_form_response`.

This commit adds this information to the result that is returned from `ResultAdjudicator`. This has a few advantages:

1. We have a consistent result since the information is added before bing written to Redis. This will allows the `SocureShadowModeProofingJob` to pick it up and log it.
2. It provides an overview of what PII and redacted PII is logged in one place.
3. It ensures that PII is logged consistently even if vendors or stages change in the future

Finally, this commit adds the year of birth to the logs to address LG-14371.
