### PR TITLE
Pass analytics to StepInfo preconditions proc

### DIFF
--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -103,7 +103,11 @@ module IdvStepConcern
   end
 
   def flow_policy
-    @flow_policy ||= Idv::FlowPolicy.new(idv_session: idv_session, user: current_user)
+    @flow_policy ||= Idv::FlowPolicy.new(
+      analytics: analytics,
+      idv_session: idv_session,
+      user: current_user,
+    )
   end
 
   def confirm_step_allowed

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -33,7 +33,9 @@ module Idv
         controller: self,
         action: :new,
         next_steps: [:verify_info],
-        preconditions: ->(idv_session:, user:) { idv_session.remote_document_capture_complete? },
+        preconditions: ->(idv_session:, user:, analytics:) do
+          idv_session.remote_document_capture_complete?
+        end,
         undo_step: ->(idv_session:, user:) { idv_session.updated_user_address = nil },
       )
     end

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -54,7 +54,9 @@ module Idv
         key: :agreement,
         controller: self,
         next_steps: [:hybrid_handoff, :document_capture, :how_to_verify],
-        preconditions: ->(idv_session:, user:) { idv_session.welcome_visited },
+        preconditions: ->(idv_session:, user:, analytics:) do
+          idv_session.welcome_visited
+        end,
         undo_step: ->(idv_session:, user:) do
           idv_session.idv_consent_given_at = nil
           idv_session.skip_hybrid_handoff = nil

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -33,7 +33,7 @@ module Idv
           controller: self,
           action: :index,
           next_steps: [:enter_password],
-          preconditions: ->(idv_session:, user:) do
+          preconditions: ->(idv_session:, user:, analytics:) do
             idv_session.verify_info_step_complete?
           end,
           undo_step: ->(idv_session:, user:) { idv_session.address_verification_mechanism = nil },

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -65,7 +65,7 @@ module Idv
         key: :document_capture,
         controller: self,
         next_steps: [:ssn, :ipp_ssn], # :ipp_state_id
-        preconditions: ->(idv_session:, user:) {
+        preconditions: ->(idv_session:, user:, analytics:) {
                          idv_session.flow_path == 'standard' && (
                            # mobile
                            idv_session.skip_doc_auth_from_handoff ||

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -85,7 +85,7 @@ module Idv
         controller: self,
         action: :new,
         next_steps: [:personal_key],
-        preconditions: ->(idv_session:, user:) do
+        preconditions: ->(idv_session:, user:, analytics:) do
           idv_session.phone_or_address_step_complete?
         end,
         undo_step: ->(idv_session:, user:) {},

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -59,7 +59,7 @@ module Idv
         key: :how_to_verify,
         controller: self,
         next_steps: [:hybrid_handoff, :document_capture],
-        preconditions: ->(idv_session:, user:) do
+        preconditions: ->(idv_session:, user:, analytics:) do
           self.enabled? &&
           idv_session.idv_consent_given? &&
           idv_session.service_provider&.in_person_proofing_enabled

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -60,7 +60,7 @@ module Idv
         key: :hybrid_handoff,
         controller: self,
         next_steps: [:link_sent, :document_capture],
-        preconditions: ->(idv_session:, user:) {
+        preconditions: ->(idv_session:, user:, analytics:) {
                          idv_session.idv_consent_given? &&
                            (self.selected_remote(idv_session: idv_session) || # from opt-in screen
                              # back from ipp doc capture screen

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -53,7 +53,9 @@ module Idv
           key: :ipp_address,
           controller: self,
           next_steps: [:ipp_ssn],
-          preconditions: ->(idv_session:, user:) { idv_session.ipp_state_id_complete? },
+          preconditions: ->(idv_session:, user:, analytics:) do
+            idv_session.ipp_state_id_complete?
+          end,
           undo_step: ->(idv_session:, user:) do
             flow_session[:pii_from_user][:address1] = nil
             flow_session[:pii_from_user][:address2] = nil

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -63,7 +63,9 @@ module Idv
           key: :ipp_ssn,
           controller: self,
           next_steps: [:ipp_verify_info],
-          preconditions: ->(idv_session:, user:) { idv_session.ipp_document_capture_complete? },
+          preconditions: ->(idv_session:, user:, analytics:) do
+            idv_session.ipp_document_capture_complete?
+          end,
           undo_step: ->(idv_session:, user:) { idv_session.ssn = nil },
         )
       end

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -79,7 +79,9 @@ module Idv
           key: :ipp_state_id,
           controller: self,
           next_steps: [:ipp_address, :ipp_ssn],
-          preconditions: ->(idv_session:, user:) { user.establishing_in_person_enrollment },
+          preconditions: ->(idv_session:, user:, analytics:) do
+            user.establishing_in_person_enrollment
+          end,
           undo_step: ->(idv_session:, user:) do
             pii_from_user[:identity_doc_address1] = nil
             pii_from_user[:identity_doc_address2] = nil

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -39,7 +39,7 @@ module Idv
           key: :ipp_verify_info,
           controller: self,
           next_steps: [:phone],
-          preconditions: ->(idv_session:, user:) do
+          preconditions: ->(idv_session:, user:, analytics:) do
             idv_session.ssn && idv_session.ipp_document_capture_complete?
           end,
           undo_step: ->(idv_session:, user:) do

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -43,7 +43,9 @@ module Idv
         key: :link_sent,
         controller: self,
         next_steps: [:ssn],
-        preconditions: ->(idv_session:, user:) { idv_session.flow_path == 'hybrid' },
+        preconditions: ->(idv_session:, user:, analytics:) do
+          idv_session.flow_path == 'hybrid'
+        end,
         undo_step: ->(idv_session:, user:) do
           idv_session.pii_from_doc = nil
           idv_session.invalidate_in_person_pii_from_user!

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -40,7 +40,9 @@ module Idv
         key: :otp_verification,
         controller: self,
         next_steps: [:enter_password],
-        preconditions: ->(idv_session:, user:) { idv_session.phone_otp_sent? },
+        preconditions: ->(idv_session:, user:, analytics:) do
+          idv_session.phone_otp_sent?
+        end,
         undo_step: ->(idv_session:, user:) { idv_session.user_phone_confirmation = nil },
       )
     end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -53,7 +53,7 @@ module Idv
         key: :personal_key,
         controller: self,
         next_steps: [FlowPolicy::FINAL],
-        preconditions: ->(idv_session:, user:) do
+        preconditions: ->(idv_session:, user:, analytics:) do
           idv_session.phone_or_address_step_complete? &&
             user.active_or_pending_profile &&
             !idv_session.personal_key_acknowledged

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -73,7 +73,7 @@ module Idv
         controller: self,
         action: :new,
         next_steps: [:otp_verification],
-        preconditions: ->(idv_session:, user:) do
+        preconditions: ->(idv_session:, user:, analytics:) do
           idv_session.verify_info_step_complete? && !idv_session.verify_by_mail?
         end,
         undo_step: ->(idv_session:, user:) do

--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -46,7 +46,9 @@ module Idv
         controller: self,
         action: :failure,
         next_steps: [FlowPolicy::FINAL],
-        preconditions: ->(idv_session:, user:) { idv_session.previous_phone_step_params.present? },
+        preconditions: ->(idv_session:, user:, analytics:) do
+          idv_session.previous_phone_step_params.present?
+        end,
         undo_step: ->(idv_session:, user:) {},
       )
     end

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -61,7 +61,9 @@ module Idv
         key: :ssn,
         controller: self,
         next_steps: [:verify_info],
-        preconditions: ->(idv_session:, user:) { idv_session.remote_document_capture_complete? },
+        preconditions: ->(idv_session:, user:, analytics:) do
+          idv_session.remote_document_capture_complete?
+        end,
         undo_step: ->(idv_session:, user:) { idv_session.ssn = nil },
       )
     end

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -44,7 +44,7 @@ module Idv
         key: :verify_info,
         controller: self,
         next_steps: [:phone, :request_letter],
-        preconditions: ->(idv_session:, user:) do
+        preconditions: ->(idv_session:, user:, analytics:) do
           idv_session.ssn && idv_session.remote_document_capture_complete?
         end,
         undo_step: ->(idv_session:, user:) do

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -35,7 +35,9 @@ module Idv
         key: :welcome,
         controller: self,
         next_steps: [:agreement],
-        preconditions: ->(idv_session:, user:) { !user.gpo_verification_pending_profile? },
+        preconditions: ->(idv_session:, user:, analytics:) do
+          !user.gpo_verification_pending_profile?
+        end,
         undo_step: ->(idv_session:, user:) do
           idv_session.welcome_visited = nil
           idv_session.document_capture_session_uuid = nil

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -94,7 +94,11 @@ RSpec.describe Idv::PersonalKeyController do
 
     describe '#preconditions' do
       let(:preconditions) do
-        step_info.preconditions.call(idv_session: idv_session, user: user)
+        step_info.preconditions.call(
+          analytics: @analytics,
+          idv_session: idv_session,
+          user: user,
+        )
       end
 
       context 'when all conditions met' do

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe 'Idv::FlowPolicy' do
   let(:user_phone_confirmation_session) { nil }
   let(:has_gpo_pending_profile) { nil }
 
-  subject { Idv::FlowPolicy.new(idv_session: idv_session, user: user) }
+  let(:analytics) { FakeAnalytics.new }
+
+  subject { Idv::FlowPolicy.new(analytics: analytics, idv_session: idv_session, user: user) }
 
   context '#controller_allowed?' do
     it 'allows the welcome step' do
@@ -141,6 +143,17 @@ RSpec.describe 'Idv::FlowPolicy' do
           idv_session.had_barcode_attention_error
         }
       end
+    end
+  end
+
+  context '#step_allowed?' do
+    it 'passes analytics to preconditions' do
+      expect(subject.steps[:root].preconditions).to receive(:call).with(
+        analytics: analytics,
+        idv_session: anything,
+        user: anything,
+      ).and_call_original
+      expect(subject.step_allowed?(key: :root)).to eql(true)
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Relates to work for [LG-14393](https://cm-jira.usa.gov/browse/LG-14393)

## 🛠 Summary of changes

Over on #11254 there was a great suggestion to log an event when a certain step's preconditions fail. The problem was that `step_info` is implemented as a static method on controllers, and `analytics` is only available to individual instances.

So this PR updates the signature of the `preconditions` proc to include an `analytics:` argument, and ensures that it is passed properly by `IdvStepConcern`.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
