### PR TITLE
Remove unused single country variant from phone input component

### DIFF
--- a/app/components/phone_input_component.scss
+++ b/app/components/phone_input_component.scss
@@ -18,16 +18,6 @@ lg-phone-input {
   .iti__dial-code {
     color: color('ink');
   }
-
-  .iti:not(.iti--allow-dropdown) input {
-    padding-left: 36px;
-    padding-right: 6px;
-  }
-
-  .iti:not(.iti--allow-dropdown) .iti__flag-container {
-    left: 0;
-    right: auto;
-  }
 }
 
 .phone-input__international-code-wrapper {

--- a/app/javascript/packages/phone-input/index.spec.ts
+++ b/app/javascript/packages/phone-input/index.spec.ts
@@ -4,23 +4,6 @@ import { computeAccessibleName } from 'dom-accessibility-api';
 import * as analytics from '@18f/identity-analytics';
 import { useSandbox } from '@18f/identity-test-helpers';
 
-const MULTIPLE_OPTIONS_HTML = `
-  <select class="phone-input__international-code" data-countries="[&quot;CA&quot;,&quot;US&quot;]" id="phone_form_international_code">
-    <option data-supports-sms="true" data-supports-voice="true" data-country-code="1" data-country-name="United States" value="US">United States +1</option>
-    <option data-supports-sms="true" data-supports-voice="false" data-country-code="1" data-country-name="Canada" value="CA">Canada +1</option>
-    <option data-supports-sms="false" data-supports-voice="false" data-country-code="94" data-country-name="Sri Lanka" value="LK">Sri Lanka +94</option>
-  </select>`;
-
-const SINGLE_OPTION_HTML = `
-  <select class="phone-input__international-code" data-countries="[&quot;US&quot;]" id="phone_form_international_code">
-    <option data-supports-sms="true" data-supports-voice="true" data-country-code="1" data-country-name="United States" value="US">United States +1</option>
-  </select>`;
-
-const SINGLE_OPTION_SELECT_NON_US_HTML = `
-  <select class="phone-input__international-code" data-countries="[&quot;CA&quot;]" id="phone_form_international_code">
-    <option data-supports-sms="true" data-supports-voice="false" data-country-code="1" data-country-name="Canada" value="CA">Canada +1</option>
-  </select>`;
-
 describe('PhoneInput', () => {
   const sandbox = useSandbox();
 
@@ -35,13 +18,10 @@ describe('PhoneInput', () => {
   });
 
   function createAndConnectElement({
-    isUSSingleOption = false,
-    isInternationalSingleOption = false,
     deliveryMethods = ['sms', 'voice'],
     translatedCountryCodeNames = {},
     phoneInputValue = undefined,
   }: {
-    isUSSingleOption?: boolean;
     isInternationalSingleOption?: Boolean;
     deliveryMethods?: string[];
     translatedCountryCodeNames?: Record<string, string>;
@@ -74,9 +54,11 @@ describe('PhoneInput', () => {
       </script>
       <div class="phone-input__international-code-wrapper">
         <label class="usa-label" for="phone_form_international_code">Country code</label>
-        ${isUSSingleOption ? SINGLE_OPTION_HTML : ''}
-        ${isInternationalSingleOption ? SINGLE_OPTION_SELECT_NON_US_HTML : ''}
-        ${!isUSSingleOption && !isInternationalSingleOption ? MULTIPLE_OPTIONS_HTML : ''}
+        <select class="phone-input__international-code" data-countries="[&quot;CA&quot;,&quot;US&quot;]" id="phone_form_international_code">
+          <option data-supports-sms="true" data-supports-voice="true" data-country-code="1" data-country-name="United States" value="US">United States +1</option>
+          <option data-supports-sms="true" data-supports-voice="false" data-country-code="1" data-country-name="Canada" value="CA">Canada +1</option>
+          <option data-supports-sms="false" data-supports-voice="false" data-country-code="94" data-country-name="Sri Lanka" value="LK">Sri Lanka +94</option>
+        </select>
       </div>
       <label class="usa-label" for="phone_form_phone">Phone number</label>
       <lg-validated-field>
@@ -93,12 +75,6 @@ describe('PhoneInput', () => {
 
     return element;
   }
-
-  it('initializes with dropdown', () => {
-    const input = createAndConnectElement();
-
-    expect(input.querySelector('.iti.iti--allow-dropdown')).to.be.ok();
-  });
 
   context('with US phone number', () => {
     it('validates input', async () => {
@@ -238,25 +214,6 @@ describe('PhoneInput', () => {
     expect(name).to.equal('Country code');
     expect(value).to.equal('United States: +1');
     expect(controlled).to.equal(listbox);
-  });
-
-  context('with single option', () => {
-    it('initializes without dropdown', () => {
-      const input = createAndConnectElement({ isUSSingleOption: true });
-
-      expect(input.querySelector('.iti:not(.iti--allow-dropdown)')).to.be.ok();
-    });
-
-    it('validates phone from region', async () => {
-      const input = createAndConnectElement({ isInternationalSingleOption: true });
-
-      const phoneNumber = getByLabelText(input, 'Phone number') as HTMLInputElement;
-
-      await userEvent.type(phoneNumber, '5135551234');
-      expect(phoneNumber.validationMessage).to.equal(
-        'Enter a phone number with the correct number of digits.',
-      );
-    });
   });
 
   context('with constrained delivery options', () => {

--- a/app/javascript/packages/phone-input/index.ts
+++ b/app/javascript/packages/phone-input/index.ts
@@ -106,10 +106,6 @@ export class PhoneInputElement extends HTMLElement {
     return this.iti.selectedFlag.querySelector('.usa-sr-only')!;
   }
 
-  get hasDropdown(): boolean {
-    return Boolean(this.supportedCountryCodes && this.supportedCountryCodes.length > 1);
-  }
-
   /**
    * Logs an event when the country code has been changed.
    */
@@ -127,12 +123,10 @@ export class PhoneInputElement extends HTMLElement {
     const countryCode = this.getSelectedCountryCode();
     if (countryCode) {
       this.codeInput.value = countryCode;
-      if (this.hasDropdown) {
-        // Move value text from title attribute to the flag's hidden text element.
-        // See: https://github.com/jackocnr/intl-tel-input/blob/d54b127/src/js/intlTelInput.js#L1191-L1197
-        this.valueText.textContent = this.iti.selectedFlag.title;
-        this.iti.selectedFlag.removeAttribute('title');
-      }
+      // Move value text from title attribute to the flag's hidden text element.
+      // See: https://github.com/jackocnr/intl-tel-input/blob/d54b127/src/js/intlTelInput.js#L1191-L1197
+      this.valueText.textContent = this.iti.selectedFlag.title;
+      this.iti.selectedFlag.removeAttribute('title');
       if (fireChangeEvent) {
         this.codeInput.dispatchEvent(new CustomEvent('change', { bubbles: true }));
       }
@@ -148,32 +142,29 @@ export class PhoneInputElement extends HTMLElement {
       localizedCountries: countryCodePairs,
       onlyCountries: supportedCountryCodes,
       autoPlaceholder: 'off',
-      allowDropdown: this.hasDropdown,
     }) as IntlTelInput;
 
     this.iti = iti;
 
-    if (this.hasDropdown) {
-      // Remove duplicate items in the country list
-      const preferred: NodeListOf<HTMLLIElement> =
-        iti.countryList.querySelectorAll('.iti__preferred');
-      preferred.forEach((listItem) => {
-        const { countryCode } = listItem.dataset;
-        const duplicates: NodeListOf<HTMLLIElement> = iti.countryList.querySelectorAll(
-          `.iti__standard[data-country-code="${countryCode}"]`,
-        );
-        duplicates.forEach((duplicateListItem) => {
-          duplicateListItem.parentNode?.removeChild(duplicateListItem);
-        });
+    // Remove duplicate items in the country list
+    const preferred: NodeListOf<HTMLLIElement> =
+      iti.countryList.querySelectorAll('.iti__preferred');
+    preferred.forEach((listItem) => {
+      const { countryCode } = listItem.dataset;
+      const duplicates: NodeListOf<HTMLLIElement> = iti.countryList.querySelectorAll(
+        `.iti__standard[data-country-code="${countryCode}"]`,
+      );
+      duplicates.forEach((duplicateListItem) => {
+        duplicateListItem.parentNode?.removeChild(duplicateListItem);
       });
+    });
 
-      // Improve base accessibility of intl-tel-input
-      const valueText = document.createElement('div');
-      valueText.classList.add('usa-sr-only');
-      iti.selectedFlag.appendChild(valueText);
-      iti.selectedFlag.setAttribute('aria-label', this.strings.country_code_label);
-      iti.selectedFlag.removeAttribute('aria-owns');
-    }
+    // Improve base accessibility of intl-tel-input
+    const valueText = document.createElement('div');
+    valueText.classList.add('usa-sr-only');
+    iti.selectedFlag.appendChild(valueText);
+    iti.selectedFlag.setAttribute('aria-label', this.strings.country_code_label);
+    iti.selectedFlag.removeAttribute('aria-owns');
 
     this.syncCountryToCodeInput({ fireChangeEvent: false });
 

--- a/spec/components/previews/phone_input_component_preview.rb
+++ b/spec/components/previews/phone_input_component_preview.rb
@@ -8,10 +8,6 @@ class PhoneInputComponentPreview < BaseComponentPreview
   def limited_country_selection
     render(PhoneInputComponent.new(form: form_builder, allowed_countries: ['US', 'CA', 'FR']))
   end
-
-  def single_country_selection
-    render(PhoneInputComponent.new(form: form_builder, allowed_countries: ['US']))
-  end
   # @!endgroup
 
   # @display form true


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-14382](https://cm-jira.usa.gov/browse/LG-14382)

## 🛠 Summary of changes

Updates `PhoneInputComponent` to remove special consideration for a case where only a single country is supported, which would avoid rendering country list as a dropdown selector.

This was originally added in #5619, specifically for IdV phone verification step. At the time, we only accepted U.S. phone numbers for phone verification. This has since been expanded to support U.S. territories. Therefore, we don't currently use this functionality at all in the application.

These changes facilitate the work being done in #11257, where the single country variant does not work as expected after the upgrade.

Easier to review with whitespace changes hidden: https://github.com/18F/identity-idp/pull/11260/files?w=1

## 📜 Testing Plan

1. Go to http://localhost:3000/components/inspect/phone_input/workbench
2. Observe no regressions in the behavior of phone input component
3. Go to http://localhost:3000/components/inspect/phone_input/workbench?allowed_countries=US
4. Observe that the phone input component still works even if we only had one option, it just isn't an especially optimized experience