### PR TITLE
Fix flaky `RECAPTCHA_SIGN_IN` A/B test

### DIFF
--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -78,7 +78,7 @@ module AbTests
     elsif user
       user.uuid
     else
-      SecureRandom.alphanumeric(1)
+      SecureRandom.alphanumeric(8)
     end
   end.freeze
 end

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -78,7 +78,7 @@ module AbTests
     elsif user
       user.uuid
     else
-      SecureRandom.gen_random(1)
+      SecureRandom.alphanumeric(1)
     end
   end.freeze
 end


### PR DESCRIPTION
The `RECAPTCHA_SIGN_IN` A/B test has a discriminator block that does the following:

1. Return `nil` if captcha was not performed
2. Return the user's UUID if the user is present
3. Return a random value if no user is present with the intent of sorting them into a bucket

The implementation of `AbTest#bucket` checks if the discriminator resolved by this discriminator block is blank and returns `nil` if it is ([ref](https://github.com/18F/identity-idp/blob/983e21648dc7695f11c37e3eff7997ef4bd90f1e/lib/ab_test.rb#L46)).

The `blank?` method has a special implementation for `String` ([ref](https://github.com/rails/rails/blob/dfd1e951aa1aeef06c39fffb2994db8a8fa1914f/activesupport/lib/active_support/core_ext/object/blank.rb#L141-L163)) that returns `true` if the string consists of only whitespace.

The random value here was generated using `SecureRandom.gen_random`. This value was then used in the `AbTest#bucket` to randomly sort unidentified users into AB test buckets. `SecureRandom.gen_random` returns a string of random bytes which can include `" "`, `"\n"`, `"\r"`, etc.

The combination of the above meant that the discriminator could generate a value that caused the `AbTest#bucket` to return `nil` for `RECAPTCHA_SIGN_IN` when it was intended to return a bucket. This lead to a flaky test ([this spec](https://github.com/18F/identity-idp/blob/983e21648dc7695f11c37e3eff7997ef4bd90f1e/spec/config/initializers/ab_tests_spec.rb#L197-L203) tests that the bucket is not nil; it is nil in the case where `SecureRandom.gen_random` returns a blank string).

This commit changes the call to `SecureRandom` so that it only ever generates alphanumeric strings which will never be blank.
