### PR TITLE
Fix flaky spec on the welcome controller

### DIFF
--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -78,9 +78,7 @@ RSpec.describe Idv::WelcomeController do
       end
 
       it 'does not overwrite the proofing started timestamp' do
-        get :show
-
-        expect(subject.idv_session.proofing_started_at).to eq(5.minutes.ago.iso8601)
+        expect { get :show }.to_not change { subject.idv_session.proofing_started_at }
       end
 
       context 'and verify info already completed' do


### PR DESCRIPTION
The welcome controller had a test that checked that something matched a timestamp. This test failed when the clock advanced before we ran our expectation. This commit changes the test to expect the value to not change which is what we really intend to test.
