### PR TITLE
Stop logging the year of birth in proofing results

### DIFF
--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -123,7 +123,6 @@ module Proofing
                                      StringRedacter.redact_alphanumeric(state_id_number)
                                    end
         {
-          birth_year: applicant_pii[:dob]&.to_date&.year,
           state: applicant_pii[:state],
           identity_doc_address_state: applicant_pii[:identity_doc_address_state],
           state_id_jurisdiction: applicant_pii[:state_id_jurisdiction],

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -108,7 +108,6 @@ RSpec.feature 'Analytics Regression', :js do
         },
       },
       biographical_info: {
-        birth_year: 1938,
         identity_doc_address_state: nil,
         same_address_as_id: nil,
         state: 'MT',
@@ -146,7 +145,6 @@ RSpec.feature 'Analytics Regression', :js do
         },
       },
       biographical_info: {
-        birth_year: 1938,
         identity_doc_address_state: 'ND',
         same_address_as_id: 'false',
         state: 'MT',

--- a/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
+++ b/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe SocureShadowModeProofingJob do
           },
         },
         biographical_info: {
-          birth_year: 1938,
           identity_doc_address_state: nil,
           same_address_as_id: nil,
           state: 'MT',
@@ -259,7 +258,6 @@ RSpec.describe SocureShadowModeProofingJob do
             threatmetrix_review_status: 'pass',
             timed_out: false,
             biographical_info: {
-              birth_year: 1938,
               identity_doc_address_state: nil,
               same_address_as_id: nil,
               state: 'MT',

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -102,7 +102,6 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
           result = subject.adjudicated_result
 
           expect(result.extra[:biographical_info]).to eq(
-            birth_year: 1938,
             state: 'MT',
             identity_doc_address_state: nil,
             state_id_jurisdiction: 'ND',
@@ -119,7 +118,6 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
           result = subject.adjudicated_result
 
           expect(result.extra[:biographical_info]).to eq(
-            birth_year: 1938,
             state: 'MT',
             identity_doc_address_state: 'MT',
             state_id_jurisdiction: 'ND',


### PR DESCRIPTION
This commit removes the birth year from the logged biographical info in the proofing results. We are walking this back while we do some additional work with privacy to describe this.
