### PR TITLE
LG-14492 Accept a string in the ipp helper scrub method

### DIFF
--- a/app/helpers/ipp_helper.rb
+++ b/app/helpers/ipp_helper.rb
@@ -8,8 +8,12 @@ module IppHelper
   def scrub_body(body)
     return nil if body.nil?
 
-    body = body.with_indifferent_access
-    body[:responseMessage] = scrub_message(body[:responseMessage])
-    body
+    if body.is_a?(String)
+      scrub_message(body)
+    else
+      body = body.with_indifferent_access
+      body[:responseMessage] = scrub_message(body[:responseMessage])
+      body
+    end
   end
 end

--- a/spec/helpers/ipp_helper_spec.rb
+++ b/spec/helpers/ipp_helper_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe IppHelper do
+  include IppHelper
+
+  describe '#scrub_body' do
+    let(:message) { "This is a test message with sponsorID #{sponsor_id}" }
+    let(:sponsor_id) { 1111111 }
+
+    context 'when body is a String' do
+      it 'scrubs the sponsorID from the message' do
+        expect(scrub_body(message)).to eq("This is a test message with sponsorID [FILTERED]")
+      end
+    end
+
+    context 'when body is a Hash' do
+      it 'scrubs the responseMessage' do
+        body = { responseMessage: message }
+        expect(scrub_body(body)).to eq("responseMessage" => "This is a test message with sponsorID [FILTERED]")
+      end
+    end
+
+    context 'when body is nil' do
+      it 'returns nil' do
+        expect(scrub_body(nil)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/helpers/ipp_helper_spec.rb
+++ b/spec/helpers/ipp_helper_spec.rb
@@ -9,14 +9,16 @@ RSpec.describe IppHelper do
 
     context 'when body is a String' do
       it 'scrubs the sponsorID from the message' do
-        expect(scrub_body(message)).to eq("This is a test message with sponsorID [FILTERED]")
+        expect(scrub_body(message)).to eq('This is a test message with sponsorID [FILTERED]')
       end
     end
 
     context 'when body is a Hash' do
       it 'scrubs the responseMessage' do
         body = { responseMessage: message }
-        expect(scrub_body(body)).to eq("responseMessage" => "This is a test message with sponsorID [FILTERED]")
+        expect(scrub_body(body)).to eq(
+          'responseMessage' => 'This is a test message with sponsorID [FILTERED]',
+        )
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14492](https://cm-jira.usa.gov/browse/LG-14492)



## 🛠 Summary of changes

Errors in NewRelic revealed that some USPS exceptions include a response body with a String instead of a hash, but we were assuming the body would be a hash in our method to scrub it for sponsor ID, causing the error `undefined method 'with_indifferent_access'  for instance of a String`.

This accepts a String and still ensures that it is scrubbed of a sponsor ID.



## 📜 Testing Plan

- [ ] Automated tests pass

