### PR TITLE
Update google-protobuf

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -466,7 +466,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
-    pg_query (4.2.3)
+    pg_query (5.1.0)
       google-protobuf (>= 3.22.3)
     phonelib (0.9.1)
     pkcs11 (0.3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,9 @@ GEM
       fugit (>= 1.1)
       railties (>= 6.0.0)
       thor (>= 0.14.1)
-    google-protobuf (3.24.4)
+    google-protobuf (4.28.2)
+      bigdecimal
+      rake (>= 13)
     hashdiff (1.1.0)
     heapy (0.2.0)
       thor


### PR DESCRIPTION
Updates google-protobuf to address a [security advisory](https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-735f-pc8j-v9w8). This only affects the JRuby version, so we should not be directly vulnerable to this.

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
