### PR TITLE
Add NewRelic method tracers to the AbTest bucket tooling

### DIFF
--- a/lib/ab_test.rb
+++ b/lib/ab_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AbTest
+  include ::NewRelic::Agent::MethodTracer
+
   attr_reader :buckets, :experiment_name, :default_bucket, :should_log
 
   MAX_SHA = (16 ** 64) - 1
@@ -106,4 +108,7 @@ class AbTest
   def within_100_percent?
     valid_bucket_data_structure? && buckets.values.sum <= 100
   end
+
+  add_method_tracer :bucket, "Custom/#{name}/bucket"
+  add_method_tracer :percent, "Custom/#{name}/percent"
 end


### PR DESCRIPTION
We are considering using a different hash algorithm for the `AbTest#bucket` method.  We expect a different hashing algorithm to give us better performance which could be a meaningful bump considering how much we call the `#bucket` method every request.

This commit lays some groundwork by adding method tracers to the impacted methods. This will allow us to assess the impact this change could have.
