### PR TITLE
Fix `NoMethodError` in `UspsLocationsController`

### DIFF
--- a/app/helpers/ipp_helper.rb
+++ b/app/helpers/ipp_helper.rb
@@ -9,7 +9,9 @@ module IppHelper
     return nil if body.nil?
 
     body = body.with_indifferent_access
-    body[:responseMessage] = scrub_message(body[:responseMessage])
+    if body[:responseMessage].present?
+      body[:responseMessage] = scrub_message(body[:responseMessage])
+    end
     body
   end
 end

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -324,6 +324,35 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
         expect(status).to eq 422
       end
     end
+
+    context 'with 400 error without a response message' do
+      let(:response_message) { 'SponsorID 57 is not registered as an IPP client' }
+      let(:response_body) { { differentMessage: 'Something else is wrong' } }
+      let(:error_response) { { body: response_body, status: 400 } }
+      let(:sponsor_id_error) { Faraday::BadRequestError.new(response_message, error_response) }
+      let(:filtered_message) { 'sponsorID [FILTERED] is not registered as an IPP client' }
+
+      before do
+        allow(proofer).to receive(:request_facilities).and_raise(sponsor_id_error)
+      end
+
+      it 'returns an unprocessible entity client error with scrubbed analytics event' do
+        subject
+
+        expect(@analytics).to have_logged_event(
+          'Request USPS IPP locations: request failed',
+          api_status_code: 422,
+          exception_class: sponsor_id_error.class,
+          exception_message: filtered_message,
+          response_body_present: true,
+          response_body: response_body,
+          response_status_code: 400,
+        )
+
+        status = response.status
+        expect(status).to eq 422
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
The `UspsLocationsController` is used to search for USPS locations where the user can go to do in-person proofing. This action involves making a request to a USPS API that occasionally errors. We have a method for scrubbing the sponsor ID from the message to avoid exposing it in logs.

The method for scrubbing the sponsor ID assumed that the sponsor ID would be present under a property named `responseMessage`. We have observed some errors where the `responseMessage` property is not present. This leads to a `NoMethodError` when we try to scrub the sponsor ID from nil.

This commit adds a condition to avoid the error case above.
