### PR TITLE
Refactor + clean up AAMVA proofer

### DIFF
--- a/app/services/proofing/aamva/response/verification_response.rb
+++ b/app/services/proofing/aamva/response/verification_response.rb
@@ -22,13 +22,6 @@ module Proofing
           'AddressZIP5MatchIndicator' => :zipcode,
         }.freeze
 
-        REQUIRED_VERIFICATION_ATTRIBUTES = %i[
-          state_id_number
-          dob
-          last_name
-          first_name
-        ].freeze
-
         attr_reader :verification_results, :transaction_locator_id
 
         def initialize(http_response)
@@ -46,14 +39,6 @@ module Proofing
 
           error_message = @errors.join('; ')
           raise VerificationError.new(error_message)
-        end
-
-        def success?
-          REQUIRED_VERIFICATION_ATTRIBUTES.each do |verification_attribute|
-            return false unless verification_results[verification_attribute]
-          end
-
-          true
         end
 
         private

--- a/app/services/proofing/aamva/response/verification_response.rb
+++ b/app/services/proofing/aamva/response/verification_response.rb
@@ -48,18 +48,6 @@ module Proofing
           raise VerificationError.new(error_message)
         end
 
-        def reasons
-          REQUIRED_VERIFICATION_ATTRIBUTES.map do |verification_attribute|
-            verification_result = verification_results[verification_attribute]
-            case verification_result
-            when false
-              "Failed to verify #{verification_attribute}"
-            when nil
-              "Response was missing #{verification_attribute}"
-            end
-          end.compact
-        end
-
         def success?
           REQUIRED_VERIFICATION_ATTRIBUTES.each do |verification_attribute|
             return false unless verification_results[verification_attribute]

--- a/spec/fixtures/proofing/aamva/responses/verification_response_namespaced_success.xml
+++ b/spec/fixtures/proofing/aamva/responses/verification_response_namespaced_success.xml
@@ -16,6 +16,7 @@
           </MessageAddress>
         </ControlData>
         <DriverLicenseNumberMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">true</DriverLicenseNumberMatchIndicator>
+        <DocumentCategoryMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">true</DocumentCategoryMatchIndicator>
         <PersonBirthDateMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">true</PersonBirthDateMatchIndicator>
         <PersonLastNameExactMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">true</PersonLastNameExactMatchIndicator>
         <PersonFirstNameExactMatchIndicator xmlns="http://aamva.org/niem/extensions/1.0">true</PersonFirstNameExactMatchIndicator>

--- a/spec/services/proofing/aamva/request/verification_request_spec.rb
+++ b/spec/services/proofing/aamva/request/verification_request_spec.rb
@@ -113,9 +113,9 @@ RSpec.describe Proofing::Aamva::Request::VerificationRequest do
         stub_request(:post, config.verification_url).
           to_return(body: AamvaFixtures.verification_response, status: 200)
 
-        result = subject.send
+        response = subject.send
 
-        expect(result.success?).to eq(true)
+        expect(response).to be_an_instance_of(Proofing::Aamva::Response::VerificationResponse)
       end
 
       it 'sends state id jurisdiction to AAMVA' do

--- a/spec/services/proofing/aamva/response/verification_response_spec.rb
+++ b/spec/services/proofing/aamva/response/verification_response_spec.rb
@@ -68,69 +68,6 @@ RSpec.describe Proofing::Aamva::Response::VerificationResponse do
     end
   end
 
-  describe '#reasons' do
-    context 'when all attributes are verified' do
-      it 'returns an empty array' do
-        expect(subject.reasons).to eq([])
-      end
-
-      context 'with a namespaced XML body' do
-        let(:response_body) { AamvaFixtures.verification_response_namespaced_success }
-
-        it 'returns an empty array' do
-          expect(subject.reasons).to eq([])
-        end
-      end
-    end
-
-    context 'when required attributes are verified' do
-      let(:response_body) do
-        modify_match_indicator(
-          AamvaFixtures.verification_response,
-          'PersonLastNameFuzzyPrimaryMatchIndicator',
-          'false',
-        )
-      end
-
-      it 'returns an empty array' do
-        expect(subject.reasons).to eq([])
-      end
-    end
-
-    context 'when required attributes are not verified' do
-      let(:response_body) do
-        body = modify_match_indicator(
-          AamvaFixtures.verification_response,
-          'PersonBirthDateMatchIndicator',
-          'false',
-        )
-        delete_match_indicator(
-          body,
-          'PersonFirstNameExactMatchIndicator',
-        )
-      end
-
-      it 'returns an array with the reasons verification failed' do
-        expect(subject.reasons).to eq(['Failed to verify dob', 'Response was missing first_name'])
-      end
-
-      context 'with a namespaced XML response' do
-        let(:response_body) { AamvaFixtures.verification_response_namespaced_failure }
-
-        it 'returns an array with the reasons verification failed' do
-          expect(subject.reasons).to eq(
-            [
-              'Failed to verify state_id_number',
-              'Response was missing dob',
-              'Response was missing last_name',
-              'Response was missing first_name',
-            ],
-          )
-        end
-      end
-    end
-  end
-
   describe '#success?' do
     context 'when all attributes are verified' do
       it { expect(subject.success?).to eq(true) }

--- a/spec/services/proofing/aamva/response/verification_response_spec.rb
+++ b/spec/services/proofing/aamva/response/verification_response_spec.rb
@@ -101,29 +101,6 @@ RSpec.describe Proofing::Aamva::Response::VerificationResponse do
         expect(subject.verification_results).to eq(expected_result)
       end
     end
-
-    context 'when required attributes are not verified' do
-      let(:response_body) do
-        modify_match_indicator(
-          AamvaFixtures.verification_response,
-          'PersonBirthDateMatchIndicator',
-          'false',
-        )
-      end
-
-      it { expect(subject.success?).to eq(false) }
-    end
-
-    context 'when required attributes are missing' do
-      let(:response_body) do
-        delete_match_indicator(
-          AamvaFixtures.verification_response,
-          'PersonBirthDateMatchIndicator',
-        )
-      end
-
-      it { expect(subject.success?).to eq(false) }
-    end
   end
 
   describe '#transaction_locator_id' do

--- a/spec/services/proofing/aamva/verification_client_spec.rb
+++ b/spec/services/proofing/aamva/verification_client_spec.rb
@@ -59,7 +59,22 @@ RSpec.describe Proofing::Aamva::VerificationClient do
     context 'when verification is successful' do
       it 'returns a successful response' do
         expect(response).to be_a Proofing::Aamva::Response::VerificationResponse
-        expect(response.success?).to eq(true)
+        expect(response.verification_results).to eq(
+          {
+            address1: true,
+            address2: nil,
+            city: true,
+            dob: true,
+            first_name: true,
+            last_name: true,
+            state: true,
+            state_id_expiration: nil,
+            state_id_issued: nil,
+            state_id_number: true,
+            state_id_type: true,
+            zipcode: true,
+          },
+        )
       end
     end
 
@@ -75,7 +90,22 @@ RSpec.describe Proofing::Aamva::VerificationClient do
 
         it 'returns an unsuccessful response with errors' do
           expect(response).to be_a Proofing::Aamva::Response::VerificationResponse
-          expect(response.success?).to eq(false)
+          expect(response.verification_results).to eq(
+            {
+              address1: true,
+              address2: nil,
+              city: true,
+              dob: false,
+              first_name: true,
+              last_name: true,
+              state: true,
+              state_id_expiration: nil,
+              state_id_issued: nil,
+              state_id_number: true,
+              state_id_type: true,
+              zipcode: true,
+            },
+          )
         end
       end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Supports work for [LG-14546](https://cm-jira.usa.gov/browse/LG-14546)

## 🛠 Summary of changes

This PR:

* Removes the `Proofing::Aamva::Response::VerificationResponse#reasons` method, which did not appear to be referenced anywhere.
* Moves `Proofing::Aamva::Response::VerificationResponse#success?` to the `Proofer` class

The idea here is that the proofer should be responsible for determining whether something succeeded rather than the response.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
