### PR TITLE
LG-14546: Require AAMVA verification of expiration dates

### DIFF
--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -28,6 +28,8 @@ module Proofing
         first_name
       ].freeze
 
+      REQUIRED_IF_PRESENT_ATTRIBUTES = [:state_id_expiration].freeze
+
       ADDRESS_ATTRIBUTES = [
         :address1,
         :address2,
@@ -132,6 +134,11 @@ module Proofing
       def successful?(verification_response)
         REQUIRED_VERIFICATION_ATTRIBUTES.each do |verification_attribute|
           return false unless verification_response.verification_results[verification_attribute]
+        end
+
+        REQUIRED_IF_PRESENT_ATTRIBUTES.each do |verification_attribute|
+          value = verification_response.verification_results[verification_attribute]
+          return false unless value.nil? || value == true
         end
 
         true

--- a/spec/services/proofing/aamva/proofer_spec.rb
+++ b/spec/services/proofing/aamva/proofer_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe Proofing::Aamva::Proofer do
         let(:match_indicator_name) { 'DriverLicenseExpirationDateMatchIndicator' }
 
         when_unverified do
-          test_still_successful
+          test_not_successful
           test_in_requested_attributes
           test_not_in_verified_attributes
         end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14546](https://cm-jira.usa.gov/browse/LG-14546)


## 🛠 Summary of changes

Updates the AAMVA proofer to require that `state_id_expiration` be verified with AAMVA for a result to be considered successful.

This requirement is applied only when the expiration date is present.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
