### PR TITLE
Increase DB query timeout in Duplicate SSN Report

### DIFF
--- a/app/jobs/reports/duplicate_ssn_report.rb
+++ b/app/jobs/reports/duplicate_ssn_report.rb
@@ -38,10 +38,12 @@ module Reports
 
       ssn_signatures = todays_profiles.map(&:ssn_signature).uniq
 
-      profiles_connected_by_ssn = Profile.
-        includes(:user).
-        where(ssn_signature: ssn_signatures).
-        to_a
+      profiles_connected_by_ssn = transaction_with_timeout do
+        Profile.
+          includes(:user).
+          where(ssn_signature: ssn_signatures).
+          to_a
+      end
 
       profiles_connected_by_ssn.sort_by!(&:id).reverse!
 

--- a/app/jobs/reports/duplicate_ssn_report.rb
+++ b/app/jobs/reports/duplicate_ssn_report.rb
@@ -38,10 +38,10 @@ module Reports
 
       ssn_signatures = todays_profiles.map(&:ssn_signature).uniq
 
-      profiles_connected_by_ssn = transaction_with_timeout do
+      profiles_connected_by_ssn = ssn_signatures.each_slice(1000).flat_map do |ssn_signature_slice|
         Profile.
           includes(:user).
-          where(ssn_signature: ssn_signatures).
+          where(ssn_signature: ssn_signature_slice).
           to_a
       end
 


### PR DESCRIPTION
- Follow-up, similar to #9818

I checked NewRelic and noticed that the Duplicate SSN report had timed out [(NewRelic link)](https://onenr.io/0KQXrBDG8Ra). Looks like the report has timed out often over the last few weeks.
