### PR TITLE
Fix 404 Error on PO Search Page for IPP Flow

### DIFF
--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -15,7 +15,6 @@ import {
 import { isCameraCapableMobile } from '@18f/identity-device';
 import { FlowContext } from '@18f/identity-verify-flow';
 import { trackEvent as baseTrackEvent } from '@18f/identity-analytics';
-import { extendSession } from '@18f/identity-session';
 import type { FlowPath, DeviceContextValue } from '@18f/identity-document-capture';
 
 /**
@@ -202,12 +201,7 @@ const App = composeComponents(
       maxSubmissionAttemptsBeforeNativeCamera: Number(maxSubmissionAttemptsBeforeNativeCamera),
     },
   ],
-  [
-    DocumentCapture,
-    {
-      onStepChange: extendSession,
-    },
-  ],
+  [DocumentCapture],
 );
 
 render(<App />, appRoot);


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14545](https://cm-jira.usa.gov/browse/LG-14545)

## 🛠 Summary of changes

On the PO search page for the IPP flow, the `extendSession` callback was being called without a `sessionURL` being provided. This is due to the IPP flow being almost entirely in Ruby and not having a current session on the React side of things.

This change conditionally adds the `extendSession` callback only if the flow is not Opt In IPP.

This issue is also not happening in the Help Center so there is no separate ticket for that work as per the AC.

## 📜 Testing Plan

- [ ] Step 1: Login or create a new account via the Sinatra app and begin IPP flow
- [ ] Step 2: Confirm that there is no 404 error in the network tab/console on the PO Search page