### PR TITLE
LG-13462 Log the Threatmetrix response body in its own event

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -207,7 +207,7 @@ module Idv
         :proofing_results, :context, :stages, :threatmetrix, :response_body
       )
       if threatmetrix_reponse_body.present?
-        analytics.idv_doc_auth_verify_threatmetrix_response_body(
+        analytics.idv_threatmetrix_response_body(
           response_body: threatmetrix_reponse_body,
         )
       end

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -203,6 +203,15 @@ module Idv
         },
       )
 
+      threatmetrix_reponse_body = form_response.extra.dig(
+        :proofing_results, :context, :stages, :threatmetrix, :response_body
+      )
+      if threatmetrix_reponse_body.present?
+        analytics.idv_doc_auth_verify_threatmetrix_response_body(
+          response_body: threatmetrix_reponse_body,
+        )
+      end
+
       summarize_result_and_rate_limit(form_response)
       delete_async
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2011,6 +2011,19 @@ module AnalyticsEvents
     )
   end
 
+  # The JSON body of the response returned from Threatmetrix. PII has been removed.
+  # @param [Hash] response_body The response body returned by ThreatMetrix
+  def idv_doc_auth_verify_threatmetrix_response_body(
+    response_body: nil,
+    **extra
+  )
+    track_event(
+      :idv_doc_auth_verify_threatmetrix_response_body,
+      response_body: response_body,
+      **extra,
+    )
+  end
+
   # User visits IdV verify step
   # @identity.idp.previous_event_name IdV: in person proofing verify visited
   # @param [String] step Current IdV step

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2013,12 +2013,12 @@ module AnalyticsEvents
 
   # The JSON body of the response returned from Threatmetrix. PII has been removed.
   # @param [Hash] response_body The response body returned by ThreatMetrix
-  def idv_doc_auth_verify_threatmetrix_response_body(
+  def idv_threatmetrix_response_body(
     response_body: nil,
     **extra
   )
     track_event(
-      :idv_doc_auth_verify_threatmetrix_response_body,
+      :idv_threatmetrix_response_body,
       response_body: response_body,
       **extra,
     )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2011,19 +2011,6 @@ module AnalyticsEvents
     )
   end
 
-  # The JSON body of the response returned from Threatmetrix. PII has been removed.
-  # @param [Hash] response_body The response body returned by ThreatMetrix
-  def idv_threatmetrix_response_body(
-    response_body: nil,
-    **extra
-  )
-    track_event(
-      :idv_threatmetrix_response_body,
-      response_body: response_body,
-      **extra,
-    )
-  end
-
   # User visits IdV verify step
   # @identity.idp.previous_event_name IdV: in person proofing verify visited
   # @param [String] step Current IdV step
@@ -4666,6 +4653,19 @@ module AnalyticsEvents
       active_profile_idv_level: active_profile_idv_level,
       pending_profile_idv_level: pending_profile_idv_level,
       profile_history: profile_history,
+      **extra,
+    )
+  end
+
+  # The JSON body of the response returned from Threatmetrix. PII has been removed.
+  # @param [Hash] response_body The response body returned by ThreatMetrix
+  def idv_threatmetrix_response_body(
+    response_body: nil,
+    **extra
+  )
+    track_event(
+      :idv_threatmetrix_response_body,
+      response_body: response_body,
       **extra,
     )
   end

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -33,7 +33,6 @@ module Idv
       idv_doc_auth_submitted_image_upload_vendor
       idv_doc_auth_submitted_pii_validation
       idv_doc_auth_verify_proofing_results
-      idv_threatmetrix_response_body
       idv_doc_auth_verify_submitted
       idv_doc_auth_verify_visited
       idv_doc_auth_warning_visited
@@ -99,6 +98,7 @@ module Idv
       idv_sdk_selfie_image_capture_opened
       idv_selfie_image_added
       idv_session_error_visited
+      idv_threatmetrix_response_body
       idv_usps_auth_token_refresh_job_completed
       idv_usps_auth_token_refresh_job_network_error
       idv_usps_auth_token_refresh_job_started

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -33,7 +33,7 @@ module Idv
       idv_doc_auth_submitted_image_upload_vendor
       idv_doc_auth_submitted_pii_validation
       idv_doc_auth_verify_proofing_results
-      idv_doc_auth_verify_threatmetrix_response_body
+      idv_threatmetrix_response_body
       idv_doc_auth_verify_submitted
       idv_doc_auth_verify_visited
       idv_doc_auth_warning_visited

--- a/app/services/idv/analytics_events_enhancer.rb
+++ b/app/services/idv/analytics_events_enhancer.rb
@@ -33,6 +33,7 @@ module Idv
       idv_doc_auth_submitted_image_upload_vendor
       idv_doc_auth_submitted_pii_validation
       idv_doc_auth_verify_proofing_results
+      idv_doc_auth_verify_threatmetrix_response_body
       idv_doc_auth_verify_submitted
       idv_doc_auth_verify_visited
       idv_doc_auth_warning_visited

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
           ),
         )
         expect(@analytics).to have_logged_event(
-          :idv_doc_auth_verify_threatmetrix_response_body,
+          :idv_threatmetrix_response_body,
           response_body: {
             session_id: 'threatmetrix_session_id',
             tmx_summary_reason_code: ['Identity_Negative_History'],

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
                 transaction_id: 1,
                 review_status: review_status,
                 response_body: {
+                  session_id: 'threatmetrix_session_id',
                   tmx_summary_reason_code: ['Identity_Negative_History'],
                 },
               },
@@ -136,6 +137,13 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
               same_address_as_id: true,
             },
           ),
+        )
+        expect(@analytics).to have_logged_event(
+          :idv_doc_auth_verify_threatmetrix_response_body,
+          response_body: {
+            session_id: 'threatmetrix_session_id',
+            tmx_summary_reason_code: ['Identity_Negative_History'],
+          },
         )
       end
     end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Idv::VerifyInfoController do
             ),
           )
           expect(@analytics).to have_logged_event(
-            :idv_doc_auth_verify_threatmetrix_response_body,
+            :idv_threatmetrix_response_body,
             response_body: hash_including(
               client: threatmetrix_client_id,
             ),

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -235,6 +235,12 @@ RSpec.describe Idv::VerifyInfoController do
               ),
             ),
           )
+          expect(@analytics).to have_logged_event(
+            :idv_doc_auth_verify_threatmetrix_response_body,
+            response_body: hash_including(
+              client: threatmetrix_client_id,
+            ),
+          )
         end
       end
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -10,21 +10,26 @@ RSpec.feature 'Analytics Regression', :js do
   let(:proofing_device_profiling) { :enabled }
   let(:threatmetrix) { true }
   let(:idv_level) { 'in_person' }
+  let(:threatmetrix_response_body) do
+    {
+      account_lex_id: 'super-cool-test-lex-id',
+      'fraudpoint.score': '500',
+      request_id: '1234',
+      request_result: 'success',
+      review_status: 'pass',
+      risk_rating: 'trusted',
+      session_id: 'super-cool-test-session-id',
+      summary_risk_score: '-6',
+      tmx_risk_rating: 'neutral',
+      tmx_summary_reason_code: ['Identity_Negative_History'],
+    }
+  end
   let(:threatmetrix_response) do
     {
       client: nil,
       errors: {},
       exception: nil,
-      response_body: { "fraudpoint.score": '500',
-                       request_id: '1234',
-                       request_result: 'success',
-                       account_lex_id: 'super-cool-test-lex-id',
-                       session_id: 'super-cool-test-session-id',
-                       review_status: 'pass',
-                       risk_rating: 'trusted',
-                       summary_risk_score: '-6',
-                       tmx_risk_rating: 'neutral',
-                       tmx_summary_reason_code: ['Identity_Negative_History'] },
+      response_body: threatmetrix_response_body,
       review_status: 'pass',
       account_lex_id: 'super-cool-test-lex-id',
       session_id: 'super-cool-test-session-id',
@@ -216,6 +221,11 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         flow_path: 'standard', step: 'verify', analytics_id: 'Doc Auth'
       },
+      idv_doc_auth_verify_threatmetrix_response_body: (
+        if threatmetrix_response_body.present?
+          { response_body: threatmetrix_response_body }
+        end
+      ),
       'IdV: doc auth verify proofing results' => {
         success: true, errors: {}, flow_path: 'standard', address_edited: false, address_line2_present: false, analytics_id: 'Doc Auth', step: 'verify',
         proofing_results: base_proofing_results
@@ -273,7 +283,7 @@ RSpec.feature 'Analytics Regression', :js do
         active_profile_idv_level: 'legacy_unsupervised',
         proofing_components: lexis_nexis_address_proofing_components
       },
-    }
+    }.compact
   end
 
   let(:happy_hybrid_path_events) do
@@ -331,6 +341,11 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         flow_path: 'hybrid', step: 'verify', analytics_id: 'Doc Auth'
       },
+      idv_doc_auth_verify_threatmetrix_response_body: (
+        if threatmetrix_response_body.present?
+          { response_body: threatmetrix_response_body }
+        end
+      ),
       'IdV: doc auth verify proofing results' => {
         success: true, errors: {}, flow_path: 'hybrid', address_edited: false, address_line2_present: false, analytics_id: 'Doc Auth', step: 'verify',
         proofing_results: base_proofing_results
@@ -388,7 +403,7 @@ RSpec.feature 'Analytics Regression', :js do
         active_profile_idv_level: 'legacy_unsupervised',
         proofing_components: lexis_nexis_address_proofing_components
       },
-    }
+    }.compact
   end
 
   let(:gpo_path_events) do
@@ -443,6 +458,11 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         flow_path: 'standard', step: 'verify', analytics_id: 'Doc Auth'
       },
+      idv_doc_auth_verify_threatmetrix_response_body: (
+        if threatmetrix_response_body.present?
+          { response_body: threatmetrix_response_body }
+        end
+      ),
       'IdV: doc auth verify proofing results' => {
         success: true, errors: {}, flow_path: 'standard', address_edited: false, address_line2_present: false, analytics_id: 'Doc Auth', step: 'verify',
         proofing_results: base_proofing_results
@@ -477,7 +497,7 @@ RSpec.feature 'Analytics Regression', :js do
         pending_profile_idv_level: 'legacy_unsupervised',
         proofing_components: gpo_letter_proofing_components,
       },
-    }
+    }.compact
   end
 
   let(:in_person_path_events) do
@@ -552,6 +572,11 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         analytics_id: 'In Person Proofing', step: 'verify', flow_path: 'standard', same_address_as_id: false
       },
+      idv_doc_auth_verify_threatmetrix_response_body: (
+        if threatmetrix_response_body.present?
+          { response_body: threatmetrix_response_body }
+        end
+      ),
       'IdV: doc auth verify proofing results' => {
         success: true, errors: {}, flow_path: 'standard', address_edited: false, address_line2_present: false, analytics_id: 'In Person Proofing', step: 'verify', same_address_as_id: false,
         proofing_results: in_person_path_proofing_results
@@ -609,7 +634,7 @@ RSpec.feature 'Analytics Regression', :js do
       },
       'IdV: user clicked what to bring link on ready to verify page' => {},
       'IdV: user clicked sp link on ready to verify page' => {},
-    }
+    }.compact
   end
 
   let(:happy_mobile_selfie_path_events) do
@@ -670,6 +695,11 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         flow_path: 'standard', step: 'verify', analytics_id: 'Doc Auth'
       },
+      idv_doc_auth_verify_threatmetrix_response_body: (
+        if threatmetrix_response_body.present?
+          { response_body: threatmetrix_response_body }
+        end
+      ),
       'IdV: doc auth verify proofing results' => {
         success: true, errors: {}, flow_path: 'standard', address_edited: false, address_line2_present: false, analytics_id: 'Doc Auth', step: 'verify',
         proofing_results: base_proofing_results
@@ -727,7 +757,7 @@ RSpec.feature 'Analytics Regression', :js do
         active_profile_idv_level: 'unsupervised_with_selfie',
         proofing_components: lexis_nexis_address_proofing_components
       },
-    }
+    }.compact
   end
   # rubocop:enable Layout/LineLength
   # rubocop:enable Layout/MultilineHashKeyLineBreaks
@@ -786,6 +816,7 @@ RSpec.feature 'Analytics Regression', :js do
     context 'proofing_device_profiling disabled' do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
+      let(:threatmetrix_response_body) { nil }
       let(:threatmetrix_response) do
         {
           client: 'tmx_disabled',
@@ -797,7 +828,7 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: nil,
+          response_body: threatmetrix_response_body,
         }
       end
 
@@ -866,6 +897,7 @@ RSpec.feature 'Analytics Regression', :js do
     context 'proofing_device_profiling disabled' do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
+      let(:threatmetrix_response_body) { nil }
       let(:threatmetrix_response) do
         {
           client: 'tmx_disabled',
@@ -877,7 +909,7 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: nil,
+          response_body: threatmetrix_response_body,
         }
       end
 
@@ -915,6 +947,7 @@ RSpec.feature 'Analytics Regression', :js do
     context 'proofing_device_profiling disabled' do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
+      let(:threatmetrix_response_body) { nil }
       let(:threatmetrix_response) do
         {
           client: 'tmx_disabled',
@@ -926,7 +959,7 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: nil,
+          response_body: threatmetrix_response_body,
         }
       end
 
@@ -976,6 +1009,7 @@ RSpec.feature 'Analytics Regression', :js do
       let(:proofing_device_profiling) { :disabled }
       let(:idv_level) { 'legacy_in_person' }
       let(:threatmetrix) { false }
+      let(:threatmetrix_response_body) { nil }
       let(:threatmetrix_response) do
         {
           client: 'tmx_disabled',
@@ -987,7 +1021,7 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: nil,
+          response_body: threatmetrix_response_body,
         }
       end
 
@@ -1047,6 +1081,7 @@ RSpec.feature 'Analytics Regression', :js do
     context 'proofing_device_profiling disabled' do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
+      let(:threatmetrix_response_body) { nil }
       let(:threatmetrix_response) do
         {
           client: 'tmx_disabled',
@@ -1058,7 +1093,7 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: nil,
+          response_body: threatmetrix_response_body,
         }
       end
 
@@ -1108,6 +1143,7 @@ RSpec.feature 'Analytics Regression', :js do
     context 'proofing_device_profiling disabled' do
       let(:proofing_device_profiling) { :disabled }
       let(:threatmetrix) { false }
+      let(:threatmetrix_response_body) { nil }
       let(:threatmetrix_response) do
         {
           client: 'tmx_disabled',
@@ -1119,7 +1155,7 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: nil,
+          response_body: threatmetrix_response_body,
         }
       end
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -221,7 +221,7 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         flow_path: 'standard', step: 'verify', analytics_id: 'Doc Auth'
       },
-      idv_doc_auth_verify_threatmetrix_response_body: (
+      idv_threatmetrix_response_body: (
         if threatmetrix_response_body.present?
           { response_body: threatmetrix_response_body }
         end
@@ -341,7 +341,7 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         flow_path: 'hybrid', step: 'verify', analytics_id: 'Doc Auth'
       },
-      idv_doc_auth_verify_threatmetrix_response_body: (
+      idv_threatmetrix_response_body: (
         if threatmetrix_response_body.present?
           { response_body: threatmetrix_response_body }
         end
@@ -458,7 +458,7 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         flow_path: 'standard', step: 'verify', analytics_id: 'Doc Auth'
       },
-      idv_doc_auth_verify_threatmetrix_response_body: (
+      idv_threatmetrix_response_body: (
         if threatmetrix_response_body.present?
           { response_body: threatmetrix_response_body }
         end
@@ -572,7 +572,7 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         analytics_id: 'In Person Proofing', step: 'verify', flow_path: 'standard', same_address_as_id: false
       },
-      idv_doc_auth_verify_threatmetrix_response_body: (
+      idv_threatmetrix_response_body: (
         if threatmetrix_response_body.present?
           { response_body: threatmetrix_response_body }
         end
@@ -695,7 +695,7 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify submitted' => {
         flow_path: 'standard', step: 'verify', analytics_id: 'Doc Auth'
       },
-      idv_doc_auth_verify_threatmetrix_response_body: (
+      idv_threatmetrix_response_body: (
         if threatmetrix_response_body.present?
           { response_body: threatmetrix_response_body }
         end


### PR DESCRIPTION
We use Threatmetrix for device profiling. When a user's device profiling transaction represents a review or reject status they need to undergo the fraud review process. Part of that process is looking at what was returned by Threatmetrix in the logged response body.

The Threatmetrix response body is incredibly large. It causes some issues with Cloudwatch parsing the JSON written to the log.

This commit adds a new event to capture the Threatmetrix response body. The plan is to verify that this new event works for our fraud analysis purposes and then stop logging it on the existing event. The change to stop logging the response body on the existing event will be in a follow-up change.
