### PR TITLE
LG-14609 Stop logging Threatmetrix response body in verify info results

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -203,9 +203,7 @@ module Idv
         },
       )
 
-      threatmetrix_reponse_body = form_response.extra.dig(
-        :proofing_results, :context, :stages, :threatmetrix, :response_body
-      )
+      threatmetrix_reponse_body = delete_threatmetrix_response_body(form_response)
       if threatmetrix_reponse_body.present?
         analytics.idv_threatmetrix_response_body(
           response_body: threatmetrix_reponse_body,
@@ -312,6 +310,18 @@ module Idv
       idv_session.applicant = pii
       idv_session.applicant[:ssn] = idv_session.ssn
       idv_session.applicant['uuid'] = current_user.uuid
+    end
+
+    def delete_threatmetrix_response_body(form_response)
+      threatmetrix_result = form_response.extra.dig(
+        :proofing_results,
+        :context,
+        :stages,
+        :threatmetrix,
+      )
+      return if threatmetrix_result.blank?
+
+      threatmetrix_result.delete(:response_body)
     end
 
     def add_cost(token, transaction_id: nil)

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe Idv::VerifyInfoController do
           context: {
             stages: {
               threatmetrix: {
+                client: threatmetrix_client_id,
                 transaction_id: 1,
                 review_status: review_status,
                 response_body: {
@@ -226,9 +227,7 @@ RSpec.describe Idv::VerifyInfoController do
                 context: hash_including(
                   stages: hash_including(
                     threatmetrix: hash_including(
-                      response_body: hash_including(
-                        client: threatmetrix_client_id,
-                      ),
+                      client: threatmetrix_client_id,
                     ),
                   ),
                 ),

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -29,7 +29,6 @@ RSpec.feature 'Analytics Regression', :js do
       client: nil,
       errors: {},
       exception: nil,
-      response_body: threatmetrix_response_body,
       review_status: 'pass',
       account_lex_id: 'super-cool-test-lex-id',
       session_id: 'super-cool-test-session-id',
@@ -828,7 +827,6 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: threatmetrix_response_body,
         }
       end
 
@@ -909,7 +907,6 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: threatmetrix_response_body,
         }
       end
 
@@ -959,7 +956,6 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: threatmetrix_response_body,
         }
       end
 
@@ -1021,7 +1017,6 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: threatmetrix_response_body,
         }
       end
 
@@ -1093,7 +1088,6 @@ RSpec.feature 'Analytics Regression', :js do
           review_status: 'pass',
           account_lex_id: nil,
           session_id: nil,
-          response_body: threatmetrix_response_body,
         }
       end
 
@@ -1162,7 +1156,6 @@ RSpec.feature 'Analytics Regression', :js do
               review_status: 'pass',
               account_lex_id: nil,
               session_id: nil,
-              response_body: threatmetrix_response_body,
             }
           end
 
@@ -1220,7 +1213,6 @@ RSpec.feature 'Analytics Regression', :js do
               review_status: 'pass',
               account_lex_id: nil,
               session_id: nil,
-              response_body: threatmetrix_response_body,
             }
           end
 
@@ -1301,7 +1293,6 @@ RSpec.feature 'Analytics Regression', :js do
             review_status: 'pass',
             account_lex_id: nil,
             session_id: nil,
-            response_body: threatmetrix_response_body,
           }
         end
 
@@ -1314,6 +1305,7 @@ RSpec.feature 'Analytics Regression', :js do
         end
       end
     end
+
     context 'in person path' do
       let(:return_sp_url) { 'https://example.com/some/idv/ipp/url' }
 
@@ -1364,7 +1356,6 @@ RSpec.feature 'Analytics Regression', :js do
             review_status: 'pass',
             account_lex_id: nil,
             session_id: nil,
-            response_body: threatmetrix_response_body,
           }
         end
 


### PR DESCRIPTION
We use Threatmetrix for device profiling. When a user's device profiling transaction represents a review or reject status they need to undergo the fraud review process. Part of that process is looking at what was returned by Threatmetrix in the logged response body.

The Threatmetrix response body is incredibly large. It causes some issues with Cloudwatch parsing the JSON written to the log.

In 2ddece00b322a3a38c577cbc172e831700200dd1 we started logging the response body on its own event. We continued to log the Threatmetrix response body in its original place on the verify info proofing results event. This was done so we can validate that the response body is properly logged on the new event and works for our purposes.

This commit follows up that previous commit by removing the response body from the original event. We can merge this once we have verified that everything is working as expected with the new event.
