### PR TITLE
update SpBiometricUpgradedProfile

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -342,7 +342,7 @@ class Profile < ApplicationRecord
   end
 
   def track_facial_match_reproof
-    SpUpgradedBiometricProfile.create(
+    SpUpgradedFacialMatchProfile.create(
       user: user,
       upgraded_at: Time.zone.now,
       idv_level: idv_level,

--- a/app/models/sp_upgraded_biometric_profile.rb
+++ b/app/models/sp_upgraded_biometric_profile.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class SpUpgradedBiometricProfile < ApplicationRecord
-  belongs_to :user
-end

--- a/app/models/sp_upgraded_facial_match_profile.rb
+++ b/app/models/sp_upgraded_facial_match_profile.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SpUpgradedFacialMatchProfile < ApplicationRecord
+  # table was created prior to the feature rename
+  self.table_name = :sp_upgraded_biometric_profiles
+
+  belongs_to :user
+end

--- a/app/policies/idv/gpo_verify_by_mail_policy.rb
+++ b/app/policies/idv/gpo_verify_by_mail_policy.rb
@@ -17,7 +17,7 @@ module Idv
 
     def send_letter_available?
       @send_letter_available ||= FeatureManagement.gpo_verification_enabled? &&
-                                 !disabled_for_biometric_comparison? &&
+                                 !disabled_for_facial_match? &&
                                  !disabled_for_ipp? &&
                                  !rate_limited?
     end
@@ -37,7 +37,7 @@ module Idv
 
     private
 
-    def disabled_for_biometric_comparison?
+    def disabled_for_facial_match?
       resolved_authn_context_result.two_pieces_of_fair_evidence?
     end
 

--- a/spec/factories/sp_upgraded_facial_match_profiles.rb
+++ b/spec/factories/sp_upgraded_facial_match_profiles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :sp_upgraded_biometric_profile do
+  factory :sp_upgraded_facial_match_profile do
     idv_level { :in_person }
   end
 end

--- a/spec/jobs/reports/idv_legacy_conversion_supplement_report_spec.rb
+++ b/spec/jobs/reports/idv_legacy_conversion_supplement_report_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Reports::IdvLegacyConversionSupplementReport do
           )
           iaa_order1.save
           create(
-            :sp_upgraded_biometric_profile,
+            :sp_upgraded_facial_match_profile,
             issuer: iaa1_sp.issuer, user_id: user1.id, upgraded_at: inside_iaa1,
           )
         end
@@ -136,12 +136,12 @@ RSpec.describe Reports::IdvLegacyConversionSupplementReport do
           )
 
           create(
-            :sp_upgraded_biometric_profile,
+            :sp_upgraded_facial_match_profile,
             issuer: iaa2_sp1.issuer, user_id: user1.id, upgraded_at: inside_iaa2,
           )
 
           create(
-            :sp_upgraded_biometric_profile,
+            :sp_upgraded_facial_match_profile,
             issuer: iaa2_sp2.issuer, user_id: user2.id, upgraded_at: inside_iaa2,
           )
         end
@@ -234,11 +234,11 @@ RSpec.describe Reports::IdvLegacyConversionSupplementReport do
           iaa_order3.integrations << integration_1
 
           create(
-            :sp_upgraded_biometric_profile,
+            :sp_upgraded_facial_match_profile,
             issuer: iaa3_sp1.issuer, user_id: user1.id, upgraded_at: iaa3_range.begin + 1.day,
           )
           create(
-            :sp_upgraded_biometric_profile,
+            :sp_upgraded_facial_match_profile,
             issuer: iaa3_sp1.issuer, user_id: user2.id, upgraded_at: iaa3_range.begin + 1.month,
           )
         end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe Profile do
 
           expect { facial_match_profile.activate }.to(
             change do
-              SpUpgradedBiometricProfile.count
+              SpUpgradedFacialMatchProfile.count
             end.by(1),
           )
         end
@@ -372,7 +372,7 @@ RSpec.describe Profile do
           facial_match_reproof = create(:profile, :facial_match_proof, user: user)
           expect { facial_match_reproof.activate }.to_not(
             change do
-              SpUpgradedBiometricProfile.count
+              SpUpgradedFacialMatchProfile.count
             end,
           )
         end
@@ -382,13 +382,13 @@ RSpec.describe Profile do
         it 'does not create a facial match conversion record' do
           profile = create(:profile, :facial_match_proof, user: user)
 
-          expect { profile.activate }.to_not(change { SpUpgradedBiometricProfile.count })
+          expect { profile.activate }.to_not(change { SpUpgradedFacialMatchProfile.count })
         end
       end
     end
 
     it 'does not create a facial match upgrade record for a non-facial match profile' do
-      expect { profile.activate }.to_not(change { SpUpgradedBiometricProfile.count })
+      expect { profile.activate }.to_not(change { SpUpgradedFacialMatchProfile.count })
     end
 
     it 'sends a reproof completed push event' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Update SpBiometricUpgradedProfile model](https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/120)

## 🛠 Summary of changes
This change continues updating our biometric_comparison language.
- Updates a private method that was accidentally left out of the first big PR
- Renames SpBiometricUpgradedProfile but has the model still refer to the original table 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
