### PR TITLE
More renaming to Facial Matching

### DIFF
--- a/app/controllers/test/oidc_test_controller.rb
+++ b/app/controllers/test/oidc_test_controller.rb
@@ -5,7 +5,7 @@ module Test
   class OidcTestController < ApplicationController
     include OidcAuthHelper
 
-    BIOMETRIC_REQUIRED = 'biometric-comparison-required'
+    FACIAL_MATCH_REQUIRED = 'facial-match-required'
 
     def initialize
       @client_id = 'urn:gov:gsa:openidconnect:sp:sinatra'
@@ -14,7 +14,7 @@ module Test
 
     def index
       # default to require
-      @start_url_selfie = "#{test_oidc_auth_request_url}?ial=biometric-comparison-required"
+      @start_url_selfie = "#{test_oidc_auth_request_url}?ial=#{FACIAL_MATCH_REQUIRED}"
       @start_url_ial2 = "#{test_oidc_auth_request_url}?ial=2"
       @start_url_ial1 = "#{test_oidc_auth_request_url}?ial=1"
       update_service_provider
@@ -46,7 +46,7 @@ module Test
       params = ial2_params(
         client_id: client_id,
         acr_values: acr_values(ial: ial, aal: aal),
-        biometric_comparison_required: ial == BIOMETRIC_REQUIRED,
+        facial_match_required: ial == FACIAL_MATCH_REQUIRED,
         state: random_value,
         nonce: random_value,
       )
@@ -70,7 +70,7 @@ module Test
         'openid email social_security_number'
       when '1', nil
         'openid email'
-      when '2', BIOMETRIC_REQUIRED
+      when '2', FACIAL_MATCH_REQUIRED
         'openid email profile social_security_number phone address'
       else
         raise ArgumentError.new("Unexpected IAL: #{ial.inspect}")
@@ -84,7 +84,7 @@ module Test
         '' => 'http://idmanagement.gov/ns/assurance/ial/1',
         '1' => 'http://idmanagement.gov/ns/assurance/ial/1',
         '2' => 'http://idmanagement.gov/ns/assurance/ial/2',
-        'biometric-comparison-required' => 'http://idmanagement.gov/ns/assurance/ial/2',
+        'facial-match-required' => 'http://idmanagement.gov/ns/assurance/ial/2',
       }[ial]
       aal_value = {
         '2' => 'http://idmanagement.gov/ns/assurance/aal/2',

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1163,7 +1163,7 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param ["hybrid","standard"] flow_path Document capture user flow
-  # @param [Boolean] liveness_checking_required Whether biometric selfie check is required
+  # @param [Boolean] liveness_checking_required Whether facial match check is required
   def idv_doc_auth_capture_complete_visited(
     step:,
     analytics_id:,
@@ -1186,8 +1186,8 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
-  # @param [Boolean] liveness_checking_required Whether biometric selfie check is required
-  # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param [Boolean] liveness_checking_required Whether facial match check is required
+  # @param [Boolean] selfie_check_required Whether facial match check is required
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
   # warning
@@ -1234,8 +1234,8 @@ module AnalyticsEvents
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
   # warning
-  # @param [Boolean] liveness_checking_required Whether biometric selfie check is required
-  # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param [Boolean] liveness_checking_required Whether facial match check is required
+  # @param [Boolean] selfie_check_required Whether facial match check is required
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
@@ -1354,7 +1354,7 @@ module AnalyticsEvents
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
   # warning
-  # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param [Boolean] selfie_check_required Whether facial match check is required
   # @param ["document_capture","send_link"] destination Where user is sent after submission
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
@@ -1401,7 +1401,7 @@ module AnalyticsEvents
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
   # warning
-  # @param [Boolean] selfie_check_required Whether biometric selfie check is required
+  # @param [Boolean] selfie_check_required Whether facial match check is required
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
   # SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -61,7 +61,7 @@ class SamlRequestValidator
     if !valid_authn_context? ||
        (identity_proofing_requested? && !service_provider.identity_proofing_allowed?) ||
        (ial_max_requested? && !service_provider.ialmax_allowed?) ||
-       (biometric_ial_requested? && !service_provider.facial_match_ial_allowed?) ||
+       (facial_match_ial_requested? && !service_provider.facial_match_ial_allowed?) ||
        (semantic_authn_contexts_requested? && !service_provider.semantic_authn_contexts_allowed?)
       errors.add(:authn_context, :unauthorized_authn_context, type: :unauthorized_authn_context)
     end
@@ -116,7 +116,7 @@ class SamlRequestValidator
     Array(authn_context).include?(Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF)
   end
 
-  def biometric_ial_requested?
+  def facial_match_ial_requested?
     Array(authn_context).any? { |ial| Saml::Idp::Constants::FACIAL_MATCH_IAL_CONTEXTS.include? ial }
   end
 

--- a/app/services/vot/supported_component_values.rb
+++ b/app/services/vot/supported_component_values.rb
@@ -34,7 +34,7 @@ module Vot
     ).freeze
     Pb = ComponentValue.new(
       name: 'Pb',
-      description: 'A biometric comparison is required as part of identity proofing',
+      description: 'A facial match is required as part of identity proofing',
       implied_component_values: ['P1'],
       requirements: [:facial_match, :two_pieces_of_fair_evidence],
     ).freeze

--- a/app/views/accounts/_identity_verification.html.erb
+++ b/app/views/accounts/_identity_verification.html.erb
@@ -4,7 +4,7 @@
   </h2>
   <div class="grid-col-auto">
     <% if @presenter.active_profile_for_authn_context? %>
-      <%= render TooltipComponent.new(tooltip_text: @presenter.identity_verified_with_facial_match? ? t('account.index.verification.verified_biometric_badge_tooltip') : t('account.index.verification.verified_badge_tooltip')) do %>
+      <%= render TooltipComponent.new(tooltip_text: @presenter.identity_verified_with_facial_match? ? t('account.index.verification.verified_facial_match_badge_tooltip') : t('account.index.verification.verified_badge_tooltip')) do %>
         <%= render BadgeComponent.new(icon: :check_circle).with_content(t('account.index.verification.verified_badge')) %>
       <% end %>
     <% elsif @presenter.pending_gpo? || @presenter.pending_ipp? %>
@@ -23,12 +23,12 @@
   <p>
     <% if @presenter.active_profile_for_authn_context? %>
       <% if @presenter.identity_verified_with_facial_match? %>
-        <%= t('account.index.verification.you_verified_your_biometric_identity', app_name: APP_NAME) %>
+        <%= t('account.index.verification.you_verified_your_facial_match_identity', app_name: APP_NAME) %>
       <% else %>
         <%= t('account.index.verification.you_verified_your_identity_html', sp_name: @presenter.user.active_profile.initiating_service_provider&.friendly_name || APP_NAME) %>
       <% end %>
     <% elsif @presenter.active_profile? %>
-      <%= t('account.index.verification.nonbiometric_verified_html', app_name: APP_NAME, date: @presenter.formatted_legacy_idv_date) %>
+      <%= t('account.index.verification.legacy_verified_html', app_name: APP_NAME, date: @presenter.formatted_legacy_idv_date) %>
     <% elsif @presenter.sp_name || @presenter.user.pending_profile.initiating_service_provider %>
       <%= t('account.index.verification.finish_verifying_html', sp_name: @presenter.sp_name || @presenter.user.pending_profile.initiating_service_provider.friendly_name) %>
     <% else %>
@@ -43,7 +43,7 @@
 
 <% if @presenter.active_profile? && !@presenter.active_profile_for_authn_context? %>
   <p>
-    <%= t('account.index.verification.verify_with_biometric_html', sp_name: @presenter.sp_name) %>
+    <%= t('account.index.verification.verify_with_facial_match_html', sp_name: @presenter.sp_name) %>
   </p>
   <p>
     <%= new_tab_link_to t('account.index.verification.learn_more_link'), help_center_redirect_path(category: 'verify-your-identity', article: 'overview', flow: :account_show, location: :idv) %>

--- a/app/views/test/oidc_test/index.html.erb
+++ b/app/views/test/oidc_test/index.html.erb
@@ -2,6 +2,6 @@
 
 <h1>OIDC Test Controller</h1>
 
-<%= link_to 'Sign in with Biometric', @start_url_selfie, class: 'sign-in-bttn' %> <br /> <br />
+<%= link_to 'Sign in with Facial Match', @start_url_selfie, class: 'sign-in-bttn' %> <br /> <br />
 <%= link_to 'Sign in with IAL2', @start_url_ial2, class: 'sign-in-bttn' %> <br /><br />
 <%= link_to 'Sign in with IAL1', @start_url_ial1, class: 'sign-in-bttn' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,7 +80,7 @@ account.index.verification.identity_verification: Identity verification
 account.index.verification.in_person_instructions_html: You must visit any participating Post Office by <strong>%{deadline}</strong> to verify your identity.
 account.index.verification.instructions: Enter your verification code to finish verifying your identity.
 account.index.verification.learn_more_link: Learn more about verifying your identity
-account.index.verification.nonbiometric_verified_html: You verified your identity with %{app_name} on <strong>%{date}</strong> using your state ID.
+account.index.verification.legacy_verified_html: You verified your identity with %{app_name} on <strong>%{date}</strong> using your state ID.
 account.index.verification.pending_badge: Pending
 account.index.verification.pending_badge_tooltip: Your identity is pending verification.
 account.index.verification.reactivate_button: Enter the verification code you received via US mail
@@ -90,9 +90,9 @@ account.index.verification.unverified_badge: Unverified
 account.index.verification.unverified_badge_tooltip: Finish verifying your identity.
 account.index.verification.verified_badge: Verified
 account.index.verification.verified_badge_tooltip: Your identity has been verified.
-account.index.verification.verified_biometric_badge_tooltip: Your identity and photo have both been verified.
-account.index.verification.verify_with_biometric_html: To access <strong>%{sp_name}</strong>, verify your identity again using a photo of yourself.
-account.index.verification.you_verified_your_biometric_identity: You have verified your identity with the information below and verified a photo of yourself which gives you access to all %{app_name} partners.
+account.index.verification.verified_facial_match_badge_tooltip: Your identity and photo have both been verified.
+account.index.verification.verify_with_facial_match_html: To access <strong>%{sp_name}</strong>, verify your identity again using a photo of yourself.
+account.index.verification.you_verified_your_facial_match_identity: You have verified your identity with the information below and verified a photo of yourself which gives you access to all %{app_name} partners.
 account.index.verification.you_verified_your_identity_html: You verified your identity for <strong>%{sp_name}</strong> with the information below.
 account.index.webauthn: Security key
 account.index.webauthn_add: Add security key

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -80,7 +80,7 @@ account.index.verification.identity_verification: Verificación de identidad
 account.index.verification.in_person_instructions_html: Para terminar de verificar su identidad, debe acudir a una oficina de correos participante antes del <strong>%{deadline}</strong>.
 account.index.verification.instructions: Ingrese su código de verificación para terminar de verificar su identidad.
 account.index.verification.learn_more_link: Obtenga más información sobre la verificación de su identidad
-account.index.verification.nonbiometric_verified_html: El <strong>%{date}</strong>, usted verificó su identidad con %{app_name} usando su identificación estatal.
+account.index.verification.legacy_verified_html: El <strong>%{date}</strong>, usted verificó su identidad con %{app_name} usando su identificación estatal.
 account.index.verification.pending_badge: Pendiente
 account.index.verification.pending_badge_tooltip: La verificación de su identidad está pendiente
 account.index.verification.reactivate_button: Ingrese el código de verificación que recibió por correo de los EE. UU.
@@ -90,9 +90,9 @@ account.index.verification.unverified_badge: No verificada
 account.index.verification.unverified_badge_tooltip: Termine de verificar su identidad.
 account.index.verification.verified_badge: Verificada
 account.index.verification.verified_badge_tooltip: Se verificó su identidad.
-account.index.verification.verified_biometric_badge_tooltip: Se verificó tanto su identidad como su fotografía.
-account.index.verification.verify_with_biometric_html: Para acceder a la <strong>%{sp_name}</strong>, verifique su identidad de nuevo usando una foto de usted.
-account.index.verification.you_verified_your_biometric_identity: Usted verificó su identidad con la información siguiente y verificó una fotografía suya, lo cual le da acceso a todos los asociados de %{app_name}.
+account.index.verification.verified_facial_match_badge_tooltip: Se verificó tanto su identidad como su fotografía.
+account.index.verification.verify_with_facial_match_html: Para acceder a la <strong>%{sp_name}</strong>, verifique su identidad de nuevo usando una foto de usted.
+account.index.verification.you_verified_your_facial_match_identity: Usted verificó su identidad con la información siguiente y verificó una fotografía suya, lo cual le da acceso a todos los asociados de %{app_name}.
 account.index.verification.you_verified_your_identity_html: Usted verificó su identidad para <strong>%{sp_name}</strong> con la información siguiente.
 account.index.webauthn: Clave de seguridad
 account.index.webauthn_add: Agregar clave de seguridad

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -80,7 +80,7 @@ account.index.verification.identity_verification: Vérification de l’identité
 account.index.verification.in_person_instructions_html: Vous devez vous rendre à un bureau de poste participant d’ici le <strong>%{deadline}</strong> pour terminer la procédure de vérification de votre identité.
 account.index.verification.instructions: Saisissez votre code de vérification pour terminer la procédure de vérification d’identité.
 account.index.verification.learn_more_link: En savoir plus sur la vérification de votre identité
-account.index.verification.nonbiometric_verified_html: Vous avez confirmé votre identité sur %{app_name} le <strong>%{date}</strong> avec votre pièce d’identité d’État.
+account.index.verification.legacy_verified_html: Vous avez confirmé votre identité sur %{app_name} le <strong>%{date}</strong> avec votre pièce d’identité d’État.
 account.index.verification.pending_badge: En cours
 account.index.verification.pending_badge_tooltip: Votre identité est en cours de vérification.
 account.index.verification.reactivate_button: Saisissez le code de vérification que vous avez reçu par la poste.
@@ -90,9 +90,9 @@ account.index.verification.unverified_badge: Non vérifiée
 account.index.verification.unverified_badge_tooltip: Terminer la vérification de votre identité.
 account.index.verification.verified_badge: Vérifiée
 account.index.verification.verified_badge_tooltip: Votre identité a été vérifiée.
-account.index.verification.verified_biometric_badge_tooltip: Votre identité et votre photo ont été vérifiées.
-account.index.verification.verify_with_biometric_html: Pour accéder à <strong>%{sp_name}</strong>, confirmez à nouveau votre identité à l’aide d’une photo de vous-même.
-account.index.verification.you_verified_your_biometric_identity: Vous avez confirmé votre identité à l’aide des informations ci-dessous et d’une photo de vous-même, ce qui vous permet d’accéder à tous les organismes partenaires de %{app_name}.
+account.index.verification.verified_facial_match_badge_tooltip: Votre identité et votre photo ont été vérifiées.
+account.index.verification.verify_with_facial_match_html: Pour accéder à <strong>%{sp_name}</strong>, confirmez à nouveau votre identité à l’aide d’une photo de vous-même.
+account.index.verification.you_verified_your_facial_match_identity: Vous avez confirmé votre identité à l’aide des informations ci-dessous et d’une photo de vous-même, ce qui vous permet d’accéder à tous les organismes partenaires de %{app_name}.
 account.index.verification.you_verified_your_identity_html: Vous avez confirmé votre identité auprès de <strong>%{sp_name}</strong> à l’aide des informations ci-dessous.
 account.index.webauthn: Clé de sécurité
 account.index.webauthn_add: Ajouter une clé de sécurité

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -80,7 +80,7 @@ account.index.verification.identity_verification: 身份验证
 account.index.verification.in_person_instructions_html: 你必须在 <strong>%{deadline}</strong> 之前去邮局完成验证你的身份。
 account.index.verification.instructions: 输入你的验证码来完成身份验证。
 account.index.verification.learn_more_link: 了解更多有关验证你身份的信息。
-account.index.verification.nonbiometric_verified_html: 你在 <strong>%{date}</strong> 使用州颁发的身份证件在%{app_name} 验证了身份。
+account.index.verification.legacy_verified_html: 你在 <strong>%{date}</strong> 使用州颁发的身份证件在%{app_name} 验证了身份。
 account.index.verification.pending_badge: 待验证
 account.index.verification.pending_badge_tooltip: 你的身份有待验证。
 account.index.verification.reactivate_button: 输入你通过邮局收到的验证码。
@@ -90,9 +90,9 @@ account.index.verification.unverified_badge: 未验证
 account.index.verification.unverified_badge_tooltip: 完成验证你的身份。
 account.index.verification.verified_badge: 已验证
 account.index.verification.verified_badge_tooltip: 你的身份已经验证。
-account.index.verification.verified_biometric_badge_tooltip: 你的身份和照片都已验证。
-account.index.verification.verify_with_biometric_html: 要访问 <strong>%{sp_name}</strong>，请使用你本人照片再次验证身份。
-account.index.verification.you_verified_your_biometric_identity: 你使用以下信息验证了身份并验证了一张你本人的照片，从而获得了访问%{app_name}所有合作伙伴机构的权限。
+account.index.verification.verified_facial_match_badge_tooltip: 你的身份和照片都已验证。
+account.index.verification.verify_with_facial_match_html: 要访问 <strong>%{sp_name}</strong>，请使用你本人照片再次验证身份。
+account.index.verification.you_verified_your_facial_match_identity: 你使用以下信息验证了身份并验证了一张你本人的照片，从而获得了访问%{app_name}所有合作伙伴机构的权限。
 account.index.verification.you_verified_your_identity_html: 你使用以下信息向 <strong>%{sp_name}</strong> 验证了身份。
 account.index.webauthn: 安全密钥
 account.index.webauthn_add: 添加安全密钥

--- a/docs/sdk-upgrade.md
+++ b/docs/sdk-upgrade.md
@@ -56,7 +56,7 @@ Steps:
     1. Look at the [Testing Considerations](#testing-considerations) for other ideas on what you might want to test.
     1. Here is a sample plan:
         - For each combination of devices and browsers above:
-            1. Locally go to `/test/oidc/login` and choose `biometrics`
+            1. Locally go to `/test/oidc/login` and choose `facial match`
             1. First test document capture
                 1. On your phone, tap to photograph your state ID card
                 1. Point the camera at the card

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -270,7 +270,10 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
 
       it 'shows content confirming verified identity' do
         expect(rendered).to have_content(
-          t('account.index.verification.you_verified_your_facial_match_identity', app_name: APP_NAME),
+          t(
+            'account.index.verification.you_verified_your_facial_match_identity',
+            app_name: APP_NAME,
+          ),
         )
         expect(rendered).to have_link(
           t('account.index.verification.learn_more_link'),

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -232,14 +232,14 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
         expect(rendered).to have_content(
           strip_tags(
             t(
-              'account.index.verification.nonbiometric_verified_html',
+              'account.index.verification.legacy_verified_html',
               app_name: APP_NAME,
               date: @presenter.formatted_legacy_idv_date,
             ),
           ),
         )
         expect(rendered).to have_content(
-          strip_tags(t('account.index.verification.verify_with_biometric_html', sp_name:)),
+          strip_tags(t('account.index.verification.verify_with_facial_match_html', sp_name:)),
         )
         expect(rendered).to have_link(
           t('account.index.verification.learn_more_link'),
@@ -270,7 +270,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
 
       it 'shows content confirming verified identity' do
         expect(rendered).to have_content(
-          t('account.index.verification.you_verified_your_biometric_identity', app_name: APP_NAME),
+          t('account.index.verification.you_verified_your_facial_match_identity', app_name: APP_NAME),
         )
         expect(rendered).to have_link(
           t('account.index.verification.learn_more_link'),


### PR DESCRIPTION
## 🎫 Ticket
https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/116

## 🛠 Summary of changes
This change wraps up the rest of the language change from biometric_comparison to facial_match.
- fixes the OIDC test controller that is used for facial match testing
- updates another private method that somehow avoided discovery the first go around
-  Updates the yml/erb files
- Updates the analytics_events field descriptions