### PR TITLE
LG-14497: LQA updates

### DIFF
--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -39,6 +39,6 @@ fr:
       ten: dix
     format_type:
       character: caractères
-      digit: digit
+      digit: chiffres
     personal_key_regeneration_notice: Une nouvelle clé personnelle a été émise pour votre compte %{app_name}. Si cela ne vient pas de vous, réinitialisez votre mot de passe.
     personal_key_sign_in_notice: Votre clé personnelle vient d’être utilisée pour vous connecter à votre compte %{app_name}. Si cela ne vient pas de vous, réinitialisez votre mot de passe.

--- a/config/locales/telephony/zh.yml
+++ b/config/locales/telephony/zh.yml
@@ -18,7 +18,7 @@ zh:
         %{app_name}: 你的一次性代码是 %{code}。此代码在 %{expiration} 分钟后作废。请勿与任何人分享此代码。
 
         @%{domain} #%{code}
-      voice: 你好！你的%{format_length}%{format_type} %{app_name} 一次性代码是%{code}。你的一次性代码是 ，%{code}。重复一下，你的一次性代码是 %{code}。此代码 %{expiration} 分钟后会作废。
+      voice: 你好！你的%{format_length}%{format_type} %{app_name} 一次性代码是，%{code}。你的一次性代码是 ，%{code}。重复一下，你的一次性代码是 %{code}。此代码 %{expiration} 分钟后会作废。
     doc_auth_link: |-
       %{app_name}: %{link} 你在验证身份以访问 %{sp_or_app_name}。拍张你身份证件的照片以继续。
     error:

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -70,7 +70,6 @@ module I18n
         { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
         { key: 'telephony.format_length.six', locales: %i[zh] }, # numeral is not translated
         { key: 'telephony.format_length.ten', locales: %i[zh] }, # numeral is not translated
-        { key: 'telephony.format_type.digit', locales: %i[fr] },
         { key: 'time.formats.event_date', locales: %i[es zh] },
         { key: 'time.formats.event_time', locales: %i[es zh] },
         { key: 'time.formats.event_timestamp', locales: %i[zh] },


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14497](https://cm-jira.usa.gov/browse/LG-14497)

## 🛠 Summary of changes

This PR contains a couple of updates identified by the LQA process:

1. Translate "digit" as "chiffres" in French in address verification OTP messages
2. Insert a missing full width comma in Simplified Chinese translation of the address verfication OTP message

