### PR TITLE
Use a list to log resolved ACRs in events

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -130,7 +130,10 @@ class Analytics
     return if resolved_result.nil?
 
     attributes = resolved_result.to_h
-    attributes[:component_values] = resolved_result.component_names
+    attributes[:component_values] = resolved_result.component_values.map do |v|
+      [v.name.sub("#{Saml::Idp::Constants::LEGACY_ACR_PREFIX}/", ''), true]
+    end.to_h
+    attributes[:component_names] = resolved_result.component_names
     attributes.reject! { |_key, value| value == false }
 
     if differentiator.present?
@@ -157,7 +160,7 @@ class Analytics
   def resolved_authn_context_result
     return nil if sp.blank? ||
                   session[:sp].blank? ||
-                  session[:sp][:vtr].blank? && session[:sp][:acr_values].blank?
+                  (session[:sp][:vtr].blank? && session[:sp][:acr_values].blank?)
     return @resolved_authn_context_result if defined?(@resolved_authn_context_result)
 
     service_provider = ServiceProvider.find_by(issuer: sp)

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -155,7 +155,9 @@ class Analytics
   end
 
   def resolved_authn_context_result
-    return nil if sp.nil? || session[:sp].blank?
+    return nil if sp.blank? ||
+                  session[:sp].blank? ||
+                  session[:sp][:vtr].blank? && session[:sp][:acr_values].blank?
     return @resolved_authn_context_result if defined?(@resolved_authn_context_result)
 
     service_provider = ServiceProvider.find_by(issuer: sp)

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -130,9 +130,7 @@ class Analytics
     return if resolved_result.nil?
 
     attributes = resolved_result.to_h
-    attributes[:component_values] = resolved_result.component_values.map do |v|
-      [v.name.sub('http://idmanagement.gov/ns/assurance/', ''), true]
-    end.to_h
+    attributes[:component_values] = resolved_result.component_names
     attributes.reject! { |_key, value| value == false }
 
     if differentiator.present?

--- a/lib/saml_idp_constants.rb
+++ b/lib/saml_idp_constants.rb
@@ -6,10 +6,13 @@ require 'idp/constants'
 module Saml
   module Idp
     module Constants
-      LOA1_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/1'
-      LOA3_AUTHN_CONTEXT_CLASSREF = 'http://idmanagement.gov/ns/assurance/loa/3'
+      LEGACY_ACR_NS = 'http://idmanagement.gov/ns'
+      LEGACY_ACR_PREFIX = "#{LEGACY_ACR_NS}/assurance".freeze
 
-      IAL_AUTHN_CONTEXT_PREFIX = 'http://idmanagement.gov/ns/assurance/ial'
+      LOA1_AUTHN_CONTEXT_CLASSREF = "#{LEGACY_ACR_PREFIX}/loa/1".freeze
+      LOA3_AUTHN_CONTEXT_CLASSREF = "#{LEGACY_ACR_PREFIX}/loa/3".freeze
+
+      IAL_AUTHN_CONTEXT_PREFIX = "#{LEGACY_ACR_PREFIX}/ial".freeze
       IAL1_AUTHN_CONTEXT_CLASSREF = "#{IAL_AUTHN_CONTEXT_PREFIX}/1".freeze
       IAL2_AUTHN_CONTEXT_CLASSREF = "#{IAL_AUTHN_CONTEXT_PREFIX}/2".freeze
       IALMAX_AUTHN_CONTEXT_CLASSREF = "#{IAL_AUTHN_CONTEXT_PREFIX}/0".freeze
@@ -29,7 +32,7 @@ module Saml
       ].freeze
 
       DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF = 'urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo'
-      AAL_AUTHN_CONTEXT_PREFIX = 'http://idmanagement.gov/ns/assurance/aal'
+      AAL_AUTHN_CONTEXT_PREFIX = "#{LEGACY_ACR_PREFIX}/aal".freeze
       AAL1_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/1".freeze
       AAL2_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/2".freeze
       AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF = "#{AAL_AUTHN_CONTEXT_PREFIX}/2?phishing_resistant=true".freeze
@@ -42,7 +45,7 @@ module Saml
       NAME_ID_FORMAT_UNSPECIFIED = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
       VALID_NAME_ID_FORMATS = [NAME_ID_FORMAT_PERSISTENT, NAME_ID_FORMAT_EMAIL].freeze
 
-      REQUESTED_ATTRIBUTES_CLASSREF = 'http://idmanagement.gov/ns/requested_attributes?ReqAttr='
+      REQUESTED_ATTRIBUTES_CLASSREF = "#{LEGACY_ACR_NS}/requested_attributes?ReqAttr=".freeze
 
       VALID_AUTHN_CONTEXTS = (if FeatureManagement.use_semantic_authn_contexts?
                                 IdentityConfig.store.valid_authn_contexts_semantic


### PR DESCRIPTION
## 🛠 Summary of changes

### Why


- Deter using the resolved ACRs directly in reporting. The resolved list of ACRs (or Vectors of Trust) is volatile and subject to relatively frequent change as service features are added, removed, or modified over time. Instead, most analytics users should use the resolved attribute flags (e.g., `facial_match` or `enhanced_ipp`) for event filtering. Going forward, the purpose of the `sp_request.component_values` field should be solely to support investigating unexpected behavior.

- Eliminate unexpected "reformatting" or "truncation" of resolved ACR names. While truncating these strings makes composing queries simpler, it introduces complexity and confusion when triaging and debugging requests. Originally, the purpose was to be able to do simple filters like `properties.sp_request.component_values.Pb`, but with the deprecation of the VoT interfaces (and thereby the 2-character string names), the filter becomes ``sp_request.component_values.`urn:acr.login.gov:verified` ``, which is much less legible than: `'urn:acr.login.gov:verified' IN sp_request.component_values`
- Why not store component values as a string? Basically, VoT/vtr style components and ACR style components "stringify" differently, which would make query composition even more complex, instead of less.

### How


- Adds an array of strings containing the ACR name will be stored in `sp_request.component_names`.
- No other changes have been made to structure of `sp_request`.
- New specs have been added for all IAL ACRs.

changelog: Internal, Analytics, Streamlining inclusion of resolved ACR names

resolves: https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/112

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket: https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/112



## 📜 Testing Plan

1. [ ] Create an account via the sample app
    * Note: Make sure to test with both an IdV enabled and disabled SP
2. [ ] Check the events.log (locally or in Cloudwatch) and verify that `components_values` is displaying as an array
3. [ ] Repeat steps 1-2 for auth-only user, verified user, a verified user that has been proofed with selfie (facial match). 
    * Note: Pay special attention when going through the "facial match preferred" flow.

## Additional notes

This will require updating Cloudwatch queries. Impacted ones are listed in the linked ticket.