### PR TITLE
LG-14067 Implement new attempts language in attempts screen

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1016,7 +1016,7 @@ idv.errors.incorrect_password: The password you entered is not correct.
 idv.errors.pattern_mismatch.ssn: Enter a nine-digit Social Security number
 idv.errors.pattern_mismatch.zipcode: Enter a 5 or 9 digit ZIP Code
 idv.errors.pattern_mismatch.zipcode_five: Enter a 5 digit ZIP Code
-idv.failure.attempts_html.one: You can try <strong>1 more time.</strong> Then, you must wait 6 hours before trying again. 
+idv.failure.attempts_html.one: You can try <strong>1 more time.</strong> Then, you must wait 6 hours before trying again.
 idv.failure.attempts_html.other: You can try <strong>%{count} more times.</strong> Then, you must wait 6 hours before trying again.
 idv.failure.button.try_online: Try again online
 idv.failure.button.warning: Try again

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -556,7 +556,7 @@ doc_auth.errors.phone_step_incomplete: You must go to your phone and upload phot
 doc_auth.errors.pii.birth_date_min_age: Your birthday does not meet the minimum age requirement.
 doc_auth.errors.rate_limited_heading: We couldn’t verify your ID
 doc_auth.errors.rate_limited_subheading: Try taking new pictures
-doc_auth.errors.rate_limited_text_html: For your security, we limit the number of times you can attempt to verify a document online. <strong>Try again in %{timeout}.</strong>
+doc_auth.errors.rate_limited_text_html: To prevent fraud, we limit the number of times someone can attempt to verify a document online. <strong>Try again in %{timeout}.</strong>
 doc_auth.errors.selfie_fail_heading: We couldn’t match the photo of yourself to your ID
 doc_auth.errors.selfie_not_live_or_poor_quality_heading: We could not verify the photo of yourself
 doc_auth.errors.send_link_limited: You tried too many times, please try again in %{timeout}. You can also go back and choose to use your computer instead.
@@ -1016,8 +1016,8 @@ idv.errors.incorrect_password: The password you entered is not correct.
 idv.errors.pattern_mismatch.ssn: Enter a nine-digit Social Security number
 idv.errors.pattern_mismatch.zipcode: Enter a 5 or 9 digit ZIP Code
 idv.errors.pattern_mismatch.zipcode_five: Enter a 5 digit ZIP Code
-idv.failure.attempts_html.one: For security reasons, you have <strong>one attempt</strong> remaining to add your ID online.
-idv.failure.attempts_html.other: For security reasons, you have <strong>%{count} attempts</strong> remaining to add your ID online.
+idv.failure.attempts_html.one: You can try <strong>1 more time.</strong> Then, you must wait 6 hours before trying again. 
+idv.failure.attempts_html.other: You can try <strong>%{count} more times.</strong> Then, you must wait 6 hours before trying again.
 idv.failure.button.try_online: Try again online
 idv.failure.button.warning: Try again
 idv.failure.exceptions.in_person_outage_error_message.post_cta.body: In the meantime, you can still begin the in-person verification process on %{app_name} and then visit a Post Office. If you urgently need access to services, please contact your agency directly.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -567,7 +567,7 @@ doc_auth.errors.phone_step_incomplete: Debe ir a su teléfono y cargar fotos de 
 doc_auth.errors.pii.birth_date_min_age: Su fecha de nacimiento no cumple con el requisito de edad mínima.
 doc_auth.errors.rate_limited_heading: No pudimos verificar su identificación
 doc_auth.errors.rate_limited_subheading: Intente tomar nuevas fotos
-doc_auth.errors.rate_limited_text_html: Por su seguridad, limitamos el número de veces que puede intentar verificar un documento en línea. <strong>Vuelva a intentarlo en %{timeout}.</strong>
+doc_auth.errors.rate_limited_text_html: Para evitar fraudes, limitamos el número de veces que puede intentar la verificación de un documento en línea. <strong>Vuelva a intentarlo en %{timeout}.</strong>
 doc_auth.errors.selfie_fail_heading: No hemos podido cotejar su foto con su identificación.
 doc_auth.errors.selfie_not_live_or_poor_quality_heading: No pudimos verificar su foto
 doc_auth.errors.send_link_limited: Lo intentó demasiadas veces; vuelva a intentarlo en %{timeout}. También puede volver atrás y elegir utilizar su computadora.
@@ -1027,8 +1027,8 @@ idv.errors.incorrect_password: La contraseña que ingresó no es la correcta.
 idv.errors.pattern_mismatch.ssn: Ingrese un número de Seguro Social de nueve dígitos.
 idv.errors.pattern_mismatch.zipcode: Ingrese un código postal de 5 o 9 dígitos.
 idv.errors.pattern_mismatch.zipcode_five: Ingrese un código postal de 5 dígitos.
-idv.failure.attempts_html.one: Por motivos de seguridad, le queda <strong>un intento</strong> para añadir su identificación en línea.
-idv.failure.attempts_html.other: Por motivos de seguridad, le quedan <strong>%{count} intentos</strong> para añadir su identificación en línea.
+idv.failure.attempts_html.one: Puede intentarlo <strong>una vez más.</strong> Luego, debe esperar 6 horas antes de volver a intentarlo.
+idv.failure.attempts_html.other: Puede intentarlo <strong>%{count} veces más.</strong> Luego, debe esperar 6 horas antes de volver a intentarlo.
 idv.failure.button.try_online: Vuelva a intentarlo en línea
 idv.failure.button.warning: Vuelva a intentarlo
 idv.failure.exceptions.in_person_outage_error_message.post_cta.body: Mientras tanto, todavía puede iniciar el proceso de verificación en persona en %{app_name} y luego acudir a una oficina de correos. Si necesita acceso urgente a los servicios, contacte directamente con su agencia.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -556,7 +556,7 @@ doc_auth.errors.phone_step_incomplete: Vous devez aller sur votre téléphone et
 doc_auth.errors.pii.birth_date_min_age: Votre anniversaire ne correspond pas à l’âge minimum requis.
 doc_auth.errors.rate_limited_heading: Nous n’avons pas pu vérifier votre pièce d’identité.
 doc_auth.errors.rate_limited_subheading: Essayez de prendre de nouvelles photos.
-doc_auth.errors.rate_limited_text_html: Pour votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier un document en ligne. <strong>Réessayez dans %{timeout}.</strong>
+doc_auth.errors.rate_limited_text_html: Pour éviter la fraude, nous limitons le nombre de fois où vous pouvez tenter de confirmer votre identité en ligne. <strong>Réessayez d’ici %{timeout}.</strong>
 doc_auth.errors.selfie_fail_heading: Nous n’avons pas pu faire correspondre votre photo à celle figurant sur votre pièce d’identité.
 doc_auth.errors.selfie_not_live_or_poor_quality_heading: Nous n’avons pas pu vérifier votre photo
 doc_auth.errors.send_link_limited: Vous avez essayé trop de fois, veuillez réessayer dans %{timeout}. Vous pouvez également revenir en arrière et choisir d’utiliser votre ordinateur à la place.
@@ -1016,8 +1016,8 @@ idv.errors.incorrect_password: Le mot de passe que vous avez saisi est incorrect
 idv.errors.pattern_mismatch.ssn: Saisissez un numéro de sécurité sociale à neuf chiffres
 idv.errors.pattern_mismatch.zipcode: Saisissez un code postal à 5 ou 9 chiffres
 idv.errors.pattern_mismatch.zipcode_five: Saisissez un code postal à 5 chiffres
-idv.failure.attempts_html.one: Pour des raisons de sécurité, il vous reste <strong>une tentative</strong> pour ajouter votre pièce d’identité en ligne.
-idv.failure.attempts_html.other: Pour des raisons de sécurité, il vous reste <strong>%{count} tentatives</strong> pour ajouter votre pièce d’identité en ligne.
+idv.failure.attempts_html.one: Vous avez encore <strong>un essai.</strong> Vous devrez ensuite attendre 6 heures avant de réessayer.
+idv.failure.attempts_html.other: Vous pouvez encore essayer <strong>%{count} fois de plus.</strong> Ensuite, vous devrez ensuite attendre 6 heures avant de réessayer.
 idv.failure.button.try_online: Réessayer en ligne
 idv.failure.button.warning: Réessayer
 idv.failure.exceptions.in_person_outage_error_message.post_cta.body: En attendant, vous pouvez toujours commencer la procédure de vérification en personne sur %{app_name} avant de vous rendre dans un bureau de poste. Si vous avez un besoin urgent d’accès aux services, veuillez contacter directement l’organisme concerné.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -567,7 +567,7 @@ doc_auth.errors.phone_step_incomplete: 在继续之前你必须使用手机上�
 doc_auth.errors.pii.birth_date_min_age: 你的生日不满足最低年龄要求。
 doc_auth.errors.rate_limited_heading: 我们无法验证你的身份证件。
 doc_auth.errors.rate_limited_subheading: 尝试再拍照片
-doc_auth.errors.rate_limited_text_html: 为了你的安全，我们限制你在网上尝试验证文件的次数。<strong> %{timeout} 后再试。</strong>
+doc_auth.errors.rate_limited_text_html: 为了防止欺诈，我们限制在网上尝试验证文件的次数。<strong> %{timeout}个小时以后再试。</strong>
 doc_auth.errors.selfie_fail_heading: 我们无法把你自己的照片与你的身份证件匹配
 doc_auth.errors.selfie_not_live_or_poor_quality_heading: 我们无法验证你自己的照片
 doc_auth.errors.send_link_limited: 你尝试了太多次。请在 %{timeout}后再试。你也可以返回并选择使用电脑。
@@ -1029,8 +1029,8 @@ idv.errors.incorrect_password: 你输入的密码不对。
 idv.errors.pattern_mismatch.ssn: 输入 9 位数的社会保障号码
 idv.errors.pattern_mismatch.zipcode: 输入 5 或 9 位的邮编
 idv.errors.pattern_mismatch.zipcode_five: 输入 5 位的邮编
-idv.failure.attempts_html.one: 出于安全考虑，你在网上添加身份证件只能再试<strong>一次</strong>了。
-idv.failure.attempts_html.other: 出于安全考虑，你在网上添加身份证件只能再试<strong>%{count} </strong>次了。
+idv.failure.attempts_html.one: 您可以再试<strong>1次。</strong> 然后您必须等6个小时才能再试。
+idv.failure.attempts_html.other: 您可以再试<strong>{count}次。</strong> 然后您必须等6个小时才能再试。
 idv.failure.button.try_online: 在网上再试一下
 idv.failure.button.warning: 再试一下。
 idv.failure.exceptions.in_person_outage_error_message.post_cta.body: 与此同时，你仍然可以在 %{app_name}开始亲身验证身份流程，然后去邮局。如果你迫切需要得到服务，请直接联系该政府机构。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1030,7 +1030,7 @@ idv.errors.pattern_mismatch.ssn: 输入 9 位数的社会保障号码
 idv.errors.pattern_mismatch.zipcode: 输入 5 或 9 位的邮编
 idv.errors.pattern_mismatch.zipcode_five: 输入 5 位的邮编
 idv.failure.attempts_html.one: 您可以再试<strong>1次。</strong> 然后您必须等6个小时才能再试。
-idv.failure.attempts_html.other: 您可以再试<strong>{count}次。</strong> 然后您必须等6个小时才能再试。
+idv.failure.attempts_html.other: 您可以再试<strong>%{count}次。</strong> 然后您必须等6个小时才能再试。
 idv.failure.button.try_online: 在网上再试一下
 idv.failure.button.warning: 再试一下。
 idv.failure.exceptions.in_person_outage_error_message.post_cta.body: 与此同时，你仍然可以在 %{app_name}开始亲身验证身份流程，然后去邮局。如果你迫切需要得到服务，请直接联系该政府机构。


### PR DESCRIPTION
LG-14067 Implement new attempts language in attempts screen

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14067](https://cm-jira.usa.gov/browse/LG-14067)


## 🛠 Summary of changes

Updated text and translations for "out of attempts" screen during doc auth.


## 📜 Testing Plan


- [ ] Step 1 - Go through doc auth normally (Mobile or Desktop), failing each step until you are out of attempts. 
- [ ] Step 2 - Ensure new text matches Figma attached in ticket


## 👀 Screenshots



<details>
<summary>After:</summary>
<img width="777" alt="Screenshot 2024-10-03 at 9 45 58 AM" src="https://github.com/user-attachments/assets/c5a3e2fb-ddbe-4356-934b-2237adf4b88c">
<img width="911" alt="Screenshot 2024-10-03 at 9 46 28 AM" src="https://github.com/user-attachments/assets/1620f281-6a5f-4682-829d-4ae76b21a3af">

</details>

