### PR TITLE
Remove vot test default

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -31,9 +31,9 @@ acuant_sdk_initialization_endpoint: 'https://us.acas.acuant.net'
 add_email_link_valid_for_hours: 24
 address_identity_proofing_supported_country_codes: '["AS", "GU", "MP", "PR", "US", "VI"]'
 all_redirect_uris_cache_duration_minutes: 2
-allowed_biometric_ial_providers: '[]'
+allowed_biometric_ial_providers: '["urn:gov:gsa:openidconnect:sp:server"]'
 allowed_ialmax_providers: '[]'
-allowed_valid_authn_contexts_semantic_providers: '[]'
+allowed_valid_authn_contexts_semantic_providers: '["urn:gov:gsa:openidconnect:sp:server"]'
 allowed_verified_within_providers: '[]'
 asset_host: ''
 async_stale_job_timeout_seconds: 300

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -1055,7 +1055,10 @@ RSpec.feature 'Analytics Regression', :js do
 
       perform_in_browser(:desktop) do
         sign_in_and_2fa_user(user)
-        visit_idp_from_sp_with_ial2(:oidc, facial_match_required: true)
+        visit_idp_from_sp_with_ial2(
+          :oidc,
+          acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_PREFERRED_ACR,
+        )
         complete_doc_auth_steps_before_document_capture_step
         attach_images
         attach_selfie
@@ -1181,7 +1184,10 @@ RSpec.feature 'Analytics Regression', :js do
 
           perform_in_browser(:mobile) do
             sign_in_and_2fa_user(user)
-            visit_idp_from_sp_with_ial2(:oidc, facial_match_required: true)
+            visit_idp_from_sp_with_ial2(
+              :oidc,
+              acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_PREFERRED_ACR,
+            )
             complete_doc_auth_steps_before_document_capture_step
             attach_images
             click_continue

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -8,6 +8,10 @@ RSpec.feature 'document capture step', :js do
 
   let(:max_attempts) { IdentityConfig.store.doc_auth_max_attempts }
   let(:fake_analytics) { FakeAnalytics.new }
+  let(:acr_values) do
+    Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+  end
+  let(:issuer) { 'urn:gov:gsa:openidconnect:sp:server' }
 
   before(:each) do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
@@ -177,7 +181,7 @@ RSpec.feature 'document capture step', :js do
         context 'with a passing selfie' do
           it 'proceeds to the next page with valid info, including a selfie image' do
             perform_in_browser(:mobile) do
-              visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+              visit_idp_from_oidc_sp_with_ial2(acr_values:)
               sign_in_and_2fa_user(@user)
               complete_doc_auth_steps_before_document_capture_step
 
@@ -320,11 +324,16 @@ RSpec.feature 'document capture step', :js do
                 :in_person_proofing_enabled,
               ).and_return(true)
               allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(99)
+              allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+                and_return([ipp_service_provider.issuer])
+              allow(IdentityConfig.store).to receive(
+                :allowed_valid_authn_contexts_semantic_providers,
+              ).and_return([ipp_service_provider.issuer])
               perform_in_browser(:mobile) do
                 visit_idp_from_sp_with_ial2(
                   :oidc,
                   **{ client_id: ipp_service_provider.issuer,
-                      facial_match_required: true },
+                      acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR },
                 )
                 sign_in_and_2fa_user(@user)
                 complete_up_to_how_to_verify_step_for_opt_in_ipp(
@@ -341,7 +350,7 @@ RSpec.feature 'document capture step', :js do
             before do
               allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(99)
               perform_in_browser(:mobile) do
-                visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+                visit_idp_from_oidc_sp_with_ial2(acr_values:)
                 sign_in_and_2fa_user(@user)
                 complete_doc_auth_steps_before_document_capture_step
               end
@@ -395,7 +404,7 @@ RSpec.feature 'document capture step', :js do
         describe 'when desktop selfie not allowed' do
           it 'can only proceed to link sent page' do
             perform_in_browser(:desktop) do
-              visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+              visit_idp_from_oidc_sp_with_ial2(acr_values:)
               sign_in_and_2fa_user(@user)
               complete_doc_auth_steps_before_hybrid_handoff_step
               # we still have option to continue
@@ -414,7 +423,7 @@ RSpec.feature 'document capture step', :js do
 
           it 'proceed to the next page with valid info, including a selfie image' do
             perform_in_browser(:desktop) do
-              visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+              visit_idp_from_oidc_sp_with_ial2(acr_values:)
               sign_in_and_2fa_user(@user)
               complete_doc_auth_steps_before_hybrid_handoff_step
               # we still have option to continue on handoff, since it's desktop no skip_hand_off
@@ -457,7 +466,7 @@ RSpec.feature 'document capture step', :js do
             describe 'when ipp is selected' do
               it 'proceed to the next page and start ipp' do
                 perform_in_browser(:desktop) do
-                  visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+                  visit_idp_from_oidc_sp_with_ial2(acr_values:)
                   sign_in_and_2fa_user(@user)
                   complete_doc_auth_steps_before_hybrid_handoff_step
                   # we still have option to continue on handoff, since it's desktop no skip_hand_off
@@ -485,7 +494,7 @@ RSpec.feature 'document capture step', :js do
       allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
       allow(IdentityConfig.store).to receive(:doc_auth_selfie_capture_enabled).and_return(true)
       allow(IdentityConfig.store).to receive(:doc_auth_separate_pages_enabled).and_return(true)
-      visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+      visit_idp_from_oidc_sp_with_ial2(acr_values:)
       sign_in_and_2fa_user(@user)
       complete_doc_auth_steps_before_document_capture_step
     end
@@ -679,7 +688,7 @@ RSpec.feature 'document capture step', :js do
           context 'with a passing selfie' do
             it 'proceeds to the next page with valid info, including a selfie image' do
               perform_in_browser(:mobile) do
-                visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+                visit_idp_from_oidc_sp_with_ial2(acr_values:)
                 sign_in_and_2fa_user(@user)
                 complete_doc_auth_steps_before_document_capture_step
 
@@ -841,11 +850,16 @@ RSpec.feature 'document capture step', :js do
                   :in_person_proofing_enabled,
                 ).and_return(true)
                 allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(99)
+                allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+                  and_return([ipp_service_provider.issuer])
+                allow(IdentityConfig.store).to receive(
+                  :allowed_valid_authn_contexts_semantic_providers,
+                ).and_return([ipp_service_provider.issuer])
                 perform_in_browser(:mobile) do
                   visit_idp_from_sp_with_ial2(
                     :oidc,
                     **{ client_id: ipp_service_provider.issuer,
-                        facial_match_required: true },
+                        acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR },
                   )
                   sign_in_and_2fa_user(@user)
                   complete_up_to_how_to_verify_step_for_opt_in_ipp(
@@ -861,7 +875,7 @@ RSpec.feature 'document capture step', :js do
               before do
                 allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(99)
                 perform_in_browser(:mobile) do
-                  visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+                  visit_idp_from_oidc_sp_with_ial2(acr_values:)
                   sign_in_and_2fa_user(@user)
                   complete_doc_auth_steps_before_document_capture_step
                 end
@@ -915,7 +929,7 @@ RSpec.feature 'document capture step', :js do
           describe 'when desktop selfie not allowed' do
             it 'can only proceed to link sent page' do
               perform_in_browser(:desktop) do
-                visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+                visit_idp_from_oidc_sp_with_ial2(acr_values:)
                 sign_in_and_2fa_user(@user)
                 complete_doc_auth_steps_before_hybrid_handoff_step
                 # we still have option to continue
@@ -934,7 +948,7 @@ RSpec.feature 'document capture step', :js do
 
             it 'proceed to the next page with valid info, including a selfie image' do
               perform_in_browser(:desktop) do
-                visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+                visit_idp_from_oidc_sp_with_ial2(acr_values:)
                 sign_in_and_2fa_user(@user)
                 complete_doc_auth_steps_before_hybrid_handoff_step
                 # we still have option to continue on handoff, since it's desktop no skip_hand_off
@@ -978,7 +992,7 @@ RSpec.feature 'document capture step', :js do
               describe 'when ipp is selected' do
                 it 'proceed to the next page and start ipp' do
                   perform_in_browser(:desktop) do
-                    visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+                    visit_idp_from_oidc_sp_with_ial2(acr_values:)
                     sign_in_and_2fa_user(@user)
                     complete_doc_auth_steps_before_hybrid_handoff_step
                     # still have option to continue handoff, since it's desktop no skip_hand_off
@@ -1107,6 +1121,11 @@ RSpec.feature 'direct access to IPP on desktop', :js do
       allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(
         in_person_proofing_opt_in_enabled,
       )
+      allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+        and_return([service_provider.issuer])
+      allow(IdentityConfig.store).to receive(
+        :allowed_valid_authn_contexts_semantic_providers,
+      ).and_return([service_provider.issuer])
       allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
         and_return(false)
       visit_idp_from_sp_with_ial2(

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -8,9 +8,7 @@ RSpec.feature 'document capture step', :js do
 
   let(:max_attempts) { IdentityConfig.store.doc_auth_max_attempts }
   let(:fake_analytics) { FakeAnalytics.new }
-  let(:acr_values) do
-    Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
-  end
+  let(:acr_values) { Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR }
   let(:issuer) { 'urn:gov:gsa:openidconnect:sp:server' }
 
   before(:each) do
@@ -1107,6 +1105,8 @@ end
 RSpec.feature 'direct access to IPP on desktop', :js do
   include IdvStepHelper
   include DocAuthHelper
+
+  let(:acr_values) { Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR }
 
   context 'before handoff page' do
     let(:sp_ipp_enabled) { true }

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -333,7 +333,7 @@ RSpec.feature 'document capture step', :js do
                 visit_idp_from_sp_with_ial2(
                   :oidc,
                   **{ client_id: ipp_service_provider.issuer,
-                      acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR },
+                      acr_values: },
                 )
                 sign_in_and_2fa_user(@user)
                 complete_up_to_how_to_verify_step_for_opt_in_ipp(
@@ -859,7 +859,7 @@ RSpec.feature 'document capture step', :js do
                   visit_idp_from_sp_with_ial2(
                     :oidc,
                     **{ client_id: ipp_service_provider.issuer,
-                        acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR },
+                        acr_values: },
                   )
                   sign_in_and_2fa_user(@user)
                   complete_up_to_how_to_verify_step_for_opt_in_ipp(
@@ -1131,7 +1131,7 @@ RSpec.feature 'direct access to IPP on desktop', :js do
       visit_idp_from_sp_with_ial2(
         :oidc,
         **{ client_id: service_provider.issuer,
-            facial_match_required: facial_match_required },
+            acr_values: },
       )
       sign_in_via_branded_page(user)
       complete_doc_auth_steps_before_agreement_step

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -361,8 +361,7 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
       visit_idp_from_sp_with_ial2(
         :oidc,
         **{ client_id: service_provider.issuer,
-            acr_values:,
-        },
+            acr_values: },
       )
       sign_in_via_branded_page(user)
       complete_doc_auth_steps_before_agreement_step

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
   include DocCaptureHelper
 
   let(:fake_analytics) { FakeAnalytics.new }
+  let(:acr_values) { Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR }
 
   before do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
@@ -239,7 +240,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
       before do
         allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
         allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:fail)
-        start_idv_from_sp(facial_match_required: true)
+        start_idv_from_sp(acr_values:)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_success_face_match_fail
@@ -261,7 +262,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
       before do
         allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
 
-        start_idv_from_sp(facial_match_required: true)
+        start_idv_from_sp(acr_values:)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_pass_and_portrait_match_not_live
@@ -304,7 +305,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
       before do
         allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
 
-        start_idv_from_sp(facial_match_required: true)
+        start_idv_from_sp(acr_values:)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_failure_face_match_pass
@@ -346,7 +347,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
       before do
         allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
         allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:fail)
-        start_idv_from_sp(facial_match_required: true)
+        start_idv_from_sp(acr_values:)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_fail_face_match_fail
@@ -367,7 +368,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
         pii[:address1] = nil
         allow_any_instance_of(DocAuth::LexisNexis::Responses::TrueIdResponse).
           to receive(:pii_from_doc).and_return(Pii::StateId.new(**pii))
-        start_idv_from_sp(facial_match_required: true)
+        start_idv_from_sp(acr_values:)
         sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_pass_face_match_pass_no_address1
@@ -651,7 +652,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
         before do
           allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
           allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:fail)
-          start_idv_from_sp(facial_match_required: true)
+          start_idv_from_sp(acr_values:)
           sign_in_and_2fa_user
           complete_doc_auth_steps_before_document_capture_step
           mock_doc_auth_success_face_match_fail
@@ -674,7 +675,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
         before do
           allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
 
-          start_idv_from_sp(facial_match_required: true)
+          start_idv_from_sp(acr_values:)
           sign_in_and_2fa_user
           complete_doc_auth_steps_before_document_capture_step
           mock_doc_auth_pass_and_portrait_match_not_live
@@ -718,7 +719,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
         before do
           allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
 
-          start_idv_from_sp(facial_match_required: true)
+          start_idv_from_sp(acr_values:)
           sign_in_and_2fa_user
           complete_doc_auth_steps_before_document_capture_step
           mock_doc_auth_failure_face_match_pass
@@ -761,7 +762,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
         before do
           allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
           allow_any_instance_of(DocAuth::Response).to receive(:selfie_status).and_return(:fail)
-          start_idv_from_sp(facial_match_required: true)
+          start_idv_from_sp(acr_values:)
           sign_in_and_2fa_user
           complete_doc_auth_steps_before_document_capture_step
           mock_doc_auth_fail_face_match_fail
@@ -783,7 +784,7 @@ RSpec.feature 'doc auth redo document capture', js: true, allowed_extra_analytic
           pii[:address1] = nil
           allow_any_instance_of(DocAuth::LexisNexis::Responses::TrueIdResponse).
             to receive(:pii_from_doc).and_return(Pii::StateId.new(**pii))
-          start_idv_from_sp(facial_match_required: true)
+          start_idv_from_sp(acr_values:)
           sign_in_and_2fa_user
           complete_doc_auth_steps_before_document_capture_step
           mock_doc_auth_pass_face_match_pass_no_address1

--- a/spec/features/idv/gpo_disabled_spec.rb
+++ b/spec/features/idv/gpo_disabled_spec.rb
@@ -44,7 +44,10 @@ RSpec.feature 'disabling GPO address verification' do
 
     it 'does not allow verify by mail with facial match comparison', :js do
       user = user_with_2fa
-      start_idv_from_sp(:oidc, facial_match_required: true)
+      start_idv_from_sp(
+        :oidc,
+        acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
+      )
       sign_in_and_2fa_user(user)
       complete_all_doc_auth_steps(with_selfie: true)
 
@@ -58,7 +61,7 @@ RSpec.feature 'disabling GPO address verification' do
 
     it 'does allow verify by mail without facial match comparison', :js do
       user = user_with_2fa
-      start_idv_from_sp(:oidc, facial_match_required: false)
+      start_idv_from_sp(:oidc)
       sign_in_and_2fa_user(user)
       complete_all_doc_auth_steps(with_selfie: false)
       click_on t('idv.troubleshooting.options.verify_by_mail')

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -431,7 +431,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       user = create(:user, :with_authentication_app)
 
       perform_in_browser(:desktop) do
-        start_idv_from_sp(facial_match_required: true)
+        start_idv_from_sp(acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR)
         sign_in_and_2fa_user(user)
 
         complete_doc_auth_steps_before_hybrid_handoff_step

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
         user = nil
 
         perform_in_browser(:desktop) do
-          visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+          visit_idp_from_oidc_sp_with_ial2(acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR)
 
           user = sign_up_and_2fa_ial1_user
 

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
 
   let(:phone_number) { '415-555-0199' }
   let(:sp) { :oidc }
+  let(:acr_values) { Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR }
 
   before do
     allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
@@ -116,7 +117,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
         user = nil
 
         perform_in_browser(:desktop) do
-          visit_idp_from_oidc_sp_with_ial2(acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR)
+          visit_idp_from_oidc_sp_with_ial2(acr_values:)
 
           user = sign_up_and_2fa_ial1_user
 
@@ -431,7 +432,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       user = create(:user, :with_authentication_app)
 
       perform_in_browser(:desktop) do
-        start_idv_from_sp(acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR)
+        start_idv_from_sp(acr_values:)
         sign_in_and_2fa_user(user)
 
         complete_doc_auth_steps_before_hybrid_handoff_step

--- a/spec/features/idv/step_up_spec.rb
+++ b/spec/features/idv/step_up_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe 'IdV step up flow' do
   end
 
   scenario 'User with active profile can redo idv when selfie required', js: true do
-    visit_idp_from_sp_with_ial2(sp, facial_match_required: true)
+    visit_idp_from_sp_with_ial2(
+      :oidc,
+      acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
+    )
     sign_in_live_with_2fa(user)
 
     expect(page).to have_current_path(idv_welcome_path)

--- a/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe 'state id 50/50 state', :js, allow_browser_log: true do
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
     allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+      and_return([ipp_service_provider.issuer])
+    allow(IdentityConfig.store).to receive(
+      :allowed_valid_authn_contexts_semantic_providers,
+    ).and_return([ipp_service_provider.issuer])
   end
 
   context 'when navigating to state id page from PO search location page' do

--- a/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
+++ b/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
     allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(5)
+    allow(IdentityConfig.store).to receive(
+      :allowed_valid_authn_contexts_semantic_providers,
+    ).and_return([ipp_service_provider.issuer, 'urn:gov:gsa:openidconnect:sp:server'])
   end
 
   context 'when ipp_opt_in_enabled and ipp_opt_in_enabled are both enabled' do

--- a/spec/features/idv/verify_by_mail_pending_spec.rb
+++ b/spec/features/idv/verify_by_mail_pending_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'a user that is pending verify by mail' do
     profile = create(:profile, :with_pii, :verify_by_mail_pending, user: user)
     create(:gpo_confirmation_code, profile: profile, created_at: 2.days.ago, updated_at: 2.days.ago)
 
-    start_idv_from_sp(facial_match_required: false)
+    start_idv_from_sp
     sign_in_live_with_2fa(user)
 
     expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
@@ -29,7 +29,7 @@ RSpec.feature 'a user that is pending verify by mail' do
     profile = create(:profile, :with_pii, :verify_by_mail_pending, user: user)
     create(:gpo_confirmation_code, profile: profile, created_at: 2.days.ago, updated_at: 2.days.ago)
 
-    start_idv_from_sp(facial_match_required: true)
+    start_idv_from_sp(acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR)
     sign_in_live_with_2fa(user)
 
     # The user is redirected to proofing since their pending profile does not meet

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -142,8 +142,7 @@ module IdvHelper
     state: SecureRandom.hex,
     nonce: SecureRandom.hex,
     verified_within: nil,
-    acr_values: Saml::Idp::Constants::IAL_VERIFIED_ACR,
-    facial_match_required: nil
+    acr_values: Saml::Idp::Constants::IAL_VERIFIED_ACR
   )
     params = {
       acr_values:,

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -142,9 +142,11 @@ module IdvHelper
     state: SecureRandom.hex,
     nonce: SecureRandom.hex,
     verified_within: nil,
+    acr_values: Saml::Idp::Constants::IAL_VERIFIED_ACR,
     facial_match_required: nil
   )
     params = {
+      acr_values:,
       client_id:,
       response_type: 'code',
       scope: 'openid email profile:name phone social_security_number',
@@ -154,12 +156,6 @@ module IdvHelper
       nonce:,
       verified_within:,
     }
-
-    if facial_match_required
-      params[:acr_values] = Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_PREFERRED_ACR
-    else
-      params[:acr_values] = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
-    end
 
     visit openid_connect_authorize_path(params)
   end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -156,7 +156,7 @@ module IdvHelper
     }
 
     if facial_match_required
-      params[:vtr] = ['C1.P1.Pb'].to_json
+      params[:acr_values] = Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_PREFERRED_ACR
     else
       params[:acr_values] = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
     end

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -13,9 +13,9 @@ module IdvStepHelper
     end
   end
 
-  def start_idv_from_sp(sp = :oidc, facial_match_required: nil)
+  def start_idv_from_sp(sp = :oidc, acr_values: Saml::Idp::Constants::IAL_VERIFIED_ACR)
     if sp.present?
-      visit_idp_from_sp_with_ial2(sp, facial_match_required:)
+      visit_idp_from_sp_with_ial2(sp, acr_values:)
     else
       visit root_path
     end

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -100,7 +100,7 @@ module OidcAuthHelper
     ial2_params[:prompt] = prompt if prompt
 
     if facial_match_required
-      ial2_params[:vtr] = ['C1.P1.Pb'].to_json
+      ial2_params[:acr_values] = Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_PREFERRED_ACR
     else
       ial2_params[:acr_values] = acr_values
     end


### PR DESCRIPTION
## 🛠 Summary of changes
This is part of a bigger effort to minimize our use of the vectors of trust API interface, so that we can ultimately deprecate it.

This change:
* updates our testing code to default to the new semantic facial match acr value when utilizing helpers.
~There is another option with this change, which is to rip out the `facial_match_required` attribute that is passed into the helper, and just pass the acr level through the `acr` value. that is a straightforward change, but since a lot of specs utilize this helper, will be a much larger change. Am open for feedback on the right way to do this!~ i decided to do this because (to me) it makes it clearer what is happening in the test setup is, and because the tests were relying on the vectors of trust ability to "step up" to facial match.
* Adds the default issuer to the `test` application.yml.default. this is temporary, as on november 7th both facial match and the semantic acr values will be generally available


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
