### PR TITLE
LG-14290- Add step indicator to How To Verify View - Fix Specs

### DIFF
--- a/spec/views/idv/how_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/how_to_verify/show.html.erb_spec.rb
@@ -17,49 +17,47 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
       render
     end
 
-    context 'renders the show template with' do
-      it('a step indicator with Getting started as the current step') do
-        expect(view.content_for(:pre_flash_content)).to have_css(
-          '.step-indicator__step--current',
-          text: t('step_indicator.flows.idv.getting_started'),
-        )
-      end
+    it 'renders a step indicator with Getting started as the current step' do
+      expect(view.content_for(:pre_flash_content)).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.getting_started'),
+      )
+    end
 
-      it 'a title' do
-        expect(rendered).to have_content(t('doc_auth.headings.how_to_verify'))
-      end
+    it 'renders a title' do
+      expect(rendered).to have_content(t('doc_auth.headings.how_to_verify'))
+    end
 
-      it 'two options for verifying your identity' do
-        expect(rendered).to have_content(t('doc_auth.headings.verify_online'))
-        expect(rendered).to have_content(t('doc_auth.headings.verify_at_post_office'))
-      end
+    it 'renders two options for verifying your identity' do
+      expect(rendered).to have_content(t('doc_auth.headings.verify_online'))
+      expect(rendered).to have_content(t('doc_auth.headings.verify_at_post_office'))
+    end
 
-      it 'a button for remote and ipp' do
-        expect(rendered).to have_button(t('forms.buttons.continue_remote'))
-        expect(rendered).to have_button(t('forms.buttons.continue_ipp'))
-      end
+    it 'renders a button for remote and ipp' do
+      expect(rendered).to have_button(t('forms.buttons.continue_remote'))
+      expect(rendered).to have_button(t('forms.buttons.continue_ipp'))
+    end
 
-      it 'a troubleshooting section' do
-        expect(rendered).to have_content(
-          t('doc_auth.info.how_to_verify_troubleshooting_options_header'),
-        )
-        expect(rendered).to have_link(t('doc_auth.info.verify_online_link_text'))
-        expect(rendered).to have_link(t('doc_auth.info.verify_at_post_office_link_text'))
-      end
+    it 'renders a troubleshooting section' do
+      expect(rendered).to have_content(
+        t('doc_auth.info.how_to_verify_troubleshooting_options_header'),
+      )
+      expect(rendered).to have_link(t('doc_auth.info.verify_online_link_text'))
+      expect(rendered).to have_link(t('doc_auth.info.verify_at_post_office_link_text'))
+    end
 
-      it 'a cancel link' do
-        expect(rendered).to have_link(t('links.cancel'))
-      end
+    it 'renders a cancel link' do
+      expect(rendered).to have_link(t('links.cancel'))
+    end
 
-      it 'non-selfie specific content' do
-        expect(rendered).to have_content(t('doc_auth.info.how_to_verify'))
-        expect(rendered).not_to have_content(t('doc_auth.tips.mobile_phone_required'))
-        expect(rendered).to have_content(t('doc_auth.headings.verify_online'))
-        expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction'))
-        expect(rendered).to have_content(t('doc_auth.info.verify_online_description'))
-        expect(rendered).to have_content(t('doc_auth.info.verify_at_post_office_instruction'))
-        expect(rendered).to have_content(t('doc_auth.info.verify_at_post_office_description'))
-      end
+    it 'renders non-selfie specific content' do
+      expect(rendered).to have_content(t('doc_auth.info.how_to_verify'))
+      expect(rendered).not_to have_content(t('doc_auth.tips.mobile_phone_required'))
+      expect(rendered).to have_content(t('doc_auth.headings.verify_online'))
+      expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction'))
+      expect(rendered).to have_content(t('doc_auth.info.verify_online_description'))
+      expect(rendered).to have_content(t('doc_auth.info.verify_at_post_office_instruction'))
+      expect(rendered).to have_content(t('doc_auth.info.verify_at_post_office_description'))
     end
   end
 
@@ -71,52 +69,50 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
       render
     end
 
-    context 'renders the show template with' do
-      it('a step indicator with Getting started as the current step') do
-        expect(view.content_for(:pre_flash_content)).to have_css(
-          '.step-indicator__step--current',
-          text: t('step_indicator.flows.idv.getting_started'),
-        )
-      end
+    it 'renders a step indicator with Getting started as the current step' do
+      expect(view.content_for(:pre_flash_content)).to have_css(
+        '.step-indicator__step--current',
+        text: t('step_indicator.flows.idv.getting_started'),
+      )
+    end
 
-      it 'a title' do
-        expect(rendered).to have_content(t('doc_auth.headings.how_to_verify'))
-      end
+    it 'renders a title' do
+      expect(rendered).to have_content(t('doc_auth.headings.how_to_verify'))
+    end
 
-      it 'two options for verifying your identity' do
-        expect(rendered).to have_content(t('doc_auth.headings.verify_online_selfie'))
-        expect(rendered).to have_content(t('doc_auth.headings.verify_at_post_office'))
-      end
+    it 'renders two options for verifying your identity' do
+      expect(rendered).to have_content(t('doc_auth.headings.verify_online_selfie'))
+      expect(rendered).to have_content(t('doc_auth.headings.verify_at_post_office'))
+    end
 
-      it 'a button for remote and ipp' do
-        expect(rendered).to have_button(t('forms.buttons.continue_remote_selfie'))
-        expect(rendered).to have_button(t('forms.buttons.continue_ipp'))
-      end
+    it 'renders a button for remote and ipp' do
+      expect(rendered).to have_button(t('forms.buttons.continue_remote_selfie'))
+      expect(rendered).to have_button(t('forms.buttons.continue_ipp'))
+    end
 
-      it 'a troubleshooting section' do
-        expect(rendered).to have_content(
-          t('doc_auth.info.how_to_verify_troubleshooting_options_header'),
-        )
-        expect(rendered).to have_link(t('doc_auth.info.verify_online_link_text'))
-        expect(rendered).to have_link(t('doc_auth.info.verify_at_post_office_link_text'))
-      end
+    it 'renders a troubleshooting section' do
+      expect(rendered).to have_content(
+        t('doc_auth.info.how_to_verify_troubleshooting_options_header'),
+      )
+      expect(rendered).to have_link(t('doc_auth.info.verify_online_link_text'))
+      expect(rendered).to have_link(t('doc_auth.info.verify_at_post_office_link_text'))
+    end
 
-      it 'a cancel link' do
-        expect(rendered).to have_link(t('links.cancel'))
-      end
+    it 'renders a cancel link' do
+      expect(rendered).to have_link(t('links.cancel'))
+    end
 
-      it 'selfie specific content' do
-        expect(rendered).to have_content(t('doc_auth.info.how_to_verify_selfie'))
-        expect(rendered).to have_content(t('doc_auth.tips.mobile_phone_required'))
-        expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
-        expect(rendered).to have_content(t('doc_auth.info.verify_online_description_selfie'))
-        expect(rendered).to have_content(
-          t('doc_auth.info.verify_at_post_office_instruction_selfie'),
-        )
-        expect(rendered).to have_content(
-          t('doc_auth.info.verify_at_post_office_description_selfie'),
-        )
-      end
+    it 'renders selfie specific content' do
+      expect(rendered).to have_content(t('doc_auth.info.how_to_verify_selfie'))
+      expect(rendered).to have_content(t('doc_auth.tips.mobile_phone_required'))
+      expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
+      expect(rendered).to have_content(t('doc_auth.info.verify_online_description_selfie'))
+      expect(rendered).to have_content(
+        t('doc_auth.info.verify_at_post_office_instruction_selfie'),
+      )
+      expect(rendered).to have_content(
+        t('doc_auth.info.verify_at_post_office_description_selfie'),
+      )
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-14290](https://cm-jira.usa.gov/browse/LG-14290) Eng: Add step indicator component to Opt-in page (How to Verify)

## 🛠 Summary of changes
- Update specs per review [here](https://github.com/18F/identity-idp/pull/11298#pullrequestreview-2348335219)
     1. Removed parentheses used inside it description in spec file 
     2. Update specs to make readable 

## 📜 Testing Plan

- [ ] Run specs in `spec/views/idv/how_to_verify/show.html.erb_spec.rb` and check for readability (you can also look in screenshots)

## 👀 Screenshots

<details>
<summary>Before:</summary>

<img width="423" alt="Screenshot 2024-10-04 at 12 31 01 PM" src="https://github.com/user-attachments/assets/614b7187-bb62-435c-9cb4-9d6ff39c7a8e">

</details>

<details>
<summary>After:</summary>

<img width="469" alt="Screenshot 2024-10-04 at 12 29 26 PM" src="https://github.com/user-attachments/assets/c89595ab-034c-4af6-96af-b6e88b89aaf7">

</details>
