### PR TITLE
LG-14398: Add translations for "Email not yet selected"

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -41,7 +41,7 @@ account_reset.request.yes_continue: Sí, continuar con la eliminación
 account.connected_apps.associated_attributes_html: 'Conectado el %{timestamp_html} con:'
 account.connected_apps.associated_html: 'Conectado: %{timestamp_html}'
 account.connected_apps.description: Con su cuenta de %{app_name}, puede conectarse de manera segura a muchas cuentas del gobierno en línea. Esta es una lista de todas las cuentas que tiene conectadas actualmente.
-account.connected_apps.email_not_selected: Email not yet selected
+account.connected_apps.email_not_selected: No se seleccionó correo electrónico aún
 account.email_language.default: '%{language} (predeterminado)'
 account.email_language.edit_title: Editar la preferencia de idioma del correo electrónico
 account.email_language.languages_list: Recibirá mensajes de correo electrónico de %{app_name} en el idioma que elija.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -41,7 +41,7 @@ account_reset.request.yes_continue: Oui, continuer la suppression
 account.connected_apps.associated_attributes_html: 'Connecté %{timestamp_html} avec :'
 account.connected_apps.associated_html: Connecté %{timestamp_html}
 account.connected_apps.description: Avec votre compte %{app_name}, vous pouvez vous connecter en toute sécurité à plusieurs comptes de l’administration en ligne. Vous trouverez ci-dessous une liste de tous vos comptes actuellement connectés.
-account.connected_apps.email_not_selected: Email not yet selected
+account.connected_apps.email_not_selected: Adresse e-mail non encore sélectionnée
 account.email_language.default: '%{language} (par défaut)'
 account.email_language.edit_title: Modifier la langue dans laquelle vous préférez recevoir les e-mails
 account.email_language.languages_list: Vous recevrez des e-mails de %{app_name} dans la langue de votre choix.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -41,7 +41,7 @@ account_reset.request.yes_continue: 是的，继续删除
 account.connected_apps.associated_attributes_html: '在 %{timestamp_html} 用以下电邮做的连接：'
 account.connected_apps.associated_html: 已连接 %{timestamp_html}
 account.connected_apps.description: 使用你的 %{app_name} 账户，你可以安全地连接到网上多个政府账户。以下列出了你目前已连接的所有账户。
-account.connected_apps.email_not_selected: Email not yet selected
+account.connected_apps.email_not_selected: 尚未选择电邮
 account.email_language.default: '%{language} （默认）'
 account.email_language.edit_title: 编辑电邮语言选择
 account.email_language.languages_list: 您将收到%{app_name}用您选择的语言发送的电子邮件。

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -75,7 +75,6 @@ module I18n
         { key: 'time.formats.event_timestamp', locales: %i[zh] },
         { key: 'time.formats.full_date', locales: %i[es] }, # format is the same in Spanish and English
         { key: 'time.formats.sms_date' }, # for us date format
-        { key: 'account.connected_apps.email_not_selected' }, # See: LG-14398
       ].freeze
       # rubocop:enable Layout/LineLength
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-14398](https://cm-jira.usa.gov/browse/LG-14398)

## 🛠 Summary of changes

Adds translations for the text "Email not yet selected".

This was implemented behind a feature flag in [LG-13665](https://cm-jira.usa.gov/browse/LG-13665) (#11196), but translations were not available for this particular string because it was not known to be needed until implementation had already started (see [related Slack discussion](https://gsa-tts.slack.com/archives/C05R6BLVAQG/p1725033025669399)), and the turnaround time for translations is long.

## 📜 Testing Plan

1. Prerequisite: Have a connection with a service provider ([documentation](https://github.com/18F/identity-idp/blob/main/docs/local-development.md#simulating-a-partner-authentication-request))
2. Go to http://localhost:3000
3. Sign in (if not already)
4. From account dashboard, go to "Connected accounts"
5. (If you see a selected email here, you'll need to destroy the association. In `rails console`, run `User.find_with_email('<insert email address>').identities.update_all(email_address_id: nil)` and reload the page)
6. Note text "Email not yet selected"
7. Change page language
8. Note that the text for "Email not yet selected" is translated

## 👀 Screenshots

Language|Before|After
---|---|---
English|![Screenshot 2024-10-07 at 9 53 20 AM](https://github.com/user-attachments/assets/5a1b6cbc-1f0f-4176-8053-a41c35bc24fa)|![Screenshot 2024-10-07 at 9 53 20 AM](https://github.com/user-attachments/assets/5a1b6cbc-1f0f-4176-8053-a41c35bc24fa)
Spanish|![Screenshot 2024-10-07 at 9 54 29 AM](https://github.com/user-attachments/assets/6b698aaa-69c6-4cd5-bab1-cf9195e7e7cc)|![Screenshot 2024-10-07 at 9 53 25 AM](https://github.com/user-attachments/assets/43c52266-22e2-4d19-81f7-663d3d39c67f)
French|![Screenshot 2024-10-07 at 9 54 25 AM](https://github.com/user-attachments/assets/3345c219-0cee-4f8e-af75-e99c9fcd20e7)|![Screenshot 2024-10-07 at 9 53 29 AM](https://github.com/user-attachments/assets/38dd633d-758d-4157-a2f8-8fa48b65d057)
Chinese|![Screenshot 2024-10-07 at 9 54 21 AM](https://github.com/user-attachments/assets/ea3da273-db8e-41c5-8721-079604ff2cd0)|![Screenshot 2024-10-07 at 9 53 33 AM](https://github.com/user-attachments/assets/57ed85fc-6cb2-465f-87a2-1078a9afd7a7)