### PR TITLE
LG-14389: Add analytics for consent screen email selection

### DIFF
--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -21,7 +21,7 @@ module SignUp
 
       result = @select_email_form.submit(form_params)
 
-      analytics.sp_select_email_submitted(**result.to_h)
+      analytics.sp_select_email_submitted(**result.to_h, needs_completion_screen_reason:)
 
       if result.success?
         user_session[:selected_email_id] = form_params[:selected_email_id]

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -13,12 +13,16 @@ module SignUp
       @user_emails = user_emails
       @last_sign_in_email_address = last_email
       @select_email_form = build_select_email_form
+      analytics.sp_select_email_visited(needs_completion_screen_reason:)
     end
 
     def create
       @select_email_form = build_select_email_form
 
       result = @select_email_form.submit(form_params)
+
+      analytics.sp_select_email_submitted(**result.to_h)
+
       if result.success?
         user_session[:selected_email_id] = form_params[:selected_email_id]
         redirect_to sign_up_completed_path

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -78,7 +78,11 @@ RSpec.describe SignUp::SelectEmailController do
 
       response
 
-      expect(@analytics).to have_logged_event(:sp_select_email_submitted, success: true)
+      expect(@analytics).to have_logged_event(
+        :sp_select_email_submitted,
+        success: true,
+        needs_completion_screen_reason: :new_attributes,
+      )
     end
 
     context 'with a corrupted email selected_email_id form' do
@@ -99,6 +103,7 @@ RSpec.describe SignUp::SelectEmailController do
           :sp_select_email_submitted,
           success: false,
           error_details: { selected_email_id: { not_found: true } },
+          needs_completion_screen_reason: :new_attributes,
         )
       end
     end

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SignUp::SelectEmailController do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, :with_multiple_emails) }
   let(:sp) { create(:service_provider) }
 
   before do
@@ -29,6 +29,17 @@ RSpec.describe SignUp::SelectEmailController do
   describe '#show' do
     subject(:response) { get :show }
 
+    it 'logs analytics event' do
+      stub_analytics
+
+      response
+
+      expect(@analytics).to have_logged_event(
+        :sp_select_email_visited,
+        needs_completion_screen_reason: :new_attributes,
+      )
+    end
+
     it 'assigns view variables' do
       response
 
@@ -51,32 +62,44 @@ RSpec.describe SignUp::SelectEmailController do
   end
 
   describe '#create' do
-    let(:email) { 'michael.motorist@email.com' }
-    let(:email2) { 'michael.motorist2@email.com' }
-    let(:email3) { 'david.motorist@email.com' }
-    let(:params) { { selected_email_id: email2 } }
+    let(:selected_email) { user.confirmed_email_addresses.sample }
+    let(:params) { { select_email_form: { selected_email_id: selected_email.id } } }
 
     subject(:response) { post :create, params: params }
-
-    before do
-      create(:email_address, user:, email: email)
-      create(:email_address, user:, email: email2)
-    end
 
     it 'updates selected email address' do
       response
 
-      expect(user.email_addresses.last.email).
-        to include('michael.motorist2@email.com')
+      expect(controller.user_session[:selected_email_id]).to eq(selected_email.id.to_s)
+    end
+
+    it 'logs analytics event' do
+      stub_analytics
+
+      response
+
+      expect(@analytics).to have_logged_event(:sp_select_email_submitted, success: true)
     end
 
     context 'with a corrupted email selected_email_id form' do
-      let(:params) { { selected_email_id: email3 } }
+      let(:other_user) { create(:user) }
+      let(:selected_email) { other_user.confirmed_email_addresses.sample }
 
       it 'rejects email not belonging to the user' do
         expect(response).to redirect_to(sign_up_select_email_path)
-        expect(user.email_addresses.last.email).
-          to include('michael.motorist2@email.com')
+        expect(controller.user_session[:selected_email_id]).to eq(nil)
+      end
+
+      it 'logs analytics event' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(
+          :sp_select_email_submitted,
+          success: false,
+          error_details: { selected_email_id: { not_found: true } },
+        )
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-14389](https://cm-jira.usa.gov/browse/LG-14389)

## 🛠 Summary of changes

Logs analytics events when the user visits and submits the email selection screen when prompted to consent to share information with a partner.

This leverages existing analytics events created for changing the selected email for a partner in [LG-13665](https://cm-jira.usa.gov/browse/LG-13665) (#11196), using the property `needs_completion_screen_reason` to differentiate if the email was changed stemming from the consent screen.

## 📜 Testing Plan

Prerequisites:

- If you've already consented for the OIDC sample application, sign in and revoke consent from the "Connected accounts" page of your account dashboard
- You must have multiple email addresses associated with your account

Validate that the expected events are logged:

1. Run `make watch_events` in a separate terminal process
2. Run [sample application](https://github.com/18f/identity-oidc-sinatra) in a separate terminal process
4. Go to http://localhost:9292
5. Click "Sign in"
6. Sign in
7. When prompted to consent to share information, click "Edit email address"
8. Observe in `make watch_events` terminal process the event `sp_select_email_visited` with a `needs_completion_screen_reason` value
9. Submit the page with your preferred email to share
8. Observe in `make watch_events` terminal process the event `sp_select_email_submitted` with `success: true` and a `needs_completion_screen_reason` value