### PR TITLE
LG-14360: Update sign out link

### DIFF
--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -241,13 +241,15 @@
   <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'barcode') %>
   <% if @presenter.service_provider_homepage_url.present? %>
   <br />
+  <%= render ClickObserverComponent.new(event_name: 'IdV: user clicked sp link on ready to verify page') do %>
     <%= link_to(
-          t(
-            'in_person_proofing.body.barcode.return_to_partner_link',
-            sp_name: @presenter.sp_name,
-          ),
-          @presenter.service_provider_homepage_url,
-          class: 'display-inline-block padding-top-2',
-        ) %>
-         <% end %>
+      t(
+        'in_person_proofing.body.barcode.return_to_partner_link',
+        sp_name: @presenter.sp_name,
+      ),
+      @presenter.service_provider_homepage_url,
+      class: 'display-inline-block padding-top-2',
+    ) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -232,24 +232,21 @@
 <p><%= t('in_person_proofing.body.expect.info') %></p>
 
 <p class="margin-top-3 margin-bottom-4">
-  <% if @presenter.service_provider_homepage_url.present? %>
-    <%= render ClickObserverComponent.new(event_name: 'IdV: user clicked sp link on ready to verify page') do %>
-      <%= t(
-            'in_person_proofing.body.barcode.return_to_partner_html',
-            link_html: link_to(
-              t(
-                'in_person_proofing.body.barcode.return_to_partner_link',
-                sp_name: @presenter.sp_name,
-              ),
-              @presenter.service_provider_homepage_url,
-            ),
-          ) %>
-    <% end %>
-  <% else %>
+  <% if @presenter.service_provider_homepage_url.blank? %>  
     <%= t('in_person_proofing.body.barcode.close_window') %>
   <% end %>
 </p>
 
 <%= render PageFooterComponent.new do %>
   <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'barcode') %>
+  <% if @presenter.service_provider_homepage_url.present? %>
+  <br />
+    <%= link_to(
+              t(
+                'in_person_proofing.body.barcode.return_to_partner_link',
+                sp_name: @presenter.sp_name,
+              ),
+              @presenter.service_provider_homepage_url,
+            ) %>
+         <% end %>
 <% end %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -246,10 +246,10 @@
               sp_name: @presenter.sp_name,
             ),
             @presenter.service_provider_homepage_url,
-            class: 'display-inline-block padding-bottom-105',
+            class: 'display-inline-block padding-bottom-1',
           ) %>
     <% end %>
     <br />
   <% end %>
-  <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'barcode') %>
+  <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'barcode'), class: 'display-inline-block padding-top-1' %>
 <% end %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -243,13 +243,13 @@
   <br />
   <%= render ClickObserverComponent.new(event_name: 'IdV: user clicked sp link on ready to verify page') do %>
     <%= link_to(
-      t(
-        'in_person_proofing.body.barcode.return_to_partner_link',
-        sp_name: @presenter.sp_name,
-      ),
-      @presenter.service_provider_homepage_url,
-      class: 'display-inline-block padding-top-2',
-    ) %>
+          t(
+            'in_person_proofing.body.barcode.return_to_partner_link',
+            sp_name: @presenter.sp_name,
+          ),
+          @presenter.service_provider_homepage_url,
+          class: 'display-inline-block padding-top-2',
+        ) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -238,9 +238,7 @@
 </p>
 
 <%= render PageFooterComponent.new do %>
-  <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'barcode') %>
   <% if @presenter.service_provider_homepage_url.present? %>
-  <br />
   <%= render ClickObserverComponent.new(event_name: 'IdV: user clicked sp link on ready to verify page') do %>
     <%= link_to(
           t(
@@ -248,8 +246,10 @@
             sp_name: @presenter.sp_name,
           ),
           @presenter.service_provider_homepage_url,
-          class: 'display-inline-block padding-top-2',
+          class: 'display-inline-block padding-bottom-2',
         ) %>
-    <% end %>
-  <% end %>
+          <% end %>
+          <% end %>
+          <br />
+  <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'barcode') %>
 <% end %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -246,7 +246,7 @@
               sp_name: @presenter.sp_name,
             ),
             @presenter.service_provider_homepage_url,
-            class: 'display-inline-block padding-bottom-205',
+            class: 'display-inline-block padding-bottom-105',
           ) %>
     <% end %>
     <br />

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -239,17 +239,17 @@
 
 <%= render PageFooterComponent.new do %>
   <% if @presenter.service_provider_homepage_url.present? %>
-  <%= render ClickObserverComponent.new(event_name: 'IdV: user clicked sp link on ready to verify page') do %>
-    <%= link_to(
-          t(
-            'in_person_proofing.body.barcode.return_to_partner_link',
-            sp_name: @presenter.sp_name,
-          ),
-          @presenter.service_provider_homepage_url,
-          class: 'display-inline-block padding-bottom-2',
-        ) %>
-          <% end %>
-          <% end %>
-          <br />
+    <%= render ClickObserverComponent.new(event_name: 'IdV: user clicked sp link on ready to verify page') do %>
+      <%= link_to(
+            t(
+              'in_person_proofing.body.barcode.return_to_partner_link',
+              sp_name: @presenter.sp_name,
+            ),
+            @presenter.service_provider_homepage_url,
+            class: 'display-inline-block padding-bottom-205',
+          ) %>
+    <% end %>
+    <br />
+  <% end %>
   <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'barcode') %>
 <% end %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -237,16 +237,16 @@
   <% end %>
 </p>
 
-<%= render PageFooterComponent.new do %>
+<%= render PageFooterComponent.new(class: 'site') do %>
   <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'barcode') %>
   <% if @presenter.service_provider_homepage_url.present? %>
   <br />
     <%= link_to(
-              t(
-                'in_person_proofing.body.barcode.return_to_partner_link',
-                sp_name: @presenter.sp_name,
-              ),
-              @presenter.service_provider_homepage_url,
-            ) %>
+          t(
+            'in_person_proofing.body.barcode.return_to_partner_link',
+            sp_name: @presenter.sp_name,
+          ),
+          @presenter.service_provider_homepage_url,
+        ) %>
          <% end %>
 <% end %>

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -237,7 +237,7 @@
   <% end %>
 </p>
 
-<%= render PageFooterComponent.new(class: 'site') do %>
+<%= render PageFooterComponent.new do %>
   <%= link_to t('in_person_proofing.body.barcode.cancel_link_text'), idv_cancel_path(step: 'barcode') %>
   <% if @presenter.service_provider_homepage_url.present? %>
   <br />
@@ -247,6 +247,7 @@
             sp_name: @presenter.sp_name,
           ),
           @presenter.service_provider_homepage_url,
+          class: 'display-inline-block padding-top-2',
         ) %>
          <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1197,7 +1197,7 @@ in_person_proofing.body.barcode.questions: Questions?
 in_person_proofing.body.barcode.retail_hours: Retail hours
 in_person_proofing.body.barcode.retail_hours_closed: Closed
 in_person_proofing.body.barcode.return_to_partner_html: You may now %{link_html} to complete any next steps you can access until your identity has been verified.
-in_person_proofing.body.barcode.return_to_partner_link: sign out and return to %{sp_name}
+in_person_proofing.body.barcode.return_to_partner_link: Return to %{sp_name}
 in_person_proofing.body.barcode.what_to_expect: What to expect at the Post Office
 in_person_proofing.body.cta.button: Try in person
 in_person_proofing.body.cta.prompt_detail: You may be able to verify your identity at a participating Post Office near you.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1196,7 +1196,6 @@ in_person_proofing.body.barcode.location_details: Location details
 in_person_proofing.body.barcode.questions: Questions?
 in_person_proofing.body.barcode.retail_hours: Retail hours
 in_person_proofing.body.barcode.retail_hours_closed: Closed
-in_person_proofing.body.barcode.return_to_partner_html: You may now %{link_html} to complete any next steps you can access until your identity has been verified.
 in_person_proofing.body.barcode.return_to_partner_link: Return to %{sp_name}
 in_person_proofing.body.barcode.what_to_expect: What to expect at the Post Office
 in_person_proofing.body.cta.button: Try in person

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1207,7 +1207,6 @@ in_person_proofing.body.barcode.location_details: Detalles del lugar
 in_person_proofing.body.barcode.questions: '¿Tiene alguna pregunta?'
 in_person_proofing.body.barcode.retail_hours: Horario de atención al público
 in_person_proofing.body.barcode.retail_hours_closed: Cerrado
-in_person_proofing.body.barcode.return_to_partner_html: Ahora puede %{link_html} para completar los pasos siguientes a los que tenga acceso hasta que se haya verificado su identidad.
 in_person_proofing.body.barcode.return_to_partner_link: Volver a %{sp_name}
 in_person_proofing.body.barcode.what_to_expect: Qué esperar en la oficina de correos
 in_person_proofing.body.cta.button: Intentar en persona

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1208,7 +1208,7 @@ in_person_proofing.body.barcode.questions: '¿Tiene alguna pregunta?'
 in_person_proofing.body.barcode.retail_hours: Horario de atención al público
 in_person_proofing.body.barcode.retail_hours_closed: Cerrado
 in_person_proofing.body.barcode.return_to_partner_html: Ahora puede %{link_html} para completar los pasos siguientes a los que tenga acceso hasta que se haya verificado su identidad.
-in_person_proofing.body.barcode.return_to_partner_link: cerrar sesión y volver a %{sp_name}
+in_person_proofing.body.barcode.return_to_partner_link: Volver a %{sp_name}
 in_person_proofing.body.barcode.what_to_expect: Qué esperar en la oficina de correos
 in_person_proofing.body.cta.button: Intentar en persona
 in_person_proofing.body.cta.prompt_detail: Es posible que pueda verificar su identidad en una oficina de correos participante cercana.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1197,7 +1197,7 @@ in_person_proofing.body.barcode.questions: Des questions ?
 in_person_proofing.body.barcode.retail_hours: Heures d’ouverture
 in_person_proofing.body.barcode.retail_hours_closed: Fermé
 in_person_proofing.body.barcode.return_to_partner_html: Vous pouvez maintenant %{link_html} afin d’effectuer toutes les étapes suivantes auxquelles vous pouvez accéder jusqu’à ce que votre identité ait été vérifiée.
-in_person_proofing.body.barcode.return_to_partner_link: vous déconnecter et retourner à %{sp_name}
+in_person_proofing.body.barcode.return_to_partner_link: Revenir à %{sp_name}
 in_person_proofing.body.barcode.what_to_expect: À quoi s’attendre au bureau de poste
 in_person_proofing.body.cta.button: Essayer en personne
 in_person_proofing.body.cta.prompt_detail: Vous pourrez peut-être confirmer votre identité dans un bureau de poste participant près de chez vous.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1196,7 +1196,7 @@ in_person_proofing.body.barcode.location_details: Détails de l’emplacement
 in_person_proofing.body.barcode.questions: Des questions ?
 in_person_proofing.body.barcode.retail_hours: Heures d’ouverture
 in_person_proofing.body.barcode.retail_hours_closed: Fermé
-in_person_proofing.body.barcode.return_to_partner_link: Revenir à %{sp_name}
+in_person_proofing.body.barcode.return_to_partner_link: Retourner à %{sp_name}
 in_person_proofing.body.barcode.what_to_expect: À quoi s’attendre au bureau de poste
 in_person_proofing.body.cta.button: Essayer en personne
 in_person_proofing.body.cta.prompt_detail: Vous pourrez peut-être confirmer votre identité dans un bureau de poste participant près de chez vous.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1196,7 +1196,6 @@ in_person_proofing.body.barcode.location_details: Détails de l’emplacement
 in_person_proofing.body.barcode.questions: Des questions ?
 in_person_proofing.body.barcode.retail_hours: Heures d’ouverture
 in_person_proofing.body.barcode.retail_hours_closed: Fermé
-in_person_proofing.body.barcode.return_to_partner_html: Vous pouvez maintenant %{link_html} afin d’effectuer toutes les étapes suivantes auxquelles vous pouvez accéder jusqu’à ce que votre identité ait été vérifiée.
 in_person_proofing.body.barcode.return_to_partner_link: Revenir à %{sp_name}
 in_person_proofing.body.barcode.what_to_expect: À quoi s’attendre au bureau de poste
 in_person_proofing.body.cta.button: Essayer en personne

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1209,7 +1209,6 @@ in_person_proofing.body.barcode.location_details: 详细地址信息
 in_person_proofing.body.barcode.questions: 有问题吗？
 in_person_proofing.body.barcode.retail_hours: 营业时间
 in_person_proofing.body.barcode.retail_hours_closed: 关闭
-in_person_proofing.body.barcode.return_to_partner_html: 你现在可以 %{link_html}来完成你可做的任何随后步骤，直到你的身份得到验证。
 in_person_proofing.body.barcode.return_to_partner_link: 返回 %{sp_name}
 in_person_proofing.body.barcode.what_to_expect: 在邮局会发生什么
 in_person_proofing.body.cta.button: 尝试亲身去

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1210,7 +1210,7 @@ in_person_proofing.body.barcode.questions: 有问题吗？
 in_person_proofing.body.barcode.retail_hours: 营业时间
 in_person_proofing.body.barcode.retail_hours_closed: 关闭
 in_person_proofing.body.barcode.return_to_partner_html: 你现在可以 %{link_html}来完成你可做的任何随后步骤，直到你的身份得到验证。
-in_person_proofing.body.barcode.return_to_partner_link: 登出 %{sp_name} 并返回 %{sp_name}
+in_person_proofing.body.barcode.return_to_partner_link: 返回 %{sp_name}
 in_person_proofing.body.barcode.what_to_expect: 在邮局会发生什么
 in_person_proofing.body.cta.button: 尝试亲身去
 in_person_proofing.body.cta.prompt_detail: 你也许可以到附近一个参与本项目的邮局去亲身验证你的身份证件。

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -77,12 +77,8 @@ module IdvStepHelper
   end
 
   def click_sp_link_in_person_ready_to_verify
-    expect(page).to have_content(sp_text)
+    expect(page).to have_content(link_text)
     click_link(link_text)
-  end
-
-  def sp_text
-    t('in_person_proofing.body.barcode.return_to_partner_html', link_html: link_text)
   end
 
   def complete_enter_password_step(user = user_with_2fa)


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14360](https://cm-jira.usa.gov/browse/LG-14360)


## 🛠 Summary of changes

Move and update content on sign out link


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create IPP Enrollment
- [ ] Stop at Barcode Page
- [ ] Observe the content at the bottom of the page around signing out is updated from "Sign out and Return to your [SERVICE PROVIDER]" instead to "Return to your [SERVICE PROVIDER]"

With no Service Provider
- [ ] Create IPP Enrollment (not from the [Sinatra OIDC](https://github.com/18F/identity-oidc-sinatra))
- [ ] Stop at Barcode Page
- [ ] Observe the content at the bottom of the page around signing out is **not** there.


## 👀 Screenshots

English
![en-screenshot-2](https://github.com/user-attachments/assets/6018e043-6a71-4889-82b7-8222b9d03903)

Spanish
![es-screenshot-2](https://github.com/user-attachments/assets/dfbb3acb-a7ef-4c10-bcc5-e77a521beda1)

French
![fr-screenshot-2](https://github.com/user-attachments/assets/3af64eff-010b-4940-bad9-e2df0298639a)

Chinese
![zh-screenshot-2](https://github.com/user-attachments/assets/7653ee08-1b8d-4fae-8928-185fcfe8a027)

No Service Provider
![en-screenshot-no-sp](https://github.com/user-attachments/assets/bcd71deb-348e-4336-9c3a-1bd2938935f3)


