### PR TITLE
LG-14435: Log edit distance for SSNs on SSN update

### DIFF
--- a/app/controllers/concerns/idv_session_concern.rb
+++ b/app/controllers/concerns/idv_session_concern.rb
@@ -63,4 +63,9 @@ module IdvSessionConcern
     resolved_authn_context_result.facial_match? &&
       !idv_session_user.identity_verified_with_facial_match?
   end
+
+  def previous_ssn_edit_distance
+    return if idv_session.ssn.blank? || idv_session.previous_ssn.blank?
+    Idv::SsnEditDistanceCalculator.new(idv_session.previous_ssn, idv_session.ssn).compute
+  end
 end

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -45,17 +45,19 @@ module Idv
           ssn_form: ssn_form,
           step_indicator_steps: step_indicator_steps,
         )
-        analytics.idv_doc_auth_ssn_submitted(
-          **analytics_arguments.merge(form_response.to_h),
-        )
 
         if form_response.success?
+          idv_session.previous_ssn = idv_session.ssn
           idv_session.ssn = params[:doc_auth][:ssn]
           redirect_to next_url
         else
           flash[:error] = form_response.first_error_message
           render 'idv/shared/ssn', locals: threatmetrix_view_variables(ssn_presenter.updating_ssn?)
         end
+
+        analytics.idv_doc_auth_ssn_submitted(
+          **analytics_arguments.merge(form_response.to_h),
+        )
       end
 
       def self.step_info
@@ -89,6 +91,7 @@ module Idv
           flow_path: idv_session.flow_path,
           step: 'ssn',
           analytics_id: 'In Person Proofing',
+          previous_ssn_edit_distance: previous_ssn_edit_distance,
         }.merge(ab_test_analytics_buckets).
           merge(**extra_analytics_properties)
       end

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -43,17 +43,19 @@ module Idv
         ssn_form: ssn_form,
         step_indicator_steps: step_indicator_steps,
       )
-      analytics.idv_doc_auth_ssn_submitted(
-        **analytics_arguments.merge(form_response.to_h),
-      )
 
       if form_response.success?
+        idv_session.previous_ssn = idv_session.ssn
         idv_session.ssn = params[:doc_auth][:ssn]
         redirect_to next_url
       else
         flash[:error] = form_response.first_error_message
         render 'idv/shared/ssn', locals: threatmetrix_view_variables(ssn_presenter.updating_ssn?)
       end
+
+      analytics.idv_doc_auth_ssn_submitted(
+        **analytics_arguments.merge(form_response.to_h),
+      )
     end
 
     def self.step_info
@@ -81,6 +83,7 @@ module Idv
         flow_path: idv_session.flow_path,
         step: 'ssn',
         analytics_id: 'Doc Auth',
+        previous_ssn_edit_distance: previous_ssn_edit_distance,
       }.merge(ab_test_analytics_buckets)
     end
   end

--- a/app/forms/idv/ssn_format_form.rb
+++ b/app/forms/idv/ssn_format_form.rb
@@ -24,8 +24,13 @@ module Idv
       FormResponse.new(
         success: valid?,
         errors: errors,
-        extra: { pii_like_keypaths: [[:same_address_as_id], [:errors, :ssn],
-                                     [:error_details, :ssn]] },
+        extra: {
+          pii_like_keypaths: [
+            [:same_address_as_id],
+            [:errors, :ssn],
+            [:error_details, :ssn],
+          ],
+        },
       )
     end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1484,6 +1484,7 @@ module AnalyticsEvents
   # @param [Boolean] same_address_as_id
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  # @param [Number] previous_ssn_edit_distance The edit distance to the previous submitted SSN
   def idv_doc_auth_redo_ssn_submitted(
     step:,
     analytics_id:,
@@ -1491,6 +1492,7 @@ module AnalyticsEvents
     opted_in_to_in_person_proofing: nil,
     skip_hybrid_handoff: nil,
     same_address_as_id: nil,
+    previous_ssn_edit_distance: nil,
     **extra
   )
     track_event(
@@ -1501,6 +1503,7 @@ module AnalyticsEvents
       opted_in_to_in_person_proofing:,
       skip_hybrid_handoff:,
       same_address_as_id:,
+      previous_ssn_edit_distance:,
       **extra,
     )
   end
@@ -1541,6 +1544,7 @@ module AnalyticsEvents
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] same_address_as_id
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  # @param [Number] previous_ssn_edit_distance The edit distance to the previous submitted SSN
   def idv_doc_auth_ssn_submitted(
     success:,
     errors:,
@@ -1552,6 +1556,7 @@ module AnalyticsEvents
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     same_address_as_id: nil,
+    previous_ssn_edit_distance: nil,
     **extra
   )
     track_event(
@@ -1566,6 +1571,7 @@ module AnalyticsEvents
       flow_path:,
       opted_in_to_in_person_proofing:,
       same_address_as_id:,
+      previous_ssn_edit_distance:,
       **extra,
     )
   end
@@ -1579,6 +1585,7 @@ module AnalyticsEvents
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] same_address_as_id
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  # @param [Number] previous_ssn_edit_distance The edit distance to the previous submitted SSN
   def idv_doc_auth_ssn_visited(
     step:,
     analytics_id:,
@@ -1587,6 +1594,7 @@ module AnalyticsEvents
     acuant_sdk_upgrade_ab_test_bucket: nil,
     skip_hybrid_handoff: nil,
     same_address_as_id: nil,
+    previous_ssn_edit_distance: nil,
     **extra
   )
     track_event(
@@ -1598,6 +1606,7 @@ module AnalyticsEvents
       flow_path:,
       opted_in_to_in_person_proofing:,
       same_address_as_id:,
+      previous_ssn_edit_distance:,
       **extra,
     )
   end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -21,6 +21,7 @@ module Idv
       personal_key_acknowledged
       phone_for_mobile_flow
       previous_phone_step_params
+      previous_ssn
       profile_id
       proofing_started_at
       redo_document_capture

--- a/app/services/idv/ssn_edit_distance_calculator.rb
+++ b/app/services/idv/ssn_edit_distance_calculator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Idv
+  class SsnEditDistanceCalculator
+    attr_reader :previous_ssn, :current_ssn
+
+    # @param previous_ssn [String]
+    def initialize(previous_ssn, current_ssn)
+      @previous_ssn = previous_ssn
+      @current_ssn = current_ssn
+    end
+
+    def compute
+      previous_ssn.chars.zip(current_ssn.chars).reduce(0) do |acc, chars|
+        if chars.first == chars.last || chars.last.nil?
+          acc
+        else
+          acc + 1
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -141,6 +141,28 @@ RSpec.describe Idv::InPerson::SsnController do
 
         expect(response).to redirect_to idv_in_person_verify_info_url
       end
+
+      context 'when the user has previously submitted an ssn' do
+        let(:analytics_args) do
+          {
+            analytics_id: 'In Person Proofing',
+            flow_path: 'standard',
+            step: 'ssn',
+            success: true,
+            previous_ssn_edit_distance: 6,
+            same_address_as_id: true,
+            errors: {},
+          }
+        end
+
+        it 'updates idv_session.ssn' do
+          subject.idv_session.ssn = '900-95-7890'
+
+          expect { put :update, params: params }.to change { subject.idv_session.ssn }.
+            from('900-95-7890').to(ssn)
+          expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+        end
+      end
     end
 
     context 'invalid ssn' do

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -166,6 +166,28 @@ RSpec.describe Idv::SsnController do
       it 'updates idv_session.ssn' do
         expect { put :update, params: params }.to change { subject.idv_session.ssn }.
           from(nil).to(ssn)
+        expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+      end
+
+      context 'when the user has previously submitted an ssn' do
+        let(:analytics_args) do
+          {
+            analytics_id: 'Doc Auth',
+            flow_path: 'standard',
+            step: 'ssn',
+            success: true,
+            previous_ssn_edit_distance: 6,
+            errors: {},
+          }
+        end
+
+        it 'updates idv_session.ssn' do
+          subject.idv_session.ssn = '900-95-7890'
+
+          expect { put :update, params: params }.to change { subject.idv_session.ssn }.
+            from('900-95-7890').to(ssn)
+          expect(@analytics).to have_logged_event(analytics_name, analytics_args)
+        end
       end
 
       context 'with a Puerto Rico address and pii_from_doc in idv_session' do

--- a/spec/services/idv/ssn_edit_distance_calculator_spec.rb
+++ b/spec/services/idv/ssn_edit_distance_calculator_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Idv::SsnEditDistanceCalculator do
+  describe '#calculate' do
+    context 'two strings are equal' do
+      it 'returns 0' do
+        result = Idv::SsnEditDistanceCalculator.new('900-12-3456', '900-12-3456').compute
+        expect(result).to eql(0)
+      end
+    end
+
+    context 'two strings are different' do
+      it 'returns correct edit distance' do
+        result = Idv::SsnEditDistanceCalculator.new('900-11-3456', '900-12-3456').compute
+        expect(result).to eql(1)
+      end
+    end
+
+    context 'the strings have different lengths' do
+      it 'returns the edit distance for the shortest string' do
+        result = Idv::SsnEditDistanceCalculator.new('900-11-1256', '900-12-12').compute
+        expect(result).to eql(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why

* Identify when people change their SSNs whether they are 1) correcting a typo (e.g., single-character changes) or 2) wholesale changing the SSN (i.e., use as a fraud signal).

### How

* We store the previous SSN on the Idv::Session in `previous_ssn`

* We compute how many characters are different between the previous entered SSN and the newly submitted SSN and log that difference using an algorithm similar to the Levenshtein distance.

* Why not do real Levenshtein calculation? This is unnecessary as SSNs are fixed-width and are validated on submission.

changelog: Internal, Analytics, Log edit distance for SSNs