### PR TITLE
Extend session when changing document capture steps

### DIFF
--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -15,6 +15,7 @@ import {
 import { isCameraCapableMobile } from '@18f/identity-device';
 import { FlowContext } from '@18f/identity-verify-flow';
 import { trackEvent as baseTrackEvent } from '@18f/identity-analytics';
+import { extendSession } from '@18f/identity-session';
 import type { FlowPath, DeviceContextValue } from '@18f/identity-document-capture';
 
 /**
@@ -40,6 +41,7 @@ interface AppRootData {
   docAuthSelfieDesktopTestMode: string;
   locationsUrl: string;
   addressSearchUrl: string;
+  sessionsUrl: string;
   docAuthSeparatePagesEnabled: string;
 }
 
@@ -112,6 +114,7 @@ const {
   docAuthSeparatePagesEnabled,
   locationsUrl: locationsURL,
   addressSearchUrl: addressSearchURL,
+  sessionsUrl: sessionsURL,
 } = appRoot.dataset as DOMStringMap & AppRootData;
 
 let parsedUsStatesTerritories = [];
@@ -201,7 +204,12 @@ const App = composeComponents(
       maxSubmissionAttemptsBeforeNativeCamera: Number(maxSubmissionAttemptsBeforeNativeCamera),
     },
   ],
-  [DocumentCapture],
+  [
+    DocumentCapture,
+    {
+      onStepChange: () => extendSession(sessionsURL),
+    },
+  ],
 );
 
 render(<App />, appRoot);

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -43,6 +43,7 @@
       how_to_verify_url: idv_how_to_verify_url,
       previous_step_url: @previous_step_url,
       locations_url: idv_in_person_usps_locations_url,
+      sessions_url: api_internal_sessions_path,
       doc_auth_separate_pages_enabled: IdentityConfig.store.doc_auth_separate_pages_enabled,
       address_search_url: '',
     } %>

--- a/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
@@ -18,6 +18,7 @@ import { FlowContext } from '@18f/identity-verify-flow';
 import { expect } from 'chai';
 import { useSandbox } from '@18f/identity-test-helpers';
 import { AcuantDocumentType } from '@18f/identity-document-capture/components/acuant-camera';
+import sinon from 'sinon';
 import { render, useAcuant, useDocumentCaptureForm } from '../../../support/document-capture';
 import { getFixtureFile } from '../../../support/file';
 
@@ -311,6 +312,7 @@ describe('document-capture/components/document-capture', () => {
 
     context('in person steps', () => {
       it('renders the step indicator', async () => {
+        const callback = sinon.spy();
         const endpoint = '/upload';
         const { getByLabelText, getByText, queryByText, findByText } = render(
           <UploadContextProvider upload={httpUpload} endpoint={endpoint}>
@@ -326,7 +328,7 @@ describe('document-capture/components/document-capture', () => {
                     inPersonURL: '/in_person',
                   }}
                 >
-                  <DocumentCapture />
+                  <DocumentCapture onStepChange={callback} />
                 </InPersonContext.Provider>
               </FlowContext.Provider>
             </ServiceProviderContextProvider>
@@ -364,6 +366,7 @@ describe('document-capture/components/document-capture', () => {
 
         expect(step).to.be.ok();
         expect(step.closest('.step-indicator__step--current')).to.exist();
+        expect(callback).to.have.been.calledOnce();
       });
     });
   });

--- a/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-spec.jsx
@@ -18,7 +18,6 @@ import { FlowContext } from '@18f/identity-verify-flow';
 import { expect } from 'chai';
 import { useSandbox } from '@18f/identity-test-helpers';
 import { AcuantDocumentType } from '@18f/identity-document-capture/components/acuant-camera';
-import sinon from 'sinon';
 import { render, useAcuant, useDocumentCaptureForm } from '../../../support/document-capture';
 import { getFixtureFile } from '../../../support/file';
 
@@ -312,7 +311,7 @@ describe('document-capture/components/document-capture', () => {
 
     context('in person steps', () => {
       it('renders the step indicator', async () => {
-        const callback = sinon.spy();
+        const callback = sandbox.spy();
         const endpoint = '/upload';
         const { getByLabelText, getByText, queryByText, findByText } = render(
           <UploadContextProvider upload={httpUpload} endpoint={endpoint}>


### PR DESCRIPTION
## 🎫 Ticket

[LG-14545](https://cm-jira.usa.gov/browse/LG-14545)

## 🛠 Summary of changes

This fixes a regression from https://github.com/18F/identity-idp/pull/10894 which added an argument to `extendSession`, but did not add it for the usage in document capture. https://github.com/18F/identity-idp/pull/11287 was a short-term fix, and this more fully addresses it by defining sessionsURL as we do for other URLs.

The regression is something that TypeScript could catch, but requires bigger changes.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
