### PR TITLE
Use semantic acr values as test default

### DIFF
--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -63,16 +63,7 @@ class IdTokenBuilder
 
   def acr
     return nil unless identity.acr_values.present?
-
-    if resolved_authn_context_result.facial_match?
-      Vot::AcrComponentValues::IAL2_BIO_REQUIRED.name
-    elsif resolved_authn_context_result.ialmax?
-      determine_ial_max_acr.name
-    elsif resolved_authn_context_result.identity_proofing?
-      Vot::AcrComponentValues::IAL2.name
-    else
-      Vot::AcrComponentValues::IAL1.name
-    end
+    resolved_authn_context.asserted_ial_acr
   end
 
   def sp_requests_vot?
@@ -94,12 +85,16 @@ class IdTokenBuilder
   end
 
   def resolved_authn_context_result
-    @resolved_authn_context_result ||= AuthnContextResolver.new(
+    @resolved_authn_context_result ||= resolved_authn_context.result
+  end
+
+  def resolved_authn_context
+    @resolved_authn_context ||= AuthnContextResolver.new(
       user: identity.user,
       service_provider: identity.service_provider_record,
       vtr: parsed_vtr_value,
       acr_values: identity.acr_values,
-    ).result
+    )
   end
 
   def parsed_vtr_value

--- a/app/services/id_token_builder.rb
+++ b/app/services/id_token_builder.rb
@@ -73,7 +73,7 @@ class IdTokenBuilder
 
   def vot
     return nil unless sp_requests_vot?
-    resolved_authn_context_result.component_values.map(&:name).join('.')
+    resolved_authn_context.result.component_values.map(&:name).join('.')
   end
 
   def determine_ial_max_acr
@@ -82,10 +82,6 @@ class IdTokenBuilder
     else
       Vot::AcrComponentValues::IAL1
     end
-  end
-
-  def resolved_authn_context_result
-    @resolved_authn_context_result ||= resolved_authn_context.result
   end
 
   def resolved_authn_context

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -525,6 +525,8 @@ test:
   aamva_private_key: 123abc
   aamva_public_key: 123abc
   account_reset_fraud_user_wait_period_days: 30
+  allowed_biometric_ial_providers: '["urn:gov:gsa:openidconnect:sp:server"]'
+  allowed_valid_authn_contexts_semantic_providers: '["urn:gov:gsa:openidconnect:sp:server"]'
   attribute_encryption_key: 2086dfbd15f5b0c584f3664422a1d3409a0d2aa6084f65b6ba57d64d4257431c124158670c7655e45cabe64194f7f7b6c7970153c285bdb8287ec0c4f7553e25
   attribute_encryption_key_queue: '[{ "key": "11111111111111111111111111111111" }, { "key": "22222222222222222222222222222222" }]'
   dashboard_api_token: 123ABC

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -320,6 +320,11 @@ RSpec.feature 'document capture step', :js do
                 :in_person_proofing_enabled,
               ).and_return(true)
               allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(99)
+              allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+                and_return([ipp_service_provider.issuer])
+              allow(IdentityConfig.store).to receive(
+                :allowed_valid_authn_contexts_semantic_providers,
+              ).and_return([ipp_service_provider.issuer])
               perform_in_browser(:mobile) do
                 visit_idp_from_sp_with_ial2(
                   :oidc,
@@ -841,6 +846,11 @@ RSpec.feature 'document capture step', :js do
                   :in_person_proofing_enabled,
                 ).and_return(true)
                 allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(99)
+                allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+                  and_return([ipp_service_provider.issuer])
+                allow(IdentityConfig.store).to receive(
+                  :allowed_valid_authn_contexts_semantic_providers,
+                ).and_return([ipp_service_provider.issuer])
                 perform_in_browser(:mobile) do
                   visit_idp_from_sp_with_ial2(
                     :oidc,
@@ -1107,6 +1117,11 @@ RSpec.feature 'direct access to IPP on desktop', :js do
       allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(
         in_person_proofing_opt_in_enabled,
       )
+      allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+        and_return([service_provider.issuer])
+      allow(IdentityConfig.store).to receive(
+        :allowed_valid_authn_contexts_semantic_providers,
+      ).and_return([service_provider.issuer])
       allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
         and_return(false)
       visit_idp_from_sp_with_ial2(

--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -20,6 +20,11 @@ RSpec.feature 'how to verify step', js: true do
     }
     allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
       and_return(service_provider_in_person_proofing_enabled)
+    allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+      and_return([ipp_service_provider.issuer])
+    allow(IdentityConfig.store).to receive(
+      :allowed_valid_authn_contexts_semantic_providers,
+    ).and_return([ipp_service_provider.issuer])
     visit_idp_from_sp_with_ial2(
       :oidc, **{ client_id: ipp_service_provider.issuer,
                  facial_match_required: facial_match_required }

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -341,6 +341,11 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
       )
       allow_any_instance_of(ServiceProvider).to receive(:in_person_proofing_enabled).
         and_return(sp_ipp_enabled)
+      allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+        and_return([service_provider.issuer])
+      allow(IdentityConfig.store).to receive(
+        :allowed_valid_authn_contexts_semantic_providers,
+      ).and_return([service_provider.issuer])
       visit_idp_from_sp_with_ial2(
         :oidc,
         **{ client_id: service_provider.issuer,

--- a/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_50_50_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe 'state id 50/50 state', :js, allow_browser_log: true do
   before do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
     allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:allowed_biometric_ial_providers).
+      and_return([ipp_service_provider.issuer])
+    allow(IdentityConfig.store).to receive(
+      :allowed_valid_authn_contexts_semantic_providers,
+    ).and_return([ipp_service_provider.issuer])
   end
 
   context 'when navigating to state id page from PO search location page' do

--- a/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
+++ b/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true do
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
     allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
     allow(IdentityConfig.store).to receive(:otp_delivery_blocklist_maxretry).and_return(5)
+    allow(IdentityConfig.store).to receive(
+      :allowed_valid_authn_contexts_semantic_providers,
+    ).and_return([ipp_service_provider.issuer, 'urn:gov:gsa:openidconnect:sp:server'])
   end
 
   context 'when ipp_opt_in_enabled and ipp_opt_in_enabled are both enabled' do

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -1239,7 +1239,7 @@ RSpec.describe 'OpenID Connect' do
       expect(decoded_id_token[:acr]).to eq(nil)
       expect(decoded_id_token[:vot]).to eq(vot)
     else
-      expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
+      expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::IAL_VERIFIED_ACR)
       expect(decoded_id_token[:vot]).to eq(nil)
     end
 
@@ -1261,7 +1261,7 @@ RSpec.describe 'OpenID Connect' do
       expect(userinfo_response).not_to have_key(:aal)
       expect(userinfo_response[:vot]).to eq(vot)
     else
-      expect(userinfo_response[:ial]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
+      expect(userinfo_response[:ial]).to eq(Saml::Idp::Constants::IAL_VERIFIED_ACR)
       expect(userinfo_response[:aal]).to eq(
         Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
       )

--- a/spec/features/reports/authorization_count_spec.rb
+++ b/spec/features/reports/authorization_count_spec.rb
@@ -186,6 +186,9 @@ RSpec.describe 'authorization count' do
 
     before do
       reset_monthly_auth_count_and_login(user)
+      allow(IdentityConfig.store).to receive(
+        :allowed_valid_authn_contexts_semantic_providers,
+      ).and_return([client_id_1, client_id_2])
     end
 
     context 'using oidc' do

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -83,6 +83,8 @@ RSpec.describe IdTokenBuilder do
 
     context 'context sp requests ACR values' do
       context 'aal and ial request' do
+        let(:user) { create(:user, :proofed) }
+
         before do
           identity.aal = 2
           acr_values = [
@@ -98,6 +100,8 @@ RSpec.describe IdTokenBuilder do
       end
 
       context 'ial2 request' do
+        let(:user) { create(:user, :proofed) }
+
         before do
           identity.ial = 2
           identity.acr_values = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
@@ -109,6 +113,8 @@ RSpec.describe IdTokenBuilder do
       end
 
       context 'ial2 with facial match comparison required' do
+        let(:user) { create(:user, :proofed_with_selfie) }
+
         before do
           identity.ial = 2
           identity.acr_values = Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -156,9 +156,9 @@ module IdvHelper
     }
 
     if facial_match_required
-      params[:vtr] = ['C1.P1.Pb'].to_json
+      params[:acr_values] = Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
     else
-      params[:acr_values] = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+      params[:acr_values] = Saml::Idp::Constants::IAL_VERIFIED_ACR
     end
 
     visit openid_connect_authorize_path(params)

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -175,7 +175,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       expect(sub).to be_present
       expect(decoded_id_token[:nonce]).to eq(@nonce)
       expect(decoded_id_token[:aud]).to eq(@client_id)
-      expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF)
+      expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::IAL_VERIFIED_ACR)
       expect(decoded_id_token[:iss]).to eq(root_url)
       expect(decoded_id_token[:email]).to eq(user.confirmed_email_addresses.first.email)
       expect(decoded_id_token[:given_name]).to eq('FAKEY')

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -86,7 +86,7 @@ module OidcAuthHelper
     state: SecureRandom.hex,
     nonce: SecureRandom.hex,
     client_id: OIDC_ISSUER,
-    acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+    acr_values: Saml::Idp::Constants::IAL_VERIFIED_ACR,
     facial_match_required: false
   )
     ial2_params = {
@@ -100,7 +100,7 @@ module OidcAuthHelper
     ial2_params[:prompt] = prompt if prompt
 
     if facial_match_required
-      ial2_params[:vtr] = ['C1.P1.Pb'].to_json
+      ial2_params[:acr_values] = Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
     else
       ial2_params[:acr_values] = acr_values
     end


### PR DESCRIPTION
## 🛠 Summary of changes
This is part of a bigger effort to minimize our use of the vectors of trust API interface, so that we can ultimately deprecate it.

This change:
- updates our testing code to default to the new semantic facial match acr value when utilizing helpers.
- Adds the default issuer to the test application.yml.default. this is temporary, as on november 7th both facial match and the semantic acr values will be generally available
- fixes a bug where the id_token `acr` field was only returning legacy acr values. (the `id_token_builder_spec` is on my [list of spec files](https://docs.google.com/document/d/1zKDhHaOdH6Kyz2NivJSEZHnknkMLujYw2kbts2QAycY/edit) that need increased semantic acr value testing. )

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
