### PR TITLE
Dmm/add query to protocol report

### DIFF
--- a/lib/reporting/protocols_report.rb
+++ b/lib/reporting/protocols_report.rb
@@ -264,7 +264,7 @@ module Reporting
 
     def aal3_issuers_query
       params = {
-        event: quote([SAML_AUTH_EVENT, OIDC_AUTH_EVENT]),
+        events: quote([SAML_AUTH_EVENT, OIDC_AUTH_EVENT]),
       }
 
       format(<<~QUERY, params)
@@ -273,9 +273,9 @@ module Reporting
           properties.event_properties.acr_values as acr
         | parse @message '"authn_context":[*]' as authn
         | filter
-          name IN %{event}
+          name IN %{events}
           AND (authn like /aal\\/3/ or acr like /aal\\/3/)
-          AND properties.event_properties.success= 1
+          AND properties.event_properties.success = 1
         | display issuer
         | sort issuer
         | dedup issuer
@@ -285,7 +285,9 @@ module Reporting
     def facial_match_issuers_query
       format(<<~QUERY)
         fields
-          coalesce(properties.event_properties.service_provider, properties.event_properties.client_id, properties.service_provider) as issuer
+          coalesce(properties.event_properties.service_provider,
+          properties.event_properties.client_id,
+          properties.service_provider) as issuer
         | filter properties.sp_request.facial_match
         | display issuer
         | sort issuer
@@ -332,7 +334,7 @@ module Reporting
 
     def saml_signature_query
       params = {
-        event: quote([SAML_AUTH_EVENT]),
+        events: quote([SAML_AUTH_EVENT]),
       }
 
       format(<<~QUERY, params)
@@ -341,7 +343,7 @@ module Reporting
           properties.event_properties.request_signed = 1 AS signed,
           properties.event_properties.request_signed != 1 AS not_signed,
           isempty(properties.event_properties.matching_cert_serial) AND signed AS invalid_signature
-        | filter name IN %{event}
+        | filter name IN %{events}
           AND properties.event_properties.success = 1
         | stats
           sum(not_signed) AS unsigned_count,

--- a/lib/reporting/protocols_report.rb
+++ b/lib/reporting/protocols_report.rb
@@ -157,8 +157,8 @@ module Reporting
         [
           'IdV with Facial Match',
           facial_match_data.length,
-          facial_match_data.join(', ')
-        ]
+          facial_match_data.join(', '),
+        ],
       ]
     end
 
@@ -283,10 +283,6 @@ module Reporting
     end
 
     def facial_match_issuers_query
-      params = {
-        event: quote([SAML_AUTH_EVENT, OIDC_AUTH_EVENT]),
-      }
-
       format(<<~QUERY)
         fields
           coalesce(properties.event_properties.service_provider, properties.event_properties.client_id, properties.service_provider) as issuer

--- a/spec/lib/reporting/protocols_report_spec.rb
+++ b/spec/lib/reporting/protocols_report_spec.rb
@@ -206,15 +206,15 @@ RSpec.describe Reporting::ProtocolsReport do
          string_or_num(strings, 2)],
       ],
       [
-        ['Issue', 'Count of issuers with the issue', 'List of issuers with the issue'],
+        ['Issue', 'Count of issuers', 'List of issuers'],
         ['Not signing SAML authentication requests', string_or_num(strings, 2), 'Issuer1, Issuer3'],
         ['Incorrectly signing SAML authentication requests', string_or_num(strings, 1), 'Issuer1'],
       ],
       [
         [
           'Deprecated Parameter',
-          'Count of issuers using the parameter',
-          'List of issuers using the parameter',
+          'Count of issuers',
+          'List of issuers',
         ],
         [
           'LOA',

--- a/spec/lib/reporting/protocols_report_spec.rb
+++ b/spec/lib/reporting/protocols_report_spec.rb
@@ -81,11 +81,21 @@ RSpec.describe Reporting::ProtocolsReport do
       },
     ]
 
+    facial_match_issuers_query_response = [
+      {
+        'issuer' => 'Issuer1',
+      },
+      {
+        'issuer' => 'Issuer8',
+      },
+    ]
+
     stub_multiple_cloudwatch_logs(
       protocol_query_response,
       saml_signature_query_response,
       loa_issuers_query_response,
       aal3_issuers_query_response,
+      facial_match_issuers_query_response,
     )
   end
 
@@ -109,7 +119,7 @@ RSpec.describe Reporting::ProtocolsReport do
   describe '#to_csvs' do
     it 'generates a csv' do
       csv_string_list = report.to_csvs
-      expect(csv_string_list.count).to be 4
+      expect(csv_string_list.count).to be 5
 
       csvs = csv_string_list.map { |csv| CSV.parse(csv) }
 
@@ -225,6 +235,18 @@ RSpec.describe Reporting::ProtocolsReport do
           'AAL3',
           string_or_num(strings, 2),
           'Issuer1, Issuer3',
+        ],
+      ],
+      [
+        [
+          'Feature',
+          'Count of issuers',
+          'List of issuers',
+        ],
+        [
+          'IdV with Facial Match',
+          string_or_num(strings, 2),
+          'Issuer1, Issuer8',
         ],
       ],
     ]


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Add facial match issuer query to weekly reports](https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/123)

## 🛠 Summary of changes
This change
- reorders the `protocols_report.rb` file because it was hard to find things in it
- adds a feature usage table, where we can track feature usage based on API requests
- adds a query to keep track of who is using facial match in production

Note: The reorganization was very noisy, so I split this PR into two commits. The first commit shows the reorganization, the second commit is the meat of the actual change. 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
