### PR TITLE
Remove unused 2FA no_option route view

### DIFF
--- a/app/views/two_factor_authentication/options/no_option.html.erb
+++ b/app/views/two_factor_authentication/options/no_option.html.erb
@@ -1,3 +1,0 @@
-<% self.title = t('titles.no_auth_option') %>
-
-<%= t('two_factor_authentication.no_auth_option') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1595,7 +1595,6 @@ titles.idv.reset_password: Reset Password
 titles.idv.verify_info: Verify your information
 titles.mfa_setup.face_touch_unlock_confirmation: Face or touch unlock added
 titles.mfa_setup.suggest_second_mfa: You’ve added your first authentication method! Add a second method as a backup.
-titles.no_auth_option: No sign-in method found
 titles.openid_connect.authorization: OpenID Connect Authorization
 titles.openid_connect.logout: OpenID Connect Logout
 titles.passwords.change: Change the password for your account
@@ -1686,7 +1685,6 @@ two_factor_authentication.max_otp_requests_reached: For your security, your acco
 two_factor_authentication.max_personal_key_login_attempts_reached: For your security, your account is temporarily locked because you have entered the personal key incorrectly too many times.
 two_factor_authentication.max_piv_cac_login_attempts_reached: For your security, your account is temporarily locked because you have presented your piv/cac credential incorrectly too many times.
 two_factor_authentication.mobile_terms_of_service: Mobile terms of service
-two_factor_authentication.no_auth_option: No authentication option could be found for you to sign in.
 two_factor_authentication.opt_in.error_retry: Sorry, we are having trouble opting you in. Please try again.
 two_factor_authentication.opt_in.opted_out_html: You’ve opted out of receiving text messages at %{phone_number_html}. You can opt in and receive a security code again to that phone number.
 two_factor_authentication.opt_in.opted_out_last_30d_html: You’ve opted out of receiving text messages at %{phone_number_html} within the last 30 days. We can only opt in a phone number once every 30 days.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1607,7 +1607,6 @@ titles.idv.reset_password: Restablecer la contraseña
 titles.idv.verify_info: Verifique su información
 titles.mfa_setup.face_touch_unlock_confirmation: Se agregó el desbloqueo facial o táctil
 titles.mfa_setup.suggest_second_mfa: Agregó su primer método de autenticación. Agregue un segundo método como respaldo.
-titles.no_auth_option: No se encontró ningún método de inicio de sesión
 titles.openid_connect.authorization: Autorización de OpenID Connect
 titles.openid_connect.logout: Cierre de sesión de OpenID Connect
 titles.passwords.change: Cambie la contraseña de su cuenta
@@ -1698,7 +1697,6 @@ two_factor_authentication.max_otp_requests_reached: Para su seguridad, su cuenta
 two_factor_authentication.max_personal_key_login_attempts_reached: Para su seguridad, su cuenta está bloqueada temporalmente porque ingresó mal la clave personal demasiadas veces.
 two_factor_authentication.max_piv_cac_login_attempts_reached: Para su seguridad, su cuenta está bloqueada temporalmente porque presentó mal su tarjeta PIV o CAC demasiadas veces.
 two_factor_authentication.mobile_terms_of_service: Condiciones del servicio móvil
-two_factor_authentication.no_auth_option: No se pudo encontrar ninguna opción de autenticación para que iniciara sesión.
 two_factor_authentication.opt_in.error_retry: Lo sentimos, estamos teniendo problema para admitirlo; inténtelo de nuevo.
 two_factor_authentication.opt_in.opted_out_html: Optó por no recibir mensajes de texto en el %{phone_number_html}. Puede optar por recibir un código de seguridad de nuevo en ese número de teléfono.
 two_factor_authentication.opt_in.opted_out_last_30d_html: Optó por no recibir mensajes de texto en el %{phone_number_html} en los últimos 30 días. Solo podemos admitir un número telefónico una vez cada 30 días.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1595,7 +1595,6 @@ titles.idv.reset_password: Réinitialiser le mot de passe
 titles.idv.verify_info: Vérifier vos informations
 titles.mfa_setup.face_touch_unlock_confirmation: Déverrouillage facial ou tactile ajouté
 titles.mfa_setup.suggest_second_mfa: Vous avez ajouté votre première méthode d’authentification ! Ajoutez-en une deuxième en guise de sauvegarde.
-titles.no_auth_option: Aucune méthode de connexion trouvée
 titles.openid_connect.authorization: Autorisation OpenID Connect
 titles.openid_connect.logout: Déconnexion OpenID Connect
 titles.passwords.change: Changer le mot de passe de votre compte
@@ -1686,7 +1685,6 @@ two_factor_authentication.max_otp_requests_reached: Pour votre sécurité, votre
 two_factor_authentication.max_personal_key_login_attempts_reached: Pour votre sécurité, votre compte est temporairement verrouillé en raison de la saisie erronée de la clé personnelle à de trop nombreuses reprises.
 two_factor_authentication.max_piv_cac_login_attempts_reached: Pour votre sécurité, votre compte est temporairement verrouillé en raison de la présentation erronée de votre certificat PIV/CAC à de trop nombreuses reprises.
 two_factor_authentication.mobile_terms_of_service: Conditions de service mobile
-two_factor_authentication.no_auth_option: Aucune option d’authentification n’a pu être trouvée pour vous connecter
 two_factor_authentication.opt_in.error_retry: Désolé, nous rencontrons actuellement des difficultés pour vous inscrire. Veuillez réessayer.
 two_factor_authentication.opt_in.opted_out_html: Vous avez choisi de ne pas recevoir de SMS au %{phone_number_html}. Vous pouvez vous inscrire et recevoir à nouveau un code de sécurité à ce numéro de téléphone.
 two_factor_authentication.opt_in.opted_out_last_30d_html: Vous avez choisi de ne plus recevoir de SMS au %{phone_number_html} au cours des 30 derniers jours. Nous ne pouvons inscrire un numéro de téléphone qu’une fois tous les 30 jours.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1608,7 +1608,6 @@ titles.idv.reset_password: 重设密码
 titles.idv.verify_info: 验证你的信息
 titles.mfa_setup.face_touch_unlock_confirmation: 人脸或触摸解锁已添加
 titles.mfa_setup.suggest_second_mfa: 你已添加了第一个身份证实方法！添加第二个做备份
-titles.no_auth_option: 没找到登录方法
 titles.openid_connect.authorization: OpenID Connect 授权
 titles.openid_connect.logout: OpenID Connect 登出
 titles.passwords.change: 更改你账户密码
@@ -1699,7 +1698,6 @@ two_factor_authentication.max_otp_requests_reached: 为了你的安全，你的�
 two_factor_authentication.max_personal_key_login_attempts_reached: 为了你的安全，你的账户暂时被锁住，因为你错误输入个人密钥太多次。
 two_factor_authentication.max_piv_cac_login_attempts_reached: 为了你的安全，你的账户暂时被锁住，因为你错误提供 piv/cac 凭据太多次。
 two_factor_authentication.mobile_terms_of_service: 移动服务条款
-two_factor_authentication.no_auth_option: 找不到身份证实选项让你登录。
 two_factor_authentication.opt_in.error_retry: 抱歉，我们让你加入有困难。请再试一次。
 two_factor_authentication.opt_in.opted_out_html: 你选择不在 %{phone_number_html} 接受短信。你可以选择加入并再在那个电话号码接受安全代码。
 two_factor_authentication.opt_in.opted_out_last_30d_html: 你选择过去 30 天里不在 %{phone_number_html} 接受短信。我们每 30 天只能允许加入一次电话号码。


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused view code `two_factor_authentication/options/no_option`.

Added in #3839, last reference removed in #7063.

## 📜 Testing Plan

Verify build passes.

Confirm no lingering references to view.