### PR TITLE
Expand acr_values test coverage

### DIFF
--- a/spec/controllers/idv/by_mail/resend_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/resend_letter_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Idv::ByMail::ResendLetterController do
       )
     end
 
-    context 'using vtr values' do
+    context 'when using vtr values' do
       it 'uses the GPO confirmation maker to send another letter and redirects', :freeze_time do
         expect_to_resend_letter_and_redirect(vtr: true)
 

--- a/spec/controllers/idv/by_mail/resend_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/resend_letter_controller_spec.rb
@@ -84,6 +84,31 @@ RSpec.describe Idv::ByMail::ResendLetterController do
       )
     end
 
+    context 'using vtr values' do
+      it 'uses the GPO confirmation maker to send another letter and redirects', :freeze_time do
+        expect_to_resend_letter_and_redirect(vtr: true)
+
+        expect(@analytics).to have_logged_event(
+          'IdV: USPS address letter requested',
+          hash_including(
+            resend: true,
+            first_letter_requested_at: user.pending_profile.gpo_verification_pending_at,
+            hours_since_first_letter: 24,
+          ),
+        )
+
+        expect(@analytics).to have_logged_event(
+          'IdV: USPS address letter enqueued',
+          hash_including(
+            resend: true,
+            first_letter_requested_at: user.pending_profile.gpo_verification_pending_at,
+            hours_since_first_letter: 24,
+            enqueued_at: Time.zone.now,
+          ),
+        )
+      end
+    end
+
     it 'redirects to capture password controller if the PII is locked' do
       pii_cacher = instance_double(Pii::Cacher)
       allow(pii_cacher).to receive(:fetch).and_return(nil)
@@ -96,7 +121,7 @@ RSpec.describe Idv::ByMail::ResendLetterController do
     end
   end
 
-  def expect_to_resend_letter_and_redirect
+  def expect_to_resend_letter_and_redirect(vtr: false)
     pii = user.pending_profile.decrypt_pii(user.password).to_h
     pii_cacher = instance_double(Pii::Cacher)
     allow(pii_cacher).to receive(:fetch).with(user.pending_profile.id).and_return(pii)
@@ -104,7 +129,13 @@ RSpec.describe Idv::ByMail::ResendLetterController do
     allow(Pii::Cacher).to receive(:new).and_return(pii_cacher)
 
     service_provider = create(:service_provider, issuer: '123abc')
-    session[:sp] = { issuer: service_provider.issuer, vtr: ['C1'] }
+    session[:sp] = { issuer: service_provider.issuer }
+
+    if vtr
+      session[:sp][:vtr] = ['C1']
+    else
+      session[:sp][:acr_values] = Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF
+    end
 
     gpo_confirmation_maker = instance_double(GpoConfirmationMaker)
     allow(GpoConfirmationMaker).to receive(:new).

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -414,15 +414,36 @@ RSpec.describe Idv::PersonalKeyController do
 
   describe '#update' do
     context 'user selected phone verification' do
-      it 'redirects to sign up completed for an sp' do
-        subject.session[:sp] = {
-          issuer: create(:service_provider).issuer,
-          vtr: ['C1'],
-        }
-        patch :update
+      context 'with an sp' do
+        let(:acr_values) { Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF }
+        let(:vtr) { nil}
 
-        expect(response).to redirect_to sign_up_completed_url
+        before do
+          subject.session[:sp] = {
+          issuer: create(:service_provider).issuer,
+          acr_values:,
+          vtr:,
+          }
+        end
+
+        it 'redirects to sign up completed for the sp' do
+          patch :update
+
+          expect(response).to redirect_to sign_up_completed_url
+        end
+
+        context 'with vtr values' do
+          let(:acr_values) { nil }
+          let(:vtr) { ['C1'] }
+
+          it 'redirects to sign up completed for the sp' do
+            patch :update
+
+            expect(response).to redirect_to sign_up_completed_url
+          end
+        end
       end
+
 
       it 'redirects to the account path when no sp present' do
         patch :update

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -416,13 +416,13 @@ RSpec.describe Idv::PersonalKeyController do
     context 'user selected phone verification' do
       context 'with an sp' do
         let(:acr_values) { Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF }
-        let(:vtr) { nil}
+        let(:vtr) { nil }
 
         before do
           subject.session[:sp] = {
-          issuer: create(:service_provider).issuer,
-          acr_values:,
-          vtr:,
+            issuer: create(:service_provider).issuer,
+            acr_values:,
+            vtr:,
           }
         end
 
@@ -443,7 +443,6 @@ RSpec.describe Idv::PersonalKeyController do
           end
         end
       end
-
 
       it 'redirects to the account path when no sp present' do
         patch :update

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -450,7 +450,7 @@ RSpec.describe Idv::VerifyInfoController do
         allow(controller).to receive(:sp_session).and_return(sp_session)
       end
 
-      it 'modifies pii as expected' do
+      it 'modifies PII as expected' do
         expect(Idv::Agent).to receive(:new).with(
           hash_including(
             ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
@@ -466,7 +466,7 @@ RSpec.describe Idv::VerifyInfoController do
         let(:acr_values) { nil }
         let(:vtr) { ['C1'] }
 
-        it 'modifies pii as expected' do
+        it 'modifies PII as expected' do
           expect(Idv::Agent).to receive(:new).with(
             hash_including(
               ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -440,22 +440,48 @@ RSpec.describe Idv::VerifyInfoController do
       expect(response).to redirect_to idv_verify_info_url
     end
 
-    it 'modifies pii as expected' do
-      app_id = 'hello-world'
-      sp = create(:service_provider, app_id: app_id)
-      sp_session = { issuer: sp.issuer, vtr: ['C1'] }
-      allow(controller).to receive(:sp_session).and_return(sp_session)
+    context 'with an sp' do
+      let(:sp) { create(:service_provider) }
+      let(:acr_values) { Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF }
+      let(:vtr) { nil }
+      let(:sp_session) { { issuer: sp.issuer, vtr:, acr_values:} }
 
-      expect(Idv::Agent).to receive(:new).with(
-        hash_including(
-          ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
-          consent_given_at: controller.idv_session.idv_consent_given_at,
-          **Idp::Constants::MOCK_IDV_APPLICANT,
-        ),
-      ).and_call_original
+      before do
+        allow(controller).to receive(:sp_session).and_return(sp_session)
+      end
 
-      put :update
+      it 'modifies pii as expected' do
+        sp_session = { issuer: sp.issuer, vtr: ['C1'] }
+
+
+        expect(Idv::Agent).to receive(:new).with(
+          hash_including(
+            ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
+            consent_given_at: controller.idv_session.idv_consent_given_at,
+            **Idp::Constants::MOCK_IDV_APPLICANT,
+          ),
+        ).and_call_original
+
+        put :update
+      end
+      context 'with vtr values' do
+        let(:acr_values) { nil }
+        let(:vtr) { ['C1']}
+
+        it 'modifies pii as expected' do
+          expect(Idv::Agent).to receive(:new).with(
+            hash_including(
+              ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
+              consent_given_at: controller.idv_session.idv_consent_given_at,
+              **Idp::Constants::MOCK_IDV_APPLICANT,
+            ),
+          ).and_call_original
+
+          put :update
+        end
+      end
     end
+
 
     it 'updates DocAuthLog verify_submit_count' do
       doc_auth_log = DocAuthLog.create(user_id: user.id)

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -451,8 +451,6 @@ RSpec.describe Idv::VerifyInfoController do
       end
 
       it 'modifies pii as expected' do
-        sp_session = { issuer: sp.issuer, vtr: ['C1'] }
-
         expect(Idv::Agent).to receive(:new).with(
           hash_including(
             ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
@@ -463,6 +461,7 @@ RSpec.describe Idv::VerifyInfoController do
 
         put :update
       end
+
       context 'with vtr values' do
         let(:acr_values) { nil }
         let(:vtr) { ['C1'] }

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -444,7 +444,7 @@ RSpec.describe Idv::VerifyInfoController do
       let(:sp) { create(:service_provider) }
       let(:acr_values) { Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF }
       let(:vtr) { nil }
-      let(:sp_session) { { issuer: sp.issuer, vtr:, acr_values:} }
+      let(:sp_session) { { issuer: sp.issuer, vtr:, acr_values: } }
 
       before do
         allow(controller).to receive(:sp_session).and_return(sp_session)
@@ -452,7 +452,6 @@ RSpec.describe Idv::VerifyInfoController do
 
       it 'modifies pii as expected' do
         sp_session = { issuer: sp.issuer, vtr: ['C1'] }
-
 
         expect(Idv::Agent).to receive(:new).with(
           hash_including(
@@ -466,7 +465,7 @@ RSpec.describe Idv::VerifyInfoController do
       end
       context 'with vtr values' do
         let(:acr_values) { nil }
-        let(:vtr) { ['C1']}
+        let(:vtr) { ['C1'] }
 
         it 'modifies pii as expected' do
           expect(Idv::Agent).to receive(:new).with(
@@ -481,7 +480,6 @@ RSpec.describe Idv::VerifyInfoController do
         end
       end
     end
-
 
     it 'updates DocAuthLog verify_submit_count' do
       doc_auth_log = DocAuthLog.create(user_id: user.id)

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe IdvController do
         let(:current_sp) { create(:service_provider) }
         before do
           session[:sp] =
-          {
-            issuer: current_sp.issuer,
-            acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
-          }
+            {
+              issuer: current_sp.issuer,
+              acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
+            }
         end
 
         it 'redirects to welcome' do
@@ -263,8 +263,8 @@ RSpec.describe IdvController do
 
             before do
               allow(IdentityConfig).to receive(
-                :allowed_valid_authn_context_semantic_providers
-                ).and_return([current_sp])
+                :allowed_valid_authn_context_semantic_providers,
+              ).and_return([current_sp])
             end
 
             it 'redirects back to the account page' do
@@ -294,8 +294,8 @@ RSpec.describe IdvController do
 
             before do
               allow(IdentityConfig).to receive(
-                :allowed_valid_authn_context_semantic_providers
-                ).and_return([current_sp])
+                :allowed_valid_authn_context_semantic_providers,
+              ).and_return([current_sp])
             end
 
             it 'begins the identity proofing process' do
@@ -323,8 +323,8 @@ RSpec.describe IdvController do
 
             before do
               allow(IdentityConfig).to receive(
-                :allowed_valid_authn_context_semantic_providers
-                ).and_return([current_sp])
+                :allowed_valid_authn_context_semantic_providers,
+              ).and_return([current_sp])
             end
 
             context 'when an SP is required' do
@@ -352,8 +352,8 @@ RSpec.describe IdvController do
 
             before do
               allow(IdentityConfig).to receive(
-                :allowed_valid_authn_context_semantic_providers
-                ).and_return([current_sp])
+                :allowed_valid_authn_context_semantic_providers,
+              ).and_return([current_sp])
             end
 
             it 'begins the identity proofing process' do

--- a/spec/controllers/idv_controller_spec.rb
+++ b/spec/controllers/idv_controller_spec.rb
@@ -58,15 +58,29 @@ RSpec.describe IdvController do
 
       context 'but user needs to redo idv with facial match' do
         let(:current_sp) { create(:service_provider) }
-
         before do
           session[:sp] =
-            { issuer: current_sp.issuer, vtr: ['C2.Pb'] }
+          {
+            issuer: current_sp.issuer,
+            acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+          }
         end
 
         it 'redirects to welcome' do
           get :index
           expect(response).to redirect_to idv_welcome_url
+        end
+
+        context 'using vectors of trust' do
+          before do
+            session[:sp] =
+              { issuer: current_sp.issuer, vtr: ['C2.Pb'] }
+          end
+
+          it 'redirects to welcome' do
+            get :index
+            expect(response).to redirect_to idv_welcome_url
+          end
         end
       end
     end
@@ -243,6 +257,27 @@ RSpec.describe IdvController do
             get :index
             expect(response).to redirect_to idv_welcome_url
           end
+
+          context 'when using semantic acr_values' do
+            let(:acr_values) { Saml::Idp::Constants::IAL_AUTH_ONLY_ACR }
+
+            before do
+              allow(IdentityConfig).to receive(
+                :allowed_valid_authn_context_semantic_providers
+                ).and_return([current_sp])
+            end
+
+            it 'redirects back to the account page' do
+              get :index
+              expect(response).to redirect_to account_url
+            end
+
+            it 'begins the proofing process if the user has a profile' do
+              create(:profile, :verified, user: user)
+              get :index
+              expect(response).to redirect_to idv_welcome_url
+            end
+          end
         end
 
         context 'no SP required' do
@@ -252,6 +287,22 @@ RSpec.describe IdvController do
             get :index
 
             expect(response).to redirect_to idv_welcome_url
+          end
+
+          context 'when using semantic acr_values' do
+            let(:acr_values) { Saml::Idp::Constants::IAL_AUTH_ONLY_ACR }
+
+            before do
+              allow(IdentityConfig).to receive(
+                :allowed_valid_authn_context_semantic_providers
+                ).and_return([current_sp])
+            end
+
+            it 'begins the identity proofing process' do
+              get :index
+
+              expect(response).to redirect_to idv_welcome_url
+            end
           end
         end
       end
@@ -266,6 +317,25 @@ RSpec.describe IdvController do
             get :index
             expect(response).to redirect_to idv_welcome_url
           end
+
+          context 'with semantic acr_values' do
+            let(:acr_values) { Saml::Idp::Constants::IAL_VERIFIED_ACR }
+
+            before do
+              allow(IdentityConfig).to receive(
+                :allowed_valid_authn_context_semantic_providers
+                ).and_return([current_sp])
+            end
+
+            context 'when an SP is required' do
+              let(:idv_sp_required) { true }
+
+              it 'begins the identity proofing process' do
+                get :index
+                expect(response).to redirect_to idv_welcome_url
+              end
+            end
+          end
         end
 
         context 'no SP required' do
@@ -275,6 +345,22 @@ RSpec.describe IdvController do
             get :index
 
             expect(response).to redirect_to idv_welcome_url
+          end
+
+          context 'with semantic acr_values' do
+            let(:acr_values) { Saml::Idp::Constants::IAL_VERIFIED_ACR }
+
+            before do
+              allow(IdentityConfig).to receive(
+                :allowed_valid_authn_context_semantic_providers
+                ).and_return([current_sp])
+            end
+
+            it 'begins the identity proofing process' do
+              get :index
+
+              expect(response).to redirect_to idv_welcome_url
+            end
           end
         end
       end

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe Users::PivCacLoginController do
 
       context 'with a valid token' do
         let(:service_provider) { create(:service_provider) }
-        let(:sp_session) { { ial: 1, issuer: service_provider.issuer, vtr: vtr } }
+        let(:acr_values) { Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF }
+        let(:sp_session) { { ial: 1, issuer: service_provider.issuer, acr_values: } }
         let(:nonce) { SecureRandom.base64(20) }
-        let(:vtr) { ['C1'] }
         let(:data) do
           {
             nonce: nonce,
@@ -219,13 +219,6 @@ RSpec.describe Users::PivCacLoginController do
                     issuer: service_provider.issuer,
                   }
                 end
-                let(:sp_session) do
-                  {
-                    ial: Idp::Constants::IAL2,
-                    issuer: service_provider.issuer,
-                    vtr: vtr,
-                  }
-                end
 
                 it 'redirects to account' do
                   expect(response).to redirect_to(account_url)
@@ -234,7 +227,7 @@ RSpec.describe Users::PivCacLoginController do
 
               context 'ial_max service level' do
                 let(:sp_session) do
-                  { ial: Idp::Constants::IAL_MAX, issuer: service_provider.issuer, vtr: vtr }
+                  { ial: Idp::Constants::IAL_MAX, issuer: service_provider.issuer, acr_values: }
                 end
 
                 it 'redirects to the after_sign_in_path_for' do

--- a/spec/policies/pending_profile_policy_spec.rb
+++ b/spec/policies/pending_profile_policy_spec.rb
@@ -30,9 +30,10 @@ RSpec.describe PendingProfilePolicy do
 
       context 'with resolved authn context result' do
         let(:acr_values) do
-          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF +
-            ' ' +
-            Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+          [
+            Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
+          ].join(' ')
         end
 
         it 'has a usable pending profile' do

--- a/spec/policies/pending_profile_policy_spec.rb
+++ b/spec/policies/pending_profile_policy_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe PendingProfilePolicy do
   let(:user) { create(:user) }
   let(:resolved_authn_context_result) do
     AuthnContextResolver.new(
-      user: user,
+      user:,
       service_provider: nil,
-      vtr: vtr,
-      acr_values: acr_values,
+      vtr:,
+      acr_values:,
     ).result
   end
   let(:vtr) { nil }

--- a/spec/policies/pending_profile_policy_spec.rb
+++ b/spec/policies/pending_profile_policy_spec.rb
@@ -29,10 +29,23 @@ RSpec.describe PendingProfilePolicy do
       end
 
       context 'with resolved authn context result' do
-        let(:vtr) { ['C2.Pb'] }
+        let(:acr_values) do
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF +
+            ' ' +
+            Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+        end
 
         it 'has a usable pending profile' do
           expect(policy.user_has_pending_profile?).to eq(true)
+        end
+
+        context 'with vtr values' do
+          let(:acr_values) { nil }
+          let(:vtr) { ['C2.Pb'] }
+
+          it 'has a usable pending profile' do
+            expect(policy.user_has_pending_profile?).to eq(true)
+          end
         end
       end
 

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -198,8 +198,10 @@ RSpec.describe AccountShowPresenter do
 
     context 'with sp request for non-facial match' do
       let(:acr_values) do
-        Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF + ' ' +
-          Saml::Idp::Constants::IAL_VERIFIED_ACR
+        [
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::IAL_VERIFIED_ACR,
+        ].join(' ')
       end
 
       it { is_expected.to eq(true) }

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe AccountShowPresenter do
       it { is_expected.to eq(false) }
     end
 
-
     context 'using vtr values' do
       let(:acr_values) { nil }
       let(:vtr) { ['C2'] }

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -1,15 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe AccountShowPresenter do
-  let(:vtr) { ['C2'] }
+  let(:acr_values) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
+  let(:vtr) { nil }
   let(:decrypted_pii) { nil }
   let(:sp_session_request_url) { nil }
   let(:authn_context) do
     AuthnContextResolver.new(
       user:,
       service_provider: nil,
-      vtr: vtr,
-      acr_values: nil,
+      vtr:,
+      acr_values:,
     ).result
   end
   let(:sp_name) { nil }
@@ -36,6 +37,17 @@ RSpec.describe AccountShowPresenter do
         user.identity_verified_with_facial_match?,
       )
     end
+
+    context 'using vtr values' do
+      let(:acr_values) { nil }
+      let(:vtr) { ['C2'] }
+
+      it 'delegates to user' do
+        expect(identity_verified_with_facial_match?).to eq(
+          user.identity_verified_with_facial_match?,
+        )
+      end
+    end
   end
 
   describe '#showing_alerts?' do
@@ -55,6 +67,26 @@ RSpec.describe AccountShowPresenter do
 
       it { is_expected.to eq(true) }
     end
+
+    context 'using vtr values' do
+      let(:acr_values) { nil }
+      let(:vtr) { ['C2'] }
+
+      it { is_expected.to eq(false) }
+
+      context 'with associated sp' do
+        let(:sp_session_request_url) { 'http://example.test' }
+        let(:sp_name) { 'Example SP' }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'with password reset profile' do
+        let(:user) { build(:user, :deactivated_password_reset_profile) }
+
+        it { is_expected.to eq(true) }
+      end
+    end
   end
 
   describe '#active_profile?' do
@@ -73,6 +105,26 @@ RSpec.describe AccountShowPresenter do
 
       it { is_expected.to eq(false) }
     end
+
+
+    context 'using vtr values' do
+      let(:acr_values) { nil }
+      let(:vtr) { ['C2'] }
+
+      it { is_expected.to eq(false) }
+
+      context 'with proofed user' do
+        let(:user) { build(:user, :proofed) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'with user who proofed but has pending profile' do
+        let(:user) { build(:user, :deactivated_password_reset_profile) }
+
+        it { is_expected.to eq(false) }
+      end
+    end
   end
 
   describe '#active_profile_for_authn_context?' do
@@ -86,15 +138,34 @@ RSpec.describe AccountShowPresenter do
       it { is_expected.to eq(true) }
 
       context 'with sp request for non-facial match' do
-        let(:vtr) { ['C2.P1'] }
+        let(:acr_values) do
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF + ' ' +
+            Saml::Idp::Constants::IAL_VERIFIED_ACR
+        end
 
         it { is_expected.to eq(true) }
+
+        context 'with vtr values' do
+          let(:vtr) { ['C2.P1'] }
+
+          it { is_expected.to eq(true) }
+        end
       end
 
       context 'with sp request for facial match' do
-        let(:vtr) { ['C2.Pb'] }
+        let(:acr_values) do
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF + ' ' +
+            Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+        end
 
         it { is_expected.to eq(false) }
+
+        context 'with vtr values' do
+          let(:acr_values) { nil }
+          let(:vtr) { ['C2.Pb'] }
+
+          it { is_expected.to eq(false) }
+        end
       end
     end
 
@@ -104,9 +175,19 @@ RSpec.describe AccountShowPresenter do
       it { is_expected.to eq(true) }
 
       context 'with sp request for facial match' do
-        let(:vtr) { ['C2.Pb'] }
+        let(:acr_values) do
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF + ' ' +
+            Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+        end
 
         it { is_expected.to eq(true) }
+
+        context 'with acr values' do
+          let(:acr_values) { nil }
+          let(:vtr) { ['C2.Pb'] }
+
+          it { is_expected.to eq(true) }
+        end
       end
     end
   end
@@ -117,7 +198,10 @@ RSpec.describe AccountShowPresenter do
     it { is_expected.to eq(false) }
 
     context 'with sp request for non-facial match' do
-      let(:vtr) { ['C2.P1'] }
+      let(:acr_values) do
+        Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF + ' ' +
+          Saml::Idp::Constants::IAL_VERIFIED_ACR
+      end
 
       it { is_expected.to eq(true) }
 
@@ -126,10 +210,26 @@ RSpec.describe AccountShowPresenter do
 
         it { is_expected.to eq(false) }
       end
+
+      context 'with vtr values' do
+        let(:acr_values) { nil }
+        let(:vtr) { ['C2.P1'] }
+
+        it { is_expected.to eq(true) }
+
+        context 'with non-facial match proofed user' do
+          let(:user) { build(:user, :proofed) }
+
+          it { is_expected.to eq(false) }
+        end
+      end
     end
 
     context 'with sp request for facial match' do
-      let(:vtr) { ['C2.Pb'] }
+      let(:acr_values) do
+        Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF + ' ' +
+          Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+      end
 
       it { is_expected.to eq(true) }
 
@@ -143,6 +243,25 @@ RSpec.describe AccountShowPresenter do
         let(:user) { build(:user, :proofed_with_selfie) }
 
         it { is_expected.to eq(false) }
+      end
+
+      context 'with vtr values' do
+        let(:acr_values) { nil }
+        let(:vtr) { ['C2.Pb'] }
+
+        it { is_expected.to eq(true) }
+
+        context 'with non-facial match proofed user' do
+          let(:user) { build(:user, :proofed) }
+
+          it { is_expected.to eq(true) }
+        end
+
+        context 'with facial match proofed user' do
+          let(:user) { build(:user, :proofed_with_selfie) }
+
+          it { is_expected.to eq(false) }
+        end
       end
     end
   end
@@ -226,9 +345,19 @@ RSpec.describe AccountShowPresenter do
 
     context 'with pending idv' do
       let(:user) { build(:user, :proofed) }
-      let(:vtr) { ['C2.Pb'] }
+      let(:acr_values) do
+        Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF + ' ' +
+          Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+      end
 
       it { is_expected.to eq(true) }
+
+      context 'with vtr values' do
+        let(:acr_values) { nil }
+        let(:vtr) { ['C2.Pb'] }
+
+        it { is_expected.to eq(true) }
+      end
     end
 
     context 'with user pending ipp verification' do

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AttributeAsserter do
   let(:authn_context) do
     [
       Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-      Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+      Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
     ]
   end
   let(:options) { { authn_context: } }
@@ -71,188 +71,194 @@ RSpec.describe AttributeAsserter do
   end
 
   describe '#build' do
+
     context 'when an IAL2 request is made' do
-      let(:authn_context) do
-        [
-          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-        ]
-      end
-
-      context 'when the user has been proofed without facial match' do
-        context 'custom bundle includes email, phone, and first_name' do
-          before do
-            user.identities << identity
-            allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
-              and_return(%w[email phone first_name])
-            subject.build
-          end
-
-          it 'includes all requested attributes + uuid' do
-            expect(user.asserted_attributes.keys).
-              to eq(%i[uuid email phone first_name verified_at aal ial])
-          end
-
-          it 'creates getter function' do
-            expect(get_asserted_attribute(user, :first_name)).to eq 'Jåné'
-          end
-
-          it 'formats the phone number as e164' do
-            expect(get_asserted_attribute(user, :phone)).to eq '+18888675309'
-          end
-
-          it 'gets UUID from Service Provider' do
-            expect(get_asserted_attribute(user, :uuid)).to eq user.last_identity.uuid
-          end
+      [
+        Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+        Saml::Idp::Constants::IAL_VERIFIED_ACR]
+      .each do |ial_value|
+        let(:authn_context) do
+          [
+          ial_value,
+          ]
         end
 
-        context 'custom bundle includes dob' do
-          before do
-            user.identities << identity
-            allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
-              and_return(%w[dob])
-            subject.build
-          end
-
-          it 'formats the dob in an international format' do
-            expect(get_asserted_attribute(user, :dob)).to eq '1970-12-31'
-          end
-        end
-
-        context 'custom bundle includes zipcode' do
-          before do
-            user.identities << identity
-            allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
-              and_return(%w[zipcode])
-            subject.build
-          end
-
-          it 'formats zipcode as 5 digits' do
-            expect(get_asserted_attribute(user, :zipcode)).to eq '12345'
-          end
-        end
-
-        context 'bundle includes :ascii' do
-          before do
-            user.identities << identity
-            allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
-              and_return(%w[email phone first_name ascii])
-            subject.build
-          end
-
-          it 'skips ascii as an attribute' do
-            expect(user.asserted_attributes.keys).
-              to eq(%i[uuid email phone first_name verified_at aal ial])
-          end
-
-          it 'transliterates attributes to ASCII' do
-            expect(get_asserted_attribute(user, :first_name)).to eq 'Jane'
-          end
-        end
-
-        context 'Service Provider does not specify bundle' do
-          before do
-            allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
-              and_return(nil)
-            subject.build
-          end
-
-          context 'authn request does not specify bundle' do
-            it 'only returns uuid, verified_at, aal, and ial' do
-              expect(user.asserted_attributes.keys).to eq %i[uuid verified_at aal ial]
+        context 'when the user has been proofed without facial match' do
+          context 'custom bundle includes email, phone, and first_name' do
+            before do
+              user.identities << identity
+              allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+                and_return(%w[email phone first_name])
+              subject.build
             end
-          end
 
-          context 'authn request specifies bundle' do
-            # rubocop:disable Layout/LineLength
-            let(:authn_context) do
-              [
-                Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-                "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
-                "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
-              ]
-            end
-            # rubocop:enable Layout/LineLength
-
-            it 'uses authn request bundle' do
+            it 'includes all requested attributes + uuid' do
               expect(user.asserted_attributes.keys).
-                to eq(%i[uuid email first_name last_name ssn phone verified_at aal ial])
+                to eq(%i[uuid email phone first_name verified_at aal ial])
+            end
+
+            it 'creates getter function' do
+              expect(get_asserted_attribute(user, :first_name)).to eq 'Jåné'
+            end
+
+            it 'formats the phone number as e164' do
+              expect(get_asserted_attribute(user, :phone)).to eq '+18888675309'
+            end
+
+            it 'gets UUID from Service Provider' do
+              expect(get_asserted_attribute(user, :uuid)).to eq user.last_identity.uuid
+            end
+          end
+
+          context 'custom bundle includes dob' do
+            before do
+              user.identities << identity
+              allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+                and_return(%w[dob])
+              subject.build
+            end
+
+            it 'formats the dob in an international format' do
+              expect(get_asserted_attribute(user, :dob)).to eq '1970-12-31'
+            end
+          end
+
+          context 'custom bundle includes zipcode' do
+            before do
+              user.identities << identity
+              allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+                and_return(%w[zipcode])
+              subject.build
+            end
+
+            it 'formats zipcode as 5 digits' do
+              expect(get_asserted_attribute(user, :zipcode)).to eq '12345'
+            end
+          end
+
+          context 'bundle includes :ascii' do
+            before do
+              user.identities << identity
+              allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+                and_return(%w[email phone first_name ascii])
+              subject.build
+            end
+
+            it 'skips ascii as an attribute' do
+              expect(user.asserted_attributes.keys).
+                to eq(%i[uuid email phone first_name verified_at aal ial])
+            end
+
+            it 'transliterates attributes to ASCII' do
+              expect(get_asserted_attribute(user, :first_name)).to eq 'Jane'
+            end
+          end
+
+          context 'Service Provider does not specify bundle' do
+            before do
+              allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+                and_return(nil)
+              subject.build
+            end
+
+            context 'authn request does not specify bundle' do
+              it 'only returns uuid, verified_at, aal, and ial' do
+                expect(user.asserted_attributes.keys).to eq %i[uuid verified_at aal ial]
+              end
+            end
+
+            context 'authn request specifies bundle' do
+              # rubocop:disable Layout/LineLength
+              let(:authn_context) do
+                [
+                  ial_value,
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}first_name:last_name email, ssn",
+                  "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
+                ]
+              end
+              # rubocop:enable Layout/LineLength
+
+              it 'uses authn request bundle' do
+                expect(user.asserted_attributes.keys).
+                  to eq(%i[uuid email first_name last_name ssn phone verified_at aal ial])
+              end
+            end
+          end
+
+          context 'Service Provider specifies empty bundle' do
+            before do
+              allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+                and_return([])
+              subject.build
+            end
+
+            it 'only includes uuid, verified_at, aal, and ial' do
+              expect(user.asserted_attributes.keys).to eq(%i[uuid verified_at aal ial])
+            end
+          end
+
+          context 'custom bundle has invalid attribute name' do
+            before do
+              allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
+                %w[email foo],
+              )
+              subject.build
+            end
+
+            it 'silently skips invalid attribute name' do
+              expect(user.asserted_attributes.keys).to eq(%i[uuid email verified_at aal ial])
+            end
+          end
+
+          context 'x509 attributes included in the SP attribute bundle' do
+            before do
+              allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
+                and_return(%w[email x509_subject x509_issuer x509_presented])
+              subject.build
+            end
+
+            context 'user did not present piv/cac' do
+              let(:user_session) do
+                {
+                  decrypted_x509: nil,
+                }
+              end
+
+              it 'does not include x509_subject, x509_issuer, and x509_presented' do
+                expect(user.asserted_attributes.keys).to eq %i[uuid email verified_at aal ial]
+              end
+            end
+
+            context 'user presented piv/cac' do
+              let(:user_session) do
+                {
+                  decrypted_x509: {
+                    subject: 'x509 subject',
+                    presented: true,
+                  }.to_json,
+                }
+              end
+
+              it 'includes x509_subject x509_issuer x509_presented' do
+                expected = %i[uuid email verified_at aal ial x509_subject x509_issuer x509_presented]
+                expect(user.asserted_attributes.keys).to eq expected
+              end
             end
           end
         end
 
-        context 'Service Provider specifies empty bundle' do
+        context 'when the user has been proofed with facial match' do
+          let(:user) { create(:profile, :active, :verified, idv_level: :in_person).user }
+
           before do
-            allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
-              and_return([])
+            user.identities << identity
             subject.build
           end
 
-          it 'only includes uuid, verified_at, aal, and ial' do
-            expect(user.asserted_attributes.keys).to eq(%i[uuid verified_at aal ial])
+          it 'asserts IAL2' do
+            expected_ial = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
+            expect(get_asserted_attribute(user, :ial)).to eq expected_ial
           end
-        end
-
-        context 'custom bundle has invalid attribute name' do
-          before do
-            allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).and_return(
-              %w[email foo],
-            )
-            subject.build
-          end
-
-          it 'silently skips invalid attribute name' do
-            expect(user.asserted_attributes.keys).to eq(%i[uuid email verified_at aal ial])
-          end
-        end
-
-        context 'x509 attributes included in the SP attribute bundle' do
-          before do
-            allow(service_provider.metadata).to receive(:[]).with(:attribute_bundle).
-              and_return(%w[email x509_subject x509_issuer x509_presented])
-            subject.build
-          end
-
-          context 'user did not present piv/cac' do
-            let(:user_session) do
-              {
-                decrypted_x509: nil,
-              }
-            end
-
-            it 'does not include x509_subject, x509_issuer, and x509_presented' do
-              expect(user.asserted_attributes.keys).to eq %i[uuid email verified_at aal ial]
-            end
-          end
-
-          context 'user presented piv/cac' do
-            let(:user_session) do
-              {
-                decrypted_x509: {
-                  subject: 'x509 subject',
-                  presented: true,
-                }.to_json,
-              }
-            end
-
-            it 'includes x509_subject x509_issuer x509_presented' do
-              expected = %i[uuid email verified_at aal ial x509_subject x509_issuer x509_presented]
-              expect(user.asserted_attributes.keys).to eq expected
-            end
-          end
-        end
-      end
-
-      context 'when the user has been proofed with facial match' do
-        let(:user) { create(:profile, :active, :verified, idv_level: :in_person).user }
-
-        before do
-          user.identities << identity
-          subject.build
-        end
-
-        it 'asserts IAL2' do
-          expected_ial = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
-          expect(get_asserted_attribute(user, :ial)).to eq expected_ial
         end
       end
     end
@@ -1038,7 +1044,7 @@ RSpec.describe AttributeAsserter do
             let(:service_provider_aal) { 1 }
 
             it 'asserts aal1' do
-              # we do not enforce aal1, we enforce default aal, so this should be updated
+              # we don't really have an aal1 level to enforce, so this should be updated
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
               )
@@ -1048,8 +1054,7 @@ RSpec.describe AttributeAsserter do
           context 'default_aal is 2' do
             let(:service_provider_aal) { 2 }
 
-            it 'asserts aal1' do
-              # we do not enforce aal1, we enforce default aal, so this should be updated
+            it 'asserts aal2' do
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
               )
@@ -1059,8 +1064,8 @@ RSpec.describe AttributeAsserter do
           context 'default_aal is 3' do
             let(:service_provider_aal) { 3 }
 
-            it 'asserts aal1' do
-              # we do not enforce aal1, we enforce default aal, so this should be updated
+            it 'asserts aal3' do
+              # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
               )
@@ -1124,8 +1129,8 @@ RSpec.describe AttributeAsserter do
               ]
             end
 
-            # identity proofing enforces aal2, so that is what should be asserted
             it 'asserts the default value' do
+              # identity proofing enforces aal2, so that is what should be asserted
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
               )
@@ -1138,7 +1143,7 @@ RSpec.describe AttributeAsserter do
         let(:options) do
           {
             authn_context: [
-              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+              Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF,
             ],
             authn_context_comparison: 'minimum',
           }

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -71,15 +71,15 @@ RSpec.describe AttributeAsserter do
   end
 
   describe '#build' do
-
     context 'when an IAL2 request is made' do
       [
         Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-        Saml::Idp::Constants::IAL_VERIFIED_ACR]
-      .each do |ial_value|
+        Saml::Idp::Constants::IAL_VERIFIED_ACR,
+      ].
+        each do |ial_value|
         let(:authn_context) do
           [
-          ial_value,
+            ial_value,
           ]
         end
 
@@ -240,7 +240,8 @@ RSpec.describe AttributeAsserter do
               end
 
               it 'includes x509_subject x509_issuer x509_presented' do
-                expected = %i[uuid email verified_at aal ial x509_subject x509_issuer x509_presented]
+                expected = %i[uuid email verified_at aal ial x509_subject x509_issuer
+                              x509_presented]
                 expect(user.asserted_attributes.keys).to eq expected
               end
             end

--- a/spec/services/vot/parser_spec.rb
+++ b/spec/services/vot/parser_spec.rb
@@ -9,20 +9,42 @@ RSpec.describe Vot::Parser do
       end
     end
 
-    context 'when a vector is completely expanded' do
-      it 'returns the vector along with requirements' do
-        vector_of_trust = 'C1.C2.Cb'
+    context 'when input components are completely expanded' do
+      let(:acr_values) do
+        [
+          Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::IAL_VERIFIED_ACR,
+        ].join(' ')
+      end
 
-        result = Vot::Parser.new(vector_of_trust:).parse
+      it 'parses ACR values to component values' do
+        result = Vot::Parser.new(acr_values:).parse
 
-        expect(result.expanded_component_values).to eq('C1.C2.Cb')
+        expect(result.component_values.map(&:name).join(' ')).to eq(acr_values)
         expect(result.aal2?).to eq(true)
         expect(result.phishing_resistant?).to eq(false)
         expect(result.hspd12?).to eq(true)
-        expect(result.identity_proofing?).to eq(false)
+        expect(result.identity_proofing?).to eq(true)
         expect(result.facial_match?).to eq(false)
         expect(result.ialmax?).to eq(false)
         expect(result.enhanced_ipp?).to eq(false)
+      end
+
+      context 'with vectors of trust' do
+        it 'returns the vector along with requirements' do
+          vector_of_trust = 'C1.C2.Cb'
+
+          result = Vot::Parser.new(vector_of_trust:).parse
+
+          expect(result.expanded_component_values).to eq('C1.C2.Cb')
+          expect(result.aal2?).to eq(true)
+          expect(result.phishing_resistant?).to eq(false)
+          expect(result.hspd12?).to eq(true)
+          expect(result.identity_proofing?).to eq(false)
+          expect(result.facial_match?).to eq(false)
+          expect(result.ialmax?).to eq(false)
+          expect(result.enhanced_ipp?).to eq(false)
+        end
       end
     end
 
@@ -52,51 +74,70 @@ RSpec.describe Vot::Parser do
       end
     end
 
-    it 'adds the two pieces of fair evidence components' do
-      vector_of_trust = 'Pb'
+    context 'when two pieces of fair evidence is required' do
+      let(:acr_values) { Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR }
 
-      result = Vot::Parser.new(vector_of_trust:).parse
+      it 'adds the two pieces of fair evidence requirement' do
+        result = Vot::Parser.new(acr_values:).parse
 
-      expect(result.expanded_component_values).to eq('C1.C2.P1.Pb')
-      expect(result.two_pieces_of_fair_evidence?).to eq(true)
-    end
+        expect(result.expanded_component_values).to eq(acr_values)
+        expect(result.two_pieces_of_fair_evidence?).to eq(true)
+      end
 
-    context 'when a vector includes unrecognized components' do
-      it 'raises an exception' do
-        vector_of_trust = 'C1.C2.Xx'
+      context 'with vectors of trust' do
+        it 'adds the two pieces of fair evidence components' do
+          vector_of_trust = 'Pb'
 
-        expect { Vot::Parser.new(vector_of_trust:).parse }.to raise_exception(
-          Vot::Parser::UnsupportedComponentsException,
-          /'Xx'$/,
-        )
+          result = Vot::Parser.new(vector_of_trust:).parse
+
+          expect(result.expanded_component_values).to eq('C1.C2.P1.Pb')
+          expect(result.two_pieces_of_fair_evidence?).to eq(true)
+        end
       end
     end
 
-    context 'when a vector include duplicate components' do
+    context 'when input includes unrecognized components' do
+      let(:acr_values) { 'i-am-not-an-acr-value' }
       it 'raises an exception' do
-        vector_of_trust = 'C1.C1'
-        expect { Vot::Parser.new(vector_of_trust:).parse }.to raise_exception(
+        expect { Vot::Parser.new(acr_values:).parse }.to raise_exception(
+          Vot::Parser::UnsupportedComponentsException,
+          /'i-am-not-an-acr-value'$/,
+        )
+      end
+
+      context 'with vectors of trust' do
+        it 'raises an exception' do
+          vector_of_trust = 'C1.C2.Xx'
+
+          expect { Vot::Parser.new(vector_of_trust:).parse }.to raise_exception(
+            Vot::Parser::UnsupportedComponentsException,
+            /'Xx'$/,
+          )
+        end
+      end
+    end
+
+    context 'when input include duplicate components' do
+      let(:acr_values) do
+        [
+          Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::IAL_VERIFIED_ACR,
+          Saml::Idp::Constants::IAL_VERIFIED_ACR,
+        ].join(' ')
+      end
+
+      it 'raises an exception' do
+        expect { Vot::Parser.new(acr_values:).parse }.to raise_exception(
           Vot::Parser::DuplicateComponentsException,
         )
       end
 
-      context 'when ACR values are provided' do
-        it 'parses ACR values to component values' do
-          acr_values = [
-            'http://idmanagement.gov/ns/assurance/aal/2?hspd12=true',
-            'http://idmanagement.gov/ns/assurance/ial/2',
-          ].join(' ')
-
-          result = Vot::Parser.new(acr_values:).parse
-
-          expect(result.component_values.map(&:name).join(' ')).to eq(acr_values)
-          expect(result.aal2?).to eq(true)
-          expect(result.phishing_resistant?).to eq(false)
-          expect(result.hspd12?).to eq(true)
-          expect(result.identity_proofing?).to eq(true)
-          expect(result.facial_match?).to eq(false)
-          expect(result.ialmax?).to eq(false)
-          expect(result.enhanced_ipp?).to eq(false)
+      context 'with vectors of trust' do
+        it 'raises an exception' do
+          vector_of_trust = 'C1.C1'
+          expect { Vot::Parser.new(vector_of_trust:).parse }.to raise_exception(
+            Vot::Parser::DuplicateComponentsException,
+          )
         end
       end
     end

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
     let(:sp_name) { 'Example SP' }
     let(:acr_values) do
       acrs = Saml::Idp::Constants::IAL_VERIFIED_ACR
-      acrs += " " + Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
+      acrs += ' ' + Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
     end
 
     context 'with unproofed user' do
@@ -119,7 +119,10 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           expect(rendered).to have_content(
             strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
           )
-          expect(rendered).to have_link(t('account.index.verification.continue_idv'), href: idv_path)
+          expect(rendered).to have_link(
+            t('account.index.verification.continue_idv'),
+            href: idv_path,
+          )
         end
       end
     end
@@ -370,7 +373,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
     let(:sp_name) { 'Example SP' }
     let(:acr_values) do
       acrs = Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
-      acrs += " " + Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
+      acrs += ' ' + Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
     end
 
     context 'with unproofed user' do
@@ -401,7 +404,10 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           expect(rendered).to have_content(
             strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
           )
-          expect(rendered).to have_link(t('account.index.verification.continue_idv'), href: idv_path)
+          expect(rendered).to have_link(
+            t('account.index.verification.continue_idv'),
+            href: idv_path,
+          )
         end
       end
     end
@@ -482,7 +488,10 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           expect(rendered).to have_content(
             t('account.index.verification.finish_verifying_no_sp', app_name: APP_NAME),
           )
-          expect(rendered).to have_link(t('account.index.verification.continue_idv'), href: idv_path)
+          expect(rendered).to have_link(
+            t('account.index.verification.continue_idv'),
+            href: idv_path,
+          )
         end
       end
     end

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
         expect(rendered).to have_content(t('account.index.verification.unverified_badge'))
       end
 
-      it 'shows warning alert instructing user to complete identity verificaton' do
+      it 'shows warning alert instructing user to complete identity verification' do
         expect(rendered).to have_css('.usa-alert.usa-alert--warning')
         expect(rendered).to have_content(
           strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
@@ -116,7 +116,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           expect(rendered).to have_content(t('account.index.verification.unverified_badge'))
         end
 
-        it 'shows warning alert instructing user to complete identity verificaton' do
+        it 'shows warning alert instructing user to complete identity verification' do
           expect(rendered).to have_css('.usa-alert.usa-alert--warning')
           expect(rendered).to have_content(
             strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
@@ -387,7 +387,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
         expect(rendered).to have_content(t('account.index.verification.unverified_badge'))
       end
 
-      it 'shows warning alert instructing user to complete identity verificaton' do
+      it 'shows warning alert instructing user to complete identity verification' do
         expect(rendered).to have_css('.usa-alert.usa-alert--warning')
         expect(rendered).to have_content(
           strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
@@ -403,7 +403,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           expect(rendered).to have_content(t('account.index.verification.unverified_badge'))
         end
 
-        it 'shows warning alert instructing user to complete identity verificaton' do
+        it 'shows warning alert instructing user to complete identity verification' do
           expect(rendered).to have_css('.usa-alert.usa-alert--warning')
           expect(rendered).to have_content(
             strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
@@ -447,7 +447,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
         )
       end
 
-      it 'shows warning alert instructing user to complete identity verificaton' do
+      it 'shows warning alert instructing user to complete identity verification' do
         expect(rendered).to have_css('.usa-alert.usa-alert--warning')
         expect(rendered).to have_content(
           t('account.index.verification.finish_verifying_no_sp', app_name: APP_NAME),
@@ -487,7 +487,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           )
         end
 
-        it 'shows warning alert instructing user to complete identity verificaton' do
+        it 'shows warning alert instructing user to complete identity verification' do
           expect(rendered).to have_css('.usa-alert.usa-alert--warning')
           expect(rendered).to have_content(
             t('account.index.verification.finish_verifying_no_sp', app_name: APP_NAME),
@@ -555,7 +555,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           )
         end
 
-        it 'renders pii' do
+        it 'renders PII' do
           expect(rendered).to render_template(partial: 'accounts/_pii')
         end
       end

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -1,14 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe 'accounts/_identity_verification.html.erb' do
-  let(:vtr) { ['C2'] }
+  let(:vtr) { nil }
+  let(:acr_values) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
   let(:sp_name) { nil }
   let(:authn_context) do
     AuthnContextResolver.new(
       user:,
       service_provider: nil,
-      vtr: vtr,
-      acr_values: nil,
+      vtr:,
+      acr_values:,
     ).result
   end
   let(:user) { build(:user) }
@@ -41,6 +42,17 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
         strip_tags(t('account.index.verification.finish_verifying_html', sp_name: gpo_sp_name)),
       )
     end
+
+    context 'with vtr values' do
+      let(:vtr) { ['C2'] }
+      let(:acr_values) { nil }
+
+      it 'references initiating sp with prompt to finish verifying their identity' do
+        expect(rendered).to have_content(
+          strip_tags(t('account.index.verification.finish_verifying_html', sp_name: gpo_sp_name)),
+        )
+      end
+    end
   end
 
   context 'with user pending ipp verification' do
@@ -59,11 +71,25 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
         strip_tags(t('account.index.verification.finish_verifying_html', sp_name: ipp_sp_name)),
       )
     end
+
+    context 'with vtr values' do
+      let(:vtr) { ['C2'] }
+      let(:acr_values) { nil }
+
+      it 'references initiating sp with prompt to finish verifying their identity' do
+        expect(rendered).to have_content(
+          strip_tags(t('account.index.verification.finish_verifying_html', sp_name: ipp_sp_name)),
+        )
+      end
+    end
   end
 
   context 'with partner requesting non-facial match verification' do
     let(:sp_name) { 'Example SP' }
-    let(:vtr) { ['C2.P1'] }
+    let(:acr_values) do
+      acrs = Saml::Idp::Constants::IAL_VERIFIED_ACR
+      acrs += " " + Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
+    end
 
     context 'with unproofed user' do
       let(:user) { build(:user) }
@@ -78,6 +104,23 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
         )
         expect(rendered).to have_link(t('account.index.verification.continue_idv'), href: idv_path)
+      end
+
+      context 'with vtr values' do
+        let(:acr_values) { nil }
+        let(:vtr) { ['C2.P1'] }
+
+        it 'shows unverified badge' do
+          expect(rendered).to have_content(t('account.index.verification.unverified_badge'))
+        end
+
+        it 'shows warning alert instructing user to complete identity verificaton' do
+          expect(rendered).to have_css('.usa-alert.usa-alert--warning')
+          expect(rendered).to have_content(
+            strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
+          )
+          expect(rendered).to have_link(t('account.index.verification.continue_idv'), href: idv_path)
+        end
       end
     end
 
@@ -118,6 +161,46 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           href: idv_in_person_ready_to_verify_url,
         )
       end
+
+      context 'with vtr values' do
+        let(:acr_values) { nil }
+        let(:vtr) { ['C2.P1'] }
+
+        it 'shows pending badge' do
+          expect(rendered).to have_content(t('account.index.verification.pending_badge'))
+        end
+
+        it 'shows content explaining that the user needs to finish verifying their identity' do
+          expect(rendered).to have_content(
+            strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
+          )
+          expect(rendered).to have_link(
+            t('account.index.verification.learn_more_link'),
+            href: help_center_redirect_path(
+              category: 'verify-your-identity',
+              article: 'overview',
+              flow: :account_show,
+              location: :idv,
+            ),
+          )
+        end
+
+        it 'shows info alert instructing user to go to the post office to complete verification' do
+          expect(rendered).to have_css('.usa-alert.usa-alert--info')
+          expect(rendered).to have_content(
+            strip_tags(
+              t(
+                'account.index.verification.in_person_instructions_html',
+                deadline: @presenter.formatted_ipp_due_date,
+              ),
+            ),
+          )
+          expect(rendered).to have_link(
+            t('account.index.verification.show_bar_code', app_name: APP_NAME),
+            href: idv_in_person_ready_to_verify_url,
+          )
+        end
+      end
     end
 
     context 'with user pending gpo verification' do
@@ -149,6 +232,39 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           t('account.index.verification.reactivate_button'),
           href: idv_verify_by_mail_enter_code_path,
         )
+      end
+
+      context 'with vtr values' do
+        let(:acr_values) { nil }
+        let(:vtr) { ['C2.P1'] }
+
+        it 'shows pending badge' do
+          expect(rendered).to have_content(t('account.index.verification.pending_badge'))
+        end
+
+        it 'shows content explaining that the user needs to finish verifying their identity' do
+          expect(rendered).to have_content(
+            strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
+          )
+          expect(rendered).to have_link(
+            t('account.index.verification.learn_more_link'),
+            href: help_center_redirect_path(
+              category: 'verify-your-identity',
+              article: 'overview',
+              flow: :account_show,
+              location: :idv,
+            ),
+          )
+        end
+
+        it 'shows info alert instructing user to enter their gpo verification code' do
+          expect(rendered).to have_css('.usa-alert.usa-alert--info')
+          expect(rendered).to have_content(t('account.index.verification.instructions'))
+          expect(rendered).to have_link(
+            t('account.index.verification.reactivate_button'),
+            href: idv_verify_by_mail_enter_code_path,
+          )
+        end
       end
     end
 
@@ -198,12 +314,64 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           )
         end
       end
+
+      context 'with vtr values' do
+        let(:acr_values) { nil }
+        let(:vtr) { ['C2.P1'] }
+
+        it 'shows verified badge' do
+          expect(rendered).to have_content(t('account.index.verification.verified_badge'))
+        end
+
+        it 'shows content confirming verified identity' do
+          expect(rendered).to have_content(
+            strip_tags(
+              t('account.index.verification.you_verified_your_identity_html', sp_name: APP_NAME),
+            ),
+          )
+          expect(rendered).to have_link(
+            t('account.index.verification.learn_more_link'),
+            href: help_center_redirect_path(
+              category: 'verify-your-identity',
+              article: 'overview',
+              flow: :account_show,
+              location: :idv,
+            ),
+          )
+        end
+
+        it 'renders pii' do
+          expect(rendered).to render_template(partial: 'accounts/_pii')
+        end
+
+        context 'with initiating sp for active profile' do
+          let(:sp_name) { 'Example SP' }
+          let(:sp_issuer) { 'urn:gov:gsa:openidconnect:sp:example_sp' }
+          let(:sp) { create(:service_provider, issuer: sp_issuer, friendly_name: sp_name) }
+
+          before do
+            sp
+            user.active_profile.update(initiating_service_provider_issuer: sp_issuer)
+          end
+
+          it 'shows content confirming verified identity for initiating sp' do
+            expect(rendered).to have_content(
+              strip_tags(
+                t('account.index.verification.you_verified_your_identity_html', sp_name:),
+              ),
+            )
+          end
+        end
+      end
     end
   end
 
   context 'with partner requesting facial match verification' do
     let(:sp_name) { 'Example SP' }
-    let(:vtr) { ['C2.Pb'] }
+    let(:acr_values) do
+      acrs = Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+      acrs += " " + Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
+    end
 
     context 'with unproofed user' do
       let(:user) { build(:user) }
@@ -218,6 +386,23 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
           strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
         )
         expect(rendered).to have_link(t('account.index.verification.continue_idv'), href: idv_path)
+      end
+
+      context 'with vtr values' do
+        let(:vtr) { ['C2.Pb'] }
+        let(:acr_values) { nil }
+
+        it 'shows unverified badge' do
+          expect(rendered).to have_content(t('account.index.verification.unverified_badge'))
+        end
+
+        it 'shows warning alert instructing user to complete identity verificaton' do
+          expect(rendered).to have_css('.usa-alert.usa-alert--warning')
+          expect(rendered).to have_content(
+            strip_tags(t('account.index.verification.finish_verifying_html', sp_name:)),
+          )
+          expect(rendered).to have_link(t('account.index.verification.continue_idv'), href: idv_path)
+        end
       end
     end
 
@@ -259,6 +444,47 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
         )
         expect(rendered).to have_link(t('account.index.verification.continue_idv'), href: idv_path)
       end
+
+      context 'with vtr values' do
+        let(:vtr) { ['C2.Pb'] }
+        let(:acr_values) { nil }
+
+        it 'shows unverified badge' do
+          expect(rendered).to have_content(t('account.index.verification.unverified_badge'))
+        end
+
+        it 'shows content explaining that the user needs to verify their identity again' do
+          expect(rendered).to have_content(
+            strip_tags(
+              t(
+                'account.index.verification.legacy_verified_html',
+                app_name: APP_NAME,
+                date: @presenter.formatted_legacy_idv_date,
+              ),
+            ),
+          )
+          expect(rendered).to have_content(
+            strip_tags(t('account.index.verification.verify_with_facial_match_html', sp_name:)),
+          )
+          expect(rendered).to have_link(
+            t('account.index.verification.learn_more_link'),
+            href: help_center_redirect_path(
+              category: 'verify-your-identity',
+              article: 'overview',
+              flow: :account_show,
+              location: :idv,
+            ),
+          )
+        end
+
+        it 'shows warning alert instructing user to complete identity verificaton' do
+          expect(rendered).to have_css('.usa-alert.usa-alert--warning')
+          expect(rendered).to have_content(
+            t('account.index.verification.finish_verifying_no_sp', app_name: APP_NAME),
+          )
+          expect(rendered).to have_link(t('account.index.verification.continue_idv'), href: idv_path)
+        end
+      end
     end
 
     context 'with facial match proofed user' do
@@ -288,6 +514,37 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
 
       it 'renders pii' do
         expect(rendered).to render_template(partial: 'accounts/_pii')
+      end
+
+      context 'with vtr values' do
+        let(:vtr) { ['C2.Pb'] }
+        let(:acr_values) { nil }
+
+        it 'shows verified badge' do
+          expect(rendered).to have_content(t('account.index.verification.verified_badge'))
+        end
+
+        it 'shows content confirming verified identity' do
+          expect(rendered).to have_content(
+            t(
+              'account.index.verification.you_verified_your_facial_match_identity',
+              app_name: APP_NAME,
+            ),
+          )
+          expect(rendered).to have_link(
+            t('account.index.verification.learn_more_link'),
+            href: help_center_redirect_path(
+              category: 'verify-your-identity',
+              article: 'overview',
+              flow: :account_show,
+              location: :idv,
+            ),
+          )
+        end
+
+        it 'renders pii' do
+          expect(rendered).to render_template(partial: 'accounts/_pii')
+        end
       end
     end
   end

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -87,8 +87,10 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
   context 'with partner requesting non-facial match verification' do
     let(:sp_name) { 'Example SP' }
     let(:acr_values) do
-      acrs = Saml::Idp::Constants::IAL_VERIFIED_ACR
-      acrs += ' ' + Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
+      [
+        Saml::Idp::Constants::IAL_VERIFIED_ACR,
+        Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+      ].join(' ')
     end
 
     context 'with unproofed user' do
@@ -372,8 +374,10 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
   context 'with partner requesting facial match verification' do
     let(:sp_name) { 'Example SP' }
     let(:acr_values) do
-      acrs = Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
-      acrs += ' ' + Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
+      [
+        Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
+        Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+      ].join(' ')
     end
 
     context 'with unproofed user' do


### PR DESCRIPTION
## 🎫 Ticket
[Expand acr values coverage](https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/113)
As part of the Service Level initiative, we want to expand test coverage to include acr_values, both original and new semantic values.

## 🛠 Summary of changes
This change expands test coverage in various spec files that were mostly testing using vtr values. 

-  makes acr_values the default test case (to make it easier to remove vtr test cases in the future)
- adds acr_values test cases
- includes semantic acr_values

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
