### PR TITLE
LG-14711: Enable reCAPTCHA in log-only mode

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -39,7 +39,7 @@ module Users
       return process_rate_limited if session_bad_password_count_max_exceeded?
       return process_locked_out_user if current_user && user_locked_out?(current_user)
       return process_rate_limited if rate_limited?
-      return process_failed_captcha if !valid_captcha_result?
+      return process_failed_captcha unless valid_captcha_result? || log_captcha_failures_only?
 
       rate_limit_password_failure = true
       self.resource = warden.authenticate!(auth_options)
@@ -204,7 +204,10 @@ module Users
     def track_authentication_attempt
       user = user_from_params || AnonymousUser.new
 
-      success = current_user.present? && !user_locked_out?(user) && valid_captcha_result?
+      success = current_user.present? &&
+                !user_locked_out?(user) &&
+                (valid_captcha_result? || log_captcha_failures_only?)
+
       analytics.email_and_password_auth(
         success: success,
         user_id: user.uuid,
@@ -307,6 +310,10 @@ module Users
     def randomize_check_password?
       SecureRandom.random_number(IdentityConfig.store.compromised_password_randomizer_value) >=
         IdentityConfig.store.compromised_password_randomizer_threshold
+    end
+
+    def log_captcha_failures_only?
+      IdentityConfig.store.sign_in_recaptcha_log_failures_only
     end
   end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -340,6 +340,7 @@ short_term_phone_otp_max_attempt_window_in_seconds: 10
 short_term_phone_otp_max_attempts: 2
 show_unsupported_passkey_platform_authentication_setup: false
 show_user_attribute_deprecation_warnings: false
+sign_in_recaptcha_log_failures_only: false
 sign_in_recaptcha_percent_tested: 0
 sign_in_recaptcha_score_threshold: 0.0
 sign_in_user_id_per_ip_attempt_window_exponential_factor: 1.1

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -397,6 +397,7 @@ module IdentityConfig
     config.add(:sign_in_user_id_per_ip_attempt_window_in_minutes, type: :integer)
     config.add(:sign_in_user_id_per_ip_attempt_window_max_minutes, type: :integer)
     config.add(:sign_in_user_id_per_ip_max_attempts, type: :integer)
+    config.add(:sign_in_recaptcha_log_failures_only, type: :boolean)
     config.add(:sign_in_recaptcha_percent_tested, type: :integer)
     config.add(:sign_in_recaptcha_score_threshold, type: :float)
     config.add(:skip_encryption_allowed_list, type: :json)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -341,33 +341,55 @@ RSpec.describe Users::SessionsController, devise: true do
           and_return(:sign_in_recaptcha)
       end
 
-      it 'tracks unsuccessful authentication for failed reCAPTCHA' do
-        user = create(:user, :fully_registered)
+      context 'when configured to log failures only' do
+        before do
+          allow(IdentityConfig.store).to receive(:sign_in_recaptcha_log_failures_only).
+            and_return(true)
+        end
 
-        stub_analytics
+        it 'redirects unsuccessful authentication for failed reCAPTCHA to failed page' do
+          user = create(:user, :fully_registered)
 
-        post :create, params: { user: { email: user.email, password: user.password, score: 0.1 } }
+          post :create, params: { user: { email: user.email, password: user.password, score: 0.1 } }
 
-        expect(@analytics).to have_logged_event(
-          'Email and Password Authentication',
-          success: false,
-          user_id: user.uuid,
-          user_locked_out: false,
-          rate_limited: false,
-          valid_captcha_result: false,
-          captcha_validation_performed: true,
-          bad_password_count: 0,
-          remember_device: false,
-          sp_request_url_present: false,
-        )
+          expect(response).to redirect_to user_two_factor_authentication_url
+        end
       end
 
-      it 'redirects unsuccessful authentication for failed reCAPTCHA to failed page' do
-        user = create(:user, :fully_registered)
+      context 'when not configured to log failures only' do
+        before do
+          allow(IdentityConfig.store).to receive(:sign_in_recaptcha_log_failures_only).
+            and_return(false)
+        end
 
-        post :create, params: { user: { email: user.email, password: user.password, score: 0.1 } }
+        it 'tracks unsuccessful authentication for failed reCAPTCHA' do
+          user = create(:user, :fully_registered)
 
-        expect(response).to redirect_to sign_in_security_check_failed_url
+          stub_analytics
+
+          post :create, params: { user: { email: user.email, password: user.password, score: 0.1 } }
+
+          expect(@analytics).to have_logged_event(
+            'Email and Password Authentication',
+            success: false,
+            user_id: user.uuid,
+            user_locked_out: false,
+            rate_limited: false,
+            valid_captcha_result: false,
+            captcha_validation_performed: true,
+            bad_password_count: 0,
+            remember_device: false,
+            sp_request_url_present: false,
+          )
+        end
+
+        it 'redirects unsuccessful authentication for failed reCAPTCHA to failed page' do
+          user = create(:user, :fully_registered)
+
+          post :create, params: { user: { email: user.email, password: user.password, score: 0.1 } }
+
+          expect(response).to redirect_to sign_in_security_check_failed_url
+        end
       end
     end
 


### PR DESCRIPTION
changelog: Upcoming Features, reCAPTCHA, Enable reCAPTCHA in log-only mode

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-14711](https://cm-jira.usa.gov/browse/LG-14711)


## 🛠 Summary of changes

1. Add a feature flag `sign_in_recaptcha_log_failures_only` that is by default `false` in all environments.
2. When reCAPTCHA fails during sign-in, sign out the user and redirect them to an error page only if the flag `sign_in_recaptcha_log_failures_only` is set to `true`.


## 📜 Testing Plan

Set up an environment with the following config settings:

1. recaptcha_mock_validator: true
2. sign_in_recaptcha_log_failures_only: false
3. sign_in_recaptcha_percent_tested: 100
4. sign_in_recaptcha_score_threshold: 0.3


1. Go to http://localhost:3000/ in an Incognito/Private Browsing window
2. Sign in while setting reCAPTCHA to fail, e.g. a value of say 0.2
3. Observe that you are shown a page with "Security check failed" as shown in the screenshot below
4. Set sign_in_recaptcha_log_failures_only to `true` and restart the application
5. Go to http://localhost:3000/ in an Incognito/Private Browsing window
6. Sign in while setting reCAPTCHA to fail, e.g. a value of say 0.2
7. Observe that you are not shown a page with "Security check failed". Instead you are taken to the next step of authentication.
8. If you examine the events log, you should see an event named "Email and Password Authentication" with event_properties of `{"success":true,"valid_captcha_result":false}` - the authentication is successful even though the captcha test failed.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.


<img width="583" alt="Screenshot 2024-10-16 at 12 04 33 PM" src="https://github.com/user-attachments/assets/20ff65b5-f8be-45fa-991a-b903c5031e3b">



