### PR TITLE
LG-14325: Change from default to discouraged for authentication

### DIFF
--- a/app/javascript/packages/webauthn/verify-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/verify-webauthn-device.spec.ts
@@ -46,6 +46,7 @@ describe('verifyWebauthnDevice', () => {
               transports: ['internal', 'hybrid'],
             },
           ],
+          userVerification: 'discouraged',
           timeout: 800000,
         },
       };

--- a/app/javascript/packages/webauthn/verify-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/verify-webauthn-device.ts
@@ -39,6 +39,7 @@ async function verifyWebauthnDevice({
       challenge: new Uint8Array(JSON.parse(userChallenge)),
       rpId: window.location.hostname,
       allowCredentials: credentials.map(mapVerifyCredential),
+      userVerification: 'discouraged',
       timeout: 800000,
     },
   })) as PublicKeyCredential;


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-14325](https://cm-jira.usa.gov/browse/LG-14325)

## 🛠 Summary of changes

This makes it so when a user is leveraging webauthn as an MFA, it should not have to prompt user to enter in another credential before accepting the MFA. 

## 📜 Testing Plan
When signing in with Security key and F/T Unlock, User should not be prompted to enter in PIN. 
