### PR TITLE
Restructure PIV/CAC setup spec for consistency

### DIFF
--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -12,76 +12,72 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
     end
   end
 
-  describe 'when not signed in' do
-    describe 'GET index' do
+  describe '#new' do
+    context 'when not signed in' do
       it 'redirects to root url' do
         get :new
 
         expect(response).to redirect_to(root_url)
       end
     end
-  end
 
-  describe 'when signed out' do
-    describe 'GET index' do
+    context 'when signed out' do
       it 'redirects to sign in page' do
         get :new
 
         expect(response).to redirect_to(new_user_session_url)
       end
     end
-  end
 
-  describe 'when signing in' do
-    before(:each) { stub_sign_in_before_2fa(user) }
-    let(:user) do
-      create(:user, :fully_registered, :with_piv_or_cac, with: { phone: '+1 (703) 555-0000' })
-    end
+    context 'when signing in' do
+      before { stub_sign_in_before_2fa(user) }
 
-    describe 'GET index' do
+      let(:user) do
+        create(:user, :fully_registered, :with_piv_or_cac, with: { phone: '+1 (703) 555-0000' })
+      end
+
       it 'redirects to 2fa entry' do
         get :new
+
         expect(response).to redirect_to(user_two_factor_authentication_url)
       end
     end
-  end
 
-  describe 'when signed in' do
-    before(:each) { stub_sign_in(user) }
+    context 'when signed in' do
+      before { stub_sign_in(user) }
 
-    context 'without associated piv/cac' do
-      let(:user) do
-        create(:user, :fully_registered, with: { phone: '+1 (703) 555-0000' })
-      end
-      let(:nickname) { 'Card 1' }
+      context 'without associated piv/cac' do
+        let(:user) do
+          create(:user, :fully_registered, with: { phone: '+1 (703) 555-0000' })
+        end
+        let(:nickname) { 'Card 1' }
 
-      before(:each) do
-        allow(PivCacService).to receive(:decode_token).with(good_token) { good_token_response }
-        allow(PivCacService).to receive(:decode_token).with(bad_token) { bad_token_response }
-        allow(subject).to receive(:user_session).and_return(piv_cac_nonce: nonce)
-        subject.user_session[:piv_cac_nickname] = nickname
-      end
+        before(:each) do
+          allow(PivCacService).to receive(:decode_token).with(good_token) { good_token_response }
+          allow(PivCacService).to receive(:decode_token).with(bad_token) { bad_token_response }
+          allow(subject).to receive(:user_session).and_return(piv_cac_nonce: nonce)
+          subject.user_session[:piv_cac_nickname] = nickname
+        end
 
-      let(:nonce) { 'nonce' }
+        let(:nonce) { 'nonce' }
 
-      let(:good_token) { 'good-token' }
-      let(:good_token_response) do
-        {
-          'subject' => 'some dn',
-          'uuid' => 'some-random-string',
-          'nonce' => nonce,
-        }
-      end
+        let(:good_token) { 'good-token' }
+        let(:good_token_response) do
+          {
+            'subject' => 'some dn',
+            'uuid' => 'some-random-string',
+            'nonce' => nonce,
+          }
+        end
 
-      let(:bad_token) { 'bad-token' }
-      let(:bad_token_response) do
-        {
-          'error' => 'certificate.bad',
-          'nonce' => nonce,
-        }
-      end
+        let(:bad_token) { 'bad-token' }
+        let(:bad_token_response) do
+          {
+            'error' => 'certificate.bad',
+            'nonce' => nonce,
+          }
+        end
 
-      describe 'GET index' do
         context 'when rendered without a token' do
           it 'renders the "new" template' do
             get :new


### PR DESCRIPTION
## 🎫 Ticket

Refactoring related to [LG-14455](https://cm-jira.usa.gov/browse/LG-14455)

## 🛠 Summary of changes

Updates specs for `Users::PivCacAuthenticationSetupController` to fix inaccuracies and follow conventions:

- Specs described `#index` where the controller has no `index` action, fixed to `#new`
- Specs used `describe` to prescribe contextual scenarios, updated to `context`
- Specs were written context-first, rather than action-first

Easier to review with whitespace changes hidden: https://github.com/18F/identity-idp/pull/11355/files?w=1

Example before/after:

```rb
# Before:

describe 'when not signed in' do
  describe '#index' do
    it '...' do
      # ...
    end
  end
end

describe 'when signed out' do
  describe '#index' do
    it '...' do
      # ...
    end
  end
end

# After

describe '#new' do
  context 'when not signed in' do
    it '...' do
      # ...
    end
  end

  context 'when signed out' do
    it '...' do
      # ...
    end
  end
end
```

## 📜 Testing Plan

```
rspec spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
```