### PR TITLE
Ignore unknown authncontext

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -174,6 +174,7 @@ module OpenidConnect
           user_fully_authenticated: user_fully_authenticated?,
           referer: request.referer,
           vtr_param: params[:vtr],
+          unknown_authn_contexts:,
         ),
       )
       return if result.success?
@@ -257,6 +258,13 @@ module OpenidConnect
 
     def sp_handoff_bouncer
       @sp_handoff_bouncer ||= SpHandoffBouncer.new(sp_session)
+    end
+
+    def unknown_authn_contexts
+      return nil if params[:vtr].present? || params[:acr_values].blank?
+
+      (params[:acr_values].split - Saml::Idp::Constants::VALID_AUTHN_CONTEXTS).
+        join(' ').presence
     end
   end
 end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -234,10 +234,13 @@ class SamlIdpController < ApplicationController
     return nil if saml_request.requested_vtr_authn_contexts.present?
     return nil if requested_authn_contexts.blank?
 
-    (requested_authn_contexts -
-      Saml::Idp::Constants::VALID_AUTHN_CONTEXTS).reject do |authn_context|
+    unmatched_authn_contexts.reject do |authn_context|
       authn_context.match(req_attrs_regexp)
     end.join(' ').presence
+  end
+
+  def unmatched_authn_contexts
+    requested_authn_contexts - Saml::Idp::Constants::VALID_AUTHN_CONTEXTS
   end
 
   def requested_authn_contexts

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -245,6 +245,6 @@ class SamlIdpController < ApplicationController
   end
 
   def req_attrs_regexp
-    'http:\/\/idmanagement.gov\/ns\/requested_attributes\?ReqAttr='
+    Regexp.escape(Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF)
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5526,6 +5526,7 @@ module AnalyticsEvents
   # @param [String, nil] vtr_param
   # @param [Boolean] unauthorized_scope
   # @param [Boolean] user_fully_authenticated
+  # @param [String] unknown_authn_contexts space separated list of unknown contexts
   def openid_connect_request_authorization(
     success:,
     errors:,
@@ -5542,6 +5543,7 @@ module AnalyticsEvents
     unauthorized_scope:,
     user_fully_authenticated:,
     error_details: nil,
+    unknown_authn_contexts: nil,
     **extra
   )
     track_event(
@@ -5561,6 +5563,7 @@ module AnalyticsEvents
       vtr_param:,
       unauthorized_scope:,
       user_fully_authenticated:,
+      unknown_authn_contexts:,
       **extra,
     )
   end
@@ -6337,6 +6340,7 @@ module AnalyticsEvents
   # matches the request certificate in a successful, signed request
   # @param [Hash] cert_error_details Details for errors that occurred because of an invalid
   # signature
+  # @param [String] unknown_authn_contexts space separated list of unknown contexts
   def saml_auth(
     success:,
     errors:,
@@ -6353,6 +6357,7 @@ module AnalyticsEvents
     matching_cert_serial:,
     error_details: nil,
     cert_error_details: nil,
+    unknown_authn_contexts: nil,
     **extra
   )
     track_event(
@@ -6372,6 +6377,7 @@ module AnalyticsEvents
       request_signed:,
       matching_cert_serial:,
       cert_error_details:,
+      unknown_authn_contexts:,
       **extra,
     )
   end
@@ -6383,6 +6389,7 @@ module AnalyticsEvents
   # @param [Boolean] force_authn
   # @param [Boolean] final_auth_request
   # @param [String] service_provider
+  # @param [String] unknown_authn_contexts space separated list of unknown contexts
   # @param [Boolean] user_fully_authenticated
   # An external request for SAML Authentication was received
   def saml_auth_request(
@@ -6393,6 +6400,7 @@ module AnalyticsEvents
     force_authn:,
     final_auth_request:,
     service_provider:,
+    unknown_authn_contexts:,
     user_fully_authenticated:,
     **extra
   )
@@ -6405,6 +6413,7 @@ module AnalyticsEvents
       force_authn:,
       final_auth_request:,
       service_provider:,
+      unknown_authn_contexts:,
       user_fully_authenticated:,
       **extra,
     )

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -88,7 +88,10 @@ class SamlRequestValidator
       next true if classref.match?(SamlIdp::Request::VTR_REGEXP) &&
                    IdentityConfig.store.use_vot_in_sp_requests
     end
-    authn_contexts.all? do |classref|
+    # SAML requests are allowed to "default" to the integration's IAL default.
+    return true if authn_contexts.empty?
+
+    authn_contexts.any? do |classref|
       valid_contexts.include?(classref)
     end
   end

--- a/app/services/vot/parser.rb
+++ b/app/services/vot/parser.rb
@@ -4,8 +4,6 @@ module Vot
   class Parser
     class ParseException < StandardError; end
 
-    class UnsupportedComponentsException < ParseException; end
-
     class DuplicateComponentsException < ParseException; end
 
     Result = Data.define(
@@ -87,8 +85,7 @@ module Vot
       @initial_components ||= component_string.split(component_separator).map do |component_name|
         component_map.fetch(component_name)
       rescue KeyError
-        raise_unsupported_component_exception(component_name)
-      end
+      end.compact
     end
 
     def component_separator
@@ -110,16 +107,6 @@ module Vot
     def validate_component_uniqueness!(component_values)
       if component_values.length != component_values.uniq.length
         raise_duplicate_component_exception
-      end
-    end
-
-    def raise_unsupported_component_exception(component_value_name)
-      if vector_of_trust.present?
-        raise UnsupportedComponentsException,
-              "'#{vector_of_trust}' contains unknown component '#{component_value_name}'"
-      else
-        raise UnsupportedComponentsException,
-              "'#{acr_values}' contains unknown acr value '#{component_value_name}'"
       end
     end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -486,6 +486,20 @@ RSpec.describe ApplicationController do
         expect(result.identity_proofing?).to eq(true)
       end
 
+      context 'when an unknow acr value is passed in' do
+        let(:acr_values) do
+          [
+            'http://idmanagement.gov/ns/assurance/aal/1',
+            'unknown-acr-value',
+          ].join(' ')
+        end
+
+        it 'returns a resolved authn context result' do
+          expect(result.aal2?).to eq(true)
+          expect(result.identity_proofing?).to eq(true)
+        end
+      end
+
       context 'without an SP' do
         let(:sp) { nil }
         let(:sp_session) { nil }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -486,17 +486,28 @@ RSpec.describe ApplicationController do
         expect(result.identity_proofing?).to eq(true)
       end
 
-      context 'when an unknow acr value is passed in' do
-        let(:acr_values) do
-          [
-            'http://idmanagement.gov/ns/assurance/aal/1',
-            'unknown-acr-value',
-          ].join(' ')
+      context 'when an unknown acr value is passed in' do
+        let(:acr_values) { 'unknown-acr-value' }
+
+        it 'raises an exception' do
+          expect { result }.to raise_exception(
+            Vot::Parser::ParseException,
+            'VoT parser called without VoT or ACR values',
+          )
         end
 
-        it 'returns a resolved authn context result' do
-          expect(result.aal2?).to eq(true)
-          expect(result.identity_proofing?).to eq(true)
+        context 'with a known acr value' do
+          let(:acr_values) do
+            [
+              'http://idmanagement.gov/ns/assurance/aal/1',
+              'unknown-acr-value',
+            ].join(' ')
+          end
+
+          it 'returns a resolved authn context result' do
+            expect(result.aal2?).to eq(true)
+            expect(result.identity_proofing?).to eq(true)
+          end
         end
       end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe ApplicationController do
       let(:vtr) { nil }
       let(:acr_values) do
         [
-          'http://idmanagement.gov/ns/assurance/aal/1',
+          Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
         ].join(' ')
       end
 
@@ -499,7 +499,7 @@ RSpec.describe ApplicationController do
         context 'with a known acr value' do
           let(:acr_values) do
             [
-              'http://idmanagement.gov/ns/assurance/aal/1',
+              Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
               'unknown-acr-value',
             ].join(' ')
           end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -2029,6 +2029,65 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
       end
 
+      context 'when there are unknown acr_values params' do
+        let(:unknown_value) { 'unknown-acr-value' }
+        let(:acr_values) { unknown_value }
+
+        context 'when there is only an unknown acr_value' do
+          it 'tracks the event with errors' do
+            stub_analytics
+
+            action
+
+            expect(@analytics).to have_logged_event(
+              'OpenID Connect: authorization request',
+              success: false,
+              client_id:,
+              prompt:,
+              allow_prompt_login: true,
+              unauthorized_scope: false,
+              errors: hash_including(:acr_values),
+              error_details: hash_including(:acr_values),
+              user_fully_authenticated: true,
+              acr_values: '',
+              code_challenge_present: false,
+              scope: 'openid profile',
+              unknown_authn_contexts: unknown_value,
+            )
+          end
+
+          context 'when there is also a valid acr_value' do
+            let(:known_value) { Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF }
+            let(:acr_values) do
+              [
+                unknown_value,
+                known_value,
+              ].join(' ')
+            end
+
+            it 'tracks the event' do
+              stub_analytics
+
+              action
+              expect(@analytics).to have_logged_event(
+                'OpenID Connect: authorization request',
+                success: true,
+                client_id:,
+                prompt:,
+                allow_prompt_login: true,
+                unauthorized_scope: false,
+                user_fully_authenticated: true,
+                acr_values: known_value,
+                code_challenge_present: false,
+                scope: 'openid profile',
+                unknown_authn_contexts: unknown_value,
+                errors: {},
+              )
+            end
+          end
+        end
+      end
+
       context 'vtr with invalid params that do not interfere with the redirect_uri' do
         let(:acr_values) { nil }
         let(:vtr) { ['C1'].to_json }

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1046,9 +1046,7 @@ RSpec.describe SamlIdpController do
               ),
             )
           end
-
         end
-
       end
     end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1027,6 +1027,28 @@ RSpec.describe SamlIdpController do
             ),
           )
         end
+
+        context 'when it includes the ReqAttributes AuthnContext' do
+          let(:authn_context) do
+            [
+              Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF,
+              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+              unknown_value,
+            ]
+          end
+
+          it 'logs the unknown authn_context value' do
+            expect(response.status).to eq(302)
+            expect(@analytics).to have_logged_event(
+              'SAML Auth Request',
+              hash_including(
+                unknown_authn_contexts: unknown_value,
+              ),
+            )
+          end
+
+        end
+
       end
     end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -970,15 +970,22 @@ RSpec.describe SamlIdpController do
     end
 
     context 'authn_context is invalid' do
-      it 'renders an error page' do
+      let(:unknown_value) do
+        'http://idmanagement.gov/ns/assurance/loa/5'
+      end
+      let(:authn_context) { unknown_value }
+
+      before do
         stub_analytics
 
         saml_get_auth(
           saml_settings(
-            overrides: { authn_context: 'http://idmanagement.gov/ns/assurance/loa/5' },
+            overrides: { authn_context: },
           ),
         )
+      end
 
+      it 'renders an error page' do
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)
         expect(response.body).to include(t('errors.messages.unauthorized_authn_context'))
@@ -989,7 +996,7 @@ RSpec.describe SamlIdpController do
             errors: { authn_context: [t('errors.messages.unauthorized_authn_context')] },
             error_details: { authn_context: { unauthorized_authn_context: true } },
             nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
-            authn_context: ['http://idmanagement.gov/ns/assurance/loa/5'],
+            authn_context: [unknown_value],
             authn_context_comparison: 'exact',
             service_provider: 'http://localhost:3000',
             request_signed: true,
@@ -998,8 +1005,28 @@ RSpec.describe SamlIdpController do
             idv: false,
             finish_profile: false,
             matching_cert_serial: saml_test_sp_cert_serial,
+            unknown_authn_contexts: unknown_value,
           ),
         )
+      end
+
+      context 'there is also a valid authn_context' do
+        let(:authn_context) do
+          [
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            unknown_value,
+          ]
+        end
+
+        it 'logs the unknown authn_context value' do
+          expect(response.status).to eq(302)
+          expect(@analytics).to have_logged_event(
+            'SAML Auth Request',
+            hash_including(
+              unknown_authn_contexts: unknown_value,
+            ),
+          )
+        end
       end
     end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -476,8 +476,8 @@ RSpec.describe OpenidConnectAuthorizeForm do
     let(:vtr) { nil }
     let(:acr_value_list) do
       [
-        'http://idmanagement.gov/ns/assurance/aal/3',
-        'http://idmanagement.gov/ns/assurance/loa/1',
+        Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+        Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
       ]
     end
     let(:acr_values) { acr_value_list.join(' ') }
@@ -489,8 +489,8 @@ RSpec.describe OpenidConnectAuthorizeForm do
     context 'when an unknown acr value is included' do
       let(:acr_value_list) do
         [
-          'http://idmanagement.gov/ns/assurance/loa/1',
-          'http://idmanagement.gov/ns/assurance/aal/3',
+          Saml::Idp::Constants::LOA1_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
         ]
       end
       let(:acr_values) { (acr_value_list + ['fake-value']).join(' ') }

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
     )
   end
 
-  let(:acr_values) {  nil }
+  let(:acr_values) { nil }
   let(:vtr) { ['C1'].to_json }
   let(:client_id) { 'urn:gov:gsa:openidconnect:test' }
   let(:nonce) { SecureRandom.hex }
@@ -200,13 +200,13 @@ RSpec.describe OpenidConnectAuthorizeForm do
       context 'with a known IAL value' do
         before do
           allow(IdentityConfig.store).to receive(
-            :allowed_valid_authn_contexts_semantic_providers
+            :allowed_valid_authn_contexts_semantic_providers,
           ).and_return(client_id)
         end
         let(:acr_values) do
           [
             'unknown-value',
-            Saml::Idp::Constants::IAL_AUTH_ONLY_ACR
+            Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
           ].join(' ')
         end
 
@@ -214,7 +214,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
           expect(valid?).to eq(true)
         end
       end
-
     end
 
     context 'with ialmax requested' do
@@ -249,7 +248,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
           context 'when the service provider is allowed to use facial match ials' do
             before do
               allow(IdentityConfig.store).to receive(
-                :allowed_biometric_ial_providers
+                :allowed_biometric_ial_providers,
               ).and_return([client_id])
             end
 
@@ -277,7 +276,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
       context 'when using semantic acr_values' do
         before do
           allow(IdentityConfig.store).to receive(
-            :allowed_valid_authn_contexts_semantic_providers
+            :allowed_valid_authn_contexts_semantic_providers,
           ).and_return([client_id])
         end
         it_behaves_like 'allows facial match IAL only if sp is authorized',
@@ -609,7 +608,9 @@ RSpec.describe OpenidConnectAuthorizeForm do
         let(:acr_values) { '' }
 
         it 'returns the default AAL value' do
-          expect(form.requested_aal_value).to eq Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
+          expect(form.requested_aal_value).to eq(
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+          )
         end
       end
 
@@ -617,7 +618,9 @@ RSpec.describe OpenidConnectAuthorizeForm do
         let(:acr_values) { 'fake-value' }
 
         it 'returns the default AAL value' do
-          expect(form.requested_aal_value).to eq Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
+          expect(form.requested_aal_value).to eq(
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+          )
         end
       end
     end

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -107,6 +107,20 @@ RSpec.describe AttributeAsserter do
             it 'gets UUID from Service Provider' do
               expect(get_asserted_attribute(user, :uuid)).to eq user.last_identity.uuid
             end
+
+            context 'when authn_context includes an unknown value' do
+              let(:authn_context) do
+                [
+                  ial_value,
+                  'unknown/authn/context',
+                ]
+              end
+
+              it 'includes all requested attributes + uuid' do
+                expect(user.asserted_attributes.keys).
+                  to eq(%i[uuid email phone first_name verified_at aal ial])
+              end
+            end
           end
 
           context 'custom bundle includes dob' do

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe AuthnContextResolver do
       vtr = ['C2.Pb']
 
       acr_values = [
-        'http://idmanagement.gov/ns/assurance/aal/2',
-        'http://idmanagement.gov/ns/assurance/ial/2',
+        Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+        Saml::Idp::Constants::IAL_VERIFIED_ACR,
       ].join(' ')
 
       result = AuthnContextResolver.new(
@@ -152,8 +152,8 @@ RSpec.describe AuthnContextResolver do
     context 'with no service provider' do
       it 'parses an ACR value into requirements' do
         acr_values = [
-          'http://idmanagement.gov/ns/assurance/aal/2',
-          'http://idmanagement.gov/ns/assurance/ial/1',
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
         ].join(' ')
 
         result = AuthnContextResolver.new(
@@ -175,7 +175,7 @@ RSpec.describe AuthnContextResolver do
 
       it 'properly parses an ACR value without an AAL ACR' do
         acr_values = [
-          'http://idmanagement.gov/ns/assurance/ial/1',
+          Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
         ].join(' ')
 
         result = AuthnContextResolver.new(
@@ -197,7 +197,7 @@ RSpec.describe AuthnContextResolver do
 
       it 'properly parses an ACR value without an IAL ACR' do
         acr_values = [
-          'http://idmanagement.gov/ns/assurance/aal/2',
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
         ].join(' ')
 
         result = AuthnContextResolver.new(
@@ -223,8 +223,8 @@ RSpec.describe AuthnContextResolver do
         service_provider = build(:service_provider, default_aal: 2)
 
         acr_values = [
-          'http://idmanagement.gov/ns/assurance/aal/1',
-          'http://idmanagement.gov/ns/assurance/ial/1',
+          Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
         ].join(' ')
 
         result = AuthnContextResolver.new(
@@ -241,7 +241,7 @@ RSpec.describe AuthnContextResolver do
         service_provider = build(:service_provider, default_aal: 2)
 
         acr_values = [
-          'http://idmanagement.gov/ns/assurance/ial/1',
+          Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
         ].join(' ')
 
         result = AuthnContextResolver.new(
@@ -259,7 +259,7 @@ RSpec.describe AuthnContextResolver do
         service_provider = build(:service_provider, default_aal: 3)
 
         acr_values = [
-          'http://idmanagement.gov/ns/assurance/ial/1',
+          Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
         ].join(' ')
 
         result = AuthnContextResolver.new(
@@ -295,10 +295,10 @@ RSpec.describe AuthnContextResolver do
       let(:service_provider) { build(:service_provider, ial: 2) }
       subject do
         AuthnContextResolver.new(
-          user: user,
-          service_provider: service_provider,
+          user:,
+          service_provider:,
           vtr: nil,
-          acr_values: acr_values,
+          acr_values:,
         )
       end
 
@@ -307,8 +307,8 @@ RSpec.describe AuthnContextResolver do
       context 'if IAL ACR value is present' do
         let(:acr_values) do
           [
-            'http://idmanagement.gov/ns/assurance/ial/1',
-            'http://idmanagement.gov/ns/assurance/aal/1',
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           ].join(' ')
         end
 
@@ -318,12 +318,12 @@ RSpec.describe AuthnContextResolver do
         end
       end
 
-      context 'if multiple IAL ACR values are present' do
+      context 'when multiple IAL ACR values are present' do
         let(:acr_values) do
           [
-            'http://idmanagement.gov/ns/assurance/ial/1',
-            'http://idmanagement.gov/ns/assurance/ial/2',
-            'http://idmanagement.gov/ns/assurance/aal/1',
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           ].join(' ')
         end
 
@@ -331,12 +331,28 @@ RSpec.describe AuthnContextResolver do
           expect(result.identity_proofing?).to be true
           expect(result.aal2?).to be true
         end
+
+        context 'when one of the acr values is unknown' do
+          let(:acr_values) do
+            [
+              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+              Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+              Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+              'unknown-acr-value',
+            ].join(' ')
+          end
+
+          it 'ignores the unknown value and uses the highest IAL ACR' do
+            expect(result.identity_proofing?).to eq(true)
+            expect(result.aal2?).to eq(true)
+          end
+        end
       end
 
       context 'if No IAL ACR is present' do
         let(:acr_values) do
           [
-            'http://idmanagement.gov/ns/assurance/aal/1',
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           ].join(' ')
         end
 
@@ -346,12 +362,23 @@ RSpec.describe AuthnContextResolver do
         end
       end
 
+      context 'when the only ACR value is unknown' do
+        let(:acr_values) { 'unknown-acr-value' }
+
+        it 'errors out as if there were no values' do
+          expect { result }.to raise_error Vot::Parser::ParseException
+        end
+      end
+
       context 'if requesting facial match comparison' do
-        let(:bio_value) { 'required' }
+        let(:bio_acr_value) do
+          Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF
+        end
+
         let(:acr_values) do
           [
-            "http://idmanagement.gov/ns/assurance/ial/2?bio=#{bio_value}",
-            'http://idmanagement.gov/ns/assurance/aal/1',
+            bio_acr_value,
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           ].join(' ')
         end
 
@@ -391,7 +418,9 @@ RSpec.describe AuthnContextResolver do
         end
 
         context 'with facial match comparison is preferred' do
-          let(:bio_value) { 'preferred' }
+          let(:bio_acr_value) do
+            Saml::Idp::Constants::IAL2_BIO_PREFERRED_AUTHN_CONTEXT_CLASSREF
+          end
 
           context 'when the user is already verified' do
             context 'without facial match comparison' do
@@ -478,7 +507,7 @@ RSpec.describe AuthnContextResolver do
     context 'with no service provider' do
       it 'parses an ACR value into requirements' do
         acr_values = [
-          'http://idmanagement.gov/ns/assurance/aal/2',
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
           Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
         ]
 
@@ -525,7 +554,7 @@ RSpec.describe AuthnContextResolver do
 
       it 'properly parses an ACR value without an IAL ACR' do
         acr_values = [
-          'http://idmanagement.gov/ns/assurance/aal/2',
+          Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
         ]
         resolver = AuthnContextResolver.new(
           user: user,
@@ -561,8 +590,8 @@ RSpec.describe AuthnContextResolver do
       context 'if IAL ACR value is present' do
         let(:acr_values) do
           [
-            'http://idmanagement.gov/ns/assurance/ial/1',
-            'http://idmanagement.gov/ns/assurance/aal/1',
+            Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           ]
         end
 
@@ -572,12 +601,12 @@ RSpec.describe AuthnContextResolver do
         end
       end
 
-      context 'if multiple IAL ACR values are present' do
+      context 'when multiple IAL ACR values are present' do
         let(:acr_values) do
           [
-            'http://idmanagement.gov/ns/assurance/ial/1',
-            'urn:acr.login.gov:verified',
-            'http://idmanagement.gov/ns/assurance/aal/1',
+            Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
+            Saml::Idp::Constants::IAL_VERIFIED_ACR,
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           ]
         end
 
@@ -585,12 +614,28 @@ RSpec.describe AuthnContextResolver do
           expect(result.identity_proofing?).to be true
           expect(result.aal2?).to be true
         end
+
+        context 'when one of the acr values is unknown' do
+          let(:acr_values) do
+            [
+              Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
+              Saml::Idp::Constants::IAL_VERIFIED_ACR,
+              Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+              'unknown-acr-value',
+            ]
+          end
+
+          it 'ignores the unknown value and uses the highest IAL ACR' do
+            expect(result.identity_proofing?).to eq(true)
+            expect(result.aal2?).to eq(true)
+          end
+        end
       end
 
       context 'if No IAL ACR is present' do
         let(:acr_values) do
           [
-            'http://idmanagement.gov/ns/assurance/aal/1',
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           ]
         end
 
@@ -616,11 +661,14 @@ RSpec.describe AuthnContextResolver do
       end
 
       context 'if requesting facial match comparison' do
-        let(:bio_value) { 'required' }
+        let(:bio_acr_value) do
+          Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+        end
+
         let(:acr_values) do
           [
-            "urn:acr.login.gov:verified-facial-match-#{bio_value}",
-            'http://idmanagement.gov/ns/assurance/aal/1',
+            bio_acr_value,
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           ]
         end
 
@@ -674,7 +722,9 @@ RSpec.describe AuthnContextResolver do
         end
 
         context 'with facial match comparison is preferred' do
-          let(:bio_value) { 'preferred' }
+          let(:bio_acr_value) do
+            Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_PREFERRED_ACR
+          end
 
           context 'when the user is already verified' do
             context 'without facial match comparison' do

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SamlRequestValidator do
         use_vot_in_sp_requests,
       )
       allow(IdentityConfig.store).to receive(
-        :allowed_biometric_ial_providers
+        :allowed_biometric_ial_providers,
       ).and_return([issuer])
       allow(IdentityConfig.store).to receive(
         :allowed_valid_authn_contexts_semantic_providers,
@@ -239,7 +239,7 @@ RSpec.describe SamlRequestValidator do
           Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
           Saml::Idp::Constants::IAL_VERIFIED_ACR,
         ].each do |ial_value|
-        let(:authn_context) { [ial_value] }
+          let(:authn_context) { [ial_value] }
 
           it 'returns FormResponse with success: false' do
             errors = {

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe SamlRequestValidator do
   describe '#call' do
-    let(:sp) { ServiceProvider.find_by(issuer: 'http://localhost:3000') }
+    let(:issuer) { 'http://localhost:3000' }
+    let(:sp) { ServiceProvider.find_by(issuer:) }
     let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT }
     let(:authn_context) { [Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF] }
     let(:comparison) { 'exact' }
@@ -31,15 +32,27 @@ RSpec.describe SamlRequestValidator do
       ).and_return(
         use_vot_in_sp_requests,
       )
+      allow(IdentityConfig.store).to receive(
+        :allowed_biometric_ial_providers
+      ).and_return([issuer])
+      allow(IdentityConfig.store).to receive(
+        :allowed_valid_authn_contexts_semantic_providers,
+      ).and_return([issuer])
     end
 
     context 'valid authn context and sp and authorized nameID format' do
-      it 'returns FormResponse with success: true' do
-        expect(response.to_h).to include(
-          success: true,
-          errors: {},
-          **extra,
-        )
+      [
+        Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
+      ].each do |ial_value|
+        let(:authn_context) { [ial_value] }
+        it 'returns FormResponse with success: true' do
+          expect(response.to_h).to include(
+            success: true,
+            errors: {},
+            **extra,
+          )
+        end
       end
 
       context 'ialmax authncontext and ialmax provider' do
@@ -56,6 +69,17 @@ RSpec.describe SamlRequestValidator do
             **extra,
           )
         end
+      end
+    end
+
+    context 'no authn context and sp and authorized nameID format' do
+      let(:authn_context) { [] }
+      it 'returns FormResponse with success: true' do
+        expect(response.to_h).to include(
+          success: true,
+          errors: {},
+          **extra,
+        )
       end
     end
 
@@ -180,8 +204,8 @@ RSpec.describe SamlRequestValidator do
       end
     end
 
-    context 'invalid authn context and valid sp and authorized nameID format' do
-      context 'unknown auth context' do
+    context 'unknown context and valid sp and authorized nameID format' do
+      context 'only the unknown authn_context is requested' do
         let(:authn_context) { ['IAL1'] }
 
         it 'returns FormResponse with success: false' do
@@ -196,22 +220,39 @@ RSpec.describe SamlRequestValidator do
             **extra,
           )
         end
+
+        context 'unknwn authn_context requested along with a valid one' do
+          let(:authn_context) { ['IAL1', Saml::Idp::Constants::IAL_AUTH_ONLY_ACR] }
+
+          it 'returns FormResponse with success: true' do
+            expect(response.to_h).to include(
+              success: true,
+              errors: {},
+              **extra,
+            )
+          end
+        end
       end
 
       context 'authn context is ial2 when sp is ial 1' do
-        let(:authn_context) { [Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF] }
+        [
+          Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::IAL_VERIFIED_ACR,
+        ].each do |ial_value|
+        let(:authn_context) { [ial_value] }
 
-        it 'returns FormResponse with success: false' do
-          errors = {
-            authn_context: [t('errors.messages.unauthorized_authn_context')],
-          }
+          it 'returns FormResponse with success: false' do
+            errors = {
+              authn_context: [t('errors.messages.unauthorized_authn_context')],
+            }
 
-          expect(response.to_h).to include(
-            success: false,
-            errors: errors,
-            error_details: hash_including(*errors.keys),
-            **extra,
-          )
+            expect(response.to_h).to include(
+              success: false,
+              errors: errors,
+              error_details: hash_including(*errors.keys),
+              **extra,
+            )
+          end
         end
       end
 
@@ -237,9 +278,8 @@ RSpec.describe SamlRequestValidator do
 
         context "when the IAL requested is #{facial_match_ial}" do
           context 'when the service provider is allowed to use facial match ials' do
-            let(:sp) { create(:service_provider, :idv) }
-
             before do
+              sp.update(ial: 2)
               allow_any_instance_of(ServiceProvider).to receive(:facial_match_ial_allowed?).
                 and_return(true)
             end
@@ -281,14 +321,19 @@ RSpec.describe SamlRequestValidator do
       it_behaves_like 'allows facial match IAL only if sp is authorized',
                       Saml::Idp::Constants::IAL2_BIO_PREFERRED_AUTHN_CONTEXT_CLASSREF
 
+      it_behaves_like 'allows facial match IAL only if sp is authorized',
+                      Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_PREFERRED_ACR
+
+      it_behaves_like 'allows facial match IAL only if sp is authorized',
+                      Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR
+
       shared_examples 'allows semantic IAL only if sp is authorized' do |semantic_ial|
         let(:authn_context) { [semantic_ial] }
 
         context "when the IAL requested is #{semantic_ial}" do
           context 'when the service provider is allowed to use semantic ials' do
-            let(:sp) { create(:service_provider, :idv) }
-
             before do
+              sp.update(ial: 2)
               allow_any_instance_of(ServiceProvider).
                 to receive(:semantic_authn_contexts_allowed?).
                 and_return(true)

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe SamlRequestValidator do
           )
         end
 
-        context 'unknwn authn_context requested along with a valid one' do
+        context 'unknown authn_context requested along with a valid one' do
           let(:authn_context) { ['IAL1', Saml::Idp::Constants::IAL_AUTH_ONLY_ACR] }
 
           it 'returns FormResponse with success: true' do

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe SamlRequestValidator do
       end
     end
 
-    context 'no authn context and sp and authorized nameID format' do
+    context 'no authn context and valid sp and authorized nameID format' do
       let(:authn_context) { [] }
       it 'returns FormResponse with success: true' do
         expect(response.to_h).to include(

--- a/spec/services/vot/parser_spec.rb
+++ b/spec/services/vot/parser_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Vot::Parser do
             result = Vot::Parser.new(acr_values:).parse
 
             expect(result.component_values.map(&:name).join(' ')).to eq(
-              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+              Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             )
             expect(result.aal2?).to eq(false)
             expect(result.phishing_resistant?).to eq(false)
@@ -142,7 +142,7 @@ RSpec.describe Vot::Parser do
               result = Vot::Parser.new(acr_values:).parse
 
               expect(result.component_values.map(&:name).join(' ')).to eq(
-                Saml::Idp::Constants::IAL_AUTH_ONLY_ACR
+                Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
               )
               expect(result.aal2?).to eq(false)
               expect(result.phishing_resistant?).to eq(false)
@@ -168,14 +168,14 @@ RSpec.describe Vot::Parser do
           end
         end
 
-        context 'along with a known vector'
+        context 'along with a known vector' do
           it 'parses the vector' do
             vector_of_trust = 'C1.C2.Xx'
 
             result = Vot::Parser.new(vector_of_trust:).parse
 
             expect(result.component_values.map(&:name).join(' ')).to eq(
-              'C1 C2'
+              'C1 C2',
             )
             expect(result.aal2?).to eq(true)
             expect(result.phishing_resistant?).to eq(false)
@@ -185,6 +185,7 @@ RSpec.describe Vot::Parser do
             expect(result.ialmax?).to eq(false)
             expect(result.enhanced_ipp?).to eq(false)
           end
+        end
       end
     end
 

--- a/spec/services/vot/parser_spec.rb
+++ b/spec/services/vot/parser_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Vot::Parser do
       end
     end
 
-    context 'when a vector includes unrecognized components' do
+    context 'when input includes unrecognized components' do
       let(:acr_values) { 'unknown-acr-value' }
 
       context 'only an unknown acr_value is passed in' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Ignore unknown authentication contexts](https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/119)
[Link to 1-pager](https://docs.google.com/document/d/1PrKobld51OX3pZA1uklu9Rm3IHUkqrVJ-c0-z0aFSWc/edit#heading=h.x444b6dcc7j5)

## 🛠 Summary of changes
This change updates our SAML integration to allow and ignore unknown authentication context class reference (ACR) values that are sent via the request, as long as there is at least one valid AuthnContext value that we can assert. (OIDC already allowed arbitrary values to be passed in.)

[SAML spec line 1820](http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)
> If Comparison is set to "exact" or omitted, then the resulting authentication context in the authentication
statement MUST be the exact match of at least one of the authentication contexts specified.

This change also:
* Includes any unknown ACR values in authentication events
* Adds/updates associated tests
 
Open questions:
I am currently handling the case of a partner passing in only *unknown* ACR values as invalid. 

However, we do allow SAML partners to pass in *no* ACR values, in which case we use their service provider defaults, so an argument could be made that if we get only unknown ACR values, we should default to the SP's defaults.  

My thinking is that if they are purposefully sending ACR values, that should override any defaults we have -- if they are only sending one, unknown ACR values that is more likely a mistake. Am open to arguments in favor/against this approach!

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Update your local identity-saml-sinatra repo to include 'unknown-authn-context-value' here https://github.com/18F/identity-saml-sinatra/blob/main/app.rb#L144:
- [ ] run sinatra app with `make run`
- [ ] run your local `main` IdP with `make run`
- [ ] go to http://localhost:4567/
- [ ] click `sign in`
- [ ] observer an `Authn context Unauthorized authentication context` error
- [ ] kill the local IdP, and checkout this branch
- [ ] run local IdP with `make run`
- [ ] go to http://localhost:4567/
- [ ] click `sign in`
- [ ] you should now be able to log in


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
