### PR TITLE
LG-14591 Cancel enrollments with deactivated profiles in proofing job

### DIFF
--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -155,6 +155,11 @@ class InPersonEnrollment < ApplicationRecord
     IdentityConfig.store.usps_eipp_sponsor_id == sponsor_id
   end
 
+  # @return [String, nil] The enrollment's profile deactivation reason or nil.
+  def profile_deactivation_reason
+    profile&.deactivation_reason
+  end
+
   private
 
   def days_to_expire

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -159,10 +159,6 @@ class Profile < ApplicationRecord
   def activate_after_passing_in_person
     transaction do
       update!(
-        fraud_review_pending_at: nil,
-        fraud_rejection_at: nil,
-        fraud_pending_reason: nil,
-        deactivation_reason: nil,
         in_person_verification_pending_at: nil,
       )
       activate

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3238,20 +3238,20 @@ module AnalyticsEvents
   # @param [String] enrollment_code
   # @param [String] enrollment_id
   # @param [Float] minutes_since_established
-  # @param [Boolean] fraud_suspected
   # @param [Boolean] passed did this enrollment pass or fail?
   # @param [String] reason why did this enrollment pass or fail?
   # @param [String] tmx_status the tmx_status of the enrollment profile profile
   # @param [Integer] profile_age_in_seconds How many seconds have passed since profile created
+  # @param [Boolean] fraud_suspected
   def idv_in_person_usps_proofing_results_job_enrollment_updated(
     enrollment_code:,
     enrollment_id:,
     minutes_since_established:,
-    fraud_suspected:,
     passed:,
     reason:,
     tmx_status:,
     profile_age_in_seconds:,
+    fraud_suspected: nil,
     **extra
   )
     track_event(
@@ -3259,11 +3259,11 @@ module AnalyticsEvents
       enrollment_code: enrollment_code,
       enrollment_id: enrollment_id,
       minutes_since_established: minutes_since_established,
-      fraud_suspected: fraud_suspected,
       passed: passed,
       reason: reason,
       tmx_status: tmx_status,
       profile_age_in_seconds: profile_age_in_seconds,
+      fraud_suspected: fraud_suspected,
       **extra,
     )
   end

--- a/spec/features/idv/get_proofing_results_job_scenarios_spec.rb
+++ b/spec/features/idv/get_proofing_results_job_scenarios_spec.rb
@@ -65,19 +65,19 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       # When the user logs out
       logout(@user)
       # And the user visits USPS to complete their enrollment
-      # And USPS enrollment passed
+      # And USPS enrollment "passed"
       stub_request_passed_proofing_results
       # And GetUspsProofingResultsJob is performed
       perform_get_usps_proofing_results_job(@user)
 
-      # And the user has an InPersonEnrollment with status "passed"
+      # Then the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
-        status: 'passed',
+        status: 'cancelled',
       )
-      # And the user has a Profile that is active
+      # And the user has a Profile that is deactivated with reason "encryption_error"
       expect(@user.in_person_enrollments.first.profile).to have_attributes(
-        active: true,
-        deactivation_reason: nil,
+        active: false,
+        deactivation_reason: 'encryption_error',
         in_person_verification_pending_at: nil,
       )
 
@@ -86,9 +86,9 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
 
       # Then the user is taken to the /verify/welcome page
       expect(current_path).to eq(idv_welcome_path)
-      # And the user has an InPersonEnrollment with status "passed"
+      # And the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
-        status: 'passed',
+        status: 'cancelled',
       )
       # And the user has a Profile that is deactivated with reason "encryption_error"
       expect(@user.in_person_enrollments.first.profile).to have_attributes(
@@ -149,9 +149,9 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
         # And GetUspsProofingResultsJob is performed
         perform_get_usps_proofing_results_job(@user)
 
-        # Then the user has an InPersonEnrollment with status "failed|cancelled|expired"
+        # Then the user has an InPersonEnrollment with status "cancelled"
         expect(@user.in_person_enrollments.first).to have_attributes(
-          status: status,
+          status: 'cancelled',
         )
         # And the user has a Profile that is deactivated with reason "encryption_error"
         expect(@user.in_person_enrollments.first.profile).to have_attributes(
@@ -165,9 +165,9 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
 
         # Then the user is taken to the /verify/welcome page
         expect(current_path).to eq(idv_welcome_path)
-        # And the user has an InPersonEnrollment with status "failed|cancelled|expired"
+        # And the user has an InPersonEnrollment with status "cancelled"
         expect(@user.in_person_enrollments.first).to have_attributes(
-          status: status,
+          status: 'cancelled',
         )
         # And the user has a Profile that is deactivated with reason "encryption_error"
         expect(@user.in_person_enrollments.first.profile).to have_attributes(
@@ -205,7 +205,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       )
 
       # And the user visits USPS to complete their enrollment
-      # And USPS enrollment passed
+      # And USPS enrollment "passed"
       stub_request_passed_proofing_results
       # And GetUspsProofingResultsJob is performed
       perform_get_usps_proofing_results_job(@user)
@@ -313,7 +313,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       )
 
       # When the user visits USPS to complete their enrollment
-      # And USPS enrollment passed
+      # And USPS enrollment "passed"
       stub_request_passed_proofing_results
       # And GetUspsProofingResultsJob is performed
       perform_get_usps_proofing_results_job(@user)
@@ -378,7 +378,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       )
 
       # When the user visits USPS to complete their enrollment
-      # And USPS enrollment passed
+      # And USPS enrollment "passed"
       stub_request_passed_proofing_results
       # And GetUspsProofingResultsJob is performed
       perform_get_usps_proofing_results_job(@user)
@@ -554,14 +554,14 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       # When the user logs out
       logout(@user)
       # And the user visits USPS to complete their enrollment
-      # And USPS enrollment passed
+      # And USPS enrollment "passed"
       stub_request_passed_proofing_results
       # And GetUspsProofingResultsJob is performed
       perform_get_usps_proofing_results_job(@user)
 
-      # And the user has an InPersonEnrollment with status "passed"
+      # Then the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
-        status: 'passed',
+        status: 'cancelled',
       )
       # And the user has a Profile that is deactivated with reason "encryption_error" and
       # pending fraud review
@@ -578,9 +578,9 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
 
       # Then the user is taken to the /verify/welcome page
       expect(current_path).to eq(idv_welcome_path)
-      # And the user has an InPersonEnrollment with status "passed"
+      # And the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
-        status: 'passed',
+        status: 'cancelled',
       )
       # And the user has a Profile that is deactivated with reason "encryption_error" and
       # pending fraud review
@@ -634,7 +634,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       )
 
       # And the user visits USPS to complete their enrollment
-      # And USPS enrollment passed
+      # And USPS enrollment "passed"
       stub_request_passed_proofing_results
       # And GetUspsProofingResultsJob is performed
       perform_get_usps_proofing_results_job(@user)

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
       enrollments_network_error: 0,
       enrollments_expired: 0,
       enrollments_failed: 0,
+      enrollments_cancelled: 0,
       enrollments_in_progress: 0,
       enrollments_passed: 0,
       duration_seconds: 0.0,
@@ -794,6 +795,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                 ).with(
                   **default_job_completion_analytics,
                   enrollments_checked: 1,
+                  enrollments_cancelled: 1,
                 )
               end
             end
@@ -872,6 +874,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                 ).with(
                   **default_job_completion_analytics,
                   enrollments_checked: 1,
+                  enrollments_cancelled: 1,
                 )
               end
             end
@@ -2663,6 +2666,65 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                 end
               end
             end
+          end
+        end
+
+        context 'when the enrollment has a profile with a deactivation reason' do
+          let(:deactivation_reason) { 'encryption_error' }
+
+          before do
+            enrollment.profile.update(deactivation_reason: deactivation_reason)
+            allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_enrollment_updated)
+            subject.perform(current_time)
+          end
+
+          it 'logs the job started analytic' do
+            expect(analytics).to have_received(
+              :idv_in_person_usps_proofing_results_job_started,
+            ).with(
+              enrollments_count: 1,
+              reprocess_delay_minutes: 5,
+              job_name: described_class.name,
+            )
+          end
+
+          it 'logs the job enrollment updated analytic' do
+            expect(analytics).to have_received(
+              :idv_in_person_usps_proofing_results_job_enrollment_updated,
+            ).with(
+              **enrollment_analytics,
+              response_present: false,
+              passed: false,
+              reason: "Profile has a deactivation reason of #{deactivation_reason}",
+              job_name: described_class.name,
+              tmx_status: nil,
+              profile_age_in_seconds: enrollment.profile&.profile_age_in_seconds,
+              enhanced_ipp: false,
+            )
+          end
+
+          it 'cancels the enrollment' do
+            expect(enrollment.reload).to have_attributes(
+              status: 'cancelled',
+            )
+          end
+
+          it "deactivates the enrollment's profile" do
+            expect(enrollment.reload.profile).to have_attributes(
+              active: false,
+              deactivation_reason: 'encryption_error',
+              in_person_verification_pending_at: nil,
+            )
+          end
+
+          it 'logs the job completed analytic' do
+            expect(analytics).to have_received(
+              :idv_in_person_usps_proofing_results_job_completed,
+            ).with(
+              **default_job_completion_analytics,
+              enrollments_checked: 1,
+              enrollments_cancelled: 1,
+            )
           end
         end
 

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -533,4 +533,33 @@ RSpec.describe InPersonEnrollment, type: :model do
       end
     end
   end
+
+  describe '#profile_deactivation_reason' do
+    let(:profile) { create(:profile) }
+    let(:enrollment) { create(:in_person_enrollment, user: profile.user, profile: profile) }
+
+    context "when the enrollment's profile has a deactivation reason" do
+      before do
+        profile.update!(deactivation_reason: 'encryption_error')
+      end
+
+      it "returns the profile's deactivation reason" do
+        expect(enrollment.profile_deactivation_reason).to eq('encryption_error')
+      end
+    end
+
+    context 'when the profile does not have a deactivation reason' do
+      it 'returns nil' do
+        expect(enrollment.profile_deactivation_reason).to be_nil
+      end
+    end
+
+    context 'when the enrollment does not have a profile' do
+      let(:enrollment) { create(:in_person_enrollment, user: profile.user, profile: nil) }
+
+      it 'returns nil' do
+        expect(enrollment.profile_deactivation_reason).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14591](https://cm-jira.usa.gov/browse/LG-14591)

## 🛠 Summary of changes

Cancel enrollments that have profiles with a deactivation reason during the GetUspsProofingResultsJob. 

This PR also improves the `Profile.activate_after_passing_in_person` method by not allowing profiles with deactivation reasons or fraud pending reasons to be activated. Currently this method nils out `deactivation_reason`, fraud_review_pending_at, fraud_rejection_at, and fraud_pending_reason without any presence checks allowing profiles with fraud or deactivation reasons to become activated when calling the activate method. This will no longer be the case and the activate_after_passing_in_person will throw an error when the profile has a deactivation reason or reasons not to activate the profile (i.e. Fraud Pending).

## 📜 Testing Plan

Scenario: User creates a enrollment and has to reset their password

- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the flow for an IPP enrollment (landing on the barcode page)
- [x] Logout
- [x] Go through the password reset flow
- [x] Login
- [x] Allow the `GetUspsProofingResultsJob` to run
- [x] Ensure the enrollment status is "cancelled" and the profile still has a deactivation reason of "encryption_error"
- [x] Ensure event `GetUspsProofingResultsJob: Enrollment status updated` is logged with a reason including the profile deactivation reason and the `GetUspsProofingResultsJob: Job completed` event log includes a `enrollments_cancelled` metric.
