### PR TITLE
Update rubocop-rails to lint deprecated enum keywords

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -843,6 +843,9 @@ Rails/Blank:
 Rails/CompactBlank:
   Enabled: false
 
+Rails/DangerousColumnNames:
+  Enabled: true
+
 Rails/Delegate:
   Enabled: false
 
@@ -866,6 +869,12 @@ Rails/DynamicFindBy:
     - spec/features/**/*.rb
 
 Rails/EagerEvaluationLogMessage:
+  Enabled: true
+
+Rails/EnumSyntax:
+  Enabled: true
+
+Rails/EnvLocal:
   Enabled: true
 
 Rails/ExpandedDateRange:
@@ -932,6 +941,9 @@ Rails/PluckInWhere:
 Rails/Present:
   Enabled: false
 
+Rails/RedundantActiveRecordAllMethod:
+  Enabled: true
+
 Rails/RedundantPresenceValidationOnBelongsTo:
   Enabled: false
 
@@ -957,6 +969,9 @@ Rails/RootPathnameMethods:
   Enabled: false
 
 Rails/RootPublicPath:
+  Enabled: true
+
+Rails/SelectMap:
   Enabled: true
 
 Rails/ShortI18n:
@@ -998,6 +1013,9 @@ Rails/TransactionExitStatement:
 Rails/UnusedIgnoredColumns:
   Enabled: true
 
+Rails/UnusedRenderContent:
+  Enabled: true
+
 Rails/WhereEquals:
   Enabled: true
 
@@ -1012,6 +1030,9 @@ Rails/WhereNot:
 
 Rails/WhereNotWithMultipleConditions:
   Enabled: true
+
+Rails/WhereRange:
+  Enabled: false
 
 RSpec/LeakyConstantDeclaration:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 6.0'
   gem 'rubocop', '~> 1.62.0', require: false
   gem 'rubocop-performance', '~> 1.20.2', require: false
-  gem 'rubocop-rails', '>= 2.5.2', require: false
+  gem 'rubocop-rails', '>= 2.26.2', require: false
   gem 'rubocop-rspec', require: false
   gem 'sqlite3', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -633,10 +633,11 @@ GEM
     rubocop-performance (1.20.2)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
-    rubocop-rails (2.20.2)
+    rubocop-rails (2.26.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 1.33.0, < 2.0)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rspec (2.24.1)
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
@@ -851,7 +852,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (~> 1.62.0)
   rubocop-performance (~> 1.20.2)
-  rubocop-rails (>= 2.5.2)
+  rubocop-rails (>= 2.26.2)
   rubocop-rspec
   ruby-progressbar
   ruby-saml

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,7 @@ class Event < ApplicationRecord
   belongs_to :user
   belongs_to :device
 
-  enum event_type: {
+  enum :event_type, {
     account_created: 1,
     phone_confirmed: 2,
     password_changed: 3,

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -20,7 +20,7 @@ class InPersonEnrollment < ApplicationRecord
   STATUS_EXPIRED = 'expired'
   STATUS_CANCELLED = 'cancelled'
 
-  enum status: {
+  enum :status, {
     STATUS_ESTABLISHING.to_sym => 0,
     STATUS_PENDING.to_sym => 1,
     STATUS_PASSED.to_sym => 2,

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -8,7 +8,7 @@ class PhoneConfiguration < ApplicationRecord
 
   encrypted_attribute(name: :phone)
 
-  enum delivery_preference: { sms: 0, voice: 1 }
+  enum :delivery_preference, { sms: 0, voice: 1 }
 
   def formatted_phone
     PhoneFormatter.format(phone)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -21,7 +21,7 @@ class Profile < ApplicationRecord
           class_name: 'InPersonEnrollment', foreign_key: :profile_id, inverse_of: :profile,
           dependent: :destroy
 
-  enum deactivation_reason: {
+  enum :deactivation_reason, {
     password_reset: 1,
     encryption_error: 2,
     gpo_verification_pending_NO_LONGER_USED: 3, # deprecated
@@ -29,12 +29,12 @@ class Profile < ApplicationRecord
     in_person_verification_pending_NO_LONGER_USED: 5, # deprecated
   }
 
-  enum fraud_pending_reason: {
+  enum :fraud_pending_reason, {
     threatmetrix_review: 1,
     threatmetrix_reject: 2,
   }
 
-  enum idv_level: {
+  enum :idv_level, {
     legacy_unsupervised: 1,
     legacy_in_person: 2,
     unsupervised_with_selfie: 3,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
   MAX_RECENT_EVENTS = 5
   MAX_RECENT_DEVICES = 5
 
-  enum otp_delivery_preference: { sms: 0, voice: 1 }
+  enum :otp_delivery_preference, { sms: 0, voice: 1 }
 
   # rubocop:disable Rails/HasManyOrHasOneDependent
   # identities need to be orphaned to prevent UUID reuse

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -37,7 +37,7 @@ class AccessTokenVerifier
   end
 
   def load_identity(access_token)
-    identity = ServiceProviderIdentity.where(access_token: access_token).take
+    identity = ServiceProviderIdentity.find_by(access_token: access_token)
 
     if identity && OutOfBandSessionAccessor.new(identity.rails_session_id).ttl.positive?
       @identity = identity

--- a/app/services/agency_identity_linker.rb
+++ b/app/services/agency_identity_linker.rb
@@ -16,25 +16,25 @@ class AgencyIdentityLinker
   def self.for(user:, service_provider:)
     agency = service_provider.agency
 
-    ai = AgencyIdentity.where(user: user, agency: agency).take
+    ai = AgencyIdentity.find_by(user: user, agency: agency)
     return ai if ai.present?
 
-    spi = ServiceProviderIdentity.where(
+    spi = ServiceProviderIdentity.find_by(
       user: user, service_provider: service_provider.issuer,
-    ).take
+    )
 
     return nil unless spi.present?
     new(spi).link_identity
   end
 
   def self.sp_identity_from_uuid_and_sp(uuid, service_provider)
-    ai = AgencyIdentity.where(uuid: uuid).take
+    ai = AgencyIdentity.find_by(uuid: uuid)
     criteria = if ai
                  { user_id: ai.user_id, service_provider: service_provider }
                else
                  { uuid: uuid, service_provider: service_provider }
                end
-    ServiceProviderIdentity.where(criteria).take
+    ServiceProviderIdentity.find_by(criteria)
   end
 
   private
@@ -53,11 +53,11 @@ class AgencyIdentityLinker
   end
 
   def agency_identity
-    ai = AgencyIdentity.where(uuid: @sp_identity.uuid).take
+    ai = AgencyIdentity.find_by(uuid: @sp_identity.uuid)
     return ai if ai
-    sp = ServiceProvider.where(issuer: @sp_identity.service_provider).take
+    sp = ServiceProvider.find_by(issuer: @sp_identity.service_provider)
     return unless agency_id(sp)
-    AgencyIdentity.where(agency_id: agency_id, user_id: @sp_identity.user_id).take
+    AgencyIdentity.find_by(agency_id: agency_id, user_id: @sp_identity.user_id)
   end
 
   def agency_id(service_provider = nil)

--- a/app/services/create_new_device_alert.rb
+++ b/app/services/create_new_device_alert.rb
@@ -8,7 +8,7 @@ class CreateNewDeviceAlert < ApplicationJob
     User.where(
       sql_query_for_users_with_new_device,
       tvalue: now - IdentityConfig.store.new_device_alert_delay_in_minutes.minutes,
-    ).each do |user|
+    ).find_each do |user|
       emails_sent += 1 if expire_sign_in_notification_timeframe_and_send_alert(user)
     end
 

--- a/app/services/gpo_reminder_sender.rb
+++ b/app/services/gpo_reminder_sender.rb
@@ -8,7 +8,7 @@ class GpoReminderSender
       IdentityConfig.store.usps_confirmation_max_days.days.ago..for_letters_sent_before
     profiles_due_for_reminder(for_letters_sent_before).each do |profile|
       next if profile.user.active_profile
-      profile.gpo_confirmation_codes.all.each do |gpo_code|
+      profile.gpo_confirmation_codes.find_each do |gpo_code|
         next if gpo_code.reminder_sent_at
         next unless reminder_eligible_range.cover?(gpo_code.created_at)
 

--- a/app/services/proofing/socure/reason_codes/importer.rb
+++ b/app/services/proofing/socure/reason_codes/importer.rb
@@ -24,7 +24,7 @@ module Proofing
           end
 
           create_or_update_downloaded_reason_codes
-          deactive_missing_reason_codes
+          deactivate_missing_reason_codes
 
           FormResponse.new(
             success: true,
@@ -64,14 +64,14 @@ module Proofing
           end
         end
 
-        def deactive_missing_reason_codes
+        def deactivate_missing_reason_codes
           active_codes = downloaded_reason_codes.flat_map do |_group, reason_codes|
             reason_codes.keys
           end
           deactivated_at = Time.zone.now
-          SocureReasonCode.active.where.not(code: active_codes).each do |deactivateable_reason_code|
-            deactivateable_reason_code.update!(deactivated_at:)
-            deactivated_reason_code_records.push(deactivateable_reason_code)
+          SocureReasonCode.active.where.not(code: active_codes).find_each do |reason_code|
+            reason_code.update!(deactivated_at:)
+            deactivated_reason_code_records.push(reason_code)
           end
         end
 

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -92,7 +92,7 @@ module UspsInPersonProofing
         user.
           in_person_enrollments.
           where(status: :establishing).
-          each(&:cancelled!)
+          find_each(&:cancelled!)
       end
 
       def usps_proofer

--- a/lib/identity_cors.rb
+++ b/lib/identity_cors.rb
@@ -11,7 +11,7 @@ class IdentityCors
   ].freeze
 
   def self.allowed_origins_static_sites
-    return STATIC_SITE_ALLOWED_ORIGINS unless Rails.env.development? || Rails.env.test?
+    return STATIC_SITE_ALLOWED_ORIGINS unless Rails.env.local?
     allowed_origins = STATIC_SITE_ALLOWED_ORIGINS.dup
     allowed_origins << %r{https?://localhost(:\d+)?\z}
     allowed_origins << %r{https?://127\.0\.0\.1(:\d+)?\z}

--- a/lib/reporting/authentication_report.rb
+++ b/lib/reporting/authentication_report.rb
@@ -211,7 +211,6 @@ module Reporting
   end
 end
 
-# rubocop:disable Rails/Output
 if __FILE__ == $PROGRAM_NAME
   options = Reporting::CommandLineOptions.new.parse!(ARGV)
 
@@ -219,4 +218,3 @@ if __FILE__ == $PROGRAM_NAME
     puts csv
   end
 end
-# rubocop:enable Rails/Output

--- a/lib/reporting/drop_off_report.rb
+++ b/lib/reporting/drop_off_report.rb
@@ -450,7 +450,6 @@ module Reporting
   end
 end
 
-# rubocop:disable Rails/Output
 if __FILE__ == $PROGRAM_NAME
   options = Reporting::CommandLineOptions.new.parse!(ARGV, require_issuer: false)
 
@@ -458,4 +457,3 @@ if __FILE__ == $PROGRAM_NAME
     puts csv
   end
 end
-# rubocop:enable Rails/Output

--- a/lib/reporting/mfa_report.rb
+++ b/lib/reporting/mfa_report.rb
@@ -182,7 +182,6 @@ module Reporting
   end
 end
 
-# rubocop:disable Rails/Output
 if __FILE__ == $PROGRAM_NAME
   options = Reporting::CommandLineOptions.new.parse!(ARGV)
 
@@ -190,4 +189,3 @@ if __FILE__ == $PROGRAM_NAME
     puts csv
   end
 end
-# rubocop:enable Rails/Output

--- a/lib/reporting/protocols_report.rb
+++ b/lib/reporting/protocols_report.rb
@@ -375,7 +375,6 @@ module Reporting
   end
 end
 
-# rubocop:disable Rails/Output
 if __FILE__ == $PROGRAM_NAME
   options = Reporting::CommandLineOptions.new.parse!(ARGV, require_issuer: false)
 
@@ -383,4 +382,3 @@ if __FILE__ == $PROGRAM_NAME
     puts csv
   end
 end
-# rubocop:enable Rails/Output

--- a/spec/jobs/in_person/send_proofing_notification_job_spec.rb
+++ b/spec/jobs/in_person/send_proofing_notification_job_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe InPerson::SendProofingNotificationJob do
 
       context 'enrollment does not exist' do
         it 'returns without doing anything' do
-          bad_id = (InPersonEnrollment.all.pluck(:id).max || 0) + 1
+          bad_id = (InPersonEnrollment.pluck(:id).max || 0) + 1
           job.perform(bad_id)
           expect(analytics).not_to have_logged_event('SendProofingNotificationJob: job started')
           expect(analytics).to have_logged_event('SendProofingNotificationJob: job skipped')

--- a/spec/services/agency_identity_linker_spec.rb
+++ b/spec/services/agency_identity_linker_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe AgencyIdentityLinker do
 
         it 'persists the service provider identity as an agency identity' do
           expect(subject.uuid).to eq uuid
-          ai = AgencyIdentity.where(user: user, agency: agency).take
+          ai = AgencyIdentity.find_by(user: user, agency: agency)
           expect(subject).to eq ai
         end
       end

--- a/spec/services/funnel/registration/add_mfa_spec.rb
+++ b/spec/services/funnel/registration/add_mfa_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Funnel::Registration::AddMfa do
     user = create(:user)
     user.id
   end
-  let(:funnel) { RegistrationLog.all.first }
+  let(:funnel) { RegistrationLog.first }
 
   it 'shows user is not fully registered with no mfa' do
     expect(funnel&.registered_at).to_not be_present

--- a/spec/support/ab_tests_helper.rb
+++ b/spec/support/ab_tests_helper.rb
@@ -1,8 +1,10 @@
 module AbTestsHelper
   def reload_ab_tests
+    # rubocop:disable Rails/FindEach
     AbTests.all.each do |(name, _)|
       AbTests.send(:remove_const, name)
     end
+    # rubocop:enable Rails/FindEach
     load('config/initializers/ab_tests.rb')
   end
 end

--- a/spec/support/matchers/accessibility.rb
+++ b/spec/support/matchers/accessibility.rb
@@ -3,6 +3,7 @@ RSpec::Matchers.define :have_valid_idrefs do
 
   match do |page|
     ['aria-describedby', 'aria-labelledby'].each do |idref_attribute|
+      # rubocop:disable Rails/FindEach
       page.all(:css, "[#{idref_attribute}]").each do |element|
         element[idref_attribute].split(' ').each do |referenced_id|
           page.find_by_id(referenced_id, visible: :all)
@@ -10,6 +11,7 @@ RSpec::Matchers.define :have_valid_idrefs do
       rescue Capybara::ElementNotFound
         invalid_idref_messages << "[#{idref_attribute}=\"#{element[idref_attribute]}\"]"
       end
+      # rubocop:enable Rails/FindEach
     end
 
     invalid_idref_messages.blank?
@@ -28,9 +30,11 @@ RSpec::Matchers.define :label_required_fields do
   elements = []
 
   match do |page|
+    # rubocop:disable Rails/FindEach
     page.all(:css, 'input[required]').each do |input|
       elements << input if input['aria-invalid'].blank?
     end
+    # rubocop:enable Rails/FindEach
     elements.empty?
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `rubocop-rails` to the latest version and addresses identified issues.

In particular, this supports #11357, where Rails 7.2 will now noisily output deprecation messages for `enum` usage with keyword arguments, slated to be removed in Rails 8 (see https://github.com/rails/rails/pull/50987). Newer versions of `rubocop-rails` includes [a `Rails/EnumSyntax` cop](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsenumsyntax) to help identify these.

## 📜 Testing Plan

Verify build passes.

Review relevant cops for changes to identify any incompatibilities with "Safety" notes from documentation:

https://docs.rubocop.org/rubocop-rails/cops_rails.html