### PR TITLE
LG-14651: add different hover states to login-button component

### DIFF
--- a/app/assets/stylesheets/variables/_email.scss
+++ b/app/assets/stylesheets/variables/_email.scss
@@ -21,7 +21,6 @@ $success-color: #3adb76;
 $warning-color: #ffae00;
 $alert-color: #ec5840;
 $light-gray: #f3f3f3;
-$darkest: #1b1b1b;
 $black: #111;
 $white: #fff;
 $gray: #5b616a;

--- a/app/assets/stylesheets/variables/_email.scss
+++ b/app/assets/stylesheets/variables/_email.scss
@@ -21,6 +21,7 @@ $success-color: #3adb76;
 $warning-color: #ffae00;
 $alert-color: #ec5840;
 $light-gray: #f3f3f3;
+$darkest: #1b1b1b;
 $black: #111;
 $white: #fff;
 $gray: #5b616a;

--- a/app/components/login_button_component.scss
+++ b/app/components/login_button_component.scss
@@ -9,8 +9,8 @@
   @include u-text('primary-darker');
 
   &:hover {
-    @include u-bg('primary-lighter');
-    @include u-text('primary-darker');
+    @include u-bg('primary-light');
+    @include u-text('darkest');
   }
 }
 
@@ -22,9 +22,9 @@
 
   &:hover {
     @include u-border(1px);
-    @include u-bg('white');
-    @include u-text('primary-darker');
     @include u-border('base');
+    @include u-bg('primary-lighter');
+    @include u-text('darkest');
   }
 }
 
@@ -33,7 +33,7 @@
   @include u-text('white');
 
   &:hover {
-    @include u-bg('primary-darker');
-    @include u-text('white');
+    @include u-bg('darkest');
+    @include u-text('primary-lighter');
   }
 }

--- a/app/components/login_button_component.scss
+++ b/app/components/login_button_component.scss
@@ -10,7 +10,6 @@
 
   &:hover {
     @include u-bg('primary-light');
-    @include u-text('darkest');
   }
 }
 
@@ -24,7 +23,6 @@
     @include u-border(1px);
     @include u-border('base');
     @include u-bg('primary-lighter');
-    @include u-text('darkest');
   }
 }
 
@@ -33,7 +31,6 @@
   @include u-text('white');
 
   &:hover {
-    @include u-bg('darkest');
-    @include u-text('primary-lighter');
+    @include u-bg('primary-darkest');
   }
 }


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-14651](https://cm-jira.usa.gov/browse/LG-14651)



## 🛠 Summary of changes

Someone pointed out in Slack that the hover states on the login-button were the same as the default state. This updates the component scss so that the hover state is visible and different.



## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

PRIMARY
<details>
<summary>Before:</summary>
<img width="295" alt="Screenshot 2024-10-18 at 1 39 37 PM" src="https://github.com/user-attachments/assets/018bac70-3576-4d5f-956e-b60e31428281">

</details>

<details>
<summary>After:</summary>
<img width="294" alt="Screenshot 2024-10-18 at 1 39 41 PM" src="https://github.com/user-attachments/assets/723232d4-85dd-45dc-ae57-0a347b28f6b3">

</details>


PRIMARY LIGHTER
<details>
<summary>Before:</summary>
<img width="287" alt="Screenshot 2024-10-18 at 1 41 28 PM" src="https://github.com/user-attachments/assets/1180f4c2-b63e-4128-b739-64f7f8d25c76">

</details>

<details>
<summary>After:</summary>
<img width="282" alt="Screenshot 2024-10-18 at 1 40 42 PM" src="https://github.com/user-attachments/assets/7c214fdf-18db-4463-8f57-a0b51fe569c7">

</details>

PRIMARY DARKER
<details>
<summary>Before:</summary>
<img width="293" alt="Screenshot 2024-10-18 at 1 42 30 PM" src="https://github.com/user-attachments/assets/5b45b31c-2ef3-4a6f-b5b4-49aa3040427c">

</details>

<details>
<summary>After:</summary>
<img width="280" alt="Screenshot 2024-10-18 at 1 42 42 PM" src="https://github.com/user-attachments/assets/5786c53d-ac6a-467d-b2cf-82664fd22c9b">


</details>

