### PR TITLE
LG-14455: Improved messaging for PIV/CAC mismatch

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -230,6 +230,7 @@ class ApplicationController < ActionController::Base
     return authentication_methods_setup_url if user_needs_sp_auth_method_setup?
     return fix_broken_personal_key_url if current_user.broken_personal_key?
     return user_session.delete(:stored_location) if user_session.key?(:stored_location)
+    return setup_piv_cac_url if user_session[:add_piv_cac_after_2fa]
     return login_add_piv_cac_prompt_url if session[:needs_to_setup_piv_cac_after_sign_in].present?
     return reactivate_account_url if user_needs_to_reactivate_account?
     return login_piv_cac_recommended_path if user_recommended_for_piv_cac?

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -154,8 +154,6 @@ module TwoFactorAuthenticatableMethods
       t('two_factor_authentication.invalid_otp')
     when 'personal_key'
       t('two_factor_authentication.invalid_personal_key')
-    when 'piv_cac'
-      t('two_factor_authentication.invalid_piv_cac')
     else
       raise "Unsupported otp method: #{type}"
     end

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -54,6 +54,7 @@ module TwoFactorAuthentication
         service_provider: current_sp,
         phishing_resistant_required: service_provider_mfa_policy.phishing_resistant_required?,
         piv_cac_required: service_provider_mfa_policy.piv_cac_required?,
+        add_piv_cac_after_2fa: user_session[:add_piv_cac_after_2fa].present?,
       )
     end
 

--- a/app/controllers/two_factor_authentication/piv_cac_mismatch_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_mismatch_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module TwoFactorAuthentication
+  class PivCacMismatchController < ApplicationController
+    include TwoFactorAuthenticatable
+
+    def show
+      analytics.piv_cac_mismatch_visited(
+        piv_cac_required: piv_cac_required?,
+        has_other_authentication_methods: has_other_authentication_methods?,
+      )
+
+      @piv_cac_required = piv_cac_required?
+      @has_other_authentication_methods = has_other_authentication_methods?
+    end
+
+    def create
+      analytics.piv_cac_mismatch_submitted(add_piv_cac_after_2fa: add_piv_cac_after_2fa?)
+      user_session[:add_piv_cac_after_2fa] = add_piv_cac_after_2fa?
+      redirect_to login_two_factor_options_url
+    end
+
+    private
+
+    def add_piv_cac_after_2fa?
+      params[:add_piv_cac_after_2fa] == 'true'
+    end
+
+    def piv_cac_required?
+      service_provider_mfa_policy.piv_cac_required?
+    end
+
+    def has_other_authentication_methods?
+      return @has_other_authentication_methods if defined?(@has_other_authentication_methods)
+      @has_other_authentication_methods = mfa_context.two_factor_configurations.any? do |config|
+        config.mfa_enabled? && !config.is_a?(PivCacConfiguration)
+      end
+    end
+
+    def mfa_context
+      @mfa_context ||= MfaContext.new(current_user)
+    end
+  end
+end

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -18,6 +18,8 @@ module Users
     helper_method :in_multi_mfa_selection_flow?
 
     def new
+      @piv_cac_required = service_provider_mfa_policy.piv_cac_required?
+
       if params.key?(:token)
         process_piv_cac_setup
       else
@@ -35,7 +37,10 @@ module Users
     end
 
     def submit_new_piv_cac
-      if good_nickname
+      if skip?
+        user_session.delete(:add_piv_cac_after_2fa)
+        redirect_to after_sign_in_path_for(current_user)
+      elsif good_nickname?
         user_session[:piv_cac_nickname] = params[:name]
         create_piv_cac_nonce
         redirect_to piv_cac_service_url_with_redirect, allow_other_host: true
@@ -100,6 +105,7 @@ module Users
       )
       create_user_event(:piv_cac_enabled)
       track_mfa_method_added
+      user_session.delete(:add_piv_cac_after_2fa)
       session[:needs_to_setup_piv_cac_after_sign_in] = false
       redirect_to next_setup_path || after_sign_in_path_for(current_user)
     end
@@ -119,7 +125,11 @@ module Users
       end
     end
 
-    def good_nickname
+    def skip?
+      params[:skip] == 'true'
+    end
+
+    def good_nickname?
       name = params[:name]
       name.present? && !PivCacConfiguration.exists?(user_id: current_user.id, name: name)
     end

--- a/app/presenters/two_factor_authentication/sign_in_piv_cac_selection_presenter.rb
+++ b/app/presenters/two_factor_authentication/sign_in_piv_cac_selection_presenter.rb
@@ -6,12 +6,21 @@ module TwoFactorAuthentication
       :piv_cac
     end
 
+    def render_in(view_context, &block)
+      @disabled = view_context.user_session.key?(:add_piv_cac_after_2fa)
+      view_context.capture(&block)
+    end
+
     def label
       t('two_factor_authentication.login_options.piv_cac')
     end
 
     def info
       t('two_factor_authentication.login_options.piv_cac_info')
+    end
+
+    def disabled?
+      @disabled.present?
     end
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5939,6 +5939,24 @@ module AnalyticsEvents
     track_event(:piv_cac_login_visited)
   end
 
+  # User submits prompt to replace PIV/CAC after failing to authenticate due to mismatched subject
+  # @param [Boolean] add_piv_cac_after_2fa User chooses to replace PIV/CAC authenticator
+  def piv_cac_mismatch_submitted(add_piv_cac_after_2fa:, **extra)
+    track_event(:piv_cac_mismatch_submitted, add_piv_cac_after_2fa:, **extra)
+  end
+
+  # User visits prompt to replace PIV/CAC after failing to authenticate due to mismatched subject
+  # @param [Boolean] piv_cac_required Partner requires HSPD12 authentication
+  # @param [Boolean] has_other_authentication_methods User has non-PIV authentication methods
+  def piv_cac_mismatch_visited(piv_cac_required:, has_other_authentication_methods:, **extra)
+    track_event(
+      :piv_cac_mismatch_visited,
+      piv_cac_required:,
+      has_other_authentication_methods:,
+      **extra,
+    )
+  end
+
   # @param [String] action what action user made
   # Tracks when user submits an action on Piv Cac recommended page
   def piv_cac_recommended(action: nil, **extra)

--- a/app/views/two_factor_authentication/options/index.html.erb
+++ b/app/views/two_factor_authentication/options/index.html.erb
@@ -2,6 +2,13 @@
 
 <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice])) %>
 
+<% if @presenter.add_piv_cac_after_2fa? %>
+  <%= render AlertComponent.new(
+        type: :info,
+        class: 'margin-bottom-4',
+      ).with_content(t('two_factor_authentication.piv_cac_mismatch.2fa_before_add')) %>
+<% end %>
+
 <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
 <p>

--- a/app/views/two_factor_authentication/piv_cac_mismatch/show.html.erb
+++ b/app/views/two_factor_authentication/piv_cac_mismatch/show.html.erb
@@ -1,0 +1,38 @@
+<% self.title = t('two_factor_authentication.piv_cac_mismatch.title') %>
+
+<%= render PageHeadingComponent.new.with_content(t('two_factor_authentication.piv_cac_mismatch.title')) %>
+
+<% if @has_other_authentication_methods %>
+  <p><%= t('two_factor_authentication.piv_cac_mismatch.instructions') %></p>
+
+  <%= render ButtonComponent.new(
+        url: login_two_factor_piv_cac_mismatch_url,
+        method: :post,
+        params: { add_piv_cac_after_2fa: 'true' },
+        big: true,
+        wide: true,
+        class: 'display-block margin-top-5',
+      ).with_content(t('two_factor_authentication.piv_cac_mismatch.cta')) %>
+
+  <% if !@piv_cac_required %>
+    <%= render ButtonComponent.new(
+          url: login_two_factor_piv_cac_mismatch_url,
+          method: :post,
+          unstyled: true,
+          class: 'display-block margin-top-2',
+        ).with_content(t('two_factor_authentication.piv_cac_mismatch.skip')) %>
+  <% end %>
+<% else %>
+  <p><%= t('two_factor_authentication.piv_cac_mismatch.instructions_no_other_method', app_name: APP_NAME) %></p>
+
+  <%= render ButtonComponent.new(
+        url: account_reset_recovery_options_url,
+        big: true,
+        wide: true,
+        class: 'display-inline-block margin-top-3',
+      ).with_content(t('two_factor_authentication.piv_cac_mismatch.delete_account')) %>
+<% end %>
+
+<%= render PageFooterComponent.new do %>
+  <%= link_to t('links.cancel'), sign_out_url %>
+<% end %>

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -31,8 +31,22 @@
     <% end %>
   <% end %>
 
-  <%= f.submit t('forms.piv_cac_setup.submit'), class: 'display-block margin-y-5' %>
+  <%= f.submit t('forms.piv_cac_setup.submit'), class: 'display-block margin-top-5 margin-bottom-2' %>
 <% end %>
 
+<% if user_session[:add_piv_cac_after_2fa] && !@piv_cac_required %>
+  <%= render ButtonComponent.new(
+        url: submit_new_piv_cac_url,
+        method: :post,
+        params: { skip: 'true' },
+        unstyled: true,
+      ).with_content(t('mfa.skip')) %>
+<% end %>
 
-<%= render 'shared/cancel_or_back_to_options' %>
+<% if user_session[:add_piv_cac_after_2fa] %>
+  <%= render PageFooterComponent.new do %>
+    <%= link_to t('links.cancel'), sign_out_path %>
+  <% end %>
+<% else %>
+  <%= render 'shared/cancel_or_back_to_options' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1716,6 +1716,13 @@ two_factor_authentication.phone_verification.troubleshooting.code_not_received: 
 two_factor_authentication.phone.delete.failure: Unable to remove your phone.
 two_factor_authentication.phone.delete.success: Your phone has been removed.
 two_factor_authentication.piv_cac_header_text: Insert your government employee ID
+two_factor_authentication.piv_cac_mismatch.2fa_before_add: You need to authenticate with another method before adding your PIV/CAC.
+two_factor_authentication.piv_cac_mismatch.cta: Authenticate and add PIV/CAC
+two_factor_authentication.piv_cac_mismatch.delete_account: Delete your account
+two_factor_authentication.piv_cac_mismatch.instructions: Click “Authenticate and add PIV/CAC” below to authenticate with another method before adding this PIV/CAC to your account.
+two_factor_authentication.piv_cac_mismatch.instructions_no_other_method: If you were reissued your PIV/CAC, you will need to delete your %{app_name} account and create a new account to use your reissued PIV/CAC.
+two_factor_authentication.piv_cac_mismatch.skip: Skip adding PIV/CAC
+two_factor_authentication.piv_cac_mismatch.title: This government employee ID is not connected to your account
 two_factor_authentication.piv_cac_upsell.add_piv: Add PIV/CAC card
 two_factor_authentication.piv_cac_upsell.choose_other_method: Choose other methods instead
 two_factor_authentication.piv_cac_upsell.explain: This will improve your account security and let you skip entering your email and password when signing in.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1728,6 +1728,13 @@ two_factor_authentication.phone_verification.troubleshooting.code_not_received: 
 two_factor_authentication.phone.delete.failure: No se puede eliminar su teléfono.
 two_factor_authentication.phone.delete.success: Su teléfono fue eliminado.
 two_factor_authentication.piv_cac_header_text: Inserte su identificación de empleado del gobierno
+two_factor_authentication.piv_cac_mismatch.2fa_before_add: Debe realizar la autenticación con otro método antes de añadir su tarjeta PIV o CAC.
+two_factor_authentication.piv_cac_mismatch.cta: Autenticar y añadir tarjeta PIV o CAC
+two_factor_authentication.piv_cac_mismatch.delete_account: Eliminar su cuenta
+two_factor_authentication.piv_cac_mismatch.instructions: Haga clic en “Autenticar y añadir tarjeta PIV o CAC” más abajo para autenticar con otro método antes de añadir esta tarjeta PIV o CAC a su cuenta.
+two_factor_authentication.piv_cac_mismatch.instructions_no_other_method: Si se le emitió una nueva tarjeta PIV o CAC, para poder usarla, deberá eliminar su cuenta de %{app_name} y crear una cuenta nueva.
+two_factor_authentication.piv_cac_mismatch.skip: Saltar añadir tarjeta PIV o CAC
+two_factor_authentication.piv_cac_mismatch.title: Esta tarjeta de identificación de empleado del gobierno no está conectada a su cuenta
 two_factor_authentication.piv_cac_upsell.add_piv: Agregar tarjeta PIV/CAC
 two_factor_authentication.piv_cac_upsell.choose_other_method: Elegir otros métodos
 two_factor_authentication.piv_cac_upsell.explain: Esto hará que su cuenta sea más segura y no tendrá que ingresar su correo electrónico ni su contraseña cuando inicie sesión.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1716,6 +1716,13 @@ two_factor_authentication.phone_verification.troubleshooting.code_not_received: 
 two_factor_authentication.phone.delete.failure: Impossible de supprimer votre téléphone.
 two_factor_authentication.phone.delete.success: Votre téléphone a été supprimé.
 two_factor_authentication.piv_cac_header_text: Insérer votre carte d’employé fédéral
+two_factor_authentication.piv_cac_mismatch.2fa_before_add: Vous devez vous authentifier à l’aide d’une autre méthode avant d’ajouter votre carte PIV/CAC.
+two_factor_authentication.piv_cac_mismatch.cta: S’authentifier et ajouter une carte PIV/CAC
+two_factor_authentication.piv_cac_mismatch.delete_account: Supprimer votre compte
+two_factor_authentication.piv_cac_mismatch.instructions: Cliquez sur « S’authentifier et ajouter une carte PIV/CAC » ci-dessous pour vous authentifier au moyen d’une autre méthode avant d’ajouter cette carte PIV/CAC à votre compte.
+two_factor_authentication.piv_cac_mismatch.instructions_no_other_method: Si l’on vous a à nouveau délivré une carte PIV/CAC, vous devez supprimer votre compte %{app_name} et en créer un nouveau pour l’utiliser.
+two_factor_authentication.piv_cac_mismatch.skip: Sauter l’ajout de carte PIV/CAC
+two_factor_authentication.piv_cac_mismatch.title: Cette carte d’employé fédéral n’est pas associée à votre compte.
 two_factor_authentication.piv_cac_upsell.add_piv: Ajouter une carte PIV/CAC
 two_factor_authentication.piv_cac_upsell.choose_other_method: Choisir plutôt d’autres méthodes
 two_factor_authentication.piv_cac_upsell.explain: Ceci permettra de renforcer la sécurité de votre compte et de sauter l’étape de saisie de votre e-mail et mot de passe quand vous vous connecterez.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1729,6 +1729,13 @@ two_factor_authentication.phone_verification.troubleshooting.code_not_received: 
 two_factor_authentication.phone.delete.failure: 无法去掉你的电话。
 two_factor_authentication.phone.delete.success: 你的电话已被去掉。
 two_factor_authentication.piv_cac_header_text: 插入您的政府雇员ID
+two_factor_authentication.piv_cac_mismatch.2fa_before_add: 添加你的PIV/CAC之前，你需要使用另外一种方法进行身份证实。
+two_factor_authentication.piv_cac_mismatch.cta: 进行身份证实并添加PIV/CAC
+two_factor_authentication.piv_cac_mismatch.delete_account: 删除你的帐户
+two_factor_authentication.piv_cac_mismatch.instructions: 点击下边的“进行身份证实并添加PIV/CAC”，以在将该PIV/CAC添加到你账户之前使用另外一种方法进行身份证实。
+two_factor_authentication.piv_cac_mismatch.instructions_no_other_method: 如果你的PIV/CAV是重新颁发的，你需要删除自己的%{app_name}帐户，并使用重新颁发的PIV/CAC 设立一个新账户。
+two_factor_authentication.piv_cac_mismatch.skip: 跳过添加 PIV/CAC
+two_factor_authentication.piv_cac_mismatch.title: 该政府雇员身份证件与你的账户没有连接起来
 two_factor_authentication.piv_cac_upsell.add_piv: 添加 PIV/CAC 卡
 two_factor_authentication.piv_cac_upsell.choose_other_method: 选择其他方法
 two_factor_authentication.piv_cac_upsell.explain: 这将改善你账户安全，而且你在登录时无需再输入电邮和密码。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,9 @@ Rails.application.routes.draw do
       get '/login/two_factor/options' => 'two_factor_authentication/options#index'
       post '/login/two_factor/options' => 'two_factor_authentication/options#create'
 
+      get '/login/two_factor/piv_cac_mismatch' => 'two_factor_authentication/piv_cac_mismatch#show'
+      post '/login/two_factor/piv_cac_mismatch' => 'two_factor_authentication/piv_cac_mismatch#create'
+
       get '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#show'
       post '/login/two_factor/authenticator' => 'two_factor_authentication/totp_verification#create'
       get '/login/two_factor/personal_key' => 'two_factor_authentication/personal_key_verification#show'

--- a/spec/controllers/two_factor_authentication/piv_cac_mismatch_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_mismatch_controller_spec.rb
@@ -1,0 +1,178 @@
+require 'rails_helper'
+
+RSpec.describe TwoFactorAuthentication::PivCacMismatchController do
+  let(:user) { create(:user, :with_piv_or_cac) }
+
+  before do
+    stub_sign_in_before_2fa(user) if user
+  end
+
+  describe '#show' do
+    subject(:response) { get :show }
+
+    context 'with user having piv as their only authentication method' do
+      let(:user) { create(:user, :with_piv_or_cac) }
+
+      it 'assigns has_other_authentication_methods as false' do
+        response
+
+        expect(assigns(:has_other_authentication_methods)).to eq(false)
+      end
+
+      it 'logs an analytics event' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(
+          :piv_cac_mismatch_visited,
+          piv_cac_required: false,
+          has_other_authentication_methods: false,
+        )
+      end
+    end
+
+    context 'with user having other authentication methods' do
+      let(:user) { create(:user, :with_piv_or_cac, :with_phone) }
+
+      it 'assigns has_other_authentication_methods as true' do
+        response
+
+        expect(assigns(:has_other_authentication_methods)).to eq(true)
+      end
+
+      it 'logs an analytics event' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(
+          :piv_cac_mismatch_visited,
+          piv_cac_required: false,
+          has_other_authentication_methods: true,
+        )
+      end
+    end
+
+    context 'with partner not requiring hspd12 authentication' do
+      before do
+        controller.session[:sp] = {
+          issuer: SamlAuthHelper::SP_ISSUER,
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+        }
+      end
+
+      it 'assigns piv_cac_required as false' do
+        response
+
+        expect(assigns(:piv_cac_required)).to eq(false)
+      end
+
+      it 'logs an analytics event' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(
+          :piv_cac_mismatch_visited,
+          piv_cac_required: false,
+          has_other_authentication_methods: false,
+        )
+      end
+    end
+
+    context 'with partner requiring hspd12 authentication' do
+      before do
+        controller.session[:sp] = {
+          issuer: SamlAuthHelper::SP_ISSUER,
+          acr_values: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+        }
+      end
+
+      it 'assigns piv_cac_required as true' do
+        response
+
+        expect(assigns(:piv_cac_required)).to eq(true)
+      end
+
+      it 'logs an analytics event' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(
+          :piv_cac_mismatch_visited,
+          piv_cac_required: true,
+          has_other_authentication_methods: false,
+        )
+      end
+    end
+
+    context 'if user is not signed in' do
+      let(:user) { nil }
+
+      it 'redirects user to sign in' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'if user is already authenticated' do
+      let(:user) { nil }
+
+      before do
+        stub_sign_in
+      end
+
+      it 'redirects user to the signed in path' do
+        expect(response).to redirect_to(account_path)
+      end
+    end
+  end
+
+  describe '#create' do
+    let(:params) { {} }
+    subject(:response) { post :create, params: params }
+
+    context 'when user chooses to add piv' do
+      let(:params) { { add_piv_cac_after_2fa: 'true' } }
+
+      it 'assigns session value to add piv after authenticating' do
+        response
+
+        expect(controller.user_session[:add_piv_cac_after_2fa]).to eq(true)
+      end
+
+      it 'logs an analytics event' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(
+          :piv_cac_mismatch_submitted,
+          add_piv_cac_after_2fa: true,
+        )
+      end
+    end
+
+    context 'when user chooses to skip adding piv' do
+      let(:params) { {} }
+
+      it 'assigns session value to skip adding piv after authenticating' do
+        response
+
+        expect(controller.user_session[:add_piv_cac_after_2fa]).to eq(false)
+      end
+
+      it 'logs an analytics event' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(
+          :piv_cac_mismatch_submitted,
+          add_piv_cac_after_2fa: false,
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -34,11 +34,7 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
       'key_id' => 'foo',
     )
     allow(PivCacService).to receive(:decode_token).with('bad-token').and_return(
-      'uuid' => 'bad-uuid',
-      'subject' => bad_dn,
-      'issuer' => x509_issuer,
-      'nonce' => nonce,
-      'key_id' => 'foo',
+      'error' => 'token.bad',
     )
     allow(PivCacService).to receive(:decode_token).with('bad-nonce').and_return(
       'uuid' => user.piv_cac_configurations.first.x509_dn_uuid,
@@ -206,26 +202,50 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
     end
 
     context 'when the user presents a different piv/cac' do
+      subject(:response) { get :show, params: { token: 'good-other-token' } }
+
       before do
         stub_sign_in_before_2fa(user)
-
-        get :show, params: { token: 'good-other-token' }
       end
 
       it 'increments second_factor_attempts_count' do
-        expect(subject.current_user.reload.second_factor_attempts_count).to eq 1
+        response
+
+        expect(controller.current_user.reload.second_factor_attempts_count).to eq 1
       end
 
-      it 'redirects to the piv/cac entry screen' do
-        expect(response).to redirect_to login_two_factor_piv_cac_path
-      end
-
-      it 'displays flash error message' do
-        expect(flash[:error]).to eq t('two_factor_authentication.invalid_piv_cac')
+      it 'redirects to the piv/cac mismatch screen' do
+        expect(response).to redirect_to login_two_factor_piv_cac_mismatch_path
       end
 
       it 'resets the piv/cac session information' do
-        expect(subject.user_session[:decrypted_x509]).to be_nil
+        response
+
+        expect(controller.user_session[:decrypted_x509]).to be_nil
+      end
+
+      context 'when user session context is not authentication' do
+        before do
+          allow(UserSessionContext).to receive(:authentication_context?).and_return(false)
+        end
+
+        it 'redirects to authenticate again, including error message' do
+          expect(response).to redirect_to login_two_factor_piv_cac_path
+          expect(flash[:error]).to eq t('two_factor_authentication.invalid_piv_cac')
+        end
+      end
+
+      context 'when user has maximum number of piv/cac associated with their account' do
+        before do
+          while user.piv_cac_configurations.count < IdentityConfig.store.max_piv_cac_per_account
+            create(:piv_cac_configuration, user:)
+          end
+        end
+
+        it 'redirects to authenticate again, including error message' do
+          expect(response).to redirect_to login_two_factor_piv_cac_path
+          expect(flash[:error]).to eq t('two_factor_authentication.invalid_piv_cac')
+        end
       end
     end
 
@@ -240,8 +260,6 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
 
         stub_analytics
 
-        piv_cac_mismatch = { type: 'user.piv_cac_mismatch' }
-
         expect(PushNotification::HttpPush).to receive(:deliver).
           with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 
@@ -251,13 +269,11 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
         expect(@analytics).to have_logged_event(
           'Multi-Factor Authentication',
           success: false,
-          errors: piv_cac_mismatch,
+          errors: { type: 'token.invalid' },
           context: 'authentication',
           multi_factor_auth_method: 'piv_cac',
           enabled_mfa_methods_count: 2,
           new_device: true,
-          key_id: 'foo',
-          piv_cac_configuration_dn_uuid: 'bad-uuid',
           attempts: 1,
         )
         expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -13,18 +13,11 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
   end
 
   describe '#new' do
-    context 'when not signed in' do
-      it 'redirects to root url' do
-        get :new
-
-        expect(response).to redirect_to(root_url)
-      end
-    end
+    let(:params) { nil }
+    subject(:response) { get :new, params: params }
 
     context 'when signed out' do
       it 'redirects to sign in page' do
-        get :new
-
         expect(response).to redirect_to(new_user_session_url)
       end
     end
@@ -37,14 +30,36 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
       end
 
       it 'redirects to 2fa entry' do
-        get :new
-
         expect(response).to redirect_to(user_two_factor_authentication_url)
       end
     end
 
     context 'when signed in' do
+      let(:user) { create(:user, :fully_registered) }
       before { stub_sign_in(user) }
+
+      it 'assigns piv_cac_required instance variable as false' do
+        response
+
+        expect(assigns(:piv_cac_required)).to eq(false)
+      end
+
+      context 'when SP requires PIV/CAC' do
+        let(:service_provider) { create(:service_provider) }
+
+        before do
+          controller.session[:sp] = {
+            issuer: service_provider.issuer,
+            acr_values: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+          }
+        end
+
+        it 'assigns piv_cac_required instance variable as true' do
+          response
+
+          expect(assigns(:piv_cac_required)).to eq(true)
+        end
+      end
 
       context 'without associated piv/cac' do
         let(:user) do
@@ -55,8 +70,8 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
         before(:each) do
           allow(PivCacService).to receive(:decode_token).with(good_token) { good_token_response }
           allow(PivCacService).to receive(:decode_token).with(bad_token) { bad_token_response }
-          allow(subject).to receive(:user_session).and_return(piv_cac_nonce: nonce)
-          subject.user_session[:piv_cac_nickname] = nickname
+          allow(controller).to receive(:user_session).and_return(piv_cac_nonce: nonce)
+          controller.user_session[:piv_cac_nickname] = nickname
         end
 
         let(:nonce) { 'nonce' }
@@ -80,14 +95,13 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
 
         context 'when rendered without a token' do
           it 'renders the "new" template' do
-            get :new
             expect(response).to render_template(:new)
           end
 
           it 'tracks the analytic event of visited' do
             stub_analytics
 
-            get :new
+            response
 
             expect(@analytics).to have_logged_event(
               :piv_cac_setup_visited,
@@ -98,19 +112,19 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
         end
 
         context 'when redirected with a good token' do
-          let(:user) do
-            create(:user)
-          end
+          let(:params) { { token: good_token } }
+          let(:user) { create(:user) }
           let(:mfa_selections) { ['piv_cac', 'voice'] }
+
           before do
-            subject.user_session[:mfa_selections] = mfa_selections
+            controller.user_session[:mfa_selections] = mfa_selections
           end
 
           context 'with no additional MFAs chosen on setup' do
             let(:mfa_selections) { ['piv_cac'] }
             it 'redirects to suggest 2nd MFA page' do
               stub_analytics
-              get :new, params: { token: good_token }
+
               expect(response).to redirect_to(auth_method_confirmation_url)
 
               expect(@analytics).to have_logged_event(
@@ -126,8 +140,9 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
 
             it 'logs mfa attempts commensurate to number of attempts' do
               stub_analytics
+
               get :new, params: { token: bad_token }
-              get :new, params: { token: good_token }
+              response
 
               expect(@analytics).to have_logged_event(
                 'Multi-Factor Authentication Setup',
@@ -141,58 +156,98 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
             end
 
             it 'sets the piv/cac session information' do
-              get :new, params: { token: good_token }
+              response
+
               json = {
                 'subject' => 'some dn',
                 'issuer' => nil,
                 'presented' => true,
               }.to_json
 
-              expect(subject.user_session[:decrypted_x509]).to eq json
+              expect(controller.user_session[:decrypted_x509]).to eq json
             end
 
             it 'sets the session to not require piv setup upon sign-in' do
-              get :new, params: { token: good_token }
+              response
 
-              expect(subject.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
+              expect(controller.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
+            end
+
+            context 'when user adds after piv cac mismatch error' do
+              before do
+                controller.user_session[:add_piv_cac_after_2fa] = true
+              end
+
+              it 'deletes add_piv_cac_after_2fa session value' do
+                response
+
+                expect(controller.user_session).not_to have_key(:add_piv_cac_after_2fa)
+              end
             end
           end
 
           context 'with additional MFAs leftover' do
             it 'redirects to Mfa Confirmation page' do
-              get :new, params: { token: good_token }
               expect(response).to redirect_to(phone_setup_url)
             end
 
             it 'sets the piv/cac session information' do
-              get :new, params: { token: good_token }
+              response
+
               json = {
                 'subject' => 'some dn',
                 'issuer' => nil,
                 'presented' => true,
               }.to_json
 
-              expect(subject.user_session[:decrypted_x509]).to eq json
+              expect(controller.user_session[:decrypted_x509]).to eq json
             end
 
             it 'sets the session to not require piv setup upon sign-in' do
-              get :new, params: { token: good_token }
+              response
 
-              expect(subject.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
+              expect(controller.session[:needs_to_setup_piv_cac_after_sign_in]).to eq false
             end
           end
         end
 
         context 'when redirected with an error token' do
+          let(:params) { { token: bad_token } }
+
           it 'renders the error template' do
-            get :new, params: { token: bad_token }
             expect(response).to redirect_to setup_piv_cac_error_path(error: 'certificate.bad')
           end
 
           it 'resets the piv/cac session information' do
-            expect(subject.user_session[:decrypted_x509]).to be_nil
+            response
+
+            expect(controller.user_session[:decrypted_x509]).to be_nil
           end
         end
+      end
+    end
+  end
+
+  describe '#submit_new_piv_cac' do
+    let(:user) { create(:user, :fully_registered) }
+
+    before { stub_sign_in(user) }
+
+    context 'when user opts to skip adding piv cac after 2fa' do
+      subject(:response) { post :submit_new_piv_cac, params: { skip: 'true' } }
+
+      before do
+        allow(controller).to receive(:user_session).and_return(add_piv_cac_after_2fa: true)
+      end
+
+      it 'deletes add_piv_cac_after_2fa session value' do
+        response
+
+        expect(controller.user_session).not_to have_key(:add_piv_cac_after_2fa)
+      end
+
+      it 'redirects to after sign in path' do
+        expect(response).to redirect_to(account_path)
       end
     end
   end

--- a/spec/factories/piv_cac_configurations.rb
+++ b/spec/factories/piv_cac_configurations.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
 
   factory :piv_cac_configuration do
     name { Faker::Lorem.unique.words.join(' ') }
-    x509_dn_uuid { 'helloworld' }
+    x509_dn_uuid { Random.uuid }
     user
   end
 end

--- a/spec/features/two_factor_authentication/piv_cac_sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/piv_cac_sign_in_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+RSpec.feature 'sign in with piv/cac' do
+  include SamlAuthHelper
+  include OidcAuthHelper
+
+  let(:user) { create(:user, :with_piv_or_cac, :with_phone) }
+
+  before do
+    sign_in_before_2fa(user)
+  end
+
+  context 'with piv/cac mismatch error' do
+    before do
+      stub_piv_cac_service(error: 'user.piv_cac_mismatch')
+    end
+
+    it 'allows a user to add a replacement piv after authenticating with another method' do
+      click_on t('forms.piv_cac_login.submit')
+      follow_piv_cac_redirect
+
+      expect(page).to have_current_path(login_two_factor_piv_cac_mismatch_path)
+      expect(page).to have_button(t('two_factor_authentication.piv_cac_mismatch.skip'))
+
+      click_on t('two_factor_authentication.piv_cac_mismatch.cta')
+
+      expect(page).to have_current_path(login_two_factor_options_path)
+      expect(page).to have_content(t('two_factor_authentication.piv_cac_mismatch.2fa_before_add'))
+      expect(page).to have_field(t('two_factor_authentication.login_options.sms'))
+      expect(page).to have_field(
+        t('two_factor_authentication.login_options.piv_cac'),
+        disabled: true,
+      )
+
+      select_2fa_option(:sms)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(page).to have_current_path(setup_piv_cac_path)
+      expect(page).to have_button(t('mfa.skip'))
+
+      stub_piv_cac_service
+      fill_in t('forms.totp_setup.totp_step_1'), with: 'New PIV'
+      click_on t('forms.piv_cac_setup.submit')
+      follow_piv_cac_redirect
+
+      expect(page).to have_current_path(account_path)
+      within(page.find('.card', text: t('headings.account.federal_employee_id'))) do
+        expect(page).to have_css('lg-manageable-authenticator', count: 2)
+      end
+    end
+
+    context 'with partner requiring piv/cac' do
+      before do
+        visit_idp_from_oidc_sp_with_hspd12_and_require_piv_cac
+      end
+
+      it 'does not allow a user to skip adding piv/cac' do
+        click_on t('forms.piv_cac_login.submit')
+        follow_piv_cac_redirect
+
+        expect(page).to have_current_path(login_two_factor_piv_cac_mismatch_path)
+        expect(page).not_to have_button(t('two_factor_authentication.piv_cac_mismatch.skip'))
+
+        click_on t('two_factor_authentication.piv_cac_mismatch.cta')
+
+        expect(page).to have_current_path(login_two_factor_options_path)
+        expect(page).to have_content(t('two_factor_authentication.piv_cac_mismatch.2fa_before_add'))
+        expect(page).to have_field(t('two_factor_authentication.login_options.sms'))
+        expect(page).to have_field(
+          t('two_factor_authentication.login_options.piv_cac'),
+          disabled: true,
+        )
+
+        select_2fa_option(:sms)
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        expect(page).to have_current_path(setup_piv_cac_path)
+        expect(page).not_to have_button(t('mfa.skip'))
+
+        stub_piv_cac_service
+        fill_in t('forms.totp_setup.totp_step_1'), with: 'New PIV'
+        click_on t('forms.piv_cac_setup.submit')
+        follow_piv_cac_redirect
+
+        expect(current_path).to eq(sign_up_completed_path)
+
+        click_agree_and_continue
+        expect(oidc_decoded_id_token[:x509_presented]).to eq(true)
+        expect(oidc_decoded_id_token[:x509_subject]).to be_present
+      end
+    end
+
+    context 'if the user chooses to skip adding piv/cac when prompted with mismatch' do
+      it 'allows the user to authenticate with another method' do
+        click_on t('forms.piv_cac_login.submit')
+        follow_piv_cac_redirect
+
+        expect(page).to have_current_path(login_two_factor_piv_cac_mismatch_path)
+        expect(page).to have_button(t('two_factor_authentication.piv_cac_mismatch.skip'))
+
+        click_on t('two_factor_authentication.piv_cac_mismatch.skip')
+
+        expect(page).to have_current_path(login_two_factor_options_path)
+        expect(page).not_to have_content(
+          t('two_factor_authentication.piv_cac_mismatch.2fa_before_add'),
+        )
+        expect(page).to have_field(t('two_factor_authentication.login_options.sms'))
+        expect(page).to have_field(
+          t('two_factor_authentication.login_options.piv_cac'),
+          disabled: true,
+        )
+
+        select_2fa_option(:sms)
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        expect(page).to have_current_path(account_path)
+      end
+    end
+
+    context 'with no other mfa methods available' do
+      let(:user) { create(:user, :with_piv_or_cac) }
+
+      it 'prompts the user to reset their account' do
+        click_on t('forms.piv_cac_login.submit')
+        follow_piv_cac_redirect
+
+        expect(page).to have_current_path(login_two_factor_piv_cac_mismatch_path)
+        expect(page).not_to have_button(t('two_factor_authentication.piv_cac_mismatch.cta'))
+        expect(page).not_to have_button(t('two_factor_authentication.piv_cac_mismatch.skip'))
+        expect(page).to have_link(t('two_factor_authentication.piv_cac_mismatch.delete_account'))
+
+        click_on t('two_factor_authentication.piv_cac_mismatch.delete_account')
+
+        expect(page).to have_current_path(account_reset_recovery_options_path)
+      end
+    end
+  end
+end

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -415,18 +415,6 @@ RSpec.feature 'Two Factor Authentication' do
       expect(current_path).to eq account_path
     end
 
-    scenario 'user uses incorrect PIV/CAC as their second factor' do
-      user = user_with_piv_cac
-      sign_in_before_2fa(user)
-      stub_piv_cac_service(uuid: Random.uuid)
-
-      click_on t('forms.piv_cac_mfa.submit')
-      follow_piv_cac_redirect
-
-      expect(current_path).to eq login_two_factor_piv_cac_path
-      expect(page).to have_content(t('two_factor_authentication.invalid_piv_cac'))
-    end
-
     context 'user with Voice preference sends SMS, causing a Telephony error' do
       let(:user) do
         create(

--- a/spec/presenters/two_factor_authentication/sign_in_piv_cac_selection_presenter_spec.rb
+++ b/spec/presenters/two_factor_authentication/sign_in_piv_cac_selection_presenter_spec.rb
@@ -14,6 +14,43 @@ RSpec.describe TwoFactorAuthentication::SignInPivCacSelectionPresenter do
     end
   end
 
+  describe '#render_in' do
+    let(:user_session) { {} }
+    let(:view_context) { ActionController::Base.new.view_context }
+
+    before do
+      allow(view_context).to receive(:user_session).and_return(user_session)
+    end
+
+    it 'assigns disabled instance variable to false ahead of capture' do
+      expect(view_context).to receive(:capture) do
+        expect(presenter.instance_variable_get(:@disabled)).to eq(false)
+      end
+
+      presenter.render_in(view_context)
+    end
+
+    it 'renders captured block content' do
+      expect(view_context).to receive(:capture) do |*_args, &block|
+        expect(block.call).to eq('content')
+      end
+
+      presenter.render_in(view_context) { 'content' }
+    end
+
+    context 'when view context user session incudes add_piv_cac_after_2fa key' do
+      let(:user_session) { { add_piv_cac_after_2fa: :anything } }
+
+      it 'assigns disabled instance variable to true ahead of capture' do
+        expect(view_context).to receive(:capture) do
+          expect(presenter.instance_variable_get(:@disabled)).to eq(true)
+        end
+
+        presenter.render_in(view_context)
+      end
+    end
+  end
+
   describe '#label' do
     it 'returns the label text' do
       expect(presenter.label).to eq(
@@ -27,6 +64,26 @@ RSpec.describe TwoFactorAuthentication::SignInPivCacSelectionPresenter do
       expect(presenter.info).to eq(
         t('two_factor_authentication.login_options.piv_cac_info'),
       )
+    end
+  end
+
+  describe '#disabled?' do
+    subject(:disabled?) { presenter.disabled? }
+
+    context 'when disabled instance variable is unassigned' do
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when disabled instance variable is false' do
+      before { presenter.instance_variable_set(:@disabled, false) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when disabled instance variable is true' do
+      before { presenter.instance_variable_set(:@disabled, true) }
+
+      it { is_expected.to eq(true) }
     end
   end
 end

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -9,15 +9,17 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
   let(:piv_cac_required) { false }
   let(:reauthentication_context) { false }
   let(:service_provider) { nil }
+  let(:add_piv_cac_after_2fa) { false }
 
   subject(:presenter) do
     TwoFactorLoginOptionsPresenter.new(
-      user: user,
-      view: view,
-      reauthentication_context: reauthentication_context,
-      service_provider: service_provider,
-      phishing_resistant_required: phishing_resistant_required,
-      piv_cac_required: piv_cac_required,
+      user:,
+      view:,
+      reauthentication_context:,
+      service_provider:,
+      phishing_resistant_required:,
+      piv_cac_required:,
+      add_piv_cac_after_2fa:,
     )
   end
 
@@ -44,6 +46,12 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
     subject { presenter.info }
 
     context 'default user session context' do
+      it { should eq t('two_factor_authentication.login_intro') }
+    end
+
+    context 'add piv cac after 2fa' do
+      let(:add_piv_cac_after_2fa) { true }
+
       it { should eq t('two_factor_authentication.login_intro') }
     end
 
@@ -146,6 +154,24 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
           )
         end
       end
+
+      context 'add piv cac after 2fa' do
+        let(:add_piv_cac_after_2fa) { true }
+
+        it 'returns all mfas associated with account' do
+          expect(options_classes).to eq(
+            [
+              TwoFactorAuthentication::SignInPhoneSelectionPresenter,
+              TwoFactorAuthentication::SignInPhoneSelectionPresenter,
+              TwoFactorAuthentication::SignInWebauthnSelectionPresenter,
+              TwoFactorAuthentication::SignInBackupCodeSelectionPresenter,
+              TwoFactorAuthentication::SignInPivCacSelectionPresenter,
+              TwoFactorAuthentication::SignInAuthAppSelectionPresenter,
+              TwoFactorAuthentication::SignInPersonalKeySelectionPresenter,
+            ],
+          )
+        end
+      end
     end
 
     context 'phishing resistant required' do
@@ -162,6 +188,24 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
 
       context 'in reauthentication context' do
         let(:reauthentication_context) { true }
+
+        it 'returns all mfas associated with account' do
+          expect(options_classes).to eq(
+            [
+              TwoFactorAuthentication::SignInPhoneSelectionPresenter,
+              TwoFactorAuthentication::SignInPhoneSelectionPresenter,
+              TwoFactorAuthentication::SignInWebauthnSelectionPresenter,
+              TwoFactorAuthentication::SignInBackupCodeSelectionPresenter,
+              TwoFactorAuthentication::SignInPivCacSelectionPresenter,
+              TwoFactorAuthentication::SignInAuthAppSelectionPresenter,
+              TwoFactorAuthentication::SignInPersonalKeySelectionPresenter,
+            ],
+          )
+        end
+      end
+
+      context 'add piv cac after 2fa' do
+        let(:add_piv_cac_after_2fa) { true }
 
         it 'returns all mfas associated with account' do
           expect(options_classes).to eq(
@@ -212,6 +256,12 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
 
         it { should be_nil }
       end
+
+      context 'add piv cac after 2fa' do
+        let(:add_piv_cac_after_2fa) { true }
+
+        it { should be_nil }
+      end
     end
 
     context 'piv cac required' do
@@ -238,6 +288,12 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
 
       context 'in reauthentication context' do
         let(:reauthentication_context) { true }
+
+        it { should be_nil }
+      end
+
+      context 'add piv cac after 2fa' do
+        let(:add_piv_cac_after_2fa) { true }
 
         it { should be_nil }
       end

--- a/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
@@ -5,18 +5,22 @@ RSpec.describe 'two_factor_authentication/options/index.html.erb' do
   let(:phishing_resistant_required) { false }
   let(:piv_cac_required) { false }
   let(:reauthentication_context) { false }
+  let(:add_piv_cac_after_2fa) { false }
+
+  subject(:rendered) { render }
 
   before do
     allow(view).to receive(:user_session).and_return({})
     allow(view).to receive(:current_user).and_return(User.new)
 
     @presenter = TwoFactorLoginOptionsPresenter.new(
-      user: user,
-      view: view,
-      reauthentication_context: reauthentication_context,
+      user:,
+      view:,
+      reauthentication_context:,
       service_provider: nil,
-      phishing_resistant_required: phishing_resistant_required,
-      piv_cac_required: piv_cac_required,
+      phishing_resistant_required:,
+      piv_cac_required:,
+      add_piv_cac_after_2fa:,
     )
     @two_factor_options_form = TwoFactorLoginOptionsForm.new(user)
   end
@@ -26,27 +30,27 @@ RSpec.describe 'two_factor_authentication/options/index.html.erb' do
       t('two_factor_authentication.login_options_title'),
     )
 
-    render
+    rendered
   end
 
   it 'has a localized heading' do
-    render
-
     expect(rendered).to have_content \
       t('two_factor_authentication.login_options_title')
   end
 
   it 'has a localized intro text' do
-    render
-
     expect(rendered).to have_content \
       t('two_factor_authentication.login_intro')
   end
 
   it 'has a cancel link' do
-    render
-
     expect(rendered).to have_link(t('links.cancel_account_creation'), href: sign_up_cancel_path)
+  end
+
+  it 'does not display info text for adding piv cac after 2fa' do
+    expect(rendered).not_to have_content(
+      t('two_factor_authentication.piv_cac_mismatch.2fa_before_add'),
+    )
   end
 
   context 'phone vendor outage' do
@@ -54,8 +58,6 @@ RSpec.describe 'two_factor_authentication/options/index.html.erb' do
       create(:phone_configuration, user: user, phone: '(202) 555-1111')
       allow_any_instance_of(OutageStatus).to receive(:vendor_outage?).and_return(false)
       allow_any_instance_of(OutageStatus).to receive(:vendor_outage?).with(:sms).and_return(true)
-
-      render
     end
 
     it 'renders alert banner' do
@@ -76,10 +78,19 @@ RSpec.describe 'two_factor_authentication/options/index.html.erb' do
     end
   end
 
+  context 'when adding piv cac after 2fa' do
+    let(:add_piv_cac_after_2fa) { true }
+
+    it 'displays info text for adding piv cac after 2fa' do
+      expect(rendered).to have_selector(
+        '.usa-alert.usa-alert--info',
+        text: t('two_factor_authentication.piv_cac_mismatch.2fa_before_add'),
+      )
+    end
+  end
+
   context 'with phishing resistant required' do
     let(:phishing_resistant_required) { true }
-
-    before { render }
 
     it 'displays warning text' do
       expect(rendered).to have_selector(
@@ -93,8 +104,6 @@ RSpec.describe 'two_factor_authentication/options/index.html.erb' do
 
   context 'with piv cac required' do
     let(:piv_cac_required) { true }
-
-    before { render }
 
     it 'displays warning text' do
       expect(rendered).to have_selector(
@@ -110,15 +119,11 @@ RSpec.describe 'two_factor_authentication/options/index.html.erb' do
     let(:reauthentication_context) { true }
 
     it 'has a localized heading' do
-      render
-
       expect(rendered).to have_content \
         t('two_factor_authentication.login_options_reauthentication_title')
     end
 
     it 'has a localized intro text' do
-      render
-
       expect(rendered).to have_content \
         t('two_factor_authentication.login_intro_reauthentication')
     end

--- a/spec/views/two_factor_authentication/piv_cac_mismatch/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/piv_cac_mismatch/show.html.erb_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'two_factor_authentication/piv_cac_mismatch/show.html.erb' do
+  let(:has_other_authentication_methods) {}
+  let(:piv_cac_required) {}
+
+  subject(:rendered) { render }
+
+  before do
+    @has_other_authentication_methods = has_other_authentication_methods
+    @piv_cac_required = piv_cac_required
+    allow(view).to receive(:user_session).and_return({})
+  end
+
+  context 'when user does not have other authentication methods' do
+    let(:has_other_authentication_methods) { false }
+
+    it 'renders instructions with a link to delete their account' do
+      expect(rendered).to have_content(
+        t(
+          'two_factor_authentication.piv_cac_mismatch.instructions_no_other_method',
+          app_name: APP_NAME,
+        ),
+      )
+      expect(rendered).to have_link(
+        t('two_factor_authentication.piv_cac_mismatch.delete_account'),
+        href: account_reset_recovery_options_url,
+      )
+    end
+  end
+
+  context 'when user has other authentication methods' do
+    let(:has_other_authentication_methods) { true }
+
+    it 'renders instructions with a link to authenticate' do
+      expect(rendered).to have_content(t('two_factor_authentication.piv_cac_mismatch.instructions'))
+      expect(rendered).to have_button(t('two_factor_authentication.piv_cac_mismatch.cta'))
+    end
+
+    context 'when piv cac is required' do
+      let(:piv_cac_required) { true }
+
+      it 'does not provide an option to skip setting up piv/cac' do
+        expect(rendered).not_to have_button(t('two_factor_authentication.piv_cac_mismatch.skip'))
+      end
+    end
+
+    context 'when piv cac is not required' do
+      let(:piv_cac_required) { false }
+
+      it 'provides an option to skip setting up piv/cac' do
+        expect(rendered).to have_button(t('two_factor_authentication.piv_cac_mismatch.skip'))
+      end
+    end
+  end
+end

--- a/spec/views/users/piv_cac_authentication_setup/new.html.erb_spec.rb
+++ b/spec/views/users/piv_cac_authentication_setup/new.html.erb_spec.rb
@@ -1,35 +1,77 @@
 require 'rails_helper'
 
 RSpec.describe 'users/piv_cac_authentication_setup/new.html.erb' do
+  let(:user) { create(:user) }
+  let(:user_session) { {} }
+  let(:in_multi_mfa_selection_flow) { false }
+
+  subject(:rendered) { render }
+
+  before do
+    allow(view).to receive(:user_session).and_return(user_session)
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:in_multi_mfa_selection_flow?).and_return(in_multi_mfa_selection_flow)
+    form = OpenStruct.new
+    @presenter = PivCacAuthenticationSetupPresenter.new(user, true, form)
+  end
+
+  it 'does not show option to skip setting up piv/cac' do
+    expect(rendered).not_to have_button(t('mfa.skip'))
+  end
+
   context 'user has sufficient factors' do
+    let(:user) { create(:user, :fully_registered) }
+
     it 'renders a link to cancel and go back to the account page' do
-      user = create(:user, :fully_registered)
-      allow(view).to receive(:current_user).and_return(user)
-      allow(view).to receive(:user_session).and_return(signing_up: false)
-      allow(view).to receive(:in_multi_mfa_selection_flow?).and_return(false)
-      form = OpenStruct.new
-      @presenter = PivCacAuthenticationSetupPresenter.new(user, true, form)
-
-      render
-
       expect(rendered).to have_link(t('links.cancel'), href: account_path)
+    end
+
+    context 'user is in the process of setting up multiple MFAs' do
+      let(:in_multi_mfa_selection_flow) { true }
+
+      it 'renders a link to choose a different option' do
+        expect(rendered).to have_link(
+          t('two_factor_authentication.choose_another_option'),
+          href: authentication_methods_setup_path,
+        )
+      end
     end
   end
 
   context 'user is setting up 2FA' do
+    let(:user) { create(:user) }
+
     it 'renders a link to choose a different option' do
-      user = create(:user)
-      allow(view).to receive(:current_user).and_return(user)
-      allow(view).to receive(:user_session).and_return(signing_up: true)
-      form = OpenStruct.new
-      @presenter = PivCacAuthenticationSetupPresenter.new(user, false, form)
-
-      render
-
       expect(rendered).to have_link(
         t('two_factor_authentication.choose_another_option'),
         href: authentication_methods_setup_path,
       )
+    end
+  end
+
+  context 'when adding piv cac after 2fa' do
+    let(:user_session) { { add_piv_cac_after_2fa: true } }
+
+    it 'shows option to skip setting up piv/cac' do
+      expect(rendered).to have_button(t('mfa.skip'))
+    end
+
+    it 'renders a link to cancel and sign out' do
+      expect(rendered).to have_link(t('links.cancel'), href: sign_out_path)
+    end
+
+    context 'when SP requires PIV/CAC' do
+      before do
+        @piv_cac_required = true
+      end
+
+      it 'does not show option to skip setting up piv/cac' do
+        expect(rendered).not_to have_button(t('mfa.skip'))
+      end
+
+      it 'renders a link to cancel and sign out' do
+        expect(rendered).to have_link(t('links.cancel'), href: sign_out_path)
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-14455](https://cm-jira.usa.gov/browse/LG-14455)

## 🛠 Summary of changes

Implements a new workflow to help guide a user to adding a replacement PIV/CAC if they attempt to authenticate with a PIV which isn't the one associated with their account, such as if a user receives a new PIV/CAC card.

## 📜 Testing Plan

This is easiest to test using the simulated PIV/CAC service in local development, where you can create custom subject names for PIV/CAC to force a mismatch:

```
# config/application.yml
identity_pki_disabled: true
```

Verify that the PIV/CAC mismatch replacement workflow is shown under expected circumstances:

1. Have [sample application](https://github.com/18f/identity-oidc-sinatra) running in a separate process
2. Go to http://localhost:3000
3. Create an account with PIV/CAC as an authenticator. Optionally add another MFA, as this will affect the experience that follows
4. From account dashboard, click "Forget all browsers" and confirm the prompt
5. Sign out
6. Go to http://localhost:9292 . Optionally change "Authentication Assurance Level (AAL)" to "HSPD12 required", as this will affect the experience that follows
7. Click  "Sign in"
8. Submit email and password for the account you just created
9. When prompted to authenticate with PIV/CAC, submit with a subject different from what you set up with
10. Observe that you see a screen "This government employee ID is not connected to your account".
    1. If you did not add any other MFAs to your account, observe that this only gives you the option to delete your account
    2. Observe that you see an option to skip adding PIV/CAC, unless you chose "HSPD12" required in sample application
12. Click primary action button
13. If you chose to "Authenticate and add PIV/CAC", observe that you're brought to the MFA options page with all options listed, PIV/CAC disabled, and an alert banner indicating you'll add PIV after authenticating
14. Authenticate with another MFA method
15. Observe that you're brought to the PIV/CAC setup screen. You're given another option to skip adding PIV/CAC, unless you chose "HSPD12" required in sample application
16. Setup new PIV/CAC
17. Observe that you're sent along to confirm consent to share information with partner application

## 👀 Screenshots

Language|Mismatch Prompt|Mismatch Prompt (HSPD12)|Mismatch Prompt (No other options)|MFA Options|PIV/CAC Setup|PIV/CAC Setup (HSPD12)
---|---|---|---|---|---|---
English|![mismatch-prompt-een](https://github.com/user-attachments/assets/076a48cc-0401-49db-b93b-5e2497e86db4)|![mismatch-prompt-hspd12-en](https://github.com/user-attachments/assets/3e2eccee-979c-497d-80d0-014ed89798fb)|![mismatch-prompt-no-mfa-en](https://github.com/user-attachments/assets/c21fe2af-3226-429a-af53-84a96e4c4f69)|![mismatch-mfa-en](https://github.com/user-attachments/assets/a5275777-5938-41f7-8387-c256d3ad5c45)|![mismatch-piv-setup-skippable-en](https://github.com/user-attachments/assets/0992ec67-1617-4a03-b90c-0eb80f3adfa4)|![mismatch-piv-setup-hspd12-en](https://github.com/user-attachments/assets/7ce2ff25-6350-4c1d-8d23-09df30be3f46)
Spanish|![mismatch-prompt-es](https://github.com/user-attachments/assets/f38b2af1-1298-4e7e-80ed-e992d242e8c9)|![mismatch-prompt-hspd12-es](https://github.com/user-attachments/assets/e1e289a8-c55f-4d83-a015-64cb9c8e30eb)|![mismatch-prompt-no-mfa-es](https://github.com/user-attachments/assets/9dc287d5-abb3-46cf-9406-37657dcf9734)|![mismatch-mfa-es](https://github.com/user-attachments/assets/0a2ac508-cce5-4e7f-9ed4-90be42f2bd50)|![mismatch-piv-setup-skippable-es](https://github.com/user-attachments/assets/4df981d2-152b-48df-9993-493c15396a1d)|![mismatch-piv-setup-hspd12-es](https://github.com/user-attachments/assets/cf3c9ee2-f097-47ff-a615-d25b423f51ae)
French|![mismatch-prompt-fr](https://github.com/user-attachments/assets/75fd8efa-1cb3-430e-9997-1f2d911cfe55)|![mismatch-prompt-hspd12-fr](https://github.com/user-attachments/assets/a7dee0a9-e1e6-41e3-9299-b837e403ed70)|![mismatch-prompt-no-mfa-fr](https://github.com/user-attachments/assets/575053cf-179a-4eac-934a-2d3b7691b9a0)|![mismatch-mfa-fr](https://github.com/user-attachments/assets/ae6d239f-b6e8-4e19-8601-a96700191a1e)|![mismatch-piv-setup-skippable-fr](https://github.com/user-attachments/assets/7d045f33-4482-44d4-9092-f5f7c799b1dc)|![mismatch-piv-setup-hspd12-fr](https://github.com/user-attachments/assets/51f704e3-b9ad-4eb5-ab99-8888197321a0)
Chinese|![mismatch-prompt-zh](https://github.com/user-attachments/assets/82a235c5-392e-42d1-8202-d20d6ee1db86)|![mismatch-prompt-hspd12-zh](https://github.com/user-attachments/assets/4caef6c1-844f-4cd2-aaeb-8eee31e96e16)|![mismatch-prompt-no-mfa-zh](https://github.com/user-attachments/assets/605ad785-6af3-42e5-8f0c-6337adb298d2)|![mismatch-mfa-zh](https://github.com/user-attachments/assets/8a583691-31d5-453f-bb83-ceadfd74af29)|![mismatch-piv-setup-skippable-zh](https://github.com/user-attachments/assets/097dd16a-5c7e-4d21-83dc-1b39cf1ea21a)|![mismatch-piv-setup-hspd12-zh](https://github.com/user-attachments/assets/06fbcef9-fec9-4892-a83c-041478255953)