### PR TITLE
Add feature usage table to Protocols Report

### DIFF
--- a/app/jobs/reports/protocols_report.rb
+++ b/app/jobs/reports/protocols_report.rb
@@ -8,6 +8,11 @@ module Reports
 
     attr_accessor :report_date
 
+    def initialize(report_date = nil, *args, **rest)
+      @report_date = report_date
+      super(*args, **rest)
+    end
+
     def perform(report_date)
       return unless IdentityConfig.store.s3_reports_enabled
 
@@ -33,10 +38,14 @@ module Reports
     private
 
     def weekly_protocols_emailable_reports
-      Reporting::ProtocolsReport.new(
+      report.as_emailable_reports
+    end
+
+    def report
+      @report ||= Reporting::ProtocolsReport.new(
         issuers: nil,
         time_range: report_date.all_week,
-      ).as_emailable_reports
+      )
     end
 
     def report_configs

--- a/lib/reporting/protocols_report.rb
+++ b/lib/reporting/protocols_report.rb
@@ -72,6 +72,10 @@ module Reporting
           title: 'Deprecated Parameter Usage',
           table: deprecated_parameters_table,
         ),
+        Reporting::EmailableReport.new(
+          title: 'Feature Usage',
+          table: feature_use_table,
+        ),
       ]
     end
 

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -23,6 +23,21 @@ class ReportMailerPreview < ActionMailer::Preview
     )
   end
 
+  def protocols_report
+    date = Time.zone.yesterday
+    report = Reports::ProtocolsReport.new(date)
+
+    stub_cloudwatch_client(report.send(:report))
+
+    ReportMailer.tables_report(
+      email: 'test@example.com',
+      subject: "Weekly Protocols Report - #{date}",
+      message: "Report: protocols-report #{date}",
+      attachment_format: :csv,
+      reports: report.send(:weekly_protocols_emailable_reports),
+    )
+  end
+
   def fraud_metrics_report
     fraud_metrics_report = Reports::FraudMetricsReport.new(Time.zone.yesterday)
 


### PR DESCRIPTION
## 🎫 Ticket
Add facial match query to protocols report](https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/123)

## 🛠 Summary of changes
My first ticket related to these changes didn't include the new table in the emailable report method, so when the weekly email went out the feature usage table was not included.

This change:
- adds the table to the report
- adds the report to the [mailer previews](https://github.com/18F/identity-idp/blob/main/docs/local-development.md#email-template-previews) that can be accessed at `localhost:3000/rails/mailers` so it's easier to catch these kinds of issues.
 
<img width="885" alt="Preview of Weekly Protocols Report with several tables, including a 'Feature Usage' table" src="https://github.com/user-attachments/assets/2b9b3c3c-2e47-4fbb-8c57-1728bfc5fc00">

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
