### PR TITLE
Extract common spec helpers for decoding OIDC tokens

### DIFF
--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -17,9 +17,8 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
         fill_in_code_with_last_phone_otp
         click_submit_default
         click_agree_and_continue if current_path == sign_up_completed_path
-        decoded_id_token = fetch_oidc_id_token_info
-        expect(decoded_id_token[:email]).to eq(emails.first)
-        expect(decoded_id_token[:all_emails]).to be_nil
+        expect(oidc_decoded_id_token[:email]).to eq(emails.first)
+        expect(oidc_decoded_id_token[:all_emails]).to be_nil
 
         Capybara.reset_session!
       end
@@ -41,8 +40,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
 
       expect(current_path).to eq(sign_up_completed_path)
       click_agree_and_continue
-      decoded_id_token = fetch_oidc_id_token_info
-      expect(decoded_id_token[:email]).to eq(emails.second)
+      expect(oidc_decoded_id_token[:email]).to eq(emails.second)
     end
 
     scenario 'signing in with OIDC after deleting email linked to identity' do
@@ -69,8 +67,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       # Sign in again to partner application
       visit_idp_from_oidc_sp(scope: 'openid email')
 
-      decoded_id_token = fetch_oidc_id_token_info
-      expect(decoded_id_token[:email]).to eq(email1.email)
+      expect(oidc_decoded_id_token[:email]).to eq(email1.email)
     end
 
     scenario 'signing in with SAML sends the email address used to sign in' do
@@ -161,8 +158,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       click_submit_default
       click_agree_and_continue
 
-      decoded_id_token = fetch_oidc_id_token_info
-      expect(decoded_id_token[:all_emails]).to match_array(emails)
+      expect(oidc_decoded_id_token[:all_emails]).to match_array(emails)
     end
 
     scenario 'signing in with SAML sends all emails' do
@@ -205,42 +201,5 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       prompt: 'select_account',
       nonce: SecureRandom.hex,
     )
-  end
-
-  def fetch_oidc_id_token_info
-    redirect_uri = URI(oidc_redirect_url)
-    redirect_params = Rack::Utils.parse_query(redirect_uri.query).with_indifferent_access
-    code = redirect_params[:code]
-
-    jwt_payload = {
-      iss: 'urn:gov:gsa:openidconnect:sp:server',
-      sub: 'urn:gov:gsa:openidconnect:sp:server',
-      aud: api_openid_connect_token_url,
-      jti: SecureRandom.hex,
-      exp: 5.minutes.from_now.to_i,
-    }
-
-    client_assertion = JWT.encode(jwt_payload, client_private_key, 'RS256')
-    client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-
-    page.driver.post(
-      api_openid_connect_token_path,
-      grant_type: 'authorization_code',
-      code: code,
-      client_assertion_type: client_assertion_type,
-      client_assertion: client_assertion,
-    )
-
-    token_response = JSON.parse(page.body).with_indifferent_access
-    id_token = token_response[:id_token]
-    JWT.decode(id_token, nil, false).first.with_indifferent_access
-  end
-
-  def client_private_key
-    @client_private_key ||= begin
-      OpenSSL::PKey::RSA.new(
-        File.read(Rails.root.join('keys', 'saml_test_sp.key')),
-      )
-    end
   end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -292,8 +292,7 @@ module Features
     end
 
     def acknowledge_and_confirm_personal_key
-      checkbox_header = t('forms.personal_key.required_checkbox')
-      find('label', text: /#{checkbox_header}/).click
+      check t('forms.personal_key.required_checkbox')
       click_continue
     end
 

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -135,7 +135,8 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
   end
 
   def expect_successful_oidc_handoff
-    token_response = oidc_decoded_id_token
+    token_response = oidc_decoded_token
+    decoded_id_token = oidc_decoded_id_token
 
     sub = decoded_id_token[:sub]
     expect(sub).to be_present

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples 'sp handoff after identity verification' do |sp|
   include SamlAuthHelper
+  include OidcAuthHelper
   include IdvHelper
   include JavascriptDriverHelper
 
@@ -134,67 +135,31 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
   end
 
   def expect_successful_oidc_handoff
-    redirect_uri = URI(current_url)
-    redirect_params = Rack::Utils.parse_query(redirect_uri.query).with_indifferent_access
+    token_response = oidc_decoded_id_token
 
-    expect(redirect_uri.to_s).to start_with('http://localhost:7654/auth/result')
-    expect(redirect_params[:state]).to eq(@state)
+    sub = decoded_id_token[:sub]
+    expect(sub).to be_present
+    expect(decoded_id_token[:nonce]).to eq(@nonce)
+    expect(decoded_id_token[:aud]).to eq(@client_id)
+    expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::IAL_VERIFIED_ACR)
+    expect(decoded_id_token[:iss]).to eq(root_url)
+    expect(decoded_id_token[:email]).to eq(user.confirmed_email_addresses.first.email)
+    expect(decoded_id_token[:given_name]).to eq('FAKEY')
+    expect(decoded_id_token[:social_security_number]).to eq(DocAuthHelper::GOOD_SSN)
 
-    code = redirect_params[:code]
-    expect(code).to be_present
+    access_token = token_response[:access_token]
+    expect(access_token).to be_present
 
-    jwt_payload = {
-      iss: @client_id,
-      sub: @client_id,
-      aud: api_openid_connect_token_url,
-      jti: SecureRandom.hex,
-      exp: 5.minutes.from_now.to_i,
-    }
+    page.driver.get api_openid_connect_userinfo_path,
+                    {},
+                    'HTTP_AUTHORIZATION' => "Bearer #{access_token}"
 
-    client_assertion = JWT.encode(jwt_payload, client_private_key, 'RS256')
-    client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-
-    Capybara.using_driver(:desktop_rack_test) do
-      page.driver.post api_openid_connect_token_path,
-                       grant_type: 'authorization_code',
-                       code: code,
-                       client_assertion_type: client_assertion_type,
-                       client_assertion: client_assertion
-
-      expect(page.status_code).to eq(200)
-      token_response = JSON.parse(page.body).with_indifferent_access
-
-      id_token = token_response[:id_token]
-      expect(id_token).to be_present
-
-      decoded_id_token, _headers = JWT.decode(
-        id_token, sp_public_key, true, algorithm: 'RS256'
-      ).map(&:with_indifferent_access)
-
-      sub = decoded_id_token[:sub]
-      expect(sub).to be_present
-      expect(decoded_id_token[:nonce]).to eq(@nonce)
-      expect(decoded_id_token[:aud]).to eq(@client_id)
-      expect(decoded_id_token[:acr]).to eq(Saml::Idp::Constants::IAL_VERIFIED_ACR)
-      expect(decoded_id_token[:iss]).to eq(root_url)
-      expect(decoded_id_token[:email]).to eq(user.confirmed_email_addresses.first.email)
-      expect(decoded_id_token[:given_name]).to eq('FAKEY')
-      expect(decoded_id_token[:social_security_number]).to eq(DocAuthHelper::GOOD_SSN)
-
-      access_token = token_response[:access_token]
-      expect(access_token).to be_present
-
-      page.driver.get api_openid_connect_userinfo_path,
-                      {},
-                      'HTTP_AUTHORIZATION' => "Bearer #{access_token}"
-
-      userinfo_response = JSON.parse(page.body).with_indifferent_access
-      expect(userinfo_response[:sub]).to eq(sub)
-      expect(AgencyIdentity.where(user_id: user.id, agency_id: 2).first.uuid).to eq(sub)
-      expect(userinfo_response[:email]).to eq(user.confirmed_email_addresses.first.email)
-      expect(userinfo_response[:given_name]).to eq('FAKEY')
-      expect(userinfo_response[:social_security_number]).to eq(DocAuthHelper::GOOD_SSN)
-    end
+    userinfo_response = JSON.parse(page.body).with_indifferent_access
+    expect(userinfo_response[:sub]).to eq(sub)
+    expect(AgencyIdentity.where(user_id: user.id, agency_id: 2).first.uuid).to eq(sub)
+    expect(userinfo_response[:email]).to eq(user.confirmed_email_addresses.first.email)
+    expect(userinfo_response[:given_name]).to eq('FAKEY')
+    expect(userinfo_response[:social_security_number]).to eq(DocAuthHelper::GOOD_SSN)
   end
 
   def expect_successful_saml_handoff
@@ -208,22 +173,5 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       expect(current_url).to eq @saml_authn_request
     end
     expect(xmldoc.phone_number.children.children.to_s).to eq(Phonelib.parse(profile_phone).e164)
-  end
-
-  def client_private_key
-    @client_private_key ||= begin
-      OpenSSL::PKey::RSA.new(
-        File.read(Rails.root.join('keys', 'saml_test_sp.key')),
-      )
-    end
-  end
-
-  def sp_public_key
-    page.driver.get api_openid_connect_certs_path
-
-    expect(page.status_code).to eq(200)
-    certs_response = JSON.parse(page.body).with_indifferent_access
-
-    JWT::JWK.import(certs_response[:keys].first).public_key
   end
 end

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -185,15 +185,15 @@ module OidcAuthHelper
     client_assertion = JWT.encode(jwt_payload, client_private_key, 'RS256')
     client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
 
-    page.driver.post(
-      api_openid_connect_token_path,
+    response = Faraday.post(
+      api_openid_connect_token_url,
       grant_type: 'authorization_code',
       code:,
       client_assertion_type:,
       client_assertion:,
     )
 
-    @oidc_decoded_token = JSON.parse(page.body).with_indifferent_access
+    @oidc_decoded_token = JSON.parse(response.body).with_indifferent_access
   end
 
   def oidc_decoded_id_token

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -1,4 +1,8 @@
+require_relative 'features/javascript_driver_helper'
+
 module OidcAuthHelper
+  include JavascriptDriverHelper
+
   OIDC_ISSUER = 'urn:gov:gsa:openidconnect:sp:server'.freeze
   OIDC_IAL1_ISSUER = 'urn:gov:gsa:openidconnect:sp:server_ial1'.freeze
   OIDC_AAL3_ISSUER = 'urn:gov:gsa:openidconnect:sp:server_requiring_aal3'.freeze
@@ -155,6 +159,9 @@ module OidcAuthHelper
   end
 
   def oidc_redirect_url
+    # Page will redirect automatically if JavaScript is enabled
+    return current_url if javascript_enabled?
+
     case IdentityConfig.store.openid_connect_redirect
     when 'client_side'
       extract_meta_refresh_url

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -192,15 +192,16 @@ module OidcAuthHelper
     client_assertion = JWT.encode(jwt_payload, client_private_key, 'RS256')
     client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
 
-    response = Faraday.post(
-      api_openid_connect_token_url,
-      grant_type: 'authorization_code',
-      code:,
-      client_assertion_type:,
-      client_assertion:,
-    )
-
-    @oidc_decoded_token = JSON.parse(response.body).with_indifferent_access
+    Capybara.using_driver(:desktop_rack_test) do
+      page.driver.post(
+        api_openid_connect_token_url,
+        grant_type: 'authorization_code',
+        code:,
+        client_assertion_type:,
+        client_assertion:,
+      )
+      @oidc_decoded_token = JSON.parse(page.body).with_indifferent_access
+    end
   end
 
   def oidc_decoded_id_token


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-14455](https://cm-jira.usa.gov/browse/LG-14455) (#11368)

## 🛠 Summary of changes

Creates new common spec helpers for decoding OIDC tokens, refactoring existing specs to use them.

Specifically, these helpers can be used to help assert that specific information is shared with a partner after the user authenticates.

This helper is extracted from #11368, with revisions to distinguish decoded token vs. decoded `id_token`.

## 📜 Testing Plan

Verify build passes.