### PR TITLE
Update good_job in preparation for 4.0 upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
       ffi (~> 1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    good_job (3.21.1)
+    good_job (3.99.1)
       activejob (>= 6.0.0)
       activerecord (>= 6.0.0)
       concurrent-ruby (>= 1.0.2)

--- a/app/jobs/good_job_v4_ready_job.rb
+++ b/app/jobs/good_job_v4_ready_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class GoodJobV4ReadyJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    IdentityJobLogSubscriber.new.logger.info(
+      {
+        name: 'good_job_v4_ready',
+        ready: GoodJob.v4_ready?,
+      }.to_json,
+    )
+
+    true
+  end
+end

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -164,6 +164,11 @@ else
         class: 'ThreatMetrixJsVerificationJob',
         cron: cron_1h,
       },
+      # Periodically check whether we can upgrade to GoodJob V4
+      good_job_v4_ready: {
+        class: 'GoodJobV4ReadyJob',
+        cron: cron_1h,
+      },
       # Reject profiles that have been in fraud_review_pending for 30 days
       fraud_rejection: {
         class: 'FraudRejectionDailyJob',

--- a/db/worker_jobs_migrate/20241021192429_recreate_good_job_cron_indexes_with_conditional.rb
+++ b/db/worker_jobs_migrate/20241021192429_recreate_good_job_cron_indexes_with_conditional.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class RecreateGoodJobCronIndexesWithConditional < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
+          add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)",
+                    name: :index_good_jobs_on_cron_key_and_created_at_cond, algorithm: :concurrently
+        end
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
+          add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true,
+                    name: :index_good_jobs_on_cron_key_and_cron_at_cond, algorithm: :concurrently
+        end
+
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_created_at
+        end
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_cron_at
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at)
+          add_index :good_jobs, [:cron_key, :created_at],
+                    name: :index_good_jobs_on_cron_key_and_created_at, algorithm: :concurrently
+        end
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at)
+          add_index :good_jobs, [:cron_key, :cron_at], unique: true,
+                    name: :index_good_jobs_on_cron_key_and_cron_at, algorithm: :concurrently
+        end
+
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_created_at_cond
+        end
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_cron_at_cond)
+          remove_index :good_jobs, name: :index_good_jobs_on_cron_key_and_cron_at_cond
+        end
+      end
+    end
+  end
+end

--- a/db/worker_jobs_migrate/20241021192430_create_good_job_labels.rb
+++ b/db/worker_jobs_migrate/20241021192430_create_good_job_labels.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobLabels < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :labels)
+      end
+    end
+
+    add_column :good_jobs, :labels, :text, array: true
+  end
+end

--- a/db/worker_jobs_migrate/20241021192431_create_good_job_labels_index.rb
+++ b/db/worker_jobs_migrate/20241021192431_create_good_job_labels_index.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateGoodJobLabelsIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
+          add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)",
+            name: :index_good_jobs_on_labels, algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
+          remove_index :good_jobs, name: :index_good_jobs_on_labels
+        end
+      end
+    end
+  end
+end

--- a/db/worker_jobs_migrate/20241021192432_remove_good_job_active_id_index.rb
+++ b/db/worker_jobs_migrate/20241021192432_remove_good_job_active_id_index.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RemoveGoodJobActiveIdIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          remove_index :good_jobs, name: :index_good_jobs_on_active_job_id
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          add_index :good_jobs, :active_job_id, name: :index_good_jobs_on_active_job_id
+        end
+      end
+    end
+  end
+end

--- a/db/worker_jobs_migrate/20241021192433_create_index_good_job_jobs_for_candidate_lookup.rb
+++ b/db/worker_jobs_migrate/20241021192433_create_index_good_job_jobs_for_candidate_lookup.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexGoodJobJobsForCandidateLookup < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_job_jobs_for_candidate_lookup)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup,
+      algorithm: :concurrently
+  end
+end

--- a/db/worker_jobs_migrate/20241021192434_create_good_job_execution_error_backtrace.rb
+++ b/db/worker_jobs_migrate/20241021192434_create_good_job_execution_error_backtrace.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutionErrorBacktrace < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_executions, :error_backtrace)
+      end
+    end
+
+    add_column :good_job_executions, :error_backtrace, :text, array: true
+  end
+end

--- a/db/worker_jobs_migrate/20241021192435_create_good_job_process_lock_ids.rb
+++ b/db/worker_jobs_migrate/20241021192435_create_good_job_process_lock_ids.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :locked_by_id)
+      end
+    end
+
+    add_column :good_jobs, :locked_by_id, :uuid
+    add_column :good_jobs, :locked_at, :datetime
+    add_column :good_job_executions, :process_id, :uuid
+    add_column :good_job_processes, :lock_type, :integer, limit: 2
+  end
+end

--- a/db/worker_jobs_migrate/20241021192436_create_good_job_process_lock_indexes.rb
+++ b/db/worker_jobs_migrate/20241021192436_create_good_job_process_lock_indexes.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+          add_index :good_jobs, [:priority, :scheduled_at],
+                    order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+                    where: "finished_at IS NULL AND locked_by_id IS NULL",
+                    name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+          add_index :good_jobs, :locked_by_id,
+                    where: "locked_by_id IS NOT NULL",
+                    name: :index_good_jobs_on_locked_by_id,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+          add_index :good_job_executions, [:process_id, :created_at],
+                    name: :index_good_job_executions_on_process_id_and_created_at,
+                    algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        remove_index(:good_jobs, name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+        remove_index(:good_jobs, name: :index_good_jobs_on_locked_by_id) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+        remove_index(:good_job_executions, name: :index_good_job_executions_on_process_id_and_created_at) if connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+      end
+    end
+  end
+end

--- a/db/worker_jobs_migrate/20241021192437_create_good_job_execution_duration.rb
+++ b/db/worker_jobs_migrate/20241021192437_create_good_job_execution_duration.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateGoodJobExecutionDuration < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_executions, :duration)
+      end
+    end
+
+    add_column :good_job_executions, :duration, :interval
+  end
+end

--- a/db/worker_jobs_schema.rb
+++ b/db/worker_jobs_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_18_163221) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_21_192437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -41,13 +41,18 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_18_163221) do
     t.datetime "finished_at"
     t.text "error"
     t.integer "error_event", limit: 2
+    t.text "error_backtrace", array: true
+    t.uuid "process_id"
+    t.interval "duration"
     t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
+    t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
   end
 
   create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "state"
+    t.integer "lock_type", limit: 2
   end
 
   create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -79,15 +84,21 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_18_163221) do
     t.integer "executions_count"
     t.text "job_class"
     t.integer "error_event", limit: 2
+    t.text "labels", array: true
+    t.uuid "locked_by_id"
+    t.datetime "locked_at"
     t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
-    t.index ["active_job_id"], name: "index_good_jobs_on_active_job_id"
     t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
     t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
     t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
-    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at"
-    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at", unique: true
+    t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
+    t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
+    t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
+    t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
     t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end

--- a/spec/jobs/good_job_v4_ready_job_spec.rb
+++ b/spec/jobs/good_job_v4_ready_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe GoodJobV4ReadyJob, type: :job do
+  describe '#perform' do
+    it 'logs goodjob v4 readiness' do
+      expect(Rails.logger).to receive(:info) do |str|
+        msg = JSON.parse(str, symbolize_names: true)
+        expect(msg).to eq(
+          {
+            name: 'good_job_v4_ready',
+            ready: GoodJob.v4_ready?,
+          },
+        )
+      end
+
+      GoodJobV4ReadyJob.new.perform
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

We're quite far behind on good_job versions, and a major version update was released back in July. The structure of jobs has changed, and we must complete all jobs scheduled or queued in the old format prior. This is described further in the [v3 to v4 update guide](https://github.com/bensheldon/good_job/tree/main?tab=readme-ov-file#upgrading-v3-to-v4).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
