### PR TITLE
Remove controller-level "bypass" check for SP MFA requirement

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -90,17 +90,6 @@ module TwoFactorAuthenticatableMethods
     redirect_to after_sign_in_path_for(current_user)
   end
 
-  def check_sp_required_mfa_bypass(auth_method:)
-    return unless service_provider_mfa_policy.user_needs_sp_auth_method_verification?
-    return if service_provider_mfa_policy.phishing_resistant_required? &&
-              TwoFactorAuthenticatable::AuthMethod.phishing_resistant?(auth_method)
-    if service_provider_mfa_policy.piv_cac_required? &&
-       auth_method == TwoFactorAuthenticatable::AuthMethod::PIV_CAC
-      return
-    end
-    prompt_to_verify_sp_required_mfa
-  end
-
   def reset_attempt_count_if_user_no_longer_locked_out
     return unless current_user.no_longer_locked_out?
 

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -6,7 +6,6 @@ module TwoFactorAuthentication
     include NewDeviceConcern
 
     prepend_before_action :authenticate_user
-    before_action :check_sp_required_mfa
 
     def show
       analytics.multi_factor_auth_enter_backup_code_visit(context: context)
@@ -79,10 +78,6 @@ module TwoFactorAuthentication
 
     def handle_valid_backup_code
       redirect_to after_sign_in_path_for(current_user)
-    end
-
-    def check_sp_required_mfa
-      check_sp_required_mfa_bypass(auth_method: 'backup_code')
     end
   end
 end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -6,7 +6,6 @@ module TwoFactorAuthentication
     include MfaSetupConcern
     include NewDeviceConcern
 
-    before_action :check_sp_required_mfa
     before_action :confirm_multiple_factors_enabled
     before_action :redirect_if_blank_phone, only: [:show]
     before_action :confirm_voice_capability, only: [:show]
@@ -195,10 +194,6 @@ module TwoFactorAuthentication
 
     def confirmation_for_add_phone?
       UserSessionContext.confirmation_context?(context) && user_fully_authenticated?
-    end
-
-    def check_sp_required_mfa
-      check_sp_required_mfa_bypass(auth_method: params[:otp_delivery_preference])
     end
 
     def assign_phone

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -5,7 +5,6 @@ module TwoFactorAuthentication
     include TwoFactorAuthenticatable
     include NewDeviceConcern
 
-    before_action :check_sp_required_mfa
     before_action :confirm_totp_enabled
 
     def show
@@ -56,10 +55,6 @@ module TwoFactorAuthentication
       {
         two_factor_authentication_method: 'authenticator',
       }.merge(generic_data)
-    end
-
-    def check_sp_required_mfa
-      check_sp_required_mfa_bypass(auth_method: 'authenticator')
     end
   end
 end

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -6,7 +6,6 @@ module TwoFactorAuthentication
     include TwoFactorAuthenticatable
     include NewDeviceConcern
 
-    before_action :check_sp_required_mfa
     before_action :confirm_webauthn_enabled, only: :show
 
     def show
@@ -122,10 +121,6 @@ module TwoFactorAuthentication
         webauthn_error: params[:webauthn_error],
         screen_lock_error: params[:screen_lock_error],
       )
-    end
-
-    def check_sp_required_mfa
-      check_sp_required_mfa_bypass(auth_method: 'webauthn')
     end
 
     def platform_authenticator_param?

--- a/spec/features/openid_connect/phishing_resistant_required_spec.rb
+++ b/spec/features/openid_connect/phishing_resistant_required_spec.rb
@@ -60,36 +60,42 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
       context 'with piv cac configured' do
         let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
-        it 'sends user to authenticate with piv cac' do
+        it 'sends user to authenticate with piv cac and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_piv_cac_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:piv_cac)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn) }
 
-        it 'sends user to authenticate with webauthn' do
+        it 'sends user to authenticate with webauthn and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn platform configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
 
-        it 'sends user to authenticate with webauthn platform' do
+        it 'sends user to authenticate with webauthn platform and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_idp_from_ial1_oidc_sp_requesting_aal3(prompt: 'select_account')
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn_platform)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
@@ -132,36 +138,42 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
       context 'with piv cac configured' do
         let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
-        it 'sends user to authenticate with piv cac' do
+        it 'sends user to authenticate with piv cac and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_piv_cac_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:piv_cac)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn) }
 
-        it 'sends user to authenticate with webauthn' do
+        it 'sends user to authenticate with webauthn and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn platform configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
 
-        it 'sends user to authenticate with webauthn platform' do
+        it 'sends user to authenticate with webauthn platform and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn_platform)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
@@ -204,36 +216,42 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
       context 'with piv cac configured' do
         let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
-        it 'sends user to authenticate with piv cac' do
+        it 'sends user to authenticate with piv cac and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_piv_cac_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:piv_cac)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn) }
 
-        it 'sends user to authenticate with webauthn' do
+        it 'sends user to authenticate with webauthn and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn platform configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
 
-        it 'sends user to authenticate with webauthn platform' do
+        it 'sends user to authenticate with webauthn platform and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_idp_from_ial1_oidc_sp_defaulting_to_aal3(prompt: 'select_account')
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn_platform)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
@@ -261,5 +279,12 @@ RSpec.describe 'Phishing-resistant authentication required in an OIDC context' d
         end
       end
     end
+  end
+
+  def has_2fa_option?(auth_method)
+    page.find("label[for='two_factor_options_form_selection_#{auth_method}']")
+    true
+  rescue Capybara::ElementNotFound
+    false
   end
 end

--- a/spec/features/saml/phishing_resistant_required_spec.rb
+++ b/spec/features/saml/phishing_resistant_required_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
       context 'with piv cac configured' do
         let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
-        it 'sends user to authenticate with piv cac' do
+        it 'sends user to authenticate with piv cac and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_saml_authn_request_url(
@@ -75,15 +75,17 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
               authn_context: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
             },
           )
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_piv_cac_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:piv_cac)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn) }
 
-        it 'sends user to authenticate with webauthn' do
+        it 'sends user to authenticate with webauthn and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_saml_authn_request_url(
@@ -92,15 +94,17 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
               authn_context: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
             },
           )
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn platform configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
 
-        it 'sends user to authenticate with webauthn platform' do
+        it 'sends user to authenticate with webauthn platform and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_saml_authn_request_url(
@@ -109,8 +113,10 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
               authn_context: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
             },
           )
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn_platform)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
@@ -157,7 +163,7 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
       context 'with piv cac configured' do
         let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
-        it 'sends user to authenticate with piv cac' do
+        it 'sends user to authenticate with piv cac and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_saml_authn_request_url(
@@ -165,15 +171,17 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
               issuer: sp1_issuer, authn_context: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
             },
           )
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_piv_cac_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:piv_cac)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn) }
 
-        it 'sends user to authenticate with webauthn' do
+        it 'sends user to authenticate with webauthn and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_saml_authn_request_url(
@@ -181,15 +189,17 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
               issuer: sp1_issuer, authn_context: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
             },
           )
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn platform configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
 
-        it 'sends user to authenticate with webauthn platform' do
+        it 'sends user to authenticate with webauthn platform and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_saml_authn_request_url(
@@ -197,8 +207,10 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
               issuer: sp1_issuer, authn_context: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
             },
           )
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn_platform)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
@@ -245,7 +257,7 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
       context 'with piv cac configured' do
         let(:user) { create(:user, :fully_registered, :with_piv_or_cac) }
 
-        it 'sends user to authenticate with piv cac' do
+        it 'sends user to authenticate with piv cac and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_saml_authn_request_url(
@@ -253,15 +265,17 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
               issuer: aal3_issuer, authn_context: nil
             },
           )
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_piv_cac_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:piv_cac)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn) }
 
-        it 'sends user to authenticate with webauthn' do
+        it 'sends user to authenticate with webauthn and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_saml_authn_request_url(
@@ -269,15 +283,17 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
               issuer: aal3_issuer, authn_context: nil
             },
           )
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url)
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
       context 'with webauthn platform configured' do
         let(:user) { create(:user, :fully_registered, :with_webauthn_platform) }
 
-        it 'sends user to authenticate with webauthn platform' do
+        it 'sends user to authenticate with webauthn platform and removes weaker options' do
           sign_in_before_2fa(user)
 
           visit_saml_authn_request_url(
@@ -285,8 +301,10 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
               issuer: aal3_issuer, authn_context: nil
             },
           )
-          visit login_two_factor_path(otp_delivery_preference: 'sms')
           expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))
+          click_on t('two_factor_authentication.login_options_link_text')
+          expect(has_2fa_option?(:webauthn_platform)).to eq(true)
+          expect(has_2fa_option?(:sms)).to eq(false)
         end
       end
 
@@ -323,5 +341,12 @@ RSpec.describe 'Phishing-resistant authentication required in an SAML context' d
         end
       end
     end
+  end
+
+  def has_2fa_option?(auth_method)
+    page.find("label[for='two_factor_options_form_selection_#{auth_method}']")
+    true
+  rescue Capybara::ElementNotFound
+    false
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-14455](https://cm-jira.usa.gov/browse/LG-14455)

## 🛠 Summary of changes

Removes a `before_action` check from MFA controllers to ensure that a user is only allowed to MFA with a phishing-resistant MFA or PIV/CAC if required by the partner.

These are not effective bypass checks, and are already considered as part of `confirm_two_factor_authenticated` for final authentication checks of [OIDC](https://github.com/18F/identity-idp/blob/da770f38fd02f062be98435ccc3ad4b21859c97e/app/controllers/openid_connect/authorization_controller.rb#L25) and [SAML](https://github.com/18F/identity-idp/blob/da770f38fd02f062be98435ccc3ad4b21859c97e/app/controllers/saml_idp_controller.rb#L30). Since weaker MFA options are excluded from the options listing when phishing-resistant or PIV/CAC is required from a partner, the only way a user would be able to visit these pages is by manually crafting the URL. If they were to do this (see "Testing Plan"), they'd still be redirected back to authenticate with a phishing-resistant method or PIV/CAC after authenticating with the other method.

## 📜 Testing Plan

Verify no regressions of [LG-3209](https://cm-jira.usa.gov/browse/LG-3209) and [LG-3185](https://cm-jira.usa.gov/browse/LG-3185).

Verify that build passes, and notably there are [specs with effective bypass attempt checking](https://github.com/18F/identity-idp/blob/da770f38fd02f062be98435ccc3ad4b21859c97e/spec/features/openid_connect/phishing_resistant_required_spec.rb#L96-L101) that still pass.

Attempt to bypass partner requirements, and verify that you are unable:

Prerequisite: Have an account with a phishing-resistant method (ideally PIV/CAC) and at least one phishable method (e.g. phone).

1. Start [OIDC sample application](https://github.com/18f/identity-oidc-sinatra) or [SAML sample application](https://github.com/18f/identity-saml-sinatra) in a separate process
2. Visit sample application
   - OIDC: http://localhost:9292
   - SAML: http://localhost:4567
4. Change "Authentication Assurance Level (AAL)" to "Phishing-resistant AAL2" or "HSDP12 required"
5. Click "Sign in"
6. Sign in with email and password
7. When prompted for MFA, change URL to http://localhost:3000/login/two_factor/sms (or replace "sms" with another phishable MFA on your account)
8. Authenticate with your phishable method. For phone in local development, the code may not populate immediately, so click "Send another code" to auto-fill
9. Observe that you're prompted for your non-phishable method, indicating you're not able to finish authenticating without MFA-ing with a valid method per partner requirements