### PR TITLE
Add cpu_time and idle_time to job logs

### DIFF
--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -163,6 +163,8 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
   def default_attributes(event, job)
     {
       duration_ms: event.duration,
+      cpu_time_ms: event.cpu_time,
+      idle_time_ms: event.idle_time,
       timestamp: Time.zone.now,
       name: event.name,
       job_class: job.class.name,

--- a/spec/lib/identity_job_log_subscriber_spec.rb
+++ b/spec/lib/identity_job_log_subscriber_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
       expect(json['job_class']).to eq('AddressProofingJob')
       expect(json.key?('trace_id'))
       expect(json.key?('duration_ms'))
+      expect(json.key?('cpu_time_ms'))
+      expect(json.key?('idle_time_ms'))
       expect(json.key?('job_id'))
       expect(json.key?('timestamp'))
     end
@@ -65,6 +67,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
         'RetryEvent',
         payload: { wait: 1, job: double('Job', job_id: '1', queue_name: 'Default', arguments: []) },
         duration: 1,
+        cpu_time: 1,
+        idle_time: 1,
         name: 'TestEvent',
       )
 
@@ -85,6 +89,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           error: double('Exception'),
         },
         duration: 1,
+        cpu_time: 1,
+        idle_time: 1,
         name: 'TestEvent',
       )
 
@@ -120,6 +126,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
 
         expect(payload).to match(
           duration_ms: kind_of(Numeric),
+          cpu_time_ms: kind_of(Numeric),
+          idle_time_ms: kind_of(Numeric),
           exception_class_warn: 'ActiveRecord::RecordNotUnique',
           exception_message_warn: /(cron_key, cron_at)/,
           job_class: 'HeartbeatJob',
@@ -156,6 +164,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
 
         expect(payload).to match(
           duration_ms: kind_of(Float),
+          cpu_time_ms: kind_of(Numeric),
+          idle_time_ms: kind_of(Numeric),
           exception_class_warn: 'Errno::ECONNREFUSED',
           exception_message_warn: 'Connection refused',
           job_class: 'RiscDeliveryJob',
@@ -193,6 +203,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
 
         expect(payload).to match(
           duration_ms: kind_of(Float),
+          cpu_time_ms: kind_of(Numeric),
+          idle_time_ms: kind_of(Numeric),
           halted: true,
           job_class: 'RiscDeliveryJob',
           job_id: job.job_id,
@@ -229,6 +241,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
 
         expect(payload).to match(
           duration_ms: kind_of(Float),
+          cpu_time_ms: kind_of(Numeric),
+          idle_time_ms: kind_of(Numeric),
           timestamp: kind_of(String),
           name: 'enqueue.active_job',
           job_class: 'RiscDeliveryJob',
@@ -292,6 +306,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
 
         expect(payload).to match(
           duration_ms: kind_of(Float),
+          cpu_time_ms: kind_of(Numeric),
+          idle_time_ms: kind_of(Numeric),
           exception_class_warn: 'Errno::ECONNREFUSED',
           exception_message_warn: 'Connection refused',
           job_class: 'RiscDeliveryJob',
@@ -350,6 +366,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
 
         expect(payload).to match(
           duration_ms: kind_of(Float),
+          cpu_time_ms: kind_of(Numeric),
+          idle_time_ms: kind_of(Numeric),
           halted: true,
           job_class: 'RiscDeliveryJob',
           job_id: job.job_id,
@@ -386,6 +404,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
 
         expect(payload).to match(
           duration_ms: kind_of(Float),
+          cpu_time_ms: kind_of(Numeric),
+          idle_time_ms: kind_of(Numeric),
           timestamp: kind_of(String),
           name: 'enqueue.active_job',
           job_class: 'RiscDeliveryJob',
@@ -428,6 +448,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
 
         expect(payload).to match(
           duration_ms: kind_of(Float),
+          cpu_time_ms: kind_of(Numeric),
+          idle_time_ms: kind_of(Numeric),
           timestamp: kind_of(String),
           name: 'enqueue.active_job',
           job_class: 'RiscDeliveryJob',


### PR DESCRIPTION
## 🛠 Summary of changes

While working to troubleshoot some job queue alarms, we're hoping it is helpful to add some additional information around CPU and idle time for each job performed. This PR adds both `cpu_time` and `idle_time` to the default job event metrics: https://github.com/rails/rails/blob/fe0fb9fdf04f638996e785d3e291f5fe8bc138a0/activesupport/lib/active_support/notifications/instrumenter.rb#L161-L172

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
