### PR TITLE
Add convention on asset retention

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -233,6 +233,10 @@ For example, consider a **Password Input** component:
 - A web component would be named `PasswordInputElement`
 - A web components file would be named `app/javascript/packages/password-input/password-input-element.ts`
 
+#### Graphical Assets
+
+Web graphic assets like images, GIFs, and videos are artifacts authored in other tools. As such, there is no need to keep multiple variants of an asset (e.g., SVG and PNG) in the repository if they are not in use.
+
 ## Testing
 
 ### Stylelint


### PR DESCRIPTION
**Why**
While authoring a different feature, it became apparent that we do not store multiple variants of asset "just in case". We can re-export from our authoring tools (i.e., Figma) if need be.

This adds a note why we do not do this for developers from the future.

[skip changelog]