### PR TITLE
Add a service provider with a homepage URL to account verified mailer preview

### DIFF
--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -145,7 +145,12 @@ class UserMailerPreview < ActionMailer::Preview
   end
 
   def account_verified
-    service_provider = ServiceProvider.find_by(friendly_name: 'Example Sinatra App')
+    service_provider = unsaveable(
+      ServiceProvider.new(
+        friendly_name: 'Example Sinatra App',
+        return_to_sp_url: 'http://example.com',
+      ),
+    )
     UserMailer.with(user: user, email_address: email_address_record).account_verified(
       profile: unsaveable(
         Profile.new(


### PR DESCRIPTION
We expect that most users who receive the `account_verified` email will have proofed with a service provider that has a `return_to_sp_url` and thus a `homepage_url`. This commit updates the mailer preview to replicate that situation so the email is displayed as expected.
