### PR TITLE
Log the user of a fraud rejected profile on automatic rejection

### DIFF
--- a/app/jobs/fraud_rejection_daily_job.rb
+++ b/app/jobs/fraud_rejection_daily_job.rb
@@ -6,7 +6,7 @@ class FraudRejectionDailyJob < ApplicationJob
   def perform(_date)
     profiles_eligible_for_fraud_rejection.find_each do |profile|
       profile.reject_for_fraud(notify_user: false)
-      analytics.automatic_fraud_rejection(
+      analytics(user: profile.user).automatic_fraud_rejection(
         fraud_rejection_at: profile.fraud_rejection_at,
       )
     end
@@ -14,11 +14,11 @@ class FraudRejectionDailyJob < ApplicationJob
 
   private
 
-  def analytics(user: AnonymousUser.new)
+  def analytics(user:)
     Analytics.new(user: user, request: nil, session: {}, sp: nil)
   end
 
   def profiles_eligible_for_fraud_rejection
-    Profile.where(fraud_review_pending_at: ..30.days.ago)
+    Profile.includes(:user).where(fraud_review_pending_at: ..30.days.ago)
   end
 end

--- a/spec/jobs/fraud_rejection_daily_job_spec.rb
+++ b/spec/jobs/fraud_rejection_daily_job_spec.rb
@@ -4,16 +4,15 @@ RSpec.describe FraudRejectionDailyJob do
   subject(:job) { FraudRejectionDailyJob.new }
   let(:job_analytics) { FakeAnalytics.new }
 
-  before do
-    allow(job).to receive(:analytics).and_return(job_analytics)
-  end
-
   describe '#perform' do
     it 'rejects profiles which have been review pending for more than 30 days' do
-      create(:profile, fraud_review_pending_at: 31.days.ago)
+      rejectedable_profile = create(:profile, fraud_review_pending_at: 31.days.ago)
       create(:profile, fraud_review_pending_at: 20.days.ago)
 
       rejected_profiles = Profile.where.not(fraud_rejection_at: nil)
+
+      allow(job).to receive(:analytics).with(user: rejectedable_profile.user).
+        and_return(job_analytics)
 
       expect { job.perform(Time.zone.today) }.to change { rejected_profiles.count }.by(1)
       expect(job_analytics).to have_logged_event(


### PR DESCRIPTION
If a user is in fraud review for over 30 days they are automatically rejected by the `FraudRejectionDailyJob`. Prior to this commit the analytics service was initialized with an anonymous user. As a result the event was not logged for the fraud review rejected user. This commit fixes that issue so these events will appear associated with the rejected user.
