### PR TITLE
Update browserslist database

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2459,9 +2459,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001587:
-  version "1.0.30001605"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz#ca12d7330dd8bcb784557eb9aa64f0037870d9d6"
-  integrity sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==
+  version "1.0.30001669"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz"
+  integrity sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==
 
 chai-as-promised@^7.1.1:
   version "7.1.1"


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the browserslist `caniuse-lite` database dependency.

**Why?**

- More accurate usage data for browser support
- Resolve warning message when building:

```
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

**Impact**

Summary:

- Android Chrome: Minimum version increased from 123 to 129
- Chrome: Unchanged
- iOS (All browsers): Unchanged
- macOS Safari: Minimum version increased from 17.2 to 17.5
- Firefox: Minimum version increased from 122 to 129

Full difference of `browsers.json`:

Before:

```
["and_chr 123","and_uc 15.5","android 123","chrome 122","chrome 121","chrome 120","chrome 119","chrome 109","edge 122","edge 121","firefox 122","ios_saf 17.3","ios_saf 17.2","ios_saf 17.1","ios_saf 16.6-16.7","ios_saf 16.1","ios_saf 15.6-15.8","op_mob 80","opera 106","safari 17.2","samsung 23"]
```

After:

```
["and_chr 129","and_uc 15.5","chrome 128","chrome 127","chrome 126","chrome 109","edge 128","edge 127","firefox 129","ios_saf 17.6","ios_saf 17.5","ios_saf 16.6-16.7","ios_saf 15.6-15.8","op_mob 80","safari 17.5","samsung 25"]
```

## 📜 Testing Plan

Verify that `browsers.json` builds successfully without warnings.

1. Run `make browsers.json`
2. Observe that content of `browsers.json` is same as "After" above