### PR TITLE
Fix migration check method call arguments

### DIFF
--- a/lib/tasks/check_for_pending_migrations.rake
+++ b/lib/tasks/check_for_pending_migrations.rake
@@ -12,7 +12,7 @@ namespace :db do
     )
       warn('Skipping pending migration check, idp_run_migrations=true')
     else
-      ActiveRecord::Migration.check_all_pending!(ActiveRecord::Base.connection)
+      ActiveRecord::Migration.check_all_pending!
     end
   end
 end

--- a/spec/lib/tasks/check_for_pending_migrations_rake_spec.rb
+++ b/spec/lib/tasks/check_for_pending_migrations_rake_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'check for pending migrations rake tasks' do
+  before do
+    Rake.application.rake_require 'tasks/check_for_pending_migrations'
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'db:check_for_pending_migrations' do
+    it 'runs successfully' do
+      Rake::Task['db:check_for_pending_migrations'].invoke
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

#11357 updated a deprecated method, but it no longer takes arguments. This addresses it by removing the argument.

Error:
```
ArgumentError: wrong number of arguments (given 1, expected 0) (ArgumentError)
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
