### PR TITLE
LG-14673: Add SP info to fraud review events

### DIFF
--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -6,6 +6,11 @@ class Analytics
 
   attr_reader :user, :request, :sp, :session, :ahoy
 
+  # @param [User] user
+  # @param [ActionDispatch::Request,nil] request
+  # @param [String,nil] sp Service provider issuer string.
+  # @param [Hash] session
+  # @param [Ahoy::Tracker,nil] ahoy
   def initialize(user:, request:, sp:, session:, ahoy: nil)
     @user = user
     @request = request

--- a/app/services/analytics.rb
+++ b/app/services/analytics.rb
@@ -21,6 +21,7 @@ class Analytics
       event_properties: attributes.except(:user_id).compact,
       new_event: first_event_this_session?,
       path: request&.path,
+      service_provider: sp,
       session_duration: session_duration,
       user_id: attributes[:user_id] || user.uuid,
       locale: I18n.locale,
@@ -58,7 +59,6 @@ class Analytics
       user_ip: request.remote_ip,
       hostname: request.host,
       pid: Process.pid,
-      service_provider: sp,
       trace_id: request.headers['X-Amzn-Trace-Id'],
     }
 

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -267,6 +267,7 @@ class ActionAccount
 
       messages = []
       users.each do |user|
+        profile = nil
         profile_fraud_review_pending_at = nil
         success = false
 
@@ -276,7 +277,6 @@ class ActionAccount
         elsif FraudReviewChecker.new(user).fraud_review_eligible?
           profile = user.fraud_review_pending_profile
           profile_fraud_review_pending_at = profile.fraud_review_pending_at
-          profile_age_in_seconds = profile.profile_age_in_seconds
           profile.activate_after_passing_review
           success = true
 
@@ -308,13 +308,16 @@ class ActionAccount
         end
 
         Analytics.new(
-          user: user, request: nil, session: {}, sp: nil,
+          user: user,
+          request: nil,
+          session: {},
+          sp: profile&.initiating_service_provider_issuer,
         ).fraud_review_passed(
           success:,
           errors: analytics_error_hash,
           exception: nil,
           profile_fraud_review_pending_at: profile_fraud_review_pending_at,
-          profile_age_in_seconds: profile_age_in_seconds,
+          profile_age_in_seconds: profile&.profile_age_in_seconds,
         )
       end
 

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -177,6 +177,7 @@ class ActionAccount
       messages = []
 
       users.each do |user|
+        profile = nil
         profile_fraud_review_pending_at = nil
         success = false
 
@@ -187,7 +188,6 @@ class ActionAccount
         elsif FraudReviewChecker.new(user).fraud_review_eligible?
           profile = user.fraud_review_pending_profile
           profile_fraud_review_pending_at = profile.fraud_review_pending_at
-          profile_age_in_seconds = profile.profile_age_in_seconds
           profile.reject_for_fraud(notify_user: true)
           success = true
 
@@ -211,13 +211,16 @@ class ActionAccount
         end
 
         Analytics.new(
-          user: user, request: nil, session: {}, sp: nil,
+          user: user,
+          request: nil,
+          session: {},
+          sp: profile&.initiating_service_provider_issuer,
         ).fraud_review_rejected(
           success:,
           errors: analytics_error_hash,
           exception: nil,
-          profile_fraud_review_pending_at: profile_fraud_review_pending_at,
-          profile_age_in_seconds: profile_age_in_seconds,
+          profile_fraud_review_pending_at:,
+          profile_age_in_seconds: profile&.profile_age_in_seconds,
         )
       end
 

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -224,8 +224,10 @@ class ActionAccount
         )
       end
 
-      if config.include_missing?
-        (uuids - users.map(&:uuid)).each do |missing_uuid|
+      missing_uuids = (uuids - users.map(&:uuid))
+
+      if config.include_missing? && !missing_uuids.empty?
+        missing_uuids.each do |missing_uuid|
           table, messages = log_message(
             uuid: missing_uuid,
             log: log_text[:missing_uuid],
@@ -321,8 +323,9 @@ class ActionAccount
         )
       end
 
-      if config.include_missing?
-        (uuids - users.map(&:uuid)).each do |missing_uuid|
+      missing_uuids = (uuids - users.map(&:uuid))
+      if config.include_missing? && !missing_uuids.empty?
+        missing_uuids.each do |missing_uuid|
           table, messages = log_message(
             uuid: missing_uuid,
             log: log_text[:missing_uuid],

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -261,6 +261,26 @@ RSpec.describe ActionAccount do
           errors: { message: 'Error: Could not find user with that UUID' },
         )
       end
+
+      context 'when profile has initiating_service_provider_issuer' do
+        let(:user) do
+          create(
+            :profile,
+            :fraud_review_pending,
+            initiating_service_provider_issuer: 'test-issuer',
+          ).user
+        end
+
+        it 'attributes analytics events to the SP' do
+          expect(Analytics).to receive(:new).
+            with(hash_including(sp: 'test-issuer')).
+            and_return(analytics)
+
+          subtask.run(args:, config:)
+
+          expect(analytics).to have_logged_event('Fraud: Profile review passed')
+        end
+      end
     end
   end
 

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -182,6 +182,26 @@ RSpec.describe ActionAccount do
           errors: { message: 'Error: Could not find user with that UUID' },
         )
       end
+
+      context 'when profile has initiating_service_provider_issuer' do
+        let(:user) do
+          create(
+            :profile,
+            :fraud_review_pending,
+            initiating_service_provider_issuer: 'test-issuer',
+          ).user
+        end
+
+        it 'attributes analytics events to the SP' do
+          expect(Analytics).to receive(:new).
+            with(hash_including(sp: 'test-issuer')).
+            and_return(analytics)
+
+          subtask.run(args:, config:)
+
+          expect(analytics).to have_logged_event('Fraud: Profile review rejected')
+        end
+      end
     end
   end
 

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Analytics do
       user_id: current_user.uuid,
       new_event: true,
       path: path,
+      service_provider: 'http://localhost:3000',
       session_duration: nil,
       locale: I18n.locale,
       git_sha: IdentityConfig::GIT_SHA,

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Analytics do
       browser_bot: false,
       hostname: FakeRequest.new.host,
       pid: Process.pid,
-      service_provider: 'http://localhost:3000',
       trace_id: nil,
     }
   end
@@ -190,6 +189,19 @@ RSpec.describe Analytics do
             analytics_attributes,
           )
 
+          analytics.track_event('Trackable Event')
+        end
+      end
+    end
+
+    context 'when no request specified' do
+      let(:request) { nil }
+      context 'but an SP was specified via initializer' do
+        it 'logs the SP' do
+          expect(ahoy).to receive(:track).with(
+            'Trackable Event',
+            hash_including(service_provider: 'http://localhost:3000'),
+          )
           analytics.track_event('Trackable Event')
         end
       end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14673](https://cm-jira.usa.gov/browse/LG-14673)

## 🛠 Summary of changes

When an operator executes the `review-pass` or `review-reject` scripts, they log an analytics event. This PR updates those analytics events to be attributed to the SP that was associated with the initial profile creation.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Start from an SP and go through IdV. Intend to commit fraud so that you get caught and put into the fraud review queue.
- [ ] Reject your fraud review request: `bin/action-account review-reject $(bin/rails runner 'puts User.last.uuid')`
- [ ] Verify that the "Fraud: Profile review rejected" event logged includes the `properties.service_provider` key, set to the SP you were originally going through IdV for.
- [ ] Repeat this process, but this time approve your fraud review request: `bin/action-account review-pass $(bin/rails runner 'puts User.last.uuid'`
- [ ] Verify that the "Fraud: Profile review passed" event logged includes the `properties.service_provider` key, set to the SP you were originally going through IdV for.
