### PR TITLE
LG-14717: Log Socure reason code descriptions

### DIFF
--- a/app/services/proofing/mock/resolution_mock_client.rb
+++ b/app/services/proofing/mock/resolution_mock_client.rb
@@ -50,7 +50,7 @@ module Proofing
         resolution_result(
           success: false,
           errors: {},
-          exception: Proofing::TimeoutError.new('address mock timeout'),
+          exception: Proofing::TimeoutError.new('resolution mock timeout'),
         )
       end
 

--- a/app/services/proofing/socure/id_plus/proofer.rb
+++ b/app/services/proofing/socure/id_plus/proofer.rb
@@ -77,9 +77,10 @@ module Proofing
         # @param [Proofing::Socure::IdPlus::Response] response
         # @return [Hash]
         def reason_codes_as_errors(response)
-          {
-            reason_codes: response.kyc_reason_codes.sort,
-          }
+          known_codes = SocureReasonCode.where(
+            code: response.kyc_reason_codes,
+          ).pluck(:code, :description).to_h
+          response.kyc_reason_codes.index_with { |code| known_codes[code] || '' }
         end
 
         # @param [Proofing::Socure::IdPlus::Response] response

--- a/app/services/proofing/socure/id_plus/proofer.rb
+++ b/app/services/proofing/socure/id_plus/proofer.rb
@@ -7,6 +7,7 @@ module Proofing
         attr_reader :config
 
         VENDOR_NAME = 'socure_kyc'
+        UNKNOWN_REASON_CODE = '[unknown]'
 
         VERIFIED_ATTRIBUTE_MAP = {
           address: %i[streetAddress city state zip].freeze,
@@ -80,7 +81,7 @@ module Proofing
           known_codes = SocureReasonCode.where(
             code: response.kyc_reason_codes,
           ).pluck(:code, :description).to_h
-          response.kyc_reason_codes.index_with { |code| known_codes[code] || '' }
+          response.kyc_reason_codes.index_with { |code| known_codes[code] || UNKNOWN_REASON_CODE }
         end
 
         # @param [Proofing::Socure::IdPlus::Response] response

--- a/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
+++ b/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe SocureShadowModeProofingJob do
           satisfy do |attributes|
             errors = attributes.dig(:socure_result, :errors)
             expect(errors).to include(
-              'I000' => '',
+              'I000' => '[unknown]',
             )
           end,
         )

--- a/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
+++ b/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
@@ -148,9 +148,8 @@ RSpec.describe SocureShadowModeProofingJob do
         referenceId: 'a1234b56-e789-0123-4fga-56b7c890d123',
         kyc: {
           reasonCodes: [
-            'I919',
-            'I914',
-            'I905',
+            'I123',
+            'R890',
           ],
           fieldValidations: {
             firstName: 0.99,
@@ -171,7 +170,19 @@ RSpec.describe SocureShadowModeProofingJob do
       }
     end
 
+    let(:known_reason_codes) do
+      {
+        I123: 'Person is over seven feet tall.',
+        R567: 'Person may be an armadillo.',
+        R890: 'Help! I am trapped in a reason code factory!',
+      }
+    end
+
     before do
+      known_reason_codes.each do |(code, description)|
+        SocureReasonCode.create(code:, description:)
+      end
+
       stub_request(:post, 'https://example.org/api/3.0/EmailAuthScore').
         to_return(
           headers: {
@@ -256,7 +267,10 @@ RSpec.describe SocureShadowModeProofingJob do
           socure_result: {
             attributes_requiring_additional_verification: [],
             can_pass_with_additional_verification: false,
-            errors: { reason_codes: ['I905', 'I914', 'I919'] },
+            errors: {
+              'I123' => 'Person is over seven feet tall.',
+              'R890' => 'Help! I am trapped in a reason code factory!',
+            },
             exception: nil,
             reference: '',
             success: true,
@@ -371,6 +385,27 @@ RSpec.describe SocureShadowModeProofingJob do
       end
       it 'raises an error' do
         expect { perform }.to raise_error(JSON::ParserError)
+      end
+    end
+
+    context 'when an unknown reason code is encountered' do
+      let(:socure_response_body) do
+        super().tap do |body|
+          body[:kyc][:reasonCodes] << 'I000'
+        end
+      end
+
+      it 'still logs it' do
+        perform
+        expect(analytics).to have_logged_event(
+          :idv_socure_shadow_mode_proofing_result,
+          satisfy do |attributes|
+            errors = attributes.dig(:socure_result, :errors)
+            expect(errors).to include(
+              'I000' => '',
+            )
+          end,
+        )
       end
     end
   end

--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Idv::Agent do
         )
         result = document_capture_session.load_proofing_result.result
 
-        expect(result[:exception].to_s).to include('address mock timeout')
+        expect(result[:exception].to_s).to include('resolution mock timeout')
         expect(result).to include(
           success: false,
           timed_out: true,

--- a/spec/services/proofing/mock/resolution_mock_client_spec.rb
+++ b/spec/services/proofing/mock/resolution_mock_client_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Proofing::Mock::ResolutionMockClient do
         expect(result.to_h).to eq(
           success: false,
           errors: {},
-          exception: Proofing::TimeoutError.new('address mock timeout'),
+          exception: Proofing::TimeoutError.new('resolution mock timeout'),
           timed_out: true,
           reference: reference,
           transaction_id: transaction_id,

--- a/spec/services/proofing/socure/id_plus/proofer_spec.rb
+++ b/spec/services/proofing/socure/id_plus/proofer_spec.rb
@@ -73,11 +73,9 @@ RSpec.describe Proofing::Socure::IdPlus::Proofer do
   it 'reports reason codes as errors' do
     expect(result.errors).to eql(
       {
-        reason_codes: [
-          'I905',
-          'I914',
-          'I919',
-        ],
+        'I905' => '',
+        'I914' => '',
+        'I919' => '',
       },
     )
   end

--- a/spec/services/proofing/socure/id_plus/proofer_spec.rb
+++ b/spec/services/proofing/socure/id_plus/proofer_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe Proofing::Socure::IdPlus::Proofer do
   it 'reports reason codes as errors' do
     expect(result.errors).to eql(
       {
-        'I905' => '',
-        'I914' => '',
-        'I919' => '',
+        'I905' => '[unknown]',
+        'I914' => '[unknown]',
+        'I919' => '[unknown]',
       },
     )
   end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14717](https://cm-jira.usa.gov/browse/LG-14717)

## 🛠 Summary of changes

Updates `SocureShadowModeProofingJob` to log reason code descriptions (now that we have them available thanks to #11350) along with the codes themselves. This will hopefully make the job of checking these logs to verify things are functioning correctly a little easier.

Right now the intention is for this verbose logging to be in place for the relatively short shadow mode test period. Whether or not we continue this when we move fully into prod will depend on whether we find it useful.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Download the latest Socure reason codes:
  1. Set the `idv_socure_reason_code_download_enabled`, `socure_reason_code_api_key`, and `socure_reason_code_base_url` configs in your application.yml
  2. From the rails console execute `SocureReasonCodeDownloadJob.new.perform`
- [ ] Enable shadow mode by setting the `idv_socure_shadow_mode_enabled`, `socure_idplus_api_key`, and `socure_idplus_base_url` settings
- [ ] Go through IdV until you reach the phone number screen
- [ ] Check your `log/event.log` file and verify you have a `idv_socure_shadow_mode_proofing_result` event that has a `socure_result` that includes an `errors` object where keys are reason codes and values are descriptions, e.g.:

```jsonc
{
  "name": "idv_socure_shadow_mode_proofing_result",
  "properties": {
    "event_properties": {
      // ...
      "socure_result": {
        "success": true,
        "errors": {
          "I919": "Full name, address, and SSN/ITIN can be resolved to the individual"
        },
      // ...
    }
  }
}
```

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
