### PR TITLE
Refactor 2FA setup controller specs

### DIFF
--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -130,37 +130,37 @@ RSpec.describe Users::TwoFactorAuthenticationSetupController do
     context 'when multi selection with phone first' do
       let(:params) { { two_factor_options_form: { selection: ['phone', 'auth_app'] } } }
 
-      it { should redirect_to phone_setup_url }
+      it { is_expected.to redirect_to phone_setup_url }
     end
 
     context 'when multi selection with auth app first' do
       let(:params) { { two_factor_options_form: { selection: ['auth_app', 'phone', 'webauthn'] } } }
 
-      it { should redirect_to authenticator_setup_url }
+      it { is_expected.to redirect_to authenticator_setup_url }
     end
 
     context 'when the selection is auth_app' do
       let(:params) { { two_factor_options_form: { selection: ['auth_app'] } } }
 
-      it { should redirect_to authenticator_setup_url }
+      it { is_expected.to redirect_to authenticator_setup_url }
     end
 
     context 'when the selection is webauthn' do
       let(:params) { { two_factor_options_form: { selection: ['webauthn'] } } }
 
-      it { should redirect_to webauthn_setup_url }
+      it { is_expected.to redirect_to webauthn_setup_url }
     end
 
     context 'when the selection is webauthn platform authenticator' do
       let(:params) { { two_factor_options_form: { selection: ['webauthn_platform'] } } }
 
-      it { should redirect_to webauthn_setup_url(platform: true) }
+      it { is_expected.to redirect_to webauthn_setup_url(platform: true) }
     end
 
     context 'when the selection is piv_cac' do
       let(:params) { { two_factor_options_form: { selection: ['piv_cac'] } } }
 
-      it { should redirect_to setup_piv_cac_url }
+      it { is_expected.to redirect_to setup_piv_cac_url }
     end
 
     context 'when the selection is not valid' do


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-14655](https://cm-jira.usa.gov/browse/LG-14655)

## 🛠 Summary of changes

Refactors specs for `Users::TwoFactorAuthenticationSetupController#create`.

Specific improvements:

- Update `describe` description to follow conventions for controller action method names (`'PATCH create'` ➡️ `'#create'`)
- Remove duplicate assertions for expected analytics logging
- Avoid testing internal implementation details irrelevant for expected outcomes (asserting that form class is called)
- Reduce boilerplate, using combination of `subject` and `before` common setup
- Leverage [RSpec one-liner syntax](https://rspec.info/features/3-12/rspec-core/subject/one-liner-syntax/) to simplify redirect expectations
- Add test coverage for expected error message on invalid submission

This is split from the work of [LG-14655](https://cm-jira.usa.gov/browse/LG-14655), which requires revisions to these controller specs building upon the improvements here.

## 📜 Testing Plan

```
rspec spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
```