### PR TITLE
Changing LOGIN_ENV to properly construct piv url

### DIFF
--- a/dockerfiles/application.yaml
+++ b/dockerfiles/application.yaml
@@ -89,7 +89,7 @@ spec:
               value: "true"
             - op: add
               path: /data/LOGIN_ENV
-              value: "review-app"
+              value: "reviewapps"
             - op: add
               path: /data/LOGIN_DOMAIN
               value: "identitysandbox.gov"
@@ -162,7 +162,7 @@ spec:
               value: "true"
             - op: add
               path: /data/LOGIN_ENV
-              value: "review-app"
+              value: "reviewapps"
             - op: add
               path: /data/LOGIN_DOMAIN
               value: "identitysandbox.gov"

--- a/dockerfiles/application.yaml
+++ b/dockerfiles/application.yaml
@@ -47,7 +47,7 @@ spec:
               value: "prefer"
             - op: add
               path: /data/LOGIN_ENV
-              value: "{{ENVIRONMENT}}"
+              value: "reviewapps"
             - op: add
               path: /data/LOGIN_HOST_ROLE
               value: "idp"
@@ -120,7 +120,7 @@ spec:
               value: "prefer"
             - op: add
               path: /data/LOGIN_ENV
-              value: "{{ENVIRONMENT}}"
+              value: "reviewapps"
             - op: add
               path: /data/LOGIN_HOST_ROLE
               value: "idp"
@@ -188,7 +188,7 @@ spec:
               value: "{{ENVIRONMENT}}-idp-pg.review-apps"
             - op: add
               path: /data/LOGIN_ENV
-              value: "{{ENVIRONMENT}}"
+              value: "reviewapps"
             - op: add
               path: /data/LOGIN_HOST_ROLE
               value: "worker"
@@ -225,7 +225,7 @@ spec:
               value: "{{ENVIRONMENT}}-idp-pg.review-apps"
             - op: add
               path: /data/LOGIN_ENV
-              value: "{{ENVIRONMENT}}"
+              value: "reviewapps"
             - op: add
               path: /data/LOGIN_HOST_ROLE
               value: "worker"


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

At the moment the `LOGIN_ENV` variable that is set breaks the CSP check for the pivcac integration since it uses that to construct the idp's CSP settings. Switching this to `reviewapps` to fix.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] The console does not show a CSP error when trying to add a piv to your account

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
