### PR TITLE
Delete deprecated code

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -101,9 +101,6 @@ class GetUspsProofingResultsJob < ApplicationJob
   end
 
   def check_enrollment(enrollment)
-    # Add a unique ID for enrollments that don't have one
-    enrollment.update(unique_id: enrollment.usps_unique_id) if enrollment.unique_id.blank?
-
     status_check_attempted_at = Time.zone.now
     enrollment_outcomes[:enrollments_checked] += 1
 

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -146,11 +146,6 @@ class InPersonEnrollment < ApplicationRecord
     notification_phone_configuration.present? && (passed? || failed?)
   end
 
-  # (deprecated) Returns the value to use for the USPS enrollment ID
-  def usps_unique_id
-    user.uuid.delete('-').slice(0, 18)
-  end
-
   def enhanced_ipp?
     IdentityConfig.store.usps_eipp_sponsor_id == sponsor_id
   end

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -62,13 +62,9 @@ module UspsInPersonProofing
       # @return [String] The enrollment code
       # @raise [Exception::RequestEnrollException] Raised with a problem creating the enrollment
       def create_usps_enrollment(enrollment, pii, is_enhanced_ipp)
-        # Use the enrollment's unique_id value if it exists, otherwise use the deprecated
-        # #usps_unique_id value in order to remain backwards-compatible. LG-7024 will remove this
-        unique_id = enrollment.unique_id || enrollment.usps_unique_id
-
         applicant = UspsInPersonProofing::Applicant.new(
           {
-            unique_id: unique_id,
+            unique_id: enrollment.unique_id,
             first_name: transliterate(pii[:first_name]),
             last_name: transliterate(pii[:last_name]),
             address: transliterate(pii[:address1]),

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -2728,18 +2728,6 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
           end
         end
 
-        context 'when the enrollment does not have a unique_id' do
-          before do
-            enrollment.update(unique_id: nil)
-            allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_exception)
-            subject.perform(current_time)
-          end
-
-          it 'updates the enrollment to have a unique_id' do
-            expect(enrollment.reload.unique_id).to be_present
-          end
-        end
-
         context 'when multiple pending InPersonEnrollments exist' do
           let(:enrollments) do
             [

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -180,20 +180,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
           end
         end
 
-        context 'when the enrollment does not have a unique ID' do
-          it 'generates a usps_unique_id value to create the enrollment' do
-            enrollment.update(unique_id: nil)
-            expect(proofer).to receive(:request_enroll) do |applicant|
-              # The InPersonEnrollment#usps_unique_id method is deprecated
-              expect(applicant.unique_id).to eq(enrollment.usps_unique_id)
-
-              UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
-            end
-
-            subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-          end
-        end
-
         it <<~STR.squish do
           sets enrollment status to pending, sponsor_id to usps_ipp_sponsor_id,
           and sets established at date and unique id


### PR DESCRIPTION
This PR is a follow-up to [a conversation](https://docs.google.com/document/d/1xYSYHCU9k5oRQt_h93XtMDuevHpeSNECCORGAdWLh28/edit#bookmark=id.3tmqufqzuddp) we had 10/22/24 in Joy Engineering Huddle.  The instance method `usps_unique_id` was marked as deprecated in the `in_person_enrollment` model.  I did research and found PR #6883, which replaced the deprecated `usps_unique_id` method with the class method `set_unique_id`.  `usps_unique_id` used 18 characters from the in_person_enrollment's uuid, whereas `set_unique_id` randomly generates 18 characters.

As noted in [this github comment from 2022](https://github.com/18F/identity-idp/pull/6883#discussion_r963657507), it would have been safe to remove any references to `usps_unique_id` after letting the job run once to assign a unique ID to all records missing a unique id.  During that job run, any records that didn't have a unique_id would have had the old unique id format (18 characters of the uuid) sent in the request to the USPS API, rather than the new format (18 randomly generated characters.) As a result, we would have needed to use the old id format, in order to be able to match between our in_person_enrollment records and USPS's enrollment records.  Two years later, this is no longer a concern.

Lastly, I did queries in dev, int, staging, and prod, in order to confirm that we are no longer generating any in_person_enrollments without unique_ids.  See below:

Dev
- 101 enrollments had a nil unique_id field
- 63 were “establishing”
- 0 were “pending”
- 4 were “passed”
- 27 were “cancelled”
- 7 were “failed”
- 0 were “expired”
Last one created Thursday, September 1, 2022 (before PR #6883 was deployed)

Int
- 2 in_person_enrollments had a nil unique_id field
- Both were cancelled
Last one created August 12, 2022 (before PR #6883 was deployed)

Staging
- 13 in_person_enrollments had a nil unique_id field
- 7 were “establishing”
- 6 were “cancelled”
Last one created august 17. 2022 (before PR #6883 was deployed)

Prod
- Two in_person_enrollments had a nil unique_id field
- Both had the status "establishing"
Last one created august 19, 2022 (before PR #6883 was deployed)

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
