### PR TITLE
Add id_token_hint usage tracking

### DIFF
--- a/lib/reporting/protocols_report.rb
+++ b/lib/reporting/protocols_report.rb
@@ -372,7 +372,7 @@ module Reporting
           query:,
           from: time_range.begin,
           to: time_range.end,
-        )
+        ),
       )
     end
 

--- a/spec/lib/reporting/protocols_report_spec.rb
+++ b/spec/lib/reporting/protocols_report_spec.rb
@@ -90,11 +90,21 @@ RSpec.describe Reporting::ProtocolsReport do
       },
     ]
 
+    id_token_hint_query_response = [
+      {
+        'issuer' => 'Issuer3',
+      },
+      {
+        'issuer' => 'Issuer4',
+      },
+    ]
+
     stub_multiple_cloudwatch_logs(
       protocol_query_response,
       saml_signature_query_response,
       loa_issuers_query_response,
       aal3_issuers_query_response,
+      id_token_hint_query_response,
       facial_match_issuers_query_response,
     )
   end
@@ -235,6 +245,11 @@ RSpec.describe Reporting::ProtocolsReport do
           'AAL3',
           string_or_num(strings, 2),
           'Issuer1, Issuer3',
+        ],
+        [
+          'id_token_hint',
+          string_or_num(strings, 2),
+          'Issuer3, Issuer4',
         ],
       ],
       [


### PR DESCRIPTION
## 🎫 Ticket
[Add id_token_hint usage to weekly protocols report](https://gitlab.login.gov/lg-people/Melba/backlog-fy24/-/issues/129)

## 🛠 Summary of changes
This change:
- Adds a row in the weekly protocols report to track id_token_hint usage
- Refactors some code to reduce duplication

<img width="743" alt="Weekly reports table including an id_token_hint row" src="https://github.com/user-attachments/assets/4010338f-b8e1-4817-8092-09914c76e120">
