### PR TITLE
changelog: Internal, Analytics, Fix weekly protocols report

### DIFF
--- a/app/jobs/reports/protocols_report.rb
+++ b/app/jobs/reports/protocols_report.rb
@@ -8,11 +8,6 @@ module Reports
 
     attr_accessor :report_date
 
-    def initialize(report_date = nil, *args, **rest)
-      @report_date = report_date
-      super(*args, **rest)
-    end
-
     def perform(date = Time.zone.yesterday.end_of_day)
       return unless IdentityConfig.store.s3_reports_enabled
 

--- a/app/jobs/reports/protocols_report.rb
+++ b/app/jobs/reports/protocols_report.rb
@@ -13,10 +13,10 @@ module Reports
       super(*args, **rest)
     end
 
-    def perform(report_date)
+    def perform(date = Time.zone.yesterday.end_of_day)
       return unless IdentityConfig.store.s3_reports_enabled
 
-      self.report_date = report_date
+      @report_date = date
       message = "Report: #{REPORT_NAME} #{report_date}"
       subject = "Weekly Protocols Report - #{report_date}"
 

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -25,7 +25,7 @@ class ReportMailerPreview < ActionMailer::Preview
 
   def protocols_report
     date = Time.zone.yesterday
-    report = Reports::ProtocolsReport.new(date)
+    report = Reports::ProtocolsReport.new.tap { |r| r.report_date = date }
 
     stub_cloudwatch_client(report.send(:report))
 


### PR DESCRIPTION
## 🛠 Summary of changes

Last week's update of the ProtocolsReport led to an [Argument Error](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=43200000&state=87de4533-e030-dc27-4af6-da3c56c7144d) when the cron job attempted to run.

I'm not totally sure how the GoodJob cron jobs work, but I believe it's because I added an `initializer` method for the Mailer Preview feature, and that the report_date argument was being passed into that rather than the `perform` method. There may be a different way to solve this, but I wasn't sure how to test it.