### PR TITLE
LG-14887: Log action name with reCAPTCHA assessment result received

### DIFF
--- a/app/forms/recaptcha_form.rb
+++ b/app/forms/recaptcha_form.rb
@@ -120,6 +120,7 @@ class RecaptchaForm
       evaluated_as_valid: recaptcha_result_valid?(result),
       exception_class: error&.class&.name,
       form_class: self.class.name,
+      recaptcha_action:,
       **extra_analytics_properties,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6138,13 +6138,15 @@ module AnalyticsEvents
   # @param [Boolean] evaluated_as_valid Whether result was considered valid
   # @param [String] form_class Class name of form
   # @param [String, nil] exception_class Class name of exception, if error occurred
-  # @param [String, nil] phone_country_code Country code associated with reCAPTCHA phone result
+  # @param [String] recaptcha_action reCAPTCHA action name, for distinct user flow
+  # @param [String, nil] phone_country_code Country code associated with reCAPTCHA phone results
   def recaptcha_verify_result_received(
     recaptcha_result:,
     score_threshold:,
     evaluated_as_valid:,
     form_class:,
     exception_class:,
+    recaptcha_action:,
     phone_country_code: nil,
     **extra
   )
@@ -6155,6 +6157,7 @@ module AnalyticsEvents
       evaluated_as_valid:,
       form_class:,
       exception_class:,
+      recaptcha_action:,
       phone_country_code:,
       **extra,
     )

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -232,6 +232,7 @@ RSpec.describe 'Add a new phone number' do
       evaluated_as_valid: false,
       score_threshold: 0.6,
       phone_country_code: 'AU',
+      recaptcha_action: 'phone_setup',
       form_class: 'RecaptchaMockForm',
     )
 

--- a/spec/forms/recaptcha_enterprise_form_spec.rb
+++ b/spec/forms/recaptcha_enterprise_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RecaptchaEnterpriseForm do
   let(:score_threshold) { 0.2 }
   let(:analytics) { FakeAnalytics.new }
   let(:extra_analytics_properties) { {} }
-  let(:action) { 'example_action' }
+  let(:recaptcha_action) { 'example_action' }
   let(:recaptcha_enterprise_api_key) { 'recaptcha_enterprise_api_key' }
   let(:recaptcha_enterprise_project_id) { 'project_id' }
   let(:recaptcha_site_key) { 'recaptcha_site_key' }
@@ -19,7 +19,7 @@ RSpec.describe RecaptchaEnterpriseForm do
 
   subject(:form) do
     described_class.new(
-      recaptcha_action: action,
+      recaptcha_action:,
       score_threshold:,
       analytics:,
       extra_analytics_properties:,
@@ -121,11 +121,11 @@ RSpec.describe RecaptchaEnterpriseForm do
       before do
         stub_recaptcha_response(
           body: {
-            tokenProperties: { valid: false, action:, invalidReason: 'EXPIRED' },
+            tokenProperties: { valid: false, action: recaptcha_action, invalidReason: 'EXPIRED' },
             event: {},
             name:,
           },
-          action:,
+          action: recaptcha_action,
           token:,
         )
       end
@@ -155,6 +155,7 @@ RSpec.describe RecaptchaEnterpriseForm do
           evaluated_as_valid: false,
           score_threshold: score_threshold,
           form_class: 'RecaptchaEnterpriseForm',
+          recaptcha_action:,
         )
       end
     end
@@ -167,7 +168,7 @@ RSpec.describe RecaptchaEnterpriseForm do
           body: {
             error: { code: 400, status: 'INVALID_ARGUMENT' },
           },
-          action:,
+          action: recaptcha_action,
           token:,
         )
       end
@@ -194,6 +195,7 @@ RSpec.describe RecaptchaEnterpriseForm do
           evaluated_as_valid: true,
           score_threshold: score_threshold,
           form_class: 'RecaptchaEnterpriseForm',
+          recaptcha_action:,
         )
       end
     end
@@ -221,6 +223,7 @@ RSpec.describe RecaptchaEnterpriseForm do
           score_threshold: score_threshold,
           form_class: 'RecaptchaEnterpriseForm',
           exception_class: 'Faraday::ConnectionFailed',
+          recaptcha_action:,
         )
       end
     end
@@ -233,12 +236,12 @@ RSpec.describe RecaptchaEnterpriseForm do
       before do
         stub_recaptcha_response(
           body: {
-            tokenProperties: { valid: true, action: },
+            tokenProperties: { valid: true, action: recaptcha_action },
             riskAnalysis: { score:, reasons: ['AUTOMATION'] },
             event: {},
             name:,
           },
-          action:,
+          action: recaptcha_action,
           token:,
         )
       end
@@ -268,6 +271,7 @@ RSpec.describe RecaptchaEnterpriseForm do
           evaluated_as_valid: false,
           score_threshold: score_threshold,
           form_class: 'RecaptchaEnterpriseForm',
+          recaptcha_action:,
         )
       end
 
@@ -275,12 +279,12 @@ RSpec.describe RecaptchaEnterpriseForm do
         before do
           stub_recaptcha_response(
             body: {
-              tokenProperties: { valid: true, action: },
+              tokenProperties: { valid: true, action: recaptcha_action },
               riskAnalysis: { score:, reasons: ['LOW_CONFIDENCE_SCORE'] },
               event: {},
               name:,
             },
-            action:,
+            action: recaptcha_action,
             token:,
           )
         end
@@ -307,6 +311,7 @@ RSpec.describe RecaptchaEnterpriseForm do
             evaluated_as_valid: true,
             score_threshold: score_threshold,
             form_class: 'RecaptchaEnterpriseForm',
+            recaptcha_action:,
           )
         end
       end
@@ -320,12 +325,12 @@ RSpec.describe RecaptchaEnterpriseForm do
       around do |example|
         stubbed_request = stub_recaptcha_response(
           body: {
-            tokenProperties: { valid: true, action: },
+            tokenProperties: { valid: true, action: recaptcha_action },
             riskAnalysis: { score:, reasons: ['LOW_CONFIDENCE'] },
             event: {},
             name:,
           },
-          action:,
+          action: recaptcha_action,
           token:,
         )
         example.run
@@ -354,6 +359,7 @@ RSpec.describe RecaptchaEnterpriseForm do
           evaluated_as_valid: true,
           score_threshold: score_threshold,
           form_class: 'RecaptchaEnterpriseForm',
+          recaptcha_action:,
         )
       end
 
@@ -368,7 +374,7 @@ RSpec.describe RecaptchaEnterpriseForm do
               event: {},
               name:,
             },
-            action:,
+            action: recaptcha_action,
             token:,
           )
         end
@@ -402,6 +408,7 @@ RSpec.describe RecaptchaEnterpriseForm do
             evaluated_as_valid: true,
             score_threshold: score_threshold,
             form_class: 'RecaptchaEnterpriseForm',
+            recaptcha_action:,
             extra: true,
           )
         end

--- a/spec/forms/recaptcha_form_spec.rb
+++ b/spec/forms/recaptcha_form_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe RecaptchaForm do
   let(:analytics) { FakeAnalytics.new }
   let(:extra_analytics_properties) { {} }
   let(:recaptcha_secret_key) { 'recaptcha_secret_key' }
+  let(:recaptcha_action) { 'example_action' }
 
   subject(:form) do
-    RecaptchaForm.new(score_threshold:, analytics:, extra_analytics_properties:)
+    RecaptchaForm.new(score_threshold:, recaptcha_action:, analytics:, extra_analytics_properties:)
   end
 
   before do
@@ -129,6 +130,7 @@ RSpec.describe RecaptchaForm do
           evaluated_as_valid: false,
           score_threshold: score_threshold,
           form_class: 'RecaptchaForm',
+          recaptcha_action:,
         )
       end
 
@@ -163,6 +165,7 @@ RSpec.describe RecaptchaForm do
               evaluated_as_valid: true,
               score_threshold: score_threshold,
               form_class: 'RecaptchaForm',
+              recaptcha_action:,
             )
           end
         end
@@ -197,6 +200,7 @@ RSpec.describe RecaptchaForm do
               evaluated_as_valid: true,
               score_threshold: score_threshold,
               form_class: 'RecaptchaForm',
+              recaptcha_action:,
             )
           end
         end
@@ -226,6 +230,7 @@ RSpec.describe RecaptchaForm do
           score_threshold: score_threshold,
           form_class: 'RecaptchaForm',
           exception_class: 'Faraday::ConnectionFailed',
+          recaptcha_action:,
         )
       end
     end
@@ -263,6 +268,7 @@ RSpec.describe RecaptchaForm do
           evaluated_as_valid: false,
           score_threshold: score_threshold,
           form_class: 'RecaptchaForm',
+          recaptcha_action:,
         )
       end
     end
@@ -299,6 +305,7 @@ RSpec.describe RecaptchaForm do
           evaluated_as_valid: true,
           score_threshold: score_threshold,
           form_class: 'RecaptchaForm',
+          recaptcha_action:,
         )
       end
 
@@ -320,6 +327,7 @@ RSpec.describe RecaptchaForm do
             evaluated_as_valid: true,
             score_threshold: score_threshold,
             form_class: 'RecaptchaForm',
+            recaptcha_action:,
             extra: true,
           )
         end

--- a/spec/forms/recaptcha_mock_form_spec.rb
+++ b/spec/forms/recaptcha_mock_form_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe RecaptchaMockForm do
   let(:score_threshold) { 0.2 }
   let(:analytics) { FakeAnalytics.new }
   let(:score) { nil }
+  let(:recaptcha_action) { 'example_action' }
   subject(:form) do
-    RecaptchaMockForm.new(score_threshold:, analytics:, score:)
+    RecaptchaMockForm.new(score_threshold:, analytics:, recaptcha_action:, score:)
   end
 
   around do |example|
@@ -44,6 +45,7 @@ RSpec.describe RecaptchaMockForm do
           evaluated_as_valid: false,
           score_threshold: score_threshold,
           form_class: 'RecaptchaMockForm',
+          recaptcha_action:,
         )
       end
     end
@@ -74,6 +76,7 @@ RSpec.describe RecaptchaMockForm do
           evaluated_as_valid: true,
           score_threshold: score_threshold,
           form_class: 'RecaptchaMockForm',
+          recaptcha_action:,
         )
       end
 

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -348,6 +348,7 @@ RSpec.shared_examples 'logs reCAPTCHA event and redirects appropriately' do |suc
       },
       evaluated_as_valid: false,
       score_threshold: 0.2,
+      recaptcha_action: 'sign_in',
       form_class: 'RecaptchaMockForm',
     )
     expect(fake_analytics).to have_logged_event(


### PR DESCRIPTION
## 🎫 Ticket

[LG-14887](https://cm-jira.usa.gov/browse/LG-14887)

## 🛠 Summary of changes

Updates reCAPTCHA analytics logging to include the expected ["action" name](https://cloud.google.com/recaptcha/docs/actions-website), so that we can more clearly differentiate reCAPTCHA results between sign-in and phone setup.

## 📜 Testing Plan

1. In a separate terminal process, run `make watch_events`
2. Go to http://localhost:3000 in a private browsing window
3. Sign in to an account
4. In the `make watch_events` output, find the event for "reCAPTCHA verify result received", and observe the expected `properties.event_properties.recaptcha_action: 'sign_in'`
5. Optionally, repeat these same steps for the phone setup flow for international numbers, and verify the expected value of `phone_setup`