### PR TITLE
Update local development documentation for working with PKI

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -75,6 +75,21 @@ Running the sample application requires a few additional steps, but can be usefu
 test the experience of a user being redirected to an external site, or if you want to configure
 different options of the authentication request, such as AAL or IAL.
 
+### PIV/CAC authentication using PKI service
+
+The IdP's PIV/CAC features are not maintained as part of this codebase, and are instead managed in a
+separate application whose code can be found in the [`18F/identity-pki`](https://github.com/18f/identity-pki)
+GitHub repository.
+
+In local development, you have two choices for working with PIV/CAC:
+
+- Follow the [setup instructions for `identity-pki`](https://github.com/18f/identity-pki#local-development)
+  and run the application in parallel to the IdP. The IdP is configured by default to connect to the
+  default port of a locally-running `identity-pki` instance (http://localhost:8443)
+- Override application configuration to set `identity_pki_disabled: true` in your local `config/application.yml`.
+  This will allow you to simulate PKI results without having an instance running, and can be useful
+  for testing different error scenarios or distinct PIV/CAC subject identifiers.
+
 ### Running tests locally
 
 Login.gov uses the following tools for our testing:


### PR DESCRIPTION
## 🛠 Summary of changes

Adds documentation for how to use PIV/CAC in local development, since this is a core feature of the application yet is not explicitly documented for how to operate locally.

## 📜 Testing Plan

Reads through the revised documentation and verify that you are able to understand the instructions well enough to get up-and-running if you were unfamiliar with using PKI in local development.