### PR TITLE
Update rexml dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -576,7 +576,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     retries (0.0.5)
-    rexml (3.3.7)
+    rexml (3.3.9)
     rotp (6.3.0)
     rouge (4.2.0)
     rqrcode (2.1.0)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `rexml` from `3.3.7` to `3.3.9`, to resolve a security advisory:

https://www.ruby-lang.org/en/news/2024/10/28/redos-rexml-cve-2024-49761/

## 📜 Testing Plan

Verify that build passes, and the application runs after `bundle install`.