### PR TITLE
LG-14431 update email report table colors

### DIFF
--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -25,8 +25,3 @@
     }
   }
 }
-
-.report-table tbody th {
-  font-weight: 700;
-  background-color: color('base-lightest');
-}

--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -5,9 +5,11 @@
 
 $secondary-color: #112e51;
 $light-gray: #f3f3f3;
-$white: #ffffff;
+$white: #fff;
 
-h1, h2, h3 {
+h1,
+h2,
+h3 {
   color: $secondary-color;
 }
 

--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -1,7 +1,13 @@
+@use 'variables/email' as *;
+
 @forward 'uswds-core';
 @forward 'usa-prose';
 @forward 'usa-table';
 @forward 'usa-alert';
+
+h1, h2, h3 {
+  color: $secondary-color;
+}
 
 .table-number {
   font-variant-numeric: tabular-nums;
@@ -13,5 +19,22 @@
     &::before {
       background-image: url('email/info.png');
     }
+  }
+}
+
+.usa-table {
+  tr th,
+  tr td {
+    border: 2px solid $secondary-color;
+  }
+
+  thead th[scope='col'] {
+    background-color: $secondary-color;
+    color: $white;
+  }
+
+  tbody th {
+    font-weight: 700;
+    background-color: $light-gray;
   }
 }

--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -1,16 +1,16 @@
-@forward 'uswds-core';
+@use 'uswds-core' as * with (
+  $theme-table-border-color: 'primary-darker',
+  $theme-table-header-background-color: 'primary-darker',
+  $theme-table-header-text-color: 'white'
+);
+
 @forward 'usa-prose';
 @forward 'usa-table';
 @forward 'usa-alert';
 
-$secondary-color: #112e51;
-$light-gray: #f3f3f3;
-$white: #fff;
-
-h1,
-h2,
-h3 {
-  color: $secondary-color;
+.report-title,
+.report-subtitle {
+  color: color('primary-darker');
 }
 
 .table-number {
@@ -26,19 +26,7 @@ h3 {
   }
 }
 
-.usa-table {
-  tr th,
-  tr td {
-    border: 2px solid $secondary-color;
-  }
-
-  thead th[scope='col'] {
-    background-color: $secondary-color;
-    color: $white;
-  }
-
-  tbody th {
-    font-weight: 700;
-    background-color: $light-gray;
-  }
+.report-table tbody th {
+  font-weight: 700;
+  background-color: color('base-lightest');
 }

--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -1,9 +1,11 @@
-@use 'variables/email' as *;
-
 @forward 'uswds-core';
 @forward 'usa-prose';
 @forward 'usa-table';
 @forward 'usa-alert';
+
+$secondary-color: #112e51;
+$light-gray: #f3f3f3;
+$white: #ffffff;
 
 h1, h2, h3 {
   color: $secondary-color;

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -24,14 +24,24 @@
     <tbody>
       <% rows.each do |row| %>
         <tr>
-          <% row.each do |cell| %>
-            <td <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
-              <% if cell.is_a?(Float) && report.float_as_percent? %>
-                <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
-              <% else %>
-                <%= number_with_delimiter(cell) %>
-              <% end %>
-            </td>
+          <% row.each_with_index do |cell, index| %>
+            <% if index == 0 %>
+              <th scope="row" <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
+                <% if cell.is_a?(Float) && report.float_as_percent? %>
+                  <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
+                <% else %>
+                  <%= number_with_delimiter(cell) %>
+                <% end %>
+              </th>
+            <% else %>
+              <td <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
+                <% if cell.is_a?(Float) && report.float_as_percent? %>
+                  <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
+                <% else %>
+                  <%= number_with_delimiter(cell) %>
+                <% end %>
+              </td>
+            <% end %>
           <% end %>
         </tr>
       <% end %>

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -7,13 +7,13 @@
   <% header, *rows = report.table %>
   <%# Allow nil title if a subtitle is set %>
   <% if report.title && report.title != report.subtitle %>
-    <h2><%= report.title %></h2>
+    <h2 class="report-title"><%= report.title %></h2>
   <% end %>
   <% if report.subtitle %>
-    <h3><%= report.subtitle %></h3>
+    <h3 class="report-subtitle"><%= report.subtitle %></h3>
   <% end %>
 
-  <table class="usa-table">
+  <table class="usa-table report-table">
     <thead>
       <tr>
         <% header.each do |head| %>
@@ -24,24 +24,22 @@
     <tbody>
       <% rows.each do |row| %>
         <tr>
-          <% row.each_with_index do |cell, index| %>
-            <% if index == 0 %>
-              <th scope="row" <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
-                <% if cell.is_a?(Float) && report.float_as_percent? %>
-                  <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
-                <% else %>
-                  <%= number_with_delimiter(cell) %>
-                <% end %>
-              </th>
+          <% first, *rest = row %>
+          <th scope="row" <%= first.is_a?(Numeric) ? 'class=table-number' : nil %> >
+            <% if first.is_a?(Float) && report.float_as_percent? %>
+              <%= number_to_percentage(first * 100, precision: report.precision || 2) %>
             <% else %>
-              <td <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
-                <% if cell.is_a?(Float) && report.float_as_percent? %>
-                  <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
-                <% else %>
-                  <%= number_with_delimiter(cell) %>
-                <% end %>
-              </td>
+              <%= number_with_delimiter(first) %>
             <% end %>
+          </th>
+          <% rest.each do |cell| %>
+            <td <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
+              <% if cell.is_a?(Float) && report.float_as_percent? %>
+                <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
+              <% else %>
+                <%= number_with_delimiter(cell) %>
+              <% end %>
+            </td>
           <% end %>
         </tr>
       <% end %>

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -13,7 +13,7 @@
     <h3 class="report-subtitle"><%= report.subtitle %></h3>
   <% end %>
 
-  <table class="usa-table report-table">
+  <table class="usa-table">
     <thead>
       <tr>
         <% header.each do |head| %>
@@ -24,15 +24,7 @@
     <tbody>
       <% rows.each do |row| %>
         <tr>
-          <% first, *rest = row %>
-          <th scope="row" <%= first.is_a?(Numeric) ? 'class=table-number' : nil %> >
-            <% if first.is_a?(Float) && report.float_as_percent? %>
-              <%= number_to_percentage(first * 100, precision: report.precision || 2) %>
-            <% else %>
-              <%= number_with_delimiter(first) %>
-            <% end %>
-          </th>
-          <% rest.each do |cell| %>
+          <% row.each do |cell| %>
             <td <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
               <% if cell.is_a?(Float) && report.float_as_percent? %>
                 <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14431](https://cm-jira.usa.gov/browse/LG-14431)

## 🛠 Summary of changes

Updated The text and background colors of report tables sent as HTML emails.

## 📜 Testing Plan
Reports can be previewed locally at [http://localhost:3000/rails/mailers/report_mailer](http://localhost:3000/rails/mailers/report_mailer) 

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="672" alt="Screenshot 2024-10-28 at 2 52 30 PM" src="https://github.com/user-attachments/assets/59703dac-d5f3-48b2-b186-6d24525d9bff">
</details>

<details>
<summary>After:</summary>
<img width="700" alt="Screenshot 2024-10-28 at 3 20 57 PM" src="https://github.com/user-attachments/assets/d5342998-407f-4f80-b13d-ffac77655d6e">
</details>
