### PR TITLE
LG-14031 Fix missing success banner on phone page

### DIFF
--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -204,7 +204,7 @@ module Idv
     end
 
     def verify_step_request?
-      request.referer == idv_verify_info_url
+      [idv_verify_info_url, idv_in_person_verify_info_url].include?(request.referer)
     end
 
     def should_keep_flash_success?

--- a/spec/features/idv/steps/in_person/verify_info_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_info_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true do
     complete_verify_step(user)
 
     # phone page
+    expect(page).to have_content(t('doc_auth.forms.doc_success'))
     expect(page).to have_content(t('titles.idv.phone'))
   end
 
@@ -138,6 +139,7 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true do
     complete_verify_step(user)
 
     # phone page
+    expect(page).to have_content(t('doc_auth.forms.doc_success'))
     expect(page).to have_content(t('titles.idv.phone'))
   end
 


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-14031](https://cm-jira.usa.gov/browse/LG-14031)

## 🛠 Summary of changes

Fixes missing success banner on phone page. The IPP verify info URL was not included as an acceptable referrer URL in the phone controller. This adds it.

Provide a checklist of steps to confirm the changes.


#### Checking that the banner appears on the phone page in IPP: 
- [x] Enter the in-person proofing flow (Starting from [Sinatra](http://localhost:9292/) and choosing identity-verified)
- [x] Complete in-person proofing steps up until you reach the phone page (/verify/phone)
- [x] Verify that the success banner is present at the top.

#### Checking that the banner is still present in the remote flow, and that changes don't adversely affect the phone page from remote flow:
- [x] Enter the remote proofing flow (Starting from [Sinatra](http://localhost:9292/) and choosing identity-verified)
- [x] Complete remote proofing steps up until you reach the phone page (/verify/phone)
  - [x] On the how to verify page, choose "Continue online"
  - [x] Choose "Upload photos"
  - [x] Upload passing yml files
  - [x] Complete ssn step and verify info step
- [x] Verify that the success banner is present at the top.


## 👀 Screenshots

https://github.com/user-attachments/assets/4ab5f09d-e134-43b4-9c89-371ad13b5bc1


