### PR TITLE
Display instructions when asserting logged event without stubbing analytics

### DIFF
--- a/spec/support/fake_analytics_spec.rb
+++ b/spec/support/fake_analytics_spec.rb
@@ -529,6 +529,22 @@ RSpec.describe FakeAnalytics do
         end
       end
     end
+
+    context 'with analytics not stubbed' do
+      let(:code_under_test) { -> { expect(analytics).to have_logged_event } }
+      subject(:analytics) { nil }
+
+      it 'raises with message explaining that analytics needs to be stubbed' do
+        expect(&code_under_test).
+          to raise_error(RSpec::Expectations::ExpectationNotMetError) do |err|
+          assert_error_messages_equal(err, <<~MESSAGE)
+            Matching expected logged events requires analytics to be stubbed.
+
+            Check that you've called `stub_analytics` before asserting `have_logged_event`.
+          MESSAGE
+        end
+      end
+    end
   end
 
   describe FakeAnalytics::PiiAlerter do


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `have_logged_event` matcher to output an instructional error message if called without analytics being stubbed.

This would have saved me a few minutes of debugging a cryptic error message, not realizing that analytics hadn't already been stubbed in the context of the test I was writing.

Before:

```
     Failure/Error:
       (events[expected_event_name] || []).filter do |actual_attributes|
         values_match?(expected_attributes, actual_attributes)
       end
     
     NoMethodError:
       undefined method `[]' for nil
     # ./spec/support/have_logged_event_matcher.rb:43:in `matches?'
     # ./spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb:452:in `block (5 levels) in <top (required)>'
     # ./spec/support/fake_analytics.rb:182:in `block (2 levels) in <main>'
```

After:

```
     Failure/Error:
       expect(@analytics).to have_logged_event('Multi-Factor Authentication')
     
       Matching expected logged events requires analytics to be stubbed.
     
       Check that you've called `stub_analytics` before asserting `have_logged_event`.
     # ./spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb:452:in `block (5 levels) in <top (required)>'
     # ./spec/support/fake_analytics.rb:182:in `block (2 levels) in <main>'
```

## 📜 Testing Plan

Verify build passes.

Find a random spec calling `have_logged_event` and remove the preceding `stub_analytics` call, and verify that running the specs produces the error message shown above.