### PR TITLE
LG 14404 Add email at confirmation to share with service provider

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -28,6 +28,7 @@ module SignUp
       if decider.go_back_to_mobile_app?
         sign_user_out_and_instruct_to_go_back_to_mobile_app
       else
+        user_session.delete(:pending_completions_consent)
         redirect_to(
           sp_session_request_url_with_updated_params || account_url,
           allow_other_host: true,

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -44,7 +44,11 @@ module Users
       confirm_and_notify(email_address)
       if current_user
         flash[:success] = t('devise.confirmations.confirmed')
-        redirect_to account_url
+        if user_session[:pending_completions_consent] == true
+          redirect_to sign_up_completed_url
+        else
+          redirect_to account_url
+        end
       else
         flash[:success] = t('devise.confirmations.confirmed_but_sign_in')
         redirect_to root_url

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -45,7 +45,7 @@ module Users
       if current_user
         flash[:success] = t('devise.confirmations.confirmed')
         if user_session[:pending_completions_consent] == true
-          redirect_to sign_up_completed_url
+          redirect_to sign_up_select_email_url
         else
           redirect_to account_url
         end

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -22,6 +22,10 @@ module Users
       result = @add_user_email_form.submit(current_user, permitted_params)
       analytics.add_email_request(**result.to_h)
 
+      if pending_completions_consent?
+        user_session[:pending_completions_consent] = true
+      end
+
       if result.success?
         process_successful_creation
       else

--- a/spec/controllers/users/email_confirmations_controller_spec.rb
+++ b/spec/controllers/users/email_confirmations_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Users::EmailConfirmationsController do
 
         get :create, params: { confirmation_token: email_record.reload.confirmation_token }
 
-        expect(response).to redirect_to(sign_up_completed_url)
+        expect(response).to redirect_to(sign_up_select_email_url)
       end
 
       it 'adds an email from the account page' do


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-14404](https://cm-jira.usa.gov/browse/LG-14404)



## 🛠 Summary of changes

Remedies the user flow from adding a new email address at Service Provider linking confirmation. 

Expected behavior:
Clicking the link that appears in the added email address confirmation email message should return you to where you left off from selecting an email to pass over to the SP

Actual behavior:
You end up at the account dashboard and have to click the Return to SP link to get back on track.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Using a simulated SP such as SAML or OIDC log in with an account that hasn't been connected yet.
- [ ] Proceed to the flow and choose to add a new email
- [ ] Observe that by clicking the confirmation link you are returned to where you can select that email and proceed on to the service provider.



## 👀 Screenshots


https://github.com/user-attachments/assets/786811aa-0983-472f-996d-2fe8bbc4a0b6


