### PR TITLE
ProgressiveProofer refactor 1/N: ThreatMetrix

### DIFF
--- a/app/services/proofing/resolution/plugins/threat_metrix_plugin.rb
+++ b/app/services/proofing/resolution/plugins/threat_metrix_plugin.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Proofing
+  module Resolution
+    module Plugins
+      class ThreatMetrixPlugin
+        def call(
+          applicant_pii:,
+          current_sp:,
+          request_ip:,
+          threatmetrix_session_id:,
+          timer:,
+          user_email:
+        )
+          unless FeatureManagement.proofing_device_profiling_collecting_enabled?
+            return threatmetrix_disabled_result
+          end
+
+          # The API call will fail without a session ID, so do not attempt to make
+          # it to avoid leaking data when not required.
+          return threatmetrix_id_missing_result if threatmetrix_session_id.blank?
+          return threatmetrix_pii_missing_result if applicant_pii.blank?
+
+          ddp_pii = applicant_pii.dup
+          ddp_pii[:threatmetrix_session_id] = threatmetrix_session_id
+          ddp_pii[:email] = user_email
+          ddp_pii[:request_ip] = request_ip
+
+          timer.time('threatmetrix') do
+            proofer.proof(ddp_pii)
+          end.tap do |result|
+            Db::SpCost::AddSpCost.call(
+              current_sp, :threatmetrix,
+              transaction_id: result.transaction_id
+            )
+          end
+        end
+
+        def proofer
+          @proofer ||=
+            if IdentityConfig.store.lexisnexis_threatmetrix_mock_enabled
+              Proofing::Mock::DdpMockClient.new
+            else
+              Proofing::LexisNexis::Ddp::Proofer.new(
+                api_key: IdentityConfig.store.lexisnexis_threatmetrix_api_key,
+                org_id: IdentityConfig.store.lexisnexis_threatmetrix_org_id,
+                base_url: IdentityConfig.store.lexisnexis_threatmetrix_base_url,
+              )
+            end
+        end
+
+        def threatmetrix_disabled_result
+          Proofing::DdpResult.new(
+            success: true,
+            client: 'tmx_disabled',
+            review_status: 'pass',
+          )
+        end
+
+        def threatmetrix_pii_missing_result
+          Proofing::DdpResult.new(
+            success: false,
+            client: 'tmx_pii_missing',
+            review_status: 'reject',
+          )
+        end
+
+        def threatmetrix_id_missing_result
+          Proofing::DdpResult.new(
+            success: false,
+            client: 'tmx_session_id_missing',
+            review_status: 'reject',
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -8,12 +8,12 @@ module Proofing
     #   2. The user has only provided one address for their residential and identity document
     #      address or separate residential and identity document addresses
     class ProgressiveProofer
-      attr_reader :applicant_pii,
-                  :request_ip,
-                  :threatmetrix_session_id,
-                  :timer,
-                  :user_email,
-                  :current_sp
+      attr_reader :applicant_pii, :timer, :current_sp
+      attr_reader :threatmetrix_plugin
+
+      def initialize
+        @threatmetrix_plugin = Plugins::ThreatMetrixPlugin.new
+      end
 
       # @param [Hash] applicant_pii keys are symbols and values are strings, confidential user info
       # @param [Boolean] ipp_enrollment_in_progress flag that indicates if user will have
@@ -33,14 +33,19 @@ module Proofing
         current_sp:
       )
         @applicant_pii = applicant_pii.except(:best_effort_phone_number_for_socure)
-        @request_ip = request_ip
-        @threatmetrix_session_id = threatmetrix_session_id
         @timer = timer
-        @user_email = user_email
         @ipp_enrollment_in_progress = ipp_enrollment_in_progress
         @current_sp = current_sp
 
-        @device_profiling_result = proof_with_threatmetrix_if_needed
+        device_profiling_result = threatmetrix_plugin.call(
+          applicant_pii:,
+          current_sp:,
+          threatmetrix_session_id:,
+          request_ip:,
+          timer:,
+          user_email:,
+        )
+
         @residential_instant_verify_result = proof_residential_address_if_needed
         @instant_verify_result = proof_id_address_with_lexis_nexis_if_needed
         @state_id_result = proof_id_with_aamva_if_needed
@@ -63,28 +68,6 @@ module Proofing
                   :residential_instant_verify_result,
                   :instant_verify_result,
                   :state_id_result
-
-      def proof_with_threatmetrix_if_needed
-        unless FeatureManagement.proofing_device_profiling_collecting_enabled?
-          return threatmetrix_disabled_result
-        end
-
-        # The API call will fail without a session ID, so do not attempt to make
-        # it to avoid leaking data when not required.
-        return threatmetrix_id_missing_result if threatmetrix_session_id.blank?
-        return threatmetrix_pii_missing_result if applicant_pii.blank?
-
-        ddp_pii = applicant_pii.dup
-        ddp_pii[:threatmetrix_session_id] = threatmetrix_session_id
-        ddp_pii[:email] = user_email
-        ddp_pii[:request_ip] = request_ip
-
-        timer.time('threatmetrix') do
-          lexisnexis_ddp_proofer.proof(ddp_pii)
-        end.tap do |result|
-          add_sp_cost(:threatmetrix, result.transaction_id)
-        end
-      end
 
       def proof_residential_address_if_needed
         return residential_address_unnecessary_result unless ipp_enrollment_in_progress?
@@ -173,30 +156,6 @@ module Proofing
         @ipp_enrollment_in_progress
       end
 
-      def threatmetrix_disabled_result
-        Proofing::DdpResult.new(
-          success: true,
-          client: 'tmx_disabled',
-          review_status: 'pass',
-        )
-      end
-
-      def threatmetrix_pii_missing_result
-        Proofing::DdpResult.new(
-          success: false,
-          client: 'tmx_pii_missing',
-          review_status: 'reject',
-        )
-      end
-
-      def threatmetrix_id_missing_result
-        Proofing::DdpResult.new(
-          success: false,
-          client: 'tmx_session_id_missing',
-          review_status: 'reject',
-        )
-      end
-
       def out_of_aamva_jurisdiction_result
         Proofing::StateIdResult.new(
           errors: {},
@@ -204,19 +163,6 @@ module Proofing
           success: true,
           vendor_name: 'UnsupportedJurisdiction',
         )
-      end
-
-      def lexisnexis_ddp_proofer
-        @lexisnexis_ddp_proofer ||=
-          if IdentityConfig.store.lexisnexis_threatmetrix_mock_enabled
-            Proofing::Mock::DdpMockClient.new
-          else
-            Proofing::LexisNexis::Ddp::Proofer.new(
-              api_key: IdentityConfig.store.lexisnexis_threatmetrix_api_key,
-              org_id: IdentityConfig.store.lexisnexis_threatmetrix_org_id,
-              base_url: IdentityConfig.store.lexisnexis_threatmetrix_base_url,
-            )
-          end
       end
 
       def resolution_proofer

--- a/spec/services/proofing/resolution/plugins/threatmetrix_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/threatmetrix_plugin_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe Proofing::Resolution::Plugins::ThreatMetrixPlugin do
+  let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
+  let(:current_sp) { build(:service_provider) }
+  let(:proofer_result) do
+    instance_double(Proofing::DdpResult, success?: true, transaction_id: 'ddp-123')
+  end
+  let(:request_ip) { Faker::Internet.ip_v4_address }
+  let(:threatmetrix_session_id) { 'cool-session-id' }
+  let(:user_email) { Faker::Internet.email }
+
+  subject(:plugin) do
+    described_class.new
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_mock_enabled).
+      and_return(false)
+    allow(plugin.proofer).to receive(:proof).and_return(proofer_result)
+  end
+
+  describe '#call' do
+    subject(:call) do
+      plugin.call(
+        applicant_pii:,
+        current_sp:,
+        request_ip:,
+        threatmetrix_session_id:,
+        timer: JobHelpers::Timer.new,
+        user_email:,
+      )
+    end
+
+    context 'ThreatMetrix is enabled' do
+      before do
+        allow(FeatureManagement).to receive(:proofing_device_profiling_collecting_enabled?).
+          and_return(true)
+      end
+
+      it 'calls the ThreatMetrix proofer' do
+        call
+        expect(plugin.proofer).to have_received(:proof)
+      end
+
+      it 'creates a ThreatMetrix associated cost' do
+        expect { call }.
+          to change {
+               SpCost.where(cost_type: :threatmetrix, issuer: current_sp.issuer).count
+             }.to eql(1)
+      end
+
+      context 'session id is missing' do
+        let(:threatmetrix_session_id) { nil }
+
+        it 'does not call the ThreatMetrix proofer' do
+          expect(plugin.proofer).not_to receive(:proof)
+          call
+        end
+
+        it 'returns a failed result' do
+          call.tap do |result|
+            expect(result.success).to be(false)
+            expect(result.client).to eq('tmx_session_id_missing')
+            expect(result.review_status).to eq('reject')
+          end
+        end
+      end
+
+      context 'pii is missing' do
+        let(:applicant_pii) { {} }
+
+        it 'does not call the ThreatMetrix proofer' do
+          expect(plugin.proofer).not_to receive(:proof)
+          call
+        end
+
+        it 'returns a failed result' do
+          call.tap do |result|
+            expect(result.success).to be(false)
+            expect(result.client).to eq('tmx_pii_missing')
+            expect(result.review_status).to eq('reject')
+          end
+        end
+      end
+    end
+
+    context 'ThreatMetrix is disabled' do
+      before do
+        allow(FeatureManagement).to receive(:proofing_device_profiling_collecting_enabled?).
+          and_return(false)
+      end
+
+      it 'returns a disabled result' do
+        call.tap do |result|
+          expect(result.success).to be(true)
+          expect(result.client).to eq('tmx_disabled')
+          expect(result.review_status).to eq('pass')
+        end
+      end
+
+      it 'does not create a ThreatMetrix associated cost' do
+        expect { call }.
+          not_to change {
+                   SpCost.where(cost_type: :threatmetrix, issuer: current_sp.issuer).count
+                 }
+      end
+    end
+  end
+end

--- a/spec/services/proofing/resolution/progressive_proofer_spec.rb
+++ b/spec/services/proofing/resolution/progressive_proofer_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe Proofing::Resolution::ProgressiveProofer do
   let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
   let(:ipp_enrollment_in_progress) { false }
+  let(:request_ip) { Faker::Internet.ip_v4_address }
   let(:threatmetrix_session_id) { SecureRandom.uuid }
+  let(:user_email) { Faker::Internet.email }
   let(:current_sp) { build(:service_provider) }
 
   let(:instant_verify_proofing_success) { true }
@@ -32,9 +34,17 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
   end
   let(:aamva_proofer) { instance_double(Proofing::Aamva::Proofer, proof: aamva_proofer_result) }
 
-  let(:threatmetrix_proofer_result) do
-    instance_double(Proofing::DdpResult, success?: true, transaction_id: 'ddp-123')
+  let(:threatmetrix_plugin) do
+    Proofing::Resolution::Plugins::ThreatMetrixPlugin.new
   end
+
+  let(:threatmetrix_proofer_result) do
+    Proofing::DdpResult.new(
+      success: true,
+      transaction_id: 'ddp-123',
+    )
+  end
+
   let(:threatmetrix_proofer) do
     instance_double(
       Proofing::LexisNexis::Ddp::Proofer,
@@ -101,11 +111,20 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
   end
 
   before do
+    allow(progressive_proofer).to receive(:threatmetrix_plugin).and_return(threatmetrix_plugin)
+    allow(threatmetrix_plugin).to receive(:proofer).and_return(threatmetrix_proofer)
+
     allow(progressive_proofer).to receive(:resolution_proofer).and_return(instant_verify_proofer)
     allow(progressive_proofer).to receive(:lexisnexis_ddp_proofer).and_return(threatmetrix_proofer)
     allow(progressive_proofer).to receive(:state_id_proofer).and_return(aamva_proofer)
 
     block_real_instant_verify_requests
+  end
+
+  it 'assigns threatmetrix_plugin' do
+    expect(described_class.new.threatmetrix_plugin).to be_a(
+      Proofing::Resolution::Plugins::ThreatMetrixPlugin,
+    )
   end
 
   describe '#proof' do
@@ -115,90 +134,51 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
 
     subject(:proof) do
       progressive_proofer.proof(
-        applicant_pii: applicant_pii,
-        ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-        request_ip: Faker::Internet.ip_v4_address,
-        threatmetrix_session_id: threatmetrix_session_id,
+        applicant_pii:,
+        ipp_enrollment_in_progress:,
+        request_ip:,
+        threatmetrix_session_id:,
         timer: JobHelpers::Timer.new,
-        user_email: Faker::Internet.email,
-        current_sp: current_sp,
+        user_email:,
+        current_sp:,
       )
+    end
+
+    context 'remote unsupervised proofing' do
+      it 'calls ThreatMetrixPlugin' do
+        expect(threatmetrix_plugin).to receive(:call).with(
+          applicant_pii:,
+          current_sp:,
+          request_ip:,
+          threatmetrix_session_id:,
+          timer: an_instance_of(JobHelpers::Timer),
+          user_email:,
+        )
+        proof
+      end
+    end
+
+    context 'in-person proofing' do
+      let(:ipp_enrollment_in_progress) { true }
+      let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID }
+
+      it 'calls ThreatMetrixPlugin' do
+        expect(threatmetrix_plugin).to receive(:call).with(
+          applicant_pii:,
+          current_sp:,
+          request_ip:,
+          threatmetrix_session_id:,
+          timer: an_instance_of(JobHelpers::Timer),
+          user_email:,
+        )
+        proof
+      end
     end
 
     context 'remote proofing' do
       it 'returns a ResultAdjudicator' do
         expect(proof).to be_an_instance_of(Proofing::Resolution::ResultAdjudicator)
         expect(proof.same_address_as_id).to eq(nil)
-      end
-
-      context 'ThreatMetrix is enabled' do
-        before do
-          enable_threatmetrix
-          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_mock_enabled).
-            and_return(false)
-
-          proof
-        end
-
-        it 'makes a request to the ThreatMetrix proofer' do
-          expect(threatmetrix_proofer).to have_received(:proof)
-        end
-
-        it 'creates a ThreatMetrix associated cost' do
-          threatmetrix_sp_costs = SpCost.where(cost_type: :threatmetrix, issuer: current_sp.issuer)
-          expect(threatmetrix_sp_costs.count).to eq(1)
-        end
-
-        context 'session id is missing' do
-          let(:threatmetrix_session_id) { nil }
-
-          it 'does not make a request to the ThreatMetrix proofer' do
-            expect(threatmetrix_proofer).not_to have_received(:proof)
-          end
-
-          it 'returns a failed result' do
-            device_profiling_result = proof.device_profiling_result
-
-            expect(device_profiling_result.success).to be(false)
-            expect(device_profiling_result.client).to eq('tmx_session_id_missing')
-            expect(device_profiling_result.review_status).to eq('reject')
-          end
-        end
-
-        context 'pii is missing' do
-          let(:applicant_pii) { {} }
-
-          it 'does not make a request to the ThreatMetrix proofer' do
-            expect(threatmetrix_proofer).not_to have_received(:proof)
-          end
-
-          it 'returns a failed result' do
-            device_profiling_result = proof.device_profiling_result
-
-            expect(device_profiling_result.success).to be(false)
-            expect(device_profiling_result.client).to eq('tmx_pii_missing')
-            expect(device_profiling_result.review_status).to eq('reject')
-          end
-        end
-      end
-
-      context 'ThreatMetrix is disabled' do
-        before do
-          disable_threatmetrix
-        end
-
-        it 'returns a disabled result' do
-          device_profiling_result = proof.device_profiling_result
-
-          expect(device_profiling_result.success).to be(true)
-          expect(device_profiling_result.client).to eq('tmx_disabled')
-          expect(device_profiling_result.review_status).to eq('pass')
-        end
-
-        it 'does not create a ThreatMetrix associated cost' do
-          threatmetrix_sp_costs = SpCost.where(cost_type: :threatmetrix, issuer: current_sp.issuer)
-          expect(threatmetrix_sp_costs.count).to eq(0)
-        end
       end
 
       context 'AAMVA raises an exception' do


### PR DESCRIPTION
## 🛠 Summary of changes

Ahead of integrating a new vendor into the ProgressiveProofer, I'm going to do a series of PRs that extract code for individual vendors out into separate files/classes. I'm calling these "plugins" because I think that will _ultimately_ describe the kind of architecture we're going for here, but for now these are basically just the old `proof_with_X_if_needed` methods extracted out into a new class with a `call` method.

Right now, each plugin's `call` method lays out exactly what its dependencies are. Each plugin also gets its own spec file, mainly focused on these primary scenarios:

* Remote unsupervised proofing
* In-person proofing (residential address == id address)
* In-person proofing (residential address != id address)

In some cases I am pulling spec code out of the existing ProgressiveProofer spec, and in some cases I am modifying it slightly to ensure it addresses the above scenarios.

This PR implements the first (and simplest) "plugin", which does the ThreatMetrix Session Query API call. There are not significant differences in implementation for the Remote and IPP flows here, and there's not really any "new" code being introduced--this is mostly moving existing code around.

See also
* The "How Login.gov does identity resolution and validation" section of the [Identity Verification Business Logic doc](https://docs.google.com/document/d/14YlABNtMZWz6C_Imcchu2tFXonc6kpvtX2iaxbc8nlA/edit?tab=t.0#heading=h.gt76n5jwci2k), which is essentially an breakdown explanation of what exactly the ProgressiveProofer is doing.
* This [RFC](https://docs.google.com/document/d/1utOJ2c5M9JfR-85fx_bSS0Ow3FUNsPDCdmI3oo_OyWk/edit?tab=t.0) about pulling the ProgressiveProofer apart. This work corresponds roughly to the "Phase One" identified in the RFC.
