### PR TITLE
Fix error in screenreader by removing the useEffect that sets the file input value to null

### DIFF
--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -267,40 +267,6 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
     }
   }
 
-  /**
-   * @param {string} fileLabel String value of the label for input to display
-   * @param {Blob|string|null|undefined} fileValue File or string for which to generate label.
-   * @return {{'aria-label': string} | {'aria-labelledby': string}}
-   */
-  function getAriaLabelPropsFromValue(
-    fileLabel: string,
-    fileValue: Blob | string | null | undefined,
-  ): AriaLabelReturnType {
-    if (fileValue instanceof window.File) {
-      return {
-        'aria-label': `${fileLabel} - ${fileValue.name}`,
-      };
-    }
-
-    if (fileValue) {
-      return {
-        'aria-label': `${fileLabel} - ${t('doc_auth.forms.captured_image')}`,
-      };
-    }
-
-    // When no file is selected, provide a slightly more verbose label
-    // including the actual <label> contents and the prompt to drag a file or
-    // choose from a folder.
-    if (showInnerHint) {
-      return {
-        'aria-labelledby': `${labelId} ${innerHintId}`,
-      };
-    }
-    return {
-      'aria-labelledby': `${labelId}`,
-    };
-  }
-
   const shownErrorMessage = errorMessage ?? ownErrorMessage;
 
   let successMessage: string | undefined;
@@ -427,7 +393,6 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
             id={inputId}
             className="usa-file-input__input"
             type="file"
-            {...getAriaLabelPropsFromValue(label, value)}
             aria-busy={isValuePending}
             onChange={onChangeIfValid}
             onClick={onClick}

--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -2,7 +2,6 @@ import {
   useContext,
   useState,
   useMemo,
-  useEffect,
   forwardRef,
   useRef,
   useImperativeHandle,
@@ -232,19 +231,6 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
   const [ownErrorMessage, setOwnErrorMessage] = useState<string | null>(null);
   useMemo(() => setOwnErrorMessage(null), [value]);
   useImperativeHandle(ref, () => inputRef.current);
-  useEffect(() => {
-    // This is not a controlled component in the sense that the value is reflected onto the input
-    // element. Clear any DOM value that happens to be set, so that the browser doesn't suppress a
-    // change event based on what it assumes the current value to be.
-    //
-    // "In React, an <input type="file" /> is always an uncontrolled component because its value can
-    // only be set by a user, and not programmatically."
-    //
-    // See: https://reactjs.org/docs/uncontrolled-components.html#the-file-input-tag
-    if (inputRef.current && inputRef.current.files?.length) {
-      inputRef.current.value = '';
-    }
-  }, [value]);
   const inputId = `file-input-${instanceId}`;
   const hintId = `${inputId}-hint`;
   const errorId = `${inputId}-error`;

--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -99,8 +99,6 @@ interface FileInputProps {
   onError?: (message: ReactNode) => void;
 }
 
-type AriaLabelReturnType = { 'aria-labelledby': string } | { 'aria-label': string };
-
 /**
  * Given a token of an file input accept attribute, returns an equivalent regular expression
  * pattern, or undefined if a pattern cannot be determined. This is an approximation, and not fully

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -566,7 +566,6 @@ doc_auth.errors.sharpness.failed_short: Image is blurry, please try again.
 doc_auth.errors.sharpness.top_msg: We couldn’t read your ID. Your photo may be too blurry or dark. Try taking a new picture in a bright area.
 doc_auth.errors.sharpness.top_msg_plural: We couldn’t read your ID. Your photos may be too blurry or dark. Try taking new pictures in a bright area.
 doc_auth.errors.upload_error: Sorry, something went wrong on our end.
-doc_auth.forms.captured_image: Captured Image
 doc_auth.forms.change_file: Change file
 doc_auth.forms.choose_file_html: Drag file here or <lg-underline>choose from folder</lg-underline>
 doc_auth.forms.doc_success: We verified your information

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -577,7 +577,6 @@ doc_auth.errors.sharpness.failed_short: La imagen está borrosa; inténtelo de n
 doc_auth.errors.sharpness.top_msg: No pudimos leer su identificación. Es posible que su foto esté demasiado borrosa u oscura. Intente tomar una nueva foto en un lugar iluminado.
 doc_auth.errors.sharpness.top_msg_plural: No pudimos leer su identificación. Es posible que sus fotos estén demasiado borrosas u oscuras. Intente tomar nuevas fotos en un lugar iluminado.
 doc_auth.errors.upload_error: Lo sentimos, algo no funcionó bien.
-doc_auth.forms.captured_image: Imagen capturada
 doc_auth.forms.change_file: Cambiar archivo
 doc_auth.forms.choose_file_html: Arrastrar el archivo aquí o <lg-underline>seleccionarlo de la carpeta</lg-underline>
 doc_auth.forms.doc_success: Verificamos su información

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -566,7 +566,6 @@ doc_auth.errors.sharpness.failed_short: L’image est floue, veuillez réessayer
 doc_auth.errors.sharpness.top_msg: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que votre photo soit trop floue ou trop sombre. Essayez de prendre une nouvelle photo dans un endroit bien éclairé.
 doc_auth.errors.sharpness.top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que vos photos soient trop floues ou trop sombres. Essayez de prendre de nouvelles photos dans un endroit bien éclairé.
 doc_auth.errors.upload_error: Désolé, il y a eu un problème de notre côté.
-doc_auth.forms.captured_image: Image capturée
 doc_auth.forms.change_file: Changer de fichier
 doc_auth.forms.choose_file_html: Faites glisser le fichier ici ou <lg-underline>choisissez dans un dossier</lg-underline>
 doc_auth.forms.doc_success: Nous avons vérifié vos informations

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -577,7 +577,6 @@ doc_auth.errors.sharpness.failed_short: 图像模糊，请再试一次。
 doc_auth.errors.sharpness.top_msg: 我们无法读取你的身份证件。你的照片可能太模糊或太暗。尝试在明亮的地方重拍一张。
 doc_auth.errors.sharpness.top_msg_plural: 我们无法读取你的身份证件。你的照片可能太模糊或太暗。尝试在明亮的地方重拍一张。
 doc_auth.errors.upload_error: 抱歉，我们这边出错了。
-doc_auth.forms.captured_image: 扫描到的图像
 doc_auth.forms.change_file: 更改文件
 doc_auth.forms.choose_file_html: 将文件拖到此处或者<lg-underline>从文件夹中选择</lg-underline>。
 doc_auth.forms.doc_success: 我们验证了你的信息

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -193,10 +193,7 @@ RSpec.describe 'In Person Proofing', js: true, allowed_extra_analytics: [:*] do
     expect(page).to have_content(t('doc_auth.headings.review_issues'))
 
     # Images should still be present
-    front_label = [t('doc_auth.headings.document_capture_front'), 'logo.png'].join(' - ')
-    back_label = [t('doc_auth.headings.document_capture_back'), 'logo.png'].join(' - ')
-    expect(page).to have_field(front_label)
-    expect(page).to have_field(back_label)
+    expect(page).to have_text('logo.png', count: 2)
   end
 
   context 'after in-person proofing is completed and passed for a partner' do

--- a/spec/javascript/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/file-input-spec.jsx
@@ -176,19 +176,6 @@ describe('document-capture/components/file-input', () => {
     );
   });
 
-  it('always emits a change event, regardless what the browser assumes is the current value', async () => {
-    const onChange = sinon.spy();
-    const { rerender, getByLabelText } = render(<FileInput label="File" onChange={onChange} />);
-
-    const input = getByLabelText('File');
-    await userEvent.upload(input, file);
-
-    rerender(<FileInput label="File" value={null} onChange={onChange} />);
-    await userEvent.upload(input, file);
-
-    expect(onChange).to.have.been.calledTwice();
-  });
-
   it('renders a value preview for a data URL', async () => {
     const { container, findByRole, getByLabelText } = render(
       <FileInput

--- a/spec/javascript/packages/document-capture/components/file-input-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/file-input-spec.jsx
@@ -220,41 +220,6 @@ describe('document-capture/components/file-input', () => {
     expect(onChange.getCall(0).args[0]).to.equal(file);
   });
 
-  it('has an appropriate 2-part aria-label with no input added when on desktop', () => {
-    const { getByLabelText } = render(
-      <DeviceContext.Provider value={{ isMobile: false }}>
-        <FileInput label="File" bannerText="File" />
-      </DeviceContext.Provider>,
-    );
-
-    const queryByAriaLabel = getByLabelText('File doc_auth.forms.choose_file_html');
-
-    expect(queryByAriaLabel).to.exist();
-  });
-
-  it('has aria-label with label and filename', () => {
-    const fileName = 'file2.jpg';
-    const file2 = new window.File([file], fileName);
-    const { getByLabelText } = render(<FileInput label="File" value={file2} />);
-
-    const queryByAriaLabel = getByLabelText(`File - ${fileName}`);
-
-    expect(queryByAriaLabel).to.exist();
-  });
-
-  it('has aria-label with Captured Image', () => {
-    const { getByLabelText } = render(
-      <FileInput
-        label="File"
-        value="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
-      />,
-    );
-
-    const queryByAriaLabel = getByLabelText(`File - ${'doc_auth.forms.captured_image'}`);
-
-    expect(queryByAriaLabel).to.exist();
-  });
-
   it('has aria-describedby set to null by default', () => {
     const { getByLabelText } = render(<FileInput label="File" />);
     const input = getByLabelText('File');


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14592](https://cm-jira.usa.gov/browse/LG-14592)



## 🛠 Summary of changes

Currently screen readers read "No file chosen" on the input even though a file is uploaded. The useEffect in FileInput suppresses the input value causing 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV to Doc Auth
- [ ] Upload an image.
- [ ] Confirm using a screenreader that it does not say "No File chosen"


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
