### PR TITLE
Log if password matches current for password reset event

### DIFF
--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -3,6 +3,8 @@
 module Users
   class ResetPasswordsController < Devise::PasswordsController
     include AuthorizationCountConcern
+    include AbTestingConcern
+
     before_action :store_sp_metadata_in_session, only: [:edit]
     before_action :store_token_in_session, only: [:edit]
 
@@ -43,7 +45,13 @@ module Users
     # PUT /resource/password
     def update
       self.resource = user_matching_token(user_params[:reset_password_token])
-      @reset_password_form = ResetPasswordForm.new(user: resource)
+      @reset_password_form = ResetPasswordForm.new(
+        user: resource,
+        log_password_matches_existing: ab_test_bucket(
+          :LOG_PASSWORD_RESET_MATCHES_EXISTING,
+          user: resource,
+        ) == :log,
+      )
 
       result = @reset_password_form.submit(user_params)
 

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -42,7 +42,6 @@ module Users
       end
     end
 
-    # PUT /resource/password
     def update
       self.resource = user_matching_token(user_params[:reset_password_token])
       @reset_password_form = ResetPasswordForm.new(

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -47,7 +47,7 @@ class ResetPasswordForm
   end
 
   def update_user
-    @password_different = !user.valid_password?(password)
+    @password_matches_existing = user.valid_password?(password)
 
     attributes = { password: password }
 
@@ -89,7 +89,7 @@ class ResetPasswordForm
     {
       user_id: user.uuid,
       profile_deactivated: active_profile.present?,
-      password_different: @password_different,
+      password_matches_existing: @password_matches_existing,
       pending_profile_invalidated: pending_profile.present?,
       pending_profile_pending_reasons: (pending_profile&.pending_reasons || [])&.join(','),
     }

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -5,11 +5,14 @@ class ResetPasswordForm
   include FormPasswordValidator
 
   attr_accessor :reset_password_token
+  private attr_reader :log_password_matches_existing
+  alias_method :log_password_matches_existing?, :log_password_matches_existing
 
   validate :valid_token
 
-  def initialize(user:)
+  def initialize(user:, log_password_matches_existing: false)
     @user = user
+    @log_password_matches_existing = log_password_matches_existing
     @reset_password_token = @user.reset_password_token
     @validate_confirmation = true
     @active_profile = user.active_profile
@@ -47,7 +50,7 @@ class ResetPasswordForm
   end
 
   def update_user
-    @password_matches_existing = user.valid_password?(password)
+    @password_matches_existing = user.valid_password?(password) if log_password_matches_existing?
 
     attributes = { password: password }
 

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -47,6 +47,8 @@ class ResetPasswordForm
   end
 
   def update_user
+    @password_different = !user.valid_password?(password)
+
     attributes = { password: password }
 
     ActiveRecord::Base.transaction do
@@ -87,6 +89,7 @@ class ResetPasswordForm
     {
       user_id: user.uuid,
       profile_deactivated: active_profile.present?,
+      password_different: @password_different,
       pending_profile_invalidated: pending_profile.present?,
       pending_profile_pending_reasons: (pending_profile&.pending_reasons || [])&.join(','),
     }

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5697,6 +5697,7 @@ module AnalyticsEvents
   # @param [String] pending_profile_pending_reasons Comma-separated list of the pending states
   # associated with the associated profile.
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
+  # @param [Boolean] password_different Whether the password is different from the user's current
   # The user changed the password for their account via the password reset flow
   def password_reset_password(
     success:,
@@ -5704,6 +5705,7 @@ module AnalyticsEvents
     profile_deactivated:,
     pending_profile_invalidated:,
     pending_profile_pending_reasons:,
+    password_different:,
     error_details: {},
     **extra
   )
@@ -5715,6 +5717,7 @@ module AnalyticsEvents
       profile_deactivated:,
       pending_profile_invalidated:,
       pending_profile_pending_reasons:,
+      password_different:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5697,7 +5697,7 @@ module AnalyticsEvents
   # @param [String] pending_profile_pending_reasons Comma-separated list of the pending states
   # associated with the associated profile.
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  # @param [Boolean] password_different Whether the password is different from the user's current
+  # @param [Boolean] password_matches_existing Whether the password is same as the user's current
   # The user changed the password for their account via the password reset flow
   def password_reset_password(
     success:,
@@ -5705,7 +5705,7 @@ module AnalyticsEvents
     profile_deactivated:,
     pending_profile_invalidated:,
     pending_profile_pending_reasons:,
-    password_different:,
+    password_matches_existing:,
     error_details: {},
     **extra
   )
@@ -5717,7 +5717,7 @@ module AnalyticsEvents
       profile_deactivated:,
       pending_profile_invalidated:,
       pending_profile_pending_reasons:,
-      password_different:,
+      password_matches_existing:,
       **extra,
     )
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -225,6 +225,7 @@ lexisnexis_trueid_username: test_username
 lexisnexis_username: test_username
 ###################################################################
 lockout_period_in_minutes: 10
+log_password_reset_matches_existing_ab_test_percent: 0
 log_to_stdout: false
 login_otp_confirmation_max_attempts: 10
 logins_per_email_and_ip_bantime: 60

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -81,4 +81,10 @@ module AbTests
       SecureRandom.alphanumeric(8)
     end
   end.freeze
+
+  LOG_PASSWORD_RESET_MATCHES_EXISTING = AbTest.new(
+    experiment_name: 'Log password_matches_existing event property on password reset',
+    should_log: ['Password Reset: Password Submitted'].to_set,
+    buckets: { log: IdentityConfig.store.log_password_reset_matches_existing_ab_test_percent },
+  ).freeze
 end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -234,6 +234,7 @@ module IdentityConfig
     config.add(:lexisnexis_trueid_username, type: :string)
     config.add(:lexisnexis_username, type: :string)
     config.add(:lockout_period_in_minutes, type: :integer)
+    config.add(:log_password_reset_matches_existing_ab_test_percent, type: :integer)
     config.add(:log_to_stdout, type: :boolean)
     config.add(:login_otp_confirmation_max_attempts, type: :integer)
     config.add(:logins_per_email_and_ip_bantime, type: :integer)

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -409,7 +409,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         let(:user) { create(:user, :proofed) }
         let(:password) { user.password }
 
-        it 'logs event indicating password deactivated while password the same' do
+        it 'logs event indicating profile deactivated while password the same' do
           stub_analytics
 
           reset_password_token = user.set_reset_password_token

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
             profile_deactivated: false,
             pending_profile_invalidated: false,
             pending_profile_pending_reasons: '',
-            password_different: true,
+            password_matches_existing: false,
           )
           expect(user.events.password_changed.size).to be 1
 
@@ -399,7 +399,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           profile_deactivated: true,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
-          password_different: true,
+          password_matches_existing: false,
         )
         expect(user.active_profile.present?).to eq false
         expect(response).to redirect_to new_user_session_path
@@ -424,7 +424,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
 
           expect(@analytics).to have_logged_event(
             'Password Reset: Password Submitted',
-            hash_including(profile_deactivated: true, password_different: false),
+            hash_including(profile_deactivated: true, password_matches_existing: true),
           )
         end
       end
@@ -469,7 +469,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
-          password_different: true,
+          password_matches_existing: false,
         )
         expect(user.reload.confirmed?).to eq true
         expect(response).to redirect_to new_user_session_path

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -350,6 +350,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
             profile_deactivated: false,
             pending_profile_invalidated: false,
             pending_profile_pending_reasons: '',
+            password_different: true,
           )
           expect(user.events.password_changed.size).to be 1
 
@@ -398,9 +399,34 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           profile_deactivated: true,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
+          password_different: true,
         )
         expect(user.active_profile.present?).to eq false
         expect(response).to redirect_to new_user_session_path
+      end
+
+      context 'proofed user submits same password as current' do
+        let(:user) { create(:user, :proofed) }
+        let(:password) { user.password }
+
+        it 'logs event indicating password deactivated while password the same' do
+          stub_analytics
+
+          reset_password_token = user.set_reset_password_token
+
+          put :update, params: {
+            reset_password_form: {
+              password:,
+              password_confirmation: password,
+              reset_password_token:,
+            },
+          }
+
+          expect(@analytics).to have_logged_event(
+            'Password Reset: Password Submitted',
+            hash_including(profile_deactivated: true, password_different: false),
+          )
+        end
       end
     end
 
@@ -443,6 +469,7 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
+          password_different: true,
         )
         expect(user.reload.confirmed?).to eq true
         expect(response).to redirect_to new_user_session_path

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ResetPasswordForm, type: :model do
-  subject { ResetPasswordForm.new(user: build_stubbed(:user, uuid: '123')) }
+  let(:user) { create(:user, uuid: '123') }
+  subject(:form) { ResetPasswordForm.new(user:) }
 
   let(:password) { 'a good and powerful password' }
   let(:password_confirmation) { password }
@@ -15,202 +16,152 @@ RSpec.describe ResetPasswordForm, type: :model do
   it_behaves_like 'password validation'
 
   describe '#submit' do
+    subject(:result) { form.submit(params) }
+
     context 'when the password is valid but the token has expired' do
-      it 'returns a hash with errors' do
-        user = build_stubbed(:user, uuid: '123')
+      before do
         allow(user).to receive(:reset_password_period_valid?).and_return(false)
+      end
 
-        form = ResetPasswordForm.new(user: user)
-
-        password = 'valid password'
-
-        errors = { reset_password_token: ['token_expired'] }
-
-        extra = { user_id: '123', profile_deactivated: false }
-
-        expect(
-          form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h,
-        ).to include(
+      it 'returns a hash with errors' do
+        expect(result.to_h).to eq(
           success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
+          errors: { reset_password_token: ['token_expired'] },
+          error_details: { reset_password_token: { token_expired: true } },
+          user_id: '123',
+          profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
+          password_matches_existing: nil,
         )
       end
     end
 
     context 'when the password is invalid and token is valid' do
-      it 'returns a hash with errors' do
-        user = build_stubbed(:user, uuid: '123')
+      let(:password) { 'invalid' }
+
+      before do
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
+      end
 
-        form = ResetPasswordForm.new(user: user)
-
-        password = 'invalid'
-
-        errors = {
-          password:
-            ["Password must be at least #{Devise.password_length.first} characters long"],
-          password_confirmation: [I18n.t(
-            'errors.messages.too_short',
-            count: Devise.password_length.first,
-          )],
-        }
-
-        extra = { user_id: '123', profile_deactivated: false }
-
-        expect(
-          form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h,
-        ).to include(
+      it 'returns a hash with errors' do
+        expect(result.to_h).to eq(
           success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
+          errors: {
+            password:
+              ["Password must be at least #{Devise.password_length.first} characters long"],
+            password_confirmation: [I18n.t(
+              'errors.messages.too_short',
+              count: Devise.password_length.first,
+            )],
+          },
+          error_details: {
+            password: { too_short: true },
+            password_confirmation: { too_short: true },
+          },
+          user_id: '123',
+          profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
+          password_matches_existing: nil,
         )
       end
     end
 
     context 'when both the password and token are valid' do
-      it 'sets the user password to the submitted password' do
-        user = create(:user, uuid: '123')
+      before do
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
+      end
 
-        form = ResetPasswordForm.new(user: user)
-        password = 'valid password'
+      it 'sets the user password to the submitted password' do
+        expect { result }.to change { user.reload.encrypted_password_digest }
 
-        result = nil
-        expect do
-          result = form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h
-        end.to(change { user.reload.encrypted_password_digest })
-
-        expect(result).to eq(
+        expect(result.to_h).to eq(
           success: true,
           errors: {},
           user_id: '123',
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
+          password_matches_existing: false,
         )
       end
     end
 
     context 'when both the password and token are invalid' do
-      it 'returns a hash with errors' do
-        user = build_stubbed(:user, uuid: '123')
+      let(:password) { 'short' }
+
+      before do
         allow(user).to receive(:reset_password_period_valid?).and_return(false)
+      end
 
-        form = ResetPasswordForm.new(user: user)
-
-        password = 'short'
-
-        errors = {
-          password: [
-            t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
-          ],
-          password_confirmation: [I18n.t(
-            'errors.messages.too_short',
-            count: Devise.password_length.first,
-          )],
-          reset_password_token: ['token_expired'],
-        }
-
-        extra = { user_id: '123', profile_deactivated: false }
-
-        expect(
-          form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h,
-        ).to include(
+      it 'returns a hash with errors' do
+        expect(result.to_h).to eq(
           success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
+          errors: {
+            password: [
+              t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
+            ],
+            password_confirmation: [
+              t('errors.messages.too_short', count: Devise.password_length.first),
+            ],
+            reset_password_token: ['token_expired'],
+          },
+          error_details: {
+            password: { too_short: true },
+            password_confirmation: { too_short: true },
+            reset_password_token: { token_expired: true },
+          },
+          user_id: '123',
+          profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
+          password_matches_existing: nil,
         )
       end
     end
 
     context 'when the user does not exist in the db' do
+      let(:user) { User.new }
+
       it 'returns a hash with errors' do
-        user = User.new
-
-        form = ResetPasswordForm.new(user: user)
-        errors = {
-          password: [
-            t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
-          ],
-          password_confirmation: [I18n.t(
-            'errors.messages.too_short',
-            count: Devise.password_length.first,
-          )],
-          reset_password_token: ['invalid_token'],
-        }
-
-        extra = { user_id: nil, profile_deactivated: false }
-        password = 'short'
-
-        expect(
-          form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h,
-        ).to include(
+        expect(result.to_h).to eq(
           success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
+          errors: { reset_password_token: ['invalid_token'] },
+          error_details: { reset_password_token: { invalid_token: true } },
+          user_id: nil,
+          profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
+          password_matches_existing: nil,
         )
       end
     end
 
     context 'when the user has an active profile' do
+      let(:user) { create(:user, :proofed, reset_password_sent_at: Time.zone.now) }
+
       it 'deactivates the profile' do
-        profile = create(:profile, :active, :verified)
-        user = profile.user
-        user.update(reset_password_sent_at: Time.zone.now)
-
-        form = ResetPasswordForm.new(user: user)
-
-        result = form.submit(params)
-
         expect(result.success?).to eq(true)
         expect(result.extra[:profile_deactivated]).to eq(true)
-        expect(profile.reload.active?).to eq(false)
+        expect(user.profiles.any?(&:active?)).to eq(false)
       end
     end
 
     context 'when the user does not have an active profile' do
+      let(:user) { create(:user, reset_password_sent_at: Time.zone.now) }
+
       it 'includes that the profile was not deactivated in the form response' do
-        user = create(:user)
-        user.update(reset_password_sent_at: Time.zone.now)
-
-        form = ResetPasswordForm.new(user: user)
-
-        result = form.submit(params)
-
         expect(result.success?).to eq(true)
         expect(result.extra[:profile_deactivated]).to eq(false)
       end
     end
 
     context 'when the user has a pending profile' do
+      let(:profile) { create(:profile, :verify_by_mail_pending, :in_person_verification_pending) }
+      let(:user) { create(:user, reset_password_sent_at: Time.zone.now, profiles: [profile]) }
+
       it 'includes that the profile was not deactivated in the form response' do
-        profile = create(:profile, :verify_by_mail_pending, :in_person_verification_pending)
-        user = profile.user
-        user.update(reset_password_sent_at: Time.zone.now)
-
-        form = ResetPasswordForm.new(user: user)
-        result = form.submit(params)
-
         expect(result.success?).to eq(true)
         expect(result.extra[:pending_profile_invalidated]).to eq(true)
         expect(result.extra[:pending_profile_pending_reasons]).to eq(
@@ -220,14 +171,9 @@ RSpec.describe ResetPasswordForm, type: :model do
     end
 
     context 'when the user does not have a pending profile' do
+      let(:user) { create(:user, reset_password_sent_at: Time.zone.now) }
+
       it 'includes that the profile was not deactivated in the form response' do
-        user = create(:user)
-        user.update(reset_password_sent_at: Time.zone.now)
-
-        form = ResetPasswordForm.new(user: user)
-
-        result = form.submit(params)
-
         expect(result.success?).to eq(true)
         expect(result.extra[:pending_profile_invalidated]).to eq(false)
         expect(result.extra[:pending_profile_pending_reasons]).to eq('')
@@ -235,19 +181,16 @@ RSpec.describe ResetPasswordForm, type: :model do
     end
 
     context 'when the unconfirmed email address has been confirmed by another account' do
-      it 'does not raise an error and is not successful' do
-        user = create(:user, :unconfirmed)
-        user.update(reset_password_sent_at: Time.zone.now)
-        user2 = create(:user)
+      let(:user) { create(:user, :unconfirmed, reset_password_sent_at: Time.zone.now) }
+
+      before do
         create(
-          :email_address, email: user.email_addresses.first.email, user_id: user2.id,
-                          confirmed_at: Time.zone.now
+          :user,
+          email_addresses: [create(:email_address, email: user.email_addresses.first.email)],
         )
+      end
 
-        form = ResetPasswordForm.new(user: user)
-
-        result = form.submit(params)
-
+      it 'does not raise an error and is not successful' do
         expect(result.success?).to eq(false)
         expect(result.errors).to eq({ reset_password_token: ['token_expired'] })
       end

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe ResetPasswordForm, type: :model do
         expect(result.extra[:profile_deactivated]).to eq(true)
         expect(user.profiles.any?(&:active?)).to eq(false)
       end
+
+      context 'when the password is same as current' do
+        let(:password) { user.password }
+
+        it 'includes extra detail for password matching existing' do
+          expect(result.extra[:password_matches_existing]).to eq(true)
+        end
+      end
     end
 
     context 'when the user does not have an active profile' do

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe ResetPasswordForm, type: :model do
   let(:user) { create(:user, uuid: '123') }
-  subject(:form) { ResetPasswordForm.new(user:) }
+  let(:log_password_matches_existing) { false }
+  subject(:form) { ResetPasswordForm.new(user:, log_password_matches_existing:) }
 
   let(:password) { 'a good and powerful password' }
   let(:password_confirmation) { password }
@@ -83,7 +84,7 @@ RSpec.describe ResetPasswordForm, type: :model do
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
-          password_matches_existing: false,
+          password_matches_existing: nil,
         )
       end
     end
@@ -150,8 +151,16 @@ RSpec.describe ResetPasswordForm, type: :model do
       context 'when the password is same as current' do
         let(:password) { user.password }
 
-        it 'includes extra detail for password matching existing' do
-          expect(result.extra[:password_matches_existing]).to eq(true)
+        it 'does not include extra detail for password matching existing' do
+          expect(result.extra[:password_matches_existing]).to eq(nil)
+        end
+
+        context 'when initialized to log password_matches_existing' do
+          let(:log_password_matches_existing) { true }
+
+          it 'includes extra detail for password matching existing' do
+            expect(result.extra[:password_matches_existing]).to eq(true)
+          end
         end
       end
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Adds an event property indicating whether the password was the same as the user's current password when successfully resetting a user password.

This will be used to understand how common this behavior is, in case there's improvements we could make to this workflow, particularly for users who might be impacted by identity verification profile deactivation due to password reset.

Related Slack discussion: https://gsa-tts.slack.com/archives/C01710KMYUB/p1730231046429359

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Create an account. Remember your password
3. Once you reach account dashboard, go to http://localhost:3000/verify
4. Complete identity verification
5. Sign out
6. Click "Forgot your password?
7. Submit the email address associated with your account
8. Click "Reset your password" in the email you received
9. Run `make watch_events` in a separate terminal process
10. When prompted to choose a new password, enter the same or a different password from what you know to be the user's current password
11. Observe that `password_matches_existing` is `false` if you entered a different password, or `true` if you entered the same password