### PR TITLE
LG-11857: add header post office search results

### DIFF
--- a/app/javascript/packages/address-search/CHANGELOG.md
+++ b/app/javascript/packages/address-search/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `Change Log`
 
+## v3.4.0 (2024-11-07)
+
+- Added new optional resultsSectionHeading component prop to FullAddressSearch
+
 ## v3.3.0 (2024-11-05)
 
 - Remove obsolete `is_pilot` field from PostOffice and FormattedLocation types

--- a/app/javascript/packages/address-search/components/full-address-search.spec.tsx
+++ b/app/javascript/packages/address-search/components/full-address-search.spec.tsx
@@ -370,7 +370,7 @@ describe('FullAddressSearch', () => {
       );
       await userEvent.click(getByText('in_person_proofing.body.location.po_search.search_button'));
 
-      await findByText(resultsSectionHeadingText);
+      expect(await findByText(resultsSectionHeadingText)).to.exist();
     });
   });
 });

--- a/app/javascript/packages/address-search/components/full-address-search.spec.tsx
+++ b/app/javascript/packages/address-search/components/full-address-search.spec.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import sinon from 'sinon';
 import { useSandbox } from '@18f/identity-test-helpers';
 import userEvent from '@testing-library/user-event';
@@ -338,7 +338,7 @@ describe('FullAddressSearch', () => {
       const handleLocationsFound = sandbox.stub();
       const onSelect = sinon.stub();
       const resultsSectionHeadingText = 'Mock Heading';
-      const { queryByText, getByLabelText, getByText } = render(
+      const { findByText, getByLabelText, getByText } = render(
         <SWRConfig value={{ provider: () => new Map() }}>
           <FullAddressSearch
             usStatesTerritories={usStatesTerritories}
@@ -370,7 +370,7 @@ describe('FullAddressSearch', () => {
       );
       await userEvent.click(getByText('in_person_proofing.body.location.po_search.search_button'));
 
-      await findByText(resultsSectionHeadingText)
+      await findByText(resultsSectionHeadingText);
     });
   });
 });

--- a/app/javascript/packages/address-search/components/full-address-search.spec.tsx
+++ b/app/javascript/packages/address-search/components/full-address-search.spec.tsx
@@ -370,10 +370,7 @@ describe('FullAddressSearch', () => {
       );
       await userEvent.click(getByText('in_person_proofing.body.location.po_search.search_button'));
 
-      await waitFor(() => {
-        const resultsHeading = queryByText(resultsSectionHeadingText);
-        expect(resultsHeading).to.exist();
-      });
+      await findByText(resultsSectionHeadingText)
     });
   });
 });

--- a/app/javascript/packages/address-search/components/full-address-search.tsx
+++ b/app/javascript/packages/address-search/components/full-address-search.tsx
@@ -15,6 +15,7 @@ function FullAddressSearch({
   registerField,
   resultsHeaderComponent,
   usStatesTerritories,
+  resultsSectionHeading,
 }: FullAddressSearchProps) {
   const [apiError, setApiError] = useState<Error | null>(null);
   const [foundAddress, setFoundAddress] = useState<LocationQuery | null>(null);
@@ -61,6 +62,7 @@ function FullAddressSearch({
           address={foundAddress.address || ''}
           noInPersonLocationsDisplay={noInPersonLocationsDisplay}
           resultsHeaderComponent={resultsHeaderComponent}
+          resultsSectionHeading={resultsSectionHeading}
         />
       )}
     </>

--- a/app/javascript/packages/address-search/components/in-person-locations.spec.tsx
+++ b/app/javascript/packages/address-search/components/in-person-locations.spec.tsx
@@ -88,6 +88,23 @@ describe('InPersonLocations', () => {
     ).to.not.exist();
   });
 
+  it('renders a header at the top of the results', () => {
+    const headingText = 'mock heading';
+    const testId = 'mock-heading';
+    const { getByTestId } = render(
+      <InPersonLocations
+        address={address}
+        locations={locations}
+        onSelect={onSelect}
+        noInPersonLocationsDisplay={NoLocationsViewMock}
+        resultsSectionHeading={() => <h2 data-testid={testId}>{headingText}</h2>}
+      />,
+    );
+
+    expect(getByTestId(testId)).to.exist();
+    expect(getByTestId(testId).textContent).to.equal(headingText);
+  });
+
   context('when no locations are found', () => {
     it('renders the passed in noLocations component w/ address', () => {
       const onClick = sinon.stub();

--- a/app/javascript/packages/address-search/components/in-person-locations.tsx
+++ b/app/javascript/packages/address-search/components/in-person-locations.tsx
@@ -20,6 +20,7 @@ function InPersonLocations({
   address,
   noInPersonLocationsDisplay: NoInPersonLocationsDisplay,
   resultsHeaderComponent: HeaderComponent,
+  resultsSectionHeading: ResultsSectionHeading,
 }: InPersonLocationsProps) {
   if (locations?.length === 0) {
     return <NoInPersonLocationsDisplay address={address} />;
@@ -27,6 +28,7 @@ function InPersonLocations({
 
   return (
     <>
+      {ResultsSectionHeading && <ResultsSectionHeading />}
       <h3 role="status">
         {t('in_person_proofing.body.location.po_search.results_description', {
           address,

--- a/app/javascript/packages/address-search/package.json
+++ b/app/javascript/packages/address-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-address-search",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "type": "module",
   "private": false,
   "files": [

--- a/app/javascript/packages/address-search/types.d.ts
+++ b/app/javascript/packages/address-search/types.d.ts
@@ -69,6 +69,7 @@ interface InPersonLocationsProps {
   noInPersonLocationsDisplay: ComponentType<{ address: string }>;
   onSelect;
   resultsHeaderComponent?: ComponentType;
+  resultsSectionHeading?: ComponentType;
 }
 
 interface LocationCollectionItemProps {
@@ -98,4 +99,5 @@ interface FullAddressSearchProps {
   registerField: RegisterFieldCallback;
   resultsHeaderComponent?: ComponentType;
   usStatesTerritories: string[][];
+  resultsSectionHeading?: ComponentType;
 }


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-11857](https://cm-jira.usa.gov/browse/LG-11857)

## 🛠 Summary of changes

Added an new prop to the `InPersonLocations` and `FullAddressSearch` components to show a heading on the top of the results section of the post office address search display.

## 📜 Testing Plan

### Ensure Heading does *not* appear by default
- [x] Start the In Person enrollment process
- [x] Navigate to the Post Office Search Page and perform the search
- [x] Notice *no* change between the layout and design in the post office result page and the current page in production / main branch

### Ensure Heading does *not* appear in the Help Center by default
- [ ] Create a symlink for the `app/javascript/packages/address-search` (https://github.com/18F/identity-idp/tree/main/app/javascript/packages/address-search) package (ex: [npm-link](https://docs.npmjs.com/cli/v10/commands/npm-link) or [steps below](https://github.com/18F/identity-idp/pull/11424#steps-for-testing-the-package-locally))
- [ ] Install the local package in the identity-site repo 
- [ ] Navigate to the [Find a participating Post Office Page](http://localhost:4000/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/) and perform the search
- [ ] *no* change between the layout and design in the post office result page and the current page in production / main branch

Optional test, if you want to get wild!
### [Optional] Ensure Heading does appear in the test branch of the Help Center
- [ ] Checkout the branch [keithw/LG-11857-add-header-post-office-search-results](https://github.com/GSA-TTS/identity-site/tree/keithw/LG-11857-add-header-post-office-search-results) from the identity-repo https://github.com/GSA-TTS/identity-site/tree/keithw/LG-11857-add-header-post-office-search-results
- [ ] Follow the steps to create the link to the npm package locally [below](#steps-for-testing-the-package-locally)
- [ ] Navigate to the [Find a participating Post Office Page](http://localhost:4000/help/verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office/)
- [ ] Search for a post office
- [ ] Notice the new heading of "Search results for Post Offices near you" at the top of the search results

## 👀 Screenshots

## IDP Post Office Search
![IPP-PO-Search-default-no-heading](https://github.com/user-attachments/assets/91cf064d-47a8-4f73-9514-ea2fb5631214)

## Help Center Post Office Search
![help-center-PO-Search-default-no-heading](https://github.com/user-attachments/assets/f3457804-125e-4937-a666-e8a155dca1ce)

<a id="steps-for-testing-the-package-locally"></a>
### Steps for testing the package locally
- [ ] Install the [yalc library](https://github.com/wclr/yalc?tab=readme-ov-file#installation) 
- [ ] Navigate to the `app/javascript/packages/address-search` https://github.com/18F/identity-idp/tree/main/app/javascript/packages/address-search directory
- [ ] Locally publish the package with: `yalc publish`
- [ ] Add the package to the local identity-site repo by navigating to the root of the project and running: `yalc add @18f/identity-address-search`
- [ ] Startup the identity-site repo as usual
