### PR TITLE
Add `ensure_user_stays_in_vendor_bucket` to all the controllers.

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -62,21 +62,22 @@ module Idv
       end
     end
 
-    def ensure_user_stays_in_vendor_bucket
-      in_hybrid_mobile = request.fullpath.include?('/hybrid_mobile/')
-      expected_path = doc_auth_vendor_capture_path(in_hybrid_mobile)
+    def redirect_to_correct_vendor(vendor, in_hybrid_mobile)
+      expected_doc_auth_vendor = doc_auth_vendor
+      return if expected_doc_auth_vendor == Idp::Constants::Vendors::MOCK
 
-      if I18n.locale == :en
-        actual_path = request.path
-      else
-        actual_path = "/#{I18n.locale}#{request.path}"
-      end
+      return if vendor == expected_doc_auth_vendor
 
-      puts "ensure_user_stays_in_vendor_bucket: expected_path: #{expected_path}"
-      puts "                                      actual_path: #{actual_path}"
-      puts "                                 request.fullpath: #{request.fullpath}"
+      correct_path = case expected_doc_auth_vendor
+        when Idp::Constants::Vendors::SOCURE
+          in_hybrid_mobile ? idv_hybrid_mobile_socure_document_capture_path
+                           : idv_socure_document_capture_path
+        when Idp::Constants::Vendors::LEXIS_NEXIS
+          in_hybrid_mobile ? idv_hybrid_mobile_document_capture_path
+                           : idv_document_capture_path
+        end
 
-      redirect_to expected_path if actual_path != expected_path
+      redirect_to correct_path
     end
 
     private

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -64,15 +64,15 @@ module Idv
 
     def redirect_to_correct_vendor(vendor, in_hybrid_mobile)
       expected_doc_auth_vendor = doc_auth_vendor
-      return if expected_doc_auth_vendor == Idp::Constants::Vendors::MOCK
-
       return if vendor == expected_doc_auth_vendor
+      return if vendor == Idp::Constants::Vendors::LEXIS_NEXIS &&
+                expected_doc_auth_vendor == Idp::Constants::Vendors::MOCK
 
       correct_path = case expected_doc_auth_vendor
         when Idp::Constants::Vendors::SOCURE
           in_hybrid_mobile ? idv_hybrid_mobile_socure_document_capture_path
                            : idv_socure_document_capture_path
-        when Idp::Constants::Vendors::LEXIS_NEXIS
+        when Idp::Constants::Vendors::LEXIS_NEXIS, Idp::Constants::Vendors::MOCK
           in_hybrid_mobile ? idv_hybrid_mobile_document_capture_path
                            : idv_document_capture_path
         end

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -50,6 +50,35 @@ module Idv
         stored_result.selfie_check_performed?
     end
 
+    # @returns[String] The document capture path for the current vendor
+    def doc_auth_vendor_capture_path(in_hybrid_mobile)
+      case doc_auth_vendor
+      when Idp::Constants::Vendors::SOCURE
+        in_hybrid_mobile ? idv_hybrid_mobile_socure_document_capture_path
+                         : idv_socure_document_capture_path
+      when Idp::Constants::Vendors::LEXIS_NEXIS, Idp::Constants::Vendors::MOCK
+        in_hybrid_mobile ? idv_hybrid_mobile_document_capture_path
+                         : idv_document_capture_path
+      end
+    end
+
+    def ensure_user_stays_in_vendor_bucket
+      in_hybrid_mobile = request.fullpath.include?('/hybrid_mobile/')
+      expected_path = doc_auth_vendor_capture_path(in_hybrid_mobile)
+
+      if I18n.locale == :en
+        actual_path = request.path
+      else
+        actual_path = "/#{I18n.locale}#{request.path}"
+      end
+
+      puts "ensure_user_stays_in_vendor_bucket: expected_path: #{expected_path}"
+      puts "                                      actual_path: #{actual_path}"
+      puts "                                 request.fullpath: #{request.fullpath}"
+
+      redirect_to expected_path if actual_path != expected_path
+    end
+
     private
 
     def track_document_issuing_state(user, state)

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -50,18 +50,6 @@ module Idv
         stored_result.selfie_check_performed?
     end
 
-    # @returns[String] The document capture path for the current vendor
-    def doc_auth_vendor_capture_path(in_hybrid_mobile)
-      case doc_auth_vendor
-      when Idp::Constants::Vendors::SOCURE
-        in_hybrid_mobile ? idv_hybrid_mobile_socure_document_capture_path
-                         : idv_socure_document_capture_path
-      when Idp::Constants::Vendors::LEXIS_NEXIS, Idp::Constants::Vendors::MOCK
-        in_hybrid_mobile ? idv_hybrid_mobile_document_capture_path
-                         : idv_document_capture_path
-      end
-    end
-
     def redirect_to_correct_vendor(vendor, in_hybrid_mobile)
       expected_doc_auth_vendor = doc_auth_vendor
       return if vendor == expected_doc_auth_vendor

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -20,12 +20,7 @@ module Idv
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('document_capture', :view, true)
 
-      case doc_auth_vendor
-      when Idp::Constants::Vendors::SOCURE
-        redirect_to idv_socure_document_capture_url
-      when Idp::Constants::Vendors::LEXIS_NEXIS, Idp::Constants::Vendors::MOCK
-        render :show, locals: extra_view_variables
-      end
+      render :show, locals: extra_view_variables
     end
 
     def update

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -12,7 +12,7 @@ module Idv
     before_action :confirm_step_allowed, unless: -> { allow_direct_ipp? }
     before_action :override_csp_to_allow_acuant
     before_action :set_usps_form_presenter
-    before_action :ensure_user_stays_in_vendor_bucket
+    before_action -> { redirect_to_correct_vendor(Idp::Constants::Vendors::LEXIS_NEXIS, false) }
 
     def show
       analytics.idv_doc_auth_document_capture_visited(**analytics_arguments)

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -12,6 +12,7 @@ module Idv
     before_action :confirm_step_allowed, unless: -> { allow_direct_ipp? }
     before_action :override_csp_to_allow_acuant
     before_action :set_usps_form_presenter
+    before_action :ensure_user_stays_in_vendor_bucket
 
     def show
       analytics.idv_doc_auth_document_capture_visited(**analytics_arguments)

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -11,7 +11,7 @@ module Idv
       before_action :override_csp_to_allow_acuant
       before_action :confirm_document_capture_needed, only: :show
       before_action :set_usps_form_presenter
-      before_action :ensure_user_stays_in_vendor_bucket
+      before_action -> { redirect_to_correct_vendor(Idp::Constants::Vendors::LEXIS_NEXIS, true) }
 
       def show
         analytics.idv_doc_auth_document_capture_visited(**analytics_arguments)

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -11,6 +11,7 @@ module Idv
       before_action :override_csp_to_allow_acuant
       before_action :confirm_document_capture_needed, only: :show
       before_action :set_usps_form_presenter
+      before_action :ensure_user_stays_in_vendor_bucket
 
       def show
         analytics.idv_doc_auth_document_capture_visited(**analytics_arguments)

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -11,7 +11,7 @@ module Idv
 
         check_or_render_not_found -> { IdentityConfig.store.socure_enabled }
         before_action :check_valid_document_capture_session, except: [:update]
-        before_action :ensure_user_stays_in_vendor_bucket
+        before_action -> { redirect_to_correct_vendor(Idp::Constants::Vendors::SOCURE, true) }
 
         def show
           Funnel::DocAuth::RegisterStep.new(document_capture_user.id, sp_session[:issuer]).

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -11,6 +11,7 @@ module Idv
 
         check_or_render_not_found -> { IdentityConfig.store.socure_enabled }
         before_action :check_valid_document_capture_session, except: [:update]
+        before_action :ensure_user_stays_in_vendor_bucket
 
         def show
           Funnel::DocAuth::RegisterStep.new(document_capture_user.id, sp_session[:issuer]).

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -11,7 +11,7 @@ module Idv
       check_or_render_not_found -> { IdentityConfig.store.socure_enabled }
       before_action :confirm_not_rate_limited
       before_action :confirm_step_allowed
-      before_action :ensure_user_stays_in_vendor_bucket
+      before_action -> { redirect_to_correct_vendor(Idp::Constants::Vendors::SOCURE, false) }
 
       # reconsider and maybe remove these when implementing the real
       # update handler

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -11,6 +11,7 @@ module Idv
       check_or_render_not_found -> { IdentityConfig.store.socure_enabled }
       before_action :confirm_not_rate_limited
       before_action :confirm_step_allowed
+      before_action :ensure_user_stays_in_vendor_bucket
 
       # reconsider and maybe remove these when implementing the real
       # update handler

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -102,13 +102,6 @@ RSpec.describe Idv::DocumentCaptureController do
         :set_usps_form_presenter,
       )
     end
-
-    it 'checks that we are in the correct vendor bucket' do
-      expect(subject).to have_actions(
-        :before,
-        :ensure_user_stays_in_vendor_bucket,
-      )
-    end
   end
 
   describe '#show' do

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -102,6 +102,13 @@ RSpec.describe Idv::DocumentCaptureController do
         :set_usps_form_presenter,
       )
     end
+
+    it 'checks that we are in the correct vendor bucket' do
+      expect(subject).to have_actions(
+        :before,
+        :ensure_user_stays_in_vendor_bucket,
+      )
+    end
   end
 
   describe '#show' do
@@ -116,18 +123,30 @@ RSpec.describe Idv::DocumentCaptureController do
       }
     end
 
+    let(:idv_vendor) { Idp::Constants::Vendors::LEXIS_NEXIS }
+
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_vendor).and_return(
-        Idp::Constants::Vendors::LEXIS_NEXIS,
+        idv_vendor,
       )
       allow(IdentityConfig.store).to receive(:doc_auth_vendor_default).and_return(
-        Idp::Constants::Vendors::LEXIS_NEXIS,
+        idv_vendor,
       )
     end
 
     it 'has non-nil presenter' do
       get :show
       expect(assigns(:presenter)).to be_kind_of(Idv::InPerson::UspsFormPresenter)
+    end
+
+    context 'when we try to use this controller but we should be using the Socure version' do
+      let(:idv_vendor) { Idp::Constants::Vendors::SOCURE }
+
+      it 'redirects to the Socure controller' do
+        get :show
+
+        expect(response).to redirect_to idv_socure_document_capture_url
+      end
     end
 
     it 'renders the show template' do

--- a/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/document_capture_controller_spec.rb
@@ -34,13 +34,6 @@ RSpec.describe Idv::HybridMobile::DocumentCaptureController do
         :check_valid_document_capture_session,
       )
     end
-
-    it 'checks that we are in the correct vendor bucket' do
-      expect(subject).to have_actions(
-        :before,
-        :ensure_user_stays_in_vendor_bucket,
-      )
-    end
   end
 
   describe '#show' do

--- a/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
@@ -35,13 +35,6 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
         :check_valid_document_capture_session,
       )
     end
-
-    it 'checks that we are in the correct vendor bucket' do
-      expect(subject).to have_actions(
-        :before,
-        :ensure_user_stays_in_vendor_bucket,
-      )
-    end
   end
 
   describe '#show' do
@@ -71,7 +64,7 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
     end
 
     context 'when we try to use this controller but we should be using the LN/mock version' do
-      let(:idv_vendor) { Idp::Constants::Vendors::MOCK }
+      let(:idv_vendor) { Idp::Constants::Vendors::LEXIS_NEXIS }
 
       it 'redirects to the LN/mock controller' do
         get :show

--- a/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
         :check_valid_document_capture_session,
       )
     end
+
+    it 'checks that we are in the correct vendor bucket' do
+      expect(subject).to have_actions(
+        :before,
+        :ensure_user_stays_in_vendor_bucket,
+      )
+    end
   end
 
   describe '#show' do
@@ -60,6 +67,15 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
       it 'redirects to root' do
         get :show
         expect(response).to redirect_to root_url
+      end
+    end
+
+    context 'when we try to use this controller but we should be using the LN/mock version' do
+      let(:idv_vendor) { Idp::Constants::Vendors::MOCK }
+
+      it 'redirects to the LN/mock controller' do
+        get :show
+        expect(response).to redirect_to idv_hybrid_mobile_document_capture_url
       end
     end
 

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -45,13 +45,6 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
         :confirm_two_factor_authenticated,
       )
     end
-
-    it 'checks that we are in the correct vendor bucket' do
-      expect(subject).to have_actions(
-        :before,
-        :ensure_user_stays_in_vendor_bucket,
-      )
-    end
   end
 
   describe '#show' do
@@ -73,7 +66,7 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
     end
 
     context 'when we try to use this controller but we should be using the LN/mock version' do
-      let(:idv_vendor) { Idp::Constants::Vendors::MOCK }
+      let(:idv_vendor) { Idp::Constants::Vendors::LEXIS_NEXIS }
 
       it 'redirects to the LN/mock controller' do
         get :show

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
         :confirm_two_factor_authenticated,
       )
     end
+
+    it 'checks that we are in the correct vendor bucket' do
+      expect(subject).to have_actions(
+        :before,
+        :ensure_user_stays_in_vendor_bucket,
+      )
+    end
   end
 
   describe '#show' do
@@ -63,6 +70,15 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
       stub_up_to(:hybrid_handoff, idv_session: subject.idv_session)
 
       subject.idv_session.document_capture_session_uuid = expected_uuid
+    end
+
+    context 'when we try to use this controller but we should be using the LN/mock version' do
+      let(:idv_vendor) { Idp::Constants::Vendors::MOCK }
+
+      it 'redirects to the LN/mock controller' do
+        get :show
+        expect(response).to redirect_to idv_document_capture_url
+      end
     end
 
     context 'happy path' do

--- a/spec/features/idv/hybrid_mobile/entry_spec.rb
+++ b/spec/features/idv/hybrid_mobile/entry_spec.rb
@@ -22,6 +22,10 @@ RSpec.feature 'mobile hybrid flow entry', :js do
   let(:link_to_visit) { link_sent_via_sms }
 
   context 'valid link' do
+    before do
+      allow(IdentityConfig.store).to receive(:socure_enabled).and_return(true)
+    end
+
     it 'puts the user on the document capture page' do
       expect(link_to_visit).to be
 
@@ -29,6 +33,11 @@ RSpec.feature 'mobile hybrid flow entry', :js do
         visit link_to_visit
         # Should have redirected to the actual doc capture url
         expect(current_url).to eql(idv_hybrid_mobile_document_capture_url)
+
+        # Confirm that we end up on the LN / Mock page even if we try to
+        # go to the Socure one.
+        visit idv_hybrid_mobile_socure_document_capture_url
+        expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
       end
     end
   end

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
 
   before do
     allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
+    allow(IdentityConfig.store).to receive(:socure_enabled).and_return(true)
     allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
     allow(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
       @sms_link = config[:link]
@@ -44,7 +45,11 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       # Confirm that jumping to LinkSent page does not cause errors
       visit idv_link_sent_url
       expect(page).to have_current_path(root_url)
-      visit idv_hybrid_mobile_document_capture_url
+
+      # Confirm that we end up on the LN / Mock page even if we try to
+      # go to the Socure one.
+      visit idv_hybrid_mobile_socure_document_capture_url
+      expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
 
       # Confirm that clicking cancel and then coming back doesn't cause errors
       click_link 'Cancel'


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14658](https://cm-jira.usa.gov/browse/LG-14658)

## 🛠 Summary of changes

Added a before action to all of the document capture controllers to make sure the user stays in their assigned vendor bucket. i.e., if we send them to Socure, they can't use LN by manually entering the Socure document capture URL, and vice-versa.

## 📜 Testing Plan

** IN PROGRESS **

Bring up the app running locally, with access from your phone via WiFi
`HOST=0.0.0.0 make run`

- [ ] Set your `application.yml` file to use Lexis Nexis (see below). Begin IdV on your computer, and select hybrid handoff. When you reach the document capture page, verify that the page you are on is `/idv/hybrid_mobile/document_capture`
- [ ] Manually enter the path for Socure document capture `/idv/hybrid_mobile/socure/document_capture`. Verify that you are redirected back to the same page as on the previous step.
- [ ] Cancel IdV.
- [ ] Begin IdV on your phone (i.e. *do not* use hybrid handoff). When you reach the document capture page, verify that the page you are on is `/idv/document_capture`
- [ ] Manually enter the page for Socure document capture `/idv/socure/document_capture`. Verify that you are redirected back to the same page as on the previous step
- [ ] Cancel IdV
- [ ] Set your `application.yml` file to use Socure (see below). Begin IdV on your computer, and select hybrid handoff. When you reach the document capture page, verify that the page you are on is `/idv/hybrid_mobile/socure/document_capture`
- [ ] Manually enter the path for Lexis Nexis document capture `/idv/hybrid_mobile/document_capture`. Verify that you are redirected back to the same page as on the previous step.
- [ ] Cancel IdV.
- [ ] Begin IdV on your phone (i.e. *do not* use hybrid handoff). When you reach the document capture page, verify that the page you are on is `/idv/socure/document_capture`
- [ ] Manually enter the page for Lexis Nexis document capture `/idv/document_capture`. Verify that you are redirected back to the same page as above.
- [ ] Cancel IdV

The two relevant `application.yml` values to use LN are:
```
doc_auth_vendor: 'lexis_nexis'
doc_auth_vendor_default: 'lexis_nexis'
```

The two relevant `application.yml` values to use Socure are:
```
doc_auth_vendor: 'lexis_socure'
doc_auth_vendor_default: 'lexis_socure'
```

