### PR TITLE
ProgressiveProofer refactor 2/N: AAMVA

### DIFF
--- a/app/services/proofing/resolution/plugins/aamva_plugin.rb
+++ b/app/services/proofing/resolution/plugins/aamva_plugin.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module Proofing
+  module Resolution
+    module Plugins
+      class AamvaPlugin
+        SECONDARY_ID_ADDRESS_MAP = {
+          identity_doc_address1: :address1,
+          identity_doc_address2: :address2,
+          identity_doc_city: :city,
+          identity_doc_address_state: :state,
+          identity_doc_zipcode: :zipcode,
+        }.freeze
+
+        def call(
+          applicant_pii:,
+          current_sp:,
+          instant_verify_result:,
+          ipp_enrollment_in_progress:,
+          timer:
+        )
+          should_proof = should_proof_state_id_with_aamva?(
+            applicant_pii:,
+            instant_verify_result:,
+            ipp_enrollment_in_progress:,
+          )
+
+          if !should_proof
+            return out_of_aamva_jurisdiction_result
+          end
+
+          applicant_pii_with_state_id_address =
+            if ipp_enrollment_in_progress
+              with_state_id_address(applicant_pii)
+            else
+              applicant_pii
+            end
+
+          timer.time('state_id') do
+            proofer.proof(applicant_pii_with_state_id_address)
+          end.tap do |result|
+            if result.exception.blank?
+              Db::SpCost::AddSpCost.call(
+                current_sp,
+                :aamva,
+                transaction_id: result.transaction_id,
+              )
+            end
+          end
+        end
+
+        def self.aamva_supports_state_id_jurisdiction?(applicant_pii)
+          state_id_jurisdiction = applicant_pii[:state_id_jurisdiction]
+          IdentityConfig.store.aamva_supported_jurisdictions.include?(state_id_jurisdiction)
+        end
+
+        def out_of_aamva_jurisdiction_result
+          Proofing::StateIdResult.new(
+            errors: {},
+            exception: nil,
+            success: true,
+            vendor_name: 'UnsupportedJurisdiction',
+          )
+        end
+
+        def proofer
+          @proofer ||=
+            if IdentityConfig.store.proofer_mock_fallback
+              Proofing::Mock::StateIdMockClient.new
+            else
+              Proofing::Aamva::Proofer.new(
+                auth_request_timeout: IdentityConfig.store.aamva_auth_request_timeout,
+                auth_url: IdentityConfig.store.aamva_auth_url,
+                cert_enabled: IdentityConfig.store.aamva_cert_enabled,
+                private_key: IdentityConfig.store.aamva_private_key,
+                public_key: IdentityConfig.store.aamva_public_key,
+                verification_request_timeout:
+                  IdentityConfig.store.aamva_verification_request_timeout,
+                verification_url: IdentityConfig.store.aamva_verification_url,
+              )
+            end
+        end
+
+        def same_address_as_id?(applicant_pii)
+          applicant_pii[:same_address_as_id].to_s == 'true'
+        end
+
+        def should_proof_state_id_with_aamva?(
+          applicant_pii:,
+          instant_verify_result:,
+          ipp_enrollment_in_progress:
+        )
+          return false unless AamvaPlugin.aamva_supports_state_id_jurisdiction?(applicant_pii)
+          # If the user is in in-person-proofing and they have changed their address then
+          # they are not eligible for get-to-yes
+          if !ipp_enrollment_in_progress || same_address_as_id?(applicant_pii)
+            user_can_pass_after_state_id_check?(instant_verify_result:)
+          else
+            instant_verify_result.success?
+          end
+        end
+
+        def user_can_pass_after_state_id_check?(
+          instant_verify_result:
+        )
+          return true if instant_verify_result.success?
+
+          # For failed IV results, this method validates that the user is eligible to pass if the
+          # failed attributes are covered by the same attributes in a successful AAMVA response
+          # aka the Get-to-Yes w/ AAMVA feature.
+          if !instant_verify_result.failed_result_can_pass_with_additional_verification?
+            return false
+          end
+
+          attributes_aamva_can_pass = [:address, :dob, :state_id_number]
+          attributes_requiring_additional_verification =
+            instant_verify_result.attributes_requiring_additional_verification
+          results_that_cannot_pass_aamva =
+            attributes_requiring_additional_verification - attributes_aamva_can_pass
+
+          results_that_cannot_pass_aamva.blank?
+        end
+
+        # Make a copy of pii with the user's state ID address overwriting the address keys
+        # Need to first remove the address keys to avoid key/value collision
+        def with_state_id_address(pii)
+          pii.except(*SECONDARY_ID_ADDRESS_MAP.values).
+            transform_keys(SECONDARY_ID_ADDRESS_MAP)
+        end
+      end
+    end
+  end
+end

--- a/app/services/proofing/resolution/plugins/aamva_plugin.rb
+++ b/app/services/proofing/resolution/plugins/aamva_plugin.rb
@@ -49,7 +49,7 @@ module Proofing
           end
         end
 
-        def self.aamva_supports_state_id_jurisdiction?(applicant_pii)
+        def aamva_supports_state_id_jurisdiction?(applicant_pii)
           state_id_jurisdiction = applicant_pii[:state_id_jurisdiction]
           IdentityConfig.store.aamva_supported_jurisdictions.include?(state_id_jurisdiction)
         end
@@ -90,7 +90,7 @@ module Proofing
           instant_verify_result:,
           ipp_enrollment_in_progress:
         )
-          return false unless AamvaPlugin.aamva_supports_state_id_jurisdiction?(applicant_pii)
+          return false unless aamva_supports_state_id_jurisdiction?(applicant_pii)
           # If the user is in in-person-proofing and they have changed their address then
           # they are not eligible for get-to-yes
           if !ipp_enrollment_in_progress || same_address_as_id?(applicant_pii)

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -9,9 +9,10 @@ module Proofing
     #      address or separate residential and identity document addresses
     class ProgressiveProofer
       attr_reader :applicant_pii, :timer, :current_sp
-      attr_reader :threatmetrix_plugin
+      attr_reader :aamva_plugin, :threatmetrix_plugin
 
       def initialize
+        @aamva_plugin = Plugins::AamvaPlugin.new
         @threatmetrix_plugin = Plugins::ThreatMetrixPlugin.new
       end
 
@@ -48,13 +49,21 @@ module Proofing
 
         @residential_instant_verify_result = proof_residential_address_if_needed
         @instant_verify_result = proof_id_address_with_lexis_nexis_if_needed
-        @state_id_result = proof_id_with_aamva_if_needed
+
+        state_id_result = aamva_plugin.call(
+          applicant_pii:,
+          current_sp:,
+          instant_verify_result:,
+          ipp_enrollment_in_progress:,
+          timer:,
+        )
 
         ResultAdjudicator.new(
           device_profiling_result: device_profiling_result,
           ipp_enrollment_in_progress: ipp_enrollment_in_progress,
           resolution_result: instant_verify_result,
-          should_proof_state_id: aamva_supports_state_id_jurisdiction?,
+          should_proof_state_id:
+            Plugins::AamvaPlugin.aamva_supports_state_id_jurisdiction?(applicant_pii),
           state_id_result: state_id_result,
           residential_resolution_result: residential_instant_verify_result,
           same_address_as_id: applicant_pii[:same_address_as_id],
@@ -66,8 +75,7 @@ module Proofing
 
       attr_reader :device_profiling_result,
                   :residential_instant_verify_result,
-                  :instant_verify_result,
-                  :state_id_result
+                  :instant_verify_result
 
       def proof_residential_address_if_needed
         return residential_address_unnecessary_result unless ipp_enrollment_in_progress?
@@ -104,65 +112,12 @@ module Proofing
         end
       end
 
-      def should_proof_state_id_with_aamva?
-        return false unless aamva_supports_state_id_jurisdiction?
-        # If the user is in in-person-proofing and they have changed their address then
-        # they are not eligible for get-to-yes
-        if !ipp_enrollment_in_progress? || same_address_as_id?
-          user_can_pass_after_state_id_check?
-        else
-          residential_instant_verify_result.success?
-        end
-      end
-
-      def aamva_supports_state_id_jurisdiction?
-        state_id_jurisdiction = applicant_pii[:state_id_jurisdiction]
-        IdentityConfig.store.aamva_supported_jurisdictions.include?(state_id_jurisdiction)
-      end
-
-      def proof_id_with_aamva_if_needed
-        return out_of_aamva_jurisdiction_result unless should_proof_state_id_with_aamva?
-
-        timer.time('state_id') do
-          state_id_proofer.proof(applicant_pii_with_state_id_address)
-        end.tap do |result|
-          add_sp_cost(:aamva, result.transaction_id) if result.exception.blank?
-        end
-      end
-
-      def user_can_pass_after_state_id_check?
-        return true if instant_verify_result.success?
-        # For failed IV results, this method validates that the user is eligible to pass if the
-        # failed attributes are covered by the same attributes in a successful AAMVA response
-        # aka the Get-to-Yes w/ AAMVA feature.
-        if !instant_verify_result.failed_result_can_pass_with_additional_verification?
-          return false
-        end
-
-        attributes_aamva_can_pass = [:address, :dob, :state_id_number]
-        attributes_requiring_additional_verification =
-          instant_verify_result.attributes_requiring_additional_verification
-        results_that_cannot_pass_aamva =
-          attributes_requiring_additional_verification - attributes_aamva_can_pass
-
-        results_that_cannot_pass_aamva.blank?
-      end
-
       def same_address_as_id?
         applicant_pii[:same_address_as_id].to_s == 'true'
       end
 
       def ipp_enrollment_in_progress?
         @ipp_enrollment_in_progress
-      end
-
-      def out_of_aamva_jurisdiction_result
-        Proofing::StateIdResult.new(
-          errors: {},
-          exception: nil,
-          success: true,
-          vendor_name: 'UnsupportedJurisdiction',
-        )
       end
 
       def resolution_proofer
@@ -179,23 +134,6 @@ module Proofing
               hmac_key_id: IdentityConfig.store.lexisnexis_hmac_key_id,
               hmac_secret_key: IdentityConfig.store.lexisnexis_hmac_secret_key,
               request_mode: IdentityConfig.store.lexisnexis_request_mode,
-            )
-          end
-      end
-
-      def state_id_proofer
-        @state_id_proofer ||=
-          if IdentityConfig.store.proofer_mock_fallback
-            Proofing::Mock::StateIdMockClient.new
-          else
-            Proofing::Aamva::Proofer.new(
-              auth_request_timeout: IdentityConfig.store.aamva_auth_request_timeout,
-              auth_url: IdentityConfig.store.aamva_auth_url,
-              cert_enabled: IdentityConfig.store.aamva_cert_enabled,
-              private_key: IdentityConfig.store.aamva_private_key,
-              public_key: IdentityConfig.store.aamva_public_key,
-              verification_request_timeout: IdentityConfig.store.aamva_verification_request_timeout,
-              verification_url: IdentityConfig.store.aamva_verification_url,
             )
           end
       end

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -62,8 +62,7 @@ module Proofing
           device_profiling_result: device_profiling_result,
           ipp_enrollment_in_progress: ipp_enrollment_in_progress,
           resolution_result: instant_verify_result,
-          should_proof_state_id:
-            Plugins::AamvaPlugin.aamva_supports_state_id_jurisdiction?(applicant_pii),
+          should_proof_state_id: aamva_plugin.aamva_supports_state_id_jurisdiction?(applicant_pii),
           state_id_result: state_id_result,
           residential_resolution_result: residential_instant_verify_result,
           same_address_as_id: applicant_pii[:same_address_as_id],

--- a/lib/aamva_test.rb
+++ b/lib/aamva_test.rb
@@ -45,6 +45,6 @@ class AamvaTest
   end
 
   def build_proofer
-    Proofing::Resolution::ProgressiveProofer.new.send(:state_id_proofer)
+    Proofing::Resolution::Plugins::AamvaPlugin.new.send(:proofer)
   end
 end

--- a/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
@@ -294,4 +294,55 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
       end
     end
   end
+
+  describe '#aamva_supports_state_id_jurisdiction?' do
+    let(:applicant_pii) do
+      Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
+        state: address_state,
+        state_id_jurisdiction: jurisdiction_state,
+      )
+    end
+    let(:jurisdiction_state) { 'WA' }
+    let(:address_state) { 'WA' }
+    let(:aamva_supported_jurisdictions) do
+      ['WA']
+    end
+
+    subject(:supported) do
+      described_class.new.aamva_supports_state_id_jurisdiction?(applicant_pii)
+    end
+
+    before do
+      allow(IdentityConfig.store).to receive(:aamva_supported_jurisdictions).
+        and_return(aamva_supported_jurisdictions)
+    end
+
+    context 'when jurisdiction is supported' do
+      it 'returns true' do
+        expect(supported).to eql(true)
+      end
+      context 'but address state is not' do
+        let(:address_state) { 'MT' }
+        it 'still returns true' do
+          expect(supported).to eql(true)
+        end
+      end
+    end
+
+    context 'when jurisdiction is not supported' do
+      let(:address_state) { 'MT' }
+      let(:jurisdiction_state) { 'MT' }
+
+      it 'returns false' do
+        expect(supported).to eql(false)
+      end
+
+      context 'but address state is' do
+        let(:address_state) { 'WA' }
+        it 'still returns false' do
+          expect(supported).to eql(false)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
     Proofing::StateIdResult.new(
       success: true,
       vendor_name: 'state_id:aamva',
+      transaction_id: proofer_transaction_id,
     )
   end
+  let(:proofer_transaction_id) { 'abcd-123' }
 
   subject(:plugin) do
     described_class.new
@@ -22,8 +24,16 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
   end
 
   describe '#call' do
-    def sp_cost_count
+    def sp_cost_count_for_issuer
       SpCost.where(cost_type: :aamva, issuer: current_sp.issuer).count
+    end
+
+    def sp_cost_count_with_transaction_id
+      SpCost.where(
+        cost_type: :aamva,
+        issuer: current_sp.issuer,
+        transaction_id: proofer_transaction_id,
+      ).count
     end
 
     subject(:call) do
@@ -64,7 +74,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
 
         it 'tracks an SP cost for AAMVA' do
           expect { call }.to(
-            change { sp_cost_count }.
+            change { sp_cost_count_with_transaction_id }.
               to(1),
           )
         end
@@ -79,7 +89,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
           end
 
           it 'does not track an SP cost for AAMVA' do
-            expect { call }.to_not change { sp_cost_count }
+            expect { call }.to_not change { sp_cost_count_for_issuer }
           end
         end
       end
@@ -103,7 +113,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
           it 'tracks an SP cost for AAMVA' do
             expect { call }.
               to(
-                change { sp_cost_count }.
+                change { sp_cost_count_with_transaction_id }.
                 to(1),
               )
           end
@@ -124,7 +134,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
           end
 
           it 'does not record an SP cost for AAMVA' do
-            expect { call }.not_to change { sp_cost_count }
+            expect { call }.not_to change { sp_cost_count_for_issuer }
           end
 
           it 'returns an UnsupportedJurisdiction result' do
@@ -168,7 +178,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
           end
 
           it 'records an SP cost for AAMVA' do
-            expect { call }.to change { sp_cost_count }.to(1)
+            expect { call }.to change { sp_cost_count_with_transaction_id }.to(1)
           end
         end
 
@@ -189,7 +199,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
             end
 
             it 'records an SP cost for AAMVA' do
-              expect { call }.to change { sp_cost_count }.to(1)
+              expect { call }.to change { sp_cost_count_with_transaction_id }.to(1)
             end
           end
 
@@ -208,7 +218,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
             end
 
             it 'does not record an SP cost for AAMVA' do
-              expect { call }.not_to change { sp_cost_count }
+              expect { call }.not_to change { sp_cost_count_for_issuer }
             end
 
             it 'returns an UnsupportedJurisdiction result' do
@@ -239,7 +249,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
             end
 
             it 'records an SP cost for AAMVA' do
-              expect { call }.to change { sp_cost_count }.to(1)
+              expect { call }.to change { sp_cost_count_with_transaction_id }.to(1)
             end
           end
 
@@ -260,7 +270,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
               end
 
               it 'does not record an SP cost for AAMVA' do
-                expect { call }.not_to change { sp_cost_count }
+                expect { call }.not_to change { sp_cost_count_for_issuer }
               end
             end
 
@@ -279,7 +289,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
               end
 
               it 'does not record an SP cost for AAMVA' do
-                expect { call }.not_to change { sp_cost_count }
+                expect { call }.not_to change { sp_cost_count_for_issuer }
               end
 
               it 'returns an UnsupportedJurisdiction result' do

--- a/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
@@ -1,0 +1,297 @@
+require 'rails_helper'
+
+RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
+  let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
+  let(:current_sp) { build(:service_provider) }
+  let(:instant_verify_result) { nil }
+  let(:ipp_enrollment_in_progress) { false }
+  let(:proofer) { instance_double(Proofing::Aamva::Proofer, proof: proofer_result) }
+  let(:proofer_result) do
+    Proofing::StateIdResult.new(
+      success: true,
+      vendor_name: 'state_id:aamva',
+    )
+  end
+
+  subject(:plugin) do
+    described_class.new
+  end
+
+  before do
+    allow(plugin).to receive(:proofer).and_return(proofer)
+  end
+
+  describe '#call' do
+    def sp_cost_count
+      SpCost.where(cost_type: :aamva, issuer: current_sp.issuer).count
+    end
+
+    subject(:call) do
+      plugin.call(
+        applicant_pii:,
+        current_sp:,
+        instant_verify_result:,
+        ipp_enrollment_in_progress:,
+        timer: JobHelpers::Timer.new,
+      )
+    end
+
+    context 'unsupervised remote proofing' do
+      let(:ipp_enrollment_in_progress) { false }
+      let(:state_id_address) do
+        {
+          address1: applicant_pii[:address1],
+          address2: applicant_pii[:address2],
+          city: applicant_pii[:city],
+          state: applicant_pii[:state],
+          state_id_jurisdiction: applicant_pii[:state_id_jurisdiction],
+          zipcode: applicant_pii[:zipcode],
+        }
+      end
+
+      context 'InstantVerify succeeded' do
+        let(:instant_verify_result) do
+          Proofing::Resolution::Result.new(
+            success: true,
+            vendor_name: 'lexisnexis:instant_verify',
+          )
+        end
+
+        it 'calls the AAMVA proofer' do
+          expect(plugin.proofer).to receive(:proof).with(hash_including(state_id_address))
+          call
+        end
+
+        it 'tracks an SP cost for AAMVA' do
+          expect { call }.to(
+            change { sp_cost_count }.
+              to(1),
+          )
+        end
+
+        context 'AAMVA proofer raises an exception' do
+          let(:proofer_result) do
+            Proofing::StateIdResult.new(
+              success: false,
+              transaction_id: 'aamva-123',
+              exception: RuntimeError.new('this is a fun test error!!'),
+            )
+          end
+
+          it 'does not track an SP cost for AAMVA' do
+            expect { call }.to_not change { sp_cost_count }
+          end
+        end
+      end
+
+      context 'InstantVerify failed' do
+        context 'and the failure can possibly be covered by AAMVA' do
+          let(:instant_verify_result) do
+            Proofing::Resolution::Result.new(
+              success: false,
+              vendor_name: 'lexisnexis:instant_verify',
+              failed_result_can_pass_with_additional_verification: true,
+              attributes_requiring_additional_verification: [:address],
+            )
+          end
+
+          it 'makes an AAMVA call' do
+            expect(plugin.proofer).to receive(:proof)
+            call
+          end
+
+          it 'tracks an SP cost for AAMVA' do
+            expect { call }.
+              to(
+                change { sp_cost_count }.
+                to(1),
+              )
+          end
+        end
+
+        context 'but the failure cannot be covered by AAMVA' do
+          let(:instant_verify_result) do
+            Proofing::Resolution::Result.new(
+              success: false,
+              vendor_name: 'lexisnexis:instant_verify',
+              failed_result_can_pass_with_additional_verification: false,
+            )
+          end
+
+          it 'does not make an AAMVA call' do
+            expect(plugin.proofer).not_to receive(:proof)
+            call
+          end
+
+          it 'does not record an SP cost for AAMVA' do
+            expect { call }.not_to change { sp_cost_count }
+          end
+
+          it 'returns an UnsupportedJurisdiction result' do
+            call.tap do |result|
+              expect(result.success?).to eql(true)
+              expect(result.vendor_name).to eql('UnsupportedJurisdiction')
+            end
+          end
+        end
+      end
+    end
+
+    context 'in-person proofing' do
+      let(:ipp_enrollment_in_progress) { true }
+
+      let(:state_id_address) do
+        {
+          address1: applicant_pii[:identity_doc_address1],
+          address2: applicant_pii[:identity_doc_address2],
+          city: applicant_pii[:identity_doc_city],
+          state: applicant_pii[:identity_doc_address_state],
+          state_id_jurisdiction: applicant_pii[:state_id_jurisdiction],
+          zipcode: applicant_pii[:identity_doc_zipcode],
+        }
+      end
+
+      context 'residential address same as id address' do
+        let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID }
+
+        let(:instant_verify_result) do
+          Proofing::Resolution::Result.new(
+            success: true,
+            vendor_name: 'lexisnexis:instant_verify',
+          )
+        end
+
+        context 'InstantVerify succeeded' do
+          it 'calls the AAMVA proofer' do
+            expect(plugin.proofer).to receive(:proof).with(hash_including(state_id_address))
+            call
+          end
+
+          it 'records an SP cost for AAMVA' do
+            expect { call }.to change { sp_cost_count }.to(1)
+          end
+        end
+
+        context 'InstantVerify failed' do
+          context 'and the failure can possibly be covered by AAMVA' do
+            let(:instant_verify_result) do
+              Proofing::Resolution::Result.new(
+                success: false,
+                vendor_name: 'lexisnexis:instant_verify',
+                failed_result_can_pass_with_additional_verification: true,
+                attributes_requiring_additional_verification: [:address],
+              )
+            end
+
+            it 'makes an AAMVA call' do
+              expect(plugin.proofer).to receive(:proof)
+              call
+            end
+
+            it 'records an SP cost for AAMVA' do
+              expect { call }.to change { sp_cost_count }.to(1)
+            end
+          end
+
+          context 'but the failure cannot be covered by AAMVA' do
+            let(:instant_verify_result) do
+              Proofing::Resolution::Result.new(
+                success: false,
+                vendor_name: 'lexisnexis:instant_verify',
+                failed_result_can_pass_with_additional_verification: false,
+              )
+            end
+
+            it 'does not make an AAMVA call' do
+              expect(plugin.proofer).not_to receive(:proof)
+              call
+            end
+
+            it 'does not record an SP cost for AAMVA' do
+              expect { call }.not_to change { sp_cost_count }
+            end
+
+            it 'returns an UnsupportedJurisdiction result' do
+              call.tap do |result|
+                expect(result.success?).to eql(true)
+                expect(result.vendor_name).to eql('UnsupportedJurisdiction')
+              end
+            end
+          end
+        end
+      end
+
+      context 'residential address and id address are different' do
+        let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS }
+
+        context 'InstantVerify succeeded for residential address' do
+          context 'and InstantVerify passed for id address' do
+            let(:instant_verify_result) do
+              Proofing::Resolution::Result.new(
+                success: true,
+                vendor_name: 'lexisnexis:instant_verify',
+              )
+            end
+
+            it 'calls the AAMVA proofer using the state id address' do
+              expect(plugin.proofer).to receive(:proof).with(hash_including(state_id_address))
+              call
+            end
+
+            it 'records an SP cost for AAMVA' do
+              expect { call }.to change { sp_cost_count }.to(1)
+            end
+          end
+
+          context 'and InstantVerify failed for state id address' do
+            context 'but the failure can possibly be covered by AAMVA' do
+              let(:instant_verify_result) do
+                Proofing::Resolution::Result.new(
+                  success: false,
+                  vendor_name: 'lexisnexis:instant_verify',
+                  failed_result_can_pass_with_additional_verification: true,
+                  attributes_requiring_additional_verification: [:address],
+                )
+              end
+
+              it 'does not make an AAMVA call because get to yes is not supported' do
+                expect(plugin.proofer).not_to receive(:proof)
+                call
+              end
+
+              it 'does not record an SP cost for AAMVA' do
+                expect { call }.not_to change { sp_cost_count }
+              end
+            end
+
+            context 'and the failure cannot be covered by AAMVA' do
+              let(:instant_verify_result) do
+                Proofing::Resolution::Result.new(
+                  success: false,
+                  vendor_name: 'lexisnexis:instant_verify',
+                  failed_result_can_pass_with_additional_verification: false,
+                )
+              end
+
+              it 'does not make an AAMVA call' do
+                expect(plugin.proofer).not_to receive(:proof)
+                call
+              end
+
+              it 'does not record an SP cost for AAMVA' do
+                expect { call }.not_to change { sp_cost_count }
+              end
+
+              it 'returns an UnsupportedJurisdiction result' do
+                call.tap do |result|
+                  expect(result.success?).to eql(true)
+                  expect(result.vendor_name).to eql('UnsupportedJurisdiction')
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Continuing the work in #11420, this PR extracts `proof_id_with_aamva_if_needed` into `AamvaPlugin`. It then adds a spec for the plugin covering the following use cases:

* Remote unsupervised proofing
* In-person proofing (residential address == id address)
* In-person proofing (residential address != id address)

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Run through remote unsupervised IdV using an ID from an AAMVA state
- [ ] Run through remote unsupervised IdV using an ID from a non-AAMVA state
- [ ] Run through in-person proofing using an ID from an AAMVA state (same address as id)
- [ ] Run through in-person proofing using an ID from a non-AAMVA state (same address as id)
- [ ] Run through in-person proofing using an ID from an AAMVA state (different address than id)
- [ ] Run through in-person proofing using an ID from a non-AAMVA state (different address than id)

