### PR TITLE
LG-14691: Display flash message on successful email update

### DIFF
--- a/app/controllers/accounts/connected_accounts/selected_email_controller.rb
+++ b/app/controllers/accounts/connected_accounts/selected_email_controller.rb
@@ -23,6 +23,7 @@ module Accounts
         analytics.sp_select_email_submitted(**result.to_h)
 
         if result.success?
+          flash[:email_updated_identity_id] = identity.id
           redirect_to account_connected_accounts_path
         else
           flash[:error] = result.first_error_message

--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -1,4 +1,8 @@
 <div class="padding-1 border-top border-left border-right border-primary-light">
+  <% if flash[:email_updated_identity_id] == identity.id %>
+    <%= render AlertComponent.new(type: :success, class: 'margin-bottom-2', message: t('account.connected_apps.email_update_success_html', sp_name: identity.display_name)) %>
+  <% end %>
+
   <h2 class="h3 margin-top-0 margin-bottom-1">
     <% if identity.return_to_sp_url.present? %>
       <%= link_to(identity.display_name, identity.return_to_sp_url) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ account.connected_apps.associated_attributes_html: 'Connected %{timestamp_html} 
 account.connected_apps.associated_html: Connected %{timestamp_html}
 account.connected_apps.description: With your %{app_name} account, you can securely connect to multiple government accounts online. Below is a list of all the accounts you currently have connected.
 account.connected_apps.email_not_selected: Email not yet selected
+account.connected_apps.email_update_success_html: Your email for <strong>%{sp_name}</strong> was updated successfully.
 account.email_language.default: '%{language} (default)'
 account.email_language.edit_title: Edit email language preference
 account.email_language.languages_list: You will receive emails from %{app_name} in the language you choose.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -42,6 +42,7 @@ account.connected_apps.associated_attributes_html: 'Conectado el %{timestamp_htm
 account.connected_apps.associated_html: 'Conectado: %{timestamp_html}'
 account.connected_apps.description: Con su cuenta de %{app_name}, puede conectarse de manera segura a muchas cuentas del gobierno en línea. Esta es una lista de todas las cuentas que tiene conectadas actualmente.
 account.connected_apps.email_not_selected: No se seleccionó correo electrónico aún
+account.connected_apps.email_update_success_html: Se actualizó su correo electrónico para la <strong>%{sp_name}</strong>.
 account.email_language.default: '%{language} (predeterminado)'
 account.email_language.edit_title: Editar la preferencia de idioma del correo electrónico
 account.email_language.languages_list: Recibirá mensajes de correo electrónico de %{app_name} en el idioma que elija.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -42,6 +42,7 @@ account.connected_apps.associated_attributes_html: 'Connecté %{timestamp_html} 
 account.connected_apps.associated_html: Connecté %{timestamp_html}
 account.connected_apps.description: Avec votre compte %{app_name}, vous pouvez vous connecter en toute sécurité à plusieurs comptes de l’administration en ligne. Vous trouverez ci-dessous une liste de tous vos comptes actuellement connectés.
 account.connected_apps.email_not_selected: Adresse e-mail non encore sélectionnée
+account.connected_apps.email_update_success_html: Vous avez réussi à modifier votre adresse e-mail pour <strong>%{sp_name}</strong>.
 account.email_language.default: '%{language} (par défaut)'
 account.email_language.edit_title: Modifier la langue dans laquelle vous préférez recevoir les e-mails
 account.email_language.languages_list: Vous recevrez des e-mails de %{app_name} dans la langue de votre choix.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -42,6 +42,7 @@ account.connected_apps.associated_attributes_html: '在 %{timestamp_html} 用以
 account.connected_apps.associated_html: 已连接 %{timestamp_html}
 account.connected_apps.description: 使用你的 %{app_name} 账户，你可以安全地连接到网上多个政府账户。以下列出了你目前已连接的所有账户。
 account.connected_apps.email_not_selected: 尚未选择电邮
+account.connected_apps.email_update_success_html: 你给<strong>%{sp_name}</strong>的电邮更新成功了。
 account.email_language.default: '%{language} （默认）'
 account.email_language.edit_title: 编辑电邮语言选择
 account.email_language.languages_list: 您将收到%{app_name}用您选择的语言发送的电子邮件。

--- a/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
+++ b/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
@@ -67,8 +67,9 @@ RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
     let(:params) { { identity_id:, select_email_form: { selected_email_id: selected_email.id } } }
     subject(:response) { patch :update, params: }
 
-    it 'redirects to connected accounts path' do
+    it 'redirects to connected accounts path with the appropriate flash message' do
       expect(response).to redirect_to(account_connected_accounts_path)
+      expect(flash[:email_updated_identity_id]).to eq(identity.id)
     end
 
     it 'logs analytics event' do

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -96,6 +96,12 @@ RSpec.describe 'Account connected applications' do
     end
 
     expect(page).to have_field(user.email) { |field| field[:checked] }
+
+    click_on(t('help_text.requested_attributes.change_email_link'))
+
+    expect(page).to have_content strip_tags(
+      t('account.connected_apps.email_update_success_html', sp_name: identity.display_name),
+    )
   end
 
   def build_account_connected_apps


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14691](https://cm-jira.usa.gov/browse/LG-14691)



## 🛠 Summary of changes

Whenever the email shared with a partner is changed, show a flash message next to the connected account indicating that the email was (recently) successfully changed.



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create a user associated with multiple partners, e.g., the SAML and OIDC sample apps.
- [ ] Navigate to account/connected_accounts and select the link to change the associated email address
- [ ] Make the change and apply it
- [ ] There should be a flash message in the connected apps list, immediately above the partner app for which you made the change, as shown in the screenshot below.


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="1004" alt="Screenshot 2024-10-30 at 2 40 29 PM" src="https://github.com/user-attachments/assets/85b1df4b-40c8-4e3c-8183-a207ded15210">

</details>

<details>
<summary>After:</summary>
<img width="1084" alt="Screenshot 2024-10-30 at 2 40 54 PM" src="https://github.com/user-attachments/assets/0aaaa11e-9378-4ddc-b6c0-b47c35ebc049">

</details>

