### PR TITLE
ProgressiveProofer refactor 3/N: Instant Verify residential address

### DIFF
--- a/app/services/proofing/resolution/plugins/instant_verify_residential_address_plugin.rb
+++ b/app/services/proofing/resolution/plugins/instant_verify_residential_address_plugin.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Proofing
+  module Resolution
+    module Plugins
+      class InstantVerifyResidentialAddressPlugin
+        def call(
+          applicant_pii:,
+          current_sp:,
+          ipp_enrollment_in_progress:,
+          timer:
+        )
+          return residential_address_unnecessary_result unless ipp_enrollment_in_progress
+
+          timer.time('residential address') do
+            proofer.proof(applicant_pii)
+          end.tap do |result|
+            Db::SpCost::AddSpCost.call(
+              current_sp,
+              :lexis_nexis_resolution,
+              transaction_id: result.transaction_id,
+            )
+          end
+        end
+
+        def proofer
+          @proofer ||=
+            if IdentityConfig.store.proofer_mock_fallback
+              Proofing::Mock::ResolutionMockClient.new
+            else
+              Proofing::LexisNexis::InstantVerify::Proofer.new(
+                instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
+                account_id: IdentityConfig.store.lexisnexis_account_id,
+                base_url: IdentityConfig.store.lexisnexis_base_url,
+                username: IdentityConfig.store.lexisnexis_username,
+                password: IdentityConfig.store.lexisnexis_password,
+                hmac_key_id: IdentityConfig.store.lexisnexis_hmac_key_id,
+                hmac_secret_key: IdentityConfig.store.lexisnexis_hmac_secret_key,
+                request_mode: IdentityConfig.store.lexisnexis_request_mode,
+              )
+            end
+        end
+
+        def residential_address_unnecessary_result
+          Proofing::Resolution::Result.new(
+            success: true, errors: {}, exception: nil, vendor_name: 'ResidentialAddressNotRequired',
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -383,22 +383,6 @@ RSpec.describe ResolutionProofingJob, type: :job do
         )
       end
 
-      it 'verifies ID address with AAMVA & LexisNexis & residential address with LexisNexis' do
-        stub_vendor_requests
-
-        expect_any_instance_of(Proofing::LexisNexis::InstantVerify::Proofer).to receive(:proof).
-          with(hash_including(residential_address)).and_call_original
-
-        expect_any_instance_of(Proofing::LexisNexis::InstantVerify::Proofer).to receive(:proof).
-          with(hash_including(identity_doc_address)).and_call_original
-
-        expect_any_instance_of(Proofing::Aamva::Proofer).to receive(:proof).with(
-          hash_including(identity_doc_address),
-        ).and_call_original
-
-        perform
-      end
-
       it 'stores a successful result' do
         stub_vendor_requests
 

--- a/spec/services/proofing/resolution/plugins/instant_verify_residential_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_residential_address_plugin_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe Proofing::Resolution::Plugins::InstantVerifyResidentialAddressPlugin do
+  let(:current_sp) { build(:service_provider) }
+
+  let(:ipp_enrollment_in_progress) { false }
+
+  let(:proofer_transaction_id) { 'residential-123' }
+
+  let(:proofer_result) do
+    Proofing::Resolution::Result.new(
+      success: true,
+      transaction_id: proofer_transaction_id,
+      vendor_name: 'lexisnexis:instant_verify',
+    )
+  end
+
+  subject(:plugin) do
+    described_class.new
+  end
+
+  before do
+    allow(plugin.proofer).to receive(:proof).and_return(proofer_result)
+  end
+
+  describe '#call' do
+    def sp_cost_count_for_issuer
+      SpCost.where(cost_type: :lexis_nexis_resolution, issuer: current_sp.issuer).count
+    end
+
+    def sp_cost_count_with_transaction_id
+      SpCost.where(
+        cost_type: :lexis_nexis_resolution,
+        issuer: current_sp.issuer,
+        transaction_id: proofer_transaction_id,
+      ).count
+    end
+
+    subject(:call) do
+      plugin.call(
+        applicant_pii:,
+        current_sp:,
+        ipp_enrollment_in_progress:,
+        timer: JobHelpers::Timer.new,
+      )
+    end
+
+    context 'remote unsupervised proofing' do
+      let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
+      let(:ipp_enrollment_in_progress) { false }
+
+      it 'returns a ResidentialAddressNotRequired result' do
+        call.tap do |result|
+          expect(result.success?).to eql(true)
+          expect(result.vendor_name).to eql('ResidentialAddressNotRequired')
+        end
+      end
+
+      it 'does not record a LexisNexis SP cost' do
+        expect { call }.not_to change { sp_cost_count_for_issuer }
+      end
+    end
+
+    context 'in-person proofing' do
+      let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID }
+      let(:ipp_enrollment_in_progress) { true }
+      let(:proofer_result) do
+        Proofing::Resolution::Result.new(
+          success: true,
+          transaction_id: proofer_transaction_id,
+          vendor_name: 'lexisnexis:instant_verify',
+        )
+      end
+
+      it 'calls proofer with pii' do
+        expect(plugin.proofer).to receive(:proof).with(applicant_pii)
+        call
+      end
+
+      context 'when InstantVerify call succeeds' do
+        it 'returns the proofer result' do
+          expect(call).to eql(proofer_result)
+        end
+
+        it 'records a LexisNexis SP cost' do
+          expect { call }.to change { sp_cost_count_with_transaction_id }.to(1)
+        end
+      end
+
+      context 'when InstantVerify call fails' do
+        let(:proofer_result) do
+          Proofing::Resolution::Result.new(
+            success: false,
+            errors: {},
+            exception: nil,
+            transaction_id: proofer_transaction_id,
+            vendor_name: 'lexisnexis:instant_verify',
+          )
+        end
+
+        it 'returns the proofer result' do
+          expect(call).to eql(proofer_result)
+        end
+
+        it 'records a LexisNexis SP cost' do
+          expect { call }.to change { sp_cost_count_with_transaction_id }.to(1)
+        end
+      end
+
+      context 'when InstantVerify call results in exception' do
+        let(:proofer_result) do
+          Proofing::Resolution::Result.new(
+            success: false,
+            errors: {},
+            exception: RuntimeError.new(':ohno:'),
+            transaction_id: proofer_transaction_id,
+            vendor_name: 'lexisnexis:instant_verify',
+          )
+        end
+
+        it 'returns the proofer result' do
+          expect(call).to eql(proofer_result)
+        end
+
+        it 'records a LexisNexis SP cost' do
+          expect { call }.to change { sp_cost_count_with_transaction_id }.to(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/proofing/resolution/progressive_proofer_spec.rb
+++ b/spec/services/proofing/resolution/progressive_proofer_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
   let(:user_email) { Faker::Internet.email }
   let(:current_sp) { build(:service_provider) }
 
+  let(:instant_verify_residential_address_plugin) do
+    Proofing::Resolution::Plugins::InstantVerifyResidentialAddressPlugin.new
+  end
+
   let(:instant_verify_result) do
     Proofing::Resolution::Result.new(
       success: true,
@@ -107,6 +111,11 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
     allow(progressive_proofer).to receive(:aamva_plugin).and_return(aamva_plugin)
     allow(aamva_plugin).to receive(:proofer).and_return(aamva_proofer)
 
+    allow(progressive_proofer).to receive(:instant_verify_residential_address_plugin).
+      and_return(instant_verify_residential_address_plugin)
+    allow(instant_verify_residential_address_plugin).to receive(:proofer).
+      and_return(instant_verify_proofer)
+
     allow(progressive_proofer).to receive(:resolution_proofer).and_return(instant_verify_proofer)
 
     block_real_instant_verify_requests
@@ -115,6 +124,12 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
   it 'assigns aamva_plugin' do
     expect(described_class.new.aamva_plugin).to be_a(
       Proofing::Resolution::Plugins::AamvaPlugin,
+    )
+  end
+
+  it 'assigns instant_verify_residential_address_plugin' do
+    expect(described_class.new.instant_verify_residential_address_plugin).to be_a(
+      Proofing::Resolution::Plugins::InstantVerifyResidentialAddressPlugin,
     )
   end
 
@@ -150,6 +165,16 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
           ipp_enrollment_in_progress: false,
           timer: an_instance_of(JobHelpers::Timer),
         )
+        proof
+      end
+
+      it 'calls InstantVerifyResidentialAddressPlugin' do
+        expect(instant_verify_residential_address_plugin).to receive(:call).with(
+          applicant_pii:,
+          current_sp:,
+          ipp_enrollment_in_progress: false,
+          timer: an_instance_of(JobHelpers::Timer),
+        ).and_call_original
         proof
       end
 
@@ -197,6 +222,16 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
             timer: an_instance_of(JobHelpers::Timer),
           )
 
+          proof
+        end
+
+        it 'calls InstantVerifyResidentialAddressPlugin' do
+          expect(instant_verify_residential_address_plugin).to receive(:call).with(
+            applicant_pii:,
+            current_sp:,
+            ipp_enrollment_in_progress: true,
+            timer: an_instance_of(JobHelpers::Timer),
+          ).and_call_original
           proof
         end
 
@@ -250,6 +285,16 @@ RSpec.describe Proofing::Resolution::ProgressiveProofer do
             timer: an_instance_of(JobHelpers::Timer),
             user_email:,
           )
+          proof
+        end
+
+        it 'calls InstantVerifyResidentialAddressPlugin' do
+          expect(instant_verify_residential_address_plugin).to receive(:call).with(
+            applicant_pii:,
+            current_sp:,
+            ipp_enrollment_in_progress: true,
+            timer: an_instance_of(JobHelpers::Timer),
+          ).and_call_original
           proof
         end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Continuing the work in #11420 and #11427, this PR extracts `proof_residential_address_if_needed` into `InstantVerifyResidentialAddressPlugin`. It then adds a spec for the plugin covering the following use cases:

* Remote unsupervised proofing
* In-person proofing (residential address == id address)
* In-person proofing (residential address != id address)


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Complete IdV using the unsupervised remote path
- [ ] Complete IdV using the in-person proofing path (where your residential address == your id address)
- [ ] Complete IdV using the in-person proofing path (where your residential address != your id address)
