### PR TITLE
ProgressiveProofer refactor 4/N: InstantVerify state id address

### DIFF
--- a/app/services/proofing/resolution/plugins/aamva_plugin.rb
+++ b/app/services/proofing/resolution/plugins/aamva_plugin.rb
@@ -15,13 +15,13 @@ module Proofing
         def call(
           applicant_pii:,
           current_sp:,
-          instant_verify_result:,
+          instant_verify_state_id_address_result:,
           ipp_enrollment_in_progress:,
           timer:
         )
           should_proof = should_proof_state_id_with_aamva?(
             applicant_pii:,
-            instant_verify_result:,
+            instant_verify_state_id_address_result:,
             ipp_enrollment_in_progress:,
           )
 
@@ -87,34 +87,35 @@ module Proofing
 
         def should_proof_state_id_with_aamva?(
           applicant_pii:,
-          instant_verify_result:,
+          instant_verify_state_id_address_result:,
           ipp_enrollment_in_progress:
         )
           return false unless aamva_supports_state_id_jurisdiction?(applicant_pii)
           # If the user is in in-person-proofing and they have changed their address then
           # they are not eligible for get-to-yes
           if !ipp_enrollment_in_progress || same_address_as_id?(applicant_pii)
-            user_can_pass_after_state_id_check?(instant_verify_result:)
+            user_can_pass_after_state_id_check?(instant_verify_state_id_address_result:)
           else
-            instant_verify_result.success?
+            instant_verify_state_id_address_result.success?
           end
         end
 
         def user_can_pass_after_state_id_check?(
-          instant_verify_result:
+          instant_verify_state_id_address_result:
         )
-          return true if instant_verify_result.success?
+          return true if instant_verify_state_id_address_result.success?
 
           # For failed IV results, this method validates that the user is eligible to pass if the
           # failed attributes are covered by the same attributes in a successful AAMVA response
           # aka the Get-to-Yes w/ AAMVA feature.
-          if !instant_verify_result.failed_result_can_pass_with_additional_verification?
+          if !instant_verify_state_id_address_result.
+              failed_result_can_pass_with_additional_verification?
             return false
           end
 
           attributes_aamva_can_pass = [:address, :dob, :state_id_number]
           attributes_requiring_additional_verification =
-            instant_verify_result.attributes_requiring_additional_verification
+            instant_verify_state_id_address_result.attributes_requiring_additional_verification
           results_that_cannot_pass_aamva =
             attributes_requiring_additional_verification - attributes_aamva_can_pass
 

--- a/app/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin.rb
+++ b/app/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Proofing
+  module Resolution
+    module Plugins
+      class InstantVerifyStateIdAddressPlugin
+        SECONDARY_ID_ADDRESS_MAP = {
+          identity_doc_address1: :address1,
+          identity_doc_address2: :address2,
+          identity_doc_city: :city,
+          identity_doc_address_state: :state,
+          identity_doc_zipcode: :zipcode,
+        }.freeze
+
+        def call(
+          applicant_pii:,
+          current_sp:,
+          instant_verify_residential_address_result:,
+          ipp_enrollment_in_progress:,
+          timer:
+        )
+          if same_address_as_id?(applicant_pii) && ipp_enrollment_in_progress
+            return instant_verify_residential_address_result
+          end
+
+          return resolution_cannot_pass unless instant_verify_residential_address_result.success?
+
+          applicant_pii_with_state_id_address =
+            if ipp_enrollment_in_progress
+              with_state_id_address(applicant_pii)
+            else
+              applicant_pii
+            end
+
+          timer.time('resolution') do
+            proofer.proof(applicant_pii_with_state_id_address)
+          end.tap do |result|
+            Db::SpCost::AddSpCost.call(
+              current_sp,
+              :lexis_nexis_resolution,
+              transaction_id: result.transaction_id,
+            )
+          end
+        end
+
+        def proofer
+          @proofer ||=
+            if IdentityConfig.store.proofer_mock_fallback
+              Proofing::Mock::ResolutionMockClient.new
+            else
+              Proofing::LexisNexis::InstantVerify::Proofer.new(
+                instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
+                account_id: IdentityConfig.store.lexisnexis_account_id,
+                base_url: IdentityConfig.store.lexisnexis_base_url,
+                username: IdentityConfig.store.lexisnexis_username,
+                password: IdentityConfig.store.lexisnexis_password,
+                hmac_key_id: IdentityConfig.store.lexisnexis_hmac_key_id,
+                hmac_secret_key: IdentityConfig.store.lexisnexis_hmac_secret_key,
+                request_mode: IdentityConfig.store.lexisnexis_request_mode,
+              )
+            end
+        end
+
+        def resolution_cannot_pass
+          Proofing::Resolution::Result.new(
+            success: false, errors: {}, exception: nil, vendor_name: 'ResolutionCannotPass',
+          )
+        end
+
+        def same_address_as_id?(applicant_pii)
+          applicant_pii[:same_address_as_id].to_s == 'true'
+        end
+
+        # Make a copy of pii with the user's state ID address overwriting the address keys
+        # Need to first remove the address keys to avoid key/value collision
+        def with_state_id_address(pii)
+          pii.except(*SECONDARY_ID_ADDRESS_MAP.values).
+            transform_keys(SECONDARY_ID_ADDRESS_MAP)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
   let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
   let(:current_sp) { build(:service_provider) }
-  let(:instant_verify_result) { nil }
+  let(:instant_verify_state_id_address_result) { nil }
   let(:ipp_enrollment_in_progress) { false }
   let(:proofer) { instance_double(Proofing::Aamva::Proofer, proof: proofer_result) }
   let(:proofer_result) do
@@ -40,7 +40,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
       plugin.call(
         applicant_pii:,
         current_sp:,
-        instant_verify_result:,
+        instant_verify_state_id_address_result:,
         ipp_enrollment_in_progress:,
         timer: JobHelpers::Timer.new,
       )
@@ -60,7 +60,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
       end
 
       context 'InstantVerify succeeded' do
-        let(:instant_verify_result) do
+        let(:instant_verify_state_id_address_result) do
           Proofing::Resolution::Result.new(
             success: true,
             vendor_name: 'lexisnexis:instant_verify',
@@ -96,7 +96,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
 
       context 'InstantVerify failed' do
         context 'and the failure can possibly be covered by AAMVA' do
-          let(:instant_verify_result) do
+          let(:instant_verify_state_id_address_result) do
             Proofing::Resolution::Result.new(
               success: false,
               vendor_name: 'lexisnexis:instant_verify',
@@ -120,7 +120,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
         end
 
         context 'but the failure cannot be covered by AAMVA' do
-          let(:instant_verify_result) do
+          let(:instant_verify_state_id_address_result) do
             Proofing::Resolution::Result.new(
               success: false,
               vendor_name: 'lexisnexis:instant_verify',
@@ -164,7 +164,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
       context 'residential address same as id address' do
         let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID }
 
-        let(:instant_verify_result) do
+        let(:instant_verify_state_id_address_result) do
           Proofing::Resolution::Result.new(
             success: true,
             vendor_name: 'lexisnexis:instant_verify',
@@ -184,7 +184,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
 
         context 'InstantVerify failed' do
           context 'and the failure can possibly be covered by AAMVA' do
-            let(:instant_verify_result) do
+            let(:instant_verify_state_id_address_result) do
               Proofing::Resolution::Result.new(
                 success: false,
                 vendor_name: 'lexisnexis:instant_verify',
@@ -204,7 +204,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
           end
 
           context 'but the failure cannot be covered by AAMVA' do
-            let(:instant_verify_result) do
+            let(:instant_verify_state_id_address_result) do
               Proofing::Resolution::Result.new(
                 success: false,
                 vendor_name: 'lexisnexis:instant_verify',
@@ -236,7 +236,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
 
         context 'InstantVerify succeeded for residential address' do
           context 'and InstantVerify passed for id address' do
-            let(:instant_verify_result) do
+            let(:instant_verify_state_id_address_result) do
               Proofing::Resolution::Result.new(
                 success: true,
                 vendor_name: 'lexisnexis:instant_verify',
@@ -255,7 +255,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
 
           context 'and InstantVerify failed for state id address' do
             context 'but the failure can possibly be covered by AAMVA' do
-              let(:instant_verify_result) do
+              let(:instant_verify_state_id_address_result) do
                 Proofing::Resolution::Result.new(
                   success: false,
                   vendor_name: 'lexisnexis:instant_verify',
@@ -275,7 +275,7 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
             end
 
             context 'and the failure cannot be covered by AAMVA' do
-              let(:instant_verify_result) do
+              let(:instant_verify_state_id_address_result) do
                 Proofing::Resolution::Result.new(
                   success: false,
                   vendor_name: 'lexisnexis:instant_verify',

--- a/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
 
   let(:current_sp) { build(:service_provider) }
 
-  let(:instant_verify_residential_result) do
+  let(:instant_verify_residential_address_result) do
     Proofing::Resolution::Result.new(
       success: true,
       errors: {},
@@ -39,7 +39,7 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
         applicant_pii:,
         current_sp:,
         ipp_enrollment_in_progress:,
-        instant_verify_residential_result:,
+        instant_verify_residential_address_result:,
         timer: JobHelpers::Timer.new,
       )
     end
@@ -139,7 +139,7 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
         it 'reuses residential address result' do
           result = call
           expect(plugin.proofer).not_to have_received(:proof)
-          expect(result).to eql(instant_verify_residential_result)
+          expect(result).to eql(instant_verify_residential_address_result)
         end
 
         it 'does not add a new LexisNexis SP cost (since residential address result was reused)' do
@@ -251,7 +251,7 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
           end
 
           context 'LexisNexis InstantVerify failed for residential address' do
-            let(:instant_verify_residential_result) do
+            let(:instant_verify_residential_address_result) do
               Proofing::Resolution::Result.new(
                 success: false,
                 errors: {},

--- a/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
@@ -1,0 +1,289 @@
+require 'rails_helper'
+
+RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin do
+  let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID }
+
+  let(:current_sp) { build(:service_provider) }
+
+  let(:instant_verify_residential_result) do
+    Proofing::Resolution::Result.new(
+      success: true,
+      errors: {},
+      exception: nil,
+      vendor_name: 'lexisnexis:instant_verify',
+    )
+  end
+
+  let(:ipp_enrollment_in_progress) { true }
+
+  let(:proofer_result) do
+    Proofing::Resolution::Result.new(
+      success: true,
+      errors: {},
+      exception: nil,
+      vendor_name: 'lexisnexis:instant_verify',
+    )
+  end
+
+  subject(:plugin) do
+    described_class.new
+  end
+
+  before do
+    allow(plugin.proofer).to receive(:proof).and_return(proofer_result)
+  end
+
+  describe '#call' do
+    subject(:call) do
+      plugin.call(
+        applicant_pii:,
+        current_sp:,
+        ipp_enrollment_in_progress:,
+        instant_verify_residential_result:,
+        timer: JobHelpers::Timer.new,
+      )
+    end
+
+    context 'remote unsupervised proofing' do
+      let(:ipp_enrollment_in_progress) { false }
+
+      let(:state_id_address) do
+        {
+          address1: applicant_pii[:address1],
+          address2: applicant_pii[:address2],
+          city: applicant_pii[:city],
+          state: applicant_pii[:state],
+          state_id_jurisdiction: applicant_pii[:state_id_jurisdiction],
+          zipcode: applicant_pii[:zipcode],
+        }
+      end
+
+      it 'passes state id address to proofer' do
+        expect(plugin.proofer).
+          to receive(:proof).
+          with(hash_including(state_id_address)).
+          and_call_original
+
+        call
+      end
+
+      context 'when InstantVerify call succeeds' do
+        it 'returns the proofer result' do
+          expect(call).to eql(proofer_result)
+        end
+
+        it 'records a LexisNexis SP cost' do
+          expect { call }.
+            to change {
+                 SpCost.where(
+                   cost_type: :lexis_nexis_resolution,
+                   issuer: current_sp.issuer,
+                 ).count
+               }.to(1)
+        end
+      end
+
+      context 'when InstantVerify call fails' do
+        let(:proofer_result) do
+          Proofing::Resolution::Result.new(
+            success: false,
+            errors: {},
+            exception: nil,
+            vendor_name: 'lexisnexis:instant_verify',
+          )
+        end
+
+        it 'returns the proofer result' do
+          expect(call).to eql(proofer_result)
+        end
+
+        it 'records a LexisNexis SP cost' do
+          expect { call }.
+            to change {
+                 SpCost.where(
+                   cost_type: :lexis_nexis_resolution,
+                   issuer: current_sp.issuer,
+                 ).count
+               }.to(1)
+        end
+      end
+
+      context 'when InstantVerify call results in exception' do
+        let(:proofer_result) do
+          Proofing::Resolution::Result.new(
+            success: false,
+            errors: {},
+            exception: RuntimeError.new(':ohno:'),
+            vendor_name: 'lexisnexis:instant_verify',
+          )
+        end
+
+        it 'returns the proofer result' do
+          expect(call).to eql(proofer_result)
+        end
+
+        it 'records a LexisNexis SP cost' do
+          expect { call }.
+            to change {
+                 SpCost.where(
+                   cost_type: :lexis_nexis_resolution,
+                   issuer: current_sp.issuer,
+                 ).count
+               }.to(1)
+        end
+      end
+    end
+
+    context 'in person proofing' do
+      context 'residential address and id address are the same' do
+        it 'reuses residential address result' do
+          result = call
+          expect(plugin.proofer).not_to have_received(:proof)
+          expect(result).to eql(instant_verify_residential_result)
+        end
+
+        it 'does not add a new LexisNexis SP cost (since residential address result was reused)' do
+          expect { call }.
+            not_to change {
+              SpCost.where(
+                cost_type: :lexis_nexis_resolution,
+                issuer: current_sp.issuer,
+              ).count
+            }
+        end
+      end
+
+      context 'residential address and id address are diferent' do
+        let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS }
+        let(:residential_address) do
+          {
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            city: applicant_pii[:city],
+            state: applicant_pii[:state],
+            state_id_jurisdiction: applicant_pii[:state_id_jurisdiction],
+            zipcode: applicant_pii[:zipcode],
+          }
+        end
+        let(:state_id_address) do
+          {
+            address1: applicant_pii[:identity_doc_address1],
+            address2: applicant_pii[:identity_doc_address2],
+            city: applicant_pii[:identity_doc_city],
+            state: applicant_pii[:identity_doc_address_state],
+            state_id_jurisdiction: applicant_pii[:state_id_jurisdiction],
+            zipcode: applicant_pii[:identity_doc_zipcode],
+          }
+        end
+
+        context 'LexisNexis InstantVerify passes for residential address' do
+          it 'calls the InstantVerify Proofer with state id address' do
+            expect(plugin.proofer).to receive(:proof).with(hash_including(state_id_address)).
+              and_call_original
+
+            call
+          end
+
+          context 'when InstantVerify call succeeds' do
+            it 'returns the proofer result' do
+              expect(call).to eql(proofer_result)
+            end
+
+            it 'records a LexisNexis SP cost' do
+              expect { call }.
+                to change {
+                     SpCost.where(
+                       cost_type: :lexis_nexis_resolution,
+                       issuer: current_sp.issuer,
+                     ).count
+                   }.to(1)
+            end
+          end
+
+          context 'when InstantVerify call fails' do
+            let(:proofer_result) do
+              Proofing::Resolution::Result.new(
+                success: false,
+                errors: {},
+                exception: nil,
+                vendor_name: 'lexisnexis:instant_verify',
+              )
+            end
+
+            it 'returns the proofer result' do
+              expect(call).to eql(proofer_result)
+            end
+
+            it 'records a LexisNexis SP cost' do
+              expect { call }.
+                to change {
+                     SpCost.where(
+                       cost_type: :lexis_nexis_resolution,
+                       issuer: current_sp.issuer,
+                     ).count
+                   }.to(1)
+            end
+          end
+
+          context 'when InstantVerify call results in exception' do
+            let(:proofer_result) do
+              Proofing::Resolution::Result.new(
+                success: false,
+                errors: {},
+                exception: RuntimeError.new(':ohno:'),
+                vendor_name: 'lexisnexis:instant_verify',
+              )
+            end
+
+            it 'returns the proofer result' do
+              expect(call).to eql(proofer_result)
+            end
+
+            it 'records a LexisNexis SP cost' do
+              expect { call }.
+                to change {
+                     SpCost.where(
+                       cost_type: :lexis_nexis_resolution,
+                       issuer: current_sp.issuer,
+                     ).count
+                   }.to(1)
+            end
+          end
+
+          context 'LexisNexis InstantVerify failed for residential address' do
+            let(:instant_verify_residential_result) do
+              Proofing::Resolution::Result.new(
+                success: false,
+                errors: {},
+                exception: nil,
+                vendor_name: 'lexisnexis:instant_verify',
+              )
+            end
+
+            it 'does not make unnecessary calls' do
+              expect(plugin.proofer).not_to receive(:proof)
+              call
+            end
+
+            it 'does not record an additional LexisNexis SP cost' do
+              expect { call }.
+                not_to change {
+                         SpCost.where(
+                           cost_type: :lexis_nexis_resolution,
+                           issuer: current_sp.issuer,
+                         ).count
+                       }
+            end
+
+            it 'returns a ResolutionCannotPass result' do
+              call.tap do |result|
+                expect(result.success?).to eql(false)
+                expect(result.vendor_name).to eql('ResolutionCannotPass')
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Continuing the work in #11420, #11427, and #11433 this PR extracts `proof_id_address_with_lexis_nexis_if_needed` into `InstantVerifyStateIdAddressPlugin`. It then adds a spec for the plugin covering the following use cases:

* Remote unsupervised proofing
* In-person proofing (residential address == id address)
* In-person proofing (residential address != id address)

It then cleans up some tests in the `ProgressiveProofer` spec that are now covered by individual plugin specs.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Complete IdV using the unsupervised remote path
- [ ] Complete IdV using the in-person proofing path (where your residential address == your id address)
- [ ] Complete IdV using the in-person proofing path (where your residential address != your id address)
