### PR TITLE
LG-14692: Banner message for selected email confirmation

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -19,6 +19,13 @@ class AccountsController < ApplicationController
       user: current_user,
       locked_for_session: pii_locked_for_session?(current_user),
     )
+    if session[:from_select_email_flow]
+      flash[:success] = t(
+        'account.emails.confirmed_html',
+        url: account_connected_accounts_url,
+      )
+      session.delete(:from_select_email_flow)
+    end
   end
 
   def reauthentication

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -19,12 +19,11 @@ class AccountsController < ApplicationController
       user: current_user,
       locked_for_session: pii_locked_for_session?(current_user),
     )
-    if session[:from_select_email_flow]
-      flash[:success] = t(
+    if session.delete(:from_select_email_flow)
+      flash.now[:success] = t(
         'account.emails.confirmed_html',
         url: account_connected_accounts_url,
       )
-      session.delete(:from_select_email_flow)
     end
   end
 

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -43,7 +43,7 @@ module Users
     def process_successful_confirmation(email_address)
       confirm_and_notify(email_address)
       if current_user
-        flash[:success] = t('devise.confirmations.confirmed')
+        flash[:success] = flash_message_for_successful_signed_in_confirmation
         redirect_to account_url
       else
         flash[:success] = t('devise.confirmations.confirmed_but_sign_in')
@@ -87,6 +87,17 @@ module Users
       else
         action_text = t('devise.confirmations.sign_in')
         t('devise.confirmations.already_confirmed', action: action_text)
+      end
+    end
+
+    def flash_message_for_successful_signed_in_confirmation
+      if IdentityConfig.store.feature_select_email_to_share_enabled
+        t(
+          'account.emails.confirmed_html',
+          url: account_connected_accounts_url,
+        )
+      else
+        t('devise.confirmations.confirmed')
       end
     end
 

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -45,7 +45,6 @@ module Users
       store_from_select_email_flow_in_session
       if current_user
         flash[:success] = t('devise.confirmations.confirmed')
-        session.delete(:from_select_email_flow)
         redirect_to account_url
       else
         flash[:success] = t('devise.confirmations.confirmed_but_sign_in')

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -44,7 +44,7 @@ module Users
       confirm_and_notify(email_address)
       store_from_select_email_flow_in_session
       if current_user
-        flash[:success] = flash_message_for_successful_signed_in_confirmation
+        flash[:success] = t('devise.confirmations.confirmed')
         session.delete(:from_select_email_flow)
         redirect_to account_url
       else
@@ -89,18 +89,6 @@ module Users
       else
         action_text = t('devise.confirmations.sign_in')
         t('devise.confirmations.already_confirmed', action: action_text)
-      end
-    end
-
-    def flash_message_for_successful_signed_in_confirmation
-      if IdentityConfig.store.feature_select_email_to_share_enabled &&
-         session[:from_select_email_flow]
-        t(
-          'account.emails.confirmed_html',
-          url: account_connected_accounts_url,
-        )
-      else
-        t('devise.confirmations.confirmed')
       end
     end
 

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -42,8 +42,10 @@ module Users
 
     def process_successful_confirmation(email_address)
       confirm_and_notify(email_address)
+      store_from_select_email_flow_in_session
       if current_user
         flash[:success] = flash_message_for_successful_signed_in_confirmation
+        session.delete(:from_select_email_flow)
         redirect_to account_url
       else
         flash[:success] = t('devise.confirmations.confirmed_but_sign_in')
@@ -92,7 +94,7 @@ module Users
 
     def flash_message_for_successful_signed_in_confirmation
       if IdentityConfig.store.feature_select_email_to_share_enabled &&
-         params[:from_select_email_flow].to_s == 'true'
+         session[:from_select_email_flow]
         t(
           'account.emails.confirmed_html',
           url: account_connected_accounts_url,
@@ -109,6 +111,10 @@ module Users
 
     def confirmation_params
       params.permit(:confirmation_token)
+    end
+
+    def store_from_select_email_flow_in_session
+      session[:from_select_email_flow] = params[:from_select_email_flow].to_s == 'true'
     end
   end
 end

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -91,7 +91,8 @@ module Users
     end
 
     def flash_message_for_successful_signed_in_confirmation
-      if IdentityConfig.store.feature_select_email_to_share_enabled
+      if IdentityConfig.store.feature_select_email_to_share_enabled &&
+         params[:from_select_email_flow].to_s == 'true'
         t(
           'account.emails.confirmed_html',
           url: account_connected_accounts_url,

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -12,15 +12,19 @@ module Users
 
     def show
       analytics.add_email_visit
-      @from_select_email_flow = params[:from_select_email_flow]
+      session[:in_select_email_flow] = params[:in_select_email_flow]
       @add_user_email_form = AddUserEmailForm.new
       @pending_completions_consent = pending_completions_consent?
     end
 
     def add
-      @add_user_email_form = AddUserEmailForm.new
+      @add_user_email_form = AddUserEmailForm.new(
+        session[:in_select_email_flow],
+      )
 
-      result = @add_user_email_form.submit(current_user, permitted_params)
+      result = @add_user_email_form.submit(
+        current_user, permitted_params
+      )
       analytics.add_email_request(**result.to_h)
 
       if result.success?
@@ -95,6 +99,7 @@ module Users
     end
 
     def process_successful_creation
+      session.delete(:in_select_email_flow)
       resend_confirmation = params[:user][:resend]
       session[:email] = @add_user_email_form.email
 
@@ -106,7 +111,7 @@ module Users
     end
 
     def permitted_params
-      params.require(:user).permit(:email, :from_select_email_flow)
+      params.require(:user).permit(:email)
     end
 
     def check_max_emails_per_account

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -12,6 +12,7 @@ module Users
 
     def show
       analytics.add_email_visit
+      user_session[:from_select_email_flow] = params[:from_select_email_flow]
       @add_user_email_form = AddUserEmailForm.new
       @pending_completions_consent = pending_completions_consent?
     end
@@ -19,7 +20,10 @@ module Users
     def add
       @add_user_email_form = AddUserEmailForm.new
 
-      result = @add_user_email_form.submit(current_user, permitted_params)
+      result = @add_user_email_form.submit(
+        current_user, permitted_params,
+        user_session[:from_select_email_flow]
+      )
       analytics.add_email_request(**result.to_h)
 
       if result.success?

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -76,7 +76,8 @@ module Users
       if session_email.blank?
         redirect_to add_email_url
       else
-        render :verify, locals: { email: session_email }
+        render :verify,
+               locals: { email: session_email, in_select_email_flow: params[:in_select_email_flow] }
       end
     end
 
@@ -99,11 +100,13 @@ module Users
     end
 
     def process_successful_creation
-      session.delete(:in_select_email_flow)
       resend_confirmation = params[:user][:resend]
       session[:email] = @add_user_email_form.email
 
-      redirect_to add_email_verify_email_url(resend: resend_confirmation)
+      redirect_to add_email_verify_email_url(
+        resend: resend_confirmation,
+        in_select_email_flow: session.delete(:in_select_email_flow),
+      )
     end
 
     def session_email

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -12,7 +12,7 @@ module Users
 
     def show
       analytics.add_email_visit
-      user_session[:from_select_email_flow] = params[:from_select_email_flow]
+      @from_select_email_flow = params[:from_select_email_flow]
       @add_user_email_form = AddUserEmailForm.new
       @pending_completions_consent = pending_completions_consent?
     end
@@ -20,10 +20,7 @@ module Users
     def add
       @add_user_email_form = AddUserEmailForm.new
 
-      result = @add_user_email_form.submit(
-        current_user, permitted_params,
-        user_session[:from_select_email_flow]
-      )
+      result = @add_user_email_form.submit(current_user, permitted_params)
       analytics.add_email_request(**result.to_h)
 
       if result.success?
@@ -109,7 +106,7 @@ module Users
     end
 
     def permitted_params
-      params.require(:user).permit(:email)
+      params.require(:user).permit(:email, :from_select_email_flow)
     end
 
     def check_max_emails_per_account

--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -15,10 +15,11 @@ class AddUserEmailForm
     @user ||= User.new
   end
 
-  def submit(user, params)
+  def submit(user, params, from_select_email_flow = nil)
     @user = user
     @email = params[:email]
     @email_address = email_address_record(@email)
+    @from_select_email_flow = from_select_email_flow
 
     if valid?
       process_successful_submission
@@ -42,12 +43,12 @@ class AddUserEmailForm
   private
 
   attr_writer :email
-  attr_reader :success, :email_address
+  attr_reader :success, :email_address, :from_select_email_flow
 
   def process_successful_submission
     @success = true
     email_address.save!
-    SendAddEmailConfirmation.new(user).call(email_address)
+    SendAddEmailConfirmation.new(user).call(email_address, from_select_email_flow)
   end
 
   def extra_analytics_attributes

--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -5,10 +5,14 @@ class AddUserEmailForm
   include FormAddEmailValidator
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :email
+  attr_reader :email, :in_select_email_flow
 
   def self.model_name
     ActiveModel::Name.new(self, nil, 'User')
+  end
+
+  def initialize(in_select_email_flow = nil)
+    @in_select_email_flow = in_select_email_flow
   end
 
   def user
@@ -19,7 +23,6 @@ class AddUserEmailForm
     @user = user
     @email = params[:email]
     @email_address = email_address_record(@email)
-    @from_select_email_flow = params[:from_select_email_flow]
 
     if valid?
       process_successful_submission
@@ -43,12 +46,12 @@ class AddUserEmailForm
   private
 
   attr_writer :email
-  attr_reader :success, :email_address, :from_select_email_flow
+  attr_reader :success, :email_address
 
   def process_successful_submission
     @success = true
     email_address.save!
-    SendAddEmailConfirmation.new(user).call(email_address, from_select_email_flow)
+    SendAddEmailConfirmation.new(user).call(email_address, in_select_email_flow)
   end
 
   def extra_analytics_attributes

--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -15,11 +15,11 @@ class AddUserEmailForm
     @user ||= User.new
   end
 
-  def submit(user, params, from_select_email_flow = nil)
+  def submit(user, params)
     @user = user
     @email = params[:email]
     @email_address = email_address_record(@email)
-    @from_select_email_flow = from_select_email_flow
+    @from_select_email_flow = params[:from_select_email_flow]
 
     if valid?
       process_successful_submission

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -218,14 +218,14 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def add_email(token, from_select_email_flow = false)
+  def add_email(token, from_select_email_flow = nil)
     with_user_locale(user) do
       presenter = ConfirmationEmailPresenter.new(user, view_context)
       @first_sentence = presenter.first_sentence
       @confirmation_period = presenter.confirmation_period
       @add_email_url = add_email_confirmation_url(
         confirmation_token: token,
-        from_select_email_flow: from_select_email_flow,
+        from_select_email_flow:,
         locale: locale_url_param,
       )
       mail(to: email_address.email, subject: t('user_mailer.add_email.subject'))

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -218,13 +218,14 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def add_email(token)
+  def add_email(token, from_select_email_flow = false)
     with_user_locale(user) do
       presenter = ConfirmationEmailPresenter.new(user, view_context)
       @first_sentence = presenter.first_sentence
       @confirmation_period = presenter.confirmation_period
       @add_email_url = add_email_confirmation_url(
         confirmation_token: token,
+        from_select_email_flow: from_select_email_flow,
         locale: locale_url_param,
       )
       mail(to: email_address.email, subject: t('user_mailer.add_email.subject'))

--- a/app/services/send_add_email_confirmation.rb
+++ b/app/services/send_add_email_confirmation.rb
@@ -7,8 +7,9 @@ class SendAddEmailConfirmation
     @user = user
   end
 
-  def call(email_address)
+  def call(email_address, from_select_email_flow = false)
     @email_address = email_address
+    @from_select_email_flow = from_select_email_flow
     update_email_address_record
     send_email
   end
@@ -23,7 +24,7 @@ class SendAddEmailConfirmation
     email_address.confirmation_sent_at
   end
 
-  attr_reader :email_address
+  attr_reader :email_address, :from_select_email_flow
 
   def update_email_address_record
     email_address.update!(
@@ -59,6 +60,7 @@ class SendAddEmailConfirmation
   def send_confirmation_email
     UserMailer.with(user: user, email_address: email_address).add_email(
       confirmation_token,
+      from_select_email_flow,
     ).deliver_now_or_later
   end
 end

--- a/app/services/send_add_email_confirmation.rb
+++ b/app/services/send_add_email_confirmation.rb
@@ -7,9 +7,9 @@ class SendAddEmailConfirmation
     @user = user
   end
 
-  def call(email_address, from_select_email_flow = false)
+  def call(email_address, in_select_email_flow = nil)
     @email_address = email_address
-    @from_select_email_flow = from_select_email_flow
+    @in_select_email_flow = in_select_email_flow
     update_email_address_record
     send_email
   end
@@ -24,7 +24,7 @@ class SendAddEmailConfirmation
     email_address.confirmation_sent_at
   end
 
-  attr_reader :email_address, :from_select_email_flow
+  attr_reader :email_address, :in_select_email_flow
 
   def update_email_address_record
     email_address.update!(
@@ -60,7 +60,7 @@ class SendAddEmailConfirmation
   def send_confirmation_email
     UserMailer.with(user: user, email_address: email_address).add_email(
       confirmation_token,
-      from_select_email_flow,
+      in_select_email_flow,
     ).deliver_now_or_later
   end
 end

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -34,7 +34,7 @@
   <% end %>
 
   <%= render ButtonComponent.new(
-        url: add_email_path,
+        url: add_email_path(from_select_email_flow: true),
         outline: true,
         big: true,
         wide: true,

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -34,7 +34,7 @@
   <% end %>
 
   <%= render ButtonComponent.new(
-        url: add_email_path(from_select_email_flow: true),
+        url: add_email_path(in_select_email_flow: true),
         outline: true,
         big: true,
         wide: true,

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -49,7 +49,7 @@
             <% if @presenter.multiple_emails? %>
               <%= link_to t('help_text.requested_attributes.change_email_link'), sign_up_select_email_path %>
             <% else %>
-              <%= link_to t('account.index.email_add'), add_email_path(from_select_email_flow: true) %>
+              <%= link_to t('account.index.email_add'), add_email_path(in_select_email_flow: true) %>
             <% end %>
           </p>
         </div>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -49,7 +49,7 @@
             <% if @presenter.multiple_emails? %>
               <%= link_to t('help_text.requested_attributes.change_email_link'), sign_up_select_email_path %>
             <% else %>
-              <%= link_to t('account.index.email_add'), add_email_path %>
+              <%= link_to t('account.index.email_add'), add_email_path(from_select_email_flow: true) %>
             <% end %>
           </p>
         </div>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -30,7 +30,7 @@
   <% end %>
 
   <%= render ButtonComponent.new(
-        url: add_email_path,
+        url: add_email_path(from_select_email_flow: true),
         outline: true,
         big: true,
         wide: true,

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -30,7 +30,7 @@
   <% end %>
 
   <%= render ButtonComponent.new(
-        url: add_email_path(from_select_email_flow: true),
+        url: add_email_path(in_select_email_flow: true),
         outline: true,
         big: true,
         wide: true,

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -10,6 +10,7 @@
           label: t('forms.registration.labels.email'),
           required: true,
         ) %>
+    <%= f.hidden_field(:from_select_email_flow, value: @from_select_email_flow) %>
     <%= f.submit t('forms.buttons.submit.default') %>
   <% end %>
 </div>

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -10,7 +10,6 @@
           label: t('forms.registration.labels.email'),
           required: true,
         ) %>
-    <%= f.hidden_field(:from_select_email_flow, value: @from_select_email_flow) %>
     <%= f.submit t('forms.buttons.submit.default') %>
   <% end %>
 </div>

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -22,7 +22,7 @@
 <%= t('notices.signed_up_and_confirmed.no_email_sent_explanation_start') %>
 <%= button_to(add_email_resend_path, method: :post, class: 'usa-button usa-button--unstyled', form_class: 'display-inline-block padding-left-1') { t('links.resend') } %>
 
-<p><%= t('notices.use_diff_email.text_html', link_html: link_to(t('notices.use_diff_email.link'), add_email_path)) %></p>
+<p><%= t('notices.use_diff_email.text_html', link_html: link_to(t('notices.use_diff_email.link'), add_email_path(in_select_email_flow: in_select_email_flow))) %></p>
 <p><%= t('devise.registrations.close_window') %></p>
 
 <% if FeatureManagement.enable_load_testing_mode? && EmailAddress.find_with_email(email) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文 (简体)
 account.email_language.updated: Your email language preference has been updated.
+account.emails.confirmed_html: You have confirmed your email address. Go to <a href="%{url}">your connected accounts</a> to update the email you share with connected agencies.
 account.forget_all_browsers.longer_description: Once you choose to ‘forget all browsers,’ we’ll need additional information to know that it’s actually you signing in to your account. We’ll ask for a multi-factor authentication method (such as text/SMS code or a security key) each time you want to access your account.
 account.index.auth_app_add: Add app
 account.index.auth_app_disabled: not enabled

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -50,6 +50,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文 (简体)
 account.email_language.updated: Se actualizó su preferencia de idioma del correo electrónico.
+account.emails.confirmed_html: Usted confirmó su dirección de correo electrónico. Vaya a <a href="%{url}">Sus cuentas conectadas</a> para actualizar el correo electrónico que proporcionó a las agencias conectadas.
 account.forget_all_browsers.longer_description: Una vez que elija “Olvidar todos los navegadores”, necesitaremos más información para saber que realmente es usted quien está iniciando sesión en su cuenta. Le pediremos un método de autenticación multifactor (como código de texto o de SMS, o una clave de seguridad) cada vez que desee acceder a su cuenta.
 account.index.auth_app_add: Agregar aplicación
 account.index.auth_app_disabled: no habilitada

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -50,6 +50,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文 (简体)
 account.email_language.updated: Votre langue de préférence pour les e-mails a été mise à jour.
+account.emails.confirmed_html: Vous avez confirmé votre adresse e-mail. Rendez-vous sur <a href="%{url}">vos comptes connectés</a> pour actualiser l’adresse e-mail que vous communiquez aux organismes connectés.
 account.forget_all_browsers.longer_description: Une fois que vous aurez choisi d’« oublier tous les navigateurs », nous aurons besoin d’informations supplémentaires pour savoir que c’est bien vous qui vous connectez à votre compte. Nous vous demanderons une méthode d’authentification multi-facteurs (comme un code SMS/texto ou une clé de sécurité) chaque fois que vous souhaiterez accéder à votre compte.
 account.index.auth_app_add: Ajouter une appli
 account.index.auth_app_disabled: non activé

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -50,6 +50,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文 (简体)
 account.email_language.updated: 你的电邮语言选择已更新。
+account.emails.confirmed_html: 你已确认了你的电邮地址。请到<a href="%{url}">你已连接的账户</a>来更新你与已连接机构所分享的电邮。
 account.forget_all_browsers.longer_description: 你选择“忘掉所有浏览器”后，我们将需要额外信息来知道的确是你在登录你自己的账户。每次你要访问自己的账户时，我们都会向你要一个多因素身份证实方法（比如短信/SMS 代码或安全密钥）
 account.index.auth_app_add: 添加应用程序
 account.index.auth_app_disabled: 未启用

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -80,6 +80,42 @@ RSpec.describe AccountsController do
       end
     end
 
+    context 'when user just added new email through select email flow' do
+      context 'when user is in select email form flow' do
+        before do
+          session[:from_select_email_flow] = true
+        end
+        it 'renders the proper flash message' do
+          flash_message = t(
+            'account.emails.confirmed_html',
+            url: account_connected_accounts_url,
+          )
+          user = create(:user, :fully_registered)
+          sign_in user
+
+          get :show
+
+          expect(response).to_not be_redirect
+          expect(flash[:success]).to eq(flash_message)
+          expect(session[:from_select_email_flow]).to be_nil
+        end
+      end
+
+      context 'when user is not in email form flow' do
+        before do
+          session[:from_select_email_flow] = false
+        end
+        it 'renders proper flash message' do
+          t('devise.confirmations.confirmed')
+          user = create(:user, :fully_registered)
+          sign_in user
+
+          get :show
+          expect(flash[:success]).to be_nil
+        end
+      end
+    end
+
     context 'when a profile has been deactivated by password reset' do
       it 'renders the profile and shows a deactivation banner' do
         user = create(

--- a/spec/controllers/users/email_confirmations_controller_spec.rb
+++ b/spec/controllers/users/email_confirmations_controller_spec.rb
@@ -25,54 +25,6 @@ RSpec.describe Users::EmailConfirmationsController do
         get :create, params: { confirmation_token: email_record.reload.confirmation_token }
       end
 
-      context ' when select email feature is enabled' do
-        before do
-          allow(IdentityConfig.store).to receive(:feature_select_email_to_share_enabled).
-            and_return(true)
-        end
-
-        context 'when user is in select email form flow' do
-          it 'renders the proper flash message' do
-            flash_message = t(
-              'account.emails.confirmed_html',
-              url: account_connected_accounts_url,
-            )
-            user = create(:user)
-            sign_in user
-            new_email = Faker::Internet.email
-
-            add_email_form = AddUserEmailForm.new
-            add_email_form.submit(user, email: new_email)
-            email_record = add_email_form.email_address_record(new_email)
-
-            get :create, params: {
-              confirmation_token: email_record.reload.confirmation_token,
-              from_select_email_flow: true,
-            }
-            expect(flash[:success]).to eq(flash_message)
-          end
-        end
-
-        context 'when user is not in email form flow' do
-          it 'renders proper flash message' do
-            flash_message = t('devise.confirmations.confirmed')
-            user = create(:user)
-            sign_in user
-            new_email = Faker::Internet.email
-
-            add_email_form = AddUserEmailForm.new
-            add_email_form.submit(user, email: new_email)
-            email_record = add_email_form.email_address_record(new_email)
-
-            get :create, params: {
-              confirmation_token: email_record.reload.confirmation_token,
-              from_select_email_flow: false,
-            }
-            expect(flash[:success]).to eq(flash_message)
-          end
-        end
-      end
-
       context 'when select email feature is disabled' do
         before do
           allow(IdentityConfig.store).to receive(:feature_select_email_to_share_enabled).

--- a/spec/controllers/users/email_confirmations_controller_spec.rb
+++ b/spec/controllers/users/email_confirmations_controller_spec.rb
@@ -31,21 +31,45 @@ RSpec.describe Users::EmailConfirmationsController do
             and_return(true)
         end
 
-        it 'renders the proper flash message for signed in user' do
-          flash_message = t(
-            'account.emails.confirmed_html',
-            url: account_connected_accounts_url,
-          )
-          user = create(:user)
-          sign_in user
-          new_email = Faker::Internet.email
-
-          add_email_form = AddUserEmailForm.new
-          add_email_form.submit(user, email: new_email)
-          email_record = add_email_form.email_address_record(new_email)
-
-          get :create, params: { confirmation_token: email_record.reload.confirmation_token }
-          expect(flash[:success]).to eq(flash_message)
+        context 'when user is in select email form flow' do
+          it 'renders the proper flash message' do
+            flash_message = t(
+              'account.emails.confirmed_html',
+              url: account_connected_accounts_url,
+            )
+            user = create(:user)
+            sign_in user
+            new_email = Faker::Internet.email
+  
+            add_email_form = AddUserEmailForm.new
+            add_email_form.submit(user, email: new_email)
+            email_record = add_email_form.email_address_record(new_email)
+  
+            get :create, params: { 
+                            confirmation_token: email_record.reload.confirmation_token,
+                            from_select_email_flow: true,
+                          }
+            expect(flash[:success]).to eq(flash_message)
+          end
+        end
+        
+        context 'when user is not in email form flow' do
+          it 'renders proper flash message' do
+            flash_message = t('devise.confirmations.confirmed')
+            user = create(:user)
+            sign_in user
+            new_email = Faker::Internet.email
+  
+            add_email_form = AddUserEmailForm.new
+            add_email_form.submit(user, email: new_email)
+            email_record = add_email_form.email_address_record(new_email)
+  
+            get :create, params: { 
+                            confirmation_token: email_record.reload.confirmation_token,
+                            from_select_email_flow: false,
+                          }
+            expect(flash[:success]).to eq(flash_message)
+          end
         end
       end
 

--- a/spec/controllers/users/email_confirmations_controller_spec.rb
+++ b/spec/controllers/users/email_confirmations_controller_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe Users::EmailConfirmationsController do
       end
 
       context 'when select email feature is disabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:feature_select_email_to_share_enabled).
+            and_return(false)
+        end
         it 'should render proper flash member' do
           flash_message = t('devise.confirmations.confirmed')
           user = create(:user)

--- a/spec/controllers/users/email_confirmations_controller_spec.rb
+++ b/spec/controllers/users/email_confirmations_controller_spec.rb
@@ -40,34 +40,34 @@ RSpec.describe Users::EmailConfirmationsController do
             user = create(:user)
             sign_in user
             new_email = Faker::Internet.email
-  
+
             add_email_form = AddUserEmailForm.new
             add_email_form.submit(user, email: new_email)
             email_record = add_email_form.email_address_record(new_email)
-  
-            get :create, params: { 
-                            confirmation_token: email_record.reload.confirmation_token,
-                            from_select_email_flow: true,
-                          }
+
+            get :create, params: {
+              confirmation_token: email_record.reload.confirmation_token,
+              from_select_email_flow: true,
+            }
             expect(flash[:success]).to eq(flash_message)
           end
         end
-        
+
         context 'when user is not in email form flow' do
           it 'renders proper flash message' do
             flash_message = t('devise.confirmations.confirmed')
             user = create(:user)
             sign_in user
             new_email = Faker::Internet.email
-  
+
             add_email_form = AddUserEmailForm.new
             add_email_form.submit(user, email: new_email)
             email_record = add_email_form.email_address_record(new_email)
-  
-            get :create, params: { 
-                            confirmation_token: email_record.reload.confirmation_token,
-                            from_select_email_flow: false,
-                          }
+
+            get :create, params: {
+              confirmation_token: email_record.reload.confirmation_token,
+              from_select_email_flow: false,
+            }
             expect(flash[:success]).to eq(flash_message)
           end
         end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -43,6 +43,22 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.html_part.body).to have_content(add_email_url)
       expect(mail.html_part.body).to_not have_content(sign_up_create_email_confirmation_url)
     end
+
+    context 'when user adds email from select email flow' do
+      let(:token) { SecureRandom.hex }
+      let(:mail) do
+        UserMailer.with(user: user, email_address: email_address).add_email(token, true)
+      end
+
+      it 'renders the add_email_confirmation_url' do
+        add_email_url = add_email_confirmation_url(
+          confirmation_token: token,
+          from_select_email_flow: true,
+        )
+
+        expect(mail.html_part.body).to have_content(add_email_url)
+      end
+    end
   end
 
   describe '#email_deleted' do

--- a/spec/views/users/emails/verify.html.erb_spec.rb
+++ b/spec/views/users/emails/verify.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'users/emails/verify.html.erb' do
   let(:email) { 'foo@bar.com' }
   before do
     allow(view).to receive(:email).and_return(email)
+    allow(view).to receive(:in_select_email_flow).and_return(nil)
     @resend_email_confirmation_form = ResendEmailConfirmationForm.new
   end
 


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-14692](https://cm-jira.usa.gov/browse/LG-14692)

## 🛠 Summary of changes

Update Banner message when confirming email to notify users they can update their email for connected accounts. 

## 📜 Testing Plan

1. Create Account 
2. Add new email to existing account
3. verify the new content 

## 👀 Screenshots

![Screenshot 2024-11-01 at 10 20 18 AM](https://github.com/user-attachments/assets/4f820da7-f424-4733-90a1-60e0baf82bf4)
![Screenshot 2024-11-01 at 10 21 36 AM](https://github.com/user-attachments/assets/7d3b2e63-1c0a-47a6-ae16-88ff6cd9fe15)
![Screenshot 2024-11-01 at 10 21 41 AM](https://github.com/user-attachments/assets/f5891164-a4b6-409a-955b-bb9e455200dc)
![Screenshot 2024-11-01 at 10 21 46 AM](https://github.com/user-attachments/assets/ac053aa7-a7e0-414e-923f-d34d9780ba5f)

