### PR TITLE
Add the login.gov logo and the separator bars

### DIFF
--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -25,7 +25,7 @@ hr {
 }
 
 .border-transparent {
-  border-color: transparent;
+  @include u-border-color('transparent');
 }
 
 .report-title,

--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -9,7 +9,7 @@
 @forward 'usa-alert';
 
 hr {
-  background-color: $theme-color-secondary;
+  background-color: color('secondary');
 }
 
 .margin-bottom-4 {
@@ -21,7 +21,7 @@ hr {
 }
 
 .height-05 {
-  @include u-height(4px);
+  @include u-height(0.5);
 }
 
 .border-transparent {

--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -7,6 +7,11 @@
 @forward 'usa-prose';
 @forward 'usa-table';
 @forward 'usa-alert';
+@forward "uswds-utilities";
+
+hr {
+  background-color: $theme-color-secondary;
+}
 
 .report-title,
 .report-subtitle {

--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -8,8 +8,8 @@
 @forward 'usa-table';
 @forward 'usa-alert';
 
-hr {
-  background-color: color('secondary');
+.bg-secondary {
+  @include u-bg('secondary');
 }
 
 .margin-bottom-4 {

--- a/app/assets/stylesheets/tables-report.css.scss
+++ b/app/assets/stylesheets/tables-report.css.scss
@@ -7,10 +7,25 @@
 @forward 'usa-prose';
 @forward 'usa-table';
 @forward 'usa-alert';
-@forward "uswds-utilities";
 
 hr {
   background-color: $theme-color-secondary;
+}
+
+.margin-bottom-4 {
+  @include u-margin-bottom(4);
+}
+
+.margin-top-4 {
+  @include u-margin-top(4);
+}
+
+.height-05 {
+  @include u-height(4px);
+}
+
+.border-transparent {
+  border-color: transparent;
 }
 
 .report-title,

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -3,13 +3,13 @@
 - @reports: an array of EmailableReport
 %>
 <header class="usa-header">
- <%= image_tag(
-              asset_url('logo.svg'),
-              alt: APP_NAME,
-              class: 'text-bottom',
-              width: 155,
-              height: 21,
-            ) %>
+  <%= image_tag(
+    asset_url('logo.svg'),
+    alt: APP_NAME,
+    class: 'text-bottom',
+    width: 155,
+    height: 21,
+  ) %>
 </header>
 <hr class="height-05 margin-bottom-4 border-transparent">
 <%= @message %><br>

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -4,7 +4,7 @@
 %>
 <header class="usa-header">
   <%= image_tag(
-        asset_url('logo.svg'),
+        asset_url('email/logo.png'),
         alt: APP_NAME,
         class: 'text-bottom',
         width: 155,

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -6,7 +6,6 @@
   <%= image_tag(
         asset_url('email/logo.png'),
         alt: APP_NAME,
-        class: 'text-bottom',
         width: 155,
         height: 21,
       ) %>

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -2,6 +2,16 @@
 - @message: text to put in the beginning of the email
 - @reports: an array of EmailableReport
 %>
+<header class="usa-header">
+ <%= image_tag(
+              asset_url('logo.svg'),
+              alt: APP_NAME,
+              class: 'text-bottom',
+              width: 155,
+              height: 21,
+            ) %>
+</header>
+<hr class="height-05 margin-bottom-4 border-transparent">
 <%= @message %><br>
 <% @reports.each do |report| %>
   <% header, *rows = report.table %>
@@ -38,3 +48,4 @@
     </tbody>
   </table>
 <% end %>
+<hr class="height-05 margin-top-4 border-transparent">

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -4,12 +4,12 @@
 %>
 <header class="usa-header">
   <%= image_tag(
-    asset_url('logo.svg'),
-    alt: APP_NAME,
-    class: 'text-bottom',
-    width: 155,
-    height: 21,
-  ) %>
+        asset_url('logo.svg'),
+        alt: APP_NAME,
+        class: 'text-bottom',
+        width: 155,
+        height: 21,
+      ) %>
 </header>
 <hr class="height-05 margin-bottom-4 border-transparent">
 <%= @message %><br>


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14793](https://cm-jira.usa.gov/browse/LG-14793)

## 🛠 Summary of changes

Adds Login.gov logo before the report and separators around the data to better brand the emails to Login.gov.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

## 👀 Screenshots

Before

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/0f1181c1-eb3c-4ed7-8cf5-e615a65c10b9">

After

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/b69051e5-a321-46b7-8519-018685f44d8d">
