### PR TITLE
Integrate and remove dependency on Airbnb ESLint rules

### DIFF
--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -295,17 +295,6 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
         .filter(Boolean)
         .join(' ')}
     >
-      {/*
-       * Disable reason: The Airbnb configuration of the `jsx-a11y` rule is strict in that it
-       * requires _both_ the `for` attribute and nesting, to maximize support for assistive
-       * technology. By the standard, only one or the other should be required. A form layout which
-       * includes a hint following a label cannot be nested within the label without misidentifying
-       * the hint as part of the label, which is the markup currently supported by USWDS.
-       *
-       * See: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/718
-       * See: https://github.com/airbnb/javascript/pull/2136
-       */}
-      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
       <label
         id={labelId}
         htmlFor={inputId}

--- a/app/javascript/packages/eslint-plugin/CHANGELOG.md
+++ b/app/javascript/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Backwards-compatible changes
 
+- Language ECMAVersion increased from `2018` to `"latest"`
 - Disabled many stylistic rules which would be redundant with Prettier formatting. For stylistic enforcement, it's recommended to opt-in to the optional Prettier rule extension.
   - `array-bracket-spacing`
   - `arrow-parens`
@@ -44,9 +45,20 @@
   - `no-loss-of-precision`
   - `no-redeclare`
   - `no-useless-constructor`
+- The following rules are no longer enforced:
+  - `lines-between-class-members`
+  - `no-restricted-globals`
+  - `no-restricted-properties`
 - React: The following rules are no longer enforced:
   - `react/no-array-index-key`
+  - `react/sort-comp` (use function components instead)
+- React: The following rules have been reconfigured in a backwards-compatible manner.
+  - `jsx-a11y/label-has-associated-control` now allows _either_ label for or nesting, previously requiring both.
 - `prefer-const` is only enforced on destructuring assignment if all variables should be `const` ([`destructuring: 'all'` option](https://eslint.org/docs/latest/rules/prefer-const#destructuring)).
+
+### Dependencies
+
+- Remove dependency on `eslint-config-airbnb` and `eslint-config-airbnb-base`.
 
 ## v2.0.0 (2022-03-14)
 

--- a/app/javascript/packages/eslint-plugin/configs/recommended.js
+++ b/app/javascript/packages/eslint-plugin/configs/recommended.js
@@ -2,72 +2,495 @@ const { isDependency } = require('@aduth/is-dependency');
 
 const config = {
   extends: /** @type {string[]} */ ([]),
-  plugins: /** @type {string[]} */ ([]),
+  plugins: ['import'],
   env: {
     es6: true,
+    node: true,
+  },
+  parserOptions: {
+    ecmaFeatures: {},
+    sourceType: 'module',
+  },
+  settings: {
+    'import/extensions': ['.js', '.jsx'],
+    'import/external-module-folders': ['node_modules'],
+    'import/ignore': ['node_modules'],
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.jsx'],
+      },
+    },
   },
   rules: {
-    'array-bracket-spacing': 'off',
-    'arrow-parens': 'off',
-    'arrow-spacing': 'off',
-    'block-spacing': 'off',
-    'brace-style': 'off',
-    'class-methods-use-this': 'off',
-    'comma-dangle': 'off',
-    'comma-spacing': 'off',
-    'comma-style': 'off',
-    'computed-property-spacing': 'off',
-    'consistent-return': 'off',
+    'array-callback-return': [
+      'error',
+      {
+        allowImplicit: true,
+        checkForEach: false,
+      },
+    ],
+    'arrow-body-style': [
+      'error',
+      'as-needed',
+      {
+        requireReturnForObjectLiteral: false,
+      },
+    ],
+    'block-scoped-var': 'error',
+    camelcase: [
+      'error',
+      {
+        properties: 'never',
+        ignoreDestructuring: false,
+        ignoreImports: false,
+        ignoreGlobals: false,
+      },
+    ],
+    'constructor-super': 'error',
     curly: ['error', 'all'],
-    'dot-location': 'off',
-    'func-call-spacing': 'off',
-    'func-names': 'off',
-    'function-call-argument-newline': 'off',
-    'function-paren-newline': 'off',
-    'generator-star-spacing': 'off',
-    'prefer-arrow-callback': 'off',
-    'import/prefer-default-export': 'off',
-    'import/extensions': ['off', 'never'],
-    'import/no-extraneous-dependencies': 'error',
-    indent: 'off',
-    'jsx-quotes': 'off',
-    'key-spacing': 'off',
-    'keyword-spacing': 'off',
-    'max-len': 'off',
-    'max-classes-per-file': 'off',
-    'newline-per-chained-call': 'off',
+    'default-case': 'error',
+    'default-case-last': 'error',
+    'default-param-last': 'error',
+    'dot-notation': [
+      'error',
+      {
+        allowKeywords: true,
+        allowPattern: '',
+      },
+    ],
+    'eol-last': ['error', 'always'],
+    eqeqeq: [
+      'error',
+      'always',
+      {
+        null: 'ignore',
+      },
+    ],
+    'for-direction': 'error',
+    'getter-return': [
+      'error',
+      {
+        allowImplicit: true,
+      },
+    ],
+    'global-require': 'error',
+    'grouped-accessor-pairs': 'error',
+    'guard-for-in': 'error',
+    'import/export': 'error',
+    'import/first': 'error',
+    'import/newline-after-import': 'error',
+    'import/no-absolute-path': 'error',
+    'import/no-amd': 'error',
+    'import/no-cycle': [
+      'error',
+      {
+        maxDepth: '∞',
+        ignoreExternal: false,
+        allowUnsafeDynamicCyclicDependency: false,
+      },
+    ],
+    'import/no-duplicates': 'error',
+    'import/no-dynamic-require': 'error',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: ['**/*.{test,spec}.{js,jsx,ts,tsx,cjs,mjs,cts,mts}'],
+        optionalDependencies: false,
+      },
+    ],
+    'import/no-import-module-exports': [
+      'error',
+      {
+        exceptions: [],
+      },
+    ],
+    'import/no-mutable-exports': 'error',
+    'import/no-named-as-default': 'error',
+    'import/no-named-as-default-member': 'error',
+    'import/no-named-default': 'error',
+    'import/no-relative-packages': 'error',
+    'import/no-self-import': 'error',
+    'import/no-unresolved': [
+      'error',
+      {
+        commonjs: true,
+        caseSensitive: true,
+        caseSensitiveStrict: false,
+      },
+    ],
+    'import/no-useless-path-segments': [
+      'error',
+      {
+        commonjs: true,
+      },
+    ],
+    'import/no-webpack-loader-syntax': 'error',
+    'import/order': [
+      'error',
+      {
+        groups: [['builtin', 'external', 'internal']],
+        distinctGroup: true,
+        warnOnUnassignedImports: false,
+      },
+    ],
+    'linebreak-style': ['error', 'unix'],
+    'lines-around-directive': [
+      'error',
+      {
+        before: 'always',
+        after: 'always',
+      },
+    ],
+    'new-cap': [
+      'error',
+      {
+        newIsCap: true,
+        newIsCapExceptions: [],
+        capIsNew: false,
+        capIsNewExceptions: ['Immutable.Map', 'Immutable.Set', 'Immutable.List'],
+        properties: true,
+      },
+    ],
+    'new-parens': 'error',
+    'no-alert': 'warn',
+    'no-array-constructor': 'error',
+    'no-async-promise-executor': 'error',
+    'no-await-in-loop': 'error',
+    'no-bitwise': 'error',
+    'no-buffer-constructor': 'error',
+    'no-caller': 'error',
+    'no-case-declarations': 'error',
+    'no-class-assign': 'error',
+    'no-compare-neg-zero': 'error',
     'no-cond-assign': ['error', 'except-parens'],
     'no-console': 'error',
-    'no-empty': ['error', { allowEmptyCatch: true }],
-    'no-param-reassign': ['off', 'never'],
-    'no-promise-executor-return': 'off',
-    'no-confusing-arrow': 'off',
-    'no-extra-semi': 'off',
-    'no-plusplus': 'off',
-    'no-restricted-syntax': 'off',
-    'no-tabs': 'off',
-    'no-trailing-spaces': 'off',
-    'no-unused-expressions': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-    quotes: 'off',
-    'implicit-arrow-linebreak': 'off',
-    'object-curly-newline': 'off',
-    'object-curly-spacing': 'off',
-    'operator-linebreak': 'off',
-    'padded-blocks': 'off',
-    'prefer-const': ['error', { destructuring: 'all', ignoreReadBeforeAssign: true }],
-    'quote-props': 'off',
+    'no-const-assign': 'error',
+    'no-constant-condition': 'warn',
+    'no-constructor-return': 'error',
+    'no-continue': 'error',
+    'no-control-regex': 'error',
+    'no-debugger': 'error',
+    'no-delete-var': 'error',
+    'no-dupe-args': 'error',
+    'no-dupe-class-members': 'error',
+    'no-dupe-else-if': 'error',
+    'no-dupe-keys': 'error',
+    'no-duplicate-case': 'error',
+    'no-else-return': [
+      'error',
+      {
+        allowElseIf: false,
+      },
+    ],
+    'no-empty': [
+      'error',
+      {
+        allowEmptyCatch: true,
+      },
+    ],
+    'no-empty-character-class': 'error',
+    'no-empty-function': [
+      'error',
+      {
+        allow: ['arrowFunctions', 'functions', 'methods'],
+      },
+    ],
+    'no-empty-pattern': 'error',
+    'no-eval': 'error',
+    'no-ex-assign': 'error',
+    'no-extend-native': 'error',
+    'no-extra-bind': 'error',
+    'no-extra-boolean-cast': 'error',
+    'no-extra-label': 'error',
+    'no-fallthrough': 'error',
+    'no-floating-decimal': 'error',
+    'no-func-assign': 'error',
+    'no-global-assign': [
+      'error',
+      {
+        exceptions: [],
+      },
+    ],
+    'no-implied-eval': 'error',
+    'no-import-assign': 'error',
+    'no-inner-declarations': 'error',
+    'no-invalid-regexp': 'error',
+    'no-irregular-whitespace': 'error',
+    'no-iterator': 'error',
+    'no-label-var': 'error',
+    'no-labels': [
+      'error',
+      {
+        allowLoop: false,
+        allowSwitch: false,
+      },
+    ],
+    'no-lone-blocks': 'error',
+    'no-lonely-if': 'error',
+    'no-loop-func': 'error',
+    'no-loss-of-precision': 'error',
+    'no-misleading-character-class': 'error',
+    'no-mixed-operators': [
+      'error',
+      {
+        groups: [
+          ['%', '**'],
+          ['%', '+'],
+          ['%', '-'],
+          ['%', '*'],
+          ['%', '/'],
+          ['/', '*'],
+          ['&', '|', '<<', '>>', '>>>'],
+          ['==', '!=', '===', '!=='],
+          ['&&', '||'],
+        ],
+        allowSamePrecedence: false,
+      },
+    ],
+    'no-mixed-spaces-and-tabs': 'error',
+    'no-multi-assign': 'error',
+    'no-multi-spaces': [
+      'error',
+      {
+        ignoreEOLComments: false,
+      },
+    ],
+    'no-multi-str': 'error',
+    'no-multiple-empty-lines': [
+      'error',
+      {
+        max: 1,
+        maxBOF: 0,
+        maxEOF: 0,
+      },
+    ],
+    'no-nested-ternary': 'error',
+    'no-new': 'error',
+    'no-new-func': 'error',
+    'no-new-object': 'error',
+    'no-new-require': 'error',
+    'no-new-symbol': 'error',
+    'no-new-wrappers': 'error',
+    'no-nonoctal-decimal-escape': 'error',
+    'no-obj-calls': 'error',
+    'no-octal': 'error',
+    'no-octal-escape': 'error',
+    'no-path-concat': 'error',
+    'no-proto': 'error',
+    'no-prototype-builtins': 'error',
+    'no-redeclare': 'error',
+    'no-regex-spaces': 'error',
+    'no-restricted-exports': [
+      'error',
+      {
+        restrictedNamedExports: ['default', 'then'],
+      },
+    ],
+    'no-return-assign': ['error', 'always'],
+    'no-return-await': 'error',
+    'no-script-url': 'error',
+    'no-self-assign': [
+      'error',
+      {
+        props: true,
+      },
+    ],
+    'no-self-compare': 'error',
+    'no-sequences': 'error',
+    'no-setter-return': 'error',
+    'no-shadow': 'error',
+    'no-shadow-restricted-names': 'error',
+    'no-spaced-func': 'error',
+    'no-sparse-arrays': 'error',
+    'no-template-curly-in-string': 'error',
+    'no-this-before-super': 'error',
+    'no-throw-literal': 'error',
+    'no-undef': 'error',
+    'no-undef-init': 'error',
+    'no-underscore-dangle': [
+      'error',
+      {
+        allowAfterThis: false,
+        allowAfterSuper: false,
+        enforceInMethodNames: true,
+        allowAfterThisConstructor: false,
+        allowFunctionParams: true,
+        enforceInClassFields: false,
+        allowInArrayDestructuring: true,
+        allowInObjectDestructuring: true,
+      },
+    ],
+    'no-unexpected-multiline': 'error',
+    'no-unneeded-ternary': [
+      'error',
+      {
+        defaultAssignment: false,
+      },
+    ],
+    'no-unreachable': 'error',
+    'no-unreachable-loop': [
+      'error',
+      {
+        ignore: [],
+      },
+    ],
+    'no-unsafe-finally': 'error',
+    'no-unsafe-negation': 'error',
+    'no-unsafe-optional-chaining': [
+      'error',
+      {
+        disallowArithmeticOperators: true,
+      },
+    ],
+    'no-unused-labels': 'error',
+    'no-unused-vars': [
+      'error',
+      {
+        vars: 'all',
+        args: 'after-used',
+        ignoreRestSiblings: true,
+      },
+    ],
+    'no-use-before-define': [
+      'error',
+      {
+        functions: true,
+        classes: true,
+        variables: true,
+      },
+    ],
+    'no-useless-backreference': 'error',
+    'no-useless-catch': 'error',
+    'no-useless-computed-key': 'error',
+    'no-useless-concat': 'error',
+    'no-useless-constructor': 'error',
+    'no-useless-escape': 'error',
+    'no-useless-rename': [
+      'error',
+      {
+        ignoreDestructuring: false,
+        ignoreImport: false,
+        ignoreExport: false,
+      },
+    ],
+    'no-useless-return': 'error',
+    'no-var': 'error',
+    'no-void': 'error',
+    'no-whitespace-before-property': 'error',
+    'no-with': 'error',
+    'nonblock-statement-body-position': [
+      'error',
+      'beside',
+      {
+        overrides: {},
+      },
+    ],
+    'object-property-newline': [
+      'error',
+      {
+        allowAllPropertiesOnSameLine: true,
+        allowMultiplePropertiesPerLine: false,
+      },
+    ],
+    'object-shorthand': [
+      'error',
+      'always',
+      {
+        ignoreConstructors: false,
+        avoidQuotes: true,
+      },
+    ],
+    'one-var': ['error', 'never'],
+    'one-var-declaration-per-line': ['error', 'always'],
+    'operator-assignment': ['error', 'always'],
+    'prefer-const': [
+      'error',
+      {
+        destructuring: 'all',
+        ignoreReadBeforeAssign: true,
+      },
+    ],
+    'prefer-destructuring': [
+      'error',
+      {
+        VariableDeclarator: {
+          array: false,
+          object: true,
+        },
+        AssignmentExpression: {
+          array: true,
+          object: false,
+        },
+      },
+      {
+        enforceForRenamedProperties: false,
+      },
+    ],
+    'prefer-exponentiation-operator': 'error',
+    'prefer-numeric-literals': 'error',
+    'prefer-object-spread': 'error',
+    'prefer-promise-reject-errors': [
+      'error',
+      {
+        allowEmptyReject: true,
+      },
+    ],
+    'prefer-regex-literals': [
+      'error',
+      {
+        disallowRedundantWrapping: true,
+      },
+    ],
+    'prefer-rest-params': 'error',
+    'prefer-spread': 'error',
+    'prefer-template': 'error',
+    radix: 'error',
     'require-await': 'error',
-    'rest-spread-spacing': 'off',
-    semi: 'off',
-    'semi-spacing': 'off',
-    'semi-style': 'off',
-    'space-before-function-paren': 'off',
-    'space-in-parens': 'off',
-    'switch-colon-spacing': 'off',
-    'template-curly-spacing': 'off',
-    'template-tag-spacing': 'off',
-    'yield-star-spacing': 'off',
+    'require-yield': 'error',
+    'space-before-blocks': 'error',
+    'space-infix-ops': 'error',
+    'space-unary-ops': [
+      'error',
+      {
+        words: true,
+        nonwords: false,
+        overrides: {},
+      },
+    ],
+    'spaced-comment': [
+      'error',
+      'always',
+      {
+        line: {
+          exceptions: ['-', '+'],
+          markers: ['=', '!', '/'],
+        },
+        block: {
+          exceptions: ['-', '+'],
+          markers: ['=', '!', ':', '::'],
+          balanced: true,
+        },
+      },
+    ],
+    strict: ['error', 'never'],
+    'symbol-description': 'error',
+    'unicode-bom': ['error', 'never'],
+    'use-isnan': 'error',
+    'valid-typeof': [
+      'error',
+      {
+        requireStringLiterals: true,
+      },
+    ],
+    'vars-on-top': 'error',
+    'wrap-iife': [
+      'error',
+      'outside',
+      {
+        functionPrototypeMethods: false,
+      },
+    ],
+    yoda: 'error',
   },
   overrides: /** @type {Array<import('eslint').Linter.ConfigOverride>} */ ([]),
 };
@@ -82,8 +505,181 @@ if (
   isDependency('eslint-plugin-jsx-a11y') &&
   isDependency('eslint-plugin-react-hooks')
 ) {
-  config.extends.push('airbnb');
+  config.parserOptions.ecmaFeatures.jsx = true;
+  config.plugins.push('react', 'jsx-a11y', 'react-hooks');
+  config.settings.react = {
+    pragma: 'React',
+    version: 'detect',
+  };
   Object.assign(config.rules, {
+    'jsx-a11y/alt-text': [
+      'error',
+      {
+        elements: ['img', 'object', 'area', 'input[type="image"]'],
+        img: [],
+        object: [],
+        area: [],
+        'input[type="image"]': [],
+      },
+    ],
+    'jsx-a11y/anchor-has-content': [
+      'error',
+      {
+        components: [],
+      },
+    ],
+    'jsx-a11y/anchor-is-valid': [
+      'error',
+      {
+        components: ['Link'],
+        specialLink: ['to'],
+        aspects: ['noHref', 'invalidHref', 'preferButton'],
+      },
+    ],
+    'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
+    'jsx-a11y/aria-props': 'error',
+    'jsx-a11y/aria-proptypes': 'error',
+    'jsx-a11y/aria-role': [
+      'error',
+      {
+        ignoreNonDOM: false,
+      },
+    ],
+    'jsx-a11y/aria-unsupported-elements': 'error',
+    'jsx-a11y/click-events-have-key-events': 'error',
+    'jsx-a11y/control-has-associated-label': [
+      'error',
+      {
+        labelAttributes: ['label'],
+        controlComponents: [],
+        ignoreElements: ['audio', 'canvas', 'embed', 'input', 'textarea', 'tr', 'video'],
+        ignoreRoles: [
+          'grid',
+          'listbox',
+          'menu',
+          'menubar',
+          'radiogroup',
+          'row',
+          'tablist',
+          'toolbar',
+          'tree',
+          'treegrid',
+        ],
+        depth: 5,
+      },
+    ],
+    'jsx-a11y/heading-has-content': [
+      'error',
+      {
+        components: [''],
+      },
+    ],
+    'jsx-a11y/html-has-lang': 'error',
+    'jsx-a11y/iframe-has-title': 'error',
+    'jsx-a11y/img-redundant-alt': 'error',
+    'jsx-a11y/interactive-supports-focus': 'error',
+    'jsx-a11y/label-has-associated-control': [
+      'error',
+      {
+        labelComponents: [],
+        labelAttributes: [],
+        controlComponents: [],
+        assert: 'either',
+        depth: 25,
+      },
+    ],
+    'jsx-a11y/lang': 'error',
+    'jsx-a11y/media-has-caption': [
+      'error',
+      {
+        audio: [],
+        video: [],
+        track: [],
+      },
+    ],
+    'jsx-a11y/mouse-events-have-key-events': 'error',
+    'jsx-a11y/no-access-key': 'error',
+    'jsx-a11y/no-autofocus': [
+      'error',
+      {
+        ignoreNonDOM: true,
+      },
+    ],
+    'jsx-a11y/no-distracting-elements': [
+      'error',
+      {
+        elements: ['marquee', 'blink'],
+      },
+    ],
+    'jsx-a11y/no-interactive-element-to-noninteractive-role': [
+      'error',
+      {
+        tr: ['none', 'presentation'],
+      },
+    ],
+    'jsx-a11y/no-noninteractive-element-interactions': [
+      'error',
+      {
+        handlers: ['onClick', 'onMouseDown', 'onMouseUp', 'onKeyPress', 'onKeyDown', 'onKeyUp'],
+      },
+    ],
+    'jsx-a11y/no-noninteractive-element-to-interactive-role': [
+      'error',
+      {
+        ul: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
+        ol: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
+        li: ['menuitem', 'option', 'row', 'tab', 'treeitem'],
+        table: ['grid'],
+        td: ['gridcell'],
+      },
+    ],
+    'jsx-a11y/no-noninteractive-tabindex': [
+      'error',
+      {
+        tags: [],
+        roles: ['tabpanel'],
+      },
+    ],
+    'jsx-a11y/no-redundant-roles': 'error',
+    'jsx-a11y/no-static-element-interactions': [
+      'error',
+      {
+        handlers: ['onClick', 'onMouseDown', 'onMouseUp', 'onKeyPress', 'onKeyDown', 'onKeyUp'],
+      },
+    ],
+    'jsx-a11y/role-has-required-aria-props': 'error',
+    'jsx-a11y/role-supports-aria-props': 'error',
+    'jsx-a11y/scope': 'error',
+    'jsx-a11y/tabindex-no-positive': 'error',
+    'react/button-has-type': [
+      'error',
+      {
+        button: true,
+        submit: true,
+        reset: false,
+      },
+    ],
+    'react/default-props-match-prop-types': [
+      'error',
+      {
+        allowRequiredDefaults: false,
+      },
+    ],
+    'react/destructuring-assignment': ['error', 'always'],
+    'react/forbid-foreign-prop-types': [
+      'warn',
+      {
+        allowInPropTypes: true,
+      },
+    ],
+    'react/forbid-prop-types': [
+      'error',
+      {
+        forbid: ['any', 'array', 'object'],
+        checkContextTypes: true,
+        checkChildContextTypes: true,
+      },
+    ],
     'react/function-component-definition': [
       'error',
       {
@@ -91,39 +687,150 @@ if (
         unnamedComponents: 'arrow-function',
       },
     ],
-    'react/jsx-curly-newline': 'off',
-    'react/jsx-indent': 'off',
-    'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],
-    'react/jsx-no-bind': 'off',
-    'react/jsx-no-constructed-context-values': 'off',
-    'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
-    'react/jsx-props-no-spreading': 'off',
-    'react/jsx-one-expression-per-line': 'off',
-    'react/jsx-wrap-multilines': 'off',
-    'react/jsx-uses-react': 'off',
-    'react/no-array-index-key': 'off',
-    'react/no-unstable-nested-components': 'off',
-    'react/react-in-jsx-scope': 'off',
-    'react/require-default-props': 'off',
-    'react/prop-types': 'off',
+    'react/jsx-boolean-value': [
+      'error',
+      'never',
+      {
+        always: [],
+      },
+    ],
+    'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
+    'react/jsx-closing-tag-location': 'error',
+    'react/jsx-curly-brace-presence': [
+      'error',
+      {
+        props: 'never',
+        children: 'never',
+      },
+    ],
+    'react/jsx-curly-spacing': [
+      'error',
+      'never',
+      {
+        allowMultiline: true,
+      },
+    ],
+    'react/jsx-equals-spacing': ['error', 'never'],
+    'react/jsx-filename-extension': [
+      'error',
+      {
+        extensions: ['.jsx', '.tsx'],
+      },
+    ],
+    'react/jsx-first-prop-new-line': ['error', 'multiline-multiprop'],
+    'react/jsx-fragments': ['error', 'syntax'],
+    'react/jsx-indent-props': ['error', 2],
+    'react/jsx-max-props-per-line': [
+      'error',
+      {
+        maximum: 1,
+        when: 'multiline',
+      },
+    ],
+    'react/jsx-no-comment-textnodes': 'error',
+    'react/jsx-no-duplicate-props': [
+      'error',
+      {
+        ignoreCase: true,
+      },
+    ],
+    'react/jsx-no-script-url': [
+      'error',
+      [
+        {
+          name: 'Link',
+          props: ['to'],
+        },
+      ],
+    ],
+    'react/jsx-no-target-blank': [
+      'error',
+      {
+        enforceDynamicLinks: 'always',
+        links: true,
+        forms: false,
+      },
+    ],
+    'react/jsx-no-undef': 'error',
+    'react/jsx-no-useless-fragment': [
+      'error',
+      {
+        allowExpressions: true,
+      },
+    ],
+    'react/jsx-pascal-case': [
+      'error',
+      {
+        allowAllCaps: true,
+        ignore: [],
+      },
+    ],
+    'react/jsx-props-no-multi-spaces': 'error',
+    'react/jsx-tag-spacing': [
+      'error',
+      {
+        closingSlash: 'never',
+        beforeSelfClosing: 'always',
+        afterOpening: 'never',
+        beforeClosing: 'never',
+      },
+    ],
+    'react/jsx-uses-vars': 'error',
+    'react/no-access-state-in-setstate': 'error',
+    'react/no-arrow-function-lifecycle': 'error',
+    'react/no-children-prop': 'error',
+    'react/no-danger': 'warn',
+    'react/no-danger-with-children': 'error',
+    'react/no-deprecated': 'error',
+    'react/no-did-update-set-state': 'error',
+    'react/no-find-dom-node': 'error',
+    'react/no-invalid-html-attribute': 'error',
+    'react/no-is-mounted': 'error',
+    'react/no-namespace': 'error',
+    'react/no-redundant-should-component-update': 'error',
+    'react/no-render-return-value': 'error',
+    'react/no-string-refs': 'error',
+    'react/no-this-in-sfc': 'error',
+    'react/no-typos': 'error',
+    'react/no-unescaped-entities': 'error',
+    'react/no-unknown-property': 'error',
+    'react/no-unused-class-component-methods': 'error',
+    'react/no-unused-prop-types': [
+      'error',
+      {
+        customValidators: [],
+        skipShapeProps: true,
+      },
+    ],
+    'react/no-unused-state': 'error',
+    'react/no-will-update-set-state': 'error',
+    'react/prefer-es6-class': ['error', 'always'],
+    'react/prefer-exact-props': 'error',
+    'react/prefer-stateless-function': [
+      'error',
+      {
+        ignorePureComponents: true,
+      },
+    ],
+    'react/require-render-return': 'error',
+    'react/self-closing-comp': 'error',
+    'react/state-in-constructor': ['error', 'always'],
+    'react/static-property-placement': ['error', 'property assignment'],
+    'react/style-prop-object': 'error',
+    'react/void-dom-elements-no-children': 'error',
   });
-} else {
-  config.extends.push('airbnb-base');
 }
 
 if (isDependency('@typescript-eslint/parser') && isDependency('@typescript-eslint/eslint-plugin')) {
   config.parser = '@typescript-eslint/parser';
   config.plugins.push('@typescript-eslint');
   config.extends.push('plugin:import/typescript');
+  config.settings['import/parsers'] = { '@typescript-eslint/parser': ['.ts', '.tsx'] };
+  config.settings['import/extensions'].push('.ts', '.tsx');
+  config.settings['import/external-module-folders'].push('node_modules/@types');
+  config.settings['import/resolver'].node.extensions.push('.ts', '.tsx');
   Object.assign(config.rules, {
     '@typescript-eslint/default-param-last': ['error'],
-    '@typescript-eslint/lines-between-class-members': [
-      'error',
-      'always',
-      {
-        exceptAfterSingleLine: false,
-      },
-    ],
     '@typescript-eslint/no-array-constructor': ['error'],
     '@typescript-eslint/no-dupe-class-members': ['error'],
     '@typescript-eslint/no-empty-function': [
@@ -140,7 +847,6 @@ if (isDependency('@typescript-eslint/parser') && isDependency('@typescript-eslin
     '@typescript-eslint/no-use-before-define': 'error',
     '@typescript-eslint/no-useless-constructor': ['error'],
     'default-param-last': 'off',
-    'lines-between-class-members': 'off',
     'no-array-constructor': 'off',
     'no-dupe-class-members': 'off',
     'no-empty-function': 'off',

--- a/app/javascript/packages/eslint-plugin/package.json
+++ b/app/javascript/packages/eslint-plugin/package.json
@@ -22,9 +22,7 @@
   },
   "homepage": "https://github.com/18f/identity-idp",
   "dependencies": {
-    "@aduth/is-dependency": "^1.0.0",
-    "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-airbnb-base": "^15.0.0"
+    "@aduth/is-dependency": "^1.0.0"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "*",

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -53,10 +53,6 @@ eliminate the effort involved with applying correct formatting. As a reviewer, i
 debates over code style, since there is a consistent style being enforced through the adopted
 tooling.
 
-Prettier works reasonably well in combination with Airbnb's JavaScript standards. In the few cases
-where conflicts occur, formatting rules may be disabled to err toward Prettier conventions when an
-option is not configurable.
-
 Prettier is integrated with [the project's linting setup](#eslint). Most issues can be resolved
 automatically by running `yarn run lint --fix`. You may also consider one of the
 [available editor integrations](https://prettier.io/docs/en/editors.html), which can simplify your

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,11 +2694,6 @@ concurrently@^8.2.2:
     tree-kill "^1.2.2"
     yargs "^17.7.2"
 
-confusing-browser-globals@^1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
-  integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
-
 connect-history-api-fallback@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
@@ -3255,25 +3250,6 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
-
-eslint-config-airbnb-base@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz#6b09add90ac79c2f8d723a2580e07f3925afd236"
-  integrity sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==
-  dependencies:
-    confusing-browser-globals "^1.0.10"
-    object.assign "^4.1.2"
-    object.entries "^1.1.5"
-    semver "^6.3.0"
-
-eslint-config-airbnb@^19.0.4:
-  version "19.0.4"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz#84d4c3490ad70a0ffa571138ebcdea6ab085fdc3"
-  integrity sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==
-  dependencies:
-    eslint-config-airbnb-base "^15.0.0"
-    object.assign "^4.1.2"
-    object.entries "^1.1.5"
 
 eslint-import-resolver-node@^0.3.7:
   version "0.3.7"
@@ -5177,7 +5153,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.0, object.assign@^4.1.2, object.assign@^4.1.3, object.assign@^4.1.4:
+object.assign@^4.1.0, object.assign@^4.1.3, object.assign@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
   integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==


### PR DESCRIPTION
## 🛠 Summary of changes

Updates ESLint configuration to integrate relevant rules from the Airbnb ESLint configurations `eslint-config-airbnb` and `eslint-config-airbnb-base`.

**Why?**

- Incremental step toward migrating to [ESLint 9](https://eslint.org/docs/latest/use/migrate-to-9.0.0) ([updated configuration syntax not supported by Airbnb shared configurations](https://github.com/airbnb/javascript/issues/2804))
- More explicit control over rules relevant to our projects
   - No longer need to disable stylistic rules for Prettier compatibility
   - Avoid unnecessary configuration for tools and practices not relevant to our projects (e.g. in the course of this exercise, I discovered that Airbnb includes a number of configuration for React component classes, and other tools like Vue.js)
- Shallower dependency tree, fewer dependencies to maintain
- More honesty with how we communicate our JavaScript coding standards
   - We've claimed to follow the [TTS JavaScript style recommendations](https://guides.18f.gov/engineering/languages-runtimes/javascript/#how-to-set-it-up), but we've so far diverged from the base configuration that this is mostly untrue. Keeping the dependency has largely been due to trying to maintain this claim more-so than actually needing it.

The intent of these changes is to largely keep an identical configuration to what existed previously. Minor revisions have been incorporated based on observations of the flattened configuration, reflected in the CHANGELOG.md.

These changes were implemented using ESLint's `--print-config` option to display the fully-resolved configuration, rearranging the result into relevant sub-configurations (TypeScript, Mocha, Prettier, etc.).

## 📜 Testing Plan

Verify that build passes.

Verify that lint passes:

```
yarn lint
```