### PR TITLE
Use shared examples for mailer preview specs

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -22,11 +22,10 @@ class UserMailer < ActionMailer::Base
 
   class UserEmailAddressMismatchError < StandardError; end
 
-  attr_reader :user, :email_address
-
   before_action :validate_user_and_email_address
   before_action :attach_images
   after_action :add_metadata
+
   default(
     from: email_with_name(
       IdentityConfig.store.email_from,
@@ -39,24 +38,6 @@ class UserMailer < ActionMailer::Base
   )
 
   layout 'mailer'
-
-  def validate_user_and_email_address
-    @user = params.fetch(:user)
-    @email_address = params.fetch(:email_address)
-    if @user.id != @email_address.user_id
-      raise UserEmailAddressMismatchError.new(
-        "User ID #{@user.id} does not match EmailAddress ID #{@email_address.id}",
-      )
-    end
-  end
-
-  def add_metadata
-    message.instance_variable_set(
-      :@_metadata, {
-        user: user, email_address: email_address, action: action_name
-      }
-    )
-  end
 
   def email_confirmation_instructions(token, request_id:)
     with_user_locale(user) do
@@ -450,6 +431,26 @@ class UserMailer < ActionMailer::Base
   end
 
   private
+
+  attr_reader :user, :email_address
+
+  def validate_user_and_email_address
+    @user = params.fetch(:user)
+    @email_address = params.fetch(:email_address)
+    if @user.id != @email_address.user_id
+      raise UserEmailAddressMismatchError.new(
+        "User ID #{@user.id} does not match EmailAddress ID #{@email_address.id}",
+      )
+    end
+  end
+
+  def add_metadata
+    message.instance_variable_set(
+      :@_metadata, {
+        user: user, email_address: email_address, action: action_name
+      }
+    )
+  end
 
   def account_reset_token_valid_period
     current_time = Time.zone.now

--- a/spec/mailers/previews/anonymous_mailer_preview_spec.rb
+++ b/spec/mailers/previews/anonymous_mailer_preview_spec.rb
@@ -2,17 +2,5 @@ require 'rails_helper'
 require_relative './anonymous_mailer_preview'
 
 RSpec.describe AnonymousMailerPreview do
-  AnonymousMailerPreview.instance_methods(false).each do |mailer_method|
-    describe "##{mailer_method}" do
-      it 'generates a preview without raising an error' do
-        expect { AnonymousMailerPreview.new.public_send(mailer_method).body }.to_not raise_error
-      end
-    end
-  end
-
-  it 'has a preview method for each mailer method' do
-    mailer_methods = AnonymousMailer.instance_methods(false)
-    preview_methods = AnonymousMailerPreview.instance_methods(false)
-    expect(mailer_methods - preview_methods).to be_empty
-  end
+  it_behaves_like 'a mailer preview'
 end

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -1,4 +1,13 @@
 class ReportMailerPreview < ActionMailer::Preview
+  def deleted_user_accounts_report
+    ReportMailer.deleted_user_accounts_report(
+      email: 'test@example.com',
+      name: '',
+      issuers: [],
+      data: [],
+    )
+  end
+
   def warn_error
     ReportMailer.warn_error(
       email: 'test@example.com',

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -1,12 +1,14 @@
 class ReportMailerPreview < ActionMailer::Preview
   def deleted_user_accounts_report
+    data = <<~CSV
+      2023-01-01T:00:00:00Z,00000000-0000-0000-0000-000000000000
+    CSV
+
     ReportMailer.deleted_user_accounts_report(
       email: 'test@example.com',
       name: '',
       issuers: ['test-sp-1', 'test-sp-2'],
-      data: <<~CSV
-        2023-01-01T:00:00:00Z,00000000-0000-0000-0000-000000000000
-      CSV
+      data:,
     )
   end
 

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -6,7 +6,7 @@ class ReportMailerPreview < ActionMailer::Preview
 
     ReportMailer.deleted_user_accounts_report(
       email: 'test@example.com',
-      name: '',
+      name: 'Example Partner',
       issuers: ['test-sp-1', 'test-sp-2'],
       data:,
     )

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -3,8 +3,10 @@ class ReportMailerPreview < ActionMailer::Preview
     ReportMailer.deleted_user_accounts_report(
       email: 'test@example.com',
       name: '',
-      issuers: [],
-      data: [],
+      issuers: ['test-sp-1', 'test-sp-2'],
+      data: <<~CSV
+        2023-01-01T:00:00:00Z,00000000-0000-0000-0000-000000000000
+      CSV
     )
   end
 

--- a/spec/mailers/previews/report_mailer_preview_spec.rb
+++ b/spec/mailers/previews/report_mailer_preview_spec.rb
@@ -2,13 +2,5 @@ require 'rails_helper'
 require_relative './report_mailer_preview'
 
 RSpec.describe ReportMailerPreview do
-  subject(:mailer_preview) { ReportMailerPreview.new }
-
-  ReportMailerPreview.instance_methods(false).each do |mailer_method|
-    describe "##{mailer_method}" do
-      it 'generates a preview without blowing up' do
-        expect { mailer_preview.public_send(mailer_method).body }.to_not raise_error
-      end
-    end
-  end
+  it_behaves_like 'a mailer preview'
 end

--- a/spec/mailers/previews/user_mailer_preview_spec.rb
+++ b/spec/mailers/previews/user_mailer_preview_spec.rb
@@ -2,29 +2,7 @@ require 'rails_helper'
 require_relative './user_mailer_preview'
 
 RSpec.describe UserMailerPreview do
-  UserMailerPreview.instance_methods(false).each do |mailer_method|
-    describe "##{mailer_method}" do
-      subject(:mail) { UserMailerPreview.new.public_send(mailer_method) }
-
-      it 'generates a preview without blowing up' do
-        expect { mail.body }.to_not raise_error
-      end
-
-      it 'does not include any svg images' do
-        # SVGs are typically the preferred format for their high-quality and small file size, but
-        # they are not well-supported in email clients. Instead, store a rasterized version of the
-        # image in `app/assets/images/email` for use in mailer content.
-        expect(mail.html_part.body).not_to have_selector("img[src$='.svg']")
-      end
-    end
-  end
-
-  it 'has a preview method for each mailer method' do
-    mailer_methods = UserMailer.instance_methods(false)
-    preview_methods = UserMailerPreview.instance_methods(false)
-    mailer_helper_methods = [:email_address, :user, :validate_user_and_email_address, :add_metadata]
-    expect(mailer_methods - mailer_helper_methods - preview_methods).to be_empty
-  end
+  it_behaves_like 'a mailer preview'
 
   it 'uses user and email records that cannot be saved' do
     expect(User.count).to eq(0)

--- a/spec/support/shared_examples/mailer_preview.rb
+++ b/spec/support/shared_examples/mailer_preview.rb
@@ -1,0 +1,27 @@
+RSpec.shared_examples 'a mailer preview' do
+  let(:mailer_class) { described_class.class_name.gsub(/Preview$/, '').constantize }
+
+  it 'has a preview method for each mailer method' do
+    mailer_methods = mailer_class.instance_methods(false)
+    preview_methods = described_class.instance_methods(false)
+    expect(mailer_methods - preview_methods).to be_empty
+  end
+
+  described_class.instance_methods(false).each do |mailer_method|
+    describe "##{mailer_method}" do
+      subject(:mail) { described_class.new.public_send(mailer_method) }
+      let(:body) { mail.parts.find { |part| part.content_type.start_with?('text/') }.body }
+
+      it 'generates a preview without blowing up' do
+        expect { body }.to_not raise_error
+      end
+
+      it 'does not include any svg images' do
+        # SVGs are typically the preferred format for their high-quality and small file size, but
+        # they are not well-supported in email clients. Instead, store a rasterized version of the
+        # image in `app/assets/images/email` for use in mailer content.
+        expect(body).not_to have_selector("img[src$='.svg']")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

Creates RSpec shared examples to be used for mailer previews, to ensure consistency for how these mailers are tested.

Example issues this would catch:

- Existing issue where there is no preview for `ReportMailer#deleted_user_accounts_report` because the report mailer specs did not check that all mailer methods have a corresponding preview
- [Potential issue of introducing SVG images to mailer](https://github.com/18F/identity-idp/pull/11444/files/27237bb478e6b5d511aa5383f623a9660a02391e..9197b5d102fa597e69c1d79c1c27bcbc42e5b7fa#r1826182517) because we were only testing user mailers for SVG images

## 📜 Testing Plan

Verify build passes.

Ensure no regressions of mailers: http://localhost:3000/rails/mailers/