### PR TITLE
LG-14888: Update Spanish strings for LQA feedback

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -41,7 +41,7 @@ account_reset.request.yes_continue: Sí, continuar con la eliminación
 account.connected_apps.associated_attributes_html: 'Conectado el %{timestamp_html} con:'
 account.connected_apps.associated_html: 'Conectado: %{timestamp_html}'
 account.connected_apps.description: Con su cuenta de %{app_name}, puede conectarse de manera segura a muchas cuentas del gobierno en línea. Esta es una lista de todas las cuentas que tiene conectadas actualmente.
-account.connected_apps.email_not_selected: No se seleccionó correo electrónico aún
+account.connected_apps.email_not_selected: No se ha seleccionado aún una dirección de correo electrónico
 account.connected_apps.email_update_success_html: Se actualizó su correo electrónico para la <strong>%{sp_name}</strong>.
 account.email_language.default: '%{language} (predeterminado)'
 account.email_language.edit_title: Editar la preferencia de idioma del correo electrónico
@@ -1754,8 +1754,8 @@ two_factor_authentication.piv_cac.renamed: Se ha cambiado correctamente el nombr
 two_factor_authentication.please_try_again_html: Inténtelo de nuevo en <strong>%{countdown}</strong>.
 two_factor_authentication.read_about_two_factor_authentication: Lea sobre la autenticación de dos factores
 two_factor_authentication.recaptcha.disclosure_statement_html: Este sitio está protegido por reCAPTCHA y se aplican %{google_policy_link_html} y %{google_tos_link_html} de Google. Lea %{login_tos_link_html} de %{app_name}.
-two_factor_authentication.recaptcha.google_policy_link: Política de privacidad
-two_factor_authentication.recaptcha.google_tos_link: Condiciones de servicio
+two_factor_authentication.recaptcha.google_policy_link: la Política de privacidad
+two_factor_authentication.recaptcha.google_tos_link: las Condiciones de servicio
 two_factor_authentication.recaptcha.login_tos_link: Condiciones de uso del servicio móvil
 two_factor_authentication.recommended: Recomendado
 two_factor_authentication.totp_header_text: Ingrese su código de la aplicación de autenticación


### PR DESCRIPTION
## 🎫 Ticket

[LG-14888](https://cm-jira.usa.gov/browse/LG-14888)

## 🛠 Summary of changes

Updates a few translations based on feedback from translators.

## 📜 Testing Plan

Verify updated text for reCAPTCHA disclosure in Spanish:

Prerequisite: Configure real reCAPTCHA in local development. Any credentials work, they don't need to be valid:

```yaml
# config/application.yml
development:
  recaptcha_site_key: 'test'
  recaptcha_enterprise_api_key: 'test'
  recaptcha_enterprise_project_id: 'test'
  recaptcha_mock_validator: false
  sign_in_recaptcha_score_threshold: 0.3
  sign_in_recaptcha_percent_tested: 100
```

1. Go to http://localhost:3000/es/
2. See updated translations

Verify updated text for "Email not selected" in Spanish:

1. Go to http://localhost:3000/
2. Sign in
3. From account page, go to "Your connected accounts"
4. If you don't have any connected accounts, run and sign in to [sample application](https://github.com/18f/identity-oidc-sinatra)
5. If you have a connected account that already has a linked email address, reset through `rails console`: `User.find_with_email('<insert email address>').identities.update_all(email_address_id: nil)`
6. Change page language to Spanish
7. See updated translations

## 👀 Screenshots

Text|Before|After
---|---|---
reCAPTCHA disclosure|![lqa-es-recaptcha-before](https://github.com/user-attachments/assets/36e7e97a-3c84-4cd7-9745-1a3a2ece8bf3)|![lqa-es-recaptcha-after](https://github.com/user-attachments/assets/655d45f2-d624-4ec2-aa4e-371208bac059)
Connected accounts|![lqa-es-select-email-before](https://github.com/user-attachments/assets/5bdd5765-6456-4732-8af5-105f48da08cc)|![lqa-es-select-email-after](https://github.com/user-attachments/assets/b53cc016-7eee-4f6b-a1f5-e5da022e09c3)