### PR TITLE
Add error handling for failed reCAPTCHA execute

### DIFF
--- a/app/javascript/packages/analytics/index.ts
+++ b/app/javascript/packages/analytics/index.ts
@@ -24,6 +24,8 @@ export function trackEvent(event: string, payload?: object) {
  * Logs an error.
  *
  * @param error Error object.
+ * @param event Error event, if error is caught using an `error` event handler. Including this can
+ * add additional resolution to the logged error, notably the filename where the error occurred.
  */
 export const trackError = ({ name, message, stack }: Error, event?: ErrorEvent) =>
   trackEvent('Frontend Error', { name, message, stack, filename: event?.filename });

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
@@ -1,12 +1,26 @@
+import quibble from 'quibble';
 import type { SinonStub } from 'sinon';
 import userEvent from '@testing-library/user-event';
 import { screen, waitFor, fireEvent } from '@testing-library/dom';
 import { useSandbox, useDefineProperty } from '@18f/identity-test-helpers';
 import '@18f/identity-spinner-button/spinner-button-element';
-import './captcha-submit-button-element';
 
 describe('CaptchaSubmitButtonElement', () => {
   const sandbox = useSandbox();
+  const trackError = sandbox.stub();
+
+  before(async () => {
+    quibble('@18f/identity-analytics', { trackError });
+    await import('./captcha-submit-button-element');
+  });
+
+  afterEach(() => {
+    trackError.reset();
+  });
+
+  after(() => {
+    quibble.reset();
+  });
 
   context('without ancestor form element', () => {
     beforeEach(() => {
@@ -155,6 +169,35 @@ describe('CaptchaSubmitButtonElement', () => {
 
           await userEvent.click(button);
           await waitFor(() => expect(didSubmit).to.be.true());
+        });
+      });
+
+      context('when recaptcha fails to execute', () => {
+        let error: Error;
+
+        beforeEach(() => {
+          error = new Error('Invalid site key or not loaded in api.js: badkey');
+          ((global as any).grecaptcha.execute as SinonStub).throws(error);
+        });
+
+        it('does not prevent default form submission', async () => {
+          const button = screen.getByRole('button', { name: 'Submit' });
+          const form = document.querySelector('form')!;
+
+          sandbox.stub(form, 'submit');
+
+          await userEvent.click(button);
+          await expect(form.submit).to.eventually.be.called();
+        });
+
+        it('tracks error', async () => {
+          const button = screen.getByRole('button', { name: 'Submit' });
+          const form = document.querySelector('form')!;
+
+          sandbox.stub(form, 'submit');
+          await userEvent.click(button);
+
+          await expect(trackError).to.eventually.be.calledWith(error);
         });
       });
     });

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
@@ -183,10 +183,10 @@ describe('CaptchaSubmitButtonElement', () => {
         it('does not prevent default form submission', async () => {
           const button = screen.getByRole('button', { name: 'Submit' });
           const form = document.querySelector('form')!;
-
           sandbox.stub(form, 'submit');
 
           await userEvent.click(button);
+
           await expect(form.submit).to.eventually.be.called();
         });
 

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
@@ -193,8 +193,8 @@ describe('CaptchaSubmitButtonElement', () => {
         it('tracks error', async () => {
           const button = screen.getByRole('button', { name: 'Submit' });
           const form = document.querySelector('form')!;
-
           sandbox.stub(form, 'submit');
+
           await userEvent.click(button);
 
           await expect(trackError).to.eventually.be.calledWith(error);

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -1,3 +1,5 @@
+import { trackError } from '@18f/identity-analytics';
+
 class CaptchaSubmitButtonElement extends HTMLElement {
   form: HTMLFormElement | null;
 
@@ -46,7 +48,14 @@ class CaptchaSubmitButtonElement extends HTMLElement {
   invokeChallenge() {
     this.recaptchaClient!.ready(async () => {
       const { recaptchaSiteKey: siteKey, recaptchaAction: action } = this;
-      const token = await this.recaptchaClient!.execute(siteKey!, { action });
+
+      let token;
+      try {
+        token = await this.recaptchaClient!.execute(siteKey!, { action });
+      } catch (error) {
+        trackError(error);
+      }
+
       this.tokenInput.value = token;
       this.submit();
     });


### PR DESCRIPTION
## 🛠 Summary of changes

Improves the behavior of reCAPTCHA submit buttons to ensure that a misconfigured reCAPTCHA environment does not prevent form submission.

Ideally this should never happen, since we would configure an environment correctly, but this adds additional resilience to handle if it were misconfigured. Prior to these changes, it'd be very hard to tell that there was an issue, because we would not receive events corresponding to the submission.

## 📜 Testing Plan

Validate that if reCAPTCHA is misconfigured, you're still able to sign in.

Configure reCAPTCHA in a way that uses invalid credentials:

```
# config/application.yml
development:
  recaptcha_site_key: 'test'
  recaptcha_enterprise_api_key: 'test'
  recaptcha_enterprise_project_id: 'test'
  recaptcha_mock_validator: false
  sign_in_recaptcha_score_threshold: 0.3
  sign_in_recaptcha_percent_tested: 100
```

1. In a separate terminal process, run `make watch_events`
2. In a private browsing window, go to http://localhost:3000
3. Enter email and password
4. Click "Sign in"

Before: 
- As a user, the submit button shows as stuck spinning
- In logs, there are no events received

After:
- As a user, you're redirected to MFA
- In logs:
   - There is a "reCAPTCHA verify result received" event with "PERMISSION_DENIED" error and `"evaluated_as_valid": true` property
   - There is a "Email and Password Authentication" event with `"captcha_validation_performed": true` and `"valid_captcha_result": true` 
   - It can't be easily validated, but the error will also be logged to NewRelic

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/09e3a047-3a26-499b-aa4c-d5262f485c53)|(Redirected to MFA)<br>![image](https://github.com/user-attachments/assets/319ced9b-c141-40cb-859e-25e373e14334)

