### PR TITLE
Improve race condition handling for slow reCAPTCHA load

### DIFF
--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
@@ -1,17 +1,20 @@
 import quibble from 'quibble';
 import type { SinonStub } from 'sinon';
-import userEvent from '@testing-library/user-event';
+import baseUserEvent from '@testing-library/user-event';
 import { screen, waitFor, fireEvent } from '@testing-library/dom';
 import { useSandbox, useDefineProperty } from '@18f/identity-test-helpers';
 import '@18f/identity-spinner-button/spinner-button-element';
 
 describe('CaptchaSubmitButtonElement', () => {
-  const sandbox = useSandbox();
+  let FAILED_LOAD_DELAY_MS: number;
+  const sandbox = useSandbox({ useFakeTimers: true });
+  const { clock } = sandbox;
+  const userEvent = baseUserEvent.setup({ advanceTimers: clock.tick });
   const trackError = sandbox.stub();
 
   before(async () => {
     quibble('@18f/identity-analytics', { trackError });
-    await import('./captcha-submit-button-element');
+    ({ FAILED_LOAD_DELAY_MS } = await import('./captcha-submit-button-element'));
   });
 
   afterEach(() => {
@@ -98,7 +101,6 @@ describe('CaptchaSubmitButtonElement', () => {
         defineProperty(global, 'grecaptcha', {
           configurable: true,
           value: {
-            ready: sandbox.stub().callsArg(0),
             execute: sandbox.stub().resolves(RECAPTCHA_TOKEN_VALUE),
             enterprise: {
               ready: sandbox.stub().callsArg(0),
@@ -117,12 +119,36 @@ describe('CaptchaSubmitButtonElement', () => {
         await userEvent.click(button);
         await waitFor(() => expect((form.submit as SinonStub).called).to.be.true());
 
-        expect(grecaptcha.ready).to.have.been.called();
         expect(grecaptcha.execute).to.have.been.calledWith(RECAPTCHA_SITE_KEY, {
           action: RECAPTCHA_ACTION_NAME,
         });
         expect(Object.fromEntries(new window.FormData(form))).to.deep.equal({
           recaptcha_token: RECAPTCHA_TOKEN_VALUE,
+        });
+      });
+
+      context('with recaptcha not loaded by time of submission', () => {
+        beforeEach(() => {
+          delete (global as any).grecaptcha;
+        });
+
+        it('enqueues the challenge callback to be run once recaptcha loads', async () => {
+          const button = screen.getByRole('button', { name: 'Submit' });
+          const form = document.querySelector('form')!;
+          sandbox.stub(form, 'submit');
+
+          await userEvent.click(button);
+
+          expect(form.submit).not.to.have.been.called();
+          /* eslint-disable no-underscore-dangle */
+          expect((globalThis as any).___grecaptcha_cfg).to.have.keys('fns');
+          expect((globalThis as any).___grecaptcha_cfg.fns)
+            .to.be.an('array')
+            .with.lengthOf.greaterThan(0);
+          (globalThis as any).___grecaptcha_cfg.fns.forEach((callback) => callback());
+          /* eslint-enable no-underscore-dangle */
+
+          await expect(form.submit).to.eventually.be.called();
         });
       });
 
@@ -141,7 +167,6 @@ describe('CaptchaSubmitButtonElement', () => {
           await userEvent.click(button);
           await waitFor(() => expect((form.submit as SinonStub).called).to.be.true());
 
-          expect(grecaptcha.enterprise.ready).to.have.been.called();
           expect(grecaptcha.enterprise.execute).to.have.been.calledWith(RECAPTCHA_SITE_KEY, {
             action: RECAPTCHA_ACTION_NAME,
           });
@@ -156,19 +181,18 @@ describe('CaptchaSubmitButtonElement', () => {
           delete (global as any).grecaptcha;
         });
 
-        it('does not prevent default form submission', async () => {
+        it('submits the form if recaptcha is still not loaded after reasonable delay', async () => {
           const button = screen.getByRole('button', { name: 'Submit' });
           const form = document.querySelector('form')!;
-
-          let didSubmit = false;
-          form.addEventListener('submit', (event) => {
-            expect(event.defaultPrevented).to.equal(false);
-            event.preventDefault();
-            didSubmit = true;
-          });
+          sandbox.stub(form, 'submit');
 
           await userEvent.click(button);
-          await waitFor(() => expect(didSubmit).to.be.true());
+
+          expect(form.submit).not.to.have.been.called();
+          clock.tick(FAILED_LOAD_DELAY_MS - 1);
+          expect(form.submit).not.to.have.been.called();
+          clock.tick(1);
+          expect(form.submit).to.have.been.called();
         });
       });
 

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -80,7 +80,7 @@ class CaptchaSubmitButtonElement extends HTMLElement {
 
   #onReady(callback: Parameters<ReCaptchaV2.ReCaptcha['ready']>[0]) {
     if (this.recaptchaClient) {
-      callback();
+      this.recaptchaClient.ready(callback);
     } else {
       // If reCAPTCHA hasn't finished loading by the time the form is submitted, we can enqueue the
       // callback to be invoked once loads by appending a callback to the ___grecaptcha_cfg global.

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -4,7 +4,7 @@ import { trackError } from '@18f/identity-analytics';
  * Maximum time (in milliseconds) to wait on reCAPTCHA to finish loading once a form is submitted
  * before considering reCAPTCHA as having failed to load.
  */
-export const FAILED_LOAD_DELAY_MS = 5000;
+export const FAILED_LOAD_DELAY_MS = 5_000;
 
 class CaptchaSubmitButtonElement extends HTMLElement {
   form: HTMLFormElement | null;

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -83,7 +83,7 @@ class CaptchaSubmitButtonElement extends HTMLElement {
       this.recaptchaClient.ready(callback);
     } else {
       // If reCAPTCHA hasn't finished loading by the time the form is submitted, we can enqueue the
-      // callback to be invoked once loads by appending a callback to the ___grecaptcha_cfg global.
+      // callback to be invoked once loaded by appending a callback to the ___grecaptcha_cfg global.
       //
       // See: https://developers.google.com/recaptcha/docs/loading
 

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -1,5 +1,9 @@
 import { trackError } from '@18f/identity-analytics';
 
+/**
+ * Maximum time (in milliseconds) to wait on reCAPTCHA to finish loading once a form is submitted
+ * before considering reCAPTCHA as having failed to load.
+ */
 export const FAILED_LOAD_DELAY_MS = 5000;
 
 class CaptchaSubmitButtonElement extends HTMLElement {


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `CaptchaSubmitButton` to better handle a scenario where reCAPTCHA is slow to load.

Currently, if reCAPTCHA is not loaded by the time the user submits the form, the form will submit immediately, which may produce a failing result from the backend if reCAPTCHA is being enforced.

This is rather unlikely to happen, since the [initial reCAPTCHA script](https://www.google.com/recaptcha/enterprise.js?render=example) is small (roughly 2kb in size), but still technically possible, particularly if someone is using browser extensions or system features to autofill the sign-in form.

The proposed changes here take advantage of [documented reCAPTCHA features to "queue" callbacks prior to reCAPTCHA being loaded](https://developers.google.com/recaptcha/docs/loading)†, with an additional fallback to submit the form if reCAPTCHA fails to load within a reasonable timeframe (currently 5 seconds).

†: While this feature is not explicitly documented in the reCAPTCHA Enterprise documentation, I've manually confirmed the presence of this queue behavior in the `enterprise.js` script.

## 📜 Testing Plan

Verify that reCAPTCHA validation is not impacted by these changes:

Configure reCAPTCHA for local development. You can use any credentials, they don't need to be valid.

```
# config/application.yml
development:
  sign_in_recaptcha_score_threshold: 0.3
  sign_in_recaptcha_percent_tested: 100
  recaptcha_site_key: 'test'
  recaptcha_enterprise_api_key: 'test'
  recaptcha_enterprise_project_id: 'test'
  recaptcha_mock_validator: false
```

1. Go to http://localhost:3000
2. Enter email and password
3. Click "Sign in"
4. Confirm that you are redirected to either MFA or directly to your account dashboard

Verify that the reCAPTCHA script failing to load doesn't prevent form submission:

You can simulate this by removing the reCAPTCHA script from `CaptchaSubmitButtonComponent`'s markup:

```diff
diff --git a/app/components/captcha_submit_button_component.html.erb b/app/components/captcha_submit_button_component.html.erb
index 88e7033c4a..b6a7699b10 100644
--- a/app/components/captcha_submit_button_component.html.erb
+++ b/app/components/captcha_submit_button_component.html.erb
@@ -36,5 +36,2 @@
       ).with_content(content) %>
-  <% if recaptcha_script_src.present? %>
-    <%= content_tag(:script, '', src: recaptcha_script_src, async: true) %>
-  <% end %>
 <% end %>
```

1. Go to http://localhost:3000
2. Enter email and password
3. Click "Sign in"
4. After 5 seconds of the button showing as a spinner button, confirm that you are redirected to either MFA or directly to your account dashboard

