### PR TITLE
Include FormResponse error details for reCAPTCHA at sign-in

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -436,8 +436,9 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Boolean] success
-  # @param [String] user_id
+  # @param [Boolean] success Whether form validation was successful
+  # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
+  # @param [String] user_id Database ID for user associated with attempted email address
   # @param [Boolean] user_locked_out if the user is currently locked out of their second factor
   # @param [Boolean] rate_limited Whether the user has exceeded user IP rate limiting
   # @param [Boolean] valid_captcha_result Whether user passed the reCAPTCHA check or was exempt
@@ -459,11 +460,13 @@ module AnalyticsEvents
     sp_request_url_present:,
     remember_device:,
     new_device:,
+    error_details: nil,
     **extra
   )
     track_event(
       'Email and Password Authentication',
       success:,
+      error_details:,
       user_id:,
       user_locked_out:,
       rate_limited:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -438,7 +438,7 @@ module AnalyticsEvents
 
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  # @param [String] user_id Database ID for user associated with attempted email address
+  # @param [String] user_id UUID for user associated with attempted email address
   # @param [Boolean] user_locked_out if the user is currently locked out of their second factor
   # @param [Boolean] rate_limited Whether the user has exceeded user IP rate limiting
   # @param [Boolean] valid_captcha_result Whether user passed the reCAPTCHA check or was exempt

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -447,7 +447,7 @@ module AnalyticsEvents
   # @param [Boolean] sp_request_url_present if was an SP request URL in the session
   # @param [Boolean] remember_device if the remember device cookie was present
   # @param [Boolean, nil] new_device Whether the user is authenticating from a new device. Nil if
-  # there is the attempt was unsuccessful, since it cannot be known whether it's a new device.
+  # the attempt was unsuccessful, since it cannot be known whether it's a new device.
   # Tracks authentication attempts at the email/password screen
   def email_and_password_auth(
     success:,

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -372,6 +372,7 @@ RSpec.describe Users::SessionsController, devise: true do
           expect(@analytics).to have_logged_event(
             'Email and Password Authentication',
             success: false,
+            error_details: { recaptcha_token: { blank: true } },
             user_id: user.uuid,
             user_locked_out: false,
             rate_limited: false,


### PR DESCRIPTION
## 🛠 Summary of changes

Updates sign-in analytics properties to include properties from `SignInRecaptchaForm#to_h`, notably `error_details`.

**Why?**

- So that we can attribute failure reasons when a reCAPTCHA response isn't received due to form-specific validations like [token presence](https://github.com/18F/identity-idp/blob/2ef75e5135b85b009745b1ce14e374c4ac1c91a4/app/forms/recaptcha_form.rb#L17)
- As an incremental step toward refactoring 'Email and Password Authentication' to include conventional `FormResponse` success and error details
   - For phone setup, we [merge the reCAPTCHA result](https://github.com/18F/identity-idp/blob/2ef75e5135b85b009745b1ce14e374c4ac1c91a4/app/forms/new_phone_form.rb#L133-L138) into the phone setup errors to ensure its errors are included in the corresponding "Multi-Factor Authentication Setup" event

## 📜 Testing Plan

```
rspec spec/controllers/users/sessions_controller_spec.rb
```

Verify that if reCAPTCHA form validation fails for a reason other than a failing score (e.g. absent token), you are able to observe this in analytics logging.

You can simulate this by preventing the reCAPTCHA script from loading, similar to what's being addressed in #11451. Currently, reCAPTCHA will submit immediately if the user attempts to submit the form before reCAPTCHA has loaded, which will _not_ include the expected reCAPTCHA token.

```diff
diff --git a/app/components/captcha_submit_button_component.html.erb b/app/components/captcha_submit_button_component.html.erb
index 88e7033c4a..b6a7699b10 100644
--- a/app/components/captcha_submit_button_component.html.erb
+++ b/app/components/captcha_submit_button_component.html.erb
@@ -36,5 +36,2 @@
       ).with_content(content) %>
-  <% if recaptcha_script_src.present? %>
-    <%= content_tag(:script, '', src: recaptcha_script_src, async: true) %>
-  <% end %>
 <% end %>
```

Configure reCAPTCHA for local development. You can use any credentials, they don't need to be valid.

```
# config/application.yml
development:
  sign_in_recaptcha_score_threshold: 0.3
  sign_in_recaptcha_percent_tested: 100
  recaptcha_site_key: 'test'
  recaptcha_enterprise_api_key: 'test'
  recaptcha_enterprise_project_id: 'test'
  recaptcha_mock_validator: false
```

1. In a separate terminal process, run `make watch_events`
2. In a private browsing tab, go to http://localhost:3000
3. Enter email and password
4. Click "Sign in"
5. Observe that "Email and Password Authentication" event includes `event_properties.error_details.recaptcha_token.blank = true`