### PR TITLE
Revert logging whether password matches current for password reset event

### DIFF
--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -40,7 +40,6 @@ module Users
       end
     end
 
-    # PUT /resource/password
     def update
       self.resource = user_matching_token(user_params[:reset_password_token])
       @reset_password_form = ResetPasswordForm.new(user: resource)

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -3,8 +3,6 @@
 module Users
   class ResetPasswordsController < Devise::PasswordsController
     include AuthorizationCountConcern
-    include AbTestingConcern
-
     before_action :store_sp_metadata_in_session, only: [:edit]
     before_action :store_token_in_session, only: [:edit]
 
@@ -42,15 +40,10 @@ module Users
       end
     end
 
+    # PUT /resource/password
     def update
       self.resource = user_matching_token(user_params[:reset_password_token])
-      @reset_password_form = ResetPasswordForm.new(
-        user: resource,
-        log_password_matches_existing: ab_test_bucket(
-          :LOG_PASSWORD_RESET_MATCHES_EXISTING,
-          user: resource,
-        ) == :log,
-      )
+      @reset_password_form = ResetPasswordForm.new(user: resource)
 
       result = @reset_password_form.submit(user_params)
 

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -5,14 +5,11 @@ class ResetPasswordForm
   include FormPasswordValidator
 
   attr_accessor :reset_password_token
-  private attr_reader :log_password_matches_existing
-  alias_method :log_password_matches_existing?, :log_password_matches_existing
 
   validate :valid_token
 
-  def initialize(user:, log_password_matches_existing: false)
+  def initialize(user:)
     @user = user
-    @log_password_matches_existing = log_password_matches_existing
     @reset_password_token = @user.reset_password_token
     @validate_confirmation = true
     @active_profile = user.active_profile
@@ -50,8 +47,6 @@ class ResetPasswordForm
   end
 
   def update_user
-    @password_matches_existing = user.valid_password?(password) if log_password_matches_existing?
-
     attributes = { password: password }
 
     ActiveRecord::Base.transaction do
@@ -92,7 +87,6 @@ class ResetPasswordForm
     {
       user_id: user.uuid,
       profile_deactivated: active_profile.present?,
-      password_matches_existing: @password_matches_existing,
       pending_profile_invalidated: pending_profile.present?,
       pending_profile_pending_reasons: (pending_profile&.pending_reasons || [])&.join(','),
     }

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5797,7 +5797,6 @@ module AnalyticsEvents
   # @param [String] pending_profile_pending_reasons Comma-separated list of the pending states
   # associated with the associated profile.
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  # @param [Boolean] password_matches_existing Whether the password is same as the user's current
   # The user changed the password for their account via the password reset flow
   def password_reset_password(
     success:,
@@ -5805,7 +5804,6 @@ module AnalyticsEvents
     profile_deactivated:,
     pending_profile_invalidated:,
     pending_profile_pending_reasons:,
-    password_matches_existing:,
     error_details: {},
     **extra
   )
@@ -5817,7 +5815,6 @@ module AnalyticsEvents
       profile_deactivated:,
       pending_profile_invalidated:,
       pending_profile_pending_reasons:,
-      password_matches_existing:,
       **extra,
     )
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -228,7 +228,6 @@ lexisnexis_trueid_username: test_username
 lexisnexis_username: test_username
 ###################################################################
 lockout_period_in_minutes: 10
-log_password_reset_matches_existing_ab_test_percent: 0
 log_to_stdout: false
 login_otp_confirmation_max_attempts: 10
 logins_per_email_and_ip_bantime: 60

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -82,12 +82,6 @@ module AbTests
     end
   end.freeze
 
-  LOG_PASSWORD_RESET_MATCHES_EXISTING = AbTest.new(
-    experiment_name: 'Log password_matches_existing event property on password reset',
-    should_log: ['Password Reset: Password Submitted'].to_set,
-    buckets: { log: IdentityConfig.store.log_password_reset_matches_existing_ab_test_percent },
-  ).freeze
-
   RECOMMEND_WEBAUTHN_PLATFORM_FOR_SMS_USER = AbTest.new(
     experiment_name: 'Recommend Face or Touch Unlock for SMS users',
     should_log: [

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -242,7 +242,6 @@ module IdentityConfig
     config.add(:lexisnexis_trueid_username, type: :string)
     config.add(:lexisnexis_username, type: :string)
     config.add(:lockout_period_in_minutes, type: :integer)
-    config.add(:log_password_reset_matches_existing_ab_test_percent, type: :integer)
     config.add(:log_to_stdout, type: :boolean)
     config.add(:login_otp_confirmation_max_attempts, type: :integer)
     config.add(:logins_per_email_and_ip_bantime, type: :integer)

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe ResetPasswordForm, type: :model do
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
-          password_matches_existing: nil,
         )
       end
     end
@@ -63,7 +62,6 @@ RSpec.describe ResetPasswordForm, type: :model do
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
-          password_matches_existing: nil,
         )
       end
     end
@@ -83,7 +81,6 @@ RSpec.describe ResetPasswordForm, type: :model do
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
-          password_matches_existing: false,
         )
       end
     end
@@ -116,7 +113,6 @@ RSpec.describe ResetPasswordForm, type: :model do
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
-          password_matches_existing: nil,
         )
       end
     end
@@ -133,7 +129,6 @@ RSpec.describe ResetPasswordForm, type: :model do
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
-          password_matches_existing: nil,
         )
       end
     end

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ResetPasswordForm, type: :model do
-  let(:user) { create(:user, uuid: '123') }
-  let(:log_password_matches_existing) { false }
-  subject(:form) { ResetPasswordForm.new(user:, log_password_matches_existing:) }
+  subject { ResetPasswordForm.new(user: build_stubbed(:user, uuid: '123')) }
 
   let(:password) { 'a good and powerful password' }
   let(:password_confirmation) { password }
@@ -17,168 +15,202 @@ RSpec.describe ResetPasswordForm, type: :model do
   it_behaves_like 'password validation'
 
   describe '#submit' do
-    subject(:result) { form.submit(params) }
-
     context 'when the password is valid but the token has expired' do
-      before do
-        allow(user).to receive(:reset_password_period_valid?).and_return(false)
-      end
-
       it 'returns a hash with errors' do
-        expect(result.to_h).to eq(
+        user = build_stubbed(:user, uuid: '123')
+        allow(user).to receive(:reset_password_period_valid?).and_return(false)
+
+        form = ResetPasswordForm.new(user: user)
+
+        password = 'valid password'
+
+        errors = { reset_password_token: ['token_expired'] }
+
+        extra = { user_id: '123', profile_deactivated: false }
+
+        expect(
+          form.submit(
+            password: password,
+            password_confirmation: password,
+          ).to_h,
+        ).to include(
           success: false,
-          errors: { reset_password_token: ['token_expired'] },
-          error_details: { reset_password_token: { token_expired: true } },
-          user_id: '123',
-          profile_deactivated: false,
-          pending_profile_invalidated: false,
-          pending_profile_pending_reasons: '',
-          password_matches_existing: nil,
+          errors: errors,
+          error_details: hash_including(*errors.keys),
+          **extra,
         )
       end
     end
 
     context 'when the password is invalid and token is valid' do
-      let(:password) { 'invalid' }
-
-      before do
-        allow(user).to receive(:reset_password_period_valid?).and_return(true)
-      end
-
       it 'returns a hash with errors' do
-        expect(result.to_h).to eq(
+        user = build_stubbed(:user, uuid: '123')
+        allow(user).to receive(:reset_password_period_valid?).and_return(true)
+
+        form = ResetPasswordForm.new(user: user)
+
+        password = 'invalid'
+
+        errors = {
+          password:
+            ["Password must be at least #{Devise.password_length.first} characters long"],
+          password_confirmation: [I18n.t(
+            'errors.messages.too_short',
+            count: Devise.password_length.first,
+          )],
+        }
+
+        extra = { user_id: '123', profile_deactivated: false }
+
+        expect(
+          form.submit(
+            password: password,
+            password_confirmation: password,
+          ).to_h,
+        ).to include(
           success: false,
-          errors: {
-            password:
-              ["Password must be at least #{Devise.password_length.first} characters long"],
-            password_confirmation: [I18n.t(
-              'errors.messages.too_short',
-              count: Devise.password_length.first,
-            )],
-          },
-          error_details: {
-            password: { too_short: true },
-            password_confirmation: { too_short: true },
-          },
-          user_id: '123',
-          profile_deactivated: false,
-          pending_profile_invalidated: false,
-          pending_profile_pending_reasons: '',
-          password_matches_existing: nil,
+          errors: errors,
+          error_details: hash_including(*errors.keys),
+          **extra,
         )
       end
     end
 
     context 'when both the password and token are valid' do
-      before do
-        allow(user).to receive(:reset_password_period_valid?).and_return(true)
-      end
-
       it 'sets the user password to the submitted password' do
-        expect { result }.to change { user.reload.encrypted_password_digest }
+        user = create(:user, uuid: '123')
+        allow(user).to receive(:reset_password_period_valid?).and_return(true)
 
-        expect(result.to_h).to eq(
+        form = ResetPasswordForm.new(user: user)
+        password = 'valid password'
+
+        result = nil
+        expect do
+          result = form.submit(
+            password: password,
+            password_confirmation: password,
+          ).to_h
+        end.to(change { user.reload.encrypted_password_digest })
+
+        expect(result).to eq(
           success: true,
           errors: {},
           user_id: '123',
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
-          password_matches_existing: nil,
         )
       end
     end
 
     context 'when both the password and token are invalid' do
-      let(:password) { 'short' }
-
-      before do
-        allow(user).to receive(:reset_password_period_valid?).and_return(false)
-      end
-
       it 'returns a hash with errors' do
-        expect(result.to_h).to eq(
+        user = build_stubbed(:user, uuid: '123')
+        allow(user).to receive(:reset_password_period_valid?).and_return(false)
+
+        form = ResetPasswordForm.new(user: user)
+
+        password = 'short'
+
+        errors = {
+          password: [
+            t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
+          ],
+          password_confirmation: [I18n.t(
+            'errors.messages.too_short',
+            count: Devise.password_length.first,
+          )],
+          reset_password_token: ['token_expired'],
+        }
+
+        extra = { user_id: '123', profile_deactivated: false }
+
+        expect(
+          form.submit(
+            password: password,
+            password_confirmation: password,
+          ).to_h,
+        ).to include(
           success: false,
-          errors: {
-            password: [
-              t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
-            ],
-            password_confirmation: [
-              t('errors.messages.too_short', count: Devise.password_length.first),
-            ],
-            reset_password_token: ['token_expired'],
-          },
-          error_details: {
-            password: { too_short: true },
-            password_confirmation: { too_short: true },
-            reset_password_token: { token_expired: true },
-          },
-          user_id: '123',
-          profile_deactivated: false,
-          pending_profile_invalidated: false,
-          pending_profile_pending_reasons: '',
-          password_matches_existing: nil,
+          errors: errors,
+          error_details: hash_including(*errors.keys),
+          **extra,
         )
       end
     end
 
     context 'when the user does not exist in the db' do
-      let(:user) { User.new }
-
       it 'returns a hash with errors' do
-        expect(result.to_h).to eq(
+        user = User.new
+
+        form = ResetPasswordForm.new(user: user)
+        errors = {
+          password: [
+            t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
+          ],
+          password_confirmation: [I18n.t(
+            'errors.messages.too_short',
+            count: Devise.password_length.first,
+          )],
+          reset_password_token: ['invalid_token'],
+        }
+
+        extra = { user_id: nil, profile_deactivated: false }
+        password = 'short'
+
+        expect(
+          form.submit(
+            password: password,
+            password_confirmation: password,
+          ).to_h,
+        ).to include(
           success: false,
-          errors: { reset_password_token: ['invalid_token'] },
-          error_details: { reset_password_token: { invalid_token: true } },
-          user_id: nil,
-          profile_deactivated: false,
-          pending_profile_invalidated: false,
-          pending_profile_pending_reasons: '',
-          password_matches_existing: nil,
+          errors: errors,
+          error_details: hash_including(*errors.keys),
+          **extra,
         )
       end
     end
 
     context 'when the user has an active profile' do
-      let(:user) { create(:user, :proofed, reset_password_sent_at: Time.zone.now) }
-
       it 'deactivates the profile' do
+        profile = create(:profile, :active, :verified)
+        user = profile.user
+        user.update(reset_password_sent_at: Time.zone.now)
+
+        form = ResetPasswordForm.new(user: user)
+
+        result = form.submit(params)
+
         expect(result.success?).to eq(true)
         expect(result.extra[:profile_deactivated]).to eq(true)
-        expect(user.profiles.any?(&:active?)).to eq(false)
-      end
-
-      context 'when the password is same as current' do
-        let(:password) { user.password }
-
-        it 'does not include extra detail for password matching existing' do
-          expect(result.extra[:password_matches_existing]).to eq(nil)
-        end
-
-        context 'when initialized to log password_matches_existing' do
-          let(:log_password_matches_existing) { true }
-
-          it 'includes extra detail for password matching existing' do
-            expect(result.extra[:password_matches_existing]).to eq(true)
-          end
-        end
+        expect(profile.reload.active?).to eq(false)
       end
     end
 
     context 'when the user does not have an active profile' do
-      let(:user) { create(:user, reset_password_sent_at: Time.zone.now) }
-
       it 'includes that the profile was not deactivated in the form response' do
+        user = create(:user)
+        user.update(reset_password_sent_at: Time.zone.now)
+
+        form = ResetPasswordForm.new(user: user)
+
+        result = form.submit(params)
+
         expect(result.success?).to eq(true)
         expect(result.extra[:profile_deactivated]).to eq(false)
       end
     end
 
     context 'when the user has a pending profile' do
-      let(:profile) { create(:profile, :verify_by_mail_pending, :in_person_verification_pending) }
-      let(:user) { create(:user, reset_password_sent_at: Time.zone.now, profiles: [profile]) }
-
       it 'includes that the profile was not deactivated in the form response' do
+        profile = create(:profile, :verify_by_mail_pending, :in_person_verification_pending)
+        user = profile.user
+        user.update(reset_password_sent_at: Time.zone.now)
+
+        form = ResetPasswordForm.new(user: user)
+        result = form.submit(params)
+
         expect(result.success?).to eq(true)
         expect(result.extra[:pending_profile_invalidated]).to eq(true)
         expect(result.extra[:pending_profile_pending_reasons]).to eq(
@@ -188,9 +220,14 @@ RSpec.describe ResetPasswordForm, type: :model do
     end
 
     context 'when the user does not have a pending profile' do
-      let(:user) { create(:user, reset_password_sent_at: Time.zone.now) }
-
       it 'includes that the profile was not deactivated in the form response' do
+        user = create(:user)
+        user.update(reset_password_sent_at: Time.zone.now)
+
+        form = ResetPasswordForm.new(user: user)
+
+        result = form.submit(params)
+
         expect(result.success?).to eq(true)
         expect(result.extra[:pending_profile_invalidated]).to eq(false)
         expect(result.extra[:pending_profile_pending_reasons]).to eq('')
@@ -198,16 +235,19 @@ RSpec.describe ResetPasswordForm, type: :model do
     end
 
     context 'when the unconfirmed email address has been confirmed by another account' do
-      let(:user) { create(:user, :unconfirmed, reset_password_sent_at: Time.zone.now) }
-
-      before do
-        create(
-          :user,
-          email_addresses: [create(:email_address, email: user.email_addresses.first.email)],
-        )
-      end
-
       it 'does not raise an error and is not successful' do
+        user = create(:user, :unconfirmed)
+        user.update(reset_password_sent_at: Time.zone.now)
+        user2 = create(:user)
+        create(
+          :email_address, email: user.email_addresses.first.email, user_id: user2.id,
+                          confirmed_at: Time.zone.now
+        )
+
+        form = ResetPasswordForm.new(user: user)
+
+        result = form.submit(params)
+
         expect(result.success?).to eq(false)
         expect(result.errors).to eq({ reset_password_token: ['token_expired'] })
       end

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ResetPasswordForm, type: :model do
-  subject { ResetPasswordForm.new(user: build_stubbed(:user, uuid: '123')) }
+  let(:user) { create(:user, uuid: '123') }
+  subject(:form) { ResetPasswordForm.new(user:) }
 
   let(:password) { 'a good and powerful password' }
   let(:password_confirmation) { password }
@@ -15,202 +16,152 @@ RSpec.describe ResetPasswordForm, type: :model do
   it_behaves_like 'password validation'
 
   describe '#submit' do
+    subject(:result) { form.submit(params) }
+
     context 'when the password is valid but the token has expired' do
-      it 'returns a hash with errors' do
-        user = build_stubbed(:user, uuid: '123')
+      before do
         allow(user).to receive(:reset_password_period_valid?).and_return(false)
+      end
 
-        form = ResetPasswordForm.new(user: user)
-
-        password = 'valid password'
-
-        errors = { reset_password_token: ['token_expired'] }
-
-        extra = { user_id: '123', profile_deactivated: false }
-
-        expect(
-          form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h,
-        ).to include(
+      it 'returns a hash with errors' do
+        expect(result.to_h).to eq(
           success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
+          errors: { reset_password_token: ['token_expired'] },
+          error_details: { reset_password_token: { token_expired: true } },
+          user_id: '123',
+          profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
+          password_matches_existing: nil,
         )
       end
     end
 
     context 'when the password is invalid and token is valid' do
-      it 'returns a hash with errors' do
-        user = build_stubbed(:user, uuid: '123')
+      let(:password) { 'invalid' }
+
+      before do
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
+      end
 
-        form = ResetPasswordForm.new(user: user)
-
-        password = 'invalid'
-
-        errors = {
-          password:
-            ["Password must be at least #{Devise.password_length.first} characters long"],
-          password_confirmation: [I18n.t(
-            'errors.messages.too_short',
-            count: Devise.password_length.first,
-          )],
-        }
-
-        extra = { user_id: '123', profile_deactivated: false }
-
-        expect(
-          form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h,
-        ).to include(
+      it 'returns a hash with errors' do
+        expect(result.to_h).to eq(
           success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
+          errors: {
+            password:
+              ["Password must be at least #{Devise.password_length.first} characters long"],
+            password_confirmation: [I18n.t(
+              'errors.messages.too_short',
+              count: Devise.password_length.first,
+            )],
+          },
+          error_details: {
+            password: { too_short: true },
+            password_confirmation: { too_short: true },
+          },
+          user_id: '123',
+          profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
+          password_matches_existing: nil,
         )
       end
     end
 
     context 'when both the password and token are valid' do
-      it 'sets the user password to the submitted password' do
-        user = create(:user, uuid: '123')
+      before do
         allow(user).to receive(:reset_password_period_valid?).and_return(true)
+      end
 
-        form = ResetPasswordForm.new(user: user)
-        password = 'valid password'
+      it 'sets the user password to the submitted password' do
+        expect { result }.to change { user.reload.encrypted_password_digest }
 
-        result = nil
-        expect do
-          result = form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h
-        end.to(change { user.reload.encrypted_password_digest })
-
-        expect(result).to eq(
+        expect(result.to_h).to eq(
           success: true,
           errors: {},
           user_id: '123',
           profile_deactivated: false,
           pending_profile_invalidated: false,
           pending_profile_pending_reasons: '',
+          password_matches_existing: false,
         )
       end
     end
 
     context 'when both the password and token are invalid' do
-      it 'returns a hash with errors' do
-        user = build_stubbed(:user, uuid: '123')
+      let(:password) { 'short' }
+
+      before do
         allow(user).to receive(:reset_password_period_valid?).and_return(false)
+      end
 
-        form = ResetPasswordForm.new(user: user)
-
-        password = 'short'
-
-        errors = {
-          password: [
-            t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
-          ],
-          password_confirmation: [I18n.t(
-            'errors.messages.too_short',
-            count: Devise.password_length.first,
-          )],
-          reset_password_token: ['token_expired'],
-        }
-
-        extra = { user_id: '123', profile_deactivated: false }
-
-        expect(
-          form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h,
-        ).to include(
+      it 'returns a hash with errors' do
+        expect(result.to_h).to eq(
           success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
+          errors: {
+            password: [
+              t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
+            ],
+            password_confirmation: [
+              t('errors.messages.too_short', count: Devise.password_length.first),
+            ],
+            reset_password_token: ['token_expired'],
+          },
+          error_details: {
+            password: { too_short: true },
+            password_confirmation: { too_short: true },
+            reset_password_token: { token_expired: true },
+          },
+          user_id: '123',
+          profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
+          password_matches_existing: nil,
         )
       end
     end
 
     context 'when the user does not exist in the db' do
+      let(:user) { User.new }
+
       it 'returns a hash with errors' do
-        user = User.new
-
-        form = ResetPasswordForm.new(user: user)
-        errors = {
-          password: [
-            t('errors.attributes.password.too_short.other', count: Devise.password_length.first),
-          ],
-          password_confirmation: [I18n.t(
-            'errors.messages.too_short',
-            count: Devise.password_length.first,
-          )],
-          reset_password_token: ['invalid_token'],
-        }
-
-        extra = { user_id: nil, profile_deactivated: false }
-        password = 'short'
-
-        expect(
-          form.submit(
-            password: password,
-            password_confirmation: password,
-          ).to_h,
-        ).to include(
+        expect(result.to_h).to eq(
           success: false,
-          errors: errors,
-          error_details: hash_including(*errors.keys),
-          **extra,
+          errors: { reset_password_token: ['invalid_token'] },
+          error_details: { reset_password_token: { invalid_token: true } },
+          user_id: nil,
+          profile_deactivated: false,
+          pending_profile_invalidated: false,
+          pending_profile_pending_reasons: '',
+          password_matches_existing: nil,
         )
       end
     end
 
     context 'when the user has an active profile' do
+      let(:user) { create(:user, :proofed, reset_password_sent_at: Time.zone.now) }
+
       it 'deactivates the profile' do
-        profile = create(:profile, :active, :verified)
-        user = profile.user
-        user.update(reset_password_sent_at: Time.zone.now)
-
-        form = ResetPasswordForm.new(user: user)
-
-        result = form.submit(params)
-
         expect(result.success?).to eq(true)
         expect(result.extra[:profile_deactivated]).to eq(true)
-        expect(profile.reload.active?).to eq(false)
+        expect(user.profiles.any?(&:active?)).to eq(false)
       end
     end
 
     context 'when the user does not have an active profile' do
+      let(:user) { create(:user, reset_password_sent_at: Time.zone.now) }
+
       it 'includes that the profile was not deactivated in the form response' do
-        user = create(:user)
-        user.update(reset_password_sent_at: Time.zone.now)
-
-        form = ResetPasswordForm.new(user: user)
-
-        result = form.submit(params)
-
         expect(result.success?).to eq(true)
         expect(result.extra[:profile_deactivated]).to eq(false)
       end
     end
 
     context 'when the user has a pending profile' do
+      let(:profile) { create(:profile, :verify_by_mail_pending, :in_person_verification_pending) }
+      let(:user) { create(:user, reset_password_sent_at: Time.zone.now, profiles: [profile]) }
+
       it 'includes that the profile was not deactivated in the form response' do
-        profile = create(:profile, :verify_by_mail_pending, :in_person_verification_pending)
-        user = profile.user
-        user.update(reset_password_sent_at: Time.zone.now)
-
-        form = ResetPasswordForm.new(user: user)
-        result = form.submit(params)
-
         expect(result.success?).to eq(true)
         expect(result.extra[:pending_profile_invalidated]).to eq(true)
         expect(result.extra[:pending_profile_pending_reasons]).to eq(
@@ -220,14 +171,9 @@ RSpec.describe ResetPasswordForm, type: :model do
     end
 
     context 'when the user does not have a pending profile' do
+      let(:user) { create(:user, reset_password_sent_at: Time.zone.now) }
+
       it 'includes that the profile was not deactivated in the form response' do
-        user = create(:user)
-        user.update(reset_password_sent_at: Time.zone.now)
-
-        form = ResetPasswordForm.new(user: user)
-
-        result = form.submit(params)
-
         expect(result.success?).to eq(true)
         expect(result.extra[:pending_profile_invalidated]).to eq(false)
         expect(result.extra[:pending_profile_pending_reasons]).to eq('')
@@ -235,19 +181,16 @@ RSpec.describe ResetPasswordForm, type: :model do
     end
 
     context 'when the unconfirmed email address has been confirmed by another account' do
-      it 'does not raise an error and is not successful' do
-        user = create(:user, :unconfirmed)
-        user.update(reset_password_sent_at: Time.zone.now)
-        user2 = create(:user)
+      let(:user) { create(:user, :unconfirmed, reset_password_sent_at: Time.zone.now) }
+
+      before do
         create(
-          :email_address, email: user.email_addresses.first.email, user_id: user2.id,
-                          confirmed_at: Time.zone.now
+          :user,
+          email_addresses: [create(:email_address, email: user.email_addresses.first.email)],
         )
+      end
 
-        form = ResetPasswordForm.new(user: user)
-
-        result = form.submit(params)
-
+      it 'does not raise an error and is not successful' do
         expect(result.success?).to eq(false)
         expect(result.errors).to eq({ reset_password_token: ['token_expired'] })
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Effectively reverts #11423.

This pull request is created preemptively under the assumption that the test will only run for a short amount of time to collect enough data to build a case, not because there are any specific problems with the code itself.

This keeps refactoring improvements in #11423. The specific process for reverting was:

1. `git revert a419d8c` (a419d8c)
2. `git cherry-pick ba76ff4` (ba76ff4)
3. `git cherry-pick 23e93e1` (23e93e1)
4. Commit to remove assumptions for `password_matches_existing` extra property from `ResetPasswordForm` spec (683b7d9de7c25564d8286a4ad5aaa994816f87b5)

(This is reflected in branch commit history)

## 📜 Testing Plan

Repeat testing plan from #11423, verifying that there is no `password_matches_existing` in the password reset event payload.