### PR TITLE
LG-14464: Show warning CTA on ThreatMetrix API exception

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -86,6 +86,13 @@ module Idv
         :state_id,
         :mva_exception,
       )
+      is_threatmetrix_exception = result.extra.dig(
+        :proofing_results,
+        :context,
+        :stages,
+        :threatmetrix,
+        :exception,
+      ).present?
 
       if ssn_rate_limiter.limited?
         idv_failure_log_rate_limited(:proof_ssn)
@@ -96,6 +103,9 @@ module Idv
       elsif proofing_results_exception.present? && is_mva_exception
         idv_failure_log_warning
         redirect_to state_id_warning_url
+      elsif proofing_results_exception.present? && is_threatmetrix_exception
+        idv_failure_log_warning
+        redirect_to warning_url
       elsif proofing_results_exception.present?
         idv_failure_log_error
         redirect_to exception_url

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -79,13 +79,14 @@ module Idv
 
     def idv_failure(result)
       proofing_results_exception = result.extra.dig(:proofing_results, :exception)
+      has_exception = proofing_results_exception.present?
       is_mva_exception = result.extra.dig(
         :proofing_results,
         :context,
         :stages,
         :state_id,
         :mva_exception,
-      )
+      ).present?
       is_threatmetrix_exception = result.extra.dig(
         :proofing_results,
         :context,
@@ -93,6 +94,13 @@ module Idv
         :threatmetrix,
         :exception,
       ).present?
+      resolution_failed = !result.extra.dig(
+        :proofing_results,
+        :context,
+        :stages,
+        :resolution,
+        :success,
+      )
 
       if ssn_rate_limiter.limited?
         idv_failure_log_rate_limited(:proof_ssn)
@@ -100,13 +108,14 @@ module Idv
       elsif resolution_rate_limiter.limited?
         idv_failure_log_rate_limited(:idv_resolution)
         redirect_to rate_limited_url
-      elsif proofing_results_exception.present? && is_mva_exception
+      elsif has_exception && is_mva_exception
         idv_failure_log_warning
         redirect_to state_id_warning_url
-      elsif proofing_results_exception.present? && is_threatmetrix_exception
+      elsif (has_exception && is_threatmetrix_exception) ||
+            (!has_exception && resolution_failed)
         idv_failure_log_warning
         redirect_to warning_url
-      elsif proofing_results_exception.present?
+      elsif has_exception
         idv_failure_log_error
         redirect_to exception_url
       else

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -492,6 +492,65 @@ RSpec.describe Idv::VerifyInfoController do
       end
     end
 
+    context 'when the resolution proofing job fails and there is no exception' do
+      before do
+        allow(controller).to receive(:load_async_state).and_return(async_state)
+      end
+
+      let(:document_capture_session) do
+        DocumentCaptureSession.create(user:)
+      end
+
+      let(:async_state) do
+        # Here we're trying to match the store to redis -> read from redis flow this data travels
+        adjudicated_result = Proofing::Resolution::ResultAdjudicator.new(
+          state_id_result: Proofing::StateIdResult.new(
+            success: true,
+            errors: {},
+            exception: nil,
+            vendor_name: :aamva,
+            transaction_id: 'abc123',
+            verified_attributes: [],
+          ),
+          device_profiling_result: Proofing::DdpResult.new(success: true),
+          ipp_enrollment_in_progress: true,
+          residential_resolution_result: Proofing::Resolution::Result.new(success: true),
+          resolution_result: Proofing::Resolution::Result.new(
+            success: false,
+            errors: {
+              base: [
+                "Verification failed with code: 'priority.scoring.model.verification.fail'",
+              ],
+            },
+          ),
+          same_address_as_id: true,
+          should_proof_state_id: true,
+          applicant_pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN,
+        ).adjudicated_result.to_h
+
+        document_capture_session.create_proofing_session
+
+        document_capture_session.store_proofing_result(adjudicated_result)
+
+        document_capture_session.load_proofing_result
+      end
+
+      it 'renders the warning page' do
+        get :show
+        expect(response).to redirect_to(idv_session_errors_warning_url)
+      end
+
+      it 'logs an event' do
+        get :show
+
+        expect(@analytics).to have_logged_event(
+          'IdV: doc auth warning visited',
+          step_name: 'verify_info',
+          remaining_submit_attempts: kind_of(Numeric),
+        )
+      end
+    end
+
     context 'when the resolution proofing job has not completed' do
       let(:async_state) do
         ProofingSessionAsyncResult.new(status: ProofingSessionAsyncResult::IN_PROGRESS)

--- a/spec/features/idv/threat_metrix_pending_spec.rb
+++ b/spec/features/idv/threat_metrix_pending_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature 'Users pending ThreatMetrix review', :js do
     end
   end
 
-  scenario 'users pending ThreatMetrix No Result, it results in an error', :js do
+  scenario 'users pending ThreatMetrix No Result, it results in an error but shows warning', :js do
     freeze_time do
       user = create(:user, :fully_registered)
       visit_idp_from_ial1_oidc_sp(
@@ -117,8 +117,8 @@ RSpec.feature 'Users pending ThreatMetrix review', :js do
       complete_ssn_step
       complete_verify_step
 
-      expect(page).to have_content(t('idv.failure.sessions.exception'))
-      expect(page).to have_current_path(idv_session_errors_exception_path)
+      expect(page).to have_content(t('idv.failure.sessions.warning'))
+      expect(page).to have_current_path(idv_session_errors_warning_path)
     end
   end
 


### PR DESCRIPTION
**Why**

* The "internal error" view displayed during IdV is a last resort view. Prior to this change, this view was also shown when we received a ThreatMetrix API response that included an exception message.

* Showing the internal error view for an unknown exception raised by the ThreatMetrix API is not useful for the subject undergoing proofing and it obfuscates the action that can be taken by either the proofing subject or the support agent investigating the identity resolution errors.

**How**

* Added a logic branch to the routing handling of `Idv::VerifyInfoConcern#idv_failure` that still preferences the known actionable error cases (i.e., ssn_failure, rate_limiter, etc.), which is eventually called by both `Idv::VerifyInfoController` and `Idv::InPerson::VerifyInfoController`
    1. The first new case handles the ThreatMetrix API exception
    2. The second new case handles when there is no exception, but the resolution check (e.g., InstantVerify) didn't pass.

* Updated the Idv::VerifyInfoController spec to examine the expected routing and the expected shape of the ThreatMetrix API exception response. As the exception message is an arbitrary unstructured String, we do not test for specific values and instead ensure that the *shape* of the response in our analytics meets a minimum conformance in structure and value types.


**Notes**

* This is a difficult to replicate error as it relies on blackbox behavior exhibited by our vendor APIs.

changelog: Internal, IdV resolution, Error routing for vendor API exceptions


## 🎫 Ticket

Link to the relevant ticket:
[LG-14464](https://cm-jira.usa.gov/browse/LG-14464)