### PR TITLE
LG-14425: update s3 bucket name

### DIFF
--- a/app/jobs/data_warehouse/daily_sensitive_column_job.rb
+++ b/app/jobs/data_warehouse/daily_sensitive_column_job.rb
@@ -42,7 +42,7 @@ module DataWarehouse
     end
 
     def bucket_name
-      bucket_name = IdentityConfig.store.s3_idp_internal_dw_tasks
+      bucket_name = IdentityConfig.store.s3_idp_dw_tasks
       env = Identity::Hostdata.env
       aws_account_id = Identity::Hostdata.aws_account_id
       aws_region = Identity::Hostdata.aws_region

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -344,7 +344,7 @@ ruby_workers_idv_enabled: true
 rules_of_use_horizon_years: 5
 rules_of_use_updated_at: '2022-01-19T00:00:00Z' # Production has a newer timestamp than this, update directly in S3
 s3_data_warehouse_bucket_prefix: 'login-gov-analytics-export'
-s3_idp_internal_dw_tasks: 'login-gov-idp-internal-dw-tasks'
+s3_idp_dw_tasks: 'login-gov-idp-dw-tasks'
 s3_public_reports_enabled: false
 s3_report_bucket_prefix: login-gov.reports
 s3_report_public_bucket_prefix: login-gov-pubdata

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -373,7 +373,7 @@ module IdentityConfig
     config.add(:s3_report_bucket_prefix, type: :string)
     config.add(:s3_report_public_bucket_prefix, type: :string)
     config.add(:s3_data_warehouse_bucket_prefix, type: :string)
-    config.add(:s3_idp_internal_dw_tasks, type: :string)
+    config.add(:s3_idp_dw_tasks, type: :string)
     config.add(:s3_reports_enabled, type: :boolean)
     config.add(:saml_endpoint_configs, type: :json, options: { symbolize_names: true })
     config.add(:saml_secret_rotation_enabled, type: :boolean)

--- a/spec/jobs/data_warehouse/daily_sensitive_column_report_spec.rb
+++ b/spec/jobs/data_warehouse/daily_sensitive_column_report_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe DataWarehouse::DailySensitiveColumnJob do
 
   let(:timestamp) { Date.new(2024, 10, 15).in_time_zone('UTC') }
   let(:job) { described_class.new }
-  let(:expected_bucket) { 'login-gov-ipd-internal-dw-tasks-test-1234-us-west-2' }
+  let(:expected_bucket) { 'login-gov-ipd-dw-tasks-test-1234-us-west-2' }
   let(:tables) { ['auth_app_configurations'] }
-  let(:s3_idp_internal_dw_tasks) { 'login-gov-idp-internal-dw-tasks' }
+  let(:s3_idp_dw_tasks) { 'login-gov-idp-dw-tasks' }
 
   let(:expected_json) do
     {
@@ -58,7 +58,7 @@ RSpec.describe DataWarehouse::DailySensitiveColumnJob do
     {
       body: anything,
       content_type: 'application/json',
-      bucket: 'login-gov-idp-internal-dw-tasks-int-1234-us-west-1',
+      bucket: 'login-gov-idp-dw-tasks-int-1234-us-west-1',
     }
   end
 
@@ -66,8 +66,8 @@ RSpec.describe DataWarehouse::DailySensitiveColumnJob do
     allow(Identity::Hostdata).to receive(:env).and_return('int')
     allow(Identity::Hostdata).to receive(:aws_account_id).and_return('1234')
     allow(Identity::Hostdata).to receive(:aws_region).and_return('us-west-1')
-    allow(IdentityConfig.store).to receive(:s3_idp_internal_dw_tasks).
-      and_return(s3_idp_internal_dw_tasks)
+    allow(IdentityConfig.store).to receive(:s3_idp_dw_tasks).
+      and_return(s3_idp_dw_tasks)
 
     Aws.config[:s3] = {
       stub_responses: {


### PR DESCRIPTION
changelog: Internal, Reporting, Update S3 config


## 🎫 Ticket

Link to the relevant ticket:
[LG-14425](https://cm-jira.usa.gov/browse/LG-14425)

## 🛠 Summary of changes

We discovered the bucket name would need to be shortened to prevent the bucket_name_length error in environments with long last names.

