### PR TITLE
LG-14810 Users only see "Use your phone to take photos" for Socure

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -123,12 +123,12 @@ module Idv
     end
 
     def upload_disabled?
-      (doc_auth_vendor == Idp::Constants::Vendors::SOCURE || idv_session.selfie_check_required) && !desktop_test_mode_enabled?
+      (doc_auth_vendor == Idp::Constants::Vendors::SOCURE || idv_session.selfie_check_required) &&
+        !desktop_test_mode_enabled?
     end
 
     def desktop_test_mode_enabled?
       idv_session.desktop_selfie_test_mode_enabled? || idv_session.desktop_socure_test_mode_enabled?
-
     end
 
     def build_telephony_form_response(telephony_result)

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -124,11 +124,7 @@ module Idv
 
     def upload_disabled?
       (doc_auth_vendor == Idp::Constants::Vendors::SOCURE || idv_session.selfie_check_required) &&
-        !desktop_test_mode_enabled?
-    end
-
-    def desktop_test_mode_enabled?
-      idv_session.desktop_selfie_test_mode_enabled? || idv_session.desktop_socure_test_mode_enabled?
+        !idv_session.desktop_selfie_test_mode_enabled?
     end
 
     def build_telephony_form_response(telephony_result)

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -13,7 +13,7 @@ module Idv
 
     def show
       @upload_disabled = idv_session.selfie_check_required &&
-                         !idv_session.desktop_selfie_test_mode_enabled?
+                         !desktop_test_mode_enabled?
 
       @direct_ipp_with_selfie_enabled = IdentityConfig.store.in_person_doc_auth_button_enabled &&
                                         Idv::InPersonConfig.enabled_for_issuer?(
@@ -74,6 +74,8 @@ module Idv
       )
     end
 
+    private
+
     def handle_phone_submission
       return rate_limited_failure if rate_limiter.limited?
       rate_limiter.increment!
@@ -118,6 +120,10 @@ module Idv
 
     def sp_or_app_name
       current_sp&.friendly_name.presence || APP_NAME
+    end
+
+    def desktop_test_mode_enabled?
+      idv_session.desktop_selfie_test_mode_enabled? || idv_session.desktop_socure_test_mode_enabled?
     end
 
     def build_telephony_form_response(telephony_result)

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -123,15 +123,12 @@ module Idv
     end
 
     def upload_disabled?
-      if doc_auth_vendor == Idp::Constants::Vendors::SOCURE
-        return true unless desktop_test_mode_enabled?
-      end
-
-      idv_session.selfie_check_required && !desktop_test_mode_enabled?
+      (doc_auth_vendor == Idp::Constants::Vendors::SOCURE || idv_session.selfie_check_required) && !desktop_test_mode_enabled?
     end
 
     def desktop_test_mode_enabled?
       idv_session.desktop_selfie_test_mode_enabled? || idv_session.desktop_socure_test_mode_enabled?
+
     end
 
     def build_telephony_form_response(telephony_result)

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -299,10 +299,6 @@ module Idv
       IdentityConfig.store.doc_auth_selfie_desktop_test_mode
     end
 
-    def desktop_socure_test_mode_enabled?
-      IdentityConfig.store.socure_standard_capture_desktop_enabled
-    end
-
     def idv_consent_given?
       !!session[:idv_consent_given_at]
     end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -299,6 +299,10 @@ module Idv
       IdentityConfig.store.doc_auth_selfie_desktop_test_mode
     end
 
+    def desktop_socure_test_mode_enabled?
+      IdentityConfig.store.socure_standard_capture_desktop_enabled
+    end
+
     def idv_consent_given?
       !!session[:idv_consent_given_at]
     end

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -334,7 +334,8 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
       allow(IdentityConfig.store).to receive(:socure_enabled).and_return(socure_enabled)
       allow(IdentityConfig.store).to receive(:doc_auth_vendor).and_return(doc_auth_vendor)
       allow(IdentityConfig.store).to receive(:doc_auth_vendor_default).and_return(doc_auth_vendor)
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).and_return(desktop_test_mode_enabled)
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
+        and_return(desktop_test_mode_enabled)
       allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(
         in_person_proofing_enabled,
       )

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -335,7 +335,8 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
       allow(IdentityConfig.store).to receive(:doc_auth_vendor).and_return(doc_auth_vendor)
       allow(IdentityConfig.store).to receive(:doc_auth_vendor_default).and_return(doc_auth_vendor)
       allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).and_return(false)
-      allow(IdentityConfig.store).to receive(:socure_standard_capture_desktop_enabled).and_return(desktop_test_mode_enabled)
+      allow(IdentityConfig.store).to receive(:socure_standard_capture_desktop_enabled).
+        and_return(desktop_test_mode_enabled)
       allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(
         in_person_proofing_enabled,
       )

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -332,7 +332,6 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
         service_provider.save!
       end
       allow(IdentityConfig.store).to receive(:socure_enabled).and_return(socure_enabled)
-      allow(IdentityConfig.store).to receive(:doc_auth_vendor).and_return(doc_auth_vendor)
       allow(IdentityConfig.store).to receive(:doc_auth_vendor_default).and_return(doc_auth_vendor)
       allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).
         and_return(desktop_test_mode_enabled)

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -334,9 +334,7 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
       allow(IdentityConfig.store).to receive(:socure_enabled).and_return(socure_enabled)
       allow(IdentityConfig.store).to receive(:doc_auth_vendor).and_return(doc_auth_vendor)
       allow(IdentityConfig.store).to receive(:doc_auth_vendor_default).and_return(doc_auth_vendor)
-      allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).and_return(false)
-      allow(IdentityConfig.store).to receive(:socure_standard_capture_desktop_enabled).
-        and_return(desktop_test_mode_enabled)
+      allow(IdentityConfig.store).to receive(:doc_auth_selfie_desktop_test_mode).and_return(desktop_test_mode_enabled)
       allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(
         in_person_proofing_enabled,
       )


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-14810](https://cm-jira.usa.gov/browse/LG-14810)



## 🛠 Summary of changes

Desktop users bucketed to use the Socure doc auth vendor should only see "Use your phone to take photos" unless they are configured to do so.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Set `doc_auth_vendor_default: 'socure'`  `doc_auth_selfie_desktop_test_mode: false` in application.yml
- [ ] Go through IdV
- [ ]  Confirm there is no "Continue on this computer" box
- [ ]  Set `doc_auth_selfie_desktop_test_mode: true` in application.yml
- [ ] Go through IdV
- [ ] Confirm that there is a "Continue on this computer" box.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
