### PR TITLE
Include missing bg-secondary class to make HR be red

### DIFF
--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -10,7 +10,7 @@
         height: 21,
       ) %>
 </header>
-<hr class="height-05 margin-bottom-4 border-transparent">
+<hr class="height-05 margin-bottom-4 border-transparent bg-secondary">
 <%= @message %><br>
 <% @reports.each do |report| %>
   <% header, *rows = report.table %>


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14793](https://cm-jira.usa.gov/browse/LG-14793)

## 🛠 Summary of changes

In the edits to my [previous PR](https://github.com/18F/identity-idp/pull/11444) for report branding the color for the HR was lost because the new CSS class wasn't applied to the `<hr>` in the template. This adds the class to make the horizontal rule be red.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->


## 👀 Screenshots

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/c6a00bf6-e822-4594-bb41-9513204ae2d3">