### PR TITLE
Fix duplicate logging for successful email confirmation

### DIFF
--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -30,9 +30,12 @@ module UnconfirmedUserConcern
   end
 
   def stop_if_invalid_token
-    @email_confirmation_token_validator_result = email_confirmation_token_validator.submit
-    return if @email_confirmation_token_validator_result.success?
+    return if email_confirmation_token_validator_result.success?
     process_unsuccessful_confirmation
+  end
+
+  def email_confirmation_token_validator_result
+    @email_confirmation_token_validator_result ||= email_confirmation_token_validator.submit
   end
 
   def email_confirmation_token_validator

--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -30,9 +30,8 @@ module UnconfirmedUserConcern
   end
 
   def stop_if_invalid_token
-    result = email_confirmation_token_validator.submit
-    analytics.user_registration_email_confirmation(**result.to_h)
-    return if result.success?
+    @email_confirmation_token_validator_result = email_confirmation_token_validator.submit
+    return if @email_confirmation_token_validator_result.success?
     process_unsuccessful_confirmation
   end
 

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -7,6 +7,7 @@ module SignUp
 
     before_action :find_user_with_confirmation_token
     before_action :confirm_user_needs_sign_up_confirmation
+    before_action :log_validator_result
     before_action :stop_if_invalid_token
     before_action :store_sp_metadata_in_session, only: [:create]
 
@@ -19,15 +20,18 @@ module SignUp
 
     private
 
+    def log_validator_result
+      analytics.user_registration_email_confirmation(
+        **email_confirmation_token_validator_result.to_h,
+      )
+    end
+
     def clear_setup_piv_cac_from_sign_in
       session.delete(:needs_to_setup_piv_cac_after_sign_in)
     end
 
     def process_successful_confirmation
       process_valid_confirmation_token
-      analytics.user_registration_email_confirmation(
-        **@email_confirmation_token_validator_result.to_h,
-      )
       redirect_to sign_up_enter_password_url(confirmation_token: @confirmation_token)
     end
 

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -25,6 +25,9 @@ module SignUp
 
     def process_successful_confirmation
       process_valid_confirmation_token
+      analytics.user_registration_email_confirmation(
+        **@email_confirmation_token_validator_result.to_h,
+      )
       redirect_to sign_up_enter_password_url(confirmation_token: @confirmation_token)
     end
 

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -29,12 +29,6 @@ RSpec.describe SignUp::PasswordsController do
         subject
 
         expect(@analytics).to have_logged_event(
-          'User Registration: Email Confirmation',
-          success: true,
-          errors: {},
-          user_id: user.uuid,
-        )
-        expect(@analytics).to have_logged_event(
           'Password Creation',
           success: true,
           errors: {},
@@ -78,12 +72,6 @@ RSpec.describe SignUp::PasswordsController do
           subject
 
           expect(@analytics).to have_logged_event(
-            'User Registration: Email Confirmation',
-            errors: {},
-            success: true,
-            user_id: user.uuid,
-          )
-          expect(@analytics).to have_logged_event(
             'Password Creation',
             success: false,
             errors: {
@@ -111,12 +99,6 @@ RSpec.describe SignUp::PasswordsController do
         it 'tracks invalid password_confirmation error' do
           subject
 
-          expect(@analytics).to have_logged_event(
-            'User Registration: Email Confirmation',
-            errors: {},
-            success: true,
-            user_id: user.uuid,
-          )
           expect(@analytics).to have_logged_event(
             'Password Creation',
             success: false,

--- a/spec/features/visitors/email_confirmation_spec.rb
+++ b/spec/features/visitors/email_confirmation_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature 'Email confirmation during sign up' do
   end
 
   scenario 'confirms valid email and sets valid password' do
+    stub_analytics
     reset_email
     email = 'test@example.com'
     sign_up_with(email)
@@ -27,6 +28,9 @@ RSpec.feature 'Email confirmation during sign up' do
     expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
     expect(page).to have_title t('titles.confirmations.show')
     expect(page).to have_content t('forms.confirmation.show_hdr')
+
+    # Regression: Previously, this event had been logged multiple times per confirmation.
+    expect(@analytics).to have_logged_event('User Registration: Email Confirmation').once
 
     fill_in t('forms.password'), with: Features::SessionHelper::VALID_PASSWORD
     fill_in t('components.password_confirmation.confirm_label'),

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -2,7 +2,13 @@ module AnalyticsHelper
   def stub_analytics(user: nil)
     analytics = FakeAnalytics.new
 
-    allow(controller).to receive(:analytics).and_wrap_original do |original|
+    stub = if defined?(controller)
+             allow(controller)
+           else
+             allow_any_instance_of(ApplicationController)
+           end
+
+    stub.to receive(:analytics).and_wrap_original do |original|
       expect(original.call.user).to eq(user) if user
       analytics
     end

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -2,13 +2,9 @@ module AnalyticsHelper
   def stub_analytics(user: nil)
     analytics = FakeAnalytics.new
 
-    if user
-      allow(controller).to receive(:analytics).and_wrap_original do |original|
-        expect(original.call.user).to eq(user)
-        analytics
-      end
-    else
-      controller.analytics = analytics
+    allow(controller).to receive(:analytics).and_wrap_original do |original|
+      expect(original.call.user).to eq(user)
+      analytics
     end
 
     @analytics = analytics

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -3,7 +3,7 @@ module AnalyticsHelper
     analytics = FakeAnalytics.new
 
     allow(controller).to receive(:analytics).and_wrap_original do |original|
-      expect(original.call.user).to eq(user)
+      expect(original.call.user).to eq(user) if user
       analytics
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where we currently log the 'User Registration: Email Confirmation' event twice for every account registration.

Email confirmation happens across two controllers, which each individually validate the incoming confirmation token. Since the analytics were logged as part of this shared validation, it was being logged twice.

The solution is to move the analytics logging to happen only after the first successful validation.

## 📜 Testing Plan

Verify you see a single 'User Registration: Email Confirmation' event when confirming an email address for a new account:

1. Run `make watch_events` in a separate terminal process
2. Go to http://localhost:3000
3. Click "Create an account"
4. Enter an email address
5. Confirm Rules of Use
6. Click "Submit"
7. In the email received, click "Confirm email address"
8. Observe in `make watch_events` process output that there is only a single event for 'User Registration: Email Confirmation'