### PR TITLE
Extract password view setup behaviors from shared email confirmation behavior

### DIFF
--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -46,10 +46,6 @@ module UnconfirmedUserConcern
 
   def process_valid_confirmation_token
     @confirmation_token = params[:confirmation_token]
-    @forbidden_passwords = @user.email_addresses.flat_map do |email_address|
-      ForbiddenPasswords.new(email_address.email).call
-    end
-    flash.now[:success] = t('devise.confirmations.confirmed_but_must_set_password')
     session[:user_confirmation_token] = @confirmation_token
   end
 

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -11,7 +11,8 @@ module SignUp
 
     def new
       password_form # Memoize the password form to use in the view
-      process_successful_confirmation
+      flash.now[:success] = t('devise.confirmations.confirmed_but_must_set_password')
+      @forbidden_passwords = forbidden_passwords
     end
 
     def create
@@ -28,17 +29,10 @@ module SignUp
 
     private
 
-    def process_successful_confirmation
-      process_valid_confirmation_token
-      render_page
-    end
-
-    def render_page
-      render(
-        :new,
-        locals: { confirmation_token: @confirmation_token },
-        formats: :html,
-      )
+    def forbidden_passwords
+      @user.email_addresses.flat_map do |email_address|
+        ForbiddenPasswords.new(email_address.email).call
+      end
     end
 
     def track_analytics(result)

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -11,6 +11,7 @@ module SignUp
 
     def new
       password_form # Memoize the password form to use in the view
+      process_valid_confirmation_token
       flash.now[:success] = t('devise.confirmations.confirmed_but_must_set_password')
       @forbidden_passwords = forbidden_passwords
     end

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -3,6 +3,41 @@ require 'rails_helper'
 RSpec.describe SignUp::PasswordsController do
   let(:token) { 'new token' }
 
+  describe '#new' do
+    let!(:user) { create(:user, :unconfirmed, confirmation_token: token) }
+    subject(:response) { get :new, params: { confirmation_token: token } }
+
+    it 'flashes a message informing the user that they need to set a password' do
+      response
+
+      expect(flash.now[:success]).to eq(t('devise.confirmations.confirmed_but_must_set_password'))
+    end
+
+    it 'assigns variables expected to be available in the view' do
+      response
+
+      expect(assigns(:password_form)).to be_instance_of(PasswordForm)
+      expect(assigns(:email_address)).to be_instance_of(EmailAddress)
+      expect(assigns(:forbidden_passwords)).to be_present.and all be_kind_of(String)
+      expect(assigns(:confirmation_token)).to be_kind_of(String)
+    end
+
+    context 'with invalid confirmation_token' do
+      let!(:user) do
+        create(
+          :user,
+          :unconfirmed,
+          confirmation_token: token,
+          confirmation_sent_at: (IdentityConfig.store.add_email_link_valid_for_hours + 1).hours.ago,
+        )
+      end
+
+      it 'redirects to sign up page' do
+        expect(response).to redirect_to(sign_up_register_url)
+      end
+    end
+  end
+
   describe '#create' do
     subject(:response) { post :create, params: params }
     let(:params) do
@@ -141,24 +176,6 @@ RSpec.describe SignUp::PasswordsController do
         expect(user.confirmed?).to eq false
         expect(response).to redirect_to(sign_up_register_url)
       end
-    end
-  end
-
-  describe '#new' do
-    render_views
-
-    it 'rejects when confirmation_token is invalid' do
-      invalid_confirmation_sent_at =
-        Time.zone.now - (IdentityConfig.store.add_email_link_valid_for_hours.hours.in_seconds + 1)
-      create(
-        :user,
-        :unconfirmed,
-        confirmation_token: token,
-        confirmation_sent_at: invalid_confirmation_sent_at,
-      )
-
-      get :new, params: { confirmation_token: token }
-      expect(response).to redirect_to(sign_up_register_url)
     end
   end
 end

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe SignUp::PasswordsController do
       expect(flash.now[:success]).to eq(t('devise.confirmations.confirmed_but_must_set_password'))
     end
 
+    it 'processes valid token' do
+      expect(controller).to receive(:process_valid_confirmation_token)
+
+      response
+    end
+
     it 'assigns variables expected to be available in the view' do
       response
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates shared code for email confirmation token to only be called as needed.

As mentioned in #11466, email confirmation happens across two controllers, which each individually validate the incoming confirmation token. Prior to these changes, the validation included a few things performed in _both_ the initial email confirmation, as well as the password setup screen:

- Assigning forbidden passwords instance variable
- Flashing a success message

Since these are only relevant for the display of the password setup screen, the changes here move the code into the password setup controller.

## 📜 Testing Plan

Verify no regressions of expected behavior:

1. Go to http://localhost:3000/
2. Click "Create an account"
3. Enter the email address `examplelongemailaddress@example.com`
4. Confirm Rules of Use
5. Click "Submit"
6. In the email received, click "Confirm email address"
7. Observe success banner indicating that you've confirmed email address and need to set up password
8. Try submitting a "forbidden" password `examplelongemailaddress@example.com`
9. Observe that you see an error message