### PR TITLE
LG-14863: Add UI to simulate account creation ThreatMetrix result

### DIFF
--- a/app/javascript/packs/mock-device-profiling.tsx
+++ b/app/javascript/packs/mock-device-profiling.tsx
@@ -113,15 +113,6 @@ function MockDeviceProfilingOptions() {
   );
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  const ssnInput = document.getElementsByName('doc_auth[ssn]')[0];
-
-  if (ssnInput) {
-    const passwordToggle = ssnInput.closest('lg-password-toggle');
-
-    const div = document.createElement('div');
-    passwordToggle?.parentElement?.appendChild(div);
-
-    render(<MockDeviceProfilingOptions />, div);
-  }
-});
+const appRoot = document.createElement('div');
+document.currentScript!.after(appRoot);
+render(<MockDeviceProfilingOptions />, appRoot);

--- a/app/javascript/packs/mock-device-profiling.tsx
+++ b/app/javascript/packs/mock-device-profiling.tsx
@@ -114,5 +114,5 @@ function MockDeviceProfilingOptions() {
 }
 
 const appRoot = document.createElement('div');
-document.currentScript!.after(appRoot);
+currentScript?.after(appRoot);
 render(<MockDeviceProfilingOptions />, appRoot);

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -17,15 +17,6 @@
 
 <%= render PageHeadingComponent.new.with_content(t('headings.create_account_new_users')) %>
 
-<% if FeatureManagement.account_creation_device_profiling_collecting_enabled? %>
-  <%= render partial: 'shared/threat_metrix_profiling',
-             locals: {
-               threatmetrix_session_id:,
-               threatmetrix_javascript_urls:,
-               threatmetrix_iframe_url:,
-             } %>
-<% end %>
-
 <%= simple_form_for(@register_user_email_form, url: sign_up_register_path) do |f| %>
   <%= render ValidatedFieldComponent.new(
         form: f,
@@ -50,6 +41,15 @@
         label_html: { class: 'margin-y-0' },
         required: true,
       ) %>
+
+  <% if FeatureManagement.account_creation_device_profiling_collecting_enabled? %>
+    <%= render partial: 'shared/threat_metrix_profiling',
+               locals: {
+                 threatmetrix_session_id:,
+                 threatmetrix_javascript_urls:,
+                 threatmetrix_iframe_url:,
+               } %>
+  <% end %>
 
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
 <% end %>

--- a/spec/features/account_creation/threat_metrix_spec.rb
+++ b/spec/features/account_creation/threat_metrix_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.feature 'ThreatMetrix in account creation', :js do
+  before do
+    allow(IdentityConfig.store).to receive(:account_creation_device_profiling).and_return(:enabled)
+    allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_org_id).and_return('test_org')
+  end
+
+  it 'logs the threatmetrix result once the account is fully registered' do
+    visit root_url
+    click_on t('links.create_account')
+    fill_in t('forms.registration.labels.email'), with: Faker::Internet.email
+    check t('sign_up.terms', app_name: APP_NAME)
+    select 'Reject', from: :mock_profiling_result
+    click_button t('forms.buttons.submit.default')
+    user = confirm_last_user
+    set_password(user)
+    fake_analytics = FakeAnalytics.new
+    expect_any_instance_of(AccountCreationThreatMetrixJob).to receive(:analytics).with(user).
+      and_return(fake_analytics)
+    select_2fa_option('backup_code')
+    click_continue
+
+    expect(fake_analytics).to have_logged_event(
+      :account_creation_tmx_result,
+      account_lex_id: 'super-cool-test-lex-id',
+      errors: { review_status: ['reject'] },
+      response_body: {
+        **JSON.parse(LexisNexisFixtures.ddp_success_redacted_response_json),
+        'review_status' => 'reject',
+      },
+      review_status: 'reject',
+      session_id: 'super-cool-test-session-id',
+      success: true,
+      timed_out: false,
+      transaction_id: 'ddp-mock-transaction-id-123',
+    )
+  end
+end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -127,13 +127,16 @@ module Features
       confirm_last_user
     end
 
-    def sign_up_and_set_password
-      user = sign_up
+    def set_password(user)
       user.password = VALID_PASSWORD
       fill_in t('forms.password'), with: user.password
       fill_in t('components.password_confirmation.confirm_label'), with: user.password
       click_button t('forms.buttons.continue')
       user
+    end
+
+    def sign_up_and_set_password
+      set_password(sign_up)
     end
 
     def sign_in_user(user = create(:user), email = nil)


### PR DESCRIPTION
## 🎫 Ticket

[LG-14863](https://cm-jira.usa.gov/browse/LG-14863)

## 🛠 Summary of changes

Adds a new widget to control result of ThreatMetrix result in account creation flow when mock proofer is enabled.

## 📜 Testing Plan

Repeat Testing Plan from #11340, but select a device profiling result from the "Create an account" page.

Verify that the `account_creation_tmx_result` analytics event includes the expected result.

e.g. with "Reject" selected:

```rb
{
  "name": "account_creation_tmx_result",
  "properties": {
    "event_properties": {
      "success": true,
      "errors": {
        "review_status": [
          "reject"
        ]
      },
     # ...
    },
    # ...
  },
  # ...
}
```

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/ebe2eba4-d792-473e-9238-59b1aec15edb)|![image](https://github.com/user-attachments/assets/73b714db-acb0-4fa9-9cb6-08b83bd5ee0a)
