### PR TITLE
LG-14442: Add error handling and invalid character check to public usps locations controller

### DIFF
--- a/app/controllers/idv/in_person/public/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/public/usps_locations_controller.rb
@@ -14,8 +14,7 @@ module Idv
 
         include IppHelper
 
-        rescue_from ActionController::InvalidAuthenticityToken,
-                    Faraday::Error,
+        rescue_from Faraday::Error,
                     StandardError,
                     UspsLocationsError,
                     Faraday::BadRequestError,

--- a/app/controllers/idv/in_person/public/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/public/usps_locations_controller.rb
@@ -3,8 +3,23 @@
 module Idv
   module InPerson
     module Public
+      class UspsLocationsError < StandardError
+        def initialize
+          super('Unsupported characters in address field.')
+        end
+      end
+
       class UspsLocationsController < ApplicationController
         skip_forgery_protection
+
+        include IppHelper
+
+        rescue_from ActionController::InvalidAuthenticityToken,
+                    Faraday::Error,
+                    StandardError,
+                    UspsLocationsError,
+                    Faraday::BadRequestError,
+                    with: :handle_error
 
         def index
           candidate = UspsInPersonProofing::Applicant.new(
@@ -12,6 +27,11 @@ module Idv
             city: search_params['city'], state: search_params['state'],
             zip_code: search_params['zip_code']
           )
+
+          unless candidate.has_valid_address?
+            raise UspsLocationsError.new
+          end
+
           locations = proofer.request_facilities(candidate, false)
 
           render json: localized_locations(locations).to_json
@@ -32,6 +52,27 @@ module Idv
           locations.map do |location|
             UspsInPersonProofing::EnrollmentHelper.localized_location(location)
           end
+        end
+
+        def handle_error(err)
+          remapped_error = case err
+                           when ActionController::InvalidAuthenticityToken,
+                                Faraday::Error,
+                                UspsLocationsError
+                             :unprocessable_entity
+                           else
+                             :internal_server_error
+                           end
+
+          analytics.idv_in_person_locations_request_failure(
+            api_status_code: Rack::Utils.status_code(remapped_error),
+            exception_class: err.class,
+            exception_message: scrub_message(err.message),
+            response_body_present: err.respond_to?(:response_body) && err.response_body.present?,
+            response_body: err.respond_to?(:response_body) && scrub_body(err.response_body),
+            response_status_code: err.respond_to?(:response_status) && err.response_status,
+          )
+          render json: {}, status: remapped_error
         end
 
         def search_params

--- a/app/controllers/idv/in_person/public/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/public/usps_locations_controller.rb
@@ -29,7 +29,7 @@ module Idv
           )
 
           unless candidate.has_valid_address?
-            raise UspsLocationsError.new
+            raise UspsLocationsError
           end
 
           locations = proofer.request_facilities(candidate, false)

--- a/spec/controllers/idv/in_person/public/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/public/usps_locations_controller_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Idv::InPerson::Public::UspsLocationsController do
   include Rails.application.routes.url_helpers
 
+  before do
+    stub_analytics
+  end
+
   describe '#index' do
     subject(:action) do
       post :index,
@@ -20,6 +24,60 @@ RSpec.describe Idv::InPerson::Public::UspsLocationsController do
     it 'is successful and has a response' do
       action
       expect(response).to be_ok
+    end
+
+    context 'with a 500 error from USPS' do
+      let(:server_error) { Faraday::ServerError.new }
+      let(:proofer) { double('Proofer') }
+
+      before do
+        allow(UspsInPersonProofing::EnrollmentHelper).to receive(:usps_proofer).and_return(proofer)
+        allow(proofer).to receive(:request_facilities).and_raise(server_error)
+      end
+
+      it 'returns an unprocessible entity client error' do
+        subject
+        expect(@analytics).to have_logged_event(
+          'Request USPS IPP locations: request failed',
+          api_status_code: 422,
+          exception_class: server_error.class,
+          exception_message: server_error.message,
+          response_body_present:
+          server_error.response_body.present?,
+        )
+
+        status = response.status
+        expect(status).to eq 422
+      end
+    end
+
+    context 'address has unsupported characters' do
+      let(:locale) { nil }
+      let(:usps_locations_error) { Idv::InPerson::Public::UspsLocationsError.new }
+
+      subject(:response) do
+        post :index, params: { locale: locale,
+                               address: { street_address: '1600, Pennsylvania Ave',
+                                          city: 'Washington',
+                                          state: 'DC',
+                                          zip_code: '20500' } }
+      end
+
+      it 'returns unprocessable entity' do
+        subject
+
+        expect(@analytics).to have_logged_event(
+          'Request USPS IPP locations: request failed',
+          api_status_code: 422,
+          exception_class: usps_locations_error.class,
+          exception_message: usps_locations_error.message,
+          response_body_present: false,
+          response_body: false,
+          response_status_code: false,
+        )
+
+        expect(response.status).to eq 422
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14442](https://cm-jira.usa.gov/browse/LG-14442)

## 🛠 Summary of changes

Adds error handling to the public USPS locations controller. Also adds a check for invalid characters before making the call to USPS, otherwise throwing a UspsLocationsError. Analytics added for when errors occur.

## 📜 Testing Plan

In the identity-site which calls this public controller, the front end checks should prevent invalid characters from being submitted before the controller should have to handle it. So instead of a manual test plan, automated tests have been added to test that this check and the error handling works.

- [x] Verify that the automated tests pass.

