### PR TITLE
Jmax/lg 14008 handle redirect from socure in hybrid handoff

### DIFF
--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -55,7 +55,7 @@ module Idv
           if result.success?
             redirect_to idv_ssn_url
           else
-            redirect_to idv_socure_document_capture_url
+            redirect_to idv_hybrid_mobile_socure_document_capture_url
           end
         end
 

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -51,7 +51,7 @@ module Idv
 
         def update
           result = handle_stored_result(
-            user: document_capture_user,
+            user: document_capture_session.user,
             store_in_session: false,
           )
 

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -50,26 +50,15 @@ module Idv
         end
 
         def update
-          result = handle_stored_result
+          result = handle_stored_result(
+            user: document_capture_user,
+            store_in_session: false,
+          )
 
           if result.success?
             redirect_to idv_ssn_url
           else
             redirect_to idv_hybrid_mobile_socure_document_capture_url
-          end
-        end
-
-        private
-
-        def handle_stored_result
-          if stored_result&.success? && selfie_requirement_met?
-            save_proofing_components(current_user)
-            extract_pii_from_doc(current_user, store_in_session: true)
-            flash[:success] = t('doc_auth.headings.capture_complete')
-            successful_response
-          else
-            extra = { stored_result_present: stored_result.present? }
-            failure(I18n.t('doc_auth.errors.general.network_error'), extra)
           end
         end
       end

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -27,10 +27,6 @@ module Idv
 
         # document request
         document_request = DocAuth::Socure::Requests::DocumentRequest.new(
-<<<<<<< HEAD
-=======
-          document_capture_session_uuid: document_capture_session_uuid,
->>>>>>> 5b36509c8b (LG-14008: Handle redirect from CaptureApp in hybrid flow)
           redirect_url: idv_socure_document_capture_update_url,
           language: I18n.locale,
         )

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -76,12 +76,6 @@ module Idv
         Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
           call('socure_document_capture', :update, true)
 
-<<<<<<< HEAD
-        cancel_establishing_in_person_enrollments
-
-=======
-        # cancel_establishing_in_person_enrollments
->>>>>>> 5b36509c8b (LG-14008: Handle redirect from CaptureApp in hybrid flow)
         if result.success?
           redirect_to idv_ssn_url
         else
@@ -113,21 +107,6 @@ module Idv
 
       private
 
-<<<<<<< HEAD
-=======
-      def handle_stored_result
-        if stored_result&.success? && selfie_requirement_met?
-          save_proofing_components(current_user)
-          extract_pii_from_doc(current_user, store_in_session: true)
-          flash[:success] = t('doc_auth.headings.capture_complete')
-          successful_response
-        else
-          extra = { stored_result_present: stored_result.present? }
-          failure(I18n.t('doc_auth.errors.general.network_error'), extra)
-        end
-      end
-
->>>>>>> 5b36509c8b (LG-14008: Handle redirect from CaptureApp in hybrid flow)
       def analytics_arguments
         {
           flow_path: flow_path,

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -27,6 +27,10 @@ module Idv
 
         # document request
         document_request = DocAuth::Socure::Requests::DocumentRequest.new(
+<<<<<<< HEAD
+=======
+          document_capture_session_uuid: document_capture_session_uuid,
+>>>>>>> 5b36509c8b (LG-14008: Handle redirect from CaptureApp in hybrid flow)
           redirect_url: idv_socure_document_capture_update_url,
           language: I18n.locale,
         )
@@ -72,8 +76,12 @@ module Idv
         Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
           call('socure_document_capture', :update, true)
 
+<<<<<<< HEAD
         cancel_establishing_in_person_enrollments
 
+=======
+        # cancel_establishing_in_person_enrollments
+>>>>>>> 5b36509c8b (LG-14008: Handle redirect from CaptureApp in hybrid flow)
         if result.success?
           redirect_to idv_ssn_url
         else
@@ -105,6 +113,21 @@ module Idv
 
       private
 
+<<<<<<< HEAD
+=======
+      def handle_stored_result
+        if stored_result&.success? && selfie_requirement_met?
+          save_proofing_components(current_user)
+          extract_pii_from_doc(current_user, store_in_session: true)
+          flash[:success] = t('doc_auth.headings.capture_complete')
+          successful_response
+        else
+          extra = { stored_result_present: stored_result.present? }
+          failure(I18n.t('doc_auth.errors.general.network_error'), extra)
+        end
+      end
+
+>>>>>>> 5b36509c8b (LG-14008: Handle redirect from CaptureApp in hybrid flow)
       def analytics_arguments
         {
           flow_path: flow_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -368,7 +368,7 @@ Rails.application.routes.draw do
       put '/hybrid_mobile/document_capture' => 'hybrid_mobile/document_capture#update'
       get '/hybrid_mobile/capture_complete' => 'hybrid_mobile/capture_complete#show'
       get '/hybrid_mobile/socure/document_capture' => 'hybrid_mobile/socure/document_capture#show'
-      post '/hybrid_mobile/socure/document_capture' => 'hybrid_mobile/socure/document_capture#update'
+      get '/hybrid_mobile/socure/document_capture_update' => 'hybrid_mobile/socure/document_capture#update', as: :hybrid_mobile_socure_document_capture_update
       get '/hybrid_handoff' => 'hybrid_handoff#show'
       put '/hybrid_handoff' => 'hybrid_handoff#update'
       get '/link_sent' => 'link_sent#show'

--- a/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
     let(:stored_result) do
       DocumentCaptureSessionResult.new(
         success: true,
-        selfie_status: 'pass',
+        selfie_status: 'not_processed',
         pii: { state: 'MD' },
       )
     end
@@ -282,6 +282,22 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
         get(:update)
 
         expect(response).to be_not_found
+      end
+    end
+
+    context 'when socure reports failure' do
+      let(:stored_result) do
+        DocumentCaptureSessionResult.new(
+          success: false,
+          selfie_status: 'not_processed',
+          pii: { state: 'MD' },
+        )
+      end
+
+      it 'redirects back to the capture page' do
+        get(:update)
+
+        expect(response).to redirect_to(idv_hybrid_mobile_socure_document_capture_url)
       end
     end
   end

--- a/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
@@ -267,8 +267,7 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
 
     before do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-        stub_sign_in(user)
-    #   stub_up_to(:hybrid_handoff, idv_session: nil)
+      stub_sign_in(user)
     end
 
     it 'redirects to the ssn page' do

--- a/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
                     documentType: 'license',
                     redirect: {
                       method: 'GET',
-                      url: idv_hybrid_mobile_socure_document_capture_url,
+                      url: idv_hybrid_mobile_socure_document_capture_update_url,
                     },
                     language: expected_language,
                   },
@@ -141,7 +141,7 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
                     documentType: 'license',
                     redirect: {
                       method: 'GET',
-                      url: idv_hybrid_mobile_socure_document_capture_url,
+                      url: idv_hybrid_mobile_socure_document_capture_update_url,
                     },
                     language: 'zh-cn',
                   },
@@ -257,16 +257,31 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
   end
 
   describe '#update' do
-    it 'returns OK (200)' do
-      post(:update)
+    let(:stored_result) do
+      DocumentCaptureSessionResult.new(
+        success: true,
+        selfie_status: 'pass',
+        pii: { state: 'MD' },
+      )
+    end
 
-      expect(response).to have_http_status(:ok)
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+        stub_sign_in(user)
+    #   stub_up_to(:hybrid_handoff, idv_session: nil)
+    end
+
+    it 'redirects to the ssn page' do
+      get(:update)
+
+      expect(response).to redirect_to(idv_ssn_url)
     end
 
     context 'when socure is disabled' do
       let(:socure_enabled) { false }
+
       it 'the webhook route does not exist' do
-        post(:update)
+        get(:update)
 
         expect(response).to be_not_found
       end

--- a/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
     allow(IdentityConfig.store).to receive(:doc_auth_vendor_default).and_return(idv_vendor)
 
     allow(subject).to receive(:stored_result).and_return(stored_result)
+
+    session[:doc_capture_user_id] = user&.id
+    session[:document_capture_session_uuid] = document_capture_session_uuid
   end
 
   describe 'before_actions' do
@@ -48,9 +51,6 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
         status: 200,
         body: JSON.generate(response_body),
       )
-
-      session[:doc_capture_user_id] = user&.id
-      session[:document_capture_session_uuid] = document_capture_session_uuid
     end
 
     context 'with no user id in session' do
@@ -97,7 +97,7 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
       it 'creates a DocumentRequest' do
         expect(request_class).to have_received(:new).
           with(
-            redirect_url: idv_hybrid_mobile_socure_document_capture_url,
+            redirect_url: idv_hybrid_mobile_socure_document_capture_update_url,
             language: expected_language,
           )
       end
@@ -266,7 +266,6 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
     end
 
     before do
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
       stub_sign_in(user)
     end
 

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
   end
 
   describe '#update' do
-    it 'returns OK (200)' do
+    it 'returns FOUND (302) and redirects to SSN' do
       get(:update)
 
       expect(response).to redirect_to(idv_ssn_path)
@@ -288,9 +288,8 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
 
     context 'when socure is disabled' do
       let(:socure_enabled) { false }
-      it 'the webhook route does not exist' do
-        post(:update)
 
+      it 'the webhook route does not exist' do
         expect(response).to be_not_found
       end
     end

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -290,6 +290,8 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
       let(:socure_enabled) { false }
 
       it 'the webhook route does not exist' do
+        get(:update)
+
         expect(response).to be_not_found
       end
     end


### PR DESCRIPTION
## 🎫 Ticket
[LG-14007](https://cm-jira.usa.gov/browse/LG-14008)

After successful doc auth using Socure in the hybrid flow, the user continues to the 'Enter SSN' step.

## 🛠 Summary of changes

- Added a new GET route for Socure webhook
- Pass the URL for the above route to Socure when invoking their capture app
- When we receive the webhook invocation from Socure, pick up the results from the DocumentCaptureSession and redirect the user to the SSN step.



## 📜 Testing Plan

Requires a sandbox or other externally visible environment. Also requires the Socure webhook to be pointed at the testing environment. Currently deployed to [jmax's sandbox](https://idp.jmax.identitysandbox.gov/). See jmax or Doug for help with this if needed.

- [ ] Create an account or sign in using your computer.
- [ ] Go to `/verify`
- [ ] Continue through IdV, using the hybrid flow.
- [ ] Verify that after you successfully capture and verify your ID, you are redirected on your computer to the SSN step.