### PR TITLE
Add FormResponse#to_hash to support implicit hash conversion

### DIFF
--- a/app/controllers/account_reset/cancel_controller.rb
+++ b/app/controllers/account_reset/cancel_controller.rb
@@ -6,7 +6,7 @@ module AccountReset
       return render :show unless token
 
       result = AccountReset::ValidateCancelToken.new(token).call
-      analytics.account_reset_cancel_token_validation(**result.to_h)
+      analytics.account_reset_cancel_token_validation(**result)
 
       if result.success?
         handle_valid_token
@@ -18,7 +18,7 @@ module AccountReset
     def create
       result = AccountReset::Cancel.new(session[:cancel_token]).call
 
-      analytics.account_reset_cancel(**result.to_h)
+      analytics.account_reset_cancel(**result)
 
       if result.success?
         handle_success

--- a/app/controllers/account_reset/delete_account_controller.rb
+++ b/app/controllers/account_reset/delete_account_controller.rb
@@ -6,7 +6,7 @@ module AccountReset
       render :show and return unless token
 
       result = AccountReset::ValidateGrantedToken.new(token, request, analytics).call
-      analytics.account_reset_granted_token_validation(**result.to_h)
+      analytics.account_reset_granted_token_validation(**result)
 
       if result.success?
         handle_valid_token

--- a/app/controllers/account_reset/request_controller.rb
+++ b/app/controllers/account_reset/request_controller.rb
@@ -23,7 +23,7 @@ module AccountReset
 
     def create_account_reset_request
       response = AccountReset::CreateRequest.new(current_user, sp_session[:issuer]).call
-      analytics.account_reset_request(**response.to_h, **analytics_attributes)
+      analytics.account_reset_request(**response, **analytics_attributes)
     end
 
     def confirm_two_factor_enabled

--- a/app/controllers/accounts/connected_accounts/selected_email_controller.rb
+++ b/app/controllers/accounts/connected_accounts/selected_email_controller.rb
@@ -20,7 +20,7 @@ module Accounts
 
         result = @select_email_form.submit(form_params)
 
-        analytics.sp_select_email_submitted(**result.to_h)
+        analytics.sp_select_email_submitted(**result)
 
         if result.success?
           flash[:email_updated_identity_id] = identity.id

--- a/app/controllers/accounts/personal_keys_controller.rb
+++ b/app/controllers/accounts/personal_keys_controller.rb
@@ -19,7 +19,7 @@ module Accounts
       analytics.profile_personal_key_create
       create_user_event(:new_personal_key)
       result = send_new_personal_key_notifications
-      analytics.profile_personal_key_create_notifications(**result.to_h)
+      analytics.profile_personal_key_create_notifications(**result)
 
       flash[:info] = t('account.personal_key.old_key_will_not_work')
       redirect_to manage_personal_key_url

--- a/app/controllers/api/internal/two_factor_authentication/auth_app_controller.rb
+++ b/app/controllers/api/internal/two_factor_authentication/auth_app_controller.rb
@@ -19,7 +19,7 @@ module Api
             configuration_id: params[:id],
           ).submit(name: params[:name])
 
-          analytics.auth_app_update_name_submitted(**result.to_h)
+          analytics.auth_app_update_name_submitted(**result)
 
           if result.success?
             render json: { success: true }
@@ -34,7 +34,7 @@ module Api
             configuration_id: params[:id],
           ).submit
 
-          analytics.auth_app_delete_submitted(**result.to_h)
+          analytics.auth_app_delete_submitted(**result)
 
           if result.success?
             create_user_event(:authenticator_disabled)

--- a/app/controllers/api/internal/two_factor_authentication/piv_cac_controller.rb
+++ b/app/controllers/api/internal/two_factor_authentication/piv_cac_controller.rb
@@ -20,7 +20,7 @@ module Api
             configuration_id: params[:id],
           ).submit(name: params[:name])
 
-          analytics.piv_cac_update_name_submitted(**result.to_h)
+          analytics.piv_cac_update_name_submitted(**result)
 
           if result.success?
             render json: { success: true }
@@ -35,7 +35,7 @@ module Api
             configuration_id: params[:id],
           ).submit
 
-          analytics.piv_cac_delete_submitted(**result.to_h)
+          analytics.piv_cac_delete_submitted(**result)
 
           if result.success?
             create_user_event(:piv_cac_disabled)

--- a/app/controllers/api/internal/two_factor_authentication/webauthn_controller.rb
+++ b/app/controllers/api/internal/two_factor_authentication/webauthn_controller.rb
@@ -19,7 +19,7 @@ module Api
             configuration_id: params[:id],
           ).submit(name: params[:name])
 
-          analytics.webauthn_update_name_submitted(**result.to_h)
+          analytics.webauthn_update_name_submitted(**result)
 
           if result.success?
             render json: { success: true }
@@ -34,7 +34,7 @@ module Api
             configuration_id: params[:id],
           ).submit
 
-          analytics.webauthn_delete_submitted(**result.to_h)
+          analytics.webauthn_delete_submitted(**result)
 
           if result.success?
             create_user_event(:webauthn_key_removed)

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -219,7 +219,7 @@ module Idv
         flash[:success] = t('doc_auth.forms.doc_success')
         redirect_to next_step_url
       end
-      analytics.idv_doc_auth_verify_proofing_results(**analytics_arguments, **form_response.to_h)
+      analytics.idv_doc_auth_verify_proofing_results(**analytics_arguments, **form_response)
     end
 
     def next_step_url

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -14,7 +14,7 @@ module TwoFactorAuthenticatableMethods
   def handle_verification_for_authentication_context(result:, auth_method:, extra_analytics: nil)
     increment_mfa_selection_attempt_count(auth_method)
     analytics.multi_factor_auth(
-      **result.to_h,
+      **result,
       multi_factor_auth_method: auth_method,
       enabled_mfa_methods_count: mfa_context.enabled_mfa_methods_count,
       new_device: new_device?,

--- a/app/controllers/event_disavowal_controller.rb
+++ b/app/controllers/event_disavowal_controller.rb
@@ -10,13 +10,13 @@ class EventDisavowalController < ApplicationController
       success: true,
       extra: EventDisavowal::BuildDisavowedEventAnalyticsAttributes.call(disavowed_event),
     )
-    analytics.event_disavowal(**result.to_h)
+    analytics.event_disavowal(**result)
     @forbidden_passwords = forbidden_passwords
   end
 
   def create
     result = password_reset_from_disavowal_form.submit(password_reset_params)
-    analytics.event_disavowal_password_reset(**result.to_h)
+    analytics.event_disavowal_password_reset(**result)
     if result.success?
       handle_successful_password_reset
     else
@@ -50,7 +50,7 @@ class EventDisavowalController < ApplicationController
       return
     end
 
-    analytics.event_disavowal_token_invalid(**result.to_h)
+    analytics.event_disavowal_token_invalid(**result)
     flash[:error] = (result.errors[:event] || result.errors.first.last).first
     redirect_to root_url
   end

--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -53,7 +53,7 @@ module Idv
         @gpo_verify_form = build_gpo_verify_form
 
         result = @gpo_verify_form.submit(resolved_authn_context_result.enhanced_ipp?)
-        analytics.idv_verify_by_mail_enter_code_submitted(**result.to_h)
+        analytics.idv_verify_by_mail_enter_code_submitted(**result)
 
         if !result.success?
           if rate_limiter.limited?

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -25,7 +25,7 @@ module Idv
         form_result = form.submit(flow_params)
 
         analytics.idv_in_person_proofing_residential_address_submitted(
-          **analytics_arguments.merge(**form_result.to_h),
+          **analytics_arguments.merge(**form_result),
         )
 
         if form_result.success?

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -31,7 +31,7 @@ module Idv
           end
 
           analytics.idv_in_person_proofing_state_id_submitted(
-            **analytics_arguments.merge(**form_result.to_h),
+            **analytics_arguments.merge(**form_result),
           )
           # Accept Date of Birth from both memorable date and input date components
           formatted_dob = MemorableDateComponent.extract_date_param flow_params&.[](:dob)

--- a/app/controllers/idv/otp_verification_controller.rb
+++ b/app/controllers/idv/otp_verification_controller.rb
@@ -22,7 +22,7 @@ module Idv
     def update
       clear_future_steps!
       result = phone_confirmation_otp_verification_form.submit(code: params[:code])
-      analytics.idv_phone_confirmation_otp_submitted(**result.to_h, **ab_test_analytics_buckets)
+      analytics.idv_phone_confirmation_otp_submitted(**result, **ab_test_analytics_buckets)
 
       if result.success?
         idv_session.mark_phone_step_complete!

--- a/app/controllers/idv/phone_controller.rb
+++ b/app/controllers/idv/phone_controller.rb
@@ -55,7 +55,7 @@ module Idv
       Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer).
         call(:verify_phone, :update, result.success?)
 
-      analytics.idv_phone_confirmation_form_submitted(**result.to_h, **ab_test_analytics_buckets)
+      analytics.idv_phone_confirmation_form_submitted(**result, **ab_test_analytics_buckets)
       if result.success?
         submit_proofing_attempt
         redirect_to idv_phone_path

--- a/app/controllers/idv/resend_otp_controller.rb
+++ b/app/controllers/idv/resend_otp_controller.rb
@@ -13,7 +13,7 @@ module Idv
 
     def create
       result = send_phone_confirmation_otp
-      analytics.idv_phone_confirmation_otp_resent(**result.to_h)
+      analytics.idv_phone_confirmation_otp_resent(**result)
       if result.success?
         redirect_to idv_otp_verification_url
       else

--- a/app/controllers/openid_connect/user_info_controller.rb
+++ b/app/controllers/openid_connect/user_info_controller.rb
@@ -18,7 +18,7 @@ module OpenidConnect
     def authenticate_identity_via_bearer_token
       verifier = AccessTokenVerifier.new(request.env['HTTP_AUTHORIZATION'])
       response, identity = verifier.submit
-      analytics.openid_connect_bearer_token(**response.to_h)
+      analytics.openid_connect_bearer_token(**response)
 
       if response.success?
         @current_identity = identity

--- a/app/controllers/risc/security_events_controller.rb
+++ b/app/controllers/risc/security_events_controller.rb
@@ -11,7 +11,7 @@ module Risc
       form = SecurityEventForm.new(body: request.body.read)
       result = form.submit
 
-      analytics.security_event_received(**result.to_h)
+      analytics.security_event_received(**result)
 
       if result.success?
         head :accepted

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -22,7 +22,7 @@ module SignUp
 
     def log_validator_result
       analytics.user_registration_email_confirmation(
-        **email_confirmation_token_validator_result.to_h,
+        **email_confirmation_token_validator_result,
       )
     end
 

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -21,9 +21,7 @@ module SignUp
     private
 
     def log_validator_result
-      analytics.user_registration_email_confirmation(
-        **email_confirmation_token_validator_result,
-      )
+      analytics.user_registration_email_confirmation(**email_confirmation_token_validator_result)
     end
 
     def clear_setup_piv_cac_from_sign_in

--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -42,7 +42,7 @@ module SignUp
     end
 
     def track_analytics(result)
-      analytics.password_creation(**result.to_h)
+      analytics.password_creation(**result)
     end
 
     def permitted_params

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -24,7 +24,7 @@ module SignUp
 
       result = @register_user_email_form.submit(permitted_params.merge(request_id:))
 
-      analytics.user_registration_email(**result.to_h)
+      analytics.user_registration_email(**result)
 
       if result.success?
         process_successful_creation

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -21,7 +21,7 @@ module SignUp
 
       result = @select_email_form.submit(form_params)
 
-      analytics.sp_select_email_submitted(**result.to_h, needs_completion_screen_reason:)
+      analytics.sp_select_email_submitted(**result, needs_completion_screen_reason:)
 
       if result.success?
         user_session[:selected_email_id_for_linked_identity] = form_params[:selected_email_id]

--- a/app/controllers/two_factor_authentication/options_controller.rb
+++ b/app/controllers/two_factor_authentication/options_controller.rb
@@ -34,7 +34,7 @@ module TwoFactorAuthentication
     def create
       @two_factor_options_form = TwoFactorLoginOptionsForm.new(current_user)
       result = @two_factor_options_form.submit(two_factor_options_form_params)
-      analytics.multi_factor_auth_option_list(**result.to_h)
+      analytics.multi_factor_auth_option_list(**result)
 
       if result.success?
         process_valid_form

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -61,7 +61,7 @@ module TwoFactorAuthentication
 
     def alert_user_about_personal_key_sign_in(disavowal_token)
       response = UserAlerts::AlertUserAboutPersonalKeySignIn.call(current_user, disavowal_token)
-      analytics.personal_key_alert_about_sign_in(**response.to_h)
+      analytics.personal_key_alert_about_sign_in(**response)
     end
 
     def remove_personal_key

--- a/app/controllers/users/auth_app_controller.rb
+++ b/app/controllers/users/auth_app_controller.rb
@@ -14,7 +14,7 @@ module Users
     def update
       result = form.submit(name: params.dig(:form, :name))
 
-      analytics.auth_app_update_name_submitted(**result.to_h)
+      analytics.auth_app_update_name_submitted(**result)
 
       if result.success?
         flash[:success] = t('two_factor_authentication.auth_app.renamed')
@@ -28,7 +28,7 @@ module Users
     def destroy
       result = form.submit
 
-      analytics.auth_app_delete_submitted(**result.to_h)
+      analytics.auth_app_delete_submitted(**result)
 
       if result.success?
         flash[:success] = t('two_factor_authentication.auth_app.deleted')

--- a/app/controllers/users/edit_phone_controller.rb
+++ b/app/controllers/users/edit_phone_controller.rb
@@ -18,7 +18,7 @@ module Users
     def update
       @edit_phone_form = EditPhoneForm.new(current_user, phone_configuration)
       result = @edit_phone_form.submit(edit_phone_params)
-      analytics.phone_change_submitted(**result.to_h)
+      analytics.phone_change_submitted(**result)
       if result.success?
         redirect_to account_url
       else

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -4,7 +4,7 @@ module Users
   class EmailConfirmationsController < ApplicationController
     def create
       result = email_confirmation_token_validator.submit
-      analytics.add_email_confirmation(**result.to_h)
+      analytics.add_email_confirmation(**result)
       if result.success?
         process_successful_confirmation(email_address)
       else

--- a/app/controllers/users/email_language_controller.rb
+++ b/app/controllers/users/email_language_controller.rb
@@ -10,7 +10,7 @@ module Users
 
     def update
       form_response = UpdateEmailLanguageForm.new(current_user).submit(update_email_params)
-      analytics.email_language_updated(**form_response.to_h)
+      analytics.email_language_updated(**form_response)
 
       flash[:success] = I18n.t('account.email_language.updated') if form_response.success?
 

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -25,7 +25,7 @@ module Users
       result = @add_user_email_form.submit(
         current_user, permitted_params
       )
-      analytics.add_email_request(**result.to_h)
+      analytics.add_email_request(**result)
 
       if result.success?
         process_successful_creation
@@ -58,7 +58,7 @@ module Users
 
     def delete
       result = DeleteUserEmailForm.new(current_user, email_address).submit
-      analytics.email_deletion_request(**result.to_h)
+      analytics.email_deletion_request(**result)
       if result.success?
         handle_successful_delete
       else

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -26,7 +26,7 @@ module Users
 
       result = @update_user_password_form.submit(user_password_params)
 
-      analytics.password_changed(**result.to_h)
+      analytics.password_changed(**result)
 
       if result.success?
         handle_valid_password

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -33,7 +33,7 @@ module Users
     def create
       @new_phone_form = NewPhoneForm.new(user: current_user, analytics: analytics)
       result = @new_phone_form.submit(new_phone_form_params)
-      analytics.multi_factor_auth_phone_setup(**result.to_h)
+      analytics.multi_factor_auth_phone_setup(**result)
 
       if result.success?
         handle_create_success(@new_phone_form.phone)

--- a/app/controllers/users/piv_cac_controller.rb
+++ b/app/controllers/users/piv_cac_controller.rb
@@ -16,7 +16,7 @@ module Users
     def update
       result = form.submit(name: params.dig(:form, :name))
 
-      analytics.piv_cac_update_name_submitted(**result.to_h)
+      analytics.piv_cac_update_name_submitted(**result)
 
       if result.success?
         flash[:success] = presenter.rename_success_alert_text
@@ -30,7 +30,7 @@ module Users
     def destroy
       result = form.submit
 
-      analytics.piv_cac_delete_submitted(**result.to_h)
+      analytics.piv_cac_delete_submitted(**result)
 
       if result.success?
         create_user_event(:piv_cac_disabled)

--- a/app/controllers/users/piv_cac_login_controller.rb
+++ b/app/controllers/users/piv_cac_login_controller.rb
@@ -54,7 +54,7 @@ module Users
       else
         process_invalid_submission
       end
-      analytics.piv_cac_login(**result.to_h, new_device: @new_device)
+      analytics.piv_cac_login(**result, new_device: @new_device)
     end
 
     def piv_cac_login_form

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -17,7 +17,7 @@ module Users
       @password_reset_email_form = PasswordResetEmailForm.new(email)
       result = @password_reset_email_form.submit
 
-      analytics.password_reset_email(**result.to_h)
+      analytics.password_reset_email(**result)
 
       if result.success?
         handle_valid_email
@@ -32,7 +32,7 @@ module Users
       else
         result = PasswordResetTokenValidator.new(token_user).submit
 
-        analytics.password_reset_token(**result.to_h)
+        analytics.password_reset_token(**result)
         if result.success?
           @reset_password_form = ResetPasswordForm.new(user: build_user)
           @forbidden_passwords = forbidden_passwords(token_user.email_addresses)
@@ -54,7 +54,7 @@ module Users
 
       result = @reset_password_form.submit(user_params)
 
-      analytics.password_reset_password(**result.to_h)
+      analytics.password_reset_password(**result)
 
       if result.success?
         session.delete(:reset_password_token)

--- a/app/controllers/users/rules_of_use_controller.rb
+++ b/app/controllers/users/rules_of_use_controller.rb
@@ -19,7 +19,7 @@ module Users
 
       result = @rules_of_use_form.submit(permitted_params)
 
-      analytics.rules_of_use_submitted(**result.to_h)
+      analytics.rules_of_use_submitted(**result)
 
       if result.success?
         process_successful_agreement_to_rules_of_use

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -208,7 +208,7 @@ module Users
                 (recaptcha_response.success? || log_captcha_failures_only?)
 
       analytics.email_and_password_auth(
-        **recaptcha_response.to_h,
+        **recaptcha_response,
         success: success,
         user_id: user.uuid,
         user_locked_out: user_locked_out?(user),

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -20,7 +20,7 @@ module Users
 
     def send_code
       result = otp_delivery_selection_form.submit(delivery_params)
-      analytics.otp_delivery_selection(**result.to_h)
+      analytics.otp_delivery_selection(**result)
       if result.success?
         handle_valid_otp_params(
           result,
@@ -80,7 +80,7 @@ module Users
 
     def validate_otp_delivery_preference_and_send_code
       result = otp_delivery_selection_form.submit(otp_delivery_preference: delivery_preference)
-      analytics.otp_delivery_selection(**result.to_h)
+      analytics.otp_delivery_selection(**result)
       phone_is_confirmed = UserSessionContext.authentication_or_reauthentication_context?(context)
       phone_capabilities = PhoneNumberCapabilities.new(
         parsed_phone,

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -23,7 +23,7 @@ module Users
 
     def create
       result = submit_form
-      analytics.user_registration_2fa_setup(**result.to_h)
+      analytics.user_registration_2fa_setup(**result)
       user_session[:platform_authenticator_available] =
         params[:platform_authenticator_available] == 'true'
 

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -30,7 +30,7 @@ module Users
         result = personal_key_form.submit
 
         analytics.personal_key_reactivation_submitted(
-          **result.to_h,
+          **result,
           pii_like_keypaths: [
             [:errors, :personal_key],
             [:error_details, :personal_key],

--- a/app/controllers/users/webauthn_controller.rb
+++ b/app/controllers/users/webauthn_controller.rb
@@ -15,7 +15,7 @@ module Users
     def update
       result = form.submit(name: params.dig(:form, :name))
 
-      analytics.webauthn_update_name_submitted(**result.to_h)
+      analytics.webauthn_update_name_submitted(**result)
 
       if result.success?
         flash[:success] = presenter.rename_success_alert_text
@@ -29,7 +29,7 @@ module Users
     def destroy
       result = form.submit
 
-      analytics.webauthn_delete_submitted(**result.to_h)
+      analytics.webauthn_delete_submitted(**result)
 
       if result.success?
         flash[:success] = presenter.delete_success_alert_text

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -83,7 +83,7 @@ module Idv
         extra: extra_attributes,
       )
 
-      analytics.idv_doc_auth_submitted_image_upload_form(**response.to_h)
+      analytics.idv_doc_auth_submitted_image_upload_form(**response)
       response
     end
 

--- a/app/jobs/account_creation_threat_metrix_job.rb
+++ b/app/jobs/account_creation_threat_metrix_job.rb
@@ -15,7 +15,7 @@ class AccountCreationThreatMetrixJob < ApplicationJob
     )
   ensure
     user = User.find_by(id: user_id)
-    analytics(user).account_creation_tmx_result(**device_profiling_result)
+    analytics(user).account_creation_tmx_result(**device_profiling_result.to_h)
   end
 
   def analytics(user)

--- a/app/jobs/account_creation_threat_metrix_job.rb
+++ b/app/jobs/account_creation_threat_metrix_job.rb
@@ -15,7 +15,7 @@ class AccountCreationThreatMetrixJob < ApplicationJob
     )
   ensure
     user = User.find_by(id: user_id)
-    analytics(user).account_creation_tmx_result(**device_profiling_result.to_h)
+    analytics(user).account_creation_tmx_result(**device_profiling_result)
   end
 
   def analytics(user)

--- a/app/jobs/socure_reason_code_download_job.rb
+++ b/app/jobs/socure_reason_code_download_job.rb
@@ -11,7 +11,7 @@ class SocureReasonCodeDownloadJob < ApplicationJob
     return unless IdentityConfig.store.idv_socure_reason_code_download_enabled
 
     result = Proofing::Socure::ReasonCodes::Importer.new.synchronize
-    analytics.idv_socure_reason_code_download(**result.to_h)
+    analytics.idv_socure_reason_code_download(**result)
   end
 
   def analytics

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -25,6 +25,8 @@ class FormResponse
     hash
   end
 
+  alias_method :to_hash, :to_h
+
   def merge(other)
     self.class.new(
       success: success? && other.success?,

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -129,7 +129,7 @@ class MyController < ApplicationController
     form = MyForm.new(params)
 
     result = form.submit
-    analytics.my_event(**result.to_h)
+    analytics.my_event(**result)
 
     if result.success?
       do_something(form.sensitive_value_here)

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -273,6 +273,21 @@ RSpec.describe FormResponse do
     end
   end
 
+  describe '#to_hash' do
+    it 'allows for splatting response as alias of #to_h' do
+      errors = ActiveModel::Errors.new(build_stubbed(:user))
+      errors.add(:email_language, :blank, message: 'Language cannot be blank')
+      response = FormResponse.new(success: false, errors:, serialize_error_details_only: true)
+
+      expect(**response).to eq(
+        success: false,
+        error_details: {
+          email_language: { blank: true },
+        },
+      )
+    end
+  end
+
   describe '#extra' do
     it 'returns the extra hash' do
       extra = { foo: 'bar' }


### PR DESCRIPTION
## 🛠 Summary of changes

Adds `FormResponse#to_hash` as an alias of `FormResponse#to_h` to support implicit hash conversion.

Before:

```rb
analytics.something_submitted(**result.to_h)
```

After:

```rb
analytics.something_submitted(**result)
```

Existing instances updated with find and replace pattern:

- Search: `\*\*(\w*)(result|response).to_h([),])`
- Replace: `**$1$2$3`

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1730987694583649

Related information about implicit and explicit type conversions in Ruby: https://zverok.space/blog/2016-01-18-implicit-vs-expicit.html

## 📜 Testing Plan

Verify build passes.