### PR TITLE
Remove unused email styles

### DIFF
--- a/app/assets/stylesheets/email.css.scss
+++ b/app/assets/stylesheets/email.css.scss
@@ -25,10 +25,6 @@
   margin-bottom: 30px;
 }
 
-.mr-tiny {
-  margin-right: 4px;
-}
-
 .s10 {
   font-size: 10px;
   line-height: 10px;
@@ -73,48 +69,6 @@ h6 {
   color: $gray;
   padding: 10px;
   width: 50%;
-}
-
-.footer {
-  background: $secondary-color;
-
-  a {
-    color: $white;
-    text-decoration: underline;
-  }
-
-  p {
-    color: $white;
-    padding-top: 0;
-  }
-
-  .columns {
-    padding-bottom: 0;
-  }
-
-  .wrapper-inner {
-    padding: 25px 0;
-  }
-
-  .container {
-    background: transparent;
-  }
-}
-
-.legal {
-  background: $body-background;
-
-  a {
-    color: $dark-gray;
-  }
-
-  .container {
-    background: $body-background;
-  }
-
-  .wrapper-inner {
-    padding: 15px 0;
-  }
 }
 
 .usa-alert {


### PR DESCRIPTION
## 🛠 Summary of changes

Removes a handful of styles from the email mailer stylesheet which are currently unused.

- Last reference to `.legal` and `.footer` removed in #2703
- Last reference to `.mr-tiny` removed in #1279

## 📜 Testing Plan

Verify no regressions in mailer templates visual appearance.

http://localhost:3000/rails/mailers/