### PR TITLE
Improve font optimizer to exclude telephony, mailer strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ lint_font_glyphs: ## Lints to validate content glyphs match expectations from fo
 		--exclude-gem-path=faker \
 		--exclude-gem-path=good_job \
 		--exclude-gem-path=i18n-tasks \
+		--exclude-key-scope=user_mailer \
 		> app/assets/fonts/glyphs.txt
 	(! git diff --name-only | grep "glyphs\.txt$$") || (echo "Error: New character data found. Follow 'Fonts' instructions in 'docs/frontend.md' to regenerate fonts."; exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ lint_yaml: normalize_yaml ## Lints YAML files
 lint_font_glyphs: ## Lints to validate content glyphs match expectations from fonts
 	scripts/yaml_characters \
 		--exclude-locale=zh \
+		--exclude-path=config/locales/telephony \
 		--exclude-gem-path=faker \
 		--exclude-gem-path=good_job \
 		--exclude-gem-path=i18n-tasks \

--- a/scripts/yaml_characters
+++ b/scripts/yaml_characters
@@ -5,7 +5,8 @@ require 'pathname'
 require_relative '../config/environment'
 
 excluded_locales = []
-excluded_gem_paths = []
+excluded_paths = []
+
 OptionParser.new do |opts|
   opts.banner = <<~TXT
     Usage
@@ -22,8 +23,12 @@ OptionParser.new do |opts|
     excluded_locales << locale.to_sym
   end
 
+  opts.on('--exclude-path=PATH', 'Disregard characters from the given relative path') do |path|
+    excluded_paths << File.join(Dir.pwd, path, '')
+  end
+
   opts.on('--exclude-gem-path=GEM', 'Disregard characters loaded by the given gem') do |gem|
-    excluded_gem_paths << Gem.loaded_specs[gem].full_gem_path
+    excluded_paths << File.join(Gem.loaded_specs[gem].full_gem_path, '')
   end
 
   opts.on('-h', '--help', 'Prints this help') do
@@ -50,7 +55,7 @@ def hash_values(hash)
 end
 
 I18n.load_path.reject! do |load_path|
-  excluded_gem_paths.any? { |gem_path| load_path.start_with?(gem_path) }
+  excluded_paths.any? { |path| load_path.start_with?(path) }
 end
 
 I18n.backend.eager_load!

--- a/scripts/yaml_characters
+++ b/scripts/yaml_characters
@@ -66,7 +66,7 @@ end
 I18n.backend.eager_load!
 
 data = I18n.backend.translations.slice(*I18n.available_locales - excluded_locales)
-excluded_key_scopes.each { |scope| data.each { |locale,| data[locale].delete(scope) } }
+excluded_key_scopes.each { |scope| data.each_key { |locale| data[locale].delete(scope) } }
 strings = hash_values(data)
 joined_string = strings.join('')
 sanitized_string = sanitize(joined_string)

--- a/scripts/yaml_characters
+++ b/scripts/yaml_characters
@@ -6,6 +6,7 @@ require_relative '../config/environment'
 
 excluded_locales = []
 excluded_paths = []
+excluded_key_scopes = []
 
 OptionParser.new do |opts|
   opts.banner = <<~TXT
@@ -29,6 +30,10 @@ OptionParser.new do |opts|
 
   opts.on('--exclude-gem-path=GEM', 'Disregard characters loaded by the given gem') do |gem|
     excluded_paths << File.join(Gem.loaded_specs[gem].full_gem_path, '')
+  end
+
+  opts.on('--exclude-key-scope=SCOPE', 'Exclude keys in the given top-level key scope') do |scope|
+    excluded_key_scopes << scope.to_sym
   end
 
   opts.on('-h', '--help', 'Prints this help') do
@@ -61,6 +66,7 @@ end
 I18n.backend.eager_load!
 
 data = I18n.backend.translations.slice(*I18n.available_locales - excluded_locales)
+excluded_key_scopes.each { |scope| data.each { |locale,| data[locale].delete(scope) } }
 strings = hash_values(data)
 joined_string = strings.join('')
 sanitized_string = sanitize(joined_string)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates our [font optimizer](https://github.com/18F/identity-idp/blob/main/docs/frontend.md#fonts) tooling to disregard strings used for either telephony or user mailer emails. Since these are used in contexts which do not load the affected web fonts, they shouldn't be considered.

Currently this has no net effect on the characters being used, but this would have prevented a lot of developer toil in #11203 (see [related discussion](https://github.com/18F/identity-idp/pull/11203#discussion_r1745866051)). The hope is that these changes can limit the frequency of needing to regenerate font files.

## 📜 Testing Plan

Verify that `make lint_font_glyphs` succeeds.