### PR TITLE
Set residentKey option for webauthn to preferred

### DIFF
--- a/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.spec.ts
@@ -87,6 +87,7 @@ describe('enrollWebauthnDevice', () => {
           authenticatorSelection: {
             userVerification: 'discouraged',
             authenticatorAttachment: 'cross-platform',
+            residentKey: undefined,
           },
           excludeCredentials: [
             {
@@ -126,7 +127,7 @@ describe('enrollWebauthnDevice', () => {
     });
 
     context('platform authenticator', () => {
-      it('enrolls a device with correct authenticatorAttachment', async () => {
+      it('enrolls a device with correct authenticatorAttachment and residentKey', async () => {
         await enrollWebauthnDevice({
           platformAuthenticator: true,
           user,
@@ -139,6 +140,7 @@ describe('enrollWebauthnDevice', () => {
             hints: undefined,
             authenticatorSelection: {
               authenticatorAttachment: 'platform',
+              residentKey: 'preferred',
             },
           },
         });

--- a/app/javascript/packages/webauthn/enroll-webauthn-device.ts
+++ b/app/javascript/packages/webauthn/enroll-webauthn-device.ts
@@ -101,6 +101,7 @@ async function enrollWebauthnDevice({
         // contributes to abandonment or loss of access.
         userVerification: 'discouraged',
         authenticatorAttachment: platformAuthenticator ? 'platform' : 'cross-platform',
+        residentKey: platformAuthenticator ? 'preferred' : undefined,
       },
       excludeCredentials,
     } as PublicKeyCredentialCreationOptionsWithHints,


### PR DESCRIPTION
It is expected that this will allow Android devices to create synced credentials using Google Password Manager, and for such devices to provide an AAGUID value.

changelog: User-facing Improvements, F/T Unlock passkeys, Set residentKey option for webauthn to preferred

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-14911](https://cm-jira.usa.gov/browse/LG-14911)


<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Use Face/Touch Unlock to create an account. There should be no change in behavior.
- [ ] If you use an Android device, you should see a value for `aaguid` saved in the table `webauthn_configurations`.
