### PR TITLE
Fix HTML escaping for partner email sharing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,7 @@ IdentityIdp/I18nHelperHtmlLinter:
   Include:
     - app/views/**/*.erb
     - app/components/**/*.erb
+    - app/controllers/**/*.rb
 
 IdentityIdp/AnalyticsEventNameLinter:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance
+  - ./lib/linters/i18n_helper_html_linter.rb
   - ./lib/linters/analytics_event_name_linter.rb
   - ./lib/linters/localized_validation_message_linter.rb
   - ./lib/linters/image_size_linter.rb
@@ -44,6 +45,12 @@ Bundler/InsecureProtocolSource:
 
 Gemspec/DuplicatedAssignment:
   Enabled: true
+
+IdentityIdp/I18nHelperHtmlLinter:
+  Enabled: true
+  Include:
+    - app/views/**/*.erb
+    - app/components/**/*.erb
 
 IdentityIdp/AnalyticsEventNameLinter:
   Enabled: true

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -4,7 +4,7 @@
   <% c.with_header(id: 'select-email-heading') { t('titles.select_email') } %>
 
   <p id="select-email-intro">
-    <%= I18n.t('help_text.select_preferred_email_html', sp: @sp_name) %>
+    <%= t('help_text.select_preferred_email_html', sp: @sp_name) %>
   </p>
 
   <%= simple_form_for(@select_email_form, url: sign_up_select_email_path) do |f| %>

--- a/lib/linters/i18n_helper_html_linter.rb
+++ b/lib/linters/i18n_helper_html_linter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module IdentityIdp
+      # This linter checks to ensure that strings which include HTML are rendered using Rails `t`
+      # view helper, rather than through the I18n class. Only the Rails view helper will mark the
+      # content as HTML-safe.
+      #
+      # @see https://guides.rubyonrails.org/i18n.html#using-safe-html-translations
+      #
+      # @example
+      #   # bad
+      #   I18n.t('errors.message_html')
+      #
+      #   # good
+      #   t('errors.message_html')
+      #
+      class I18nHelperHtmlLinter < RuboCop::Cop::Base
+        MSG = 'Use the Rails `t` view helper for HTML-safe strings'
+
+        RESTRICT_ON_SEND = [:t].freeze
+
+        def_node_matcher :i18n_class_send?, <<~PATTERN
+          (send (const nil? :I18n) :t $...)
+        PATTERN
+
+        def on_send(node)
+          return if !i18n_class_send?(node) || !i18n_key(node)&.end_with?('_html')
+          add_offense(node)
+        end
+
+        private
+
+        def i18n_key(node)
+          first_argument = node.arguments.first
+          return if first_argument.nil?
+          return if !first_argument.respond_to?(:value)
+          first_argument.value.to_s
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/linters/i18n_helper_html_linter_spec.rb
+++ b/spec/lib/linters/i18n_helper_html_linter_spec.rb
@@ -1,0 +1,51 @@
+require 'rubocop'
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+
+require_relative '../../../lib/linters/i18n_helper_html_linter'
+
+RSpec.describe RuboCop::Cop::IdentityIdp::I18nHelperHtmlLinter do
+  include CopHelper
+  include RuboCop::RSpec::ExpectOffense
+
+  let(:config) { RuboCop::Config.new }
+  let(:cop) { RuboCop::Cop::IdentityIdp::I18nHelperHtmlLinter.new(config) }
+
+  it 'registers offense when calling `t` from i18n class with key suffixed by "_html"' do
+    expect_offense(<<~RUBY)
+      I18n.t('errors.message_html')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/I18nHelperHtmlLinter: Use the Rails `t` view helper for HTML-safe strings
+    RUBY
+  end
+
+  it 'registers offense when calling `t` from i18n class with symbol key suffixed by "_html"' do
+    expect_offense(<<~RUBY)
+      I18n.t(:message_html)
+      ^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/I18nHelperHtmlLinter: Use the Rails `t` view helper for HTML-safe strings
+    RUBY
+  end
+
+  it 'gracefully handles `I18n.t` without arguments' do
+    expect_no_offenses(<<~RUBY)
+      I18n.t
+    RUBY
+  end
+
+  it 'gracefully handles `I18n.t` with variable key' do
+    expect_no_offenses(<<~RUBY)
+      I18n.t(key)
+    RUBY
+  end
+
+  it 'registers no offense when calling `t` from i18n class with key not suffixed by "_html"' do
+    expect_no_offenses(<<~RUBY)
+      I18n.t('errors.message')
+    RUBY
+  end
+
+  it 'registers no offense when calling `t` from Rails view helper' do
+    expect_no_offenses(<<~RUBY)
+      t('errors.message_html')
+    RUBY
+  end
+end

--- a/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
     @select_email_form = SelectEmailForm.new(user:, identity:)
   end
 
+  it 'renders introduction text' do
+    expect(rendered).to have_content(
+      strip_tags(t('help_text.select_preferred_email_html', sp: identity.display_name)),
+    )
+  end
+
   it 'renders a list of the users email addresses as radio options' do
     allow(self).to receive(:page).and_return(Capybara.string(rendered))
     inputs = page.find_all('[type="radio"]')

--- a/spec/views/sign_up/select_email/show.html.erb_spec.rb
+++ b/spec/views/sign_up/select_email/show.html.erb_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'sign_up/select_email/show.html.erb' do
     )
   end
 
-  it 'shows all of the user\'s emails' do
+  it 'shows all of the emails' do
     expect(rendered).to include('michael.motorist@email.com')
     expect(rendered).to include('michael.motorist2@email.com')
   end

--- a/spec/views/sign_up/select_email/show.html.erb_spec.rb
+++ b/spec/views/sign_up/select_email/show.html.erb_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'sign_up/select_email/show.html.erb' do
+  subject(:rendered) { render }
   let(:email) { 'michael.motorist@email.com' }
   let(:email2) { 'michael.motorist2@email.com' }
   let(:user) { create(:user) }
@@ -10,11 +11,16 @@ RSpec.describe 'sign_up/select_email/show.html.erb' do
     create(:email_address, email: email2, user:)
     @user_emails = user.confirmed_email_addresses
     @select_email_form = SelectEmailForm.new(user:)
+    @sp_name = 'Test Service Provider'
+  end
+
+  it 'renders introduction text' do
+    expect(rendered).to have_content(
+      strip_tags(t('help_text.select_preferred_email_html', sp: @sp_name)),
+    )
   end
 
   it 'shows all of the user\'s emails' do
-    render
-
     expect(rendered).to include('michael.motorist@email.com')
     expect(rendered).to include('michael.motorist2@email.com')
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where partner email selection text was showing as escaped HTML.

The content was recently updated in #11468 to add HTML, and while the string key is correctly suffixed with `_html`, one of two views uses `I18n.t` instead of `t`, which does not perform automatic unescaping ([docs](https://guides.rubyonrails.org/i18n.html#using-safe-html-translations:~:text=Automatic%20conversion%20to%20HTML%20safe%20translate%20text%20is%20only%20available%20from%20the%20translate%20(or%20t)%20helper%20method.%20This%20works%20in%20views%20and%20controllers.)).

## 📜 Testing Plan

Verify the text does not show escaped HTML:

1. Run [sample application](https://github.com/18f/identity-oidc-sinatra) in parallel to IdP
2. Prerequisite: If you've already consented with partner application, sign in and revoke consent from "Connected Accounts" account page
3. Go to http://localhost:9292
4. Click "Sign in"
5. Complete sign-in up to consent screen
6. Click "Change" if you see it. Otherwise, click "Add new email" and complete this flow 
8. Observe introduction paragraph of email selection screen does not include escaped HTML

## 👀 Screenshots

Before|After
---|---
![Screenshot 2024-11-12 at 7 23 31 AM](https://github.com/user-attachments/assets/7a81bb58-d2a7-4abd-aa9b-7420edb03000)|![Screenshot 2024-11-12 at 7 23 38 AM](https://github.com/user-attachments/assets/639f00de-49a2-4fda-9534-dbb77e71c6a1)
