### PR TITLE
Reset selected email session value on email deletion

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -99,6 +99,7 @@ module Users
 
     def handle_successful_delete
       send_delete_email_notification
+      user_session.delete(:selected_email_id_for_linked_identity)
       flash[:success] = t('email_addresses.delete.success')
       create_user_event(:email_deleted)
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates email deletion behavior to reset user session value for selected email preference.

This fixes an unlikely user path which could result in an unhandled 500 error.

## 📜 Testing Plan

1. Prerequisite: Have an account with multiple email addresses
2. Prerequisite: Disconnect from sample application if already consented, from "Connected Accounts" account page
3. Run [sample application](https://github.com/18f/identity-oidc-sinatra) in separate process from IdP
4. Go to http://localhost:9292
5. Click "Sign in"
6. Complete sign-in up to consent screen
7. Click "Change" next to email address
8. Select an email address. Remember which email you selected.
9. Click "Change"
10. In a separate tab, go to http://localhost:3000
11. From account dashboard, delete (and confirm deletion of) the email you selected on Step 8
12. Return to the original tab for the partner attributes consent screen
13. Refresh the page

**Before:** You'd encounter a `ActiveRecord::RecordNotFound` 500 error
**After:** The consent screen loads, and the email address is reset to the default value (what you'd seen at Step 6)