### PR TITLE
LG-14807 reset the socure docV url when the CaptureApp session has ended

### DIFF
--- a/app/controllers/socure_webhook_controller.rb
+++ b/app/controllers/socure_webhook_controller.rb
@@ -26,6 +26,8 @@ class SocureWebhookController < ApplicationController
     when 'DOCUMENTS_UPLOADED'
       increment_rate_limiter
       fetch_results
+    when 'SESSION_EXPIRED', 'SESSION_COMPLETE'
+      reset_docv_url
     end
   end
 
@@ -92,6 +94,13 @@ class SocureWebhookController < ApplicationController
       rate_limiter.increment!
     end
     # Logic to throw an error when no DocumentCaptureSession found will be done in ticket LG-14905
+  end
+
+  def reset_docv_url
+    if document_capture_session.present?
+      document_capture_session.socure_docv_capture_app_url = nil
+      document_capture_session.save
+    end
   end
 
   def document_capture_session

--- a/spec/controllers/socure_webhook_controller_spec.rb
+++ b/spec/controllers/socure_webhook_controller_spec.rb
@@ -158,6 +158,19 @@ RSpec.describe SocureWebhookController do
                 with(document_capture_session_uuid: dcs.uuid)
             end
 
+            it 'does not reset socure_docv_capture_app_url value' do
+              dcs = create(:document_capture_session, :socure)
+              webhook_body[:event][:docvTransactionToken] = dcs.socure_docv_transaction_token
+              allow(DocumentCaptureSession).to receive(:find_by).
+                and_return(dcs)
+              allow(SocureDocvResultsJob).to receive(:perform_later)
+              dcs.socure_docv_capture_app_url = fake_capture_app_url
+              dcs.save
+              post :create, params: webhook_body
+              dcs.reload
+              expect(dcs.socure_docv_capture_app_url).to eq(fake_capture_app_url)
+            end
+
             context 'when document capture session does not exist' do
               before do
                 allow(NewRelic::Agent).to receive(:notice_error)
@@ -174,6 +187,58 @@ RSpec.describe SocureWebhookController do
 
           context 'when SESSION_COMPLETE event received' do
             let(:event_type) { 'SESSION_COMPLETE' }
+            let(:docv_transaction_token) { 'fake-transaction-token' }
+            let(:user) { create(:user) }
+            let(:document_capture_session) do
+              DocumentCaptureSession.create(user:).tap do |dcs|
+                dcs.socure_docv_transaction_token = docv_transaction_token
+              end
+            end
+
+            before do
+              request.headers['Authorization'] = socure_secret_key
+              allow(DocumentCaptureSession).to receive(:find_by).
+                and_return(document_capture_session)
+              allow(SocureDocvResultsJob).to receive(:perform_later)
+              document_capture_session.socure_docv_capture_app_url = fake_capture_app_url
+              document_capture_session.save
+            end
+
+            it 'does not increment rate limiter of user' do
+              dcs = create(:document_capture_session, :socure)
+              webhook_body[:event][:docvTransactionToken] = dcs.socure_docv_transaction_token
+
+              i = 0
+              while i < 4
+                post :create, params: webhook_body
+                rate_limiter = RateLimiter.new(
+                  user: dcs.user,
+                  rate_limit_type: :idv_doc_auth,
+                )
+                expect(rate_limiter.attempts).to eq 0
+                i += 1
+              end
+            end
+
+            it 'does not enqueue a SocureDocvResultsJob' do
+              dcs = create(:document_capture_session, :socure)
+              webhook_body[:event][:docvTransactionToken] = dcs.socure_docv_transaction_token
+
+              post :create, params: webhook_body
+
+              expect(SocureDocvResultsJob).not_to have_received(:perform_later)
+            end
+            it 'resets socure_docv_capture_app_url to nil' do
+              expect(document_capture_session.socure_docv_capture_app_url).
+                to eq(fake_capture_app_url)
+              post :create, params: webhook_body
+              document_capture_session.reload
+              expect(document_capture_session.socure_docv_capture_app_url).to be_nil
+            end
+          end
+
+          context 'when SESSION_EXPIRED event received' do
+            let(:event_type) { 'SESSION_EXPIRED' }
             let(:docv_transaction_token) { 'fake-transaction-token' }
             let(:user) { create(:user) }
             let(:document_capture_session) do

--- a/spec/controllers/socure_webhook_controller_spec.rb
+++ b/spec/controllers/socure_webhook_controller_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe SocureWebhookController do
                   dcs.socure_docv_transaction_token = docv_transaction_token
                 end
               end
-      
+
               before do
                 request.headers['Authorization'] = socure_secret_key
                 allow(DocumentCaptureSession).to receive(:find_by).
@@ -222,7 +222,7 @@ RSpec.describe SocureWebhookController do
                 document_capture_session.socure_docv_capture_app_url = fake_capture_app_url
                 document_capture_session.save
               end
-      
+
               it 'does not increment rate limiter of user' do
                 expect(rate_limiter.attempts).to eq 0
                 post :create, params: webhook_body
@@ -230,17 +230,18 @@ RSpec.describe SocureWebhookController do
                 post :create, params: webhook_body
                 expect(rate_limiter.attempts).to eq 0
               end
-      
+
               it 'resets socure_docv_capture_app_url to nil' do
-                expect(document_capture_session.socure_docv_capture_app_url).to eq(fake_capture_app_url)
+                expect(document_capture_session.socure_docv_capture_app_url).
+                  to eq(fake_capture_app_url)
                 post :create, params: webhook_body
                 document_capture_session.reload
                 expect(document_capture_session.socure_docv_capture_app_url).to be_nil
               end
-      
+
               it 'does not enqueue a SocureDocvResultsJob' do
                 post :create, params: webhook_body
-      
+
                 expect(SocureDocvResultsJob).not_to have_received(:perform_later).
                   with(document_capture_session_uuid: document_capture_session.uuid)
               end

--- a/spec/controllers/socure_webhook_controller_spec.rb
+++ b/spec/controllers/socure_webhook_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe SocureWebhookController do
     let(:socure_secret_key_queue) { ['this-is-an-old-secret', 'this-is-an-older-secret'] }
     let(:socure_enabled) { true }
     let(:fake_capture_app_url) { 'https://fake-socure.test/capture' }
-    let(:rate_limiter) { RateLimiter.new(rate_limit_type: :idv_doc_auth, user: user) }
     let(:event_type) { 'TEST_WEBHOOK' }
     let(:event_docv_transaction_token) { 'TEST_WEBHOOK_TOKEN' }
     let(:customer_user_id) { '#1-customer' }
@@ -161,8 +160,6 @@ RSpec.describe SocureWebhookController do
             it 'does not reset socure_docv_capture_app_url value' do
               dcs = create(:document_capture_session, :socure)
               webhook_body[:event][:docvTransactionToken] = dcs.socure_docv_transaction_token
-              allow(DocumentCaptureSession).to receive(:find_by).
-                and_return(dcs)
               allow(SocureDocvResultsJob).to receive(:perform_later)
               dcs.socure_docv_capture_app_url = fake_capture_app_url
               dcs.save


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->



Link to the relevant ticket:
[LG-14807](https://cm-jira.usa.gov/browse/LG-14807)


## 🛠 Summary of changes

Remove inactive CaptureApp session from the database so that a new one can be created when rendering document capture by setting value to nil in db.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
