### PR TITLE
LG-14007: wait for Socure result if not present upon return

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -89,10 +89,5 @@ module Idv
       doc_auth_log.state = state
       doc_auth_log.save!
     end
-
-    def cancel_establishing_in_person_enrollments(user: current_user)
-      UspsInPersonProofing::EnrollmentHelper.
-        cancel_stale_establishing_enrollments_for_user(user)
-    end
   end
 end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -35,8 +35,6 @@ module Idv
       Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer]).
         call('document_capture', :update, true)
 
-      cancel_establishing_in_person_enrollments
-
       if result.success?
         redirect_to idv_ssn_url
       else

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -67,16 +67,6 @@ module Idv
         # Not used in standard flow, here for data consistency with hybrid flow.
         document_capture_session.confirm_ocr
 
-        Rails.logger.info(
-          {
-            controller: 'idv/socure/document_capture_controller',
-            method: 'update',
-            stored_result: stored_result,
-            job_sleep_seconds: IdentityConfig.store.doc_auth_socure_job_sleep_seconds,
-            refresh_interval: IdentityConfig.store.doc_auth_socure_wait_polling_refresh_max_seconds,
-            timeout: IdentityConfig.store.doc_auth_socure_wait_polling_timeout_minutes,
-          }.to_json,
-        )
         # If the stored_result is nil, the job fetching the results has not completed.
         if stored_result.nil?
           analytics.idv_doc_auth_document_capture_polling_wait_visited(**analytics_arguments)
@@ -85,7 +75,6 @@ module Idv
             # TODO: redirect to try again page LG-14873/14952/15059
             render plain: 'Technical difficulties!!!', status: :ok
           else
-            @polling_started_at = idv_session.socure_docv_wait_polling_started_at.inspect
             @refresh_interval =
               IdentityConfig.store.doc_auth_socure_wait_polling_refresh_max_seconds
             render 'idv/socure/document_capture/wait'

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -68,7 +68,7 @@ module Idv
         # If the stored_result is nil, the job fetching the results has not completed.
         if stored_result.nil?
           analytics.idv_doc_auth_document_capture_polling_wait_visited(**analytics_arguments)
-          render 'shared/wait'
+          render 'idv/socure/document_capture/wait'
           return
         end
 

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -68,6 +68,7 @@ module Idv
         # If the stored_result is nil, the job fetching the results has not completed.
         if stored_result.nil?
           analytics.idv_doc_auth_document_capture_polling_wait_visited(**analytics_arguments)
+          @refresh_interval = IdentityConfig.store.doc_auth_socure_wait_polling_refresh_max_seconds
           render 'idv/socure/document_capture/wait'
           return
         end

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -65,6 +65,13 @@ module Idv
         # Not used in standard flow, here for data consistency with hybrid flow.
         document_capture_session.confirm_ocr
 
+        # If the stored_result is nil, the job fetching the results has not completed.
+        if stored_result.nil?
+          analytics.idv_doc_auth_document_capture_polling_wait_visited(**analytics_arguments)
+          render 'shared/wait'
+          return
+        end
+
         result = handle_stored_result
         # TODO: new analytics event?
         analytics.idv_doc_auth_document_capture_submitted(**result.to_h.merge(analytics_arguments))

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -18,9 +18,7 @@ class SocureDocvResultsJob < ApplicationJob
     # )
 
     sleep_seconds = IdentityConfig.store.doc_auth_socure_job_sleep_seconds
-    Rails.logger.info "\n\n#{'Zzzz' * 20}\n\nSleeping for #{sleep_seconds} seconds..."
     sleep sleep_seconds
-    Rails.logger.info "\n    !!!!!!!!!!!! WAKE UP !!!!!!!!!\n\n#{'Zzzz' * 20}\n"
 
     result = socure_document_verification_result
     dcs.store_result_from_response(result)

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -17,9 +17,6 @@ class SocureDocvResultsJob < ApplicationJob
     #   service_provider_issuer: dcs.issuer,
     # )
 
-    sleep_seconds = IdentityConfig.store.doc_auth_socure_job_sleep_seconds
-    sleep sleep_seconds
-
     result = socure_document_verification_result
     dcs.store_result_from_response(result)
   end

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -17,6 +17,11 @@ class SocureDocvResultsJob < ApplicationJob
     #   service_provider_issuer: dcs.issuer,
     # )
 
+    sleep_seconds = IdentityConfig.store.doc_auth_socure_job_sleep_seconds
+    Rails.logger.info "\n\n#{'Zzzz' * 20}\n\nSleeping for #{sleep_seconds} seconds..."
+    sleep sleep_seconds
+    Rails.logger.info "\n    !!!!!!!!!!!! WAKE UP !!!!!!!!!\n\n#{'Zzzz' * 20}\n"
+
     result = socure_document_verification_result
     dcs.store_result_from_response(result)
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1240,6 +1240,44 @@ module AnalyticsEvents
     )
   end
 
+  # User returns from Socure document capture, but is waiting on a result to be fetched
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Boolean] liveness_checking_required Whether facial match check is required
+  # @param [Boolean] selfie_check_required Whether facial match check is required
+  # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
+  # SDK upgrades
+  def idv_doc_auth_document_capture_polling_wait_visited(
+    flow_path:,
+    step:,
+    analytics_id:,
+    redo_document_capture:,
+    skip_hybrid_handoff:,
+    liveness_checking_required:,
+    selfie_check_required:,
+    opted_in_to_in_person_proofing: nil,
+    acuant_sdk_upgrade_ab_test_bucket: nil,
+    **extra
+  )
+    track_event(
+      :idv_doc_auth_document_capture_polling_wait_visited,
+      flow_path:,
+      step:,
+      analytics_id:,
+      redo_document_capture:,
+      skip_hybrid_handoff:,
+      liveness_checking_required:,
+      selfie_check_required:,
+      opted_in_to_in_person_proofing:,
+      acuant_sdk_upgrade_ab_test_bucket:,
+      **extra,
+    )
+  end
+
   # User submits IdV document capture step
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -32,6 +32,7 @@ module Idv
       skip_doc_auth_from_handoff
       skip_doc_auth_from_how_to_verify
       skip_hybrid_handoff
+      socure_docv_wait_polling_started_at
       ssn
       threatmetrix_review_status
       threatmetrix_session_id

--- a/app/views/idv/socure/document_capture/wait.html.erb
+++ b/app/views/idv/socure/document_capture/wait.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:meta_refresh) { @refresh_interval || '15' } %>
+<%= content_for(:meta_refresh) { @refresh_interval&.to_s || '15' } %>
 <% self.title = t('titles.doc_auth.verify') %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
@@ -16,6 +16,14 @@
       height: 116,
       class: 'margin-bottom-4',
     ) %>
+
+<h1>Doug was here!</h1>
+<p>
+  Refresh interval: <%= @refresh_interval %> sec<br/>
+  Timeout: <%= IdentityConfig.store.doc_auth_socure_wait_polling_timeout_minutes %> min<br/>
+  Sleep: <%= IdentityConfig.store.doc_auth_socure_job_sleep_seconds %> sec<br/>
+  Polling started at: <%= @polling_started_at %><br/>
+</p>
 
 <%= render PageHeadingComponent.new do %>
   <%= t('doc_auth.headings.interstitial') %>

--- a/app/views/idv/socure/document_capture/wait.html.erb
+++ b/app/views/idv/socure/document_capture/wait.html.erb
@@ -1,0 +1,30 @@
+<%= content_for(:meta_refresh) { '15' } %>
+<% self.title = t('titles.doc_auth.verify') %>
+<% content_for(:pre_flash_content) do %>
+  <%= render StepIndicatorComponent.new(
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
+        current_step: :verify_id,
+        locale_scope: 'idv',
+        class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
+      ) %>
+<% end %>
+
+<%= image_tag(
+      asset_url('id-card.svg'),
+      alt: '',
+      width: 216,
+      height: 116,
+      class: 'margin-bottom-4',
+    ) %>
+
+<%= render PageHeadingComponent.new do %>
+  <%= t('doc_auth.headings.interstitial') %>
+<% end %>
+
+<p class='margin-top-2'>
+  <%= t('doc_auth.info.interstitial_eta') %>
+</p>
+
+<p>
+  <%= t('doc_auth.info.interstitial_thanks') %>
+</p>

--- a/app/views/idv/socure/document_capture/wait.html.erb
+++ b/app/views/idv/socure/document_capture/wait.html.erb
@@ -17,14 +17,6 @@
       class: 'margin-bottom-4',
     ) %>
 
-<h1>Doug was here!</h1>
-<p>
-  Refresh interval: <%= @refresh_interval %> sec<br/>
-  Timeout: <%= IdentityConfig.store.doc_auth_socure_wait_polling_timeout_minutes %> min<br/>
-  Sleep: <%= IdentityConfig.store.doc_auth_socure_job_sleep_seconds %> sec<br/>
-  Polling started at: <%= @polling_started_at %><br/>
-</p>
-
 <%= render PageHeadingComponent.new do %>
   <%= t('doc_auth.headings.interstitial') %>
 <% end %>

--- a/app/views/idv/socure/document_capture/wait.html.erb
+++ b/app/views/idv/socure/document_capture/wait.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:meta_refresh) { '15' } %>
+<%= content_for(:meta_refresh) { @refresh_interval || '15' } %>
 <% self.title = t('titles.doc_auth.verify') %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -106,7 +106,6 @@ doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_selfie_desktop_test_mode: false
-doc_auth_socure_job_sleep_seconds: 0
 doc_auth_socure_wait_polling_refresh_max_seconds: 15
 doc_auth_socure_wait_polling_timeout_minutes: 2
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -106,6 +106,7 @@ doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_selfie_desktop_test_mode: false
+doc_auth_socure_wait_polling_refresh_max_seconds: 5
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'
 doc_auth_vendor: 'mock'
 doc_auth_vendor_default: 'mock'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -107,6 +107,7 @@ doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_selfie_desktop_test_mode: false
 doc_auth_socure_wait_polling_refresh_max_seconds: 5
+doc_auth_socure_wait_polling_timeout_minutes: 5
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'
 doc_auth_vendor: 'mock'
 doc_auth_vendor_default: 'mock'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -106,8 +106,9 @@ doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_selfie_desktop_test_mode: false
-doc_auth_socure_wait_polling_refresh_max_seconds: 5
-doc_auth_socure_wait_polling_timeout_minutes: 5
+doc_auth_socure_job_sleep_seconds: 0
+doc_auth_socure_wait_polling_refresh_max_seconds: 15
+doc_auth_socure_wait_polling_timeout_minutes: 2
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'
 doc_auth_vendor: 'mock'
 doc_auth_vendor_default: 'mock'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -124,7 +124,6 @@ module IdentityConfig
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_selfie_desktop_test_mode, type: :boolean)
-    config.add(:doc_auth_socure_job_sleep_seconds, type: :integer)
     config.add(:doc_auth_socure_wait_polling_refresh_max_seconds, type: :integer)
     config.add(:doc_auth_socure_wait_polling_timeout_minutes, type: :integer)
     config.add(:doc_auth_supported_country_codes, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -125,6 +125,7 @@ module IdentityConfig
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_selfie_desktop_test_mode, type: :boolean)
     config.add(:doc_auth_socure_wait_polling_refresh_max_seconds, type: :integer)
+    config.add(:doc_auth_socure_wait_polling_timeout_minutes, type: :integer)
     config.add(:doc_auth_supported_country_codes, type: :json)
     config.add(:doc_auth_vendor, type: :string)
     config.add(:doc_auth_vendor_default, type: :string)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -124,6 +124,7 @@ module IdentityConfig
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_selfie_desktop_test_mode, type: :boolean)
+    config.add(:doc_auth_socure_job_sleep_seconds, type: :integer)
     config.add(:doc_auth_socure_wait_polling_refresh_max_seconds, type: :integer)
     config.add(:doc_auth_socure_wait_polling_timeout_minutes, type: :integer)
     config.add(:doc_auth_supported_country_codes, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -124,6 +124,7 @@ module IdentityConfig
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_selfie_desktop_test_mode, type: :boolean)
+    config.add(:doc_auth_socure_wait_polling_refresh_max_seconds, type: :integer)
     config.add(:doc_auth_supported_country_codes, type: :json)
     config.add(:doc_auth_vendor, type: :string)
     config.add(:doc_auth_vendor_default, type: :string)

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -388,19 +388,6 @@ RSpec.describe Idv::DocumentCaptureController do
       end
     end
 
-    context 'user has an establishing in-person enrollment' do
-      let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user, profile: nil) }
-
-      it 'cancels the establishing enrollment' do
-        expect(user.establishing_in_person_enrollment).to eq enrollment
-
-        put :update
-
-        expect(enrollment.reload.cancelled?).to eq(true)
-        expect(user.reload.establishing_in_person_enrollment).to be_nil
-      end
-    end
-
     context 'ocr confirmation pending' do
       before do
         subject.document_capture_session.ocr_confirmation_pending = true

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
     allow(subject).to receive(:user_session).and_return(user_session)
 
     subject.idv_session.document_capture_session_uuid = document_capture_session.uuid
+
+    stub_analytics
   end
 
   describe '#step_info' do
@@ -274,6 +276,7 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
       get(:update)
 
       expect(response).to redirect_to(idv_ssn_path)
+      expect(@analytics).to have_logged_event('IdV: doc auth document_capture submitted')
     end
 
     context 'when doc auth fails' do
@@ -283,6 +286,18 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
         get(:update)
 
         expect(response).to redirect_to(idv_socure_document_capture_path)
+        expect(@analytics).to have_logged_event('IdV: doc auth document_capture submitted')
+      end
+    end
+
+    context 'when stored_result is nil' do
+      let(:stored_result) { nil }
+
+      it 'renders the wait view' do
+        get(:update)
+
+        expect(response).to render_template('shared/wait')
+        expect(@analytics).to have_logged_event(:idv_doc_auth_document_capture_polling_wait_visited)
       end
     end
 

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -298,6 +298,18 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
         expect(response).to render_template('idv/socure/document_capture/wait')
         expect(@analytics).to have_logged_event(:idv_doc_auth_document_capture_polling_wait_visited)
       end
+
+      context 'when the wait times out' do
+        before do
+          allow(subject).to receive(:wait_timed_out?).and_return(true)
+        end
+
+        it 'renders a technical difficulties message' do
+          get(:update)
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to eq('Technical difficulties!!!')
+        end
+      end
     end
 
     context 'when socure is disabled' do

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -295,8 +295,7 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
 
       it 'renders the wait view' do
         get(:update)
-
-        expect(response).to render_template('shared/wait')
+        expect(response).to render_template('idv/socure/document_capture/wait')
         expect(@analytics).to have_logged_event(:idv_doc_auth_document_capture_polling_wait_visited)
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14007](https://cm-jira.usa.gov/browse/LG-14007)

## 🛠 Summary of changes

Upon return from Socure via the redirect url, check for the stored result (fetched by a job triggered by a webhook event). If not yet present, render the wait page that refreshes every 15 secs.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
