### PR TITLE
Remove review-app image build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,56 +93,6 @@ install:
 
 # Build a container image async, and don't block CI tests
 # Cache intermediate images for 1 week (168 hours)
-build-review-image:
-  stage: review
-  needs: []
-  environment:
-    name: review/$CI_COMMIT_REF_NAME
-  interruptible: true
-  variables:
-    BRANCH_TAGGING_STRING: ''
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-      variables:
-        BRANCH_TAGGING_STRING: '--destination ${ECR_REGISTRY}/identity-idp/review:main'
-    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
-    - if: $CI_PIPELINE_SOURCE != "merge_request_event"
-      when: never
-  tags:
-    - build-pool
-  image:
-    name: gcr.io/kaniko-project/executor:debug
-    entrypoint: ['']
-  script:
-    - mkdir -p /kaniko/.docker
-    - echo ${CI_ENVIRONMENT_SLUG}
-    - echo $CI_ENVIRONMENT_SLUG
-    - echo $CI_COMMIT_BRANCH
-    - echo $CI_COMMIT_SHA
-    - |-
-      KANIKOCFG="\"credsStore\":\"ecr-login\""
-      if [ "x${http_proxy}" != "x" -o "x${https_proxy}" != "x" ]; then
-        KANIKOCFG="${KANIKOCFG}, \"proxies\": { \"default\": { \"httpProxy\": \"${http_proxy}\", \"httpsProxy\": \"${https_proxy}\", \"noProxy\": \"${no_proxy}\"}}"
-      fi
-      KANIKOCFG="{ ${KANIKOCFG} }"
-      echo "${KANIKOCFG}" > /kaniko/.docker/config.json
-    - >-
-      /kaniko/executor
-      --context "${CI_PROJECT_DIR}"
-      --dockerfile "${CI_PROJECT_DIR}/dockerfiles/idp_review_app.Dockerfile"
-      --destination "${ECR_REGISTRY}/identity-idp/review:${CI_COMMIT_SHA}"
-      ${BRANCH_TAGGING_STRING}
-      --cache-repo="${ECR_REGISTRY}/identity-idp/review/cache"
-      --cache-ttl=168h
-      --cache=true
-      --compressed-caching=false
-      --build-arg "http_proxy=${http_proxy}"
-      --build-arg "https_proxy=${https_proxy}"
-      --build-arg "no_proxy=${no_proxy}"
-      --build-arg "ARG_CI_ENVIRONMENT_SLUG=${CI_ENVIRONMENT_SLUG}"
-      --build-arg "ARG_CI_COMMIT_BRANCH=${CI_COMMIT_BRANCH}"
-      --build-arg "ARG_CI_COMMIT_SHA=${CI_COMMIT_SHA}"
-
 build-idp-image:
   stage: review
   needs: []
@@ -672,19 +622,6 @@ secret_detection:
 
 # Export the automated ECR scan results into a format Gitlab can use
 # Report schema https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/master/dist/container-scanning-report-format.json
-ecr-scan-review-app:
-  extends: .container_scan_template
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
-    - if: $CI_PIPELINE_SOURCE != "merge_request_event"
-      when: never
-  needs:
-    - job: build-review-image
-  stage: scan
-  variables:
-    ecr_repo: identity-idp/review
-
 ecr-scan-ci:
   extends: .container_scan_template
   rules:


### PR DESCRIPTION
## 🛠 Summary of changes

Following #11452, we no longer need to build the review-app images. This PR removes them.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
