### PR TITLE
Only export stats for tables with integer id columns

### DIFF
--- a/app/jobs/data_warehouse/table_summary_stats_export_job.rb
+++ b/app/jobs/data_warehouse/table_summary_stats_export_job.rb
@@ -29,7 +29,9 @@ module DataWarehouse
     end
 
     def table_has_id_column?(table)
-      ActiveRecord::Base.connection.columns(table).map(&:name).include?('id')
+      ActiveRecord::Base.connection.columns(table).any? do |column|
+        column.name == 'id' && column.type == :integer
+      end
     end
 
     def fetch_max_id_and_count(table, timestamp)


### PR DESCRIPTION
## 🛠 Summary of changes

A column named `id` sometimes is a `uuid` type, which breaks when calling `max(id)`. Based on an error discussed [here](https://gsa-tts.slack.com/archives/C03N6KQBAKS/p1731528552864369).

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
