### PR TITLE
Avoid setting reCAPTCHA token on failed execute

### DIFF
--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
@@ -239,6 +239,9 @@ describe('CaptchaSubmitButtonElement', () => {
           await userEvent.click(button);
 
           await expect(form.submit).to.eventually.be.called();
+          await expect(Object.fromEntries(new window.FormData(form))).to.deep.equal({
+            recaptcha_token: '',
+          });
         });
 
         it('tracks error', async () => {

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -58,11 +58,11 @@ class CaptchaSubmitButtonElement extends HTMLElement {
       let token;
       try {
         token = await this.recaptchaClient!.execute(siteKey!, { action });
+        this.tokenInput.value = token;
       } catch (error) {
         trackError(error, { errorId: 'recaptchaExecute' });
       }
 
-      this.tokenInput.value = token;
       this.submit();
     });
   }

--- a/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
+++ b/app/javascript/packages/captcha-submit-button/captcha-submit-button-element.ts
@@ -55,7 +55,7 @@ class CaptchaSubmitButtonElement extends HTMLElement {
     this.#onReady(async () => {
       const { recaptchaSiteKey: siteKey, recaptchaAction: action } = this;
 
-      let token;
+      let token: string | undefined;
       try {
         token = await this.recaptchaClient!.execute(siteKey!, { action });
         this.tokenInput.value = token;


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the implementation of the reCAPTCHA submit button to avoid setting a token value if reCAPTCHA fails to execute.

Previously, if reCAPTCHA failed to execute (throws an error), the value would be `undefined`, which would be stringified to the form input as the literal string `"undefined"`. By not setting the token value, we can get more accurate error details on the backend for a "blank" form error reason ([source](https://github.com/18F/identity-idp/blob/6203407fcc77d1506795754d25735005edcb7d0f/app/forms/recaptcha_form.rb#L67-L70)).

## 📜 Testing Plan

```
yarn app/javascript/packages/captcha-submit-button/captcha-submit-button-element.spec.ts
```

Previously, this would fail with:

```
      AssertionError: expected { recaptcha_token: 'undefined' } to deeply equal { recaptcha_token: '' }
      + expected - actual

       {
      -  "recaptcha_token": "undefined"
      +  "recaptcha_token": ""
       }
```

Verify token is sent empty for failed reCAPTCHA execute:

1. Repeat testing plan from #11449, with browser developer tools "Network" tab open, and "Preserve log" checked
2. After clicking "Sign in", observe click on the POST request to the sign-in route
3. Click "Payload" tab
4. Observe that `recaptcha_token` is empty, rather than `"undefined"`