### PR TITLE
Add uncapped preload headers for style, script assets

### DIFF
--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -14,7 +14,7 @@ module ScriptHelper
       javascript_packs_tag_once(...)
       return if @scripts.blank?
       concat javascript_assets_tag
-      crossorigin = true if local_crossorigin_sources?
+      crossorigin = local_crossorigin_sources?.presence
       @scripts.each do |name, (url_params, attributes)|
         asset_sources.get_sources(name).each do |source|
           integrity = asset_sources.get_integrity(source)

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -14,9 +14,9 @@ module ScriptHelper
       javascript_packs_tag_once(...)
       return if @scripts.blank?
       concat javascript_assets_tag
+      crossorigin = true if local_crossorigin_sources?
       @scripts.each do |name, (url_params, attributes)|
         asset_sources.get_sources(name).each do |source|
-          crossorigin = true if local_crossorigin_sources?
           integrity = asset_sources.get_integrity(source)
 
           if attributes[:preload_links_header] != false

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -29,12 +29,11 @@ module ScriptHelper
             )
           end
 
-          concat javascript_include_tag(
-            UriService.add_params(source, url_params),
+          concat tag.script(
+            src: UriService.add_params(source, url_params),
             **attributes,
             crossorigin:,
             integrity:,
-            preload_links_header: false,
           )
         end
       end

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -20,7 +20,13 @@ module ScriptHelper
           integrity = asset_sources.get_integrity(source)
 
           if attributes[:preload_links_header] != false
-            AssetPreloadLinker.append(response:, as: :script, url: source, crossorigin:, integrity:)
+            AssetPreloadLinker.append(
+              headers: response.headers,
+              as: :script,
+              url: source,
+              crossorigin:,
+              integrity:,
+            )
           end
 
           concat javascript_include_tag(

--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -16,12 +16,19 @@ module ScriptHelper
       concat javascript_assets_tag
       @scripts.each do |name, (url_params, attributes)|
         asset_sources.get_sources(name).each do |source|
+          crossorigin = true if local_crossorigin_sources?
+          integrity = asset_sources.get_integrity(source)
+
+          if attributes[:preload_links_header] != false
+            AssetPreloadLinker.append(response:, as: :script, url: source, crossorigin:, integrity:)
+          end
+
           concat javascript_include_tag(
             UriService.add_params(source, url_params),
             **attributes,
-            crossorigin: local_crossorigin_sources? ? true : nil,
-            integrity: asset_sources.get_integrity(source),
-            nopush: false,
+            crossorigin:,
+            integrity:,
+            preload_links_header: false,
           )
         end
       end

--- a/app/helpers/stylesheet_helper.rb
+++ b/app/helpers/stylesheet_helper.rb
@@ -16,7 +16,7 @@ module StylesheetHelper
     safe_join(
       @stylesheets.map do |stylesheet|
         url = stylesheet_path(stylesheet)
-        AssetPreloadLinker.append(response:, as: :style, url:)
+        AssetPreloadLinker.append(headers: response.headers, as: :style, url:)
         tag.link(rel: :stylesheet, href: url)
       end,
     )

--- a/app/helpers/stylesheet_helper.rb
+++ b/app/helpers/stylesheet_helper.rb
@@ -13,7 +13,13 @@ module StylesheetHelper
   def render_stylesheet_once_tags(*names)
     stylesheet_tag_once(*names) if names.present?
     return if @stylesheets.blank?
-    safe_join(@stylesheets.map { |stylesheet| stylesheet_link_tag(stylesheet, nopush: false) })
+    safe_join(
+      @stylesheets.map do |stylesheet|
+        url = stylesheet_path(stylesheet)
+        AssetPreloadLinker.append(response:, as: :style, url:)
+        tag.link(rel: :stylesheet, href: url)
+      end,
+    )
   end
 end
 # rubocop:enable Rails/HelperInstanceVariable

--- a/app/services/asset_preload_linker.rb
+++ b/app/services/asset_preload_linker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AssetPreloadLinker
+  def self.append(response:, as:, url:, crossorigin: false, integrity: nil)
+    header = response.headers['Link'] || ''
+    header += ',' if header.present?
+    header += "<#{url}>;rel=preload;as=#{as}"
+    header += ';crossorigin' if crossorigin
+    header += ";integrity=#{integrity}" if integrity
+    response.headers['Link'] = header
+  end
+end

--- a/app/services/asset_preload_linker.rb
+++ b/app/services/asset_preload_linker.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class AssetPreloadLinker
-  def self.append(response:, as:, url:, crossorigin: false, integrity: nil)
-    header = response.headers['Link'] || ''
+  def self.append(headers:, as:, url:, crossorigin: false, integrity: nil)
+    header = headers['Link'] || ''
     header += ',' if header.present?
     header += "<#{url}>;rel=preload;as=#{as}"
     header += ';crossorigin' if crossorigin
     header += ";integrity=#{integrity}" if integrity
-    response.headers['Link'] = header
+    headers['Link'] = header
   end
 end

--- a/app/services/asset_preload_linker.rb
+++ b/app/services/asset_preload_linker.rb
@@ -2,11 +2,11 @@
 
 class AssetPreloadLinker
   def self.append(headers:, as:, url:, crossorigin: false, integrity: nil)
-    header = headers['Link'] || ''
-    header += ',' if header.present?
-    header += "<#{url}>;rel=preload;as=#{as}"
-    header += ';crossorigin' if crossorigin
-    header += ";integrity=#{integrity}" if integrity
+    header = headers['Link']&.dup || +''
+    header << ',' if header.present?
+    header << "<#{url}>;rel=preload;as=#{as}"
+    header << ';crossorigin' if crossorigin
+    header << ";integrity=#{integrity}" if integrity
     headers['Link'] = header
   end
 end

--- a/app/services/asset_preload_linker.rb
+++ b/app/services/asset_preload_linker.rb
@@ -2,11 +2,11 @@
 
 class AssetPreloadLinker
   def self.append(headers:, as:, url:, crossorigin: false, integrity: nil)
-    header = +headers['Link'].to_s
+    header = +headers['link'].to_s
     header << ',' if header != ''
     header << "<#{url}>;rel=preload;as=#{as}"
     header << ';crossorigin' if crossorigin
     header << ";integrity=#{integrity}" if integrity
-    headers['Link'] = header
+    headers['link'] = header
   end
 end

--- a/app/services/asset_preload_linker.rb
+++ b/app/services/asset_preload_linker.rb
@@ -2,8 +2,8 @@
 
 class AssetPreloadLinker
   def self.append(headers:, as:, url:, crossorigin: false, integrity: nil)
-    header = headers['Link']&.dup || +''
-    header << ',' if header.present?
+    header = +headers['Link'].to_s
+    header << ',' if header != ''
     header << "<#{url}>;rel=preload;as=#{as}"
     header << ';crossorigin' if crossorigin
     header << ";integrity=#{integrity}" if integrity

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe ScriptHelper do
         render_javascript_pack_once_tags
 
         expect(response.headers['link']).to eq(
-          '</application.js>; rel=preload; as=script,' \
-            '</document-capture.js>; rel=preload; as=script',
+          '</application.js>;rel=preload;as=script,' \
+            '</document-capture.js>;rel=preload;as=script',
         )
         expect(response.headers['link']).to_not include('nopush')
       end

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -107,6 +107,18 @@ RSpec.describe ScriptHelper do
         end
       end
 
+      context 'with preload links header disabled' do
+        before do
+          javascript_packs_tag_once('application', preload_links_header: false)
+        end
+
+        it 'does not append preload header' do
+          render_javascript_pack_once_tags
+
+          expect(response.headers['link']).to eq('</document-capture.js>;rel=preload;as=script')
+        end
+      end
+
       context 'with attributes' do
         before do
           javascript_packs_tag_once('track-errors', defer: true)

--- a/spec/helpers/stylesheet_helper_spec.rb
+++ b/spec/helpers/stylesheet_helper_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe StylesheetHelper do
       it 'adds preload header without nopush attribute' do
         render_stylesheet_once_tags
 
-        expect(response.headers['link']).to eq('</stylesheets/styles.css>; rel=preload; as=style')
+        expect(response.headers['link']).to eq('</stylesheets/styles.css>;rel=preload;as=style')
         expect(response.headers['link']).to_not include('nopush')
       end
     end

--- a/spec/services/asset_preload_linker_spec.rb
+++ b/spec/services/asset_preload_linker_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe AssetPreloadLinker do
+  describe '.append' do
+    let(:link) { nil }
+    let(:as) { 'script' }
+    let(:url) { '/script.js' }
+    let(:crossorigin) { nil }
+    let(:integrity) { nil }
+    let(:headers) { { 'Link' => link } }
+    subject(:result) do
+      AssetPreloadLinker.append(**{ headers:, as:, url:, crossorigin:, integrity: }.compact)
+    end
+
+    context 'with absent link value' do
+      let(:link) { nil }
+
+      it 'returns a string with only the appended link' do
+        expect(result).to eq('</script.js>;rel=preload;as=script')
+      end
+    end
+
+    context 'with empty link value' do
+      let(:link) { '' }
+
+      it 'returns a string with only the appended link' do
+        expect(result).to eq('</script.js>;rel=preload;as=script')
+      end
+    end
+
+    context 'with non-empty link value' do
+      let(:link) { '</a.js>;rel=preload;as=script' }
+
+      it 'returns a comma-separated link value of the new and existing link' do
+        expect(result).to eq('</a.js>;rel=preload;as=script,</script.js>;rel=preload;as=script')
+      end
+    end
+
+    context 'with crossorigin option' do
+      let(:crossorigin) { true }
+
+      it 'includes crossorigin link param' do
+        expect(result).to eq('</script.js>;rel=preload;as=script;crossorigin')
+      end
+    end
+
+    context 'with integrity option' do
+      let(:integrity) { 'abc123' }
+
+      it 'includes integrity link param' do
+        expect(result).to eq('</script.js>;rel=preload;as=script;integrity=abc123')
+      end
+    end
+  end
+end

--- a/spec/services/asset_preload_linker_spec.rb
+++ b/spec/services/asset_preload_linker_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe AssetPreloadLinker do
       it 'returns a comma-separated link value of the new and existing link' do
         expect(result).to eq('</a.js>;rel=preload;as=script,</script.js>;rel=preload;as=script')
       end
+
+      context 'with existing link value as frozen string' do
+        let(:link) { '</a.js>;rel=preload;as=script'.freeze }
+
+        it 'returns a comma-separated link value of the new and existing link' do
+          expect(result).to eq('</a.js>;rel=preload;as=script,</script.js>;rel=preload;as=script')
+        end
+      end
     end
 
     context 'with crossorigin option' do

--- a/spec/services/asset_preload_linker_spec.rb
+++ b/spec/services/asset_preload_linker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AssetPreloadLinker do
     let(:url) { '/script.js' }
     let(:crossorigin) { nil }
     let(:integrity) { nil }
-    let(:headers) { { 'Link' => link } }
+    let(:headers) { { 'link' => link } }
     subject(:result) do
       AssetPreloadLinker.append(**{ headers:, as:, url:, crossorigin:, integrity: }.compact)
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates asset helpers to bypass internal `stylesheet_link_tag` and `javascript_include_tag` logic for handling preload response headers, appending preload headers without caps. As of https://github.com/rails/rails/pull/48405 (Rails 7.1), preload headers added by tag helpers are capped at 1kb, which is very limiting, especially given our approach of loading many, smaller assets targeted as sidecar assets for UI components.

While the caps have created some incentives to be more intentional with preloading (e.g. #10612), we've already addressed the lowest hanging fruit, and a number of critical scripts are currently not being preloaded (e.g. reCAPTCHA behaviors on the sign-in screen).

References:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link

## 📜 Testing Plan

Verify that preload headers are included for all scripts and assets, including `integrity` or `crossorigin` directives as appropriate. Compare against https://secure.login.gov

```
curl -I http://localhost:3000
``` 

Verify that there are no style or script regressions in browsing the application, either in local development or in a review application.