### PR TITLE
LG-14828 Remove deprecated state ID step routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -410,10 +410,6 @@ Rails.application.routes.draw do
           # sometimes underscores get messed up when linked to via SMS
           as: :capture_doc_dashes
 
-      # Deprecated route - temporary redirect while state id changes are rolled out
-      get '/in_person_proofing/state_id' => redirect('verify/in_person/state_id', status: 307)
-      put '/in_person_proofing/state_id' => 'in_person/state_id#update'
-
       get '/in_person' => 'in_person#index'
       get '/in_person/ready_to_verify' => 'in_person/ready_to_verify#show',
           as: :in_person_ready_to_verify


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14828](https://cm-jira.usa.gov/browse/LG-14828)

## 🛠 Summary of changes

Remove deprecated state ID step routes `/verify/in_person_proofing/state_id`

## 📜 Testing Plan

Ensure that users are not able to navigate to the `/verify/in_person_proofing/state_id` route
