### PR TITLE
Add idv_resolution_default_vendor config

### DIFF
--- a/app/services/proofing/resolution/plugins/instant_verify_residential_address_plugin.rb
+++ b/app/services/proofing/resolution/plugins/instant_verify_residential_address_plugin.rb
@@ -24,8 +24,36 @@ module Proofing
         end
 
         def proofer
-          @proofer ||=
-            if IdentityConfig.store.proofer_mock_fallback
+          @proofer ||= begin
+            # Historically, proofer_mock_fallback has controlled whether we
+            # use mock implementations of the Resolution and Address proofers
+            # (true = use mock, false = don't use mock).
+            # We are transitioning to a place where we will have separate
+            # configs for both. For the time being, we want to keep support for
+            # proofer_mock_fallback here. This can be removed after this code
+            # has been deployed and configs have been updated in all relevant
+            # environments.
+
+            old_config_says_mock = IdentityConfig.store.proofer_mock_fallback
+            old_config_says_iv = !old_config_says_mock
+            new_config_says_mock =
+              IdentityConfig.store.idv_resolution_default_vendor == :mock
+            new_config_says_iv =
+              IdentityConfig.store.idv_resolution_default_vendor == :instant_verify
+
+            proofer_type =
+              if new_config_says_mock && old_config_says_iv
+                # This will be the case immediately after deployment, when
+                # environment configs have not been updated. We need to
+                # fall back to the old config here.
+                :instant_verify
+              elsif new_config_says_iv
+                :instant_verify
+              else
+                :mock
+              end
+
+            if proofer_type == :mock
               Proofing::Mock::ResolutionMockClient.new
             else
               Proofing::LexisNexis::InstantVerify::Proofer.new(
@@ -39,6 +67,7 @@ module Proofing
                 request_mode: IdentityConfig.store.lexisnexis_request_mode,
               )
             end
+          end
         end
 
         def residential_address_unnecessary_result

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -158,6 +158,7 @@ idv_available: true
 idv_contact_phone_number: (844) 555-5555
 idv_max_attempts: 5
 idv_min_age_years: 13
+idv_resolution_default_vendor: mock
 idv_send_link_attempt_window_in_minutes: 10
 idv_send_link_max_attempts: 5
 idv_socure_reason_code_download_enabled: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -176,6 +176,11 @@ module IdentityConfig
     config.add(:idv_contact_phone_number, type: :string)
     config.add(:idv_max_attempts, type: :integer)
     config.add(:idv_min_age_years, type: :integer)
+    config.add(
+      :idv_resolution_default_vendor,
+      type: :symbol,
+      enum: [:instant_verify, :mock],
+    )
     config.add(:idv_send_link_attempt_window_in_minutes, type: :integer)
     config.add(:idv_send_link_max_attempts, type: :integer)
     config.add(:idv_socure_reason_code_download_enabled, type: :boolean)

--- a/spec/services/proofing/resolution/plugins/instant_verify_residential_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_residential_address_plugin_spec.rb
@@ -147,9 +147,11 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyResidentialAddressPlu
           :instant_verify
         end
 
-        it 'creates an Instant Verify proofer because the new setting takes precedence' do
+        # rubocop:disable Layout/LineLength
+        it 'creates an Instant Verify proofer because the new setting takes precedence over the old one when the old one is set to its default value' do
           expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
         end
+        # rubocop:enable Layout/LineLength
       end
 
       context 'and idv_resolution_default_vendor is set to :mock' do

--- a/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
@@ -305,9 +305,11 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
           :instant_verify
         end
 
-        it 'creates an Instant Verify proofer because the new setting takes precedence' do
+        # rubocop:disable Layout/LineLength
+        it 'creates an Instant Verify proofer because the new setting takes precedence over the old one when the old one is set to its default value' do
           expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
         end
+        # rubocop:enable Layout/LineLength
       end
 
       context 'and idv_resolution_default_vendor is set to :mock' do

--- a/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
@@ -29,10 +29,6 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
     described_class.new
   end
 
-  before do
-    allow(plugin.proofer).to receive(:proof).and_return(proofer_result)
-  end
-
   describe '#call' do
     subject(:call) do
       plugin.call(
@@ -42,6 +38,10 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
         instant_verify_residential_address_result:,
         timer: JobHelpers::Timer.new,
       )
+    end
+
+    before do
+      allow(plugin.proofer).to receive(:proof).and_return(proofer_result)
     end
 
     context 'remote unsupervised proofing' do
@@ -282,6 +282,59 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
               end
             end
           end
+        end
+      end
+    end
+  end
+
+  describe '#proofer' do
+    subject(:proofer) { plugin.proofer }
+
+    before do
+      allow(IdentityConfig.store).to receive(:proofer_mock_fallback).
+        and_return(proofer_mock_fallback)
+      allow(IdentityConfig.store).to receive(:idv_resolution_default_vendor).
+        and_return(idv_resolution_default_vendor)
+    end
+
+    context 'when proofer_mock_fallback is set to true' do
+      let(:proofer_mock_fallback) { true }
+
+      context 'and idv_resolution_default_vendor is set to :instant_verify' do
+        let(:idv_resolution_default_vendor) do
+          :instant_verify
+        end
+
+        it 'creates an Instant Verify proofer because the new setting takes precedence' do
+          expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
+        end
+      end
+
+      context 'and idv_resolution_default_vendor is set to :mock' do
+        let(:idv_resolution_default_vendor) { :mock }
+
+        it 'creates a mock proofer because the two settings agree' do
+          expect(proofer).to be_an_instance_of(Proofing::Mock::ResolutionMockClient)
+        end
+      end
+    end
+
+    context 'when proofer_mock_fallback is set to false' do
+      let(:proofer_mock_fallback) { false }
+
+      context 'and idv_resolution_default_vendor is set to :instant_verify' do
+        let(:idv_resolution_default_vendor) { :instant_verify }
+
+        it 'creates an Instant Verify proofer because the two settings agree' do
+          expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
+        end
+      end
+
+      context 'and idv_resolution_default_vendor is set to :mock' do
+        let(:idv_resolution_default_vendor) { :mock }
+
+        it 'creates an Instant Verify proofer to support transition between configs' do
+          expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
         end
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

This PR was extracted from #11479, and is in support of 
[LG-14725](https://cm-jira.usa.gov/browse/LG-14725)

## 🛠 Summary of changes

Historically, we have used one config flag, `proofer_mock_fallback`, to control whether mocked resolution and address Proofers are used during identity verification. This value is set to `true` (use mocks) by default and `false` (don't use mocks) in production environments.

We are moving (gradually) toward a world where we have multiple identity resolution vendors, and thus 3 possible config states for identity resolution (Instant Verify, Socure KYC, and Mock). #11479 is about running Instant Verify and Socure side-by-side in production, and requires a different configuration strategy than `proofer_mock_fallback: false`.

This PR adds a new config setting, `idv_resolution_default_vendor` (the `_default_` is because there will soon be an `_alternate_` setting as well). This setting can have one of two values:

* `mock` (default)
* `instant_verify`

Hopefully it is clear which setting corresponds to which proofer being used.

## 📜 Testing Plan

The testing process here is to:

1. Set (or delete) some values in your `application.yml`
2. Restart your server
3. Run through IdV up until you submit the "Verify your information" step

| proofer_mock_fallback | idv_resolution_default_vendor | Expected result |
| -- | -- | -- |
| (not present) | (not present) | "Verify your information" succeeds and uses mock proofer |
| (not present) | `instant_verify` | "Verify your information" fails because it tried to contact Instant Verify |
| (not present) | `mock` |   "Verify your information" succeeds and uses mock proofer |
| false | (not present) | "Verify your information" fails because it tried to contact Instant Verify |
| false | `instant_verify`  | "Verify your information" fails because it tried to contact Instant Verify |
| false | `mock` | **IMPORTANT:** "Verify your information" fails because it tried to contact Instant Verify (this will be the initial config in production upon deploy) |
| true | (not present) |  "Verify your information" succeeds and uses mock proofer |
| true | `instant_verify`  | **IMPORTANT:** "Verify your information" fails because it tried to contact Instant Verify (we should not be letting the old setting tell us to use mocks) |
| true | `mock` | "Verify your information" succeeds and uses mock proofer |
| (not presetn) | `any other value` | IDP fails to start because config value is invalid |

(You can monitor `log/events.log` to see the relevant `IdV: doc auth verify proofing results` events going by.)


