### PR TITLE
Remove proofer_mock_fallback, erm, fallback

### DIFF
--- a/app/services/proofing/resolution/plugins/instant_verify_residential_address_plugin.rb
+++ b/app/services/proofing/resolution/plugins/instant_verify_residential_address_plugin.rb
@@ -24,50 +24,22 @@ module Proofing
         end
 
         def proofer
-          @proofer ||= begin
-            # Historically, proofer_mock_fallback has controlled whether we
-            # use mock implementations of the Resolution and Address proofers
-            # (true = use mock, false = don't use mock).
-            # We are transitioning to a place where we will have separate
-            # configs for both. For the time being, we want to keep support for
-            # proofer_mock_fallback here. This can be removed after this code
-            # has been deployed and configs have been updated in all relevant
-            # environments.
-
-            old_config_says_mock = IdentityConfig.store.proofer_mock_fallback
-            old_config_says_iv = !old_config_says_mock
-            new_config_says_mock =
-              IdentityConfig.store.idv_resolution_default_vendor == :mock
-            new_config_says_iv =
-              IdentityConfig.store.idv_resolution_default_vendor == :instant_verify
-
-            proofer_type =
-              if new_config_says_mock && old_config_says_iv
-                # This will be the case immediately after deployment, when
-                # environment configs have not been updated. We need to
-                # fall back to the old config here.
-                :instant_verify
-              elsif new_config_says_iv
-                :instant_verify
-              else
-                :mock
-              end
-
-            if proofer_type == :mock
-              Proofing::Mock::ResolutionMockClient.new
-            else
-              Proofing::LexisNexis::InstantVerify::Proofer.new(
-                instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
-                account_id: IdentityConfig.store.lexisnexis_account_id,
-                base_url: IdentityConfig.store.lexisnexis_base_url,
-                username: IdentityConfig.store.lexisnexis_username,
-                password: IdentityConfig.store.lexisnexis_password,
-                hmac_key_id: IdentityConfig.store.lexisnexis_hmac_key_id,
-                hmac_secret_key: IdentityConfig.store.lexisnexis_hmac_secret_key,
-                request_mode: IdentityConfig.store.lexisnexis_request_mode,
-              )
+          @proofer ||=
+            case IdentityConfig.store.idv_resolution_default_vendor
+              when :instant_verify
+                Proofing::LexisNexis::InstantVerify::Proofer.new(
+                  instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
+                  account_id: IdentityConfig.store.lexisnexis_account_id,
+                  base_url: IdentityConfig.store.lexisnexis_base_url,
+                  username: IdentityConfig.store.lexisnexis_username,
+                  password: IdentityConfig.store.lexisnexis_password,
+                  hmac_key_id: IdentityConfig.store.lexisnexis_hmac_key_id,
+                  hmac_secret_key: IdentityConfig.store.lexisnexis_hmac_secret_key,
+                  request_mode: IdentityConfig.store.lexisnexis_request_mode,
+                )
+              when :mock
+                Proofing::Mock::ResolutionMockClient.new
             end
-          end
         end
 
         def residential_address_unnecessary_result

--- a/app/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin.rb
+++ b/app/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin.rb
@@ -44,50 +44,22 @@ module Proofing
         end
 
         def proofer
-          @proofer ||= begin
-            # Historically, proofer_mock_fallback has controlled whether we
-            # use mock implementations of the Resolution and Address proofers
-            # (true = use mock, false = don't use mock).
-            # We are transitioning to a place where we will have separate
-            # configs for both. For the time being, we want to keep support for
-            # proofer_mock_fallback here. This can be removed after this code
-            # has been deployed and configs have been updated in all relevant
-            # environments.
-
-            old_config_says_mock = IdentityConfig.store.proofer_mock_fallback
-            old_config_says_iv = !old_config_says_mock
-            new_config_says_mock =
-              IdentityConfig.store.idv_resolution_default_vendor == :mock
-            new_config_says_iv =
-              IdentityConfig.store.idv_resolution_default_vendor == :instant_verify
-
-            proofer_type =
-              if new_config_says_mock && old_config_says_iv
-                # This will be the case immediately after deployment, when
-                # environment configs have not been updated. We need to
-                # fall back to the old config here.
-                :instant_verify
-              elsif new_config_says_iv
-                :instant_verify
-              else
-                :mock
-              end
-
-            if proofer_type == :mock
-              Proofing::Mock::ResolutionMockClient.new
-            else
-              Proofing::LexisNexis::InstantVerify::Proofer.new(
-                instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
-                account_id: IdentityConfig.store.lexisnexis_account_id,
-                base_url: IdentityConfig.store.lexisnexis_base_url,
-                username: IdentityConfig.store.lexisnexis_username,
-                password: IdentityConfig.store.lexisnexis_password,
-                hmac_key_id: IdentityConfig.store.lexisnexis_hmac_key_id,
-                hmac_secret_key: IdentityConfig.store.lexisnexis_hmac_secret_key,
-                request_mode: IdentityConfig.store.lexisnexis_request_mode,
-              )
+          @proofer ||=
+            case IdentityConfig.store.idv_resolution_default_vendor
+              when :instant_verify
+                Proofing::LexisNexis::InstantVerify::Proofer.new(
+                  instant_verify_workflow: IdentityConfig.store.lexisnexis_instant_verify_workflow,
+                  account_id: IdentityConfig.store.lexisnexis_account_id,
+                  base_url: IdentityConfig.store.lexisnexis_base_url,
+                  username: IdentityConfig.store.lexisnexis_username,
+                  password: IdentityConfig.store.lexisnexis_password,
+                  hmac_key_id: IdentityConfig.store.lexisnexis_hmac_key_id,
+                  hmac_secret_key: IdentityConfig.store.lexisnexis_hmac_secret_key,
+                  request_mode: IdentityConfig.store.lexisnexis_request_mode,
+                )
+              when :mock
+                Proofing::Mock::ResolutionMockClient.new
             end
-          end
         end
 
         def resolution_cannot_pass

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe ResolutionProofingJob, type: :job do
       and_return(lexisnexis_threatmetrix_mock_enabled)
     allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_base_url).
       and_return('https://www.example.com')
+    allow(IdentityConfig.store).to receive(:idv_resolution_default_vendor).
+      and_return(:instant_verify)
   end
 
   describe '#perform' do

--- a/spec/services/proofing/resolution/plugins/instant_verify_residential_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_residential_address_plugin_spec.rb
@@ -133,53 +133,23 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyResidentialAddressPlu
     subject(:proofer) { plugin.proofer }
 
     before do
-      allow(IdentityConfig.store).to receive(:proofer_mock_fallback).
-        and_return(proofer_mock_fallback)
       allow(IdentityConfig.store).to receive(:idv_resolution_default_vendor).
         and_return(idv_resolution_default_vendor)
     end
 
-    context 'when proofer_mock_fallback is set to true' do
-      let(:proofer_mock_fallback) { true }
+    context 'idv_resolution_default_vendor is set to :instant_verify' do
+      let(:idv_resolution_default_vendor) {          :instant_verify }
 
-      context 'and idv_resolution_default_vendor is set to :instant_verify' do
-        let(:idv_resolution_default_vendor) do
-          :instant_verify
-        end
-
-        # rubocop:disable Layout/LineLength
-        it 'creates an Instant Verify proofer because the new setting takes precedence over the old one when the old one is set to its default value' do
-          expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
-        end
-        # rubocop:enable Layout/LineLength
-      end
-
-      context 'and idv_resolution_default_vendor is set to :mock' do
-        let(:idv_resolution_default_vendor) { :mock }
-
-        it 'creates a mock proofer because the two settings agree' do
-          expect(proofer).to be_an_instance_of(Proofing::Mock::ResolutionMockClient)
-        end
+      it 'creates an Instant Verify proofer' do
+        expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
       end
     end
 
-    context 'when proofer_mock_fallback is set to false' do
-      let(:proofer_mock_fallback) { false }
+    context 'idv_resolution_default_vendor is set to :mock' do
+      let(:idv_resolution_default_vendor) { :mock }
 
-      context 'and idv_resolution_default_vendor is set to :instant_verify' do
-        let(:idv_resolution_default_vendor) { :instant_verify }
-
-        it 'creates an Instant Verify proofer because the two settings agree' do
-          expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
-        end
-      end
-
-      context 'and idv_resolution_default_vendor is set to :mock' do
-        let(:idv_resolution_default_vendor) { :mock }
-
-        it 'creates an Instant Verify proofer to support transition between configs' do
-          expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
-        end
+      it 'creates a mock proofer' do
+        expect(proofer).to be_an_instance_of(Proofing::Mock::ResolutionMockClient)
       end
     end
   end

--- a/spec/services/proofing/resolution/plugins/instant_verify_residential_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_residential_address_plugin_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyResidentialAddressPlu
     end
 
     context 'idv_resolution_default_vendor is set to :instant_verify' do
-      let(:idv_resolution_default_vendor) {          :instant_verify }
+      let(:idv_resolution_default_vendor) { :instant_verify }
 
       it 'creates an Instant Verify proofer' do
         expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)

--- a/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
@@ -291,53 +291,23 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
     subject(:proofer) { plugin.proofer }
 
     before do
-      allow(IdentityConfig.store).to receive(:proofer_mock_fallback).
-        and_return(proofer_mock_fallback)
       allow(IdentityConfig.store).to receive(:idv_resolution_default_vendor).
         and_return(idv_resolution_default_vendor)
     end
 
-    context 'when proofer_mock_fallback is set to true' do
-      let(:proofer_mock_fallback) { true }
+    context 'idv_resolution_default_vendor is set to :instant_verify' do
+      let(:idv_resolution_default_vendor) {          :instant_verify }
 
-      context 'and idv_resolution_default_vendor is set to :instant_verify' do
-        let(:idv_resolution_default_vendor) do
-          :instant_verify
-        end
-
-        # rubocop:disable Layout/LineLength
-        it 'creates an Instant Verify proofer because the new setting takes precedence over the old one when the old one is set to its default value' do
-          expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
-        end
-        # rubocop:enable Layout/LineLength
-      end
-
-      context 'and idv_resolution_default_vendor is set to :mock' do
-        let(:idv_resolution_default_vendor) { :mock }
-
-        it 'creates a mock proofer because the two settings agree' do
-          expect(proofer).to be_an_instance_of(Proofing::Mock::ResolutionMockClient)
-        end
+      it 'creates an Instant Verify proofer' do
+        expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
       end
     end
 
-    context 'when proofer_mock_fallback is set to false' do
-      let(:proofer_mock_fallback) { false }
+    context 'idv_resolution_default_vendor is set to :mock' do
+      let(:idv_resolution_default_vendor) { :mock }
 
-      context 'and idv_resolution_default_vendor is set to :instant_verify' do
-        let(:idv_resolution_default_vendor) { :instant_verify }
-
-        it 'creates an Instant Verify proofer because the two settings agree' do
-          expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
-        end
-      end
-
-      context 'and idv_resolution_default_vendor is set to :mock' do
-        let(:idv_resolution_default_vendor) { :mock }
-
-        it 'creates an Instant Verify proofer to support transition between configs' do
-          expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)
-        end
+      it 'creates a mock proofer' do
+        expect(proofer).to be_an_instance_of(Proofing::Mock::ResolutionMockClient)
       end
     end
   end

--- a/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/instant_verify_state_id_address_plugin_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Proofing::Resolution::Plugins::InstantVerifyStateIdAddressPlugin 
     end
 
     context 'idv_resolution_default_vendor is set to :instant_verify' do
-      let(:idv_resolution_default_vendor) {          :instant_verify }
+      let(:idv_resolution_default_vendor) { :instant_verify }
 
       it 'creates an Instant Verify proofer' do
         expect(proofer).to be_an_instance_of(Proofing::LexisNexis::InstantVerify::Proofer)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Supports work for:
[LG-14725](https://cm-jira.usa.gov/browse/LG-14725)


## 🛠 Summary of changes

#11515 added a new config setting, `idv_resolution_default_vendor`, but left the code able to use the `proofer_mock_fallback` setting in certain circumstances. This PR removes the fallback.

**This should not be merged until after #11515 is in prod and all necessary config changes have been made**

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
