### PR TITLE
Update postgres versions used in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -231,7 +231,7 @@ migrate:
     POSTGRES_HOST_AUTH_METHOD: trust
     RAILS_ENV: test
   services:
-    - name: public.ecr.aws/docker/library/postgres:13.9
+    - name: public.ecr.aws/docker/library/postgres:16.4
       alias: db-postgres
       command: ['--fsync=false', '--synchronous_commit=false', '--full_page_writes=false']
   script:
@@ -263,7 +263,7 @@ specs:
     POSTGRES_HOST_AUTH_METHOD: trust
     RAILS_ENV: test
   services:
-    - name: public.ecr.aws/docker/library/postgres:13.9
+    - name: public.ecr.aws/docker/library/postgres:16.4
       alias: db-postgres
       command: ['--fsync=false', '--synchronous_commit=false', '--full_page_writes=false']
     - name: public.ecr.aws/docker/library/redis:7.0


### PR DESCRIPTION
## 🛠 Summary of changes

After last week, we are now running Postgres 16.4 everywhere, and CI should match

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
