### PR TITLE
LG-15054: Remove GPO from IPP step indicator

### DIFF
--- a/app/controllers/concerns/idv/step_indicator_concern.rb
+++ b/app/controllers/concerns/idv/step_indicator_concern.rb
@@ -26,11 +26,7 @@ module Idv
 
     def step_indicator_steps
       if in_person_proofing?
-        if gpo_address_verification?
-          Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS_GPO
-        else
-          Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS
-        end
+        Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS
       elsif gpo_address_verification?
         Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
       else

--- a/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
+++ b/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
@@ -85,22 +85,6 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
         ]
       end
 
-      context 'via pending profile' do
-        let(:profile) do
-          create(
-            :profile,
-            gpo_verification_pending_at: 1.day.ago,
-            proofing_components: { 'document_check' => Idp::Constants::Vendors::USPS },
-          )
-        end
-
-        it 'returns in person gpo steps' do
-          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
-          create(:in_person_enrollment, :establishing, user: user)
-          expect(steps).to eq in_person_step_indicator_steps_gpo
-        end
-      end
-
       context 'via current idv session' do
         before do
           ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
@@ -109,14 +93,6 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
 
         it 'returns in person steps' do
           expect(steps).to eq in_person_step_indicator_steps
-        end
-
-        context 'with gpo address verification method' do
-          before { force_gpo }
-
-          it 'returns in person gpo steps' do
-            expect(steps).to eq in_person_step_indicator_steps_gpo
-          end
         end
       end
 


### PR DESCRIPTION
## 🎫 Ticket
[LG-15054: Ensure that GPO steps cannot display in IPP step indicator](https://cm-jira.usa.gov/browse/LG-15054)

## 🛠 Summary of changes
- Now that GPO has been removed from the IPP flow, there's no need to include GPO + IPP scenarios in the IPP step indicator.


## 📜 Testing Plan
Please manually test the IPP and GPO flow in order to ensure there are no regressions.
IPP
- [x] Log in via the identity-oidc sinatra app, select "default" as the Authentication Assurance Level (AAL) and "Identity-verified" as the Level of Service
- [x] Create an account and choose "verify your identity at a post office" for how to verify
- [x] You should see the below IPP step indicator.
<details>
<summary>Step Indicator:</summary>

![IPPIndicator](https://github.com/user-attachments/assets/78bb9c1a-9c45-4aef-b7e0-95b3b7f637e8)

</details>

GPO
- [x] Log in via the identity-oidc sinatra app, select "default" as the Authentication Assurance Level (AAL) and "Identity-verified" as the Level of Service
- [x] Create an account and choose the remote verification option
- [x] When you get to the page that confirms your phone number, enter (703)555-5555, which simulates a phone number that couldn’t be verified as belonging to the user
- [x] Select the "verify by mail" option
- [x] You should see the below GPO step indicator
<details>
<summary>Step Indicator:</summary>

![GPOIndicatorMainBranch](https://github.com/user-attachments/assets/5fae50ef-d4e5-4201-be21-cc95018035cb)

</details>
