### PR TITLE
LG-11666 Add Post Office search link to barcode page and emails

### DIFF
--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -17,6 +17,7 @@ class MarketingSite
     verify-your-identity/phone-number
     verify-your-identity/verify-your-address-by-mail
     verify-your-identity/overview
+    verify-your-identity/verify-your-identity-in-person/find-a-participating-post-office
   ].to_set.freeze
 
   def self.locale_segment

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -228,6 +228,23 @@
   </section>
 <% end %>
 
+
+<% if !@is_enhanced_ipp %>
+  <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
+  <p class="margin-bottom-4">
+    <%= t(
+          'in_person_proofing.body.location.change_location_info_html',
+          find_other_locations_link_html: link_to(
+            t('in_person_proofing.body.location.change_location_find_other_locations'),
+            help_center_redirect_url(
+              category: 'verify-your-identity',
+              article: 'verify-your-identity-in-person/find-a-participating-post-office',
+            ),
+          ),
+        ) %>
+  </p>
+<% end %>
+
 <h2 class="margin-bottom-2"><%= t('in_person_proofing.body.expect.heading') %></h2>
 <p><%= t('in_person_proofing.body.expect.info') %></p>
 

--- a/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
@@ -275,5 +275,22 @@
   </div>
 <% end %>
 
+<% if !@is_enhanced_ipp %>
+  <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
+  <p class="margin-bottom-4">
+    <%= t(
+          'in_person_proofing.body.location.change_location_info_html',
+          find_other_locations_link_html: link_to(
+            t('in_person_proofing.body.location.change_location_find_other_locations'),
+            help_center_redirect_url(
+              category: 'verify-your-identity',
+              article: 'verify-your-identity-in-person/find-a-participating-post-office',
+            ),
+          ),
+        ).html_safe %>
+  </p>
+<% end %>
+
+
 <h2 class="font-heading-lg text-bold margin-bottom-2"><%= t('in_person_proofing.body.expect.heading') %></h2>
 <p class="margin-bottom-0"><%= t('in_person_proofing.body.expect.info') %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1211,10 +1211,13 @@ in_person_proofing.body.cta.button: Try in person
 in_person_proofing.body.cta.prompt_detail: Most people who are unable to complete this step online are successful in verifying their identity at a participating Post Office. No appointment needed. Locations are available nationwide.
 in_person_proofing.body.expect.heading: What to expect after your visit
 in_person_proofing.body.expect.info: We’ll send you an email to let you know if your identity verification was successful or unsuccessful within 24 hours of your visit to the Post Office.
+in_person_proofing.body.location.change_location_find_other_locations: Find other participating Post Office locations.
+in_person_proofing.body.location.change_location_heading: Need to change your Post Office location?
+in_person_proofing.body.location.change_location_info_html: You don’t need to create a new barcode, you can bring this barcode to any participating Post Office location. %{find_other_locations_link_html}
 in_person_proofing.body.location.distance.one: '%{count} mile away'
 in_person_proofing.body.location.distance.other: '%{count} miles away'
 in_person_proofing.body.location.heading: Post Office information
-in_person_proofing.body.location.info: No appointment is needed to verify your identity. You can visit any participating Post Office location.
+in_person_proofing.body.location.info: No appointment is needed to verify your identity.
 in_person_proofing.body.location.inline_error: Enter a valid address with city, state, and ZIP code
 in_person_proofing.body.location.location_button: Select
 in_person_proofing.body.location.po_search.address_label: Address

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1222,10 +1222,13 @@ in_person_proofing.body.cta.button: Intentar en persona
 in_person_proofing.body.cta.prompt_detail: La mayoría de las personas que no pueden hacer la verificación de su identidad en línea logran verificarla en una oficina de correos participante. No es necesario hacer cita para ello, y hay oficinas en todo el país.
 in_person_proofing.body.expect.heading: Qué esperar después de la visita
 in_person_proofing.body.expect.info: En las 24 horas siguientes a su visita a la oficina de correos, recibirá un correo electrónico para informarle si se logró o no su verificación de identidad.
+in_person_proofing.body.location.change_location_find_other_locations: Busque otras oficinas de correos participantes.
+in_person_proofing.body.location.change_location_heading: ¿Necesita cambiar su oficina de correos?
+in_person_proofing.body.location.change_location_info_html: No necesita crear un nuevo código de barras, puede llevar este código de barras a cualquier oficina de correos participante. %{find_other_locations_link_html}
 in_person_proofing.body.location.distance.one: A %{count} milla de distancia
 in_person_proofing.body.location.distance.other: A %{count} millas de distancia
 in_person_proofing.body.location.heading: Información de la oficina de correos
-in_person_proofing.body.location.info: No necesita hacer una cita para verificar su identidad. Puede acudir a cualquier oficina de correos participante.
+in_person_proofing.body.location.info: No necesita hacer una cita para verificar su identidad.
 in_person_proofing.body.location.inline_error: Ingrese una dirección válida que incluya ciudad, estado y código postal
 in_person_proofing.body.location.location_button: Seleccionar
 in_person_proofing.body.location.po_search.address_label: Dirección

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1211,10 +1211,13 @@ in_person_proofing.body.cta.button: Essayer en personne
 in_person_proofing.body.cta.prompt_detail: La plupart des personnes qui ne parviennent pas à effectuer cette étape en ligne réussissent à confirmer leur identité dans un bureau de poste participant. Sans rendez-vous. Il existe des sites dans l’ensemble du pays.
 in_person_proofing.body.expect.heading: Que faire après votre visite
 in_person_proofing.body.expect.info: Nous vous enverrons un e-mail pour vous informer de la réussite ou de l’échec de la vérification de votre identité dans les 24 heures suivant votre visite au bureau de poste.
+in_person_proofing.body.location.change_location_find_other_locations: Trouvez d’autres bureaux de poste participants.
+in_person_proofing.body.location.change_location_heading: Vous devez changer de bureau de poste ?
+in_person_proofing.body.location.change_location_info_html: Pas besoin de créer un nouveau code-barres. Vous pouvez apporter le vôtre à n’importe quel bureau de poste participant. %{find_other_locations_link_html}
 in_person_proofing.body.location.distance.one: à %{count} mile
 in_person_proofing.body.location.distance.other: à %{count} miles
 in_person_proofing.body.location.heading: Informations sur les bureaux de poste
-in_person_proofing.body.location.info: Aucun rendez-vous n’est nécessaire pour vérifier votre identité. Vous pouvez vous rendre dans n’importe quel bureau de poste participant.
+in_person_proofing.body.location.info: Aucun rendez-vous n’est nécessaire pour vérifier votre identité.
 in_person_proofing.body.location.inline_error: Saisissez une adresse valide avec la ville, l’État et le code postal
 in_person_proofing.body.location.location_button: Sélectionner
 in_person_proofing.body.location.po_search.address_label: Adresse

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1224,10 +1224,13 @@ in_person_proofing.body.cta.button: 尝试亲身去
 in_person_proofing.body.cta.prompt_detail: 无法在网上完成这一步骤的大多数人都能在一个参与本项目的邮局成功地证实身份。去邮局无需预约。全国各地都有参与本项目的邮局。
 in_person_proofing.body.expect.heading: 去邮局后会发生什么
 in_person_proofing.body.expect.info: 你去邮局后 24 小时内，我们会给你发电邮，告诉你是否成功验证了身份。
+in_person_proofing.body.location.change_location_find_other_locations: 查找其他参与本项目的邮局地点。
+in_person_proofing.body.location.change_location_heading: 需要更改你的邮局地点吗？
+in_person_proofing.body.location.change_location_info_html: 你不需要创建新的条形码，你可以将这个条形码带到任何参与本项目的邮局。 %{find_other_locations_link_html}
 in_person_proofing.body.location.distance.one: 距离你 %{count} 英里
 in_person_proofing.body.location.distance.other: 距离你 %{count} 英里
 in_person_proofing.body.location.heading: 邮局信息
-in_person_proofing.body.location.info: 验证你的身份无需做预约。你可以去任何参与邮局。
+in_person_proofing.body.location.info: 验证你的身份无需做预约。
 in_person_proofing.body.location.inline_error: 请输入正确地址，包括城市、州和邮编
 in_person_proofing.body.location.location_button: 选择
 in_person_proofing.body.location.po_search.address_label: 地址

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
+  include ActionView::Helpers::UrlHelper
+
   let(:user) { create(:user) }
   let(:email_address) { user.email_addresses.first }
   let(:banned_email) { 'banned_email+123abc@gmail.com' }
@@ -762,7 +764,59 @@ RSpec.describe UserMailer, type: :mailer do
         end
       end
 
-      context 'For In-Person Proofing (IPP)' do
+      context 'Need to change location section' do
+        context 'when Enhanced IPP is not enabled' do
+          let(:is_enhanced_ipp) { false }
+          let(:mail) do
+            UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
+              enrollment: enhanced_ipp_enrollment,
+              is_enhanced_ipp: is_enhanced_ipp,
+            )
+          end
+          it 'renders the change location heading' do
+            expect(mail.html_part.body).to have_content(
+              t('in_person_proofing.body.location.change_location_heading'),
+            )
+          end
+
+          it 'renders the change location info' do
+            expect(mail.html_part.body).to have_content(
+              t(
+                'in_person_proofing.body.location.change_location_info_html',
+                find_other_locations_link_html:
+                  t('in_person_proofing.body.location.change_location_find_other_locations'),
+              ),
+            )
+          end
+        end
+        context 'when Enhanced IPP is enabled' do
+          let(:is_enhanced_ipp) { true }
+          let(:mail) do
+            UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
+              enrollment: enhanced_ipp_enrollment,
+              is_enhanced_ipp: is_enhanced_ipp,
+            )
+          end
+
+          it 'does not render the change location heading' do
+            expect(mail.html_part.body).not_to have_content(
+              t('in_person_proofing.body.location.change_location_heading'),
+            )
+          end
+
+          it 'does not render the change location info' do
+            expect(mail.html_part.body).not_to have_content(
+              t(
+                'in_person_proofing.body.location.change_location_info_html',
+                find_other_locations_link_html:
+                  t('in_person_proofing.body.location.change_location_find_other_locations'),
+              ),
+            )
+          end
+        end
+      end
+
+      context 'For Informed Delivery In-Person Proofing (ID-IPP)' do
         context 'template displays modified content' do
           it 'conditionally renders content in the what to expect section applicable to IPP' do
             aggregate_failures do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-11666](https://cm-jira.usa.gov/browse/LG-11666)


## 🛠 Summary of changes

Updates Ready to Verify barcode page and email/reminder email:

-  Removes the text "You can visit any Participating Post Office location." from the body text under the "Post Office information" heading
- For EIPP only, adds a section with the heading "Need to change your Post Office location?" and add body text under it: "You don’t need to create a new barcode, you can bring this barcode to any participating Post Office location. Find other participating Post Office locations."
- Also refactored the specs for the show.html.erb content to focus on sections of content as contexts, for readability and consistency.



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Enter through [Sinatra](http://localhost:9292/) and choose identity-verified (*not* Enhanced)
- [ ] Go through the flow to create an enrollment
- [ ] At the barcode page, observe that the "You can visit any Participating Post Office location" body text is removed, under the H2 "Post Office Information"
- [ ] Observe the added H3 "Need to change your Post Office location?" and the added body text under it: "You don’t need to create a new barcode, you can bring this barcode to any participating Post Office location. Find other participating Post Office locations."
- [ ] Verify that the link to "Find other participating Post Office locations" brings you to the help center PO search page.
- [ ] Verify that translations are present and consistent with the [translations doc](https://docs.google.com/document/d/1vhGmTiF312PjOPWYvJH9oV0X95r7OIgGnQKLDCYGeVI/edit?disco=AAABPyW6ioo)

Verify that the new H3 and body text are **not** added in the EIPP flow:

- [ ] Enter through [Sinatra](http://localhost:9292/) and choose Enhanced In-Person Proofing
- [ ] Go through the flow to create an enrollment
- [ ] At the barcode page, observe that the "You can visit any Participating Post Office location" body text **is** removed, under the H2 "Post Office Information"
- [ ] Observe the H3 "Need to change your Post Office location?" and any body text underneath are **not** added.

Verify the emails:

- [ ] Verify that the same content changes are present in the [Ready to Verify email](http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify.html?locale=en)
- [ ] Verify that the same content changes are present in the [Ready to Verify Reminder email](http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify_reminder.html?locale=en)



## 👀 Screenshots

<details>
<summary>Ready to Verify Barcode Page (ID-IPP): </summary>
<img width="1135" alt="Screenshot 2024-11-14 at 12 59 09 PM" src="https://github.com/user-attachments/assets/9130f1e7-f6ae-40d2-843e-ed45141384f6">
<img width="1146" alt="Screenshot 2024-11-14 at 12 59 26 PM" src="https://github.com/user-attachments/assets/105b8ba6-3e0d-4ec0-8dfa-3b0e682d8728">
<img width="1136" alt="Screenshot 2024-11-14 at 12 59 41 PM" src="https://github.com/user-attachments/assets/a3760290-750c-44a1-984b-341b7595185f">
<img width="1120" alt="Screenshot 2024-11-14 at 12 58 35 PM" src="https://github.com/user-attachments/assets/fd89f61e-887f-4f47-b920-a3a81b245a66">

</details>

<details>
<summary>Ready to Verify Barcode Page (EIPP): </summary>
<img width="991" alt="Screenshot 2024-11-18 at 10 47 56 AM" src="https://github.com/user-attachments/assets/afade87b-c4c5-4db3-89c5-6e3ff3e34bff">
<img width="1033" alt="Screenshot 2024-11-18 at 10 48 24 AM" src="https://github.com/user-attachments/assets/3e68db27-8d13-4bda-8fc8-444dfd
<img width="1022" alt="Screenshot 2024-11-18 at 10 48 45 AM" src="https://github.com/user-attachments/assets/35cfc8ca-a68e-4c18-a2d7-c8908ecd8c29">
e04b70">
<img width="1059" alt="Screenshot 2024-11-18 at 10 49 03 AM" src="https://github.com/user-attachments/assets/e7cc9b2e-bf2e-4845-8c98-e456f9c93abe">



</details>

<details>
<summary>Ready to Verify Email (ID-IPP): </summary>
<img width="1048" alt="Screenshot 2024-11-18 at 10 42 39 AM" src="https://github.com/user-attachments/assets/49d87db0-454f-499c-ad3c-5a77f165b31b">
<img width="1051" alt="Screenshot 2024-11-18 at 10 43 27 AM" src="https://github.com/user-attachments/assets/28e3a672-7cbb-42aa-b659-d0aa9efc88f9">
<img width="1036" alt="Screenshot 2024-11-18 at 10 43 46 AM" src="https://github.com/user-attachments/assets/b88b5c59-7139-4cc1-8b2b-1cf16ddde254">
<img width="1042" alt="Screenshot 2024-11-18 at 10 44 01 AM" src="https://github.com/user-attachments/assets/ed3223ec-b420-49c2-8c16-f3eb7b085eca">

</details>


<details>
<summary>Reminder Email (ID-IPP): </summary>
<img width="1189" alt="Screenshot 2024-11-15 at 4 56 46 PM" src="https://github.com/user-attachments/assets/1054982f-31b7-4cca-8e9a-d55301fe24d6">
<img width="1189" alt="Screenshot 2024-11-15 at 4 56 28 PM" src="https://github.com/user-attachments/assets/30e4555d-92ac-418a-8b43-a09a692e7fcc">
<img width="1188" alt="Screenshot 2024-11-15 at 4 56 08 PM" src="https://github.com/user-attachments/assets/b4bb08d4-af39-4738-9483-6bd8557ed8d3">
<img width="1186" alt="Screenshot 2024-11-15 at 4 55 44 PM" src="https://github.com/user-attachments/assets/5e236704-00d2-4962-bab4-17352dafa869">

</details>



<details>
<summary>Read to Verify email (EIPP): </summary>
<img width="1083" alt="Screenshot 2024-11-18 at 10 32 46 AM" src="https://github.com/user-attachments/assets/87215b9e-2906-4229-af1f-0223b099337f">
<img width="1162" alt="Screenshot 2024-11-18 at 10 35 01 AM" src="https://github.com/user-attachments/assets/34a3d2b7-44e2-4fe2-9317-a86af590d06b">
<img width="1163" alt="Screenshot 2024-11-18 at 10 35 22 AM" src="https://github.com/user-attachments/assets/5c39d946-2dd0-4a64-a78b-1129f3746cac">
<img width="1127" alt="Screenshot 2024-11-18 at 10 35 37 AM" src="https://github.com/user-attachments/assets/e179adc1-7658-4c1b-a57f-573ca092aff3">


</details>

<details>
<summary>Reminder email (EIPP): </summary>
<img width="1114" alt="Screenshot 2024-11-18 at 10 41 09 AM" src="https://github.com/user-attachments/assets/82d0129f-4a31-434f-94f3-b9500835b13a">
<img width="1067" alt="Screenshot 2024-11-18 at 10 41 25 AM" src="https://github.com/user-attachments/assets/c7c034db-35ae-4904-b0fe-70b7dca28aa7">
<img width="1040" alt="Screenshot 2024-11-18 at 10 41 41 AM" src="https://github.com/user-attachments/assets/6f0dda58-b692-4285-8bf4-2f45837e1e9a">
<img width="1044" alt="Screenshot 2024-11-18 at 10 41 57 AM" src="https://github.com/user-attachments/assets/d3f5c711-b86a-4bb5-a943-1912453487c8">

</details>





