### PR TITLE
LG-14814: Entering TOTP code in wrong format shows error text mentioning phone

### DIFF
--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -24,6 +24,11 @@
         code_length: @otp_code_length,
         optional_prefix: '#',
         class: 'margin-bottom-5',
+        field_options: {
+          error_messages: {
+            patternMismatch: t('errors.messages.phone_otp_format'),
+          },
+        },
       ) %>
   <%= f.submit t('forms.buttons.submit.default'), class: 'margin-bottom-5' %>
 <% end %>

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -29,6 +29,11 @@
         autofocus: true,
         value: @presenter.code_value,
         optional_prefix: '#',
+        field_options: {
+          error_messages: {
+            patternMismatch: t('errors.messages.phone_otp_format'),
+          },
+        },
       ) %>
   <%= f.input(
         :remember_device,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,13 +751,14 @@ errors.messages.invalid_voice_number: Invalid phone number. Check that you’ve 
 errors.messages.missing_field: Please fill in this field.
 errors.messages.no_pending_profile: No profile is waiting for verification
 errors.messages.not_a_number: is not a number
-errors.messages.otp_format: Enter the one-time code sent to your phone. Do not use spaces or special characters.
+errors.messages.otp_format: Enter your entire one-time code without spaces or special characters
 errors.messages.password_incorrect: Incorrect password
 errors.messages.password_mismatch: Your passwords don’t match
 errors.messages.personal_key_incorrect: Incorrect personal key
 errors.messages.phone_carrier: Sorry, we are unable to support that phone carrier at this time. Please select a different number and try again.
 errors.messages.phone_confirmation_limited: You tried too many times, please try again in %{timeout}.
 errors.messages.phone_duplicate: This account is already using the phone number you entered as an authenticator. Please use a different phone number.
+errors.messages.phone_otp_format: Enter the one-time code sent to your phone. Do not use spaces or special characters.
 errors.messages.phone_required: Phone number is required
 errors.messages.phone_unsupported: Sorry, we are unable to send SMS at this time. Please try the phone call option below, or use your personal key.
 errors.messages.premium_rate_phone: This appears to be a premium rate phone number. Please select a different number and try again.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -762,13 +762,14 @@ errors.messages.invalid_voice_number: Número de teléfono no válido. Verifique
 errors.messages.missing_field: Llene este campo.
 errors.messages.no_pending_profile: No hay ningún perfil en espera de verificación
 errors.messages.not_a_number: no es un número
-errors.messages.otp_format: Introduzca el código de un solo uso enviado a su teléfono. No utilice espacios ni caracteres especiales.
+errors.messages.otp_format: Ingrese su código de un solo uso completo, sin espacios ni caracteres especiales.
 errors.messages.password_incorrect: Contraseña incorrecta
 errors.messages.password_mismatch: Sus contraseñas no coinciden
 errors.messages.personal_key_incorrect: Clave personal incorrecta
 errors.messages.phone_carrier: Lo sentimos, no podemos admitir ese proveedor telefónico por ahora. Seleccione un número diferente e inténtelo de nuevo.
 errors.messages.phone_confirmation_limited: Lo intentó demasiadas veces; vuelva a intentarlo en %{timeout}.
 errors.messages.phone_duplicate: Esta cuenta ya usa el número de teléfono que ingresó como autenticador. Use un número de teléfono diferente.
+errors.messages.phone_otp_format: Introduzca el código de un solo uso enviado a su teléfono. No utilice espacios ni caracteres especiales.
 errors.messages.phone_required: Se requiere un número de teléfono.
 errors.messages.phone_unsupported: Lo sentimos, no podemos enviar un SMS en este momento. Intente la opción de llamada telefónica siguiente, o use su clave personal.
 errors.messages.premium_rate_phone: Parece que se trata de un número de teléfono de tarifa especial. Seleccione un número diferente e inténtelo de nuevo.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -751,13 +751,14 @@ errors.messages.invalid_voice_number: Numéro de téléphone non valide. Vérifi
 errors.messages.missing_field: Veuillez remplir ce champ.
 errors.messages.no_pending_profile: Aucun profil en attente de vérification
 errors.messages.not_a_number: n’est pas un chiffre
-errors.messages.otp_format: Entrez le code à usage unique envoyé sur votre téléphone. N’utilisez pas d’espaces ou de caractères spéciaux.
+errors.messages.otp_format: Saisissez l’intégralité de votre code à usage unique sans espaces ni caractères spéciaux
 errors.messages.password_incorrect: Mot de passe incorrect
 errors.messages.password_mismatch: Vos mots de passe ne correspondent pas
 errors.messages.personal_key_incorrect: Clé personnelle incorrecte
 errors.messages.phone_carrier: Désolé, nous ne ne sommes pas en mesure de prendre en charge cet opérateur téléphonique pour le moment. Veuillez sélectionner un autre numéro et réessayer.
 errors.messages.phone_confirmation_limited: Vous avez essayé trop de fois, veuillez réessayer dans %{timeout}.
 errors.messages.phone_duplicate: Ce compte utilise déjà le numéro de téléphone que vous avez saisi en tant qu’authentifiant. Veuillez utiliser un numéro de téléphone différent.
+errors.messages.phone_otp_format: Entrez le code à usage unique envoyé sur votre téléphone. N’utilisez pas d’espaces ou de caractères spéciaux.
 errors.messages.phone_required: Le numéro de téléphone est obligatoire
 errors.messages.phone_unsupported: Désolé, nous ne sommes pas en mesure d’envoyer des SMS pour le moment. Veuillez essayez l’option d’appel téléphonique ci-dessous ou utilisez votre clé personnelle.
 errors.messages.premium_rate_phone: Il semble s’agir d’un numéro de téléphone surtaxé. Veuillez sélectionner un autre numéro et réessayer.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -762,13 +762,14 @@ errors.messages.invalid_voice_number: 电话号码有误。检查一下你是否
 errors.messages.missing_field: 请填写这一字段。
 errors.messages.no_pending_profile: 没有等待验证的用户资料
 errors.messages.not_a_number: 不是数字
-errors.messages.otp_format: 输入发送到你手机的一次性代码。请勿使用空格或特殊字符。
+errors.messages.otp_format: 输入你完整的一次性代码（没有空白或特殊字符）
 errors.messages.password_incorrect: 密码不对。
 errors.messages.password_mismatch: 你的密码不一致
 errors.messages.personal_key_incorrect: 个人密钥不对
 errors.messages.phone_carrier: 抱歉，我们目前无法支持这一电话运营商。请选择一个不同的号码再试一次。
 errors.messages.phone_confirmation_limited: 你尝试了太多次。请在 %{timeout}后再试。
 errors.messages.phone_duplicate: 该账户已在使用你输入的电话号码作为身份证实器。请使用一个不同的电话号码。
+errors.messages.phone_otp_format: 输入发送到你手机的一次性代码。请勿使用空格或特殊字符。
 errors.messages.phone_required: 电话号码是必需的。
 errors.messages.phone_unsupported: 抱歉，我们目前无法发送短信（SMS）。请尝试下面的接听电话选项或者使用你的个人密钥。
 errors.messages.premium_rate_phone: 这好像是一个高价电话号码。请选择一个不同的号码再试一次。

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -329,29 +329,29 @@ RSpec.feature 'Two Factor Authentication' do
       # Invalid: Unsupported characters
       input.fill_in with: 'BADBAD'
       click_submit_default
-      expect(page).to have_content(t('errors.messages.otp_format'))
+      expect(page).to have_content(t('errors.messages.phone_otp_format'))
 
       # Invalid: Not enough characters, with prefix
       fill_in t('components.one_time_code_input.label'), with: '#12345'
       click_submit_default
-      expect(page).to have_content(t('errors.messages.otp_format'))
+      expect(page).to have_content(t('errors.messages.phone_otp_format'))
 
       # Invalid: Not enough characters, without prefix
       fill_in t('components.one_time_code_input.label'), with: '12345'
       click_submit_default
-      expect(page).to have_content(t('errors.messages.otp_format'))
+      expect(page).to have_content(t('errors.messages.phone_otp_format'))
 
       # Valid: Enough characters, with prefix
       input.fill_in with: '#123456'
       expect(input.value).to eq('#123456')
       page.evaluate_script('document.activeElement.closest("form").reportValidity()')
-      expect(page).not_to have_content(t('errors.messages.otp_format'))
+      expect(page).not_to have_content(t('errors.messages.phone_otp_format'))
 
       # Valid: Enough characters, without prefix
       input.fill_in with: '123456'
       expect(input.value).to eq('123456')
       page.evaluate_script('document.activeElement.closest("form").reportValidity()')
-      expect(page).not_to have_content(t('errors.messages.otp_format'))
+      expect(page).not_to have_content(t('errors.messages.phone_otp_format'))
     end
 
     scenario 'the user changes delivery method' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-14814](https://cm-jira.usa.gov/browse/LG-14814)

## 🛠 Summary of changes

Fixes an issue where entering TOTP (Authentication App) code in the wrong format shows an error message mentioning a code "sent to your phone".

This is related to LG-13450 (#10898), where we changed the error message, intending it to apply for phone-sent codes (OTP via SMS or Voice), but shared code between phone OTP and TOTP caused the error to be used in both places.

The solution here is to restore the shared code instance to use generic language, and override to use the phone-specific languages in those use-cases.

## 📜 Testing Plan

TBD

## 👀 Screenshots

TBD