### PR TITLE
Redirect to the document_capture_complete page, not the SSN page, on Socure success

### DIFF
--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -56,7 +56,7 @@ module Idv
           )
 
           if result.success?
-            redirect_to idv_ssn_url
+            redirect_to idv_hybrid_mobile_capture_complete_url
           else
             redirect_to idv_hybrid_mobile_socure_document_capture_url
           end

--- a/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
@@ -269,10 +269,10 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
       stub_sign_in(user)
     end
 
-    it 'redirects to the ssn page' do
+    it 'redirects to the capture complete page' do
       get(:update)
 
-      expect(response).to redirect_to(idv_ssn_url)
+      expect(response).to redirect_to(idv_hybrid_mobile_capture_complete_url)
     end
 
     context 'when socure is disabled' do


### PR DESCRIPTION
## 🛠 Summary of changes
[LG-14008](https://cm-jira.usa.gov/browse/LG-14008)
Made the Socure hybrid handoff controller go to the hybrid handoff complete page on success, not the SSN page.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV with Socure and verify that after success, your phone ends up on the "Go back to your computer" screen.