### PR TITLE
Remove allow extra analytics * from dev_rake_spec

### DIFF
--- a/spec/lib/tasks/dev_rake_spec.rb
+++ b/spec/lib/tasks/dev_rake_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'rake'
 
-RSpec.describe 'dev rake tasks', allowed_extra_analytics: [:*] do
+RSpec.describe 'dev rake tasks' do
   include UspsIppHelper
 
   let(:env) do


### PR DESCRIPTION
Description:

Remove allow extra analytics * from dev_rake_spec.rb to fix "Unnecessary allowed_extra_analytics" error.

