### PR TITLE
Fix a typo in the `ThreatMetrixPlugin`

### DIFF
--- a/app/services/proofing/resolution/plugins/threat_metrix_plugin.rb
+++ b/app/services/proofing/resolution/plugins/threat_metrix_plugin.rb
@@ -24,7 +24,7 @@ module Proofing
           ddp_pii = applicant_pii.merge(
             threatmetrix_session_id: threatmetrix_session_id,
             email: user_email,
-            request_id: request_ip,
+            request_ip: request_ip,
           )
 
           timer.time('threatmetrix') do

--- a/spec/services/proofing/resolution/plugins/threatmetrix_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/threatmetrix_plugin_spec.rb
@@ -44,7 +44,12 @@ RSpec.describe Proofing::Resolution::Plugins::ThreatMetrixPlugin do
 
       it 'calls the ThreatMetrix proofer' do
         call
-        expect(plugin.proofer).to have_received(:proof)
+        expect(plugin.proofer).to have_received(:proof).with(
+          **applicant_pii,
+          threatmetrix_session_id: threatmetrix_session_id,
+          email: user_email,
+          request_ip: request_ip,
+        )
       end
 
       it 'creates a ThreatMetrix associated cost' do


### PR DESCRIPTION
It looks like in 1767dd586ed9fd1cab3662a90fece1e992d679a3 we introduced a typo where `request_ip` was spelled `request_id`. This resulted in us sending a null `request_ip` to Threatmetrix.

This commit fixes the typo and modifies a spec to make sure the expected arguments are sent to the proofer.
