### PR TITLE
LG-14366 Store dynamically-generated proofing components on Profile

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -129,7 +129,13 @@ module Idv
     def init_profile
       idv_session.create_profile_from_applicant_with_password(
         password,
-        resolved_authn_context_result.enhanced_ipp?,
+        is_enhanced_ipp: resolved_authn_context_result.enhanced_ipp?,
+        proofing_components: ProofingComponents.new(
+          user: current_user,
+          idv_session:,
+          session:,
+          user_session:,
+        ).to_h,
       )
       if idv_session.verify_by_mail?
         current_user.send_email_to_all_addresses(:verify_by_mail_letter_requested)

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -2,7 +2,7 @@
 
 module Idv
   class ProfileMaker
-    attr_reader :pii_attributes
+    attr_reader :pii_attributes, :proofing_components
 
     def initialize(
       applicant:,
@@ -21,13 +21,14 @@ module Idv
       gpo_verification_needed:,
       in_person_verification_needed:,
       selfie_check_performed:,
+      proofing_components:,
       deactivation_reason: nil
     )
       profile = Profile.new(user: user, active: false, deactivation_reason: deactivation_reason)
       profile.initiating_service_provider = initiating_service_provider
       profile.deactivate_for_in_person_verification if in_person_verification_needed
       profile.encrypt_pii(pii_attributes, user_password)
-      profile.proofing_components = current_proofing_components
+      profile.proofing_components = proofing_components.to_json
       profile.fraud_pending_reason = fraud_pending_reason
 
       profile.idv_level = set_idv_level(
@@ -59,10 +60,6 @@ module Idv
       else
         :legacy_unsupervised
       end
-    end
-
-    def current_proofing_components
-      user.proofing_component&.as_json || {}
     end
 
     attr_accessor(

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -28,7 +28,7 @@ module Idv
       profile.initiating_service_provider = initiating_service_provider
       profile.deactivate_for_in_person_verification if in_person_verification_needed
       profile.encrypt_pii(pii_attributes, user_password)
-      profile.proofing_components = proofing_components.to_json
+      profile.proofing_components = proofing_components
       profile.fraud_pending_reason = fraud_pending_reason
 
       profile.idv_level = set_idv_level(

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -66,7 +66,9 @@ module Idv
       VALID_SESSION_ATTRIBUTES.include?(attr_name_sym) || super
     end
 
-    def create_profile_from_applicant_with_password(user_password, is_enhanced_ipp)
+    def create_profile_from_applicant_with_password(
+      user_password, is_enhanced_ipp:, proofing_components:
+    )
       if user_has_unscheduled_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
           user: current_user,
@@ -82,6 +84,7 @@ module Idv
         gpo_verification_needed: !phone_confirmed? || verify_by_mail?,
         in_person_verification_needed: current_user.has_in_person_enrollment?,
         selfie_check_performed: session[:selfie_check_performed],
+        proofing_components:,
       )
 
       profile.activate unless profile.reason_not_to_activate

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -69,7 +69,11 @@ RSpec.describe Idv::PersonalKeyController do
     idv_session.applicant = applicant
 
     if mint_profile_from_idv_session
-      idv_session.create_profile_from_applicant_with_password(password, is_enhanced_ipp)
+      idv_session.create_profile_from_applicant_with_password(
+        password,
+        is_enhanced_ipp:,
+        proofing_components: {},
+      )
     end
   end
 

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -315,7 +315,9 @@ RSpec.describe 'Idv::FlowPolicy' do
         it 'returns personal_key' do
           stub_up_to(:request_letter, idv_session: idv_session)
           idv_session.gpo_code_verified = true
-          idv_session.create_profile_from_applicant_with_password('password', is_enhanced_ipp)
+          idv_session.create_profile_from_applicant_with_password(
+            'password', is_enhanced_ipp:, proofing_components: {}
+          )
 
           expect(subject.info_for_latest_step.key).to eq(:personal_key)
           expect(subject.controller_allowed?(controller: Idv::PersonalKeyController)).to be
@@ -326,7 +328,9 @@ RSpec.describe 'Idv::FlowPolicy' do
         let(:is_enhanced_ipp) { false }
         it 'returns personal_key' do
           stub_up_to(:otp_verification, idv_session: idv_session)
-          idv_session.create_profile_from_applicant_with_password('password', is_enhanced_ipp)
+          idv_session.create_profile_from_applicant_with_password(
+            'password', is_enhanced_ipp:, proofing_components: {}
+          )
 
           expect(subject.info_for_latest_step.key).to eq(:personal_key)
           expect(subject.controller_allowed?(controller: Idv::PersonalKeyController)).to be

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Idv::ProfileMaker do
     let(:user_password) { user.password }
     let(:initiating_service_provider) { nil }
     let(:in_person_proofing_enforce_tmx_mock) { false }
+    let(:proofing_components) { { document_check: :mock } }
 
     subject do
       described_class.new(
@@ -18,12 +19,12 @@ RSpec.describe Idv::ProfileMaker do
     end
 
     it 'creates an inactive Profile with encrypted PII' do
-      proofing_component = ProofingComponent.create(user_id: user.id, document_check: 'mock')
       profile = subject.save_profile(
         fraud_pending_reason: nil,
         gpo_verification_needed: false,
         in_person_verification_needed: false,
         selfie_check_performed: false,
+        proofing_components:,
       )
       pii = subject.pii_attributes
 
@@ -32,7 +33,7 @@ RSpec.describe Idv::ProfileMaker do
       expect(profile.encrypted_pii).to_not be_nil
       expect(profile.encrypted_pii).to_not match('Some')
       expect(profile.fraud_pending_reason).to be_nil
-      expect(profile.proofing_components).to match(proofing_component.as_json)
+      expect(profile.proofing_components).to match(proofing_components.to_json)
       expect(profile.active).to eq(false)
       expect(profile.deactivation_reason).to be_nil
 
@@ -48,6 +49,7 @@ RSpec.describe Idv::ProfileMaker do
           deactivation_reason: :encryption_error,
           in_person_verification_needed: false,
           selfie_check_performed: false,
+          proofing_components:,
         )
       end
       it 'creates an inactive profile with deactivation reason' do
@@ -75,6 +77,7 @@ RSpec.describe Idv::ProfileMaker do
           deactivation_reason: nil,
           in_person_verification_needed: in_person_verification_needed,
           selfie_check_performed: false,
+          proofing_components:,
         )
       end
 
@@ -118,6 +121,7 @@ RSpec.describe Idv::ProfileMaker do
           deactivation_reason: nil,
           in_person_verification_needed: false,
           selfie_check_performed: false,
+          proofing_components:,
         )
       end
       it 'creates a pending profile for gpo verification' do
@@ -151,6 +155,7 @@ RSpec.describe Idv::ProfileMaker do
             deactivation_reason: nil,
             in_person_verification_needed: true,
             selfie_check_performed: false,
+            proofing_components:,
           )
         end
 
@@ -190,6 +195,7 @@ RSpec.describe Idv::ProfileMaker do
             deactivation_reason: nil,
             in_person_verification_needed: true,
             selfie_check_performed: false,
+            proofing_components:,
           )
         end
 
@@ -220,6 +226,7 @@ RSpec.describe Idv::ProfileMaker do
           deactivation_reason: nil,
           in_person_verification_needed: false,
           selfie_check_performed: selfie_check_performed,
+          proofing_components:,
         )
       end
 
@@ -267,6 +274,7 @@ RSpec.describe Idv::ProfileMaker do
           deactivation_reason: nil,
           in_person_verification_needed: false,
           selfie_check_performed: false,
+          proofing_components:,
         )
       end
       it 'creates a profile with the initiating sp recorded' do

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Idv::ProfileMaker do
       expect(profile.encrypted_pii).to_not be_nil
       expect(profile.encrypted_pii).to_not match('Some')
       expect(profile.fraud_pending_reason).to be_nil
-      expect(profile.proofing_components).to match(proofing_components.to_json)
+      expect(profile.proofing_components).to match(proofing_components)
       expect(profile.active).to eq(false)
       expect(profile.deactivation_reason).to be_nil
 

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Idv::ProfileMaker do
       expect(profile.encrypted_pii).to_not be_nil
       expect(profile.encrypted_pii).to_not match('Some')
       expect(profile.fraud_pending_reason).to be_nil
-      expect(profile.proofing_components).to match(proofing_components)
+      expect(profile.proofing_components).to match(proofing_components.as_json)
       expect(profile.active).to eq(false)
       expect(profile.deactivation_reason).to be_nil
 

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Idv::Session do
   let(:user) { create(:user) }
   let(:user_session) { {} }
-  let(:is_enhanced_ipp) { false }
 
   subject do
     Idv::Session.new(user_session: user_session, current_user: user, service_provider: nil)
@@ -128,6 +127,8 @@ RSpec.describe Idv::Session do
   end
 
   describe '#create_profile_from_applicant_with_password' do
+    let(:is_enhanced_ipp) { false }
+    let(:proofing_components) { { document_check: 'mock' } }
     let(:opt_in_param) { nil }
 
     before do
@@ -146,7 +147,9 @@ RSpec.describe Idv::Session do
           now = Time.zone.now
 
           subject.user_phone_confirmation = true
-          subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+          subject.create_profile_from_applicant_with_password(
+            user.password, is_enhanced_ipp:, proofing_components:
+          )
           profile = subject.profile
 
           expect(profile.activated_at).to eq now
@@ -165,7 +168,9 @@ RSpec.describe Idv::Session do
 
       it 'does not complete the profile if the user has not completed OTP phone confirmation' do
         subject.user_phone_confirmation = nil
-        subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+        subject.create_profile_from_applicant_with_password(
+          user.password, is_enhanced_ipp:, proofing_components:
+        )
         profile = subject.profile
 
         expect(profile.activated_at).to eq nil
@@ -200,7 +205,9 @@ RSpec.describe Idv::Session do
           end
 
           it 'creates an USPS enrollment' do
-            subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+            subject.create_profile_from_applicant_with_password(
+              user.password, is_enhanced_ipp:, proofing_components:
+            )
             expect(UspsInPersonProofing::EnrollmentHelper).to have_received(
               :schedule_in_person_enrollment,
             ).with(
@@ -212,7 +219,9 @@ RSpec.describe Idv::Session do
           end
 
           it 'creates a profile with in person verification pending' do
-            subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+            subject.create_profile_from_applicant_with_password(
+              user.password, is_enhanced_ipp:, proofing_components:
+            )
             expect(profile).to have_attributes(
               {
                 activated_at: nil,
@@ -227,12 +236,16 @@ RSpec.describe Idv::Session do
           end
 
           it 'saves the pii to the session' do
-            subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+            subject.create_profile_from_applicant_with_password(
+              user.password, is_enhanced_ipp:, proofing_components:
+            )
             expect(Pii::Cacher.new(user, user_session).fetch(profile.id)).to_not be_nil
           end
 
           it 'associates the in person enrollment with the created profile' do
-            subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+            subject.create_profile_from_applicant_with_password(
+              user.password, is_enhanced_ipp:, proofing_components:
+            )
             expect(enrollment.reload.profile_id).to eq(profile.id)
           end
         end
@@ -245,7 +258,9 @@ RSpec.describe Idv::Session do
           end
 
           it 'does not create a profile' do
-            subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+            subject.create_profile_from_applicant_with_password(
+              user.password, is_enhanced_ipp:, proofing_components:
+            )
           rescue
             expect(profile).to be_nil
           end
@@ -264,14 +279,18 @@ RSpec.describe Idv::Session do
         end
 
         it 'does not create an USPS enrollment' do
-          subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+          subject.create_profile_from_applicant_with_password(
+            user.password, is_enhanced_ipp:, proofing_components:
+          )
           expect(UspsInPersonProofing::EnrollmentHelper).to_not have_received(
             :schedule_in_person_enrollment,
           )
         end
 
         it 'creates a profile' do
-          subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+          subject.create_profile_from_applicant_with_password(
+            user.password, is_enhanced_ipp:, proofing_components:
+          )
           expect(profile).to have_attributes(
             {
               active: true,
@@ -284,7 +303,9 @@ RSpec.describe Idv::Session do
         end
 
         it 'saves the pii to the session' do
-          subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+          subject.create_profile_from_applicant_with_password(
+            user.password, is_enhanced_ipp:, proofing_components:
+          )
           expect(Pii::Cacher.new(user, user_session).fetch(profile.id)).to_not be_nil
         end
       end
@@ -297,7 +318,9 @@ RSpec.describe Idv::Session do
       end
 
       it 'sets profile to pending gpo verification' do
-        subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+        subject.create_profile_from_applicant_with_password(
+          user.password, is_enhanced_ipp:, proofing_components:
+        )
         profile = subject.profile
 
         expect(profile.activated_at).to eq nil
@@ -321,7 +344,9 @@ RSpec.describe Idv::Session do
       end
 
       it 'does not complete the user profile' do
-        subject.create_profile_from_applicant_with_password(user.password, is_enhanced_ipp)
+        subject.create_profile_from_applicant_with_password(
+          user.password, is_enhanced_ipp:, proofing_components:
+        )
         profile = subject.profile
 
         expect(profile.activated_at).to eq nil


### PR DESCRIPTION
Proofing components are intended to represent the proofing flow that was used to create a profile. Traditionally these have been generated by tracking proofing components in a database table associated with the user. There were a number of problems with this approach which 5021e2ef8237ecc6ff38f6338371e89fb8dcf06d introduced a `Idv::ProofingComponents` service to address. This service generates proofing components from the session instead of from the database table.

This commit uses the `Idv::ProofingComponents` service to generate the proofing components stored on the profile. This will allow us to drop the proofing components table in a future change.
