### PR TITLE
Exclude stale sessions in IAL2 usage query

### DIFF
--- a/lib/reporting/protocols_report.rb
+++ b/lib/reporting/protocols_report.rb
@@ -282,11 +282,18 @@ module Reporting
     end
 
     def facial_match_issuers_query
-      format(<<~QUERY)
+      params = {
+        events: quote([SAML_AUTH_EVENT, OIDC_AUTH_EVENT]),
+      }
+      # OIDC_AUTH_EVENT and SAML_AUTH_EVENTs are fired before the initiating
+      # session is stored.
+      # We are omitting those events to prevent false positives
+      format(<<~QUERY, params)
         fields
           coalesce(properties.event_properties.service_provider,
           properties.event_properties.client_id,
           properties.service_provider) as issuer
+        | filter name NOT IN %{events}
         | filter properties.sp_request.facial_match
         | display issuer
         | sort issuer

--- a/spec/lib/reporting/protocols_report_spec.rb
+++ b/spec/lib/reporting/protocols_report_spec.rb
@@ -113,6 +113,38 @@ RSpec.describe Reporting::ProtocolsReport do
     it 'generates the tabular csv data' do
       expect(report.as_tables).to eq expected_tables
     end
+
+    describe 'queries' do
+      let(:client) { report.cloudwatch_client }
+      let(:time_query) do
+        {
+          from: report.time_range.begin,
+          to: report.time_range.end,
+        }
+      end
+      before do
+        allow(client).to receive(:fetch).and_call_original
+      end
+
+      it 'calls the cloudwatch client with the expected queries' do
+        report.as_tables
+
+        %i[
+          aal3_issuers_query
+          saml_signature_query
+          facial_match_issuers_query
+          id_token_hint_query
+          loa_issuers_query
+          protocol_query
+          saml_signature_query
+        ].each do |query|
+          expect(client).to have_received(:fetch).with(
+            query: report.send(query),
+            **time_query,
+          )
+        end
+      end
+    end
   end
 
   describe '#as_emailable_reports' do

--- a/spec/lib/reporting/protocols_report_spec.rb
+++ b/spec/lib/reporting/protocols_report_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Reporting::ProtocolsReport do
           saml_signature_query
         ].each do |query|
           expect(client).to have_received(:fetch).with(
-            query: report.send(query),
+            query: report.public_send(query),
             **time_query,
           )
         end


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[Fix facial match usage query](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/134)

## 🛠 Summary of changes
- Excludes 'SAML Auth' and 'OpenID Connect: authorization request' from the IAL2 usage report
- Adds tests to make sure the queries look okay as [per feedback on last PR](https://github.com/18F/identity-idp/pull/11447#discussion_r1828018895)


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
