### PR TITLE
LG-15125: Wait for Socure result - hybrid flow

### DIFF
--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -4,11 +4,10 @@ module Idv
   module HybridMobile
     module Socure
       class DocumentCaptureController < ApplicationController
-        include Idv::AvailabilityConcern
+        include AvailabilityConcern
         include DocumentCaptureConcern
         include Idv::HybridMobile::HybridMobileConcern
         include RenderConditionConcern
-        include DocumentCaptureConcern
 
         check_or_render_not_found -> { IdentityConfig.store.socure_docv_enabled }
         before_action :check_valid_document_capture_session, except: [:update]
@@ -50,9 +49,15 @@ module Idv
         end
 
         def update
+          return if wait_for_result?
+
           result = handle_stored_result(
             user: document_capture_session.user,
             store_in_session: false,
+          )
+          # TODO: new analytics event?
+          analytics.idv_doc_auth_document_capture_submitted(
+            **result.to_h.merge(analytics_arguments),
           )
 
           if result.success?
@@ -60,6 +65,49 @@ module Idv
           else
             redirect_to idv_hybrid_mobile_socure_document_capture_url
           end
+        end
+
+        private
+
+        def wait_for_result?
+          return false if stored_result.present?
+
+          # If the stored_result is nil, the job fetching the results has not completed.
+          analytics.idv_doc_auth_document_capture_polling_wait_visited(**analytics_arguments)
+          if wait_timed_out?
+            # flash[:error] = I18n.t('errors.doc_auth.polling_timeout')
+            # TODO: redirect to try again page LG-14873/14952/15059
+            render plain: 'Technical difficulties!!!', status: :ok
+          else
+            @refresh_interval =
+              IdentityConfig.store.doc_auth_socure_wait_polling_refresh_max_seconds
+            render 'idv/socure/document_capture/wait'
+          end
+
+          true
+        end
+
+        def wait_timed_out?
+          if session[:socure_docv_wait_polling_started_at].nil?
+            session[:socure_docv_wait_polling_started_at] = Time.zone.now.to_s
+            return false
+          end
+          start = DateTime.parse(session[:socure_docv_wait_polling_started_at])
+          timeout_period =
+            IdentityConfig.store.doc_auth_socure_wait_polling_timeout_minutes.minutes || 2.minutes
+          start + timeout_period < Time.zone.now
+        end
+
+        def analytics_arguments
+          {
+            flow_path: 'hybrid',
+            step: 'socure_hybrid_document_capture',
+            analytics_id: 'Doc Auth',
+            redo_document_capture: nil,
+            skip_hybrid_handoff: false,
+            liveness_checking_required: false,
+            selfie_check_required: false,
+          }
         end
       end
     end

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -101,10 +101,8 @@ module Idv
         def analytics_arguments
           {
             flow_path: 'hybrid',
-            step: 'socure_hybrid_document_capture',
+            step: 'socure_document_capture',
             analytics_id: 'Doc Auth',
-            redo_document_capture: nil,
-            skip_hybrid_handoff: false,
             liveness_checking_required: false,
             selfie_check_required: false,
           }

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1255,10 +1255,10 @@ module AnalyticsEvents
     flow_path:,
     step:,
     analytics_id:,
-    redo_document_capture:,
-    skip_hybrid_handoff:,
     liveness_checking_required:,
     selfie_check_required:,
+    redo_document_capture: nil,
+    skip_hybrid_handoff: nil,
     opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     **extra


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15125](https://cm-jira.usa.gov/browse/LG-15125)

## 🛠 Summary of changes

As in #11500 for the standard flow, we need to wait for the Socure result to be received before we can determine where to send the user.

Currently, if the wait times out, we show a placeholder plain text of "Technical difficulties!!!" to be replaced with the appropriate "Try again?" page in a following ticket.

Note there is some identical code in the standard vs hybrid controllers that might be refactored into a concern in the future, but until all of the paths are complete, I thought it best to live with the duplication for now.
