### PR TITLE
LG-14371 Start logging year-of-birth in biographical info hash

### DIFF
--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -123,6 +123,7 @@ module Proofing
                                      StringRedacter.redact_alphanumeric(state_id_number)
                                    end
         {
+          birth_year: applicant_pii[:dob]&.to_date&.year,
           state: applicant_pii[:state],
           identity_doc_address_state: applicant_pii[:identity_doc_address_state],
           state_id_jurisdiction: applicant_pii[:state_id_jurisdiction],

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -116,6 +116,7 @@ RSpec.feature 'Analytics Regression', :js do
         },
       },
       biographical_info: {
+        birth_year: 1938,
         identity_doc_address_state: nil,
         state: 'MT',
         state_id_jurisdiction: 'ND',
@@ -158,6 +159,7 @@ RSpec.feature 'Analytics Regression', :js do
         },
       },
       biographical_info: {
+        birth_year: 1938,
         identity_doc_address_state: 'ND',
         state: 'MT',
         state_id_jurisdiction: 'ND',

--- a/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
+++ b/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe SocureShadowModeProofingJob do
           },
         },
         biographical_info: {
+          birth_year: 1938,
           identity_doc_address_state: nil,
           same_address_as_id: nil,
           state: 'MT',
@@ -257,6 +258,7 @@ RSpec.describe SocureShadowModeProofingJob do
             threatmetrix_review_status: 'pass',
             timed_out: false,
             biographical_info: {
+              birth_year: 1938,
               identity_doc_address_state: nil,
               same_address_as_id: nil,
               state: 'MT',

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
           result = subject.adjudicated_result
 
           expect(result.extra[:biographical_info]).to eq(
+            birth_year: 1938,
             state: 'MT',
             identity_doc_address_state: nil,
             state_id_jurisdiction: 'ND',
@@ -118,6 +119,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
           result = subject.adjudicated_result
 
           expect(result.extra[:biographical_info]).to eq(
+            birth_year: 1938,
             state: 'MT',
             identity_doc_address_state: 'MT',
             state_id_jurisdiction: 'ND',


### PR DESCRIPTION
In #11267 we quit logging the user's year-of-birth while we waited for additional security and privacy review. We received approval to start logging this attribute. This commit undoes the changes in #11267 so the year-of-birth is now logged
