### PR TITLE
Add name suffix to TrueID response fixture

### DIFF
--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success.json
@@ -331,6 +331,11 @@
          },
                   {
             "Group": "IDAUTH_FIELD_DATA",
+            "Name": "Fields_NameSuffix",
+            "Values": [{"Value": "JR"}]
+         },
+                  {
+            "Group": "IDAUTH_FIELD_DATA",
             "Name": "Fields_DOB_Year",
             "Values": [{"Value": "1966"}]
          },


### PR DESCRIPTION
LexisNexis informed us that the name suffix should be available in a TrueID response if the name suffix is present on the document. This commit adds the name suffix to the response fixture so that we have a fixture to represent this case.

We plan to read the name suffix and check it against the DLDV service in a future change. This commit prepares us for that.
