### PR TITLE
Remove unnecessary allowed_extra_analytics

### DIFF
--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -601,9 +601,7 @@ RSpec.describe 'OpenID Connect' do
       to include('Verified within value must be at least 30 days or older')
   end
 
-  it 'sends the user through idv again via verified_within param',
-     :js,
-     allowed_extra_analytics: [:*] do
+  it 'sends the user through idv again via verified_within param', :js do
     client_id = 'urn:gov:gsa:openidconnect:sp:server'
     allow(IdentityConfig.store).to receive(:allowed_verified_within_providers).
       and_return([client_id])

--- a/spec/features/saml/vtr_spec.rb
+++ b/spec/features/saml/vtr_spec.rb
@@ -126,9 +126,7 @@ RSpec.feature 'SAML requests using VTR' do
     expect_successful_saml_redirect
   end
 
-  scenario 'sign in with VTR request for idv requires idv',
-           :js,
-           allowed_extra_analytics: [:*] do
+  scenario 'sign in with VTR request for idv requires idv', :js do
     user = create(:user, :fully_registered)
 
     visit_saml_authn_request_url(
@@ -150,8 +148,7 @@ RSpec.feature 'SAML requests using VTR' do
     expect_successful_saml_redirect
   end
 
-  scenario 'sign in with VTR request for idv includes proofed attributes',
-           allowed_extra_analytics: [:*] do
+  scenario 'sign in with VTR request for idv includes proofed attributes' do
     pii = {
       first_name: 'Jonathan',
       ssn: '900-66-6666',
@@ -190,8 +187,7 @@ RSpec.feature 'SAML requests using VTR' do
   end
 
   scenario 'sign in with VTR request for idv with facial match requires idv with facial match',
-           :js,
-           allowed_extra_analytics: [:*] do
+           :js do
     user = create(:user, :proofed)
     user.active_profile.update!(idv_level: :legacy_unsupervised)
 

--- a/spec/features/sign_in/multiple_vot_spec.rb
+++ b/spec/features/sign_in/multiple_vot_spec.rb
@@ -38,9 +38,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         expect(user_info[:vot]).to eq('C1.C2.P1')
       end
 
-      scenario 'identity proofing with facial match is required if user is not proofed',
-               :js,
-               allowed_extra_analytics: [:*] do
+      scenario 'identity proofing with facial match is required if user is not proofed', :js do
         user = create(:user, :fully_registered)
 
         visit_idp_from_oidc_sp_with_vtr(vtr: ['C1.C2.P1.Pb', 'C1.C2.P1'])
@@ -176,9 +174,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         expect(first_name).to_not be_blank
       end
 
-      scenario 'identity proofing with facial match is required if user is not proofed',
-               :js,
-               allowed_extra_analytics: [:*] do
+      scenario 'identity proofing with facial match is required if user is not proofed', :js do
         user = create(:user, :fully_registered)
 
         visit_saml_authn_request_url(

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -158,9 +158,7 @@ RSpec.feature 'User profile' do
         expect(current_path).to eq(account_path)
       end
 
-      it 'allows the user reactivate their profile by reverifying',
-         :js,
-         allowed_extra_analytics: [:*] do
+      it 'allows the user reactivate their profile by reverifying', :js do
         profile = create(:profile, :active, :verified, pii: { ssn: '1234', dob: '1920-01-01' })
         user = profile.user
 


### PR DESCRIPTION
## 🛠 Summary of changes

As a follow-up to #11536, I discovered there were more `allowed_extra_analytics` that can be removed as-is with the analytics documentation added in that pull request.

## 📜 Testing Plan

Verify build passes.