### PR TITLE
Document usage of Lookbook for ViewComponents

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -175,6 +175,14 @@ and independent view components, rendered server-side.
 
 For more information, refer to the [components `README.md`](../app/components/README.md).
 
+To preview components and their available options, we use [Lookbook](https://lookbook.build/) to
+generate a navigable index of our available components. These previews are available at the [`/components/` route](http://localhost:3000/components/)
+in local development, review applications, and in the `dev` environment. When adding a new component
+or an option to an existing component, you should also make this component or option available in
+Lookbook previews, found under [`spec/components/previews`](https://github.com/18F/identity-idp/tree/main/spec/components/previews).
+Refer to [Lookbook's _Previews Overview_ documentation](https://lookbook.build/guide/previews) for
+more information on how to author Lookbook previews.
+
 #### React
 
 For non-trivial client-side interactivity, we use [React](https://reactjs.org/) to build and combine


### PR DESCRIPTION
## 🛠 Summary of changes

Expands on the "View Components" section of the [Frontend Architecture documentation](https://github.com/18F/identity-idp/blob/main/docs/frontend.md) to detail our use of Lookbook for component previews.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1732049308670279

## 📜 Testing Plan

Review [proposed text](https://github.com/18F/identity-idp/blob/aduth-lookbook/docs/frontend.md#view-components) as being easy-to-understand and without typos.