### PR TITLE
Update Data Request script to compute requesting issuer and have configurable depth

### DIFF
--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -212,7 +212,7 @@ class DataPull
     def compute_requesting_issuers(uuids)
       service_providers = ServiceProviderIdentity.where(uuid: uuids).pluck(:service_provider)
       return nil if service_providers.empty?
-      service_provider = service_providers.tally.max_by { |_sp, count| count }[0]
+      service_provider, _count = service_providers.tally.max_by { |_sp, count| count }
 
       if service_providers.count > 1
         warn "Multiple computed service providers: #{service_providers.join(', ')}"

--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -220,9 +220,7 @@ class DataPull
 
       warn "Computed service provider #{service_provider}"
 
-      [
-        service_provider,
-      ]
+      Array(service_provider)
     end
   end
 

--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -214,6 +214,10 @@ class DataPull
       return nil if service_providers.empty?
       service_provider = service_providers.tally.max_by { |_sp, count| count }[0]
 
+      if service_providers.count > 1
+        warn "Multiple computed service providers: #{service_providers.join(', ')}"
+      end
+
       warn "Computed service provider #{service_provider}"
 
       [

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -33,6 +33,7 @@ class ScriptBase
     :show_help,
     :requesting_issuers,
     :deflate,
+    :depth,
     :reason,
     keyword_init: true,
   ) do
@@ -109,6 +110,12 @@ class ScriptBase
         requesting issuer (used for ig-request task)
       MSG
         config.requesting_issuers << issuer
+      end
+
+      opts.on('--depth=DEPTH', <<-MSG) do |depth|
+        depth of connected devices (used for ig-request task)
+      MSG
+        config.depth = depth.to_i
       end
 
       opts.on('--help') do

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -319,6 +319,26 @@ RSpec.describe DataPull do
         expect(result.subtask).to eq('ig-request')
         expect(result.uuids).to eq([user.uuid])
       end
+
+      context 'with SP UUID argument and no requesting issuer' do
+        let(:args) { [identity.uuid] }
+        let(:config) { ScriptBase::Config.new }
+
+        it 'runs the report with computed requesting issuer', aggregate_failures: true do
+          expect(result.table).to be_nil
+          expect(result.json.first.keys).to contain_exactly(
+            :user_id,
+            :login_uuid,
+            :requesting_issuer_uuid,
+            :email_addresses,
+            :mfa_configurations,
+            :user_events,
+          )
+
+          expect(result.subtask).to eq('ig-request')
+          expect(result.uuids).to eq([user.uuid])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Following discussion yesterday [here](https://gsa-tts.slack.com/archives/C03KDV9S8T1/p1732139497048669?thread_ts=1732138386.924899&cid=C03KDV9S8T1), this PR tries to address two potential improvements in the data request script:

1. Looking up the service provider issuer automatically when the script is supplied without a requesting issuer, but is given `ServiceProviderIdentity`/`AgencyIdentity` UUIDs
2. Configurable depth (defaulting to 0)

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
