### PR TITLE
Revert "LG-14828 Remove deprecated state ID step routes"

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -410,6 +410,10 @@ Rails.application.routes.draw do
           # sometimes underscores get messed up when linked to via SMS
           as: :capture_doc_dashes
 
+      # Deprecated route - temporary redirect while state id changes are rolled out
+      get '/in_person_proofing/state_id' => redirect('verify/in_person/state_id', status: 307)
+      put '/in_person_proofing/state_id' => 'in_person/state_id#update'
+
       get '/in_person' => 'in_person#index'
       get '/in_person/ready_to_verify' => 'in_person/ready_to_verify#show',
           as: :in_person_ready_to_verify


### PR DESCRIPTION
Reverts 18F/identity-idp#11510

Temporary revert to be cherry-picked into RC 433 deployment, while we investigate requests to deprecated routes.

Related Slack discussion: https://gsa-tts.slack.com/archives/C04GA9WQ85B/p1732216903820289