### PR TITLE
LG-15171 Fixes redirect for PUT

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -412,7 +412,7 @@ Rails.application.routes.draw do
 
       # Deprecated route - temporary redirect while state id changes are rolled out
       get '/in_person_proofing/state_id' => redirect('verify/in_person/state_id', status: 307)
-      put '/in_person_proofing/state_id' => 'in_person/state_id#update'
+      put '/in_person_proofing/state_id' => redirect('verify/in_person/state_id', status: 307)
 
       get '/in_person' => 'in_person#index'
       get '/in_person/ready_to_verify' => 'in_person/ready_to_verify#show',


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15171](https://cm-jira.usa.gov/browse/LG-15171)

## 🛠 Summary of changes

Fixes redirect for put for state id routes renaming. This is so that the transition to the new routes can be made without users still being directed to the old routes. 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Enter the application through Sinatra, choosing "Identity-verified"
- [ ] Go through the IPP flow until the state id page
- [ ] Enter an address with a comma and hit submit
- [ ] Observe in the application logs that "PUT /in_person/state_id" occurs on submit, and no calls to "/in_person_proofing/state_id" are made.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
