### PR TITLE
LG-14748 Add in person warning to password reset email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -67,7 +67,8 @@ class UserMailer < ActionMailer::Base
       @token = token
       @request_id = request_id
       @gpo_verification_pending_profile = user.gpo_verification_pending_profile?
-      @hide_title = @gpo_verification_pending_profile
+      @in_person_verification_pending_profile = user.in_person_pending_profile?
+      @hide_title = @gpo_verification_pending_profile || @in_person_verification_pending_profile
       mail(to: email_address.email, subject: t('user_mailer.reset_password_instructions.subject'))
     end
   end

--- a/app/views/user_mailer/reset_password_instructions.html.erb
+++ b/app/views/user_mailer/reset_password_instructions.html.erb
@@ -15,7 +15,15 @@
   <h1>
     <%= @header || message.subject %>
   </h1>
-  <% end %>
+<% end %>
+
+<% if @in_person_verification_pending_profile %>
+  <%= render 'user_mailer/shared/in_person_warning_banner' %>
+  <h1>
+    <%= @header || message.subject %>
+  </h1>
+<% end %>
+
 <p class="lead">
   <%= t(
         'user_mailer.reset_password_instructions.header',

--- a/app/views/user_mailer/shared/_in_person_warning_banner.html.erb
+++ b/app/views/user_mailer/shared/_in_person_warning_banner.html.erb
@@ -1,0 +1,11 @@
+<table class="usa-alert usa-alert--warning margin-bottom-4">
+  <tbody>
+  <tr>
+    <td style="width:16px;">
+      <%= image_tag('email/warning.png', width: 16, height: 14, alt: 'warning icon', style: 'margin-top: 5px;') %>
+    </td>
+    <td>
+      <p><%= t('user_mailer.reset_password_instructions.in_person_warning_description_html') %></p>
+    </td>
+  </tr>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1942,6 +1942,7 @@ user_mailer.reset_password_instructions.footer: This link expires in %{expires} 
 user_mailer.reset_password_instructions.gpo_letter_description: If you reset your password, the verification code in your letter will no longer work and you’ll have to verify your identity again.
 user_mailer.reset_password_instructions.gpo_letter_header: Your letter is on the way
 user_mailer.reset_password_instructions.header: To finish resetting your password, please click the link below or copy and paste the entire link into your browser.
+user_mailer.reset_password_instructions.in_person_warning_description_html: <strong>If you reset your password now, your barcode will not work at the Post Office.</strong> You’ll have to restart the identity verification process from the beginning.
 user_mailer.reset_password_instructions.link_text: Reset your password
 user_mailer.reset_password_instructions.subject: Reset your password
 user_mailer.signup_with_your_email.help_html: If you did not request a new account or suspect an error, please visit the %{app_name_html} %{help_link_html} or %{contact_link_html}.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1954,6 +1954,7 @@ user_mailer.reset_password_instructions.footer: Este vínculo vence en %{expires
 user_mailer.reset_password_instructions.gpo_letter_description: Si restablece su contraseña, el código de verificación que recibió en su carta ya no funcionará y tendrá que volver a verificar su identidad.
 user_mailer.reset_password_instructions.gpo_letter_header: Su carta está en camino
 user_mailer.reset_password_instructions.header: Para terminar de restablecer su contraseña, haga clic en el enlace de abajo o copie y pegue el enlace completo en su navegador.
+user_mailer.reset_password_instructions.in_person_warning_description_html: <strong>If you reset your password now, your barcode will not work at the Post Office.</strong> You’ll have to restart the identity verification process from the beginning.
 user_mailer.reset_password_instructions.link_text: Restablezca su contraseña
 user_mailer.reset_password_instructions.subject: Restablezca su contraseña
 user_mailer.signup_with_your_email.help_html: Si usted no solicitó una cuenta nueva o sospecha que hubo un error, visite la %{help_link_html} de %{app_name_html} o %{contact_link_html}.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1942,6 +1942,7 @@ user_mailer.reset_password_instructions.footer: Ce lien expire dans %{expires} h
 user_mailer.reset_password_instructions.gpo_letter_description: Si vous réinitialisez votre mot de passe, le code de vérification contenu dans votre lettre ne fonctionnera plus et vous devrez reconfirmer votre identité.
 user_mailer.reset_password_instructions.gpo_letter_header: Votre lettre est en route
 user_mailer.reset_password_instructions.header: Pour terminer la réinitialisation de votre mot de passe, veuillez cliquer sur le lien ci-dessous ou copier et coller le lien complet dans votre navigateur.
+user_mailer.reset_password_instructions.in_person_warning_description_html: <strong>If you reset your password now, your barcode will not work at the Post Office.</strong> You’ll have to restart the identity verification process from the beginning.
 user_mailer.reset_password_instructions.link_text: Réinitialiser votre mot de passe
 user_mailer.reset_password_instructions.subject: Réinitialiser votre mot de passe
 user_mailer.signup_with_your_email.help_html: Si vous n’avez pas demandé un nouveau compte ou soupçonnez qu’une erreur s’est produite, veuillez visiter le %{help_link_html} de %{app_name_html} ou %{contact_link_html}.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1955,6 +1955,7 @@ user_mailer.reset_password_instructions.footer: 这一链接 %{expires} 小时�
 user_mailer.reset_password_instructions.gpo_letter_description: 如果你重设密码，信件中的一次性代码就会失效，你需要再次验证身份。
 user_mailer.reset_password_instructions.gpo_letter_header: 你的信件已寄出。
 user_mailer.reset_password_instructions.header: 要完成重设密码，请点击下面的链接或把整个链接复制并黏贴进浏览器。
+user_mailer.reset_password_instructions.in_person_warning_description_html: <strong>If you reset your password now, your barcode will not work at the Post Office.</strong> You’ll have to restart the identity verification process from the beginning.
 user_mailer.reset_password_instructions.link_text: 重设你的密码
 user_mailer.reset_password_instructions.subject: 重设你的密码
 user_mailer.signup_with_your_email.help_html: 如果你没有要求一封新电邮或怀疑有错， 请访问 %{app_name_html}的 %{help_link_html} 或者 %{contact_link_html}。

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -74,6 +74,7 @@ module I18n
         { key: 'time.formats.event_timestamp', locales: %i[zh] },
         { key: 'time.formats.full_date', locales: %i[es] }, # format is the same in Spanish and English
         { key: 'time.formats.sms_date' }, # for us date format
+        { key: 'user_mailer.reset_password_instructions.in_person_warning_description_html', locales: %i[es fr zh] }, # Temporary until spanish, french, and chinese translations come in.
         { key: 'webauthn_platform_recommended.cta' }, # English-only A/B test
         { key: 'webauthn_platform_recommended.description_private_html' }, # English-only A/B test
         { key: 'webauthn_platform_recommended.description_secure_account' }, # English-only A/B test

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -26,6 +26,14 @@ class UserMailerPreview < ActionMailer::Preview
     )
   end
 
+  def reset_password_instructions_with_pending_in_person_warning
+    UserMailer.with(
+      user: user_with_pending_in_person_profile, email_address: email_address_record,
+    ).reset_password_instructions(
+      token: SecureRandom.hex, request_id: SecureRandom.hex,
+    )
+  end
+
   def password_changed
     UserMailer.with(user: user, email_address: email_address_record).
       password_changed(disavowal_token: SecureRandom.hex)
@@ -310,6 +318,19 @@ class UserMailerPreview < ActionMailer::Preview
       ),
     )
     raw_user.send(:instance_variable_set, :@pending_profile, gpo_pending_profile)
+    raw_user
+  end
+
+  def user_with_pending_in_person_profile
+    raw_user = user
+    in_person_pending_profile = unsaveable(
+      Profile.new(
+        user: raw_user,
+        active: false,
+        in_person_verification_pending_at: Time.zone.now,
+      ),
+    )
+    raw_user.send(:instance_variable_set, :@pending_profile, in_person_pending_profile)
     raw_user
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14748](https://cm-jira.usa.gov/browse/LG-14748)

## 🛠 Summary of changes

Add a warning banner to the password reset email for users with a pending in-person enrollments.

### Scenario: When the user does not have a pending in-person enrollment

- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Logout
- [x] Attempt to reset the password of the user
- [x] Ensure the password reset email does not have the in-person warning banner.

### Scenario: When the user has a pending in-person enrollment

- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the ready to verify page.
- [x] Logout
- [x] Attempt to reset the password of the user
- [x] Ensure the password reset email has the in-person warning banner.

### (Regression Test) Scenario: When the user has a pending gpo enrollment

**Note:** You might have enable gpo flow from the environment vars 

- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [ ] Go through the remote flow and select "verify your address by mail instead" on the `/verify/phone` page
- [ ] complete gpo flow
- [x] Logout
- [x] Attempt to reset the password of the user
- [x] Ensure the password reset email does not have the in-person warning banner.
- [x] Ensure the password reset email has the gpo warning banner.

## 👀 Screenshots

<details>
<summary>Updated Password Reset Email</summary>
<h3>English:</h3>
<img width="629" alt="Screenshot 2024-11-25 at 3 06 19 PM" src="https://github.com/user-attachments/assets/b4925b1e-9257-4a7a-811a-ad6f934889f9">

<h3>Spanish:</h3>
<img width="629" alt="Screenshot 2024-11-25 at 3 11 53 PM" src="https://github.com/user-attachments/assets/7266c1f5-eea6-47bc-bbae-031ce5a33f61">

<h3>French:</h3>
<img width="629" alt="Screenshot 2024-11-25 at 3 12 47 PM" src="https://github.com/user-attachments/assets/1b6ac975-bf80-45bc-8d55-22ec511eb222">

<h3>Chinese:</h3>
<img width="629" alt="Screenshot 2024-11-25 at 3 13 52 PM" src="https://github.com/user-attachments/assets/4ddc7800-60e1-4851-902e-e237d190df75">

</details>

