### PR TITLE
LG-15098: Run the Socure DocV result job in it's own queue.

### DIFF
--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SocureDocvResultsJob < ApplicationJob
-  queue_as :default
+  queue_as :high_socure_docv
 
   attr_reader :document_capture_session_uuid
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15098](https://cm-jira.usa.gov/browse/LG-15098)

## 🛠 Summary of changes

Changes the queue of the job from `:default` to `:high_socure_docv`.
Will have no effect unless `high_socure_docv` is added to the config `good_job_queues`
