### PR TITLE
Log Face/Touch setup A/B test from session value

### DIFF
--- a/app/controllers/users/webauthn_platform_recommended_controller.rb
+++ b/app/controllers/users/webauthn_platform_recommended_controller.rb
@@ -15,11 +15,21 @@ module Users
 
     def create
       analytics.webauthn_platform_recommended_submitted(opted_to_add: opted_to_add?)
+      store_webauthn_platform_recommended_in_session if opted_to_add?
       current_user.update(webauthn_platform_recommended_dismissed_at: Time.zone.now)
       redirect_to dismiss_redirect_path
     end
 
     private
+
+    def store_webauthn_platform_recommended_in_session
+      user_session[:webauthn_platform_recommended] =
+        if in_account_creation_flow?
+          :account_creation
+        else
+          :authentication
+        end
+    end
 
     def opted_to_add?
       params[:add_method].present?

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -161,6 +161,7 @@ module Users
     def analytics_properties
       {
         in_account_creation_flow: user_session[:in_account_creation_flow] || false,
+        webauthn_platform_recommended: user_session[:webauthn_platform_recommended],
         attempts: mfa_attempts_count,
       }
     end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5361,6 +5361,8 @@ module AnalyticsEvents
   # @param [String, nil] aaguid AAGUID value of WebAuthn device
   # @param [String[], nil] unknown_transports Array of unrecognized WebAuthn transports, intended to
   # be used in case of future specification changes.
+  # @param [:authentication, :account_creation, nil] webauthn_platform_recommended A/B test for
+  # recommended Face or Touch Unlock setup, if applicable.
   def multi_factor_auth_setup(
     success:,
     multi_factor_auth_method:,
@@ -5384,6 +5386,7 @@ module AnalyticsEvents
     attempts: nil,
     aaguid: nil,
     unknown_transports: nil,
+    webauthn_platform_recommended: nil,
     **extra
   )
     track_event(
@@ -5410,6 +5413,7 @@ module AnalyticsEvents
       attempts:,
       aaguid:,
       unknown_transports:,
+      webauthn_platform_recommended:,
       **extra,
     )
   end

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -87,7 +87,7 @@ module AbTests
     should_log: [
       :webauthn_platform_recommended_visited,
       :webauthn_platform_recommended_submitted,
-      :webauthn_setup_submitted,
+      'Multi-Factor Authentication Setup',
     ].to_set,
     buckets: {
       recommend_for_account_creation:

--- a/spec/controllers/users/webauthn_platform_recommended_controller_spec.rb
+++ b/spec/controllers/users/webauthn_platform_recommended_controller_spec.rb
@@ -58,6 +58,11 @@ RSpec.describe Users::WebauthnPlatformRecommendedController do
       end
     end
 
+    it 'does not assign recommended session value' do
+      expect { response }.not_to change { controller.user_session[:webauthn_platform_recommended] }.
+        from(nil)
+    end
+
     it 'redirects user to after sign in path' do
       expect(controller).to receive(:after_sign_in_path_for).with(user).and_return(account_path)
 
@@ -91,6 +96,22 @@ RSpec.describe Users::WebauthnPlatformRecommendedController do
 
       it 'redirects user to set up platform authenticator' do
         expect(response).to redirect_to(webauthn_setup_path(platform: true))
+      end
+
+      it 'assigns recommended session value to recommendation flow' do
+        expect { response }.to change { controller.user_session[:webauthn_platform_recommended] }.
+          from(nil).to(:authentication)
+      end
+
+      context 'user is creating account' do
+        before do
+          allow(controller).to receive(:in_account_creation_flow?).and_return(true)
+        end
+
+        it 'assigns recommended session value to recommendation flow' do
+          expect { response }.to change { controller.user_session[:webauthn_platform_recommended] }.
+            from(nil).to(:account_creation)
+        end
       end
     end
   end

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -138,6 +138,21 @@ RSpec.describe Users::WebauthnSetupController do
           success: true,
         )
       end
+
+      context 'with setup from sms recommendation' do
+        before do
+          controller.user_session[:webauthn_platform_recommended] = :authentication
+        end
+
+        it 'logs setup event with session value' do
+          patch :confirm, params: params
+
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication Setup',
+            hash_including(webauthn_platform_recommended: :authentication),
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-14191](https://cm-jira.usa.gov/browse/LG-14191)

## 🛠 Summary of changes

Updates logging to include an additional property in the "Multi-Factor Authentication Setup" event corresponding to whether the user was presented the recommendation for SMS users to set up Face or Touch Unlock.

A planned CloudWatch query was proposed in the content of #11496, but it did not account for [all of the additional conditions](https://github.com/18F/identity-idp/blob/0ad50f95b31b8e4cb1c721e1488f7588061f2351/app/controllers/concerns/recommend_webauthn_platform_concern.rb#L5-L15) that apply for whether the user was part of the test group. The approach here adds a session value to accurately compute the denominators.

Revised query:

Recommendation in account creation:

```
fields (name = 'webauthn_platform_recommended_visited' and properties.ab_tests.recommend_webauthn_platform_for_sms_user.bucket = 'recommend_for_account_creation') as visited,
(name = 'Multi-Factor Authentication Setup' and properties.event_properties.auth_method = 'webauthn_platform' and properties.event_properties.success and properties.event_properties.webauthn_platform_recommended = 'account_creation') as setup
| stats sum(name = 'webauthn_platform_recommended_visited') > 0 as visited_once, sum(name = 'Multi-Factor Authentication Setup') > 0 as setup_once by properties.user_id
| stats sum(setup_once)/sum(visited_once)
```

Recommendation in authentication:

```
fields (name = 'webauthn_platform_recommended_visited' and properties.ab_tests.recommend_webauthn_platform_for_sms_user.bucket = 'recommend_for_authentication') as visited,
(name = 'Multi-Factor Authentication Setup' and properties.event_properties.auth_method = 'webauthn_platform' and properties.event_properties.success and properties.event_properties.webauthn_platform_recommended = 'authentication') as setup
| stats sum(name = 'webauthn_platform_recommended_visited') > 0 as visited_once, sum(name = 'Multi-Factor Authentication Setup') > 0 as setup_once by properties.user_id
| stats sum(setup_once)/sum(visited_once)
```

## 📜 Testing Plan

```
rspec spec/controllers/users/webauthn_platform_recommended_controller_spec.rb spec/controllers/users/webauthn_setup_controller_spec.rb
```

Verify that A/B test value is included in "Multi-Factor Authentication Setup" if and only if you were actually presented recommendation:

Configure A/B test:

```
# config/application.yml
recommend_webauthn_platform_for_sms_ab_test_account_creation_percent: 100
```

1. Run `make watch_events` in a separate terminal process
2. Go to http://localhost:3000
3. Create account up to MFA selection
4. (Optional) Simulate a supported device using [Chrome device simulation](https://developer.chrome.com/docs/devtools/device-mode) for a simulated device and reload the page
5. Select phone as your only MFA
6. Setup phone MFA (SMS)
7. Observe that you see Face/Touch recommendation if you are on a supported device from Step 3. Otherwise, you'll see the standard 2nd MFA recommendation
8. In either outcome, choose to setup Face/Touch Unlock as a second MFA method
9. After successfully setting up Face/Touch, observe log event for "Multi-Factor Authentication Setup" in `make watch_events` terminal process. There should be a `webauthn_platform_recommended: 'account_creation'` value only if you saw the Face/Touch recommendation at Step 7