### PR TITLE
Add additional logging details for partner email selection

### DIFF
--- a/app/controllers/concerns/unconfirmed_user_concern.rb
+++ b/app/controllers/concerns/unconfirmed_user_concern.rb
@@ -40,7 +40,7 @@ module UnconfirmedUserConcern
 
   def email_confirmation_token_validator
     @email_confirmation_token_validator ||= begin
-      EmailConfirmationTokenValidator.new(@email_address, current_user)
+      EmailConfirmationTokenValidator.new(email_address: @email_address, current_user:)
     end
   end
 

--- a/app/controllers/sign_up/cancellations_controller.rb
+++ b/app/controllers/sign_up/cancellations_controller.rb
@@ -38,7 +38,7 @@ module SignUp
 
       confirmation_token = session[:user_confirmation_token]
       email_address = EmailAddress.find_with_confirmation_token(confirmation_token)
-      @token_validator = EmailConfirmationTokenValidator.new(email_address, current_user)
+      @token_validator = EmailConfirmationTokenValidator.new(email_address:, current_user:)
       result = @token_validator.submit
 
       if result.success?

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -21,10 +21,7 @@ module SignUp
     private
 
     def log_validator_result
-      analytics.user_registration_email_confirmation(
-        **email_confirmation_token_validator_result,
-        from_select_email_flow: nil,
-      )
+      analytics.user_registration_email_confirmation(**email_confirmation_token_validator_result)
     end
 
     def clear_setup_piv_cac_from_sign_in

--- a/app/controllers/sign_up/email_confirmations_controller.rb
+++ b/app/controllers/sign_up/email_confirmations_controller.rb
@@ -21,7 +21,10 @@ module SignUp
     private
 
     def log_validator_result
-      analytics.user_registration_email_confirmation(**email_confirmation_token_validator_result)
+      analytics.user_registration_email_confirmation(
+        **email_confirmation_token_validator_result,
+        from_select_email_flow: nil,
+      )
     end
 
     def clear_setup_piv_cac_from_sign_in

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -3,6 +3,7 @@
 module Users
   class EmailConfirmationsController < ApplicationController
     def create
+      store_from_select_email_flow_in_session
       result = email_confirmation_token_validator.submit
       analytics.add_email_confirmation(**result)
       if result.success?
@@ -30,8 +31,9 @@ module Users
     def email_confirmation_token_validator
       @email_confirmation_token_validator ||= begin
         EmailConfirmationTokenValidator.new(
-          email_address,
-          current_user,
+          email_address:,
+          current_user:,
+          from_select_email_flow: from_select_email_flow?,
         )
       end
     end
@@ -42,7 +44,6 @@ module Users
 
     def process_successful_confirmation(email_address)
       confirm_and_notify(email_address)
-      store_from_select_email_flow_in_session
       if current_user
         flash[:success] = t('devise.confirmations.confirmed')
         if params[:request_id]
@@ -106,6 +107,10 @@ module Users
 
     def store_from_select_email_flow_in_session
       session[:from_select_email_flow] = params[:from_select_email_flow].to_s == 'true'
+    end
+
+    def from_select_email_flow?
+      session[:from_select_email_flow] == true
     end
   end
 end

--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -5,7 +5,7 @@ module Users
     def create
       store_from_select_email_flow_in_session
       result = email_confirmation_token_validator.submit
-      analytics.add_email_confirmation(**result)
+      analytics.add_email_confirmation(**result, from_select_email_flow: from_select_email_flow?)
       if result.success?
         process_successful_confirmation(email_address)
       else
@@ -29,13 +29,8 @@ module Users
     end
 
     def email_confirmation_token_validator
-      @email_confirmation_token_validator ||= begin
-        EmailConfirmationTokenValidator.new(
-          email_address:,
-          current_user:,
-          from_select_email_flow: from_select_email_flow?,
-        )
-      end
+      @email_confirmation_token_validator ||=
+        EmailConfirmationTokenValidator.new(email_address:, current_user:)
     end
 
     def email_address_already_confirmed?

--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -11,16 +11,14 @@ module Users
     before_action :confirm_recently_authenticated_2fa
 
     def show
-      analytics.add_email_visit
-      session[:in_select_email_flow] = params[:in_select_email_flow]
+      session[:in_select_email_flow] = true if params[:in_select_email_flow]
+      analytics.add_email_visit(in_select_email_flow: in_select_email_flow?)
       @add_user_email_form = AddUserEmailForm.new
       @pending_completions_consent = pending_completions_consent?
     end
 
     def add
-      @add_user_email_form = AddUserEmailForm.new(
-        session[:in_select_email_flow],
-      )
+      @add_user_email_form = AddUserEmailForm.new(in_select_email_flow: in_select_email_flow?)
 
       result = @add_user_email_form.submit(
         current_user, permitted_params.merge(request_id:)
@@ -82,6 +80,10 @@ module Users
     end
 
     private
+
+    def in_select_email_flow?
+      session[:in_select_email_flow] == true
+    end
 
     def authorize_user_to_edit_email
       return render_not_found if email_address.user != current_user

--- a/app/forms/add_user_email_form.rb
+++ b/app/forms/add_user_email_form.rb
@@ -6,12 +6,13 @@ class AddUserEmailForm
   include ActionView::Helpers::TranslationHelper
 
   attr_reader :email, :in_select_email_flow
+  alias_method :in_select_email_flow?, :in_select_email_flow
 
   def self.model_name
     ActiveModel::Name.new(self, nil, 'User')
   end
 
-  def initialize(in_select_email_flow = nil)
+  def initialize(in_select_email_flow: false)
     @in_select_email_flow = in_select_email_flow
   end
 
@@ -52,13 +53,14 @@ class AddUserEmailForm
     @success = true
     email_address.save!
     SendAddEmailConfirmation.new(user).
-      call(email_address:, in_select_email_flow:, request_id:)
+      call(email_address:, in_select_email_flow: in_select_email_flow?, request_id:)
   end
 
   def extra_analytics_attributes
     {
       user_id: existing_user.uuid,
       domain_name: email&.split('@')&.last,
+      in_select_email_flow: in_select_email_flow?,
     }
   end
 

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -30,7 +30,7 @@ class SelectEmailForm
   private
 
   def extra_analytics_attributes
-    { selected_email_id: @selected_email_id }
+    { selected_email_id: }
   end
 
   def validate_owns_selected_email

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -14,7 +14,7 @@ class SelectEmailForm
   end
 
   def submit(params)
-    @selected_email_id = params[:selected_email_id].try(:to_i)
+    @selected_email_id = params[:selected_email_id].try(:to_i) if !params[:selected_email_id].blank?
 
     success = valid?
     identity.update(email_address_id: selected_email_id) if success && identity

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -14,15 +14,24 @@ class SelectEmailForm
   end
 
   def submit(params)
-    @selected_email_id = params[:selected_email_id]
+    @selected_email_id = params[:selected_email_id].to_i if params[:selected_email_id].present?
 
     success = valid?
     identity.update(email_address_id: selected_email_id) if success && identity
 
-    FormResponse.new(success:, errors:, serialize_error_details_only: true)
+    FormResponse.new(
+      success:,
+      errors:,
+      extra: extra_analytics_attributes,
+      serialize_error_details_only: true,
+    )
   end
 
   private
+
+  def extra_analytics_attributes
+    { selected_email_id: @selected_email_id }
+  end
 
   def validate_owns_selected_email
     return if user.confirmed_email_addresses.exists?(id: selected_email_id)

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -14,7 +14,7 @@ class SelectEmailForm
   end
 
   def submit(params)
-    @selected_email_id = params[:selected_email_id].to_i if params[:selected_email_id].present?
+    @selected_email_id = params[:selected_email_id].try(:to_i)
 
     success = valid?
     identity.update(email_address_id: selected_email_id) if success && identity

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -243,14 +243,24 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] user_id User the email is linked to
+  # @param [Boolean] from_select_email_flow Whether email was added as part of partner email
+  # selection.
   # A user has clicked the confirmation link in an email
-  def add_email_confirmation(user_id:, success:, errors:, error_details: nil, **extra)
+  def add_email_confirmation(
+    user_id:,
+    success:,
+    errors:,
+    from_select_email_flow:,
+    error_details: nil,
+    **extra
+  )
     track_event(
       'Add Email: Email Confirmation',
       user_id:,
       success:,
       errors:,
       error_details:,
+      from_select_email_flow:,
       **extra,
     )
   end
@@ -259,21 +269,33 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] domain_name Domain name of email address submitted
+  # @param [Boolean] in_select_email_flow Whether email is being added as part of partner email
+  # selection.
   # Tracks request for adding new emails to an account
-  def add_email_request(success:, errors:, domain_name:, error_details: nil, **extra)
+  def add_email_request(
+    success:,
+    errors:,
+    domain_name:,
+    in_select_email_flow:,
+    error_details: nil,
+    **extra
+  )
     track_event(
       'Add Email Requested',
       success:,
       errors:,
       error_details:,
       domain_name:,
+      in_select_email_flow:,
       **extra,
     )
   end
 
   # When a user views the add email address page
-  def add_email_visit
-    track_event('Add Email Address Page Visited')
+  # @param [Boolean] in_select_email_flow Whether email is being added as part of partner email
+  # selection.
+  def add_email_visit(in_select_email_flow:, **extra)
+    track_event('Add Email Address Page Visited', in_select_email_flow:, **extra)
   end
 
   # Tracks When users visit the add phone page
@@ -6825,10 +6847,12 @@ module AnalyticsEvents
   # User submitted form to change email shared with service provider
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
+  # @param [Integer] selected_email_id Selected email address record ID
   # @param [String, nil] needs_completion_screen_reason Reason for the consent screen being shown,
   # if user is changing email in consent flow
   def sp_select_email_submitted(
     success:,
+    selected_email_id:,
     error_details: nil,
     needs_completion_screen_reason: nil,
     **extra
@@ -6838,6 +6862,7 @@ module AnalyticsEvents
       success:,
       error_details:,
       needs_completion_screen_reason:,
+      selected_email_id:,
       **extra,
     )
   end
@@ -7126,19 +7151,23 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] user_id
+  # @param [Boolean] from_select_email_flow Whether email was added as part of partner email
+  # selection.
   def user_registration_email_confirmation(
     success:,
     errors:,
     error_details: nil,
     user_id: nil,
+    from_select_email_flow: nil,
     **extra
   )
     track_event(
       'User Registration: Email Confirmation',
-      success: success,
-      errors: errors,
-      error_details: error_details,
-      user_id: user_id,
+      success:,
+      errors:,
+      error_details:,
+      user_id:,
+      from_select_email_flow:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -7151,14 +7151,11 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] user_id
-  # @param [Boolean] from_select_email_flow Whether email was added as part of partner email
-  # selection.
   def user_registration_email_confirmation(
     success:,
     errors:,
     error_details: nil,
     user_id: nil,
-    from_select_email_flow: nil,
     **extra
   )
     track_event(
@@ -7167,7 +7164,6 @@ module AnalyticsEvents
       errors:,
       error_details:,
       user_id:,
-      from_select_email_flow:,
       **extra,
     )
   end

--- a/app/services/email_confirmation_token_validator.rb
+++ b/app/services/email_confirmation_token_validator.rb
@@ -3,17 +3,16 @@
 class EmailConfirmationTokenValidator
   include ActiveModel::Model
 
-  attr_reader :email_address, :from_select_email_flow
+  attr_reader :email_address
 
   validate :token_found
   validate :email_not_already_confirmed, if: :email_address_found_with_token?
   validate :token_not_expired, if: :email_address_found_with_token?
 
-  def initialize(email_address:, current_user: nil, from_select_email_flow: nil)
+  def initialize(email_address:, current_user: nil)
     @current_user = current_user
     @email_address = email_address
     @user = email_address&.user
-    @from_select_email_flow = from_select_email_flow
   end
 
   def submit
@@ -44,9 +43,9 @@ class EmailConfirmationTokenValidator
   attr_reader :success
 
   def extra_analytics_attributes
-    attributes = { user_id: user&.uuid }
-    attributes[:from_select_email_flow] = from_select_email_flow if !from_select_email_flow.nil?
-    attributes
+    {
+      user_id: user&.uuid,
+    }
   end
 
   def confirmation_token; end

--- a/app/services/email_confirmation_token_validator.rb
+++ b/app/services/email_confirmation_token_validator.rb
@@ -3,16 +3,18 @@
 class EmailConfirmationTokenValidator
   include ActiveModel::Model
 
-  attr_reader :email_address
+  attr_reader :email_address, :from_select_email_flow
+  alias_method :from_select_email_flow?, :from_select_email_flow
 
   validate :token_found
   validate :email_not_already_confirmed, if: :email_address_found_with_token?
   validate :token_not_expired, if: :email_address_found_with_token?
 
-  def initialize(email_address, current_user = nil)
+  def initialize(email_address:, current_user: nil, from_select_email_flow: false)
     @current_user = current_user
     @email_address = email_address
     @user = email_address&.user
+    @from_select_email_flow = from_select_email_flow
   end
 
   def submit
@@ -45,6 +47,7 @@ class EmailConfirmationTokenValidator
   def extra_analytics_attributes
     {
       user_id: user&.uuid,
+      from_select_email_flow: from_select_email_flow?,
     }
   end
 

--- a/app/services/email_confirmation_token_validator.rb
+++ b/app/services/email_confirmation_token_validator.rb
@@ -44,10 +44,9 @@ class EmailConfirmationTokenValidator
   attr_reader :success
 
   def extra_analytics_attributes
-    {
-      user_id: user&.uuid,
-      from_select_email_flow: from_select_email_flow,
-    }.compact
+    attributes = { user_id: user&.uuid }
+    attributes[:from_select_email_flow] = from_select_email_flow if !from_select_email_flow.nil?
+    attributes
   end
 
   def confirmation_token; end

--- a/app/services/email_confirmation_token_validator.rb
+++ b/app/services/email_confirmation_token_validator.rb
@@ -47,7 +47,7 @@ class EmailConfirmationTokenValidator
     {
       user_id: user&.uuid,
       from_select_email_flow: from_select_email_flow,
-    }
+    }.compact
   end
 
   def confirmation_token; end

--- a/app/services/email_confirmation_token_validator.rb
+++ b/app/services/email_confirmation_token_validator.rb
@@ -4,13 +4,12 @@ class EmailConfirmationTokenValidator
   include ActiveModel::Model
 
   attr_reader :email_address, :from_select_email_flow
-  alias_method :from_select_email_flow?, :from_select_email_flow
 
   validate :token_found
   validate :email_not_already_confirmed, if: :email_address_found_with_token?
   validate :token_not_expired, if: :email_address_found_with_token?
 
-  def initialize(email_address:, current_user: nil, from_select_email_flow: false)
+  def initialize(email_address:, current_user: nil, from_select_email_flow: nil)
     @current_user = current_user
     @email_address = email_address
     @user = email_address&.user
@@ -47,7 +46,7 @@ class EmailConfirmationTokenValidator
   def extra_analytics_attributes
     {
       user_id: user&.uuid,
-      from_select_email_flow: from_select_email_flow?,
+      from_select_email_flow: from_select_email_flow,
     }
   end
 

--- a/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
+++ b/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
     end
 
     context 'with invalid submission' do
-      let(:params) { super().merge(select_email_form: { selected_email_id: nil }) }
+      let(:params) { super().merge(select_email_form: { selected_email_id: '' }) }
 
       it 'redirects to form with flash' do
         expect(response).to redirect_to(edit_connected_account_selected_email_path(identity.id))

--- a/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
+++ b/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
@@ -90,7 +90,11 @@ RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
 
       response
 
-      expect(@analytics).to have_logged_event(:sp_select_email_submitted, success: true)
+      expect(@analytics).to have_logged_event(
+        :sp_select_email_submitted,
+        success: true,
+        selected_email_id: selected_email.id,
+      )
     end
 
     context 'with invalid submission' do

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe SignUp::PasswordsController do
       end
 
       it 'rejects when confirmation_token is invalid' do
-        validator = EmailConfirmationTokenValidator.new(user.email_addresses.first)
+        validator = EmailConfirmationTokenValidator.new(email_address: user.email_addresses.first)
         result = validator.submit
         expect(result.success?).to eq false
 

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe SignUp::SelectEmailController do
         :sp_select_email_submitted,
         success: true,
         needs_completion_screen_reason: :new_attributes,
+        selected_email_id: selected_email.id,
       )
     end
 
@@ -131,6 +132,7 @@ RSpec.describe SignUp::SelectEmailController do
           success: false,
           error_details: { selected_email_id: { not_found: true } },
           needs_completion_screen_reason: :new_attributes,
+          selected_email_id: selected_email.id,
         )
       end
     end

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SelectEmailForm do
       let(:selected_email_id) { user.confirmed_email_addresses.take.id }
 
       it 'is successful' do
-        expect(response.to_h).to eq(success: true)
+        expect(response.to_h).to eq(success: true, selected_email_id:)
       end
 
       context 'with associated identity' do
@@ -35,6 +35,7 @@ RSpec.describe SelectEmailForm do
         expect(response.to_h).to eq(
           success: false,
           error_details: { selected_email_id: { not_found: true } },
+          selected_email_id:,
         )
       end
 
@@ -55,7 +56,7 @@ RSpec.describe SelectEmailForm do
     end
 
     context 'with an unconfirmed email address added' do
-      let(:selected_email_id) { user.email_addresses.find_by(confirmed_at: nil) }
+      let(:selected_email_id) { user.email_addresses.find_by(confirmed_at: nil).id }
 
       before do
         create(:email_address, :unconfirmed, user:)
@@ -65,6 +66,7 @@ RSpec.describe SelectEmailForm do
         expect(response.to_h).to eq(
           success: false,
           error_details: { selected_email_id: { not_found: true } },
+          selected_email_id:,
         )
       end
 
@@ -85,6 +87,7 @@ RSpec.describe SelectEmailForm do
         expect(response.to_h).to eq(
           success: false,
           error_details: { selected_email_id: { not_found: true } },
+          selected_email_id:,
         )
       end
 

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe SelectEmailForm do
     end
 
     context 'with an invalid email id' do
-      let(:selected_email_id) { nil }
+      let(:selected_email_id) { '' }
 
       it 'is unsuccessful' do
         expect(response.to_h).to eq(
           success: false,
           error_details: { selected_email_id: { not_found: true } },
-          selected_email_id:,
+          selected_email_id: nil,
         )
       end
 

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe SelectEmailForm do
         )
       end
 
+      context 'with present value that does not convert to numeric' do
+        let(:selected_email_id) { true }
+
+        it 'is unsuccessful without raising exception' do
+          expect(response.to_h).to eq(
+            success: false,
+            error_details: { selected_email_id: { not_found: true } },
+            selected_email_id: nil,
+          )
+        end
+      end
+
       context 'with associated identity' do
         let(:identity) do
           create(

--- a/spec/services/email_confirmation_token_validator_spec.rb
+++ b/spec/services/email_confirmation_token_validator_spec.rb
@@ -85,21 +85,6 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.extra).to eq(user_id: nil)
       end
     end
-
-    context 'in select email flow' do
-      subject { described_class.new(email_address:, current_user:, from_select_email_flow: true) }
-
-      let(:current_user) { nil }
-      let(:email_address) do
-        create(:email_address, confirmed_at: nil, confirmation_sent_at: Time.zone.now)
-      end
-
-      it 'includes log detail in extra analytics' do
-        result = subject.submit
-
-        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: true)
-      end
-    end
   end
 
   describe '#email_address_already_confirmed_by_user?' do

--- a/spec/services/email_confirmation_token_validator_spec.rb
+++ b/spec/services/email_confirmation_token_validator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EmailConfirmationTokenValidator do
   describe '#submit' do
-    subject { described_class.new(email_address, current_user) }
+    subject { described_class.new(email_address:, current_user:) }
 
     context 'the email of the user does not match the user confirming' do
       let(:current_user) { create(:user, :fully_registered) }
@@ -16,7 +16,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.success?).to eq(false)
         expect(subject.email_address_already_confirmed?).to eq(false)
         expect(subject.confirmation_period_expired?).to eq(false)
-        expect(result.extra).to eq(user_id: email_address.user.uuid)
+        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: false)
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.errors).to be_empty
         expect(subject.email_address_already_confirmed?).to eq(false)
         expect(subject.confirmation_period_expired?).to eq(false)
-        expect(result.extra).to eq(user_id: email_address.user.uuid)
+        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: false)
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.errors).to eq(confirmation_token: [t('errors.messages.expired')])
         expect(subject.email_address_already_confirmed?).to eq(false)
         expect(subject.confirmation_period_expired?).to eq(true)
-        expect(result.extra).to eq(user_id: email_address.user.uuid)
+        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: false)
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.errors).to eq(confirmation_token: [t('errors.messages.already_confirmed')])
         expect(subject.email_address_already_confirmed?).to eq(true)
         expect(subject.confirmation_period_expired?).to eq(false)
-        expect(result.extra).to eq(user_id: email_address.user.uuid)
+        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: false)
       end
     end
 
@@ -82,13 +82,28 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.errors).to eq(confirmation_token: [t('errors.messages.not_found')])
         expect(subject.email_address_already_confirmed?).to eq(false)
         expect(subject.confirmation_period_expired?).to eq(false)
-        expect(result.extra).to eq(user_id: nil)
+        expect(result.extra).to eq(user_id: nil, from_select_email_flow: false)
+      end
+    end
+
+    context 'in select email flow' do
+      subject { described_class.new(email_address:, current_user:, from_select_email_flow: true) }
+
+      let(:current_user) { nil }
+      let(:email_address) do
+        create(:email_address, confirmed_at: nil, confirmation_sent_at: Time.zone.now)
+      end
+
+      it 'includes log detail in extra analytics' do
+        result = subject.submit
+
+        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: true)
       end
     end
   end
 
   describe '#email_address_already_confirmed_by_user?' do
-    subject { described_class.new(email_address) }
+    subject { described_class.new(email_address:) }
 
     context 'the email address was confirmed by the user' do
       let(:email_address) do

--- a/spec/services/email_confirmation_token_validator_spec.rb
+++ b/spec/services/email_confirmation_token_validator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.success?).to eq(false)
         expect(subject.email_address_already_confirmed?).to eq(false)
         expect(subject.confirmation_period_expired?).to eq(false)
-        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: false)
+        expect(result.extra).to eq(user_id: email_address.user.uuid)
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.errors).to be_empty
         expect(subject.email_address_already_confirmed?).to eq(false)
         expect(subject.confirmation_period_expired?).to eq(false)
-        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: false)
+        expect(result.extra).to eq(user_id: email_address.user.uuid)
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.errors).to eq(confirmation_token: [t('errors.messages.expired')])
         expect(subject.email_address_already_confirmed?).to eq(false)
         expect(subject.confirmation_period_expired?).to eq(true)
-        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: false)
+        expect(result.extra).to eq(user_id: email_address.user.uuid)
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.errors).to eq(confirmation_token: [t('errors.messages.already_confirmed')])
         expect(subject.email_address_already_confirmed?).to eq(true)
         expect(subject.confirmation_period_expired?).to eq(false)
-        expect(result.extra).to eq(user_id: email_address.user.uuid, from_select_email_flow: false)
+        expect(result.extra).to eq(user_id: email_address.user.uuid)
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.errors).to eq(confirmation_token: [t('errors.messages.not_found')])
         expect(subject.email_address_already_confirmed?).to eq(false)
         expect(subject.confirmation_period_expired?).to eq(false)
-        expect(result.extra).to eq(user_id: nil, from_select_email_flow: false)
+        expect(result.extra).to be_blank
       end
     end
 

--- a/spec/services/email_confirmation_token_validator_spec.rb
+++ b/spec/services/email_confirmation_token_validator_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe EmailConfirmationTokenValidator do
         expect(result.errors).to eq(confirmation_token: [t('errors.messages.not_found')])
         expect(subject.email_address_already_confirmed?).to eq(false)
         expect(subject.confirmation_period_expired?).to eq(false)
-        expect(result.extra).to be_blank
+        expect(result.extra).to eq(user_id: nil)
       end
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Adds a handful of additional logging details to be able to help monitor usage with the new partner email selection feature:

- Add property `from_select_email_flow` (boolean) to `'Add Email: Email Confirmation'`: Whether email was confirmed after being added as part of partner email selection
- Add property `in_select_email_flow` (boolean) to `'Add Email Requested'`: Whether email is being added as part of partner email selection
- Add property `in_select_email_flow` (boolean) to `'Add Email Address Page Visited'`: Whether email is being added as part of partner email selection
- Add property `selected_email_id` (integer) to `:sp_select_email_submitted`: Submitted ID value for email address record

## 📜 Testing Plan

Repeat Testing Plan from #10951, and observe logging details above as applicable.