### PR TITLE
LG-14741 max email add new email link

### DIFF
--- a/app/controllers/accounts/connected_accounts/selected_email_controller.rb
+++ b/app/controllers/accounts/connected_accounts/selected_email_controller.rb
@@ -12,6 +12,7 @@ module Accounts
       def edit
         @identity = identity
         @select_email_form = build_select_email_form
+        @can_add_email = EmailPolicy.new(current_user).can_add_email?
         analytics.sp_select_email_visited
       end
 

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -14,6 +14,7 @@ module SignUp
       @user_emails = user_emails
       @last_sign_in_email_address = last_email
       @select_email_form = build_select_email_form
+      @can_add_email = EmailPolicy.new(current_user).can_add_email?
       analytics.sp_select_email_visited(needs_completion_screen_reason:)
     end
 

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -33,13 +33,15 @@
     <%= f.submit(t('help_text.requested_attributes.select_email_link'), class: 'margin-top-1') %>
   <% end %>
 
-  <%= render ButtonComponent.new(
-        url: add_email_path(in_select_email_flow: true),
-        outline: true,
-        big: true,
-        wide: true,
-        class: 'margin-top-2',
-      ).with_content(t('account.index.email_add')) %>
+  <% if @can_add_email %>
+    <%= render ButtonComponent.new(
+          url: add_email_path(in_select_email_flow: true),
+          outline: true,
+          big: true,
+          wide: true,
+          class: 'margin-top-2',
+        ).with_content(t('account.index.email_add')) %>
+  <% end %>
 
   <% c.with_footer { link_to t('forms.buttons.back'), account_connected_accounts_path } %>
 <% end %>

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -29,13 +29,15 @@
     <%= f.submit t('help_text.requested_attributes.select_email_link'), class: 'margin-top-1' %>
   <% end %>
 
-  <%= render ButtonComponent.new(
-        url: add_email_path(in_select_email_flow: true),
-        outline: true,
-        big: true,
-        wide: true,
-        class: 'margin-top-2',
-      ).with_content(t('account.index.email_add')) %>
+  <% if @can_add_email %>
+    <%= render ButtonComponent.new(
+          url: add_email_path(in_select_email_flow: true),
+          outline: true,
+          big: true,
+          wide: true,
+          class: 'margin-top-2',
+        ).with_content(t('account.index.email_add')) %>
+  <% end %>
 
   <%= render PageFooterComponent.new do %>
     <%= link_to t('forms.buttons.back'), sign_up_completed_path %>

--- a/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
+++ b/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
 
       expect(assigns(:identity)).to be_kind_of(ServiceProviderIdentity)
       expect(assigns(:select_email_form)).to be_kind_of(SelectEmailForm)
+      expect(assigns(:can_add_email)).to eq(true)
     end
 
     context 'with an identity parameter not associated with the user' do
@@ -57,6 +58,18 @@ RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
 
       it 'renders 404' do
         expect(response).to be_not_found
+      end
+    end
+
+    context 'when users has max number of emails' do
+      before do
+        allow(user).to receive(:email_address_count).and_return(2)
+        allow(IdentityConfig.store).to receive(:max_emails_per_account).and_return(2)
+      end
+
+      it 'can add email variable set to false' do
+        response
+        expect(assigns(:can_add_email)).to eq(false)
       end
     end
   end

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe SignUp::SelectEmailController do
       expect(assigns(:user_emails)).to all be_kind_of(EmailAddress)
       expect(assigns(:last_sign_in_email_address)).to be_kind_of(String)
       expect(assigns(:select_email_form)).to be_kind_of(SelectEmailForm)
+      expect(assigns(:can_add_email)).to eq(true)
     end
 
     context 'with selected email to share feature disabled' do
@@ -67,6 +68,18 @@ RSpec.describe SignUp::SelectEmailController do
         response
 
         expect(response).to redirect_to(sign_up_completed_path)
+      end
+    end
+
+    context 'when users has max number of emails' do
+      before do
+        allow(user).to receive(:email_address_count).and_return(2)
+        allow(IdentityConfig.store).to receive(:max_emails_per_account).and_return(2)
+      end
+
+      it 'can add email variable set to false' do
+        response
+        expect(assigns(:can_add_email)).to eq(false)
       end
     end
   end

--- a/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
     allow(view).to receive(:current_user).and_return(user)
     @identity = identity
     @select_email_form = SelectEmailForm.new(user:, identity:)
+    @can_add_email = true 
   end
 
   it 'renders introduction text' do
@@ -35,4 +36,24 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
     expect(inputs).to be_logically_grouped(t('titles.select_email'))
     expect(rendered).to have_content(identity.display_name)
   end
+
+  it 'renders a button to allow users to add email' do
+    expect(rendered).to have_link(
+      t('account.index.email_add'),
+      href: add_email_path(in_select_email_flow: true),
+    )
+  end
+
+  context 'if user has reached max number of emails' do
+    before do
+      @can_add_email = false
+    end
+
+    it 'does not render add email button' do
+      expect(rendered).not_to have_link(
+        t('account.index.email_add'),
+        href: add_email_path(in_select_email_flow: true),
+      )
+    end
+  end 
 end

--- a/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
     allow(view).to receive(:current_user).and_return(user)
     @identity = identity
     @select_email_form = SelectEmailForm.new(user:, identity:)
-    @can_add_email = true 
+    @can_add_email = true
   end
 
   it 'renders introduction text' do
@@ -55,5 +55,5 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
         href: add_email_path(in_select_email_flow: true),
       )
     end
-  end 
+  end
 end

--- a/spec/views/sign_up/select_email/show.html.erb_spec.rb
+++ b/spec/views/sign_up/select_email/show.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'sign_up/select_email/show.html.erb' do
     @user_emails = user.confirmed_email_addresses
     @select_email_form = SelectEmailForm.new(user:)
     @sp_name = 'Test Service Provider'
+    @can_add_email = true
   end
 
   it 'renders introduction text' do
@@ -23,5 +24,25 @@ RSpec.describe 'sign_up/select_email/show.html.erb' do
   it 'shows all of the emails' do
     expect(rendered).to include('michael.motorist@email.com')
     expect(rendered).to include('michael.motorist2@email.com')
+  end
+
+  it 'renders a button to allow users to add email' do
+    expect(rendered).to have_link(
+      t('account.index.email_add'),
+      href: add_email_path(in_select_email_flow: true),
+    )
+  end
+
+  context 'if user has reached max number of emails' do
+    before do
+      @can_add_email = false
+    end
+
+    it 'does not render add email button' do
+      expect(rendered).not_to have_link(
+        t('account.index.email_add'),
+        href: add_email_path(in_select_email_flow: true),
+      )
+    end
   end
 end


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-14741](https://cm-jira.usa.gov/browse/LG-14741)


## 🛠 Summary of changes

This will make it so when a user has their max number of emails they will not be given the option to add email 

## 📜 Testing Plan

1. Have an account with the max number of emails. 
2. When changing email for SP you shoul dnot see an option to add a new email.