### PR TITLE
Add analytics tracking for signature algorithm errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.2-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.3-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.0-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.2-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,10 +36,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 4a4bb44be578df739fcee8a3ce937ba1276b5150
-  tag: 0.23.2-18f
+  revision: 752085a6f88cd3ce75ecc7a64afe064a0e4f9e35
+  tag: 0.23.3-18f
   specs:
-    saml_idp (0.23.2.pre.18f)
+    saml_idp (0.23.3.pre.18f)
       activesupport
       builder
       faraday

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,10 +36,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 23b69117593e9b9217910af1dd627febd8d18cf4
-  tag: 0.23.0-18f
+  revision: 4a4bb44be578df739fcee8a3ce937ba1276b5150
+  tag: 0.23.2-18f
   specs:
-    saml_idp (0.23.0.pre.18f)
+    saml_idp (0.23.2.pre.18f)
       activesupport
       builder
       faraday

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -136,6 +136,13 @@ class SamlIdpController < ApplicationController
 
     if result.success? && saml_request.signed?
       analytics_payload[:cert_error_details] = saml_request.cert_errors
+
+      # analytics to determine if turning on SHA256 validation will break
+      # existing partners
+      if certs_different?
+        analytics_payload[:certs_different] = true
+        analytics_payload[:sha256_matching_cert] = sha256_alg_matching_cert_serial
+      end
     end
 
     analytics.saml_auth(**analytics_payload)
@@ -145,6 +152,21 @@ class SamlIdpController < ApplicationController
     saml_request.matching_cert&.serial&.to_s
   rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
     nil
+  end
+
+  def sha256_alg_matching_cert
+    # if sha256_alg_matching_cert is nil, fallback to the "first" cert
+    saml_request.sha256_validation_matching_cert ||
+      saml_request_service_provider&.ssl_certs&.first
+  rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
+  end
+
+  def sha256_alg_matching_cert_serial
+    sha256_alg_matching_cert&.serial&.to_s
+  end
+
+  def certs_different?
+    encryption_cert != sha256_alg_matching_cert
   end
 
   def log_external_saml_auth_request

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6442,8 +6442,12 @@ module AnalyticsEvents
   # @param [Boolean] request_signed
   # @param [String] matching_cert_serial
   # matches the request certificate in a successful, signed request
+  # @param [Boolean] certs_different Whether the matching cert changes when SHA256 validations
+  # are turned on in the saml_idp gem
   # @param [Hash] cert_error_details Details for errors that occurred because of an invalid
   # signature
+  # @param [String] sha256_matching_cert serial of the cert that matches when sha256 validations
+  # are turned on
   # @param [String] unknown_authn_contexts space separated list of unknown contexts
   def saml_auth(
     success:,
@@ -6461,6 +6465,8 @@ module AnalyticsEvents
     matching_cert_serial:,
     error_details: nil,
     cert_error_details: nil,
+    certs_different: nil,
+    sha256_matching_cert: nil,
     unknown_authn_contexts: nil,
     **extra
   )
@@ -6481,6 +6487,8 @@ module AnalyticsEvents
       request_signed:,
       matching_cert_serial:,
       cert_error_details:,
+      certs_different:,
+      sha256_matching_cert:,
       unknown_authn_contexts:,
       **extra,
     )


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Create tracking for SHA256 validations](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/136)

## 🛠 Summary of changes
This change adds some temporary event logging so that we can evaluate what level of impact turning on SHA256 error validation in the saml_idp gem might have to partner integrations.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
