### PR TITLE
Do not return User UUID in requesting_issuer_uuid when generating user report

### DIFF
--- a/lib/data_requests/deployed/create_user_report.rb
+++ b/lib/data_requests/deployed/create_user_report.rb
@@ -32,7 +32,6 @@ module DataRequests
       end
 
       def requesting_issuer_uuid
-        return user.uuid if requesting_issuers.blank?
         user.agency_identities.where(agency: requesting_agencies).first&.uuid ||
           "NonSPUser##{user.id}"
       end

--- a/spec/lib/data_requests/deployed/create_user_report_spec.rb
+++ b/spec/lib/data_requests/deployed/create_user_report_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DataRequests::Deployed::CreateUserReport do
 
     expect(result[:user_id]).to eq(user.id)
     expect(result[:login_uuid]).to eq(user.uuid)
-    expect(result[:requesting_issuer_uuid]).to eq(user.uuid)
+    expect(result[:requesting_issuer_uuid]).to eq("NonSPUser##{user.id}")
     expect(result[:email_addresses]).to be_a(Array)
     expect(result[:mfa_configurations]).to be_a(Hash)
     expect(result[:user_events]).to be_a(Array)


### PR DESCRIPTION
## 🛠 Summary of changes

A bit of a followup to #11541 and further discussion in [this thread](https://gsa-tts.slack.com/archives/C03KDV9S8T1/p1732558404564499?thread_ts=1732138386.924899&cid=C03KDV9S8T1). This makes a change so we never return the account UUID in the report in the `reporting_issuer_uuid` field.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
