### PR TITLE
Log requesting signing and certificate serial in SAML Auth Request event

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -180,6 +180,8 @@ class SamlIdpController < ApplicationController
       force_authn: saml_request&.force_authn?,
       final_auth_request: sp_session[:final_auth_request],
       service_provider: saml_request&.issuer,
+      request_signed: saml_request.signed?,
+      matching_cert_serial:,
       unknown_authn_contexts:,
       user_fully_authenticated: user_fully_authenticated?,
     )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6505,6 +6505,8 @@ module AnalyticsEvents
   # @param [Boolean] force_authn
   # @param [Boolean] final_auth_request
   # @param [String] service_provider
+  # @param [Boolean] request_signed
+  # @param [String] matching_cert_serial
   # @param [String] unknown_authn_contexts space separated list of unknown contexts
   # @param [Boolean] user_fully_authenticated
   # An external request for SAML Authentication was received
@@ -6516,6 +6518,8 @@ module AnalyticsEvents
     force_authn:,
     final_auth_request:,
     service_provider:,
+    request_signed:,
+    matching_cert_serial:,
     unknown_authn_contexts:,
     user_fully_authenticated:,
     **extra
@@ -6529,6 +6533,8 @@ module AnalyticsEvents
       force_authn:,
       final_auth_request:,
       service_provider:,
+      request_signed:,
+      matching_cert_serial:,
       unknown_authn_contexts:,
       user_fully_authenticated:,
       **extra,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -779,6 +779,8 @@ RSpec.describe SamlIdpController do
             requested_ial: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
             service_provider: sp1_issuer,
             force_authn: false,
+            request_signed: true,
+            matching_cert_serial: saml_test_sp_cert_serial,
             user_fully_authenticated: true,
           }
         )
@@ -930,6 +932,8 @@ RSpec.describe SamlIdpController do
             requested_ial: 'ialmax',
             service_provider: sp1_issuer,
             force_authn: false,
+            request_signed: true,
+            matching_cert_serial: saml_test_sp_cert_serial,
             user_fully_authenticated: true,
           }
         )
@@ -1221,6 +1225,8 @@ RSpec.describe SamlIdpController do
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            request_signed: true,
+            matching_cert_serial: saml_test_sp_cert_serial,
             force_authn: true,
             user_fully_authenticated: false,
           }
@@ -2030,6 +2036,8 @@ RSpec.describe SamlIdpController do
             requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            request_signed: true,
+            matching_cert_serial: saml_test_sp_cert_serial,
             force_authn: false,
             user_fully_authenticated: false,
           }
@@ -2464,6 +2472,7 @@ RSpec.describe SamlIdpController do
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
+            request_signed: false,
             user_fully_authenticated: true,
           }
         )
@@ -2515,6 +2524,8 @@ RSpec.describe SamlIdpController do
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
+            request_signed: true,
+            matching_cert_serial: saml_test_sp_cert_serial,
             user_fully_authenticated: true,
           }
         )
@@ -2565,6 +2576,8 @@ RSpec.describe SamlIdpController do
             service_provider: 'http://localhost:3000',
             requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
             force_authn: false,
+            request_signed: true,
+            matching_cert_serial: saml_test_sp_cert_serial,
             user_fully_authenticated: true,
           }
         )

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -508,6 +508,8 @@ RSpec.feature 'saml api' do
            service_provider: 'http://localhost:3000',
            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
            force_authn: false,
+           matching_cert_serial: saml_test_sp_cert_serial,
+           request_signed: true,
            user_fully_authenticated: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
@@ -551,6 +553,8 @@ RSpec.feature 'saml api' do
             requested_ial: 'http://idmanagement.gov/ns/assurance/ial/2',
             service_provider: 'saml_sp_ial2',
             force_authn: false,
+            matching_cert_serial: saml_test_sp_cert_serial,
+            request_signed: true,
             user_fully_authenticated: false,
           },
         ],
@@ -581,6 +585,8 @@ RSpec.feature 'saml api' do
            service_provider: 'http://localhost:3000',
            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
            force_authn: false,
+           matching_cert_serial: saml_test_sp_cert_serial,
+           request_signed: true,
            user_fully_authenticated: false }],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2


### PR DESCRIPTION
## 🛠 Summary of changes

This PR adds additional attributes to the SAML requests we receive. They are currently also logged on the `SAML Auth` event, which is only logged on successful authentication. It would be useful to also have these when the request is received even if the user does not authenticate.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
