### PR TITLE
LG-14985 Read additional document data from TrueID when configured to do so

### DIFF
--- a/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb
+++ b/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb
@@ -101,7 +101,7 @@ module DocAuth
         when 'M'
           'male'
         when 'F'
-          'femaile'
+          'female'
         end
       end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -102,6 +102,7 @@ doc_auth_error_sharpness_threshold: 40
 doc_auth_max_attempts: 5
 doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
+doc_auth_read_additional_pii_attributes_enabled: false
 doc_auth_selfie_desktop_test_mode: false
 doc_auth_socure_wait_polling_refresh_max_seconds: 15
 doc_auth_socure_wait_polling_timeout_minutes: 2

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -120,6 +120,7 @@ module IdentityConfig
     config.add(:doc_auth_max_attempts, type: :integer)
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)
+    config.add(:doc_auth_read_additional_pii_attributes_enabled, type: :boolean)
     config.add(:doc_auth_selfie_desktop_test_mode, type: :boolean)
     config.add(:doc_auth_socure_wait_polling_refresh_max_seconds, type: :integer)
     config.add(:doc_auth_socure_wait_polling_timeout_minutes, type: :integer)

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -249,6 +249,22 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         expect(response.success?).to eq(false)
       end
     end
+
+    context 'when doc_auth_read_additional_pii_attributes_enabled is enabled' do
+      let(:success_response_body) { LexisNexisFixtures.true_id_response_success }
+
+      it 'reads the additional PII attributes' do
+        allow(IdentityConfig.store).to receive(:doc_auth_read_additional_pii_attributes_enabled).
+          and_return(true)
+
+        pii_from_doc = response.pii_from_doc
+
+        expect(pii_from_doc.first_name).to eq('LICENSE')
+        expect(pii_from_doc.name_suffix).to eq('JR')
+        expect(pii_from_doc.sex).to eq('male')
+        expect(pii_from_doc.height).to eq(68)
+      end
+    end
   end
 
   context 'when there is no address line 2' do


### PR DESCRIPTION
We are working to send additional data to AAMVA when it is present on documents. This commit lays groundwork for this by reading those new attributes from TrueID when configured to do so.

We are waiting on security approval before we start writing these new attributes into the Login.gov session. For that reason the reading of these attributes is feature flagged and disabled by default.
