### PR TITLE
Fetch latest origin as part of deploy PR script

### DIFF
--- a/scripts/create-deploy-pr
+++ b/scripts/create-deploy-pr
@@ -51,7 +51,7 @@ function get_next_rc {
     LAST_RC="$1"; shift
     MAJOR=$(echo "$LAST_RC" | sed -E 's/\.[0-9]+//')
     MINOR=$(echo "$LAST_RC" | sed -E 's/[0-9]+(\.|$)//')
-    
+
     if [ "$PATCH" == "1" ]; then
         # Doing a patch, so increment minor version by 1
         if [ -z "$MINOR" ]; then
@@ -77,6 +77,7 @@ function get_staging_sha {
 }
 
 check_gh_configuration
+git fetch $GIT_REMOTE
 
 RC_BRANCH=stages/rc-$(date +'%Y-%m-%d')
 if git rev-parse "$GIT_REMOTE/$RC_BRANCH" > /dev/null 2>&1; then


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `scripts/create-deploy-pr` to run fetch the latest `git` remote before starting the script.

If the deployer hasn't recently fetched the remote repository, they can often encounter a cryptic error when trying to create the branch based on the latest commit in the staging environment.

Related Slack discussion: https://gsa-tts.slack.com/archives/C0NGESUN5/p1719949060382589

## 📜 Testing Plan

Run `DRY_RUN=1 scripts/create-deploy-pr` and verify no errors in output