### PR TITLE
LG-13763: Stop writing to the proofing_components table

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -8,7 +8,6 @@ module Idv
 
     def handle_stored_result(user: current_user, store_in_session: true)
       if stored_result&.success? && selfie_requirement_met?
-        save_proofing_components(user)
         extract_pii_from_doc(user, store_in_session: store_in_session)
         flash[:success] = t('doc_auth.headings.capture_complete')
         successful_response
@@ -16,16 +15,6 @@ module Idv
         extra = { stored_result_present: stored_result.present? }
         failure(I18n.t('doc_auth.errors.general.network_error'), extra)
       end
-    end
-
-    def save_proofing_components(user)
-      return unless user
-
-      component_attributes = {
-        document_check: doc_auth_vendor,
-        document_type: 'state_id',
-      }
-      ProofingComponent.create_or_find_by(user: user).update(component_attributes)
     end
 
     def successful_response

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -267,24 +267,9 @@ module Idv
       proofing_results_exception = summary_result.extra.dig(:proofing_results, :exception)
       resolution_rate_limiter.increment! if proofing_results_exception.blank?
 
-      if summary_result.success?
-        add_proofing_components(summary_result)
-      else
+      if !summary_result.success?
         idv_failure(summary_result)
       end
-    end
-
-    def add_proofing_components(summary_result)
-      ProofingComponent.create_or_find_by(user: current_user).update(
-        resolution_check: Idp::Constants::Vendors::LEXIS_NEXIS,
-        source_check: summary_result.extra.dig(
-          :proofing_results,
-          :context,
-          :stages,
-          :state_id,
-          :vendor_name,
-        ),
-      )
     end
 
     def load_async_state

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -48,8 +48,6 @@ module Idv
 
         log_letter_requested_analytics(resend: false)
         create_user_event(:gpo_mail_sent, current_user)
-
-        ProofingComponent.find_or_create_by(user: current_user).update(address_check: 'gpo_letter')
       end
 
       def confirm_mail_not_rate_limited

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -63,8 +63,6 @@ module Idv
           sponsor_id: enrollment_sponsor_id,
         )
 
-        add_proofing_component
-
         render json: { success: true }, status: :ok
       end
 
@@ -90,12 +88,6 @@ module Idv
 
       def proofer
         @proofer ||= EnrollmentHelper.usps_proofer
-      end
-
-      def add_proofing_component
-        ProofingComponent.
-          create_or_find_by(user: current_or_hybrid_user).
-          update(document_check: Idp::Constants::Vendors::USPS)
       end
 
       def localized_locations(locations)

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -66,8 +66,6 @@ module Idv
         render json: { success: true }, status: :ok
       end
 
-      private
-
       def idv_session
         if user_session && current_user
           @idv_session ||= Idv::Session.new(
@@ -77,6 +75,8 @@ module Idv
           )
         end
       end
+
+      private
 
       def document_capture_session
         if idv_session&.document_capture_session_uuid # standard flow

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -65,7 +65,6 @@ module Idv
     end
 
     def handle_document_verification_success
-      save_proofing_components(current_user)
       extract_pii_from_doc(current_user, store_in_session: true)
       idv_session.flow_path = 'hybrid'
     end

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -29,7 +29,6 @@ module Idv
       if pii_is_missing?
         redirect_to_retrieve_pii
       else
-        add_proofing_component
         finish_idv_session
       end
     end
@@ -76,10 +75,6 @@ module Idv
       else
         after_sign_in_path_for(current_user)
       end
-    end
-
-    def add_proofing_component
-      ProofingComponent.find_or_create_by(user: current_user).update(verified_at: Time.zone.now)
     end
 
     def finish_idv_session

--- a/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
+++ b/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
@@ -36,7 +36,6 @@ module EventDisavowal
 
       user.active_profile&.deactivate(:password_reset)
       Funnel::DocAuth::ResetSteps.call(@user.id)
-      user.proofing_component&.destroy
     end
 
     def extra_analytics_attributes

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -65,7 +65,6 @@ class ResetPasswordForm
 
     active_profile.deactivate(:password_reset)
     Funnel::DocAuth::ResetSteps.call(user.id)
-    user.proofing_component&.destroy
   end
 
   # It is possible for an account that is resetting their password to be "invalid".

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -108,7 +108,6 @@ class ResolutionProofingJob < ApplicationJob
     )
 
     log_threatmetrix_info(result.device_profiling_result, user)
-    add_threatmetrix_proofing_component(user.id, result.device_profiling_result) if user.present?
 
     CallbackLogData.new(
       device_profiling_success: result.device_profiling_result.success?,
@@ -138,12 +137,5 @@ class ResolutionProofingJob < ApplicationJob
 
   def progressive_proofer
     @progressive_proofer ||= Proofing::Resolution::ProgressiveProofer.new
-  end
-
-  def add_threatmetrix_proofing_component(user_id, threatmetrix_result)
-    ProofingComponent.
-      create_or_find_by(user_id: user_id).
-      update(threatmetrix: FeatureManagement.proofing_device_profiling_collecting_enabled?,
-             threatmetrix_review_status: threatmetrix_result.review_status)
   end
 end

--- a/app/models/proofing_component.rb
+++ b/app/models/proofing_component.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class ProofingComponent < ApplicationRecord
-  belongs_to :user
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,6 @@ class User < ApplicationRecord
   has_many :backup_code_configurations, dependent: :destroy
   has_many :document_capture_sessions, dependent: :destroy
   has_one :registration_log, dependent: :destroy
-  has_one :proofing_component, dependent: :destroy
   has_many :service_providers,
            through: :identities,
            source: :service_provider_record

--- a/app/services/idv/phone_step.rb
+++ b/app/services/idv/phone_step.rb
@@ -132,9 +132,6 @@ module Idv
     def update_idv_session
       idv_session.applicant = applicant
       idv_session.mark_phone_step_started!
-
-      ProofingComponent.find_or_create_by(user: idv_session.current_user).
-        update(address_check: 'lexis_nexis_address')
     end
 
     def start_phone_confirmation_session

--- a/app/services/idv/steps/doc_auth_base_step.rb
+++ b/app/services/idv/steps/doc_auth_base_step.rb
@@ -9,21 +9,6 @@ module Idv
 
       private
 
-      def save_proofing_components
-        return unless current_user
-
-        doc_auth_vendor = DocAuthRouter.doc_auth_vendor(
-          discriminator: flow_session[document_capture_session_uuid_key],
-          analytics: @flow.analytics,
-        )
-
-        component_attributes = {
-          document_check: doc_auth_vendor,
-          document_type: 'state_id',
-        }
-        ProofingComponent.create_or_find_by(user: current_user).update(component_attributes)
-      end
-
       def user_id_from_token
         flow_session[:doc_capture_user_id]
       end

--- a/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
+++ b/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
@@ -87,7 +87,6 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
 
       context 'via current idv session' do
         before do
-          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
           create(:in_person_enrollment, :establishing, user: user)
         end
 

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -414,7 +414,6 @@ RSpec.describe Idv::EnterPasswordController do
           stub_request_enroll
           subject.idv_session.applicant =
             Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID_WITH_PHONE
-          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
         end
 

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -374,11 +374,20 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
       end
 
       it 'updates proofing component vendor' do
-        expect(user.proofing_component&.document_check).to be_nil
+        proofing_components = Idv::ProofingComponents.new(
+          idv_session: controller.idv_session,
+          session: controller.session,
+          user_session: controller.user_session,
+          user:,
+        )
+
+        expect(proofing_components.document_check).to be_nil
 
         response
 
-        expect(user.proofing_component.document_check).to eq Idp::Constants::Vendors::USPS
+        user.reload
+
+        expect(proofing_components.document_check).to eq Idp::Constants::Vendors::USPS
       end
     end
 
@@ -404,11 +413,20 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
       end
 
       it 'updates proofing component vendor' do
-        expect(user.proofing_component&.document_check).to be_nil
+        proofing_components = Idv::ProofingComponents.new(
+          idv_session: controller.idv_session,
+          session: controller.session,
+          user_session: controller.user_session,
+          user:,
+        )
+
+        expect(proofing_components.document_check).to be_nil
 
         response
 
-        expect(user.proofing_component.document_check).to eq Idp::Constants::Vendors::USPS
+        user.reload
+
+        expect(proofing_components.document_check).to eq Idp::Constants::Vendors::USPS
       end
     end
 

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -168,9 +168,14 @@ RSpec.describe Idv::LinkSentController do
 
           expect(response).to redirect_to(idv_ssn_url)
 
-          pc = ProofingComponent.find_by(user_id: user.id)
-          expect(pc.document_check).to eq('mock')
-          expect(pc.document_type).to eq('state_id')
+          proofing_components = Idv::ProofingComponents.new(
+            idv_session: subject.idv_session,
+            session: subject.session,
+            user_session: subject.user_session,
+            user:,
+          )
+          expect(proofing_components.document_check).to eq('mock')
+          expect(proofing_components.document_type).to eq('state_id')
         end
 
         context 'redo document capture' do

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -497,7 +497,6 @@ RSpec.describe Idv::PersonalKeyController do
       end
 
       before do
-        ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
         allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
       end
 

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Identity verification', :js do
 
     validate_verify_info_page
     complete_verify_step
-    validate_verify_info_submit(user)
+    validate_verify_info_submit
 
     validate_phone_page
     try_to_skip_ahead_from_phone
@@ -265,12 +265,8 @@ RSpec.describe 'Identity verification', :js do
     expect(page).to have_text(DocAuthHelper::GOOD_SSN)
   end
 
-  def validate_verify_info_submit(user)
+  def validate_verify_info_submit
     expect(page).to have_content(t('doc_auth.forms.doc_success'))
-    expect(user.proofing_component.resolution_check).to eq(Idp::Constants::Vendors::LEXIS_NEXIS)
-    expect(user.proofing_component.source_check).to satisfy do |v|
-      Idp::Constants::Vendors::SOURCE_CHECK.include?(v)
-    end
   end
 
   def validate_phone_page
@@ -333,6 +329,15 @@ RSpec.describe 'Identity verification', :js do
     profile = user.profiles.first
 
     expect(profile.active?).to eq true
+    expect(profile.proofing_components).to eql(
+      'source_check' => 'StateIdMock',
+      'threatmetrix' => true,
+      'address_check' => 'lexis_nexis_address',
+      'document_type' => 'state_id',
+      'document_check' => 'mock',
+      'resolution_check' => 'lexis_nexis',
+      'threatmetrix_review_status' => 'pass',
+    )
     expect(GpoConfirmation.count).to eq(0)
   end
 

--- a/spec/forms/event_disavowal/password_reset_from_disavowal_form_spec.rb
+++ b/spec/forms/event_disavowal/password_reset_from_disavowal_form_spec.rb
@@ -26,26 +26,4 @@ RSpec.describe EventDisavowal::PasswordResetFromDisavowalForm, type: :model do
       expect(user.reload.valid_password?(new_password)).to eq(false)
     end
   end
-
-  context 'user has an active profile' do
-    let(:user) { create(:user, :proofed) }
-
-    it 'destroys the proofing component' do
-      ProofingComponent.create(user_id: user.id, document_check: 'mock')
-
-      subject.submit(password: new_password)
-
-      expect(user.reload.proofing_component).to be_nil
-    end
-  end
-
-  context 'user does not have an active profile' do
-    it 'does not destroy the proofing component' do
-      ProofingComponent.create(user_id: user.id, document_check: 'mock')
-
-      subject.submit(password: new_password)
-
-      expect(user.reload.proofing_component).to_not be_nil
-    end
-  end
 end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -156,10 +156,6 @@ RSpec.describe GpoVerifyForm do
           )
         end
 
-        let(:proofing_components) do
-          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
-        end
-
         before do
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
         end
@@ -192,10 +188,6 @@ RSpec.describe GpoVerifyForm do
             profile: pending_profile,
             user: user,
           )
-        end
-
-        let(:proofing_components) do
-          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
         end
 
         before do

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -138,10 +138,6 @@ RSpec.describe ResolutionProofingJob, type: :job do
         expect(result_context_stages_threatmetrix[:response_body]).to eq(
           JSON.parse(LexisNexisFixtures.ddp_success_redacted_response_json, symbolize_names: true),
         )
-
-        proofing_component = user.proofing_component
-        expect(proofing_component.threatmetrix).to equal(true)
-        expect(proofing_component.threatmetrix_review_status).to eq('pass')
       end
     end
 
@@ -340,10 +336,6 @@ RSpec.describe ResolutionProofingJob, type: :job do
         expect(result_context_stages_threatmetrix[:client]).to eq('tmx_disabled')
 
         expect(@threatmetrix_stub).to_not have_been_requested
-
-        proofing_component = user.proofing_component
-        expect(proofing_component.threatmetrix).to equal(false)
-        expect(proofing_component.threatmetrix_review_status).to eq('pass')
       end
     end
 
@@ -463,10 +455,6 @@ RSpec.describe ResolutionProofingJob, type: :job do
         expect(result_context_stages_threatmetrix[:response_body]).to eq(
           JSON.parse(LexisNexisFixtures.ddp_success_redacted_response_json, symbolize_names: true),
         )
-
-        proofing_component = user.proofing_component
-        expect(proofing_component.threatmetrix).to equal(true)
-        expect(proofing_component.threatmetrix_review_status).to eq('pass')
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe User do
     it { is_expected.to have_one(:account_reset_request) }
     it { is_expected.to have_many(:phone_configurations) }
     it { is_expected.to have_many(:webauthn_configurations) }
-    it { is_expected.to have_one(:proofing_component) }
     it { is_expected.to have_many(:in_person_enrollments).dependent(:destroy) }
     it {
       is_expected.to have_one(:pending_in_person_enrollment).

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -333,9 +333,6 @@ RSpec.describe User do
 
     describe '#has_in_person_enrollment?' do
       it 'returns the establishing IPP enrollment that has an address' do
-        ProofingComponent.find_or_create_by(user: user).
-          update!(document_check: Idp::Constants::Vendors::USPS)
-
         expect(user.has_in_person_enrollment?).to eq(true)
       end
     end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -193,7 +193,6 @@ RSpec.describe Idv::Session do
         let(:profile) { subject.profile }
 
         before do
-          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
           subject.user_phone_confirmation = true
           subject.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.with_indifferent_access
@@ -272,7 +271,6 @@ RSpec.describe Idv::Session do
 
         before do
           allow(UspsInPersonProofing::EnrollmentHelper).to receive(:schedule_in_person_enrollment)
-          ProofingComponent.create(user: user, document_check: Idp::Constants::Vendors::USPS)
           allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
           subject.user_phone_confirmation = true
           subject.applicant = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.with_indifferent_access


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-13763](https://cm-jira.usa.gov/browse/LG-13763)

## 🛠 Summary of changes

`ProofingComponent` is a model that tracks, in general terms, how a user has verified their identity. It exists in a 1:1 relationship with `User`, which gets kind of sticky / tricky for users with multiple Profiles.

Proofing components are useful for logging purposes, so we want to keep them. But instead of storing them attached to `User` in this way, we are now dynamically deriving them from the user's `IdV::Session`.

So then, now that we are doing that, we can stop writing to the old user-bound `proofing_components` stuff. That's what this PR does. We'll be dropping the table itself in a future PR.
