### PR TITLE
LG-15204 | Guard against NoMethodError when ZIP is null

### DIFF
--- a/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
+++ b/app/services/proofing/lexis_nexis/instant_verify/verification_request.rb
@@ -40,7 +40,7 @@ module Proofing
             StreetAddress2: applicant[:address2] || '',
             City: applicant[:city],
             State: applicant[:state],
-            Zip5: applicant[:zipcode].match(/^\d{5}/).to_s,
+            Zip5: applicant[:zipcode]&.match(/^\d{5}/).to_s,
             Country: 'US',
             Context: 'primary',
           }

--- a/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe Proofing::LexisNexis::InstantVerify::VerificationRequest do
       it 'returns nil without raising an exception' do
         applicant[:zipcode] = nil
 
-        expect { subject.send(:formatted_address) }.not_to raise_error(NoMethodError)
-        expect(subject.send(:formatted_address)['Zip5']).to be_nil
+        expect(subject.send(:formatted_address).fetch(:Zip5)).to eq('')
       end
     end
   end

--- a/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
+++ b/spec/services/proofing/lexis_nexis/instant_verify/verification_request_spec.rb
@@ -98,4 +98,15 @@ RSpec.describe Proofing::LexisNexis::InstantVerify::VerificationRequest do
       end
     end
   end
+
+  describe '#formatted_address' do
+    context 'when ZIP code is nil' do
+      it 'returns nil without raising an exception' do
+        applicant[:zipcode] = nil
+
+        expect { subject.send(:formatted_address) }.not_to raise_error(NoMethodError)
+        expect(subject.send(:formatted_address)['Zip5']).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15204](https://cm-jira.usa.gov/browse/LG-15204)

## 🛠 Summary of changes

There may be a deeper error, but let's at least stop raising exceptions for now.

changelog: Internal, Bug Fixes, InstantVerify requests no longer raise an exception when ZIP code is nil