### PR TITLE
LG 15156 Select your preferred email allows blank submission

### DIFF
--- a/app/controllers/accounts/connected_accounts/selected_email_controller.rb
+++ b/app/controllers/accounts/connected_accounts/selected_email_controller.rb
@@ -14,6 +14,7 @@ module Accounts
         @select_email_form = build_select_email_form
         @can_add_email = EmailPolicy.new(current_user).can_add_email?
         analytics.sp_select_email_visited
+        @last_sign_in_email_address = @identity.email_address_id || last_email
       end
 
       def update
@@ -49,6 +50,10 @@ module Accounts
       def identity
         return @identity if defined?(@identity)
         @identity = current_user.identities.find_by(id: params[:identity_id])
+      end
+
+      def last_email
+        EmailContext.new(current_user).last_sign_in_email_address.id
       end
     end
   end

--- a/app/controllers/accounts/connected_accounts/selected_email_controller.rb
+++ b/app/controllers/accounts/connected_accounts/selected_email_controller.rb
@@ -14,7 +14,7 @@ module Accounts
         @select_email_form = build_select_email_form
         @can_add_email = EmailPolicy.new(current_user).can_add_email?
         analytics.sp_select_email_visited
-        @last_sign_in_email_address = @identity.email_address_id || last_email
+        @email_id = @identity.email_address_id || last_email
       end
 
       def update

--- a/app/controllers/accounts/connected_accounts/selected_email_controller.rb
+++ b/app/controllers/accounts/connected_accounts/selected_email_controller.rb
@@ -14,7 +14,6 @@ module Accounts
         @select_email_form = build_select_email_form
         @can_add_email = EmailPolicy.new(current_user).can_add_email?
         analytics.sp_select_email_visited
-        @email_id = @identity.email_address_id || last_email
       end
 
       def update
@@ -50,10 +49,6 @@ module Accounts
       def identity
         return @identity if defined?(@identity)
         @identity = current_user.identities.find_by(id: params[:identity_id])
-      end
-
-      def last_email
-        EmailContext.new(current_user).last_sign_in_email_address.id
       end
     end
   end

--- a/app/controllers/accounts/connected_accounts/selected_email_controller.rb
+++ b/app/controllers/accounts/connected_accounts/selected_email_controller.rb
@@ -14,6 +14,7 @@ module Accounts
         @select_email_form = build_select_email_form
         @can_add_email = EmailPolicy.new(current_user).can_add_email?
         analytics.sp_select_email_visited
+        @email_id = @identity.email_address_id || last_email
       end
 
       def update
@@ -49,6 +50,10 @@ module Accounts
       def identity
         return @identity if defined?(@identity)
         @identity = current_user.identities.find_by(id: params[:identity_id])
+      end
+
+      def last_email
+        EmailContext.new(current_user).last_sign_in_email_address.id
       end
     end
   end

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -8,7 +8,7 @@ class SelectEmailForm
 
   validate :validate_owns_selected_email
   validates :selected_email_id, presence: {
-    message: proc { I18n.t('email_address.not_found') },
+    message: proc { I18n.t('simple_form.required.text') },
   }
 
   def initialize(user:, identity: nil)

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -7,6 +7,9 @@ class SelectEmailForm
   attr_reader :user, :identity, :selected_email_id
 
   validate :validate_owns_selected_email
+  validates :selected_email_id, presence: {
+    message: proc { I18n.t('email_address.not_found') },
+  }
 
   def initialize(user:, identity: nil)
     @user = user

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -15,7 +15,6 @@
     <%= f.input(
           :selected_email_id,
           as: :radio_buttons,
-          required: true,
           label: false,
           wrapper_html: {
             aria: {
@@ -27,7 +26,7 @@
             [
               email.email,
               email.id,
-              checked: email.id == @email_id,
+              checked: email.id == @identity.email_address_id,
             ]
           end,
         ) %>

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -27,7 +27,7 @@
             [
               email.email,
               email.id,
-              checked: email.id == @identity.email_address_id,
+              checked: email.id == @email_id,
             ]
           end,
         ) %>

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -27,7 +27,7 @@
             [
               email.email,
               email.id,
-              checked: email.id == @last_sign_in_email_address,
+              checked: email.id == @email_id,
             ]
           end,
         ) %>

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -16,6 +16,7 @@
           :selected_email_id,
           as: :radio_buttons,
           label: false,
+          required: true,
           wrapper_html: {
             aria: {
               labelledby: 'select-email-heading',

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -15,6 +15,7 @@
     <%= f.input(
           :selected_email_id,
           as: :radio_buttons,
+          required: true,
           label: false,
           wrapper_html: {
             aria: {

--- a/app/views/accounts/connected_accounts/selected_email/edit.html.erb
+++ b/app/views/accounts/connected_accounts/selected_email/edit.html.erb
@@ -27,7 +27,7 @@
             [
               email.email,
               email.id,
-              checked: email.id == @identity.email_address_id,
+              checked: email.id == @last_sign_in_email_address,
             ]
           end,
         ) %>

--- a/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
+++ b/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
         expect(@analytics).to have_logged_event(
           :sp_select_email_submitted,
           success: false,
-          error_details: { selected_email_id: { not_found: true } },
+          error_details: { selected_email_id: { blank: true, not_found: true } },
         )
       end
     end

--- a/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
+++ b/spec/controllers/accounts/connected_accounts/selected_email_controller_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe Accounts::ConnectedAccounts::SelectedEmailController do
       expect(assigns(:identity)).to be_kind_of(ServiceProviderIdentity)
       expect(assigns(:select_email_form)).to be_kind_of(SelectEmailForm)
       expect(assigns(:can_add_email)).to eq(true)
+      expect(assigns(:email_id)).to eq(user.email_addresses.first.id)
+    end
+
+    context 'user has signed in with a different email address than has been assigned' do
+      it 'assigns the user identity email id' do
+        identity_email = user.email_addresses.last.id
+        identity.email_address_id = identity_email
+        identity.save
+
+        response
+
+        expect(assigns(:email_id)).to eq(identity_email)
+      end
     end
 
     context 'with an identity parameter not associated with the user' do

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -3,7 +3,14 @@ require 'rails_helper'
 RSpec.describe 'Account connected applications' do
   include NavigationHelper
 
-  let(:user) { create(:user, :fully_registered, created_at: Time.zone.now - 100.days) }
+  let(:user) do
+    create(
+      :user,
+      :fully_registered,
+      :with_multiple_emails,
+      created_at: Time.zone.now - 100.days,
+    )
+  end
   let(:identity) do
     create(
       :service_provider_identity,
@@ -84,20 +91,26 @@ RSpec.describe 'Account connected applications' do
       click_link(t('help_text.requested_attributes.change_email_link'))
     end
 
-    expect(page).to have_field(user.email) { |field| !field[:checked] }
+    expect(page).to have_field(user.email) { |field| field[:checked] }
 
-    choose user.email
+    choose user.email_addresses.last.email
     click_on t('help_text.requested_attributes.select_email_link')
 
     within('li', text: identity.display_name) do
       expect(page).not_to have_content(t('account.connected_apps.email_not_selected'))
-      expect(page).to have_content(user.email)
+      expect(page).to have_content(user.email_addresses.last.email)
       click_link(t('help_text.requested_attributes.change_email_link'))
     end
 
-    expect(page).to have_field(user.email) { |field| field[:checked] }
+    expect(page).to have_field(user.email_addresses.last.email) { |field| field[:checked] }
+
+    choose user.email
 
     click_on(t('help_text.requested_attributes.select_email_link'))
+
+    within('li', text: identity.display_name) do
+      expect(page).to have_content(user.email)
+    end
 
     expect(page).to have_content strip_tags(
       t('account.connected_apps.email_update_success_html', sp_name: identity.display_name),

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -85,17 +85,13 @@ RSpec.describe 'Account connected applications' do
     expect(page).to_not have_content(identity.display_name)
   end
 
-  scenario 'changing email shared with SP', :js do
+  scenario 'changing email shared with SP' do
     within('li', text: identity.display_name) do
       expect(page).to have_content(t('account.connected_apps.email_not_selected'))
       click_link(t('help_text.requested_attributes.change_email_link'))
     end
 
-    click_on t('help_text.requested_attributes.select_email_link')
-
-    input = page.find(':focus', visible: false)
-
-    expect(input).to have_name(user.email)
+    expect(page).to have_field(user.email) { |field| field[:checked] }
 
     choose user.email_addresses.last.email
     click_on t('help_text.requested_attributes.select_email_link')
@@ -106,11 +102,7 @@ RSpec.describe 'Account connected applications' do
       click_link(t('help_text.requested_attributes.change_email_link'))
     end
 
-    input2_id = "select_email_form_selected_email_id_#{user.email_addresses.last.id}"
-
-    input2 = page.find(id: input2_id, visible: false)
-
-    expect(input2).to have_name(user.email_addresses.last.email)
+    expect(page).to have_field(user.email_addresses.last.email) { |field| field[:checked] }
 
     choose user.email
 

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -85,13 +85,27 @@ RSpec.describe 'Account connected applications' do
     expect(page).to_not have_content(identity.display_name)
   end
 
-  scenario 'changing email shared with SP' do
+  scenario 'changing email shared with SP', :js do
     within('li', text: identity.display_name) do
       expect(page).to have_content(t('account.connected_apps.email_not_selected'))
       click_link(t('help_text.requested_attributes.change_email_link'))
     end
 
-    expect(page).to have_field(user.email) { |field| !field[:checked] }
+    expect(page).not_to have_checked_field(user.email)
+
+    click_on t('help_text.requested_attributes.select_email_link')
+
+    input = page.find(':focus')
+
+    expect(input).to have_name(
+      strip_tags(
+        t(
+          'help_text.select_preferred_email_html',
+          sp: identity.display_name,
+        ),
+      ),
+    )
+    expect(input).to have_description(t('simple_form.required.text'))
 
     choose user.email_addresses.last.email
     click_on t('help_text.requested_attributes.select_email_link')

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'Account connected applications' do
       click_link(t('help_text.requested_attributes.change_email_link'))
     end
 
-    expect(page).to have_field(user.email) { |field| field[:checked] }
+    expect(page).to have_field(user.email) { |field| !field[:checked] }
 
     choose user.email_addresses.last.email
     click_on t('help_text.requested_attributes.select_email_link')

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -117,6 +117,18 @@ RSpec.describe 'Account connected applications' do
     )
   end
 
+  scenario 'changing email shared with SP when SP has an assigned email' do
+    identity.email_address_id = user.email_addresses.last.id
+    identity.save
+
+    within('li', text: identity.display_name) do
+      expect(page).to have_content(t('account.connected_apps.email_not_selected'))
+      click_link(t('help_text.requested_attributes.change_email_link'))
+    end
+
+    expect(page).to have_field(user.email_addresses.last.email) { |field| field[:checked] }
+  end
+
   def build_account_connected_apps
     identity
     identity_without_link

--- a/spec/features/account_connected_apps_spec.rb
+++ b/spec/features/account_connected_apps_spec.rb
@@ -91,21 +91,11 @@ RSpec.describe 'Account connected applications' do
       click_link(t('help_text.requested_attributes.change_email_link'))
     end
 
-    expect(page).not_to have_checked_field(user.email)
-
     click_on t('help_text.requested_attributes.select_email_link')
 
-    input = page.find(':focus')
+    input = page.find(':focus', visible: false)
 
-    expect(input).to have_name(
-      strip_tags(
-        t(
-          'help_text.select_preferred_email_html',
-          sp: identity.display_name,
-        ),
-      ),
-    )
-    expect(input).to have_description(t('simple_form.required.text'))
+    expect(input).to have_name(user.email)
 
     choose user.email_addresses.last.email
     click_on t('help_text.requested_attributes.select_email_link')
@@ -116,7 +106,11 @@ RSpec.describe 'Account connected applications' do
       click_link(t('help_text.requested_attributes.change_email_link'))
     end
 
-    expect(page).to have_field(user.email_addresses.last.email) { |field| field[:checked] }
+    input2_id = "select_email_form_selected_email_id_#{user.email_addresses.last.id}"
+
+    input2 = page.find(id: input2_id, visible: false)
+
+    expect(input2).to have_name(user.email_addresses.last.email)
 
     choose user.email
 

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SelectEmailForm do
 
     context 'with an invalid email id' do
       context 'with a blank email id' do
-        let(:selected_email_id) { nil }
+        let(:selected_email_id) { '' }
 
         it 'is unsuccessful' do
           expect(response.to_h).to eq(

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -29,14 +29,26 @@ RSpec.describe SelectEmailForm do
     end
 
     context 'with an invalid email id' do
-      let(:selected_email_id) { '' }
+      context 'with a blank email id' do
+        let(:selected_email_id) { nil }
 
-      it 'is unsuccessful' do
-        expect(response.to_h).to eq(
-          success: false,
-          error_details: { selected_email_id: { not_found: true } },
-          selected_email_id: nil,
-        )
+        it 'is unsuccessful' do
+          expect(response.to_h).to eq(
+            success: false,
+            error_details: { selected_email_id: { not_found: true } },
+          )
+        end
+      end
+
+      context 'with a non-existing email id' do
+        let(:selected_email_id) { 9000 }
+
+        it 'is unsuccessful' do
+          expect(response.to_h).to eq(
+            success: false,
+            error_details: { selected_email_id: { blank: true, not_found: true } },
+          )
+        end
       end
 
       context 'with present value that does not convert to numeric' do

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe SelectEmailForm do
           expect(response.to_h).to eq(
             success: false,
             error_details: { selected_email_id: { blank: true, not_found: true } },
+            selected_email_id: nil,
           )
         end
       end
@@ -47,6 +48,7 @@ RSpec.describe SelectEmailForm do
           expect(response.to_h).to eq(
             success: false,
             error_details: { selected_email_id: { not_found: true } },
+            selected_email_id: 9000,
           )
         end
       end
@@ -57,7 +59,7 @@ RSpec.describe SelectEmailForm do
         it 'is unsuccessful without raising exception' do
           expect(response.to_h).to eq(
             success: false,
-            error_details: { selected_email_id: { not_found: true } },
+            error_details: { selected_email_id: { not_found: true, blank: true } },
             selected_email_id: nil,
           )
         end

--- a/spec/forms/select_email_form_spec.rb
+++ b/spec/forms/select_email_form_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SelectEmailForm do
         it 'is unsuccessful' do
           expect(response.to_h).to eq(
             success: false,
-            error_details: { selected_email_id: { not_found: true } },
+            error_details: { selected_email_id: { blank: true, not_found: true } },
           )
         end
       end
@@ -46,7 +46,7 @@ RSpec.describe SelectEmailForm do
         it 'is unsuccessful' do
           expect(response.to_h).to eq(
             success: false,
-            error_details: { selected_email_id: { blank: true, not_found: true } },
+            error_details: { selected_email_id: { not_found: true } },
           )
         end
       end

--- a/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
     inputs = page.find_all('[type="radio"]')
     expect(inputs.count).to eq(2)
     expect(inputs).to be_logically_grouped(t('titles.select_email'))
-    expect(inputs.first).to be_checked
     expect(rendered).to have_content(identity.display_name)
   end
 

--- a/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
     @identity = identity
     @select_email_form = SelectEmailForm.new(user:, identity:)
     @can_add_email = true
+    @last_sign_in_email_address = user.email_addresses.first.id
   end
 
   it 'renders introduction text' do
@@ -34,6 +35,7 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
     inputs = page.find_all('[type="radio"]')
     expect(inputs.count).to eq(2)
     expect(inputs).to be_logically_grouped(t('titles.select_email'))
+    expect(inputs.first).to be_checked
     expect(rendered).to have_content(identity.display_name)
   end
 

--- a/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
     @identity = identity
     @select_email_form = SelectEmailForm.new(user:, identity:)
     @can_add_email = true
-    @last_sign_in_email_address = user.email_addresses.first.id
+    @email_id = user.email_addresses.first.id
   end
 
   it 'renders introduction text' do

--- a/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/selected_email/edit.html.erb_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'accounts/connected_accounts/selected_email/edit.html.erb' do
     @identity = identity
     @select_email_form = SelectEmailForm.new(user:, identity:)
     @can_add_email = true
-    @email_id = user.email_addresses.first.id
   end
 
   it 'renders introduction text' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-15156](https://cm-jira.usa.gov/browse/LG-15156)



## 🛠 Summary of changes

Bug fix for https://cm-jira.usa.gov/browse/LG-13665 form allows a blank submission.
This occurs when a user has a service partner connection that has not yet been associated with an email address.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create a user with a SP connection locally using OIDC or SAML and more than 1 email
- [ ] Log out of SP, log into http://localhost:3000
- [ ] Delete the email that was attached to the SP in the first step. Add another email.
- [ ] Click connected accounts. Expect to see 'Email not yet selected'
- [ ] Click change
- [ ] Select your preferred email page should not show any unselected email addresses. It will preselect your current logged in email address.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
