### PR TITLE
Update report to use earlier event

### DIFF
--- a/lib/reporting/protocols_report.rb
+++ b/lib/reporting/protocols_report.rb
@@ -17,6 +17,7 @@ module Reporting
     attr_reader :time_range
 
     SAML_AUTH_EVENT = 'SAML Auth'
+    SAML_AUTH_REQUEST_EVENT = 'SAML Auth Request'
     OIDC_AUTH_EVENT = 'OpenID Connect: authorization request'
 
     # @param [Range<Time>] time_range
@@ -352,7 +353,7 @@ module Reporting
 
     def saml_signature_query
       params = {
-        events: quote([SAML_AUTH_EVENT]),
+        events: quote([SAML_AUTH_REQUEST_EVENT]),
       }
 
       format(<<~QUERY, params)
@@ -362,7 +363,6 @@ module Reporting
           properties.event_properties.request_signed != 1 AS not_signed,
           isempty(properties.event_properties.matching_cert_serial) AND signed AS invalid_signature
         | filter name IN %{events}
-          AND properties.event_properties.success = 1
         | stats
           sum(not_signed) AS unsigned_count,
           sum(invalid_signature) AS invalid_signature_count


### PR DESCRIPTION
## 🛠 Summary of changes
Updating the SAML signature query in the weekly protocols report to use the SAML Auth Request event, rather than the SAML Auth event, as it is more accurate.

Event update [here](https://github.com/18F/identity-idp/pull/11558)

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
