### PR TITLE
WIP:  turn off connection limiting

### DIFF
--- a/dockerfiles/nginx-prod.conf
+++ b/dockerfiles/nginx-prod.conf
@@ -30,9 +30,9 @@ http {
   client_max_body_size 20k;
   large_client_header_buffers 2 20k;
   # Limit connections
-  limit_conn addr       20;
-  limit_conn_status     429;
-  limit_conn_zone       $binary_remote_addr zone=addr:5m;
+  #limit_conn addr       20;
+  #limit_conn_status     429;
+  #limit_conn_zone       $binary_remote_addr zone=addr:5m;
   # Disable sending server info and versions
   server_tokens off;
   more_clear_headers Server;


### PR DESCRIPTION
## 🛠 Summary of changes

This removes the connection limit stuff for nginx in k8s.  We need this for load testing, but I suspect that we could have this on for real in prod.

I'm just using this to generate an image right now for load testing.  Will remove WIP status if we think we don't actually need this.