### PR TITLE
Remove unused event parameter from RedirectController

### DIFF
--- a/app/controllers/redirect/redirect_controller.rb
+++ b/app/controllers/redirect/redirect_controller.rb
@@ -17,14 +17,8 @@ module Redirect
       }.compact
     end
 
-    def redirect_to_and_log(url, event: nil, tracker_method: analytics.method(:external_redirect))
-      if event
-        # Once all events have been moved to tracker methods, we can remove the event: param
-        analytics.track_event(event, redirect_url: url, **location_params)
-      else
-        tracker_method.call(redirect_url: url, **location_params)
-      end
-
+    def redirect_to_and_log(url, tracker_method: analytics.method(:external_redirect))
+      tracker_method.call(redirect_url: url, **location_params)
       redirect_url = UriService.add_params(url, partner_params)
       redirect_to(redirect_url, allow_other_host: true)
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Removes the unused `event` keyword argument from the `redirect_to_and_log` private controller method for the `RedirectController` base controller.

This was superseded by the `tracker_method` keyword argument and slated for eventual removal. Based on current usage, there are no instances of `event` keyword argument and it can be safely removed.

## 📜 Testing Plan

Verify build passes.

Double-check for existing usage of the `event` keyword argument.