### PR TITLE
LG-15183: Associate user_id for reCAPTCHA result analytics of failed sign-in

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -19,6 +19,7 @@ module Users
     before_action :check_user_needs_redirect, only: [:new]
     before_action :apply_secure_headers_override, only: [:new, :create]
     before_action :clear_session_bad_password_count_if_window_expired, only: [:create]
+    before_action :set_analytics_user_from_params, only: :create
     before_action :allow_csp_recaptcha_src, if: :recaptcha_enabled?
 
     after_action :add_recaptcha_resource_hints, if: :recaptcha_enabled?
@@ -168,6 +169,14 @@ module Users
       params.require(:user).permit(:email, :password)
     end
 
+    def set_analytics_user_from_params
+      @analytics_user = user_from_params
+    end
+
+    def analytics_user
+      @analytics_user || AnonymousUser.new
+    end
+
     def process_locked_out_user
       presenter = TwoFactorAuthCode::MaxAttemptsReachedPresenter.new(
         'generic_login_attempts',
@@ -210,7 +219,6 @@ module Users
       analytics.email_and_password_auth(
         **recaptcha_response,
         success: success,
-        user_id: user.uuid,
         user_locked_out: user_locked_out?(user),
         rate_limited: rate_limited?,
         captcha_validation_performed: captcha_validation_performed?,

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -59,6 +59,10 @@ module Users
       end
     end
 
+    def analytics_user
+      @analytics_user || AnonymousUser.new
+    end
+
     private
 
     def clear_session_bad_password_count_if_window_expired
@@ -171,10 +175,6 @@ module Users
 
     def set_analytics_user_from_params
       @analytics_user = user_from_params
-    end
-
-    def analytics_user
-      @analytics_user || AnonymousUser.new
     end
 
     def process_locked_out_user

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -478,7 +478,6 @@ module AnalyticsEvents
 
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  # @param [String] user_id UUID for user associated with attempted email address
   # @param [Boolean] user_locked_out if the user is currently locked out of their second factor
   # @param [Boolean] rate_limited Whether the user has exceeded user IP rate limiting
   # @param [Boolean] valid_captcha_result Whether user passed the reCAPTCHA check or was exempt
@@ -491,7 +490,6 @@ module AnalyticsEvents
   # Tracks authentication attempts at the email/password screen
   def email_and_password_auth(
     success:,
-    user_id:,
     user_locked_out:,
     rate_limited:,
     valid_captcha_result:,
@@ -507,7 +505,6 @@ module AnalyticsEvents
       'Email and Password Authentication',
       success:,
       error_details:,
-      user_id:,
       user_locked_out:,
       rate_limited:,
       valid_captcha_result:,

--- a/spec/support/analytics_helper.rb
+++ b/spec/support/analytics_helper.rb
@@ -9,7 +9,7 @@ module AnalyticsHelper
            end
 
     stub.to receive(:analytics).and_wrap_original do |original|
-      expect(original.call.user).to eq(user) if user
+      expect(original.call.user).to match(user) if user
       analytics
     end
 

--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -171,6 +171,10 @@ class FakeAnalytics < Analytics
   def browser_attributes
     {}
   end
+
+  def reset!
+    @events = Hash.new
+  end
 end
 
 RSpec.configure do |c|

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -350,7 +350,7 @@ RSpec.shared_examples 'logs reCAPTCHA event and redirects appropriately' do |suc
       form_class: 'RecaptchaMockForm',
     )
     asserted_expected_user = false
-    fake_analytics = FakeAnalytics.new
+    fake_analytics.reset!
 
     fill_in :user_recaptcha_mock_score, with: '0.1'
     fill_in_credentials_and_submit(user.email, user.password)

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -324,15 +324,33 @@ RSpec.shared_examples 'logs reCAPTCHA event and redirects appropriately' do |suc
     fake_analytics = FakeAnalytics.new
     allow_any_instance_of(ApplicationController).to receive(:analytics).
       and_wrap_original do |original|
-        original_analytics = original.call
-        if original_analytics.request.params[:controller] == 'users/sessions' &&
-           original_analytics.request.params[:action] == 'create'
-          expect(original_analytics.user).to eq(user)
+        if original.receiver.instance_of?(Users::SessionsController) &&
+           original.receiver.action_name == 'create'
+          expect(original.call.user).to eq(user)
           asserted_expected_user = true
         end
 
         fake_analytics
       end
+
+    fill_in_credentials_and_submit(user.email, 'wrongpassword')
+    expect(asserted_expected_user).to eq(true)
+    expect(fake_analytics).to have_logged_event(
+      'reCAPTCHA verify result received',
+      recaptcha_result: {
+        assessment_id: kind_of(String),
+        success: true,
+        score: 1.0,
+        errors: [],
+        reasons: [],
+      },
+      evaluated_as_valid: true,
+      score_threshold: 0.2,
+      recaptcha_action: 'sign_in',
+      form_class: 'RecaptchaMockForm',
+    )
+    asserted_expected_user = false
+    fake_analytics = FakeAnalytics.new
 
     fill_in :user_recaptcha_mock_score, with: '0.1'
     fill_in_credentials_and_submit(user.email, user.password)


### PR DESCRIPTION
## 🎫 Ticket

[LG-15183](https://cm-jira.usa.gov/browse/LG-15183)

## 🛠 Summary of changes

Fixes an issue where the "reCAPTCHA verify result received" event does not correctly associate the `user_id` if the sign-in attempt is unsuccessful for a reason other than reCAPTCHA.

This happens because the user is not yet signed-in. For "Email and Password Authentication" events, we work around this by [explicitly passing the `user_id` from the user associated with the given email parameter](https://github.com/18F/identity-idp/blob/2cf5663c22dc66681f293d79d62a4365756d4510/app/controllers/users/sessions_controller.rb#L213). The changes proposed here instead override the base `ApplicationController#analytics_user` to use this parameter-based user during the submission, so that all analytics logging will have that user associated.

## 📜 Testing Plan

Verify that both "Email and Password Authentication" and "reCAPTCHA verify result received" events include the `user_id` property of the user associated with the submitted email address:

1. Run `make watch_events` in a separate terminal process
2. Go to http://localhost:3000
3. Enter an email address associated with a user account (or not associated with an account, to verify expected `nil` `user_id`)
4. Enter a correct or incorrect password for that user account
5. Click "Sign in"
6. In the `make watch_events` process, observe events "Email and Password Authentication" and "reCAPTCHA verify result received" both have associated `user_id`, regardless if you entered a correct password for the account