### PR TITLE
Reload all AB tests after running AB test specs

### DIFF
--- a/spec/config/initializers/ab_tests_spec.rb
+++ b/spec/config/initializers/ab_tests_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe AbTests do
   include AbTestsHelper
 
+  after :suite do
+    reload_ab_tests
+  end
+
   describe '#all' do
     it 'returns all registered A/B tests' do
       expect(AbTests.all.values).to all(be_kind_of(AbTest))


### PR DESCRIPTION
Because of how this spec tests initializers, it can leave weirdly configured AB tests around after it runs. This is usually not a problem, but can introduce flakiness in CI.

I think this will introduce failures elsewhere in the test suite, I'm opening this PR as part of effort to suss out how much.
