### PR TITLE
LG-14749 Cancel enrollments on profile encryption error

### DIFF
--- a/app/controllers/concerns/ial2_profile_concern.rb
+++ b/app/controllers/concerns/ial2_profile_concern.rb
@@ -23,7 +23,7 @@ module Ial2ProfileConcern
       cacher.save(raw_password, profile)
     rescue Encryption::EncryptionError => err
       if profile
-        profile.deactivate(:encryption_error)
+        profile.deactivate_due_to_encryption_error
         analytics.profile_encryption_invalid(error: err.message)
       end
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -191,6 +191,20 @@ class Profile < ApplicationRecord
     update!(active: false, deactivation_reason: reason)
   end
 
+  # Update the profile's deactivation reason to "encryption_error". As a
+  # side-effect, when the profile has an associated pending in-person
+  # enrollment it will be updated to have a status of "cancelled".
+  def deactivate_due_to_encryption_error
+    update!(
+      active: false,
+      deactivation_reason: :encryption_error,
+    )
+
+    if in_person_enrollment&.pending?
+      in_person_enrollment.cancelled!
+    end
+  end
+
   def fraud_deactivation_reason?
     fraud_review_pending? || fraud_rejection?
   end

--- a/spec/controllers/concerns/ial2_profile_concern_spec.rb
+++ b/spec/controllers/concerns/ial2_profile_concern_spec.rb
@@ -1,0 +1,213 @@
+require 'rails_helper'
+
+RSpec.describe Ial2ProfileConcern do
+  let(:test_controller) do
+    Class.new do
+      include Ial2ProfileConcern
+
+      attr_accessor :current_user, :user_session, :analytics
+
+      def initialize(current_user:, user_session:, analytics:)
+        @current_user = current_user
+        @user_session = user_session
+        @analytics = analytics
+      end
+    end
+  end
+
+  let(:user) { create(:user) }
+  let(:user_session) { {} }
+  let(:analytics) { double(Analytics) }
+  let(:encryption_error) { Encryption::EncryptionError.new }
+  let(:cacher) { double(Pii::Cacher) }
+  let(:password) { 'PraiseTheSun!' }
+
+  describe '#cache_profiles' do
+    subject { test_controller.new(current_user: user, user_session:, analytics:) }
+
+    context 'when the user has a pending profile' do
+      let!(:profile) { create(:profile, :in_person_verification_pending, user:) }
+
+      context 'when the profile can be saved to cache' do
+        before do
+          allow(cacher).to receive(:save)
+          allow(Pii::Cacher).to receive(:new).and_return(cacher)
+          subject.cache_profiles(password)
+        end
+
+        it 'stores the decrypted profile in cache' do
+          expect(cacher).to have_received(:save).with(password, profile)
+        end
+      end
+
+      context 'when the profile can not be saved to cache' do
+        before do
+          allow(cacher).to receive(:save).and_raise(encryption_error)
+          allow(Pii::Cacher).to receive(:new).and_return(cacher)
+          allow(analytics).to receive(:profile_encryption_invalid)
+          subject.cache_profiles(password)
+        end
+
+        it 'deactivates the profile with reason encryption_error' do
+          expect(profile.reload).to have_attributes(
+            active: false,
+            deactivation_reason: 'encryption_error',
+          )
+        end
+
+        it 'logs the profile_encryption_invalid analytic' do
+          expect(analytics).to have_received(:profile_encryption_invalid).with(
+            error: encryption_error.message,
+          )
+        end
+      end
+    end
+
+    context 'when the user has an active profile' do
+      let!(:profile) { create(:profile, :active, user:) }
+
+      context 'when the profile can be saved to cache' do
+        before do
+          allow(cacher).to receive(:save)
+          allow(Pii::Cacher).to receive(:new).and_return(cacher)
+          subject.cache_profiles(password)
+        end
+
+        it 'stores the decrypted profile in cache' do
+          expect(cacher).to have_received(:save).with(password, profile)
+        end
+      end
+
+      context 'when the profile can not be saved to cache' do
+        before do
+          allow(cacher).to receive(:save).and_raise(encryption_error)
+          allow(Pii::Cacher).to receive(:new).and_return(cacher)
+          allow(analytics).to receive(:profile_encryption_invalid)
+          subject.cache_profiles(password)
+        end
+
+        it 'deactivates the profile with reason encryption_error' do
+          expect(profile.reload).to have_attributes(
+            active: false,
+            deactivation_reason: 'encryption_error',
+          )
+        end
+
+        it 'logs the profile_encryption_invalid analytic' do
+          expect(analytics).to have_received(:profile_encryption_invalid).with(
+            error: encryption_error.message,
+          )
+        end
+      end
+    end
+
+    context 'when the user has both an active profile and pending profile' do
+      let(:pending_profile) { create(:profile, :in_person_verification_pending, user:) }
+      let(:active_profile) { create(:profile, :active, user:) }
+
+      context 'when the active profile was activated before the pending profile was created' do
+        before do
+          pending_profile.update!(created_at: Time.zone.now)
+          active_profile.update!(activated_at: 1.day.ago)
+        end
+
+        context 'when the profiles can be saved to cache' do
+          before do
+            allow(cacher).to receive(:save)
+            allow(Pii::Cacher).to receive(:new).and_return(cacher)
+            subject.cache_profiles(password)
+          end
+
+          it 'stores the decrypted pending profile in cache' do
+            expect(cacher).to have_received(:save).with(password, pending_profile)
+          end
+
+          it 'stores the decrypted active profile in cache' do
+            expect(cacher).to have_received(:save).with(password, active_profile)
+          end
+        end
+
+        context 'when the profile can not be saved to cache' do
+          before do
+            allow(cacher).to receive(:save).and_raise(encryption_error)
+            allow(Pii::Cacher).to receive(:new).and_return(cacher)
+            allow(analytics).to receive(:profile_encryption_invalid)
+            subject.cache_profiles(password)
+          end
+
+          it 'deactivates the pending profile with reason encryption_error' do
+            expect(pending_profile.reload).to have_attributes(
+              active: false,
+              deactivation_reason: 'encryption_error',
+            )
+          end
+
+          it 'deactivates the active profile with reason encryption_error' do
+            expect(active_profile.reload).to have_attributes(
+              active: false,
+              deactivation_reason: 'encryption_error',
+            )
+          end
+
+          it 'logs the profile_encryption_invalid analytic' do
+            expect(analytics).to have_received(:profile_encryption_invalid).with(
+              error: encryption_error.message,
+            ).twice
+          end
+        end
+      end
+
+      context 'when the active profile was activated after the pending profile was created' do
+        before do
+          pending_profile.update!(created_at: 1.day.ago)
+          active_profile.update!(activated_at: Time.zone.now)
+        end
+
+        context 'when the profiles can be saved to cache' do
+          before do
+            allow(cacher).to receive(:save)
+            allow(Pii::Cacher).to receive(:new).and_return(cacher)
+            subject.cache_profiles(password)
+          end
+
+          it 'does not store the decrypted pending profile in cache' do
+            expect(cacher).not_to have_received(:save).with(password, pending_profile)
+          end
+
+          it 'stores the decrypted active profile in cache' do
+            expect(cacher).to have_received(:save).with(password, active_profile)
+          end
+        end
+
+        context 'when the profile can not be saved to cache' do
+          before do
+            allow(cacher).to receive(:save).and_raise(encryption_error)
+            allow(Pii::Cacher).to receive(:new).and_return(cacher)
+            allow(analytics).to receive(:profile_encryption_invalid)
+            subject.cache_profiles(password)
+          end
+
+          it 'does not deactivate the pending profile with reason encryption_error' do
+            expect(pending_profile.reload).to have_attributes(
+              active: false,
+              deactivation_reason: nil,
+            )
+          end
+
+          it 'deactivates the active profile with reason encryption_error' do
+            expect(active_profile.reload).to have_attributes(
+              active: false,
+              deactivation_reason: 'encryption_error',
+            )
+          end
+
+          it 'logs the profile_encryption_invalid analytic' do
+            expect(analytics).to have_received(:profile_encryption_invalid).with(
+              error: encryption_error.message,
+            ).once
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/idv/get_proofing_results_job_scenarios_spec.rb
+++ b/spec/features/idv/get_proofing_results_job_scenarios_spec.rb
@@ -51,9 +51,9 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
 
       # Then the user is taken to the /verify/welcome page
       expect(current_path).to eq(idv_welcome_path)
-      # And the user has an InPersonEnrollment with status "pending"
+      # And the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
-        status: 'pending',
+        status: 'cancelled',
       )
       # And the user has a Profile that is deactivated with reason "encryption_error"
       expect(@user.in_person_enrollments.first.profile).to have_attributes(
@@ -78,7 +78,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       expect(@user.in_person_enrollments.first.profile).to have_attributes(
         active: false,
         deactivation_reason: 'encryption_error',
-        in_person_verification_pending_at: nil,
+        in_person_verification_pending_at: be_kind_of(Time),
       )
 
       # When the user logs in
@@ -94,7 +94,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       expect(@user.in_person_enrollments.first.profile).to have_attributes(
         active: false,
         deactivation_reason: 'encryption_error',
-        in_person_verification_pending_at: nil,
+        in_person_verification_pending_at: be_kind_of(Time),
       )
     end
 
@@ -130,9 +130,9 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
 
         # Then the user is taken to the /verify/welcome page
         expect(current_path).to eq(idv_welcome_path)
-        # And the user has an InPersonEnrollment with status "pending"
+        # And the user has an InPersonEnrollment with status "cancelled"
         expect(@user.in_person_enrollments.first).to have_attributes(
-          status: 'pending',
+          status: 'cancelled',
         )
         # And the user has a Profile that is deactivated with reason "encryption_error"
         expect(@user.in_person_enrollments.first.profile).to have_attributes(
@@ -157,7 +157,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
         expect(@user.in_person_enrollments.first.profile).to have_attributes(
           active: false,
           deactivation_reason: 'encryption_error',
-          in_person_verification_pending_at: nil,
+          in_person_verification_pending_at: be_kind_of(Time),
         )
 
         # When the user logs in
@@ -173,7 +173,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
         expect(@user.in_person_enrollments.first.profile).to have_attributes(
           active: false,
           deactivation_reason: 'encryption_error',
-          in_person_verification_pending_at: nil,
+          in_person_verification_pending_at: be_kind_of(Time),
         )
       end
     end
@@ -537,9 +537,9 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
 
       # Then the user is taken to the /verify/welcome page
       expect(current_path).to eq(idv_welcome_path)
-      # And the user has an InPersonEnrollment with status "pending"
+      # And the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
-        status: 'pending',
+        status: 'cancelled',
       )
       # And the user has a Profile that is deactivated with reason "encryption_error" and
       # pending in person verification and fraud review
@@ -568,7 +568,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       expect(@user.in_person_enrollments.first.profile).to have_attributes(
         active: false,
         deactivation_reason: 'encryption_error',
-        in_person_verification_pending_at: nil,
+        in_person_verification_pending_at: be_kind_of(Time),
         fraud_pending_reason: 'threatmetrix_review',
         fraud_review_pending_at: be_kind_of(Time),
       )
@@ -587,7 +587,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true, allowed_extra_ana
       expect(@user.in_person_enrollments.first.profile).to have_attributes(
         active: false,
         deactivation_reason: 'encryption_error',
-        in_person_verification_pending_at: nil,
+        in_person_verification_pending_at: be_kind_of(Time),
         fraud_pending_reason: 'threatmetrix_review',
         fraud_review_pending_at: be_kind_of(Time),
       )


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14748](https://cm-jira.usa.gov/browse/LG-14748)

## 🛠 Summary of changes

Cancel in-person enrollments when a profile is deactivated with reason `encryption_error`.

## 📜 Testing Plan

Scenario: User has a pending in-person enrollment and resets their password

- [ ] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [ ] Create a new account
- [ ] Complete the ID-IPP flow reaching the ready to verify page.
- [ ] Logout
- [ ] Reset the password of the user.
- [ ] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [ ] Ensure user is navigated to the welcome page.
- [ ] Ensure the in-person enrollment is update to have a status of `cancelled`.
- [ ] Ensure the user is able to complete the ID-IPP flow reaching the ready to verify page.