### PR TITLE
[WIP] LG-14972 | Fix up the XML generated by AAMVA::VerificationRequest

### DIFF
--- a/app/services/proofing/aamva/request/templates/verify.xml.erb
+++ b/app/services/proofing/aamva/request/templates/verify.xml.erb
@@ -8,15 +8,11 @@
   </soap:Header>
   <soap:Body>
     <dldv:VerifyDriverLicenseData>
-      <dldv:token>
-        <%= auth_token %>
-      </dldv:token>
+      <dldv:token><%= auth_token %></dldv:token>
       <dldv:verifyDriverLicenseDataRequest>
         <aa:ControlData>
           <aa:MessageAddress>
-            <aa:TransactionLocatorId>
-              <%= transaction_locator_id %>
-            </aa:TransactionLocatorId>
+            <aa:TransactionLocatorId><%= transaction_locator_id %></aa:TransactionLocatorId>
             <aa:MessageOriginatorId>GSA</aa:MessageOriginatorId>
             <aa:MessageDestinationId></aa:MessageDestinationId>
           </aa:MessageAddress>

--- a/app/services/proofing/aamva/request/verification_request.rb
+++ b/app/services/proofing/aamva/request/verification_request.rb
@@ -130,7 +130,10 @@ module Proofing
             )
           end
 
-          @body = document.to_s
+          @body = String.new(encoding: 'UTF-8')
+          formatter = REXML::Formatters::Pretty.new
+          formatter.compact = true
+          formatter.write(document.root, @body)
         end
 
         def add_state_id_type(id_type, document)

--- a/spec/fixtures/proofing/aamva/requests/verification_request.xml
+++ b/spec/fixtures/proofing/aamva/requests/verification_request.xml
@@ -1,24 +1,20 @@
-<soap:Envelope xmlns:aa='http://aamva.org/niem/extensions/1.0' xmlns:dldv='http://aamva.org/dldv/wsdl/2.1' xmlns:nc='http://niem.gov/niem/niem-core/2.0' xmlns:soap='http://www.w3.org/2003/05/soap-envelope'>
+<soap:Envelope xmlns:soap='http://www.w3.org/2003/05/soap-envelope' xmlns:dldv='http://aamva.org/dldv/wsdl/2.1' xmlns:aa='http://aamva.org/niem/extensions/1.0' xmlns:nc='http://niem.gov/niem/niem-core/2.0'>
   <soap:Header xmlns:wsa='http://www.w3.org/2005/08/addressing'>
     <wsa:Action>http://aamva.org/dldv/wsdl/2.1/IDLDVService21/VerifyDriverLicenseData</wsa:Action>
   </soap:Header>
   <soap:Body>
     <dldv:VerifyDriverLicenseData>
-      <dldv:token>
-        KEYKEYKEY
-      </dldv:token>
+      <dldv:token>KEYKEYKEY</dldv:token>
       <dldv:verifyDriverLicenseDataRequest>
         <aa:ControlData>
           <aa:MessageAddress>
-            <aa:TransactionLocatorId>
-              1234-abcd-efgh
-            </aa:TransactionLocatorId>
+            <aa:TransactionLocatorId>1234-abcd-efgh</aa:TransactionLocatorId>
             <aa:MessageOriginatorId>GSA</aa:MessageOriginatorId>
             <aa:MessageDestinationId>CA</aa:MessageDestinationId>
           </aa:MessageAddress>
         </aa:ControlData>
         <nc:DriverLicenseIdentification>
-          <nc:IdentificationID xsi:type='nc:PersonNameTextType' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>123456789</nc:IdentificationID>
+          <nc:IdentificationID xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:type='nc:PersonNameTextType'>123456789</nc:IdentificationID>
         </nc:DriverLicenseIdentification>
         <aa:PersonBirthDate>1942-10-29</aa:PersonBirthDate>
         <nc:PersonName>
@@ -31,7 +27,8 @@
           <nc:LocationStateUsPostalServiceCode>VA</nc:LocationStateUsPostalServiceCode>
           <nc:LocationPostalCode>20176</nc:LocationPostalCode>
         </aa:Address>
-      <aa:DocumentCategoryCode>1</aa:DocumentCategoryCode></dldv:verifyDriverLicenseDataRequest>
+        <aa:DocumentCategoryCode>1</aa:DocumentCategoryCode>
+      </dldv:verifyDriverLicenseDataRequest>
     </dldv:VerifyDriverLicenseData>
   </soap:Body>
 </soap:Envelope>


### PR DESCRIPTION
[skip changelog]

**I don't think we should merge this**. Pushing up for discussion.

## 🎫 Ticket

Link to the relevant ticket:
[LG-14972](https://cm-jira.usa.gov/browse/LG-14972)

## 🛠 Summary of changes

I keep picking up "easy" tickets that turn out to be a huge headache.

LG-14972 (filed by me) asked for two things that seemed very reasonable:

1. The XML document should not be erratically formatted, with inconsistent indentation and such. I ran into this when trying to add elements to the fixture, and I had to format them "wrong" to get tests to pass.
2. We should be comparing the generated XML to the template _as XML documents_, not strings, so that a test doesn't fail for silly things like above.

Unfortunately, being XML, everything is awful.

### Comparing XML documents is weirdly hard.

It seems like you can't just natively do equality between REXML::Documents. I briefly looked at implementing something that would recursively compare elements, but felt like I was way off track. (I then considered trying to just convert from XML to JSON and do it that way, and honestly that's about the best idea that came up during this whole thing.)

But then I found that there is a gem specifically for this, [equivalent-xml](https://github.com/mbklein/equivalent-xml)! Huzzah!

Last updated in 2015, it works with nokogiri and oga. But not rexml.

There's [a StackOverflow answer](https://stackoverflow.com/a/50650387) showing a fairly clean implementation of converting rexml docs to nokogiri so you can compare them. Realistically I think we could make this work fine, but it again feels like I've wandered pretty far off course.

### Tidying has side effects.

One particular example:

```xml
<foo>
 Bar
</foo>
```

gets mapped to `<foo> Bar </foo>` (note unintended whitespace). Does a third-party XML parser ignore that whitespace or does it treat it as significant when it's not multi-line? I don't want to have to worry about the answer.

We're inconsistent in the template about what spans lines and what doesn't. I normalized it, but see the above concern.

### Reformatting the XML we send AAMVA because a test fixture is ugly seems ill-advised.

On the surface, the idea of tidying up our XML seemed like a good idea.

In practice, given the scope of the changes, I'd want to feature-flag this and make sure this doesn't break our integration with AAMVA. The kind-of-ugly XML is only noticeable when you're editing a test fixture, though, so I can't help but think this has become a case of "the juice isn't worth the squeeze."