### PR TITLE
Add recaptcha timeout

### DIFF
--- a/app/forms/recaptcha_form.rb
+++ b/app/forms/recaptcha_form.rb
@@ -89,6 +89,7 @@ class RecaptchaForm
 
   def faraday
     Faraday.new do |conn|
+      conn.options.timeout = IdentityConfig.store.recaptcha_request_timeout_in_seconds
       conn.request :instrumentation, name: 'request_log.faraday'
       conn.response :json
     end

--- a/app/jobs/risc_delivery_job.rb
+++ b/app/jobs/risc_delivery_job.rb
@@ -90,9 +90,6 @@ class RiscDeliveryJob < ApplicationJob
       f.request :instrumentation, name: 'request_log.faraday'
       f.adapter :net_http
       f.options.timeout = IdentityConfig.store.risc_notifications_request_timeout
-      f.options.read_timeout = IdentityConfig.store.risc_notifications_request_timeout
-      f.options.open_timeout = IdentityConfig.store.risc_notifications_request_timeout
-      f.options.write_timeout = IdentityConfig.store.risc_notifications_request_timeout
     end
   end
 

--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -109,9 +109,6 @@ module DocAuth
           conn.request :authorization, :basic, username, password unless hmac_auth_enabled?
           conn.adapter :net_http
           conn.options.timeout = timeout
-          conn.options.read_timeout = timeout
-          conn.options.open_timeout = timeout
-          conn.options.write_timeout = timeout
         end
       end
 

--- a/app/services/doc_auth/socure/request.rb
+++ b/app/services/doc_auth/socure/request.rb
@@ -89,9 +89,6 @@ module DocAuth
           conn.request :instrumentation, name: 'request_metric.faraday'
           conn.adapter :net_http
           conn.options.timeout = timeout
-          conn.options.read_timeout = timeout
-          conn.options.open_timeout = timeout
-          conn.options.write_timeout = timeout
         end
       end
 

--- a/app/services/outbound_health_checker.rb
+++ b/app/services/outbound_health_checker.rb
@@ -42,9 +42,6 @@ module OutboundHealthChecker
       conn.request :retry, retry_options
 
       conn.options.timeout = IdentityConfig.store.outbound_connection_check_timeout
-      conn.options.read_timeout = IdentityConfig.store.outbound_connection_check_timeout
-      conn.options.open_timeout = IdentityConfig.store.outbound_connection_check_timeout
-      conn.options.write_timeout = IdentityConfig.store.outbound_connection_check_timeout
 
       # raises errors on 4XX or 5XX responses
       conn.response :raise_error

--- a/app/services/piv_cac_service.rb
+++ b/app/services/piv_cac_service.rb
@@ -63,9 +63,6 @@ module PivCacService
       Faraday.new(ssl: ssl_config) do |f|
         f.request :instrumentation, name: 'request_metric.faraday'
         f.options.timeout = IdentityConfig.store.piv_cac_service_timeout
-        f.options.read_timeout = IdentityConfig.store.piv_cac_service_timeout
-        f.options.open_timeout = IdentityConfig.store.piv_cac_service_timeout
-        f.options.write_timeout = IdentityConfig.store.piv_cac_service_timeout
       end.post(
         verify_token_uri,
         URI.encode_www_form({ token: token }),

--- a/app/services/proofing/lexis_nexis/authenticated_request.rb
+++ b/app/services/proofing/lexis_nexis/authenticated_request.rb
@@ -10,9 +10,6 @@ module Proofing
             f.request :authorization, :basic, config.username, config.password
           end
           f.options.timeout = timeout
-          f.options.read_timeout = timeout
-          f.options.open_timeout = timeout
-          f.options.write_timeout = timeout
         end
 
         Response.new(

--- a/app/services/proofing/lexis_nexis/request.rb
+++ b/app/services/proofing/lexis_nexis/request.rb
@@ -19,9 +19,6 @@ module Proofing
         conn = Faraday.new do |f|
           f.request :instrumentation, name: 'request_metric.faraday'
           f.options.timeout = timeout
-          f.options.read_timeout = timeout
-          f.options.open_timeout = timeout
-          f.options.write_timeout = timeout
         end
 
         Response.new(

--- a/app/services/proofing/socure/id_plus/request.rb
+++ b/app/services/proofing/socure/id_plus/request.rb
@@ -56,9 +56,6 @@ module Proofing
             f.response :raise_error
             f.response :json
             f.options.timeout = config.timeout
-            f.options.read_timeout = config.timeout
-            f.options.open_timeout = config.timeout
-            f.options.write_timeout = config.timeout
           end
 
           Response.new(

--- a/app/services/proofing/socure/reason_codes/api_client.rb
+++ b/app/services/proofing/socure/reason_codes/api_client.rb
@@ -26,9 +26,6 @@ module Proofing
             f.response :raise_error
             f.response :json
             f.options.timeout = IdentityConfig.store.socure_reason_code_timeout_in_seconds
-            f.options.read_timeout = IdentityConfig.store.socure_reason_code_timeout_in_seconds
-            f.options.open_timeout = IdentityConfig.store.socure_reason_code_timeout_in_seconds
-            f.options.write_timeout = IdentityConfig.store.socure_reason_code_timeout_in_seconds
           end
 
           conn.get(url, { group: true }, headers) do |req|

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -39,6 +39,8 @@ class RecaptchaAnnotator
 
     def faraday
       Faraday.new do |conn|
+        conn.options.timeout = IdentityConfig.store.recaptcha_request_timeout_in_seconds
+
         conn.request :instrumentation, name: 'request_log.faraday'
         conn.request :json
         conn.response :json

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -119,9 +119,6 @@ module UspsInPersonProofing
     def faraday
       Faraday.new(headers: request_headers) do |conn|
         conn.options.timeout = IdentityConfig.store.usps_ipp_request_timeout
-        conn.options.read_timeout = IdentityConfig.store.usps_ipp_request_timeout
-        conn.options.open_timeout = IdentityConfig.store.usps_ipp_request_timeout
-        conn.options.write_timeout = IdentityConfig.store.usps_ipp_request_timeout
 
         # Log request metrics
         conn.request :instrumentation, name: 'request_metric.faraday'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -314,6 +314,7 @@ reauthn_window: 1200
 recaptcha_enterprise_api_key: ''
 recaptcha_enterprise_project_id: ''
 recaptcha_mock_validator: true
+recaptcha_request_timeout_in_seconds: 5
 recaptcha_secret_key: ''
 recaptcha_site_key: ''
 recommend_webauthn_platform_for_sms_ab_test_account_creation_percent: 0

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -350,6 +350,7 @@ module IdentityConfig
     config.add(:recaptcha_enterprise_api_key, type: :string)
     config.add(:recaptcha_enterprise_project_id, type: :string)
     config.add(:recaptcha_mock_validator, type: :boolean)
+    config.add(:recaptcha_request_timeout_in_seconds, type: :integer)
     config.add(:recaptcha_secret_key, type: :string)
     config.add(:recaptcha_site_key, type: :string)
     config.add(:recovery_code_length, type: :integer)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-14520](https://cm-jira.usa.gov/browse/LG-14520)


## 🛠 Summary of changes

- Add a new configurable parameter - `recaptcha_request_timeout_in_seconds`
- Use this parameter in Recaptcha form submissions and Recaptcha annotation submissions
- Remove redundant configuration of specific timeouts in other places where we make Faraday requests

## 📜 Testing Plan

It's hard to come up with a simple test plan for this. The best way is to look for timeouts that occur after deployment and confirm that they do not exceed the threshold that was set.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
