### PR TITLE
LG-14923 Update content for mobile required flow without facial matching

### DIFF
--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -96,7 +96,6 @@ module Idv
     end
 
     def mobile_required?
-      return false if idv_session.desktop_selfie_test_mode_enabled?
       idv_session.selfie_check_required || doc_auth_vendor == Idp::Constants::Vendors::SOCURE
     end
   end

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -5,6 +5,7 @@ module Idv
     include Idv::AvailabilityConcern
     include IdvStepConcern
     include RenderConditionConcern
+    include DocAuthVendorConcern
 
     before_action :confirm_step_allowed
     before_action :set_how_to_verify_presenter
@@ -86,8 +87,17 @@ module Idv
     end
 
     def set_how_to_verify_presenter
+      @mobile_required = mobile_required?
       @selfie_required = idv_session.selfie_check_required
-      @presenter = Idv::HowToVerifyPresenter.new(selfie_check_required: @selfie_required)
+      @presenter = Idv::HowToVerifyPresenter.new(
+        mobile_required: @mobile_required,
+        selfie_check_required: @selfie_required,
+      )
+    end
+
+    def mobile_required?
+      return false if idv_session.desktop_selfie_test_mode_enabled?
+      idv_session.selfie_check_required || doc_auth_vendor == Idp::Constants::Vendors::SOCURE
     end
   end
 end

--- a/app/presenters/idv/how_to_verify_presenter.rb
+++ b/app/presenters/idv/how_to_verify_presenter.rb
@@ -13,7 +13,7 @@ class Idv::HowToVerifyPresenter
 
   def how_to_verify_info
     if mobile_required
-      t('doc_auth.info.how_to_verify_selfie')
+      t('doc_auth.info.how_to_verify_mobile')
     else
       t('doc_auth.info.how_to_verify')
     end
@@ -37,7 +37,7 @@ class Idv::HowToVerifyPresenter
 
   def verify_online_text
     if mobile_required
-      t('doc_auth.headings.verify_online_selfie')
+      t('doc_auth.headings.verify_online_mobile')
     else
       t('doc_auth.headings.verify_online')
     end
@@ -52,7 +52,7 @@ class Idv::HowToVerifyPresenter
 
   def verify_online_description
     if mobile_required
-      t('doc_auth.info.verify_online_description_selfie')
+      t('doc_auth.info.verify_online_description_mobile')
     else
       t('doc_auth.info.verify_online_description')
     end
@@ -60,7 +60,7 @@ class Idv::HowToVerifyPresenter
 
   def submit
     if mobile_required
-      t('forms.buttons.continue_remote_selfie')
+      t('forms.buttons.continue_remote_mobile')
     else
       t('forms.buttons.continue_remote')
     end
@@ -76,7 +76,7 @@ class Idv::HowToVerifyPresenter
 
   def post_office_description
     if mobile_required
-      t('doc_auth.info.verify_at_post_office_description_selfie')
+      t('doc_auth.info.verify_at_post_office_description_mobile')
     else
       t('doc_auth.info.verify_at_post_office_description')
     end

--- a/app/presenters/idv/how_to_verify_presenter.rb
+++ b/app/presenters/idv/how_to_verify_presenter.rb
@@ -4,14 +4,15 @@ class Idv::HowToVerifyPresenter
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :selfie_required
+  attr_reader :mobile_required, :selfie_required
 
-  def initialize(selfie_check_required:)
+  def initialize(mobile_required:, selfie_check_required:)
+    @mobile_required = mobile_required
     @selfie_required = selfie_check_required
   end
 
   def how_to_verify_info
-    if selfie_required
+    if mobile_required
       t('doc_auth.info.how_to_verify_selfie')
     else
       t('doc_auth.info.how_to_verify')
@@ -19,7 +20,7 @@ class Idv::HowToVerifyPresenter
   end
 
   def asset_url
-    if selfie_required
+    if mobile_required
       'idv/mobile-phone-icon.svg'
     else
       'idv/remote.svg'
@@ -27,7 +28,7 @@ class Idv::HowToVerifyPresenter
   end
 
   def alt_text
-    if selfie_required
+    if mobile_required
       t('image_description.phone_icon')
     else
       t('image_description.laptop_and_phone')
@@ -35,7 +36,7 @@ class Idv::HowToVerifyPresenter
   end
 
   def verify_online_text
-    if selfie_required
+    if mobile_required
       t('doc_auth.headings.verify_online_selfie')
     else
       t('doc_auth.headings.verify_online')
@@ -43,15 +44,14 @@ class Idv::HowToVerifyPresenter
   end
 
   def verify_online_instruction
-    if selfie_required
-      t('doc_auth.info.verify_online_instruction_selfie')
-    else
-      t('doc_auth.info.verify_online_instruction')
-    end
+    return t('doc_auth.info.verify_online_instruction_selfie') if selfie_required
+    return t('doc_auth.info.verify_online_instruction_mobile_no_selfie') if mobile_required
+
+    t('doc_auth.info.verify_online_instruction')
   end
 
   def verify_online_description
-    if selfie_required
+    if mobile_required
       t('doc_auth.info.verify_online_description_selfie')
     else
       t('doc_auth.info.verify_online_description')
@@ -59,7 +59,7 @@ class Idv::HowToVerifyPresenter
   end
 
   def submit
-    if selfie_required
+    if mobile_required
       t('forms.buttons.continue_remote_selfie')
     else
       t('forms.buttons.continue_remote')
@@ -75,7 +75,7 @@ class Idv::HowToVerifyPresenter
   end
 
   def post_office_description
-    if selfie_required
+    if mobile_required
       t('doc_auth.info.verify_at_post_office_description_selfie')
     else
       t('doc_auth.info.verify_at_post_office_description')

--- a/app/views/idv/how_to_verify/show.html.erb
+++ b/app/views/idv/how_to_verify/show.html.erb
@@ -50,7 +50,7 @@
     <%= f.label(
           :selection_remote,
         ) do %>
-            <% if @selfie_required %>
+            <% if @mobile_required %>
                 <span class='usa-tag usa-tag--informative margin-bottom-2 margin-top-1'>
                   <%= t('doc_auth.tips.mobile_phone_required') %>
                 </span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -602,7 +602,7 @@ doc_auth.headings.upload_from_phone: Use your phone to take photos
 doc_auth.headings.verify_at_post_office: Verify your identity at a Post Office
 doc_auth.headings.verify_identity: Verify your identity
 doc_auth.headings.verify_online: Verify your identity online
-doc_auth.headings.verify_online_selfie: Verify your identity online using your phone
+doc_auth.headings.verify_online_mobile: Verify your identity online using your phone
 doc_auth.headings.verify_with_phone: Verify your identity using your phone
 doc_auth.headings.welcome: Let’s verify your identity for %{sp_name}
 doc_auth.hybrid_flow_warning.explanation_html: You’re using <strong>%{app_name}</strong> to verify your identity for access to <strong>%{service_provider_name}</strong> and its services.
@@ -623,7 +623,7 @@ doc_auth.info.exit.without_sp: Exit identity verification and go to your account
 doc_auth.info.getting_started_html: '%{sp_name} needs to make sure you are you — not someone pretending to be you. %{link_html}'
 doc_auth.info.getting_started_learn_more: Learn more about verifying your identity
 doc_auth.info.how_to_verify: You have the option to verify your identity online, or in person at a participating Post Office.
-doc_auth.info.how_to_verify_selfie: You have the option to verify your identity online with your phone, or in person at a participating Post Office.
+doc_auth.info.how_to_verify_mobile: You have the option to verify your identity online with your phone, or in person at a participating Post Office.
 doc_auth.info.how_to_verify_troubleshooting_options_header: Want to learn more about how to verify your identity?
 doc_auth.info.hybrid_handoff: We’ll collect information about you by reading your state‑issued ID.
 doc_auth.info.hybrid_handoff_ipp_html: '<strong>Don’t have a mobile phone?</strong> You can verify your identity at a United States Post Office instead.'
@@ -660,13 +660,13 @@ doc_auth.info.tag: Recommended
 doc_auth.info.upload_from_computer: Don’t have a phone? Upload photos of your ID from this computer.
 doc_auth.info.upload_from_phone: You won’t have to sign in again, and you’ll switch back to this computer after you take photos. Your mobile phone must have a camera and a web browser.
 doc_auth.info.verify_at_post_office_description: This option is better if you don’t have a phone to take photos of your ID.
-doc_auth.info.verify_at_post_office_description_selfie: Choose this option if you don’t have a phone to take pictures.
+doc_auth.info.verify_at_post_office_description_mobile: Choose this option if you don’t have a phone to take pictures.
 doc_auth.info.verify_at_post_office_instruction: You’ll enter your ID information online, and verify your identity in person at a participating Post Office.
 doc_auth.info.verify_at_post_office_instruction_selfie: You’ll enter your ID information online, and verify your identity in person at a participating Post Office.
 doc_auth.info.verify_at_post_office_link_text: Learn more about verifying in person
 doc_auth.info.verify_identity: We’ll ask for your ID, phone number, and other personal information to verify your identity against public records.
 doc_auth.info.verify_online_description: This option is better if you have a phone to take photos of your ID.
-doc_auth.info.verify_online_description_selfie: Choose this option if you have a phone to take pictures.
+doc_auth.info.verify_online_description_mobile: Choose this option if you have a phone to take pictures.
 doc_auth.info.verify_online_instruction: You’ll take photos of your ID to verify your identity fully online. Most users finish this process in one sitting.
 doc_auth.info.verify_online_instruction_mobile_no_selfie: You’ll take photos of your ID using a phone. Most users finish this process in one sitting.
 doc_auth.info.verify_online_instruction_selfie: You’ll take photos of your ID and a photo of yourself using a phone. Most users finish this process in one sitting.
@@ -847,7 +847,7 @@ forms.buttons.confirm: Confirm
 forms.buttons.continue: Continue
 forms.buttons.continue_ipp: Continue in person
 forms.buttons.continue_remote: Continue online
-forms.buttons.continue_remote_selfie: Continue on your phone
+forms.buttons.continue_remote_mobile: Continue on your phone
 forms.buttons.delete: Delete
 forms.buttons.disable: Delete
 forms.buttons.edit: Edit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -668,6 +668,7 @@ doc_auth.info.verify_identity: We’ll ask for your ID, phone number, and other 
 doc_auth.info.verify_online_description: This option is better if you have a phone to take photos of your ID.
 doc_auth.info.verify_online_description_selfie: Choose this option if you have a phone to take pictures.
 doc_auth.info.verify_online_instruction: You’ll take photos of your ID to verify your identity fully online. Most users finish this process in one sitting.
+doc_auth.info.verify_online_instruction_mobile_no_selfie: You’ll take photos of your ID using a phone. Most users finish this process in one sitting.
 doc_auth.info.verify_online_instruction_selfie: You’ll take photos of your ID and a photo of yourself using a phone. Most users finish this process in one sitting.
 doc_auth.info.verify_online_link_text: Learn more about verifying online
 doc_auth.info.you_entered: 'You entered:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -613,7 +613,7 @@ doc_auth.headings.upload_from_phone: Utilice su teléfono para tomar fotos
 doc_auth.headings.verify_at_post_office: Verifique su identidad en una oficina de correos
 doc_auth.headings.verify_identity: Verifique su identidad
 doc_auth.headings.verify_online: Verifique su identidad en línea
-doc_auth.headings.verify_online_selfie: Verifique su identidad en línea con su teléfono
+doc_auth.headings.verify_online_mobile: Verifique su identidad en línea con su teléfono
 doc_auth.headings.verify_with_phone: Verifique su identidad con su teléfono
 doc_auth.headings.welcome: Verifiquemos su identidad para %{sp_name}
 doc_auth.hybrid_flow_warning.explanation_html: Está utilizando <strong>%{app_name}</strong> para verificar su identidad y acceder a <strong>%{service_provider_name}</strong> y sus servicios.
@@ -634,7 +634,7 @@ doc_auth.info.exit.without_sp: Salga de la verificación de identidad y vaya a l
 doc_auth.info.getting_started_html: '%{sp_name} necesita asegurarse de que se trata de usted y no de alguien que se hace pasar por usted. %{link_html}'
 doc_auth.info.getting_started_learn_more: Obtenga más información sobre la verificación de su identidad
 doc_auth.info.how_to_verify: Tiene la opción de verificar su identidad en línea, o en persona en una oficina de correos participante.
-doc_auth.info.how_to_verify_selfie: Tiene la opción de verificar su identidad en línea con su teléfono, o en persona en una oficina de correos participante.
+doc_auth.info.how_to_verify_mobile: Tiene la opción de verificar su identidad en línea con su teléfono, o en persona en una oficina de correos participante.
 doc_auth.info.how_to_verify_troubleshooting_options_header: ¿Desea obtener más información sobre cómo verificar su identidad?
 doc_auth.info.hybrid_handoff: Recopilaremos información sobre usted leyendo su identificación emitida por el estado.
 doc_auth.info.hybrid_handoff_ipp_html: '<strong>¿No tiene un teléfono móvil?</strong> Puede verificar su identidad en una oficina de correos de los Estados Unidos.'
@@ -671,13 +671,13 @@ doc_auth.info.tag: Recomendado
 doc_auth.info.upload_from_computer: '¿No tiene un teléfono? Cargue fotos de su identificación desde esta computadora.'
 doc_auth.info.upload_from_phone: No tendrá que volver a iniciar sesión y volverá a esta computadora después de tomar las fotos. Su teléfono móvil debe tener una cámara y un navegador web.
 doc_auth.info.verify_at_post_office_description: Esta opción es mejor si no tiene un teléfono para tomar fotografías de su identificación.
-doc_auth.info.verify_at_post_office_description_selfie: Elija esta opción si no tiene un teléfono para tomar fotografías.
+doc_auth.info.verify_at_post_office_description_mobile: Elija esta opción si no tiene un teléfono para tomar fotografías.
 doc_auth.info.verify_at_post_office_instruction: Ingresará la información de su identificación en línea, y verificará su identidad en persona en una oficina de correos participante.
 doc_auth.info.verify_at_post_office_instruction_selfie: Ingresará la información de su identificación en línea, y verificará su identidad en persona en una oficina de correos participante.
 doc_auth.info.verify_at_post_office_link_text: Obtenga más información sobre la verificación en persona
 doc_auth.info.verify_identity: Le pediremos su identificación, número de teléfono y otros datos personales para verificar su identidad comparándola con los registros públicos.
 doc_auth.info.verify_online_description: Esta opción es mejor si tiene un teléfono para tomar fotografías de su identificación.
-doc_auth.info.verify_online_description_selfie: Elija esta opción si tiene un teléfono para tomar fotografías.
+doc_auth.info.verify_online_description_mobile: Elija esta opción si tiene un teléfono para tomar fotografías.
 doc_auth.info.verify_online_instruction: Tomará fotografías de su identificación para verificar su identidad por completo en línea. La mayoría de los usuarios logran terminar este proceso en una sola sesión.
 doc_auth.info.verify_online_instruction_mobile_no_selfie: Tomará fotografías de su identificación con un teléfono. La mayoría de los usuarios logran terminar este proceso en una sola sesión.
 doc_auth.info.verify_online_instruction_selfie: Tomará con un teléfono fotos de su identificación y una foto de usted. La mayoría de los usuarios logran terminar este proceso en una sola sesión.
@@ -858,7 +858,7 @@ forms.buttons.confirm: Confirmar
 forms.buttons.continue: Continuar
 forms.buttons.continue_ipp: Continúe en persona
 forms.buttons.continue_remote: Continúe en línea
-forms.buttons.continue_remote_selfie: Continúe en su teléfono
+forms.buttons.continue_remote_mobile: Continúe en su teléfono
 forms.buttons.delete: Eliminar
 forms.buttons.disable: Eliminar
 forms.buttons.edit: Editar

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -679,6 +679,7 @@ doc_auth.info.verify_identity: Le pediremos su identificación, número de telé
 doc_auth.info.verify_online_description: Esta opción es mejor si tiene un teléfono para tomar fotografías de su identificación.
 doc_auth.info.verify_online_description_selfie: Elija esta opción si tiene un teléfono para tomar fotografías.
 doc_auth.info.verify_online_instruction: Tomará fotografías de su identificación para verificar su identidad por completo en línea. La mayoría de los usuarios logran terminar este proceso en una sola sesión.
+doc_auth.info.verify_online_instruction_mobile_no_selfie: Tomará fotografías de su identificación con un teléfono. La mayoría de los usuarios logran terminar este proceso en una sola sesión.
 doc_auth.info.verify_online_instruction_selfie: Tomará con un teléfono fotos de su identificación y una foto de usted. La mayoría de los usuarios logran terminar este proceso en una sola sesión.
 doc_auth.info.verify_online_link_text: Obtenga más información sobre la verificación en línea
 doc_auth.info.you_entered: 'Usted ingresó:'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -602,7 +602,7 @@ doc_auth.headings.upload_from_phone: Utiliser votre téléphone pour prendre des
 doc_auth.headings.verify_at_post_office: Confirmer votre identité en personne dans un bureau de poste
 doc_auth.headings.verify_identity: Confirmer votre identité
 doc_auth.headings.verify_online: Confirmer votre identité en ligne
-doc_auth.headings.verify_online_selfie: Confirmer votre identité en ligne à l’aide de votre téléphone
+doc_auth.headings.verify_online_mobile: Confirmer votre identité en ligne à l’aide de votre téléphone
 doc_auth.headings.verify_with_phone: Confirmer votre identité à l’aide de votre téléphone
 doc_auth.headings.welcome: Vérifions votre identité auprès de %{sp_name}
 doc_auth.hybrid_flow_warning.explanation_html: Vous utilisez <strong>%{app_name}</strong> pour confirmer votre identité et accéder à <strong>%{service_provider_name}</strong> et à ses services.
@@ -623,7 +623,7 @@ doc_auth.info.exit.without_sp: Quitter la vérification d’identité et accéde
 doc_auth.info.getting_started_html: '%{sp_name} doit s’assurer qu’il s’agit bien de vous et non de quelqu’un qui se fait passer pour vous. %{link_html}'
 doc_auth.info.getting_started_learn_more: En savoir plus sur la vérification de votre identité
 doc_auth.info.how_to_verify: Vous pouvez confirmer votre identité en ligne ou en personne dans un bureau de poste participant.
-doc_auth.info.how_to_verify_selfie: Vous avez la possibilité de confirmer votre identité en ligne avec votre téléphone ou en personne dans un bureau de poste participant.
+doc_auth.info.how_to_verify_mobile: Vous avez la possibilité de confirmer votre identité en ligne avec votre téléphone ou en personne dans un bureau de poste participant.
 doc_auth.info.how_to_verify_troubleshooting_options_header: Vous voulez en savoir plus sur la façon de confirmer votre identité?
 doc_auth.info.hybrid_handoff: Nous recueillerons des informations vous concernant en lisant votre pièce d’identité délivrée par un État.
 doc_auth.info.hybrid_handoff_ipp_html: '<strong>Vous n’avez pas de téléphone portable?</strong> Vous pouvez confirmer votre identité dans un bureau de poste américain participant.'
@@ -660,13 +660,13 @@ doc_auth.info.tag: Recommandation
 doc_auth.info.upload_from_computer: Vous n’avez pas de téléphone ? Téléchargez les photos de votre pièce d’identité depuis cet ordinateur.
 doc_auth.info.upload_from_phone: Vous n’aurez pas à vous reconnecter. Vous reviendrez sur cet ordinateur après avoir pris des photos. Votre téléphone portable doit être équipé d’un appareil photo et d’un navigateur web.
 doc_auth.info.verify_at_post_office_description: Cette option est préférable si vous n’avez pas de téléphone permettant de prendre des photos de votre pièce d’identité.
-doc_auth.info.verify_at_post_office_description_selfie: Choisissez cette option si vous ne disposez pas d’un téléphone permettant de prendre des photos.
+doc_auth.info.verify_at_post_office_description_mobile: Choisissez cette option si vous ne disposez pas d’un téléphone permettant de prendre des photos.
 doc_auth.info.verify_at_post_office_instruction: Vous saisirez vos données d’identification en ligne et confirmerez votre identité en personne dans un bureau de poste participant.
 doc_auth.info.verify_at_post_office_instruction_selfie: Vous saisirez vos données d’identification en ligne et confirmez votre identité en personne dans un bureau de poste participant.
 doc_auth.info.verify_at_post_office_link_text: En savoir plus sur la vérification en personne
 doc_auth.info.verify_identity: Nous vous demanderons votre pièce d’identité, numéro de téléphone et d’autres renseignements personnels afin de confirmer votre identité par rapport aux registres publics.
 doc_auth.info.verify_online_description: Cette option est préférable si vous disposez d’un téléphone permettant de prendre des photos de votre pièce d’identité.
-doc_auth.info.verify_online_description_selfie: Choisissez cette option si vous disposez d’un téléphone permettant de prendre des photos.
+doc_auth.info.verify_online_description_mobile: Choisissez cette option si vous disposez d’un téléphone permettant de prendre des photos.
 doc_auth.info.verify_online_instruction: Vous prendrez des photos de votre pièce d’identité pour confirmer votre identité entièrement en ligne. La plupart des utilisateurs y parviennent en une seule prise.
 doc_auth.info.verify_online_instruction_mobile_no_selfie: Vous prendrez des photos de votre pièce d’identité à l’aide d’un téléphone. La plupart des utilisateurs effectuent l’ensemble du processus en une seule fois.
 doc_auth.info.verify_online_instruction_selfie: Vous prendrez des photos de votre pièce d’identité et une photo de vous-même avec un téléphone. La plupart des utilisateurs y parviennent en une seule prise.
@@ -847,7 +847,7 @@ forms.buttons.confirm: Confirmer
 forms.buttons.continue: Suite
 forms.buttons.continue_ipp: Continuer en personne
 forms.buttons.continue_remote: Continuer en ligne
-forms.buttons.continue_remote_selfie: Continuer sur votre téléphone
+forms.buttons.continue_remote_mobile: Continuer sur votre téléphone
 forms.buttons.delete: Supprimer
 forms.buttons.disable: Supprimer
 forms.buttons.edit: Modifier

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -668,6 +668,7 @@ doc_auth.info.verify_identity: Nous vous demanderons votre pièce d’identité,
 doc_auth.info.verify_online_description: Cette option est préférable si vous disposez d’un téléphone permettant de prendre des photos de votre pièce d’identité.
 doc_auth.info.verify_online_description_selfie: Choisissez cette option si vous disposez d’un téléphone permettant de prendre des photos.
 doc_auth.info.verify_online_instruction: Vous prendrez des photos de votre pièce d’identité pour confirmer votre identité entièrement en ligne. La plupart des utilisateurs y parviennent en une seule prise.
+doc_auth.info.verify_online_instruction_mobile_no_selfie: Vous prendrez des photos de votre pièce d’identité à l’aide d’un téléphone. La plupart des utilisateurs effectuent l’ensemble du processus en une seule fois.
 doc_auth.info.verify_online_instruction_selfie: Vous prendrez des photos de votre pièce d’identité et une photo de vous-même avec un téléphone. La plupart des utilisateurs y parviennent en une seule prise.
 doc_auth.info.verify_online_link_text: En savoir plus sur la vérification en ligne
 doc_auth.info.you_entered: 'Vous avez saisi :'

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -679,6 +679,7 @@ doc_auth.info.verify_identity: 我们会要求获得你的身份识别、电话�
 doc_auth.info.verify_online_description: 如果你没有移动设备或者无法轻松拍身份证件照片，这一选项更好。
 doc_auth.info.verify_online_description_selfie: 如果你有手机可以拍照，请选择该选项。
 doc_auth.info.verify_online_instruction: 你将拍身份证件的照片来完全在网上验证身份。大多数用户都能轻松完成这样流程。
+doc_auth.info.verify_online_instruction_mobile_no_selfie: 你将使用手机拍摄你的身份证件照片。大多数用户一次就能完成这个流程。
 doc_auth.info.verify_online_instruction_selfie: 你将用手机拍摄身份证件和本人的照片。大多数用户都能轻松完成这一流程。
 doc_auth.info.verify_online_link_text: 对网上验证获得更多了解
 doc_auth.info.you_entered: 你输入了：

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -613,7 +613,7 @@ doc_auth.headings.upload_from_phone: 使用手机拍照
 doc_auth.headings.verify_at_post_office: 去邮局验证身份
 doc_auth.headings.verify_identity: 验证你的身份
 doc_auth.headings.verify_online: 在网上验证身份
-doc_auth.headings.verify_online_selfie: 使用手机在网上验证你的身份
+doc_auth.headings.verify_online_mobile: 使用手机在网上验证你的身份
 doc_auth.headings.verify_with_phone: 使用你的电话来验证你的身份
 doc_auth.headings.welcome: 现在我们来为%{sp_name}验证你的身份
 doc_auth.hybrid_flow_warning.explanation_html: 你在使用 <strong>%{app_name}</strong> 验证身份以访问 <strong>%{service_provider_name}</strong> 及其服务。
@@ -634,7 +634,7 @@ doc_auth.info.exit.without_sp: 退出身份验证并到你的账户页面
 doc_auth.info.getting_started_html: '%{sp_name} 需要确保你是你，而不是别人冒充你。 了解更多有关验证你身份的信息 %{link_html}'
 doc_auth.info.getting_started_learn_more: 了解有关验证你身份的更多信息
 doc_auth.info.how_to_verify: 你可以选择在网上验证身份或者到参与本项目的邮局亲身验证身份。
-doc_auth.info.how_to_verify_selfie: 你可以选择用你的手机在网上验证身份或者到参与本项目的邮局亲身验证身份。
+doc_auth.info.how_to_verify_mobile: 你可以选择用你的手机在网上验证身份或者到参与本项目的邮局亲身验证身份。
 doc_auth.info.how_to_verify_troubleshooting_options_header: 想对验证身份获得更多了解吗？
 doc_auth.info.hybrid_handoff: 我们将通过读取州政府颁发给你的身份证件来收集你的信息。
 doc_auth.info.hybrid_handoff_ipp_html: '<strong>没有手机？</strong>你可以去一个美国邮局验证身份。'
@@ -671,13 +671,13 @@ doc_auth.info.tag: 建议
 doc_auth.info.upload_from_computer: 没有手机？从该电脑上传你身份证件的照片。
 doc_auth.info.upload_from_phone: 你不必重新登录，而且拍完照后可以转回到该电脑。你的手机必须带有相机和网络浏览器。
 doc_auth.info.verify_at_post_office_description: 如果你没有手机拍身份证件照片，这一选项更好。
-doc_auth.info.verify_at_post_office_description_selfie: 如果你没有手机可以拍照，请选择该选项
+doc_auth.info.verify_at_post_office_description_mobile: 如果你没有手机可以拍照，请选择该选项
 doc_auth.info.verify_at_post_office_instruction: 你在网上输入身份证件信息，然后到一个参与本项目的邮局去亲身验证身份。
 doc_auth.info.verify_at_post_office_instruction_selfie: 你在网上输入身份证件信息，然后到一个参与本项目的邮局去亲身验证身份。
 doc_auth.info.verify_at_post_office_link_text: 对亲身验证获得更多了解
 doc_auth.info.verify_identity: 我们会要求获得你的身份识别、电话号码和其他个人信息并通过与公共记录核对来验证你的身份。
 doc_auth.info.verify_online_description: 如果你没有移动设备或者无法轻松拍身份证件照片，这一选项更好。
-doc_auth.info.verify_online_description_selfie: 如果你有手机可以拍照，请选择该选项。
+doc_auth.info.verify_online_description_mobile: 如果你有手机可以拍照，请选择该选项。
 doc_auth.info.verify_online_instruction: 你将拍身份证件的照片来完全在网上验证身份。大多数用户都能轻松完成这样流程。
 doc_auth.info.verify_online_instruction_mobile_no_selfie: 你将使用手机拍摄你的身份证件照片。大多数用户一次就能完成这个流程。
 doc_auth.info.verify_online_instruction_selfie: 你将用手机拍摄身份证件和本人的照片。大多数用户都能轻松完成这一流程。
@@ -858,7 +858,7 @@ forms.buttons.confirm: 确认
 forms.buttons.continue: 继续
 forms.buttons.continue_ipp: 继续亲身验证
 forms.buttons.continue_remote: 继续在网上验证
-forms.buttons.continue_remote_selfie: 在手机上继续
+forms.buttons.continue_remote_mobile: 在手机上继续
 forms.buttons.delete: 删除
 forms.buttons.disable: 删除
 forms.buttons.edit: 编辑

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -385,7 +385,7 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
           end
           describe 'when selfie is required by sp' do
             before do
-              click_on t('forms.buttons.continue_remote_selfie')
+              click_on t('forms.buttons.continue_remote_mobile')
             end
             it 'shows selfie version of top content and ipp option section' do
               verify_handoff_page_selfie_version_content(page)

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -103,7 +103,7 @@ module DocAuthHelper
     complete_agreement_step
     if remote
       if facial_match_required
-        click_on t('forms.buttons.continue_remote_selfie')
+        click_on t('forms.buttons.continue_remote_mobile')
       else
         click_on t('forms.buttons.continue_remote')
       end

--- a/spec/views/idv/how_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/how_to_verify/show.html.erb_spec.rb
@@ -2,8 +2,14 @@ require 'rails_helper'
 
 RSpec.describe 'idv/how_to_verify/show.html.erb' do
   selection = Idv::HowToVerifyForm::IPP
+  let(:mobile_required) { false }
   let(:selfie_check_required) { false }
-  let(:presenter) { Idv::HowToVerifyPresenter.new(selfie_check_required: selfie_check_required) }
+  let(:presenter) do
+    Idv::HowToVerifyPresenter.new(
+      mobile_required: mobile_required,
+      selfie_check_required: selfie_check_required,
+    )
+  end
   let(:idv_how_to_verify_form) { Idv::HowToVerifyForm.new(selection: selection) }
 
   before do
@@ -11,9 +17,10 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     assign(:presenter, presenter)
     assign :idv_how_to_verify_form, idv_how_to_verify_form
   end
-  context 'when selfie is not required' do
+  context 'when mobile is not required' do
     before do
-      @selfie_required = false
+      @mobile_required = mobile_required
+      @selfie_required = selfie_check_required
       render
     end
 
@@ -61,11 +68,13 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     end
   end
 
-  context 'when selfie is required' do
-    let(:selfie_check_required) { true }
+  context 'when mobile is required' do
+    let(:selfie_check_required) { false }
+    let(:mobile_required) { true }
 
     before do
-      @selfie_required = true
+      @selfie_required = selfie_check_required
+      @mobile_required = mobile_required
       render
     end
 
@@ -102,17 +111,27 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
       expect(rendered).to have_link(t('links.cancel'))
     end
 
-    it 'renders selfie specific content' do
-      expect(rendered).to have_content(t('doc_auth.info.how_to_verify_selfie'))
-      expect(rendered).to have_content(t('doc_auth.tips.mobile_phone_required'))
-      expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
-      expect(rendered).to have_content(t('doc_auth.info.verify_online_description_selfie'))
+    it 'renders mobile specific content' do
       expect(rendered).to have_content(
-        t('doc_auth.info.verify_at_post_office_instruction_selfie'),
+        t('doc_auth.info.verify_online_instruction_mobile_no_selfie'),
       )
-      expect(rendered).to have_content(
-        t('doc_auth.info.verify_at_post_office_description_selfie'),
-      )
+    end
+
+    context 'when selfie is required' do
+      let(:selfie_check_required) { true }
+
+      it 'renders selfie specific content' do
+        expect(rendered).to have_content(t('doc_auth.info.how_to_verify_selfie'))
+        expect(rendered).to have_content(t('doc_auth.tips.mobile_phone_required'))
+        expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
+        expect(rendered).to have_content(t('doc_auth.info.verify_online_description_selfie'))
+        expect(rendered).to have_content(
+          t('doc_auth.info.verify_at_post_office_instruction_selfie'),
+        )
+        expect(rendered).to have_content(
+          t('doc_auth.info.verify_at_post_office_description_selfie'),
+        )
+      end
     end
   end
 end

--- a/spec/views/idv/how_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/how_to_verify/show.html.erb_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     end
 
     it 'renders two options for verifying your identity' do
-      expect(rendered).to have_content(t('doc_auth.headings.verify_online_selfie'))
+      expect(rendered).to have_content(t('doc_auth.headings.verify_online_mobile'))
       expect(rendered).to have_content(t('doc_auth.headings.verify_at_post_office'))
     end
 
     it 'renders a button for remote and ipp' do
-      expect(rendered).to have_button(t('forms.buttons.continue_remote_selfie'))
+      expect(rendered).to have_button(t('forms.buttons.continue_remote_mobile'))
       expect(rendered).to have_button(t('forms.buttons.continue_ipp'))
     end
 
@@ -121,15 +121,15 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
       let(:selfie_check_required) { true }
 
       it 'renders selfie specific content' do
-        expect(rendered).to have_content(t('doc_auth.info.how_to_verify_selfie'))
+        expect(rendered).to have_content(t('doc_auth.info.how_to_verify_mobile'))
         expect(rendered).to have_content(t('doc_auth.tips.mobile_phone_required'))
         expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
-        expect(rendered).to have_content(t('doc_auth.info.verify_online_description_selfie'))
+        expect(rendered).to have_content(t('doc_auth.info.verify_online_description_mobile'))
         expect(rendered).to have_content(
           t('doc_auth.info.verify_at_post_office_instruction_selfie'),
         )
         expect(rendered).to have_content(
-          t('doc_auth.info.verify_at_post_office_description_selfie'),
+          t('doc_auth.info.verify_at_post_office_description_mobile'),
         )
       end
     end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-14923](https://cm-jira.usa.gov/browse/LG-14923)



## 🛠 Summary of changes

Update the content for the "How To Verify" page to include a mobile flow without mentioning taking a selfie.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Make sure socure is enabled and the default vendor an you have the right IPP variables to allow "How to Verify Page"  `in_person_proofing_enabled: true, in_person_proofing_opt_in_enabled: true`
- [ ] Go through IdV with a Service Provider and check Identity Verified w/o facial matching
- [ ] Verify the "How to Verify Page" mentions mobile but does not mention selfie.



## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<img width="816" alt="Screenshot 2024-12-04 at 11 17 36 AM" src="https://github.com/user-attachments/assets/2e42a378-5eec-44b2-bc24-551ff720d032">

<img width="792" alt="Screenshot 2024-12-04 at 11 17 48 AM" src="https://github.com/user-attachments/assets/57e76416-c428-4d48-8184-912fd574b55a">

<img width="779" alt="Screenshot 2024-12-04 at 11 18 01 AM" src="https://github.com/user-attachments/assets/a409cda8-3af5-4462-a653-40db405b4d8f">

<img width="743" alt="Screenshot 2024-12-04 at 11 18 12 AM" src="https://github.com/user-attachments/assets/7cc1bcb6-b5a5-40b9-9e79-a7eecc5d2b18">




