### PR TITLE
Update saml_idp gem to add support for AES-GCM encryption algorithms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.3-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.4-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false
@@ -85,7 +85,7 @@ gem 'valid_email', '>= 0.1.3', github: 'hallelujah/valid_email', ref: '486b860'
 gem 'view_component', '~> 3.0'
 gem 'webauthn', '~> 2.5.2'
 gem 'xmldsig', '~> 0.6'
-gem 'xmlenc', '~> 0.7', '>= 0.7.1'
+gem 'xmlenc', '0.8.0'
 gem 'yard', require: false
 gem 'zlib', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,10 +36,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: 752085a6f88cd3ce75ecc7a64afe064a0e4f9e35
-  tag: 0.23.3-18f
+  revision: e5d876cf10ce9b39bba0cc523d06c4dda1af5124
+  tag: 0.23.4-18f
   specs:
-    saml_idp (0.23.3.pre.18f)
+    saml_idp (0.23.4.pre.18f)
       activesupport
       builder
       faraday
@@ -869,7 +869,7 @@ DEPENDENCIES
   webauthn (~> 2.5.2)
   webmock
   xmldsig (~> 0.6)
-  xmlenc (~> 0.7, >= 0.7.1)
+  xmlenc (= 0.8.0)
   yard
   zlib
   zonebie


### PR DESCRIPTION
## 🛠 Summary of changes

Brings in the changes from https://github.com/18F/saml_idp/pull/129 to add IDP support for AES-GCM encryption of SAML responses. Other changes are required within our service provider configurations and partner portal, so it is not available quite yet, but allows for testing manually outside of those contexts.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
