### PR TITLE
Exclude old IAAs from Combined Invoice Supplement Report V2

### DIFF
--- a/app/jobs/reports/combined_invoice_supplement_report_v2.rb
+++ b/app/jobs/reports/combined_invoice_supplement_report_v2.rb
@@ -7,7 +7,9 @@ module Reports
     REPORT_NAME = 'combined-invoice-supplement-report-v2'
 
     def perform(_date)
-      csv = build_csv(IaaReportingHelper.iaas, IaaReportingHelper.partner_accounts)
+      # Exclude IAAs that ended more than 90 days ago
+      iaas = IaaReportingHelper.iaas.filter { |x| x.end_date > 90.days.ago }
+      csv = build_csv(iaas, IaaReportingHelper.partner_accounts)
       save_report(REPORT_NAME, csv, extension: 'csv')
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Currently, the Combined Invoice Supplement Report V2 takes a long time to run. The report runs across all IAAs in the database. Since this report is primarily used for billing, inactive IAAs are less relevant. In speaking with those consuming this report, they suggested we could safely exclude IAAs that have been expired for more than 90 days, so this PR does that.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
