### PR TITLE
Improve autocomplete compatibility for sign-in form

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -29,7 +29,10 @@
         name: :email,
         label: t('account.index.email'),
         required: true,
-        input_html: { autocorrect: 'off' },
+        input_html: {
+          autocomplete: 'username',
+          autocorrect: 'off',
+        },
       ) %>
   <%= render PasswordToggleComponent.new(
         form: f,

--- a/app/views/shared/_ssn_field.html.erb
+++ b/app/views/shared/_ssn_field.html.erb
@@ -15,6 +15,12 @@ locals:
         required: true,
         pattern: '^\d{3}-?\d{2}-?\d{4}$',
         maxlength: 11,
+        # There is currently no appropriate autocomplete option for Social Security Number. Ongoing
+        # spec discussions may lead to a "national-identification-number" or equivalent, but this is
+        # not available at the time of writing.
+        #
+        # See: https://github.com/whatwg/html/issues/5740
+        autocomplete: 'off',
         input_html: { class: 'ssn-toggle', value: f.object.ssn },
         error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.ssn') },
       },

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -14,6 +14,7 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_argument('--no-sandbox')
   options.add_argument('--disable-dev-shm-usage')
   options.add_argument("--proxy-server=127.0.0.1:#{Capybara::Webmock.port_number}")
+  options.add_option('goog:loggingPrefs', { browser: 'ALL' })
 
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,
@@ -35,6 +36,7 @@ Capybara.register_driver(:headless_chrome_mobile) do |app|
   options.add_argument("--user-agent='#{user_agent_string}'")
   options.add_argument('--use-fake-device-for-media-stream')
   options.add_argument("--proxy-server=127.0.0.1:#{Capybara::Webmock.port_number}")
+  options.add_option('goog:loggingPrefs', { browser: 'ALL' })
 
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the sign-in form to assign `autocomplete=username` to the email address field.

This resolves a log message that's output in Chrome when all levels of console logging are visible:

![image](https://github.com/user-attachments/assets/b9f7c5ee-93dc-404d-90eb-d316d9e03185)

To simulate this and add regression coverage, the logging preference for the Capybara Selenium ChromeDriver has been changed to output all logs, so that it'd be caught by existing [log output checking](https://github.com/18F/identity-idp/blob/5a76ef8ce84f191c1521e64e3e8863c46801fbfe/spec/rails_helper.rb#L139-L152).

While we accept email addresses as the username, `autocomplete=username` appears to be the correct value for use in a sign-in form.

Related resources:

- [As defined by the spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#control-group-username), the Username group includes inputs with `type=email`
- [Chrome sign-in form best practices recommendations](https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/) includes an example with `type=email autocomplete=username`
- [Spec authors clarify](https://github.com/whatwg/html/issues/4445#issuecomment-476588308) that `autocomplete=username` is compatible with usernames taking the form of an email address is valid
- [Related StackOverflow answer](https://stackoverflow.com/a/57902690)

## 📜 Testing Plan

Verify no console output:

1. Go to http://localhost:3000
2. Open Chrome DevTools console
3. If dropdown shows "Default levels", expand and ensure "Verbose" is checked ([screenshot](https://github.com/user-attachments/assets/5a758f22-96f6-4c63-b66a-80257e285488))
4. Refresh the page
5. Verify no console output related to `autocomplete` attribute

Verify test coverage:

1. `git checkout main -- app/views/devise/sessions/new.html.erb`
2. `rspec spec/features/accessibility/visitor_pages_spec.rb:6`
3. See output:

```
  1) Accessibility on pages that do not require authentication login / root path
     Failure/Error: raise BrowserConsoleLogError.new(javascript_errors) if javascript_errors.present?
     
     BrowserConsoleLogError:
       Unexpected browser console logging:
     
       http://127.0.0.1:58253/ - [DOM] Input elements should have autocomplete attributes (suggested: "username"): (More info: https://goo.gl/9p2vKq) %o
```