### PR TITLE
LG-15197: Omit policy_details_api from ThreatMetrix response body logging

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/response_redacter.rb
+++ b/app/services/proofing/lexis_nexis/ddp/response_redacter.rb
@@ -152,7 +152,6 @@ module Proofing
           national_id_worst_score
           org_id
           policy
-          policy_details_api
           policy_engine_version
           policy_score
           page_time_on


### PR DESCRIPTION
## 🎫 Ticket

[LG-15197](https://cm-jira.usa.gov/browse/LG-15197)

## 🛠 Summary of changes

Updates ThreatMetrix `ResponseRedactor` to remove `policy_details_api` from the list of allowed fields, to prevent it from being logged.

The `policy_details_api` field value is very large, and its properties are available through another of the logged fields (`tmx_variables`). The net effect of removing `policy_details_api` is a 73% reduction in the log size for the `response_body` field.

## 📜 Testing Plan

While there's no test coverage spanning individual keys, the allowlist behavior can be verified with existing specs for the redactor class:

```
rspec spec/services/proofing/lexis_nexis/ddp/response_redacter_spec.rb
```