### PR TITLE
Minor refactor of profile handling in EnterPasswordController

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -127,7 +127,7 @@ module Idv
     end
 
     def init_profile
-      idv_session.create_profile_from_applicant_with_password(
+      profile = idv_session.create_profile_from_applicant_with_password(
         password,
         is_enhanced_ipp: resolved_authn_context_result.enhanced_ipp?,
         proofing_components: ProofingComponents.new(
@@ -137,12 +137,13 @@ module Idv
           user_session:,
         ).to_h,
       )
-      if idv_session.verify_by_mail?
+
+      if profile.gpo_verification_pending?
         current_user.send_email_to_all_addresses(:verify_by_mail_letter_requested)
         log_letter_enqueued_analytics(resend: false)
       end
 
-      if idv_session.profile.active?
+      if profile.active?
         create_user_event(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           profile: idv_session.profile,

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -105,6 +105,7 @@ module Idv
       VALID_SESSION_ATTRIBUTES.include?(attr_name_sym) || super
     end
 
+    # @return [Profile]
     def create_profile_from_applicant_with_password(
       user_password, is_enhanced_ipp:, proofing_components:
     )
@@ -141,6 +142,8 @@ module Idv
       if profile.gpo_verification_pending?
         create_gpo_entry(profile_maker.pii_attributes, profile)
       end
+
+      profile
     end
 
     def opt_in_param


### PR DESCRIPTION
Return a Profile from Idv::Session::create_profile_from_applicant_with_password, then use that directly in EnterPasswordController.

