### PR TITLE
LG-15000: Add idv_please_call email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -248,6 +248,20 @@ class UserMailer < ActionMailer::Base
     end
   end
 
+  def idv_please_call(**)
+    with_user_locale(user) do
+      @hide_title = true
+
+      mail(
+        to: email_address.email,
+        subject: t('user_mailer.idv_please_call.subject', app_name: APP_NAME),
+        template_name: 'idv_please_call',
+      )
+    end
+  end
+
+  alias_method :in_person_please_call, :idv_please_call
+
   def in_person_completion_survey
     with_user_locale(user) do
       @header = t('user_mailer.in_person_completion_survey.header')
@@ -369,21 +383,6 @@ class UserMailer < ActionMailer::Base
       mail(
         to: email_address.email,
         subject: t('user_mailer.in_person_failed_suspected_fraud.subject'),
-      )
-    end
-  end
-
-  def in_person_please_call(enrollment:, visited_location_name: nil)
-    with_user_locale(user) do
-      @presenter = Idv::InPerson::VerificationResultsEmailPresenter.new(
-        enrollment: enrollment,
-        url_options: url_options,
-        visited_location_name: visited_location_name,
-      )
-      @hide_title = true
-      mail(
-        to: email_address.email,
-        subject: t('user_mailer.in_person_please_call.subject', app_name: APP_NAME),
       )
     end
   end

--- a/app/views/user_mailer/idv_please_call.html.erb
+++ b/app/views/user_mailer/idv_please_call.html.erb
@@ -4,16 +4,16 @@
       width: 88,
       height: 88,
     ) %>
-<h1><%= t('user_mailer.in_person_please_call.header') %></h1>
+<h1><%= t('user_mailer.idv_please_call.header') %></h1>
 <p>
   <%= t(
-        'user_mailer.in_person_please_call.body.intro_html',
+        'user_mailer.idv_please_call.body.intro_html',
         date: I18n.l(14.days.from_now, format: I18n.t('time.formats.full_date')),
       ) %>
 </p>
 <p>
   <%= t(
-        'user_mailer.in_person_please_call.body.contact_message_html',
+        'user_mailer.idv_please_call.body.contact_message_html',
         contact_number: IdentityConfig.store.idv_contact_phone_number,
         support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code,
       ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1875,6 +1875,10 @@ user_mailer.email_deleted.header: An email address was deleted from your %{app_n
 user_mailer.email_deleted.help_html: If you did not want to delete this email address, please visit the %{app_name_html} %{help_link_html} or %{contact_link_html}.
 user_mailer.email_deleted.subject: Email address deleted
 user_mailer.help_link_text: Help Center
+user_mailer.idv_please_call.body.contact_message_html: Call <strong>%{contact_number}</strong> and provide them with the error code <strong>%{support_code}</strong>.
+user_mailer.idv_please_call.body.intro_html: Call our contact center by <strong>%{date}</strong> to continue verifying your identity.
+user_mailer.idv_please_call.header: Please give us a call
+user_mailer.idv_please_call.subject: Call %{app_name} to continue with your identity verification
 user_mailer.in_person_completion_survey.body.cta.callout: Click the button below to get started.
 user_mailer.in_person_completion_survey.body.cta.label: Take our survey
 user_mailer.in_person_completion_survey.body.greeting: Hello,
@@ -1900,10 +1904,6 @@ user_mailer.in_person_failed.intro: Your identity could not be verified at the %
 user_mailer.in_person_failed.subject: Your identity could not be verified in person
 user_mailer.in_person_failed.verifying_identity: 'When verifying your identity:'
 user_mailer.in_person_failed.verifying_step_not_expired: Your state‑issued ID or driver’s license must not be expired. We do not currently accept any other forms of identification, such as passports and military IDs.
-user_mailer.in_person_please_call.body.contact_message_html: Call <strong>%{contact_number}</strong> and provide them with the error code <strong>%{support_code}</strong>.
-user_mailer.in_person_please_call.body.intro_html: Call our contact center by <strong>%{date}</strong> to continue verifying your identity.
-user_mailer.in_person_please_call.header: Please give us a call
-user_mailer.in_person_please_call.subject: Call %{app_name} to continue with your identity verification
 user_mailer.in_person_ready_to_verify_reminder.greeting: Hello,
 user_mailer.in_person_ready_to_verify_reminder.heading.one: You have %{count} day left to verify your identity in person
 user_mailer.in_person_ready_to_verify_reminder.heading.other: You have %{count} days left to verify your identity in person

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1887,6 +1887,10 @@ user_mailer.email_deleted.header: Se eliminó una dirección de correo electrón
 user_mailer.email_deleted.help_html: Si no deseaba eliminar esta dirección de correo electrónico, visite %{help_link_html} de %{app_name_html} o %{contact_link_html}.
 user_mailer.email_deleted.subject: Dirección de correo electrónico eliminada
 user_mailer.help_link_text: Centro de ayuda
+user_mailer.idv_please_call.body.contact_message_html: Llame al <strong>%{contact_number}</strong> y proporcione el código de error <strong>%{support_code}</strong>.
+user_mailer.idv_please_call.body.intro_html: Llame a nuestro centro de contacto antes del <strong>%{date}</strong> para seguir verificando su identidad.
+user_mailer.idv_please_call.header: Llámenos
+user_mailer.idv_please_call.subject: Llame a %{app_name} para continuar con la verificación de identidad
 user_mailer.in_person_completion_survey.body.cta.callout: Haga clic en el botón siguiente para empezar.
 user_mailer.in_person_completion_survey.body.cta.label: Responda a nuestra encuesta
 user_mailer.in_person_completion_survey.body.greeting: 'Hola:'
@@ -1912,10 +1916,6 @@ user_mailer.in_person_failed.intro: No se pudo verificar su identidad en la ofic
 user_mailer.in_person_failed.subject: No se pudo verificar su identidad en persona
 user_mailer.in_person_failed.verifying_identity: 'Cuando verifique su identidad:'
 user_mailer.in_person_failed.verifying_step_not_expired: Su licencia de conducir o identificación emitida por el estado debe estar vigente. Actualmente no aceptamos otras formas de identificación, como pasaportes o identificaciones militares.
-user_mailer.in_person_please_call.body.contact_message_html: Llame al <strong>%{contact_number}</strong> y proporcione el código de error <strong>%{support_code}</strong>.
-user_mailer.in_person_please_call.body.intro_html: Llame a nuestro centro de contacto antes del <strong>%{date}</strong> para seguir verificando su identidad.
-user_mailer.in_person_please_call.header: Llámenos
-user_mailer.in_person_please_call.subject: Llame a %{app_name} para continuar con la verificación de identidad
 user_mailer.in_person_ready_to_verify_reminder.greeting: 'Hola:'
 user_mailer.in_person_ready_to_verify_reminder.heading.one: Le queda %{count} día para verificar su identidad en persona
 user_mailer.in_person_ready_to_verify_reminder.heading.other: Le quedan %{count} días para verificar su identidad en persona

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1875,6 +1875,10 @@ user_mailer.email_deleted.header: Une adresse e-mail a été supprimée de votre
 user_mailer.email_deleted.help_html: Si vous ne souhaitez pas supprimer cette adresse e-mail, veuillez visiter le %{help_link_html} de %{app_name_html} ou %{contact_link_html}.
 user_mailer.email_deleted.subject: Adresse e-mail supprimée
 user_mailer.help_link_text: Centre d’aide
+user_mailer.idv_please_call.body.contact_message_html: Appelez le <strong>%{contact_number}</strong> et indiquez le code d’erreur <strong>%{support_code}</strong>.
+user_mailer.idv_please_call.body.intro_html: Appelez notre centre de contact avant le <strong>%{date}</strong> pour continuer à vérifier votre identité.
+user_mailer.idv_please_call.header: S’il vous plaît, appelez-nous
+user_mailer.idv_please_call.subject: Appeler %{app_name} afin de poursuivre la vérification de votre identité
 user_mailer.in_person_completion_survey.body.cta.callout: Cliquez sur le bouton ci-dessous pour commencer.
 user_mailer.in_person_completion_survey.body.cta.label: Répondez à notre enquête
 user_mailer.in_person_completion_survey.body.greeting: Bonjour,
@@ -1900,10 +1904,6 @@ user_mailer.in_person_failed.intro: Votre identité n’a pas pu être vérifié
 user_mailer.in_person_failed.subject: Votre identité n’a pas pu être vérifiée en personne
 user_mailer.in_person_failed.verifying_identity: 'Lors de la vérification de votre identité :'
 user_mailer.in_person_failed.verifying_step_not_expired: Votre carte d’identité délivrée par l’État ou votre permis de conduire ne doit pas être périmé. Nous n’acceptons actuellement aucune autre pièce d’identité, comme les passeports et les cartes d’identité militaires.
-user_mailer.in_person_please_call.body.contact_message_html: Appelez le <strong>%{contact_number}</strong> et indiquez le code d’erreur <strong>%{support_code}</strong>.
-user_mailer.in_person_please_call.body.intro_html: Appelez notre centre de contact avant le <strong>%{date}</strong> pour continuer à vérifier votre identité.
-user_mailer.in_person_please_call.header: S’il vous plaît, appelez-nous
-user_mailer.in_person_please_call.subject: Appeler %{app_name} afin de poursuivre la vérification de votre identité
 user_mailer.in_person_ready_to_verify_reminder.greeting: Bonjour,
 user_mailer.in_person_ready_to_verify_reminder.heading.one: Il vous reste %{count} jour pour vérifier votre identité en personne
 user_mailer.in_person_ready_to_verify_reminder.heading.other: Il vous reste %{count} jours pour vérifier votre identité en personne

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1888,6 +1888,10 @@ user_mailer.email_deleted.header: 一个电邮地址被从你的 %{app_name} 用
 user_mailer.email_deleted.help_html: 如果你没有想删除这一电邮地址，请访问 %{app_name_html} %{help_link_html} 或者 %{contact_link_html}。
 user_mailer.email_deleted.subject: 电邮地址已删除
 user_mailer.help_link_text: 帮助中心
+user_mailer.idv_please_call.body.contact_message_html: 打电话给 <strong>%{contact_number}</strong> 并向他们提供错误 代码 <strong>%{support_code}</strong>。
+user_mailer.idv_please_call.body.intro_html: 请在 <strong>%{date}</strong> 之前给我们的联系中心打电话，以继续验证你的身份。
+user_mailer.idv_please_call.header: 请给我们打个电话
+user_mailer.idv_please_call.subject: 致电 %{app_name} 继续进行身份验证
 user_mailer.in_person_completion_survey.body.cta.callout: 点击下面的按钮来开始
 user_mailer.in_person_completion_survey.body.cta.label: 填写我们的意见调查
 user_mailer.in_person_completion_survey.body.greeting: 你好，
@@ -1913,10 +1917,6 @@ user_mailer.in_person_failed.intro: 你的身份于 %{date}在 %{location} 邮�
 user_mailer.in_person_failed.subject: 你的身份未能亲身被验证。
 user_mailer.in_person_failed.verifying_identity: '验证你的身份时:'
 user_mailer.in_person_failed.verifying_step_not_expired: 你的州政府颁发的身份证件或驾照绝对没有过期。我们目前不接受任何其他形式的身份证件，比如护照和军队身份证件。
-user_mailer.in_person_please_call.body.contact_message_html: 打电话给 <strong>%{contact_number}</strong> 并向他们提供错误 代码 <strong>%{support_code}</strong>。
-user_mailer.in_person_please_call.body.intro_html: 请在 <strong>%{date}</strong> 之前给我们的联系中心打电话，以继续验证你的身份。
-user_mailer.in_person_please_call.header: 请给我们打个电话
-user_mailer.in_person_please_call.subject: 致电 %{app_name} 继续进行身份验证
 user_mailer.in_person_ready_to_verify_reminder.greeting: 你好，
 user_mailer.in_person_ready_to_verify_reminder.heading.one: 你距离亲身验证身份截止日期还有 %{count} 天
 user_mailer.in_person_ready_to_verify_reminder.heading.other: 你距离亲身验证身份截止日期还有 %{count} 天

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -243,11 +243,8 @@ class UserMailerPreview < ActionMailer::Preview
     )
   end
 
-  def in_person_please_call
-    UserMailer.with(user: user, email_address: email_address_record).in_person_please_call(
-      enrollment: in_person_enrollment_id_ipp,
-      visited_location_name: in_person_visited_location_name,
-    )
+  def idv_please_call
+    UserMailer.with(user: user, email_address: email_address_record).idv_please_call
   end
 
   def account_rejected

--- a/spec/mailers/previews/user_mailer_preview_spec.rb
+++ b/spec/mailers/previews/user_mailer_preview_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require_relative './user_mailer_preview'
 
 RSpec.describe UserMailerPreview do
-  it_behaves_like 'a mailer preview'
+  it_behaves_like 'a mailer preview', preview_methods_that_can_be_missing: [:in_person_please_call]
 
   it 'uses user and email records that cannot be saved' do
     expect(User.count).to eq(0)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -799,6 +799,23 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
+  describe '#idv_please_call' do
+    let(:mail) do
+      UserMailer.with(user: user, email_address: email_address).idv_please_call
+    end
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
+
+    it 'renders the idv_please_call template' do
+      expect_any_instance_of(ActionMailer::Base).to receive(:mail)
+        .with(hash_including(template_name: 'idv_please_call'))
+        .and_call_original
+
+      mail.deliver_later
+    end
+  end
+
   context 'in person emails' do
     let(:current_address_matches_id) { false }
     let!(:enrollment) do
@@ -1305,6 +1322,14 @@ RSpec.describe UserMailer, type: :mailer do
 
       it_behaves_like 'a system email'
       it_behaves_like 'an email that respects user email locale preference'
+
+      it 'renders the idv_please_call template' do
+        expect_any_instance_of(ActionMailer::Base).to receive(:mail)
+          .with(hash_including(template_name: 'idv_please_call'))
+          .and_call_original
+
+        mail.deliver_later
+      end
 
       context 'when the keyword argument visited_location_name is missing' do
         let(:mail) do

--- a/spec/support/shared_examples/mailer_preview.rb
+++ b/spec/support/shared_examples/mailer_preview.rb
@@ -1,10 +1,10 @@
-RSpec.shared_examples 'a mailer preview' do
+RSpec.shared_examples 'a mailer preview' do |preview_methods_that_can_be_missing: []|
   let(:mailer_class) { described_class.class_name.gsub(/Preview$/, '').constantize }
 
   it 'has a preview method for each mailer method' do
     mailer_methods = mailer_class.instance_methods(false)
     preview_methods = described_class.instance_methods(false)
-    expect(mailer_methods - preview_methods).to be_empty
+    expect(mailer_methods - preview_methods).to eql(preview_methods_that_can_be_missing)
   end
 
   described_class.instance_methods(false).each do |mailer_method|


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

**NOTE: This is the first of three PRs, which will be spread across deploys. The next one is #11662, then #11664.**

## 🎫 Ticket

Link to the relevant ticket:
[LG-15000](https://cm-jira.usa.gov/browse/LG-15000)

## 🛠 Summary of changes

We want to update the remote flow to send the "Please call" email. Since it will be the same email the IPP flow currently sends, we're going to rename it to be more generic: `idv_please_call` rather than `in_person_please_call`.

This PR is step one of the process:

* Rename templates, i18n keys, etc
* Add `idv_please_call` method to the mailer
* Add `in_person_please_call` as an alias to that method (so we don't break)

A subsequent PR will actually add the email to the remote flow and update the in person flow to use the new name.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

1. Update your application.yml to reduce the interval at which the IDP sends the "Please call" email for IPP:

```yaml
in_person_results_delay_in_hours: -1
```
2. Go through IdV, selecting the in-person proofing route (make sure you are wicked so that you are flagged by ThreatMetrix)

3. Once you have your barcode, go to the [IPP enrollment list](http://localhost:3000/test/ipp) and approve yourself

4. Verify that the "Please call" email sends as expected