### PR TITLE
LG-15135 Add an alert when a user needs to connect to their initiating service provider

### DIFF
--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -82,6 +82,21 @@ class AccountShowPresenter
     I18n.l(user.active_profile.created_at, format: :event_date)
   end
 
+  def connect_to_initiating_idv_sp_url
+    initiating_service_provider = user.active_profile&.initiating_service_provider
+    return nil if !initiating_service_provider.present?
+
+    SpReturnUrlResolver.new(service_provider: initiating_service_provider).post_idv_follow_up_url
+  end
+
+  def connected_to_initiating_idv_sp?
+    initiating_service_provider = user.active_profile&.initiating_service_provider
+    return false if !initiating_service_provider.present?
+
+    identity = user.identities.find_by(service_provider: initiating_service_provider.issuer)
+    !!identity&.last_ial2_authenticated_at.present?
+  end
+
   def show_unphishable_badge?
     MfaPolicy.new(user).unphishable?
   end

--- a/app/views/accounts/_identity_verification.html.erb
+++ b/app/views/accounts/_identity_verification.html.erb
@@ -19,6 +19,17 @@
   </div>
 </div>
 
+<% if @presenter.active_profile? && !@presenter.connected_to_initiating_idv_sp? %>
+  <%= render AlertComponent.new(type: :warning, text_tag: 'div', class: 'margin-bottom-2') do %>
+    <p class='margin-bottom-0'><%= t('account.index.verification.connect_idv_account.intro') %></p>
+    <% if @presenter.connect_to_initiating_idv_sp_url.present? %>
+      <p><%= link_to(t('account.index.verification.connect_idv_account.cta'), @presenter.connect_to_initiating_idv_sp_url) %></p>
+    <% else %>
+      <p><%= t('account.index.verification.connect_idv_account.cta') %></p>
+    <% end %>
+  <% end %>
+<% end %>
+
 <% if @presenter.active_profile? || @presenter.pending_ipp? || @presenter.pending_gpo? %>
   <p>
     <% if @presenter.active_profile_for_authn_context? %>

--- a/app/views/accounts/_identity_verification.html.erb
+++ b/app/views/accounts/_identity_verification.html.erb
@@ -20,12 +20,12 @@
 </div>
 
 <% if @presenter.active_profile? && !@presenter.connected_to_initiating_idv_sp? %>
-  <%= render AlertComponent.new(type: :warning, text_tag: 'div', class: 'margin-bottom-2') do %>
-    <p class='margin-bottom-0'><%= t('account.index.verification.connect_idv_account.intro') %></p>
+  <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-2') do %>
+    <%= t('account.index.verification.connect_idv_account.intro') %><br />
     <% if @presenter.connect_to_initiating_idv_sp_url.present? %>
-      <p><%= link_to(t('account.index.verification.connect_idv_account.cta'), @presenter.connect_to_initiating_idv_sp_url) %></p>
+      <%= link_to(t('account.index.verification.connect_idv_account.cta'), @presenter.connect_to_initiating_idv_sp_url) %>
     <% else %>
-      <p><%= t('account.index.verification.connect_idv_account.cta') %></p>
+      <%= t('account.index.verification.connect_idv_account.cta') %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,8 @@ account.index.reactivation.instructions: Your profile was recently deactivated d
 account.index.reactivation.link: Reactivate your profile now.
 account.index.sign_in_location_and_ip: From %{ip} (IP address potentially located in %{location})
 account.index.unknown_location: unknown location
+account.index.verification.connect_idv_account.cta: Sign in to partner agency to access services.
+account.index.verification.connect_idv_account.intro: Connect your account to the partner agency.
 account.index.verification.continue_idv: Continue identity verification
 account.index.verification.finish_verifying_html: Finish verifying your identity to access <strong>%{sp_name}</strong>.
 account.index.verification.finish_verifying_no_sp: Finish the identity verification process to gain access to all %{app_name} partners.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -75,6 +75,8 @@ account.index.reactivation.instructions: Su perfil fue desactivado recientemente
 account.index.reactivation.link: Reactive su perfil ahora.
 account.index.sign_in_location_and_ip: Desde %{ip} (la dirección IP se encuentra posiblemente en %{location})
 account.index.unknown_location: ubicación desconocida
+account.index.verification.connect_idv_account.cta: Inicie sesión en la agencia asociada para acceder a los servicios.
+account.index.verification.connect_idv_account.intro: Conecte su cuenta a la agencia asociada.
 account.index.verification.continue_idv: Continuar la verificación de identidad
 account.index.verification.finish_verifying_html: Termine de verificar su identidad para acceder a la <strong>%{sp_name}</strong>.
 account.index.verification.finish_verifying_no_sp: Termine el proceso de verificación de identidad para obtener acceso a todos los asociados de %{app_name}.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -75,6 +75,8 @@ account.index.reactivation.instructions: Votre profil a été récemment désact
 account.index.reactivation.link: Réactiver votre profil maintenant.
 account.index.sign_in_location_and_ip: De %{ip} (adresse IP éventuellement située dans %{location})
 account.index.unknown_location: lieu inconnu
+account.index.verification.connect_idv_account.cta: Connectez-vous à l’organisme partenaire pour accéder à ses services.
+account.index.verification.connect_idv_account.intro: Associer votre compte à l’organisme partenaire.
 account.index.verification.continue_idv: Poursuivre la vérification d’identité
 account.index.verification.finish_verifying_html: Terminez la procédure de vérification d’identité pour pouvoir accéder à <strong>%{sp_name}</strong>.
 account.index.verification.finish_verifying_no_sp: Terminer la procédure de vérification d’identité pour pouvoir accéder à tous les organismes partenaires de %{app_name}.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -75,6 +75,8 @@ account.index.reactivation.instructions: 你的用户资料因为重设密码最
 account.index.reactivation.link: 现在重新激活你的用户资料。
 account.index.sign_in_location_and_ip: 从 %{ip}（IP 地址可能位于 %{location}）。
 account.index.unknown_location: 未知地点
+account.index.verification.connect_idv_account.cta: 登录合作伙伴机构来获得服务。
+account.index.verification.connect_idv_account.intro: 把你的账户连接到合作伙伴机构。
 account.index.verification.continue_idv: 继续身份验证
 account.index.verification.finish_verifying_html: 完成身份验证流程来获得访问 <strong>%{sp_name}</strong> 的权限。
 account.index.verification.finish_verifying_no_sp: 完成身份验证流程来获得访问%{app_name} 合作伙伴机构的权限。

--- a/spec/features/idv/sp_follow_up_spec.rb
+++ b/spec/features/idv/sp_follow_up_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature 'returning to an SP after out-of-band proofing' do
       expect(current_url).to eq(post_idv_follow_up_url)
     end
 
-    scenario 'canceling on the CTA' do
+    scenario 'canceling on the CTA and visiting from the account page' do
       post_idv_follow_up_url = 'https://example.com/idv_follow_up'
       initiating_service_provider = create(:service_provider, post_idv_follow_up_url:)
       profile = create(:profile, :verify_by_mail_pending, :with_pii, initiating_service_provider:)
@@ -101,6 +101,11 @@ RSpec.feature 'returning to an SP after out-of-band proofing' do
       click_on t('idv.by_mail.sp_follow_up.go_to_account')
 
       expect(current_url).to eq(account_url)
+
+      expect(page).to have_content(t('account.index.verification.connect_idv_account.intro'))
+      click_on(t('account.index.verification.connect_idv_account.cta'))
+
+      expect(current_url).to eq(post_idv_follow_up_url)
     end
   end
 end

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -395,6 +395,41 @@ RSpec.describe AccountShowPresenter do
     end
   end
 
+  describe '#connected_to_initiating_idv_sp?' do
+    let(:initiating_service_provider) { build(:service_provider) }
+    let(:user) { create(:user, identities: [identity].compact, profiles: [profile].compact) }
+    let(:profile) do
+      build(:profile, :active, initiating_service_provider:)
+    end
+    let(:last_ial2_authenticated_at) { 2.days.ago }
+    let(:identity) do
+      build(
+        :service_provider_identity,
+        service_provider: initiating_service_provider.issuer,
+        last_ial2_authenticated_at:,
+      )
+    end
+
+    subject(:connected_to_initiating_idv_sp?) { presenter.connected_to_initiating_idv_sp? }
+
+    context 'the user verified without an initiating service provider' do
+      let(:initiating_service_provider) { nil }
+      let(:identity) { nil }
+
+      it { expect(connected_to_initiating_idv_sp?).to eq(false) }
+    end
+
+    context 'the user has signed in to the initiating service provider' do
+      it { expect(connected_to_initiating_idv_sp?).to eq(true) }
+    end
+
+    context 'the user has not signed in to the initiating service provider' do
+      let(:last_ial2_authenticated_at) { nil }
+
+      it { expect(connected_to_initiating_idv_sp?).to eq(false) }
+    end
+  end
+
   describe '#header_personalization' do
     context 'AccountShowPresenter instance has decrypted_pii' do
       it "returns the user's first name" do

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -419,6 +419,12 @@ RSpec.describe AccountShowPresenter do
       it { expect(connected_to_initiating_idv_sp?).to eq(false) }
     end
 
+    context 'the user does not have an identity for the initiating service provider' do
+      let(:identity) { nil }
+
+      it { expect(connected_to_initiating_idv_sp?).to eq(false) }
+    end
+
     context 'the user has signed in to the initiating service provider' do
       it { expect(connected_to_initiating_idv_sp?).to eq(true) }
     end

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -599,7 +599,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
     end
 
     context 'with a user who has not connected to their initiating service provider' do
-      context 'the serive provider has a post-idv follow-up url' do
+      context 'the service provider has a post-idv follow-up url' do
         it 'renders an alert to connect to IdV SP with a link' do
           expect(rendered).to have_content(
             t('account.index.verification.connect_idv_account.intro'),
@@ -611,7 +611,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
         end
       end
 
-      context 'the serive provider does not have a post-idv follow-up url' do
+      context 'the service provider does not have a post-idv follow-up url' do
         let(:post_idv_follow_up_url) { nil }
 
         it 'renders an alert to connect to IdV SP without a link' do


### PR DESCRIPTION
This commit adds a new alert to the account page. This alert appears when a user has completed IdV, but has not connected their account to their SP (i.e. they have not gone back to the SP and done a verified sign in since completing IdV). If a link to the SP is available, a link to go back to the SP is provided.
