### PR TITLE
LG-10206 Move STEP_INDICATOR_STEP constants out of InPersonFlow

### DIFF
--- a/app/controllers/concerns/idv/step_indicator_concern.rb
+++ b/app/controllers/concerns/idv/step_indicator_concern.rb
@@ -20,13 +20,21 @@ module Idv
       { name: :secure_account },
     ].freeze
 
+    STEP_INDICATOR_STEPS_IPP = [
+      { name: :find_a_post_office },
+      { name: :verify_info },
+      { name: :verify_phone },
+      { name: :re_enter_password },
+      { name: :go_to_the_post_office },
+    ].freeze
+
     included do
       helper_method :step_indicator_steps
     end
 
     def step_indicator_steps
       if in_person_proofing?
-        Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS
+        Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP
       elsif gpo_address_verification?
         Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
       else

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -60,7 +60,7 @@ module Idv
 
       def step_indicator_steps
         if in_person_proofing?
-          Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS_GPO
+          Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP
         else
           StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
         end

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -59,11 +59,7 @@ module Idv
       end
 
       def step_indicator_steps
-        if in_person_proofing?
-          Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP
-        else
-          StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
-        end
+        StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
       end
     end
   end

--- a/app/controllers/idv/by_mail/resend_letter_controller.rb
+++ b/app/controllers/idv/by_mail/resend_letter_controller.rb
@@ -83,11 +83,7 @@ module Idv
       end
 
       def step_indicator_steps
-        if in_person_proofing?
-          Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS_GPO
-        else
-          StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
-        end
+        StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
       end
     end
   end

--- a/app/views/idv/in_person/address/show.html.erb
+++ b/app/views/idv/in_person/address/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP,
         current_step: :verify_info,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS,
+        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP,
         current_step: :verify_info,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
       is_enhanced_ipp: is_enhanced_ipp,
     )
   end
-  let(:step_indicator_steps) { Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS }
+  let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP }
   let(:sp_event_name) { 'IdV: user clicked sp link on ready to verify page' }
   let(:help_event_name) { 'IdV: user clicked what to bring link on ready to verify page' }
 

--- a/spec/views/idv/shared/ssn.html.erb_spec.rb
+++ b/spec/views/idv/shared/ssn.html.erb_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'idv/shared/ssn.html.erb' do
       :ssn_presenter,
       Idv::SsnPresenter.new(
         sp_name: sp_name, ssn_form: Idv::SsnFormatForm.new(nil),
-        step_indicator_steps: Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS
+        step_indicator_steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS
       ),
     )
     render template: 'idv/shared/ssn', locals: {


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-10206](https://cm-jira.usa.gov/browse/LG-10206)


## 🛠 Summary of changes

Moves STEP_INDICATOR_STEPS from InPersonFlow into StepIndicatorConcern. InPersonFlow is FSM-related and will get deleted in a future clean-up PR, so these constants need to be moved as they are still used for the IPP step indicator. References to the old Idv::Flows::InPersonFlow::STEP_INDICATOR_STEPS are updated to reference the new constants.

Note: For 50/50 state management, the old constants in the InPersonFlow are not being removed in this PR. 


## 📜 Testing Plan

No new features or behavior was added - regression testing would be good:

- [ ] Perform manual regression testing of the IPP flow, as well as hybrid and remote flows to be thorough.
- [ ] Ensure tests pass


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
