### PR TITLE
Fix Face/Touch recommendation duplicate submission

### DIFF
--- a/app/controllers/users/webauthn_platform_recommended_controller.rb
+++ b/app/controllers/users/webauthn_platform_recommended_controller.rb
@@ -39,7 +39,7 @@ module Users
       if opted_to_add?
         webauthn_setup_path(platform: true)
       elsif in_account_creation_flow?
-        next_setup_path
+        next_setup_path || after_mfa_setup_path
       else
         after_sign_in_path_for(current_user)
       end

--- a/app/views/users/webauthn_platform_recommended/new.html.erb
+++ b/app/views/users/webauthn_platform_recommended/new.html.erb
@@ -23,18 +23,19 @@
 
   <div class="grid-row margin-top-5">
     <div class="tablet:grid-col-9">
-      <%= render ButtonComponent.new(
+      <%= render SubmitButtonComponent.new(
             url: webauthn_platform_recommended_url,
             method: :post,
             params: { add_method: true },
-            big: true,
             full_width: true,
             class: 'margin-bottom-2',
           ).with_content(t('webauthn_platform_recommended.cta')) %>
-      <%= render ButtonComponent.new(
+      <%= render SubmitButtonComponent.new(
             url: webauthn_platform_recommended_url,
             method: :post,
             unstyled: true,
+            big: false,
+            wide: false,
           ).with_content(t('webauthn_platform_recommended.skip')) %>
     </div>
   </div>

--- a/spec/views/users/webauthn_platform_recommended/new.html.erb_spec.rb
+++ b/spec/views/users/webauthn_platform_recommended/new.html.erb_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe 'users/webauthn_platform_recommended/new.html.erb' do
   subject(:rendered) { render }
 
+  it 'renders separate forms with submission for options to add' do
+    expect(rendered).to have_css('form:has(input[name=add_method]):has([type=submit])')
+    expect(rendered).to have_css('form:not(:has(input[name=add_method])):has([type=submit])')
+  end
+
   it 'renders a help link for phishing-resistant including flow path' do
     @sign_in_flow = :example
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an edge-case where an error may occur during redirect of skipped Face/Touch Unlock recommendation if user submits multiple times.

Fixes include:

- Use `SubmitButtonComponent` which has built-in duplicate submission prevention
- Provide fallback where `nil` redirect would otherwise be used

More explanation in related Slack thread: https://gsa-tts.slack.com/archives/C01710KMYUB/p1733496464529579

## 📜 Testing Plan

Verify no 500 errors in following test flow:

Reconfigure to force recommendation A/B test to always be visible:

```yaml
# config/application.yml
recommend_webauthn_platform_for_sms_ab_test_account_creation_percent: 100
```

1. Go to http://localhost:3000
2. Click "Create an account"
3. Continue account creation up to MFA selection screen
4. At MFA selection screen, emulate mobile device using [Chrome DevTools device emulation](https://developer.chrome.com/docs/devtools/device-mode)
5. Refresh the page
6. Select phone as your sole MFA
7. Setup phone
8. At Face/Touch recommendation screen, configure [Chrome DevTools network throttling to slow network speed](https://developer.chrome.com/docs/devtools/settings/throttling) to more easily simulate the example
9. Click "Skip" multiple times in quick succession
10. Observe that you don't encounter an error