### PR TITLE
Expand on form pattern documentation validation, error handling

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -96,7 +96,7 @@ properties to the Form object that get written during `#submit`
 
 ### Form Error Handling
 
-If form validation is unsuccessful, you should inform the user what nees to be done to correct the
+If form validation is unsuccessful, you should inform the user what needs to be done to correct the
 issue by one or both of the following:
 
 - Flash message


### PR DESCRIPTION
## 🛠 Summary of changes

Expands on existing [backend form object documentation](https://github.com/18F/identity-idp/blob/main/docs/backend.md#forms-formresponse-analytics-and-controllers) to include more details on how to validate forms and handle errors.

Specific goals:

- Use human-readable error messages
- Tie errors to specific forms
- Use `FormResponse#first_error_message` as single message for flash
- Bind form object with SimpleForm

## 📜 Testing Plan

Verify that [the proposed documentation](https://github.com/18F/identity-idp/blob/aduth-form-validation-errors/docs/backend.md#forms-formresponse-analytics-and-controllers) makes sense.