### PR TITLE
Add integration error event

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -255,7 +255,7 @@ module SamlIdpAuthConcern
   end
 
   def track_integration_errors(event:, errors: nil)
-    analytics.integration_errors_present(
+    analytics.sp_integration_errors_present(
       error_details: errors || saml_request.errors.uniq,
       error_types: [:saml_request_errors],
       event:,

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -181,7 +181,7 @@ module OpenidConnect
       return if result.success?
 
       if result.extra[:integration_errors].present?
-        analytics.integration_errors_present(
+        analytics.sp_integration_errors_present(
           **result.to_h[:integration_errors],
         )
       end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -56,7 +56,7 @@ module OpenidConnect
     end
 
     def check_sp_active
-      return if @authorize_form.service_provider&.active?
+      return if service_provider&.active?
       redirect_to sp_inactive_error_url
     end
 
@@ -100,7 +100,7 @@ module OpenidConnect
     def ial_context
       IalContext.new(
         ial: resolved_authn_context_int_ial,
-        service_provider: @authorize_form.service_provider,
+        service_provider:,
         user: current_user,
       )
     end
@@ -121,7 +121,6 @@ module OpenidConnect
 
       redirect_user(
         @authorize_form.success_redirect_uri,
-        @authorize_form.service_provider.issuer,
         current_user.uuid,
       )
 
@@ -153,13 +152,13 @@ module OpenidConnect
 
     def secure_headers_override
       return if form_action_csp_disabled_and_not_server_side_redirect?(
-        issuer: @authorize_form.service_provider.issuer,
+        issuer: issuer,
         user_uuid: current_user&.uuid,
       )
 
       csp_uris = SecureHeadersAllowList.csp_with_sp_redirect_uris(
         @authorize_form.redirect_uri,
-        @authorize_form.service_provider.redirect_uris,
+        service_provider.redirect_uris,
       )
       override_form_action_csp(csp_uris)
     end
@@ -185,14 +184,14 @@ module OpenidConnect
       if redirect_uri.nil?
         render :error
       else
-        redirect_user(redirect_uri, @authorize_form.service_provider.issuer, current_user&.uuid)
+        redirect_user(redirect_uri, current_user&.uuid)
       end
     end
 
     def sign_out_if_prompt_param_is_login_and_user_is_signed_in
       if @authorize_form.prompt != 'login'
         set_issuer_forced_reauthentication(
-          issuer: @authorize_form.service_provider.issuer,
+          issuer:,
           is_forced_reauthentication: false,
         )
       end
@@ -204,7 +203,7 @@ module OpenidConnect
       unless sp_session[:request_url] == request.original_url
         sign_out
         set_issuer_forced_reauthentication(
-          issuer: @authorize_form.service_provider.issuer,
+          issuer:,
           is_forced_reauthentication: true,
         )
       end
@@ -236,8 +235,8 @@ module OpenidConnect
       track_billing_events
     end
 
-    def redirect_user(redirect_uri, issuer, user_uuid)
-      case oidc_redirect_method(issuer: issuer, user_uuid: user_uuid)
+    def redirect_user(redirect_uri, user_uuid)
+      case oidc_redirect_method(issuer:, user_uuid: user_uuid)
       when 'client_side'
         @oidc_redirect_uri = redirect_uri
         render(
@@ -256,6 +255,14 @@ module OpenidConnect
           allow_other_host: true,
         )
       end
+    end
+
+    def service_provider
+      @authorize_form.service_provider
+    end
+
+    def issuer
+      service_provider&.issuer
     end
 
     def sp_handoff_bouncer

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -171,7 +171,7 @@ module OpenidConnect
       result = @authorize_form.submit
 
       analytics.openid_connect_request_authorization(
-        **result.to_h.except(:redirect_uri, :code_digest).merge(
+        **result.to_h.except(:redirect_uri, :code_digest, :integration_errors).merge(
           user_fully_authenticated: user_fully_authenticated?,
           referer: request.referer,
           vtr_param: params[:vtr],
@@ -179,6 +179,13 @@ module OpenidConnect
         ),
       )
       return if result.success?
+
+      if result.extra[:integration_errors].present?
+        analytics.integration_errors_present(
+          **result.to_h[:integration_errors],
+        )
+      end
+
       redirect_uri = result.extra[:redirect_uri]
 
       if redirect_uri.nil?

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -26,13 +26,8 @@ module OpenidConnect
       if result.success? && redirect_uri
         handle_successful_logout_request(result, redirect_uri)
       else
-        if result.extra[:integration_errors].present?
-          analytics.integration_errors_present(
-            **result.
-              to_h[:integration_errors].
-              merge({ event: :oidc_logout_requested }),
-          )
-        end
+        track_integration_errors(result:, event: :oidc_logout_requested)
+
         render :error
       end
     end
@@ -55,13 +50,8 @@ module OpenidConnect
       if result.success? && redirect_uri
         handle_logout(result, redirect_uri)
       else
-        if result.extra[:integration_errors].present?
-          analytics.integration_errors_present(
-            **result.
-              to_h[:integration_errors].
-              merge({ event: :oidc_logout_submitted }),
-          )
-        end
+        track_integration_errors(result:, event: :oidc_logout_submitted)
+
         render :error
       end
     end
@@ -160,6 +150,16 @@ module OpenidConnect
 
     def logout_params
       params.permit(:client_id, :id_token_hint, :post_logout_redirect_uri, :state)
+    end
+
+    def track_integration_errors(result:, event:)
+      if result.extra[:integration_errors].present?
+        analytics.sp_integration_errors_present(
+          **result.
+            to_h[:integration_errors].
+            merge(event:),
+        )
+      end
     end
   end
 end

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -26,6 +26,13 @@ module OpenidConnect
       if result.success? && redirect_uri
         handle_successful_logout_request(result, redirect_uri)
       else
+        if result.extra[:integration_errors].present?
+          analytics.integration_errors_present(
+            **result.
+              to_h[:integration_errors].
+              merge({ event: :oidc_logout_requested }),
+          )
+        end
         render :error
       end
     end
@@ -48,6 +55,13 @@ module OpenidConnect
       if result.success? && redirect_uri
         handle_logout(result, redirect_uri)
       else
+        if result.extra[:integration_errors].present?
+          analytics.integration_errors_present(
+            **result.
+              to_h[:integration_errors].
+              merge({ event: :oidc_logout_submitted }),
+          )
+        end
         render :error
       end
     end
@@ -141,7 +155,7 @@ module OpenidConnect
     # Convert FormResponse into loggable analytics event
     # @param [FormResponse] result
     def to_event(result)
-      result.to_h.except(:redirect_uri)
+      result.to_h.except(:redirect_uri, :integration_errors)
     end
 
     def logout_params

--- a/app/controllers/openid_connect/token_controller.rb
+++ b/app/controllers/openid_connect/token_controller.rb
@@ -18,7 +18,7 @@ module OpenidConnect
       analytics.openid_connect_token(**analytics_attributes.except(:integration_errors))
 
       if !result.success? && analytics_attributes[:integration_errors].present?
-        analytics.integration_errors_present(
+        analytics.sp_integration_errors_present(
           **analytics_attributes[:integration_errors],
         )
       end

--- a/app/controllers/openid_connect/token_controller.rb
+++ b/app/controllers/openid_connect/token_controller.rb
@@ -15,7 +15,13 @@ module OpenidConnect
       analytics_attributes = result.to_h
       analytics_attributes[:expires_in] = response[:expires_in]
 
-      analytics.openid_connect_token(**analytics_attributes)
+      analytics.openid_connect_token(**analytics_attributes.except(:integration_errors))
+
+      if !result.success? && analytics_attributes[:integration_errors].present?
+        analytics.integration_errors_present(
+          **analytics_attributes[:integration_errors],
+        )
+      end
 
       render json: response,
              status: (result.success? ? :ok : :bad_request)

--- a/app/controllers/openid_connect/user_info_controller.rb
+++ b/app/controllers/openid_connect/user_info_controller.rb
@@ -18,11 +18,13 @@ module OpenidConnect
     def authenticate_identity_via_bearer_token
       verifier = AccessTokenVerifier.new(request.env['HTTP_AUTHORIZATION'])
       response, identity = verifier.submit
-      analytics.openid_connect_bearer_token(**response)
+      attributes = response.to_h
+      analytics.openid_connect_bearer_token(**attributes.except(:integration_errors))
 
       if response.success?
         @current_identity = identity
       else
+        analytics.integration_errors_present(**attributes[:integration_errors])
         render json: { error: verifier.errors[:access_token].join(' ') },
                status: :unauthorized
       end

--- a/app/controllers/openid_connect/user_info_controller.rb
+++ b/app/controllers/openid_connect/user_info_controller.rb
@@ -24,7 +24,7 @@ module OpenidConnect
       if response.success?
         @current_identity = identity
       else
-        analytics.integration_errors_present(**attributes[:integration_errors])
+        analytics.sp_integration_errors_present(**attributes[:integration_errors])
         render json: { error: verifier.errors[:access_token].join(' ') },
                status: :unauthorized
       end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -288,14 +288,4 @@ class SamlIdpController < ApplicationController
   def req_attrs_regexp
     Regexp.escape(Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF)
   end
-
-  def track_integration_errors(event:, errors: nil)
-    analytics.integration_errors_present(
-      error_details: errors || saml_request.errors.uniq,
-      error_types: [:saml_request_errors],
-      event:,
-      integration_exists: saml_request_service_provider.present?,
-      request_issuer: saml_request&.issuer,
-    )
-  end
 end

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -352,7 +352,7 @@ class OpenidConnectAuthorizeForm
   end
 
   def integration_errors
-    return nil if client_id.blank?
+    return nil if @success || client_id.blank?
 
     {
       error_details: errors.full_messages,

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -284,6 +284,7 @@ class OpenidConnectAuthorizeForm
       code_digest: code ? Digest::SHA256.hexdigest(code) : nil,
       code_challenge_present: code_challenge.present?,
       service_provider_pkce: service_provider&.pkce,
+      integration_errors:,
     }
   end
 
@@ -348,6 +349,18 @@ class OpenidConnectAuthorizeForm
 
   def ialmax_requested?
     Saml::Idp::Constants::AUTHN_CONTEXT_CLASSREF_TO_IAL[ial_values.sort.max] == 0
+  end
+
+  def integration_errors
+    return nil if client_id.blank?
+
+    {
+      error_details: errors.full_messages,
+      error_types: errors.attribute_names,
+      event: :oidc_request_authorization,
+      integration_exists: service_provider.present?,
+      request_issuer: client_id,
+    }
   end
 
   def facial_match_ial_requested?

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -114,6 +114,15 @@ class OpenidConnectLogoutForm
     )
   end
 
+  def integration_errors
+    {
+      error_details: errors.full_messages,
+      error_types: errors.attribute_names,
+      integration_exists: service_provider.present?,
+      request_issuer: client_id || service_provider&.issuer,
+    }
+  end
+
   def valid_client_id
     return unless client_id.present? && id_token_hint.blank?
     return if service_provider.present?
@@ -144,6 +153,7 @@ class OpenidConnectLogoutForm
       redirect_uri: redirect_uri,
       sp_initiated: true,
       oidc: true,
+      integration_errors:,
     }
   end
 

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -115,6 +115,7 @@ class OpenidConnectLogoutForm
   end
 
   def integration_errors
+    return nil if valid?
     {
       error_details: errors.full_messages,
       error_types: errors.attribute_names,

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -209,7 +209,7 @@ class OpenidConnectTokenForm
   end
 
   def integration_errors
-    return nil if client_id.blank?
+    return nil if valid? || client_id.blank?
 
     {
       error_details: errors.full_messages,

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -204,6 +204,19 @@ class OpenidConnectTokenForm
       code_verifier_present: code_verifier.present?,
       service_provider_pkce: service_provider&.pkce,
       ial: identity&.ial,
+      integration_errors:,
+    }
+  end
+
+  def integration_errors
+    return nil if client_id.blank?
+
+    {
+      error_details: errors.full_messages,
+      error_types: errors.attribute_names,
+      event: :oidc_token_request,
+      integration_exists: service_provider.present?,
+      request_issuer: client_id,
     }
   end
 

--- a/app/services/access_token_verifier.rb
+++ b/app/services/access_token_verifier.rb
@@ -21,6 +21,7 @@ class AccessTokenVerifier
       extra: {
         client_id: @identity&.service_provider,
         ial: @identity&.ial,
+        integration_errors:,
       },
     )
 
@@ -68,5 +69,15 @@ class AccessTokenVerifier
     end
 
     access_token
+  end
+
+  def integration_errors
+    {
+      error_details: errors.full_messages,
+      error_types: errors.attribute_names,
+      event: :oidc_bearer_token_auth,
+      integration_exists: @identity&.service_provider.present?,
+      request_issuer: @identity&.service_provider,
+    }
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5192,7 +5192,7 @@ module AnalyticsEvents
     request_issuer: nil,
     **extra
   )
-    types = error_types.index_with { |type| true }
+    types = error_types.index_with { |_type| true }
     track_event(
       :integration_errors_present,
       error_details:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5184,7 +5184,7 @@ module AnalyticsEvents
     error_types:,
     event:,
     integration_exists:,
-    request_issuer:
+    request_issuer: nil
   )
     track_event(
       :integration_errors_present,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5192,10 +5192,11 @@ module AnalyticsEvents
     request_issuer: nil,
     **extra
   )
+    types = error_types.index_with { |type| true }
     track_event(
       :integration_errors_present,
       error_details:,
-      error_types:,
+      error_types: types,
       event:,
       integration_exists:,
       request_issuer:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5179,31 +5179,6 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Array] error_details Full messages of the errors
-  # @param [Hash] error_types Types of errors that are surfaced
-  # @param [Symbol] event What part of the workflow the error occured in
-  # @param [Boolean] integration_exists Whether the requesting issuer maps to an SP
-  # @param [String] request_issuer The issuer in the request
-  def integration_errors_present(
-    error_details:,
-    error_types:,
-    event:,
-    integration_exists:,
-    request_issuer: nil,
-    **extra
-  )
-    types = error_types.index_with { |_type| true }
-    track_event(
-      :integration_errors_present,
-      error_details:,
-      error_types: types,
-      event:,
-      integration_exists:,
-      request_issuer:,
-      **extra,
-    )
-  end
-
   # @param [String] controller
   # @param [Boolean] user_signed_in
   # Authenticity token (CSRF) is invalid
@@ -6938,6 +6913,32 @@ module AnalyticsEvents
   # Tracks when a user visits the "This agency no longer uses Login.gov" page.
   def sp_inactive_visit
     track_event('SP inactive visited')
+  end
+
+  # @param [Array] error_details Full messages of the errors
+  # @param [Hash] error_types Types of errors that are surfaced
+  # @param [Symbol] event What part of the workflow the error occured in
+  # @param [Boolean] integration_exists Whether the requesting issuer maps to an SP
+  # @param [String] request_issuer The issuer in the request
+  # Monitoring service-provider specific integration errors
+  def sp_integration_errors_present(
+    error_details:,
+    error_types:,
+    event:,
+    integration_exists:,
+    request_issuer: nil,
+    **extra
+  )
+    types = error_types.index_with { |_type| true }
+    track_event(
+      :sp_integration_errors_present,
+      error_details:,
+      error_types: types,
+      event:,
+      integration_exists:,
+      request_issuer:,
+      **extra,
+    )
   end
 
   # Tracks when a user is redirected back to the service provider

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5179,12 +5179,18 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Array] error_details Full messages of the errors
+  # @param [Hash] error_types Types of errors that are surfaced
+  # @param [Symbol] event What part of the workflow the error occured in
+  # @param [Boolean] integration_exists Whether the requesting issuer maps to an SP
+  # @param [String] request_issuer The issuer in the request
   def integration_errors_present(
     error_details:,
     error_types:,
     event:,
     integration_exists:,
-    request_issuer: nil
+    request_issuer: nil,
+    **extra
   )
     track_event(
       :integration_errors_present,
@@ -5193,6 +5199,7 @@ module AnalyticsEvents
       event:,
       integration_exists:,
       request_issuer:,
+      **extra,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5179,6 +5179,23 @@ module AnalyticsEvents
     )
   end
 
+  def integration_errors_present(
+    error_details:,
+    error_types:,
+    event:,
+    integration_exists:,
+    request_issuer:
+  )
+    track_event(
+      :integration_errors_present,
+      error_details:,
+      error_types:,
+      event:,
+      integration_exists:,
+      request_issuer:,
+    )
+  end
+
   # @param [String] controller
   # @param [Boolean] user_signed_in
   # Authenticity token (CSRF) is invalid

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             )
 
             expect(@analytics).to_not have_logged_event(
-              :integration_errors_present,
+              :sp_integration_errors_present,
             )
           end
         end
@@ -2032,7 +2032,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
           expect(@analytics).to_not have_logged_event('SP redirect initiated')
 
           expect(@analytics).to have_logged_event(
-            :integration_errors_present,
+            :sp_integration_errors_present,
             error_details: array_including(
               'Prompt Please fill in this field.',
             ),
@@ -2052,7 +2052,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             action
 
             expect(@analytics).to have_logged_event(
-              :integration_errors_present,
+              :sp_integration_errors_present,
               error_details: array_including(
                 'Acr values Please fill in this field.',
                 'Prompt Please fill in this field.',
@@ -2093,7 +2093,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             )
 
             expect(@analytics).to have_logged_event(
-              :integration_errors_present,
+              :sp_integration_errors_present,
               error_details: array_including(
                 'Acr values Please fill in this field.',
               ),

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -2020,12 +2020,45 @@ RSpec.describe OpenidConnect::AuthorizationController do
             errors: hash_including(:prompt),
             error_details: hash_including(:prompt),
             user_fully_authenticated: true,
-            acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+            acr_values: acr_values,
             code_challenge_present: false,
             scope: 'openid',
           )
 
           expect(@analytics).to_not have_logged_event('SP redirect initiated')
+
+          expect(@analytics).to have_logged_event(
+            :integration_errors_present,
+            error_details: array_including(
+              'Prompt Please fill in this field.',
+            ),
+            error_types: [:prompt],
+            event: :oidc_request_authorization,
+            integration_exists: true,
+            request_issuer: client_id,
+          )
+        end
+
+        context 'when there are multiple issues with the request' do
+          let(:acr_values) { nil }
+
+          it 'notes all the integration errors' do
+            stub_analytics
+
+            action
+
+            expect(@analytics).to have_logged_event(
+              :integration_errors_present,
+              error_details: array_including(
+                'Acr values Please fill in this field.',
+                'Prompt Please fill in this field.',
+              ),
+              error_types: [:acr_values, :prompt],
+              event: :oidc_request_authorization,
+              integration_exists: true,
+              request_issuer: client_id,
+            )
+          end
         end
       end
 
@@ -2053,6 +2086,17 @@ RSpec.describe OpenidConnect::AuthorizationController do
               code_challenge_present: false,
               scope: 'openid profile',
               unknown_authn_contexts: unknown_value,
+            )
+
+            expect(@analytics).to have_logged_event(
+              :integration_errors_present,
+              error_details: array_including(
+                'Acr values Please fill in this field.',
+              ),
+              error_types: [:acr_values],
+              event: :oidc_request_authorization,
+              integration_exists: true,
+              request_issuer: client_id,
             )
           end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -2036,7 +2036,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             error_details: array_including(
               'Prompt Please fill in this field.',
             ),
-            error_types: [:prompt],
+            error_types: { prompt: true },
             event: :oidc_request_authorization,
             integration_exists: true,
             request_issuer: client_id,
@@ -2057,7 +2057,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 'Acr values Please fill in this field.',
                 'Prompt Please fill in this field.',
               ),
-              error_types: [:acr_values, :prompt],
+              error_types: { acr_values: true, prompt: true },
               event: :oidc_request_authorization,
               integration_exists: true,
               request_issuer: client_id,
@@ -2097,7 +2097,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
               error_details: array_including(
                 'Acr values Please fill in this field.',
               ),
-              error_types: [:acr_values],
+              error_types: { acr_values: true },
               event: :oidc_request_authorization,
               integration_exists: true,
               request_issuer: client_id,

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -153,6 +153,10 @@ RSpec.describe OpenidConnect::AuthorizationController do
               sign_in_flow:,
               acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
             )
+
+            expect(@analytics).to_not have_logged_event(
+              :integration_errors_present,
+            )
           end
         end
 

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe OpenidConnect::LogoutController do
               error_details: array_including(
                 'Redirect uri redirect_uri does not match registered redirect_uri',
               ),
-              error_types: [:redirect_uri],
+              error_types: { redirect_uri: true },
               event: :oidc_logout_requested,
               integration_exists: true,
               request_issuer: service_provider.issuer,
@@ -237,7 +237,7 @@ RSpec.describe OpenidConnect::LogoutController do
           let(:id_token_hint) { 'abc123' }
           it 'tracks events' do
             stub_analytics
-            errors_keys = [:id_token_hint]
+            errors_keys = { id_token_hint: true }
 
             action
 
@@ -259,7 +259,7 @@ RSpec.describe OpenidConnect::LogoutController do
               error_details: array_including(
                 'Id token hint id_token_hint was not recognized',
               ),
-              error_types: [:id_token_hint],
+              error_types: { id_token_hint: true },
               event: :oidc_logout_requested,
               integration_exists: false,
             )
@@ -392,7 +392,7 @@ RSpec.describe OpenidConnect::LogoutController do
               error_details: array_including(
                 'Redirect uri redirect_uri does not match registered redirect_uri',
               ),
-              error_types: [:redirect_uri],
+              error_types: { redirect_uri: true },
               event: :oidc_logout_requested,
               integration_exists: true,
               request_issuer: service_provider.issuer,
@@ -533,7 +533,7 @@ RSpec.describe OpenidConnect::LogoutController do
               'Id token hint This application is misconfigured and should not be sending ' \
                 'id_token_hint. Please send client_id instead.',
             ),
-            error_types: [:id_token_hint],
+            error_types: { id_token_hint: true },
             event: :oidc_logout_requested,
             integration_exists: true,
             request_issuer: service_provider.issuer,
@@ -583,7 +583,7 @@ RSpec.describe OpenidConnect::LogoutController do
             error_details: array_including(
               'Redirect uri redirect_uri does not match registered redirect_uri',
             ),
-            error_types: [:redirect_uri],
+            error_types: { redirect_uri: true },
             event: :oidc_logout_requested,
             integration_exists: true,
             request_issuer: service_provider.issuer,
@@ -883,7 +883,7 @@ RSpec.describe OpenidConnect::LogoutController do
                 error_details: array_including(
                   'Client client_id is missing',
                 ),
-                error_types: [:client_id],
+                error_types: { client_id: true },
                 event: :oidc_logout_submitted,
                 integration_exists: false,
               )

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe OpenidConnect::LogoutController do
           let(:id_token_hint) { 'abc123' }
           it 'tracks events' do
             stub_analytics
-            errors_keys = { id_token_hint: true }
+            errors_keys = [:id_token_hint]
 
             action
 
@@ -866,7 +866,6 @@ RSpec.describe OpenidConnect::LogoutController do
             expect(@analytics).to_not have_logged_event(
               :integration_errors_present,
             )
-            expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
           end
 
           context 'when client_id is missing' do

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe OpenidConnect::LogoutController do
             )
 
             expect(@analytics).to_not have_logged_event(
-              :integration_errors_present,
+              :sp_integration_errors_present,
             )
           end
         end
@@ -221,7 +221,7 @@ RSpec.describe OpenidConnect::LogoutController do
             )
 
             expect(@analytics).to have_logged_event(
-              :integration_errors_present,
+              :sp_integration_errors_present,
               error_details: array_including(
                 'Redirect uri redirect_uri does not match registered redirect_uri',
               ),
@@ -255,7 +255,7 @@ RSpec.describe OpenidConnect::LogoutController do
             )
 
             expect(@analytics).to have_logged_event(
-              :integration_errors_present,
+              :sp_integration_errors_present,
               error_details: array_including(
                 'Id token hint id_token_hint was not recognized',
               ),
@@ -343,7 +343,7 @@ RSpec.describe OpenidConnect::LogoutController do
               ),
             )
             expect(@analytics).to_not have_logged_event(
-              :integration_errors_present,
+              :sp_integration_errors_present,
             )
             expect(response).to render_template(:confirm_logout)
             expect(response.body).to include service_provider.friendly_name
@@ -388,7 +388,7 @@ RSpec.describe OpenidConnect::LogoutController do
             )
 
             expect(@analytics).to have_logged_event(
-              :integration_errors_present,
+              :sp_integration_errors_present,
               error_details: array_including(
                 'Redirect uri redirect_uri does not match registered redirect_uri',
               ),
@@ -485,7 +485,7 @@ RSpec.describe OpenidConnect::LogoutController do
           )
 
           expect(@analytics).to_not have_logged_event(
-            :integration_errors_present,
+            :sp_integration_errors_present,
           )
         end
       end
@@ -528,7 +528,7 @@ RSpec.describe OpenidConnect::LogoutController do
           )
 
           expect(@analytics).to have_logged_event(
-            :integration_errors_present,
+            :sp_integration_errors_present,
             error_details: array_including(
               'Id token hint This application is misconfigured and should not be sending ' \
                 'id_token_hint. Please send client_id instead.',
@@ -579,7 +579,7 @@ RSpec.describe OpenidConnect::LogoutController do
           )
 
           expect(@analytics).to have_logged_event(
-            :integration_errors_present,
+            :sp_integration_errors_present,
             error_details: array_including(
               'Redirect uri redirect_uri does not match registered redirect_uri',
             ),
@@ -864,7 +864,7 @@ RSpec.describe OpenidConnect::LogoutController do
               oidc: true,
             )
             expect(@analytics).to_not have_logged_event(
-              :integration_errors_present,
+              :sp_integration_errors_present,
             )
           end
 
@@ -878,7 +878,7 @@ RSpec.describe OpenidConnect::LogoutController do
               action
 
               expect(@analytics).to have_logged_event(
-                :integration_errors_present,
+                :sp_integration_errors_present,
                 error_details: array_including(
                   'Client client_id is missing',
                 ),

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe OpenidConnect::TokenController do
           error_details: array_including(
             'Grant type is not included in the list',
           ),
-          error_types: [:grant_type],
+          error_types: { grant_type: true },
           event: :oidc_token_request,
           integration_exists: true,
           request_issuer: client_id,

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe OpenidConnect::TokenController do
           }
         )
 
-        expect(@analytics).to_not have_logged_event(:integration_errors_present)
+        expect(@analytics).to_not have_logged_event(:sp_integration_errors_present)
       end
     end
 
@@ -103,7 +103,7 @@ RSpec.describe OpenidConnect::TokenController do
         )
 
         expect(@analytics).to have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
           error_details: array_including(
             'Grant type is not included in the list',
           ),
@@ -128,7 +128,7 @@ RSpec.describe OpenidConnect::TokenController do
         expect(json[:error]).to be_present
         expect(json).to_not have_key(:id_token)
 
-        expect(@analytics).to_not have_logged_event(:integration_errors_present)
+        expect(@analytics).to_not have_logged_event(:sp_integration_errors_present)
       end
     end
   end

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe OpenidConnect::UserInfoController do
           error_details: array_including(
             'Access token No Authorization header provided',
           ),
-          error_types: [:access_token],
+          error_types: { access_token: true },
           event: :oidc_bearer_token_auth,
           integration_exists: false,
         )
@@ -68,7 +68,7 @@ RSpec.describe OpenidConnect::UserInfoController do
           error_details: array_including(
             'Access token Malformed Authorization header',
           ),
-          error_types: [:access_token],
+          error_types: { access_token: true },
           event: :oidc_bearer_token_auth,
           integration_exists: false,
         )
@@ -102,7 +102,7 @@ RSpec.describe OpenidConnect::UserInfoController do
             'Access token Could not find authorization for the contents of the provided ' \
               'access_token or it may have expired',
           ),
-          error_types: [:access_token],
+          error_types: { access_token: true },
           event: :oidc_bearer_token_auth,
           integration_exists: false,
         )

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe OpenidConnect::UserInfoController do
         )
 
         expect(@analytics).to have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
           error_details: array_including(
             'Access token No Authorization header provided',
           ),
@@ -64,7 +64,7 @@ RSpec.describe OpenidConnect::UserInfoController do
         )
 
         expect(@analytics).to have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
           error_details: array_including(
             'Access token Malformed Authorization header',
           ),
@@ -97,7 +97,7 @@ RSpec.describe OpenidConnect::UserInfoController do
         )
 
         expect(@analytics).to have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
           error_details: array_including(
             'Access token Could not find authorization for the contents of the provided ' \
               'access_token or it may have expired',
@@ -168,7 +168,7 @@ RSpec.describe OpenidConnect::UserInfoController do
         )
 
         expect(@analytics).to_not have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
         )
       end
 

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe OpenidConnect::UserInfoController do
           errors: hash_including(:access_token),
           error_details: hash_including(:access_token),
         )
+
+        expect(@analytics).to have_logged_event(
+          :integration_errors_present,
+          error_details: array_including(
+            'Access token No Authorization header provided',
+          ),
+          error_types: [:access_token],
+          event: :oidc_bearer_token_auth,
+          integration_exists: false,
+        )
       end
     end
 
@@ -52,6 +62,16 @@ RSpec.describe OpenidConnect::UserInfoController do
           errors: hash_including(:access_token),
           error_details: hash_including(:access_token),
         )
+
+        expect(@analytics).to have_logged_event(
+          :integration_errors_present,
+          error_details: array_including(
+            'Access token Malformed Authorization header',
+          ),
+          error_types: [:access_token],
+          event: :oidc_bearer_token_auth,
+          integration_exists: false,
+        )
       end
     end
 
@@ -74,6 +94,17 @@ RSpec.describe OpenidConnect::UserInfoController do
           success: false,
           errors: hash_including(:access_token),
           error_details: hash_including(:access_token),
+        )
+
+        expect(@analytics).to have_logged_event(
+          :integration_errors_present,
+          error_details: array_including(
+            'Access token Could not find authorization for the contents of the provided ' \
+              'access_token or it may have expired',
+          ),
+          error_types: [:access_token],
+          event: :oidc_bearer_token_auth,
+          integration_exists: false,
         )
       end
     end
@@ -134,6 +165,10 @@ RSpec.describe OpenidConnect::UserInfoController do
           client_id: identity.service_provider,
           ial: identity.ial,
           errors: {},
+        )
+
+        expect(@analytics).to_not have_logged_event(
+          :integration_errors_present,
         )
       end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1085,6 +1085,14 @@ RSpec.describe SamlIdpController do
             unknown_authn_contexts: unknown_value,
           ),
         )
+        expect(@analytics).to have_logged_event(
+          :integration_errors_present,
+          error_details: ['Unauthorized authentication context'],
+          error_types: [:saml_request_errors],
+          event: :saml_auth_request,
+          integration_exists: true,
+          request_issuer: saml_settings.issuer,
+        )
       end
 
       context 'there is also a valid authn_context' do
@@ -1102,6 +1110,9 @@ RSpec.describe SamlIdpController do
             hash_including(
               unknown_authn_contexts: unknown_value,
             ),
+          )
+          expect(@analytics).to_not have_logged_event(
+            :integration_errors_present,
           )
         end
 
@@ -1349,6 +1360,14 @@ RSpec.describe SamlIdpController do
             finish_profile: false,
           ),
         )
+        expect(@analytics).to have_logged_event(
+          :integration_errors_present,
+          error_details: ['Unauthorized Service Provider'],
+          error_types: [:saml_request_errors],
+          event: :saml_auth_request,
+          integration_exists: false,
+          request_issuer: 'invalid_provider',
+        )
       end
     end
 
@@ -1394,6 +1413,14 @@ RSpec.describe SamlIdpController do
             finish_profile: false,
           ),
         )
+        expect(@analytics).to have_logged_event(
+          :integration_errors_present,
+          error_details: ['Unauthorized Service Provider', 'Unauthorized authentication context'],
+          error_types: [:saml_request_errors],
+          event: :saml_auth_request,
+          integration_exists: false,
+          request_issuer: 'invalid_provider',
+        )
       end
     end
 
@@ -1436,6 +1463,15 @@ RSpec.describe SamlIdpController do
             errors: { service_provider: [t('errors.messages.no_cert_registered')] },
             error_details: { service_provider: { no_cert_registered: true } },
           ),
+        )
+
+        expect(@analytics).to have_logged_event(
+          :integration_errors_present,
+          error_details: ['Your service provider does not have a certificate registered.'],
+          error_types: [:saml_request_errors],
+          event: :saml_auth_request,
+          integration_exists: true,
+          request_issuer: service_provider.issuer,
         )
       end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SamlIdpController do
         hash_including(sp_initiated: true, oidc: false, saml_request_valid: false),
       )
       expect(@analytics).to have_logged_event(
-        :integration_errors_present,
+        :sp_integration_errors_present,
         error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
         error_types: { saml_request_errors: true },
         event: :saml_logout_request,
@@ -140,7 +140,7 @@ RSpec.describe SamlIdpController do
           hash_including(sp_initiated: true, oidc: false, saml_request_valid: false),
         )
         expect(@analytics).to have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
           error_details: [:invalid_signature],
           error_types: { saml_request_errors: true },
           event: :saml_logout_request,
@@ -214,7 +214,7 @@ RSpec.describe SamlIdpController do
 
       expect(@analytics).to have_logged_event('Remote Logout initiated', saml_request_valid: false)
       expect(@analytics).to have_logged_event(
-        :integration_errors_present,
+        :sp_integration_errors_present,
         error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
         error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
@@ -396,7 +396,7 @@ RSpec.describe SamlIdpController do
 
       expect(response).to be_bad_request
       expect(@analytics).to have_logged_event(
-        :integration_errors_present,
+        :sp_integration_errors_present,
         error_details: [:no_user_found_from_session_index],
         error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
@@ -439,7 +439,7 @@ RSpec.describe SamlIdpController do
 
       expect(response).to be_bad_request
       expect(@analytics).to have_logged_event(
-        :integration_errors_present,
+        :sp_integration_errors_present,
         error_details: [:no_user_found_from_session_index],
         error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
@@ -482,7 +482,7 @@ RSpec.describe SamlIdpController do
 
       expect(response).to be_bad_request
       expect(@analytics).to have_logged_event(
-        :integration_errors_present,
+        :sp_integration_errors_present,
         error_details: [:no_user_found_from_session_index],
         error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
@@ -499,7 +499,7 @@ RSpec.describe SamlIdpController do
 
       expect(response).to be_bad_request
       expect(@analytics).to have_logged_event(
-        :integration_errors_present,
+        :sp_integration_errors_present,
         error_details: [:invalid_signature],
         error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
@@ -1086,7 +1086,7 @@ RSpec.describe SamlIdpController do
           ),
         )
         expect(@analytics).to have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
           error_details: ['Unauthorized authentication context'],
           error_types: { saml_request_errors: true },
           event: :saml_auth_request,
@@ -1112,7 +1112,7 @@ RSpec.describe SamlIdpController do
             ),
           )
           expect(@analytics).to_not have_logged_event(
-            :integration_errors_present,
+            :sp_integration_errors_present,
           )
         end
 
@@ -1361,7 +1361,7 @@ RSpec.describe SamlIdpController do
           ),
         )
         expect(@analytics).to have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
           error_details: ['Unauthorized Service Provider'],
           error_types: { saml_request_errors: true },
           event: :saml_auth_request,
@@ -1414,7 +1414,7 @@ RSpec.describe SamlIdpController do
           ),
         )
         expect(@analytics).to have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
           error_details: ['Unauthorized Service Provider', 'Unauthorized authentication context'],
           error_types: { saml_request_errors: true },
           event: :saml_auth_request,
@@ -1466,7 +1466,7 @@ RSpec.describe SamlIdpController do
         )
 
         expect(@analytics).to have_logged_event(
-          :integration_errors_present,
+          :sp_integration_errors_present,
           error_details: ['Your service provider does not have a certificate registered.'],
           error_types: { saml_request_errors: true },
           event: :saml_auth_request,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe SamlIdpController do
       expect(@analytics).to have_logged_event(
         :integration_errors_present,
         error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
-        error_types: [:saml_request_errors],
+        error_types: { saml_request_errors: true },
         event: :saml_logout_request,
         integration_exists: false,
       )
@@ -142,7 +142,7 @@ RSpec.describe SamlIdpController do
         expect(@analytics).to have_logged_event(
           :integration_errors_present,
           error_details: [:invalid_signature],
-          error_types: [:saml_request_errors],
+          error_types: { saml_request_errors: true },
           event: :saml_logout_request,
           integration_exists: true,
           request_issuer: service_provider.issuer,
@@ -216,7 +216,7 @@ RSpec.describe SamlIdpController do
       expect(@analytics).to have_logged_event(
         :integration_errors_present,
         error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
-        error_types: [:saml_request_errors],
+        error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
         integration_exists: false,
       )
@@ -398,7 +398,7 @@ RSpec.describe SamlIdpController do
       expect(@analytics).to have_logged_event(
         :integration_errors_present,
         error_details: [:no_user_found_from_session_index],
-        error_types: [:saml_request_errors],
+        error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
         integration_exists: true,
         request_issuer: service_provider.issuer,
@@ -441,7 +441,7 @@ RSpec.describe SamlIdpController do
       expect(@analytics).to have_logged_event(
         :integration_errors_present,
         error_details: [:no_user_found_from_session_index],
-        error_types: [:saml_request_errors],
+        error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
         integration_exists: true,
         request_issuer: service_provider.issuer,
@@ -484,7 +484,7 @@ RSpec.describe SamlIdpController do
       expect(@analytics).to have_logged_event(
         :integration_errors_present,
         error_details: [:no_user_found_from_session_index],
-        error_types: [:saml_request_errors],
+        error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
         integration_exists: true,
         request_issuer: service_provider.issuer,
@@ -501,7 +501,7 @@ RSpec.describe SamlIdpController do
       expect(@analytics).to have_logged_event(
         :integration_errors_present,
         error_details: [:invalid_signature],
-        error_types: [:saml_request_errors],
+        error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
         integration_exists: true,
         request_issuer: service_provider.issuer,
@@ -1088,7 +1088,7 @@ RSpec.describe SamlIdpController do
         expect(@analytics).to have_logged_event(
           :integration_errors_present,
           error_details: ['Unauthorized authentication context'],
-          error_types: [:saml_request_errors],
+          error_types: { saml_request_errors: true },
           event: :saml_auth_request,
           integration_exists: true,
           request_issuer: saml_settings.issuer,
@@ -1363,7 +1363,7 @@ RSpec.describe SamlIdpController do
         expect(@analytics).to have_logged_event(
           :integration_errors_present,
           error_details: ['Unauthorized Service Provider'],
-          error_types: [:saml_request_errors],
+          error_types: { saml_request_errors: true },
           event: :saml_auth_request,
           integration_exists: false,
           request_issuer: 'invalid_provider',
@@ -1416,7 +1416,7 @@ RSpec.describe SamlIdpController do
         expect(@analytics).to have_logged_event(
           :integration_errors_present,
           error_details: ['Unauthorized Service Provider', 'Unauthorized authentication context'],
-          error_types: [:saml_request_errors],
+          error_types: { saml_request_errors: true },
           event: :saml_auth_request,
           integration_exists: false,
           request_issuer: 'invalid_provider',
@@ -1468,7 +1468,7 @@ RSpec.describe SamlIdpController do
         expect(@analytics).to have_logged_event(
           :integration_errors_present,
           error_details: ['Your service provider does not have a certificate registered.'],
-          error_types: [:saml_request_errors],
+          error_types: { saml_request_errors: true },
           event: :saml_auth_request,
           integration_exists: true,
           request_issuer: service_provider.issuer,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe SamlIdpController do
         'Logout Initiated',
         hash_including(sp_initiated: true, oidc: false, saml_request_valid: false),
       )
+      expect(@analytics).to have_logged_event(
+        :integration_errors_present,
+        error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
+        error_types: [:saml_request_errors],
+        event: :saml_logout_request,
+        integration_exists: false,
+      )
     end
 
     let(:service_provider) do
@@ -112,12 +119,35 @@ RSpec.describe SamlIdpController do
       expect(response).to be_ok
     end
 
-    it 'rejects requests from a wrong cert' do
-      delete :logout, params: UriService.params(
-        OneLogin::RubySaml::Logoutrequest.new.create(wrong_cert_settings),
-      ).merge(path_year: path_year)
+    context 'when the cert is not registered' do
+      it 'rejects requests from a wrong cert' do
+        delete :logout, params: UriService.params(
+          OneLogin::RubySaml::Logoutrequest.new.create(wrong_cert_settings),
+        ).merge(path_year: path_year)
 
-      expect(response).to be_bad_request
+        expect(response).to be_bad_request
+      end
+
+      it 'tracks the request' do
+        stub_analytics
+
+        delete :logout, params: UriService.params(
+          OneLogin::RubySaml::Logoutrequest.new.create(wrong_cert_settings),
+        ).merge(path_year: path_year)
+
+        expect(@analytics).to have_logged_event(
+          'Logout Initiated',
+          hash_including(sp_initiated: true, oidc: false, saml_request_valid: false),
+        )
+        expect(@analytics).to have_logged_event(
+          :integration_errors_present,
+          error_details: [:invalid_signature],
+          error_types: [:saml_request_errors],
+          event: :saml_logout_request,
+          integration_exists: true,
+          request_issuer: service_provider.issuer,
+        )
+      end
     end
 
     context 'cert element in SAML request is blank' do
@@ -183,6 +213,13 @@ RSpec.describe SamlIdpController do
       post :remotelogout, params: { SAMLRequest: 'foo', path_year: path_year }
 
       expect(@analytics).to have_logged_event('Remote Logout initiated', saml_request_valid: false)
+      expect(@analytics).to have_logged_event(
+        :integration_errors_present,
+        error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
+        error_types: [:saml_request_errors],
+        event: :saml_remote_logout_request,
+        integration_exists: false,
+      )
     end
 
     let(:agency) { create(:agency) }
@@ -351,12 +388,21 @@ RSpec.describe SamlIdpController do
         ),
       ).to eq(true)
 
+      stub_analytics
       post :remotelogout, params: payload.to_h.merge(
         Signature: Base64.encode64(signature),
         path_year: path_year,
       )
 
       expect(response).to be_bad_request
+      expect(@analytics).to have_logged_event(
+        :integration_errors_present,
+        error_details: [:no_user_found_from_session_index],
+        error_types: [:saml_request_errors],
+        event: :saml_remote_logout_request,
+        integration_exists: true,
+        request_issuer: service_provider.issuer,
+      )
     end
 
     it 'rejects requests from a correct cert but bad session index' do
@@ -385,12 +431,21 @@ RSpec.describe SamlIdpController do
         ),
       ).to eq(true)
 
+      stub_analytics
       post :remotelogout, params: payload.to_h.merge(
         Signature: Base64.encode64(signature),
         path_year: path_year,
       )
 
       expect(response).to be_bad_request
+      expect(@analytics).to have_logged_event(
+        :integration_errors_present,
+        error_details: [:no_user_found_from_session_index],
+        error_types: [:saml_request_errors],
+        event: :saml_remote_logout_request,
+        integration_exists: true,
+        request_issuer: service_provider.issuer,
+      )
     end
 
     it 'rejects requests from a correct cert but a non-associated user' do
@@ -419,20 +474,38 @@ RSpec.describe SamlIdpController do
         ),
       ).to eq(true)
 
+      stub_analytics
       post :remotelogout, params: payload.to_h.merge(
         Signature: Base64.encode64(signature),
         path_year: path_year,
       )
 
       expect(response).to be_bad_request
+      expect(@analytics).to have_logged_event(
+        :integration_errors_present,
+        error_details: [:no_user_found_from_session_index],
+        error_types: [:saml_request_errors],
+        event: :saml_remote_logout_request,
+        integration_exists: true,
+        request_issuer: service_provider.issuer,
+      )
     end
 
     it 'rejects requests from a wrong cert' do
+      stub_analytics
       post :remotelogout, params: UriService.params(
         OneLogin::RubySaml::Logoutrequest.new.create(wrong_cert_settings),
       ).merge(path_year: path_year)
 
       expect(response).to be_bad_request
+      expect(@analytics).to have_logged_event(
+        :integration_errors_present,
+        error_details: [:invalid_signature],
+        error_types: [:saml_request_errors],
+        event: :saml_remote_logout_request,
+        integration_exists: true,
+        request_issuer: service_provider.issuer,
+      )
     end
   end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
           code_digest: nil,
           code_challenge_present: false,
           service_provider_pkce: nil,
+          integration_errors: nil,
         )
       end
     end
@@ -79,6 +80,13 @@ RSpec.describe OpenidConnectAuthorizeForm do
             code_digest: nil,
             code_challenge_present: false,
             service_provider_pkce: nil,
+            integration_errors: {
+              error_details: ['Response type is not included in the list'],
+              error_types: [:response_type],
+              event: :oidc_request_authorization,
+              integration_exists: true,
+              request_issuer: client_id,
+            },
           )
         end
       end

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -382,11 +382,12 @@ RSpec.describe OpenidConnectTokenForm do
           code_verifier_present: false,
           service_provider_pkce: nil,
           ial: 1,
+          integration_errors: nil,
         )
       end
     end
 
-    context 'with invalid params' do
+    context 'with invalid code' do
       let(:code) { nil }
 
       it 'returns FormResponse with success: false' do
@@ -399,6 +400,33 @@ RSpec.describe OpenidConnectTokenForm do
           client_id: nil,
           user_id: nil,
           code_digest: nil,
+        )
+      end
+    end
+
+    context 'with the wrong grant_type ' do
+      let(:grant_type) { 'wrong' }
+
+      it 'returns FormResponse with success: false and int error' do
+        submission = form.submit
+
+        expect(submission.to_h).to include(
+          success: false,
+          errors: form.errors.messages,
+          error_details: hash_including(:grant_type),
+          client_id: client_id,
+          user_id: user.uuid,
+          code_digest: Digest::SHA256.hexdigest(code),
+          code_verifier_present: false,
+          service_provider_pkce: nil,
+          ial: 1,
+          integration_errors: {
+            error_details: ['Grant type is not included in the list'],
+            error_types: [:grant_type],
+            event: :oidc_token_request,
+            integration_exists: true,
+            request_issuer: client_id,
+          },
         )
       end
     end


### PR DESCRIPTION
 ## 🎫 Ticket
There is no ticket! This is part of a [hackthon project](https://docs.google.com/document/d/1YEZTFIXmPRD_fVe3lA_bB4rBid66eNfgyMUFqq0BOF4/edit?tab=t.0). The goals of this project is to monitor authentication and logout requests to be on the lookout for broken integrations. This will allow us to be more proactive with partners who may be struggling with their integrations.

The existing error logging, however, was not really designed for pulling out specific details and notifying us about them, so a new event seemed like a good fit for this problem.

## 🛠 Summary of changes
This change:

- Adds a new event called `integration_errors_present`
- Wires that event into our existing code flow, whenever a request is made that can fail.

There is some duplicative code that is similar but not exactly the same. It could probably be pulled out into a shared module or something. Should I do that? Opinions welcome!

I also am happy to add more fields to the new event if they seem useful -- what do people think?

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
