### PR TITLE
Allow no certs if block_encryption is set to 'none'

### DIFF
--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -77,6 +77,7 @@ class SamlRequestValidator
     # if there is no service provider, this error has already been added
     return if service_provider.blank?
     return if service_provider.certs.present?
+    return unless service_provider.encrypt_responses?
 
     errors.add(
       :service_provider, :no_cert_registered,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1365,6 +1365,27 @@ RSpec.describe SamlIdpController do
           ),
         )
       end
+
+      context 'when service provider has block_encryption set to none' do
+        before do
+          service_provider.update!(block_encryption: 'none')
+        end
+
+        it 'is succesful' do
+          user = create(:user, :fully_registered)
+          stub_analytics
+
+          generate_saml_response(user, settings)
+
+          expect(response.body).to_not include(t('errors.messages.no_cert_registered'))
+          expect(@analytics).to have_logged_event(
+            'SAML Auth',
+            hash_including(
+              success: true,
+            ),
+          )
+        end
+      end
     end
 
     context 'service provider has multiple certs' do

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -51,24 +51,38 @@ RSpec.describe SamlRequestValidator do
 
       context 'when the sp has no certs registered' do
         before { sp.update!(certs: nil) }
-        let(:errors) do
-          {
-            service_provider: [t('errors.messages.no_cert_registered')],
-          }
-        end
-        let(:error_details) do
-          {
-            service_provider: {
-              no_cert_registered: true,
-            },
-          }
+
+        context 'when it has block_encryption turned on' do
+          before { sp.update!(block_encryption: 'aes256-cbc') }
+          let(:errors) do
+            {
+              service_provider: [t('errors.messages.no_cert_registered')],
+            }
+          end
+          let(:error_details) do
+            {
+              service_provider: {
+                no_cert_registered: true,
+              },
+            }
+          end
+
+          it 'returns an error' do
+            expect(response.to_h).to include(
+              errors:,
+              error_details:,
+            )
+          end
         end
 
-        it 'returns an error' do
-          expect(response.to_h).to include(
-            errors:,
-            error_details:,
-          )
+        context 'when block encryption is not turned on' do
+          it 'is valid' do
+            expect(response.to_h).to include(
+              success: true,
+              errors: {},
+              **extra,
+            )
+          end
         end
       end
 


### PR DESCRIPTION
Link to the relevant [slack conversation](https://gsa-tts.slack.com/archives/C01SU3NB9T3/p1733859019145089):

## 🛠 Summary of changes
Recently we added an error condition for when a partner does not have a certificate set, designed to help partners in the integration environment. It was believed this would not impact partners in product because the only two active, non-pkce integrations that did not have certificates were actually staging integrations.

However, one of our partners has pkce set, but is using SAML in the web, and so got caught in this error. They have `block_encryption` set to `none`, so they don't need a certificate. 

This change adds a condition where if a partner does not have any registered certificates, BUT is not requesting encrypted responses, then it will not error out.


Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
