### PR TITLE
[Hackathon] Allow sourcing events from stdin

### DIFF
--- a/bin/summarize-user-events
+++ b/bin/summarize-user-events
@@ -28,12 +28,9 @@ class SummarizeUserEvents
   end
 
   def run
-    results = cloudwatch_client.fetch(
-      query: query,
-      from: from_date,
-      to: to_date,
-    )
-    pp results
+    find_cloudwatch_events do |cloudwatch_event|
+      pp cloudwatch_event
+    end
   end
 
 
@@ -57,6 +54,32 @@ class SummarizeUserEvents
       log_group_name: 'prod_/srv/idp/shared/log/events.log',
     )
   end
+
+  def find_cloudwatch_events(&block)
+    if $stdin.tty?
+      cloudwatch_source(&block)
+    else
+      warn "Reading Cloudwatch events as newline-delimited JSON (ndjson) from stdin"
+      stdin_source(&block)
+    end
+  end
+
+  def stdin_source(&block)
+    $stdin.each_line do |line|
+      next if line.blank?
+      event = JSON.parse(line)
+      block.call(event)
+    end
+  end
+
+  def cloudwatch_source(&block)
+    cloudwatch_client.fetch(
+      query: query,
+      from: from_date,
+      to: to_date,
+      &block
+    )    
+  end  
 end
 
 

--- a/bin/summarize-user-events
+++ b/bin/summarize-user-events
@@ -43,6 +43,7 @@ class SummarizeUserEvents
         , @timestamp
       | filter properties.user_id = '#{uuid}'
       | sort @timestamp asc
+      | limit 10000
     QUERY
   end
 


### PR DESCRIPTION
(Context for anyone not working on this project can be found in [Slack](https://gsa.enterprise.slack.com/archives/C0849B839FC))

Sometimes it is convenient to source events locally rather than having to make a Cloudwatch query every time.

This PR checks to see if stdin is a tty, and if it's not, tries to read newline-delimited JSON (ndjson) events from it.