### PR TITLE
LG-15237 Allow the SP return URL resolver to interpolate locale values into URLs

### DIFF
--- a/app/services/sp_return_url_resolver.rb
+++ b/app/services/sp_return_url_resolver.rb
@@ -27,7 +27,7 @@ class SpReturnUrlResolver
   def post_idv_follow_up_url
     url = service_provider.post_idv_follow_up_url || homepage_url
     return if url.blank?
-    format(url.to_s, locale: I18n.locale.to_s )
+    format(url.to_s, locale: I18n.locale.to_s)
   end
 
   private

--- a/app/services/sp_return_url_resolver.rb
+++ b/app/services/sp_return_url_resolver.rb
@@ -25,7 +25,9 @@ class SpReturnUrlResolver
   end
 
   def post_idv_follow_up_url
-    service_provider.post_idv_follow_up_url || homepage_url
+    url = service_provider.post_idv_follow_up_url || homepage_url
+    return if url.blank?
+    format(url.to_s, locale: I18n.locale.to_s )
   end
 
   private

--- a/spec/services/sp_return_url_resolver_spec.rb
+++ b/spec/services/sp_return_url_resolver_spec.rb
@@ -170,5 +170,13 @@ RSpec.describe SpReturnUrlResolver do
 
       it { expect(post_idv_follow_up_url).to eq(sp_post_idv_follow_up_url) }
     end
+
+    context 'with a template param in the URL' do
+      let(:sp_post_idv_follow_up_url) { 'https://sp.gov/follow_up?locale=%{locale}' }
+
+      it 'interpolates the appropriate value' do
+        expect(post_idv_follow_up_url).to eq('https://sp.gov/follow_up?locale=en')
+      end
+    end
   end
 end


### PR DESCRIPTION
In #11591 we added a `post_idv_follow_up` URL in response to issues we were having getting users for a particular partner to return to their SP. This partner expressed concerns about have the appropriate locale for these users since they are returning to the partner without initiating a session at the partner.

The original implementation for the change in #11591 included a locale param on the `post_idv_follow_up` URL. After some discussion with other engineers we identified that this pattern of hardcoding a param onto a single service providers was undesirable. This commit introduces the ability to include template-able values in these URLs and introduces the locale as one of those values.
