### PR TITLE
Modify the personal key page such that the "Re-enter password" step is not marked complete

### DIFF
--- a/app/components/step_indicator_component.rb
+++ b/app/components/step_indicator_component.rb
@@ -3,8 +3,6 @@
 class StepIndicatorComponent < BaseComponent
   attr_reader :current_step, :locale_scope, :tag_options
 
-  ALL_STEPS_COMPLETE = :all_steps_complete
-
   def initialize(steps:, current_step:, locale_scope: nil, **tag_options)
     @steps = steps
     @current_step = current_step
@@ -23,8 +21,6 @@ class StepIndicatorComponent < BaseComponent
   private
 
   def step_status(step)
-    return :complete if current_step == ALL_STEPS_COMPLETE
-
     if step[:name] == current_step
       :current
     elsif step_index(step[:name]) < step_index(current_step)

--- a/app/controllers/idv/personal_key_controller.rb
+++ b/app/controllers/idv/personal_key_controller.rb
@@ -129,10 +129,13 @@ module Idv
     end
 
     def step_indicator_step
-      return :secure_account if idv_session.verify_by_mail?
-      return :go_to_the_post_office if in_person_proofing?
-
-      StepIndicatorComponent::ALL_STEPS_COMPLETE
+      if gpo_address_verification?
+        :secure_account
+      elsif in_person_proofing?
+        :go_to_the_post_office
+      else
+        :re_enter_password
+      end
     end
     helper_method :step_indicator_step
   end

--- a/spec/components/step_indicator_component_spec.rb
+++ b/spec/components/step_indicator_component_spec.rb
@@ -115,29 +115,6 @@ RSpec.describe StepIndicatorComponent, type: :component do
         )
       end
     end
-
-    context 'all steps complete' do
-      let(:current_step) { StepIndicatorComponent::ALL_STEPS_COMPLETE }
-
-      it 'renders current step' do
-        expect(rendered).not_to have_css('.step-indicator__step--current')
-      end
-
-      it 'renders all steps completed' do
-        expect(rendered).to have_css(
-          '.step-indicator__step--complete',
-          text: t('step_indicator.flows.example.one'),
-        )
-        expect(rendered).to have_css(
-          '.step-indicator__step--complete',
-          text: t('step_indicator.flows.example.two'),
-        )
-        expect(rendered).to have_css(
-          '.step-indicator__step--complete',
-          text: t('step_indicator.flows.example.three'),
-        )
-      end
-    end
   end
 
   describe 'locale_scope' do

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -365,10 +365,9 @@ RSpec.describe 'Identity verification', :js do
       text: t('step_indicator.flows.idv.verify_phone'),
     )
     expect(page).to have_css(
-      '.step-indicator__step--complete',
+      '.step-indicator__step--current',
       text: t('step_indicator.flows.idv.re_enter_password'),
     )
-    expect(page).not_to have_css('.step-indicator__step--current')
     expect(page).not_to have_content(t('step_indicator.flows.idv.verify_address'))
 
     # Refreshing shows same page (BUT with new personal key, we should warn the user)


### PR DESCRIPTION
We received feedback from a partner that users may think that they are done with the identity verification workflow on the personal key page because all of the steps on the step indicator are marked complete. This commit modifies the step indicator on the personal key page so the "Re-enter password" step is not complete on that page.

Since there is no longer a case where all step indicator steps are complete this change also removes the `complete` status from the `StepIndicatorComponent`.