### PR TITLE
LG-15271: Socure webhook repeater

### DIFF
--- a/app/controllers/socure_webhook_controller.rb
+++ b/app/controllers/socure_webhook_controller.rb
@@ -144,7 +144,10 @@ class SocureWebhookController < ApplicationController
       Authorization: request.headers['Authorization'],
       'Content-Type': request.headers['Content-Type'],
     }
-    wr = DocAuth::Socure::WebhookRepeater.new(body: socure_params.to_h, headers:, endpoints:)
+
+    body = socure_params.to_h
+
+    wr = DocAuth::Socure::WebhookRepeater.new(body:, headers:, endpoints:)
     wr.broadcast
   rescue => exception
     NewRelic::Agent.notice_error(

--- a/app/controllers/socure_webhook_controller.rb
+++ b/app/controllers/socure_webhook_controller.rb
@@ -12,6 +12,7 @@ class SocureWebhookController < ApplicationController
     begin
       log_webhook_receipt
       process_webhook_event
+      repeat_webhook
     rescue StandardError => e
       NewRelic::Agent.notice_error(e)
     ensure
@@ -133,5 +134,14 @@ class SocureWebhookController < ApplicationController
 
   def docv_transaction_token
     @docv_transaction_token ||= event[:docvTransactionToken] || event[:docVTransactionToken]
+  end
+
+  def repeat_webhook
+    headers = {
+      Authorization: request.headers['Authorization'],
+      'Content-Type': request.headers['Content-Type'],
+    }
+    wr = DocAuth::Socure::WebhookRepeater.new(body: socure_params.to_h, headers:)
+    wr.broadcast
   end
 end

--- a/app/controllers/socure_webhook_controller.rb
+++ b/app/controllers/socure_webhook_controller.rb
@@ -148,11 +148,7 @@ class SocureWebhookController < ApplicationController
     body = socure_params.to_h
 
     endpoints.each do |endpoint|
-      if IdentityConfig.store.ruby_workers_idv_enabled
-        SocureDocvRepeatWebhooksJob.perform_later(body:, headers:, endpoint:)
-      else
-        SocureDocvRepeatWebhooksJob.perform_now(body:, headers:, endpoint:)
-      end
+      SocureDocvRepeatWebhookJob.perform_later(body:, headers:, endpoint:)
     end
   end
 end

--- a/app/jobs/socure_docv_repeat_webhook_job.rb
+++ b/app/jobs/socure_docv_repeat_webhook_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SocureDocvRepeatWebhooksJob < ApplicationJob
+class SocureDocvRepeatWebhookJob < ApplicationJob
   queue_as :high_socure_docv
 
   def perform(body:, headers:, endpoint:)

--- a/app/jobs/socure_docv_repeat_webhooks_job.rb
+++ b/app/jobs/socure_docv_repeat_webhooks_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SocureDocvRepeatWebhooksJob < ApplicationJob
+  queue_as :high_socure_docv
+
+  def perform(body:, headers:, endpoint:)
+    wr = DocAuth::Socure::WebhookRepeater.new(body:, headers:, endpoint:)
+    wr.repeat
+  end
+end

--- a/app/services/doc_auth/socure/webhook_repeater.rb
+++ b/app/services/doc_auth/socure/webhook_repeater.rb
@@ -3,21 +3,15 @@
 module DocAuth
   module Socure
     class WebhookRepeater
-      attr_reader :body, :headers, :endpoints
+      attr_reader :body, :headers, :endpoint
 
-      def initialize(body:, headers:, endpoints:)
+      def initialize(body:, headers:, endpoint:)
         @body = body
         @headers = headers
-        @endpoints = endpoints
+        @endpoint = endpoint
       end
 
-      def broadcast
-        endpoints.each { |endpoint| repeat(endpoint) }
-      end
-
-      private
-
-      def repeat(endpoint)
+      def repeat
         send_http_post_request(endpoint)
       rescue => exception
         NewRelic::Agent.notice_error(
@@ -29,6 +23,8 @@ module DocAuth
           },
         )
       end
+
+      private
 
       def send_http_post_request(endpoint)
         faraday_connection(endpoint).post do |req|

--- a/app/services/doc_auth/socure/webhook_repeater.rb
+++ b/app/services/doc_auth/socure/webhook_repeater.rb
@@ -45,6 +45,8 @@ module DocAuth
           end,
         }
 
+        timeout = 15
+
         Faraday.new(url: url(endpoint).to_s, headers: request_headers) do |conn|
           conn.request :retry, retry_options
           conn.request :instrumentation, name: 'request_metric.faraday'
@@ -62,10 +64,6 @@ module DocAuth
 
       def request_headers(extras = {})
         headers.merge(extras)
-      end
-
-      def timeout
-        15
       end
     end
   end

--- a/app/services/doc_auth/socure/webhook_repeater.rb
+++ b/app/services/doc_auth/socure/webhook_repeater.rb
@@ -65,7 +65,7 @@ module DocAuth
       end
 
       def timeout
-        60
+        15
       end
     end
   end

--- a/app/services/doc_auth/socure/webhook_repeater.rb
+++ b/app/services/doc_auth/socure/webhook_repeater.rb
@@ -3,7 +3,6 @@
 module DocAuth
   module Socure
     class WebhookRepeater
-
       attr_reader :body, :headers, :endpoints
 
       def initialize(body:, headers:, endpoints:)

--- a/app/services/doc_auth/socure/webhook_repeater.rb
+++ b/app/services/doc_auth/socure/webhook_repeater.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module DocAuth
+  module Socure
+    class WebhookRepeater
+
+      attr_reader :body, :headers
+
+      def initialize(body:, headers:)
+        @body = body
+        @headers = headers
+      end
+
+      def broadcast
+        endpoints.each { |endpoint| repeat(endpoint) }
+      end
+
+      private
+
+      def repeat(endpoint)
+        send_http_post_request(endpoint)
+      rescue => exception
+        handle_connection_error(exception:, endpoint:)
+      end
+
+      def handle_connection_error(exception:, endpoint:)
+        NewRelic::Agent.notice_error(exception, custom_params: { endpoint: })
+      end
+
+      def send_http_post_request(endpoint)
+        faraday_connection(endpoint).post do |req|
+          req.options.context = { service_name: 'socure_webhook_repeater' }
+          req.body = body.to_json
+        end
+      end
+
+      def faraday_connection(endpoint)
+        retry_options = {
+          max: 2,
+          interval: 0.05,
+          interval_randomness: 0.5,
+          backoff_factor: 2,
+          retry_statuses: [404, 500],
+          retry_block: lambda do |env:, options:, retry_count:, exception:, will_retry_in:|
+            NewRelic::Agent.notice_error(exception, custom_params: { retry: retry_count })
+          end,
+        }
+
+        Faraday.new(url: url(endpoint).to_s, headers: request_headers) do |conn|
+          conn.request :retry, retry_options
+          conn.request :instrumentation, name: 'request_metric.faraday'
+          conn.adapter :net_http
+          conn.options.timeout = timeout
+          conn.options.read_timeout = timeout
+          conn.options.open_timeout = timeout
+          conn.options.write_timeout = timeout
+        end
+      end
+
+      def endpoints
+        @endpoints ||= IdentityConfig.store.socure_docv_webhook_repeat_endpoints
+      end
+
+      def url(endpoint)
+        URI.join(endpoint)
+      end
+
+      def request_headers(extras = {})
+        headers.merge(extras)
+      end
+
+      def timeout
+        60
+      end
+    end
+  end
+end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -387,6 +387,7 @@ socure_docv_document_request_endpoint: ''
 socure_docv_enabled: false
 socure_docv_verification_data_test_mode: false
 socure_docv_verification_data_test_mode_tokens: '[]'
+socure_docv_webhook_repeat_endpoints: '[]'
 socure_docv_webhook_secret_key: ''
 socure_docv_webhook_secret_key_queue: '[]'
 socure_idplus_api_key: ''

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -423,6 +423,7 @@ module IdentityConfig
     config.add(:socure_docv_enabled, type: :boolean)
     config.add(:socure_docv_verification_data_test_mode, type: :boolean)
     config.add(:socure_docv_verification_data_test_mode_tokens, type: :json)
+    config.add(:socure_docv_webhook_repeat_endpoints, type: :json)
     config.add(:socure_docv_webhook_secret_key_queue, type: :json)
     config.add(:socure_docv_webhook_secret_key, type: :string)
     config.add(:socure_idplus_api_key, type: :string)

--- a/spec/controllers/socure_webhook_controller_spec.rb
+++ b/spec/controllers/socure_webhook_controller_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe SocureWebhookController do
             allow(IdentityConfig.store)
               .to receive(:socure_docv_webhook_repeat_endpoints).and_return(endpoints)
 
-            allow(DocumentCaptureSession).to receive(:find_by)
-              .and_return(create(:document_capture_session))
+            dcs = create(:document_capture_session, :socure)
+            webhook_body[:event][:docvTransactionToken] = dcs.socure_docv_transaction_token
 
             request.headers['Authorization'] = headers[:Authorization]
             request.headers['Content-Type'] = headers[:'Content-Type']

--- a/spec/controllers/socure_webhook_controller_spec.rb
+++ b/spec/controllers/socure_webhook_controller_spec.rb
@@ -181,6 +181,8 @@ RSpec.describe SocureWebhookController do
           end
         end
 
+        it_behaves_like 'repeats webhooks'
+
         context 'when document capture session exists' do
           it 'logs the user\'s uuid' do
             dcs = create(:document_capture_session, :socure)

--- a/spec/controllers/socure_webhook_controller_spec.rb
+++ b/spec/controllers/socure_webhook_controller_spec.rb
@@ -96,6 +96,9 @@ RSpec.describe SocureWebhookController do
           end
 
           it 'repeats the webhook to all endpoints' do
+            expect(Faraday)
+              .to receive(:new).exactly(endpoints.length).times
+
             post :create, params: webhook_body
           end
 

--- a/spec/controllers/socure_webhook_controller_spec.rb
+++ b/spec/controllers/socure_webhook_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe SocureWebhookController do
             }
           end
           let(:endpoints) do
-            (1..3).map { |i| "https://#{i}.example.test/endpoint" }
+            3.times.map { |i| "https://#{i}.example.test/endpoint" }
           end
           let(:repeated_body) do
             b = {}.merge(webhook_body)
@@ -130,7 +130,7 @@ RSpec.describe SocureWebhookController do
               allow_any_instance_of(DocAuth::Socure::WebhookRepeater)
                 .to receive(:send_http_post_request).and_call_original
 
-              (1...3).each do |i|
+              2.times do |i|
                 allow_any_instance_of(DocAuth::Socure::WebhookRepeater)
                   .to receive(:send_http_post_request).with(endpoints[i]).and_raise('uh-oh')
 

--- a/spec/controllers/socure_webhook_controller_spec.rb
+++ b/spec/controllers/socure_webhook_controller_spec.rb
@@ -91,18 +91,18 @@ RSpec.describe SocureWebhookController do
 
             request.headers['Authorization'] = headers[:Authorization]
             request.headers['Content-Type'] = headers[:'Content-Type']
-
-            endpoints.each do |endpoint|
-              expect(SocureDocvRepeatWebhookJob).to receive(:perform_later) do |*args|
-                expect(args.first[:body]).to eq(JSON.parse(repeated_body.to_json))
-                expect(args.first[:endpoint]).to eq(endpoint)
-                expect(args.first[:headers]).to eq(headers)
-              end
-            end
           end
 
           context 'when idv workers are enabled' do
             it 'queues SocureDocvRepeatWebhook jobs' do
+              endpoints.each do |endpoint|
+                expect(SocureDocvRepeatWebhookJob).to receive(:perform_later) do |*args|
+                  expect(args.first[:body]).to eq(JSON.parse(repeated_body.to_json))
+                  expect(args.first[:endpoint]).to eq(endpoint)
+                  expect(args.first[:headers]).to eq(headers)
+                end
+              end
+
               post :create, params: webhook_body
             end
           end

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -56,6 +56,9 @@ RSpec.feature 'document capture step', :js do
           (max_attempts - 1).times do
             socure_docv_upload_documents(docv_transaction_token: @docv_transaction_token)
           end
+
+          expect(DocAuth::Socure::WebhookRepeater)
+            .to receive(:new).exctly(6).times.and_call_original
         end
 
         it 'redirects to the rate limited error page' do
@@ -138,6 +141,9 @@ RSpec.feature 'document capture step', :js do
 
       context 'reuses valid capture app urls when appropriate', allow_browser_log: true do
         context 'successfully erases capture app url when flow is complete' do
+          before do
+            expect(DocAuth::Socure::WebhookRepeater).not_to receive(:new)
+          end
           it 'proceeds to the next page with valid info' do
             document_capture_session = DocumentCaptureSession.find_by(user_id: @user.id)
             expect(document_capture_session.socure_docv_capture_app_url)
@@ -310,6 +316,11 @@ RSpec.feature 'document capture step', :js do
     context 'standard mobile flow' do
       let(:socure_docv_webhook_repeat_endpoints) do # repeat webhooks
         ['https://1.example.test/thepath', 'https://2.example.test/thepath']
+      end
+
+      before do
+        expect(DocAuth::Socure::WebhookRepeater)
+          .to receive(:new).exactly(6).times.and_call_original
       end
 
       it 'proceeds to the next page with valid info' do

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -247,7 +247,7 @@ RSpec.feature 'document capture step', :js do
         expect(DocAuthLog.find_by(user_id: @user.id).state).to be_nil
       end
 
-      it 'does track state if state tracking is disabled' do
+      it 'does track state if state tracking is enabled' do
         allow(IdentityConfig.store).to receive(:state_tracking_enabled).and_return(true)
         socure_docv_upload_documents(
           docv_transaction_token: @docv_transaction_token,

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'document capture step', :js do
           end
 
           expect(DocAuth::Socure::WebhookRepeater)
-            .to receive(:new).exctly(6).times.and_call_original
+            .to receive(:new).exactly(6).times.and_call_original
         end
 
         it 'redirects to the rate limited error page' do

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Hybrid Flow' do
   let(:fake_socure_docv_document_request_endpoint) { 'https://fake-socure.test/document-request' }
   let(:socure_docv_verification_data_test_mode) { false }
   let(:fake_analytics) { FakeAnalytics.new }
+  let(:socure_docv_webhook_repeat_endpoints) { [] }
 
   before do
     allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
@@ -21,6 +22,9 @@ RSpec.describe 'Hybrid Flow' do
     allow(IdentityConfig.store).to receive(:ruby_workers_idv_enabled).and_return(false)
     allow(IdentityConfig.store).to receive(:socure_docv_document_request_endpoint)
       .and_return(fake_socure_docv_document_request_endpoint)
+    allow(IdentityConfig.store).to receive(:socure_docv_webhook_repeat_endpoints)
+      .and_return(socure_docv_webhook_repeat_endpoints)
+    socure_docv_webhook_repeat_endpoints.each { |endpoint| stub_request(:post, endpoint) }
     allow(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
       @sms_link = config[:link]
       impl.call(**config)
@@ -165,6 +169,9 @@ RSpec.describe 'Hybrid Flow' do
 
     context 'user is rate limited on mobile' do
       let(:max_attempts) { IdentityConfig.store.doc_auth_max_attempts }
+      let(:socure_docv_webhook_repeat_endpoints) do # repeat webhooks
+        ['https://1.example.test/thepath', 'https://2.example.test/thepath']
+      end
 
       before do
         allow(IdentityConfig.store).to receive(:doc_auth_max_attempts).and_return(max_attempts)
@@ -212,49 +219,61 @@ RSpec.describe 'Hybrid Flow' do
       end
     end
 
-    it 'prefills the phone number used on the phone step if the user has no MFA phone', :js do
-      user = create(:user, :with_authentication_app)
-
-      perform_in_browser(:desktop) do
-        start_idv_from_sp(facial_match_required: false)
-        sign_in_and_2fa_user(user)
-
-        complete_doc_auth_steps_before_hybrid_handoff_step
-        clear_and_fill_in(:doc_auth_phone, phone_number)
-        click_send_link
+    context 'if the user has no MFA phone' do
+      let(:socure_docv_webhook_repeat_endpoints) do # repeat webhooks
+        ['https://1.example.test/thepath', 'https://2.example.test/thepath']
       end
 
-      expect(@sms_link).to be_present
-
-      perform_in_browser(:mobile) do
-        visit @sms_link
-
-        expect(page).to have_current_path(idv_hybrid_mobile_socure_document_capture_url)
-        click_idv_continue
-        expect(page).to have_current_path(fake_socure_document_capture_app_url)
-        socure_docv_upload_documents(docv_transaction_token: @docv_transaction_token)
-        visit idv_hybrid_mobile_socure_document_capture_update_url
-
-        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
-        expect(page).to have_text(t('doc_auth.instructions.switch_back'))
+      before do
+        # recovers when fails to repeat webhook to an endpoint
+        allow_any_instance_of(DocAuth::Socure::WebhookRepeater)
+          .to receive(:send_http_post_request).and_raise('doh')
       end
 
-      perform_in_browser(:desktop) do
-        expect(page).to have_current_path(idv_ssn_path, wait: 10)
+      it 'prefills the phone number used on the phone step', :js do
+        user = create(:user, :with_authentication_app)
 
-        fill_out_ssn_form_ok
-        click_idv_continue
+        perform_in_browser(:desktop) do
+          start_idv_from_sp(facial_match_required: false)
+          sign_in_and_2fa_user(user)
 
-        expect(page).to have_content(t('headings.verify'))
-        complete_verify_step
+          complete_doc_auth_steps_before_hybrid_handoff_step
+          clear_and_fill_in(:doc_auth_phone, phone_number)
+          click_send_link
+        end
 
-        prefilled_phone = page.find(id: 'idv_phone_form_phone').value
+        expect(@sms_link).to be_present
 
-        expect(
-          PhoneFormatter.format(prefilled_phone),
-        ).to eq(
-          PhoneFormatter.format(phone_number),
-        )
+        perform_in_browser(:mobile) do
+          visit @sms_link
+
+          expect(page).to have_current_path(idv_hybrid_mobile_socure_document_capture_url)
+          click_idv_continue
+          expect(page).to have_current_path(fake_socure_document_capture_app_url)
+          socure_docv_upload_documents(docv_transaction_token: @docv_transaction_token)
+          visit idv_hybrid_mobile_socure_document_capture_update_url
+
+          expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+          expect(page).to have_text(t('doc_auth.instructions.switch_back'))
+        end
+
+        perform_in_browser(:desktop) do
+          expect(page).to have_current_path(idv_ssn_path, wait: 10)
+
+          fill_out_ssn_form_ok
+          click_idv_continue
+
+          expect(page).to have_content(t('headings.verify'))
+          complete_verify_step
+
+          prefilled_phone = page.find(id: 'idv_phone_form_phone').value
+
+          expect(
+            PhoneFormatter.format(prefilled_phone),
+          ).to eq(
+            PhoneFormatter.format(phone_number),
+          )
+        end
       end
     end
 
@@ -303,6 +322,15 @@ RSpec.describe 'Hybrid Flow' do
 
       context 'when an invalid test token is used' do
         let(:invalid_token) { 'invalid-token' }
+        let(:socure_docv_webhook_repeat_endpoints) do # repeat webhooks
+          ['https://1.example.test/thepath', 'https://2.example.test/thepath']
+        end
+
+        before do
+          # recovers when fails to broadcast webhook
+          allow_any_instance_of(DocAuth::Socure::WebhookRepeater)
+            .to receive(:broadcast).and_raise('doh')
+        end
 
         it 'waits to fetch verificationdata using docv capture session token', js: true do
           user = nil

--- a/spec/jobs/socure_docv_repeat_webhook_job_spec.rb
+++ b/spec/jobs/socure_docv_repeat_webhook_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SocureDocvRepeatWebhookJob do
+  let(:job) { described_class.new }
+  let(:headers) do
+    {
+      Authorization: 'auhtoriztion-header',
+      'Content-Type': 'application/json',
+    }
+  end
+  let(:endpoint) { 'https://example.test/endpoint' }
+  let(:body) do
+    {
+      event: {
+        created: '2020-01-01T00:00:00Z',
+        customerUserId: 'customer-user-id',
+        eventType: 'REPEATED_EVENT',
+        docvTransactionToken: 'rando-token',
+        referenceId: 'reference-id',
+      },
+    }
+  end
+
+  before do
+    stub_request(:post, endpoint)
+      .with(body:, headers:)
+  end
+
+  describe '#perform' do
+    subject(:perform) do
+      job.perform(body:, headers:, endpoint:)
+    end
+
+    it 'repeats the webhook' do
+      expect(Faraday).to receive(:new).and_call_original
+      expect(NewRelic::Agent).not_to receive(:notice_error)
+
+      perform
+    end
+
+    context 'failed endpoint repeat' do
+      before do
+        allow_any_instance_of(DocAuth::Socure::WebhookRepeater)
+          .to receive(:send_http_post_request).with(endpoint).and_raise('uh-oh')
+      end
+
+      it 'sends message to New Relic' do
+        expect(NewRelic::Agent).to receive(:notice_error) do |*args|
+          expect(args.first).to be_a_kind_of(RuntimeError)
+          expect(args.last).to eq(
+            {
+              custom_params: {
+                event: 'Failed to repeat webhook',
+                endpoint:,
+                body:,
+              },
+            },
+          )
+        end
+
+        perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-15271](https://cm-jira.usa.gov/browse/LG-15271)

## 🛠 Summary of changes
Broadcast webhooks received from Socure to configure receivers.

## 📜 Testing Plan
Currently configured in the Timnit Sandbox
- [ ] Verify Socure Dashboard sandbox env has Timnit IdP designated to receive webhooks
- [ ] Complete DocV in the Timnit Sandbox
- [ ] Verify that webhooks appear in Cloudwatch events log for Timnit
- [ ] Verify that webhooks appear in Cloudwatch events log the sandboxes configured `socure_docv_webhook_repeat_endpoints` to receive repeated webhooks in Timnit config

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
