### PR TITLE
[HACKATHON] Output formatting tweaks

### DIFF
--- a/bin/summarize-user-events
+++ b/bin/summarize-user-events
@@ -25,6 +25,9 @@ end
 class SummarizeUserEvents
   attr_reader :uuid, :from_date, :to_date, :zone
 
+  NICE_DATE_AND_TIME_FORMAT = '%B %d, %Y at %I:%M %p %Z'
+  TIME_ONLY_FORMAT = '%I:%M %p'
+
   def initialize(user_uuid: nil, start_time: nil, end_time: nil, zone: 'UTC')
     @zone = zone
     Time.zone = zone
@@ -42,7 +45,7 @@ class SummarizeUserEvents
   def matchers
     @matchers ||= [
       EventSummarizer::ExampleMatcher.new,
-      EventSummarizer::IdvMatcher.new
+      EventSummarizer::IdvMatcher.new,
     ]
   end
 
@@ -73,17 +76,52 @@ class SummarizeUserEvents
   end
 
   def format_results(results)
-    results.map do |r|
-      title = r[:title]
+    # Each Hash in results should have _at least_ a :title key defined
 
-      [
-        "## #{title}",
-        *r[:attributes]&.map do |attr|
-          "* #{attr[:description]}"
-        end,
-        '',
-      ]
-    end.join("\n")
+    results.
+      sort_by { |r| r[:timestamp] || r[:started_at] || Time.zone.at(0) }.
+      map do |r|
+        timestamp = r[:timestamp] || r[:started_at]
+
+        heading = r[:title]
+
+        if timestamp
+          heading = "#{heading} (#{timestamp.strftime(NICE_DATE_AND_TIME_FORMAT)})"
+        end
+
+        prev_timestamp = timestamp
+
+        list_items = r[:attributes]&.
+          sort_by { |attr| attr[:timestamp] || Time.zone.at(0) }&.
+          map do |attr|
+            text = attr[:description]
+
+            formatted_timestamp = format_time(attr[:timestamp], prev_timestamp)
+            prev_timestamp = attr[:timestamp]
+
+            text = "(#{formatted_timestamp}) #{text}" if formatted_timestamp
+
+            "* #{text}"
+          end
+
+        [
+          "## #{heading}",
+          *list_items,
+          '',
+        ]
+      end.join("\n")
+  end
+
+  def format_time(timestamp, prev_timestamp = nil)
+    return if timestamp.blank?
+
+    same_date = timestamp.to_date == prev_timestamp&.to_date
+
+    if same_date
+      timestamp.strftime(TIME_ONLY_FORMAT)
+    else
+      timestamp.strftime(NICE_DATE_AND_TIME_FORMAT)
+    end
   end
 
   def query
@@ -138,7 +176,7 @@ def main
   options = {}
   basename = File.basename($0)
 
-  # rubocop:disable Metrics/BlockLength, Metrics/LineLength
+  # rubocop:disable Metrics/LineLength
   optparse = OptionParser.new do |opts|
     opts.banner = <<-EOM
 
@@ -176,7 +214,7 @@ def main
       options[:zone] = val
     end
   end
-  # rubocop:enable Metrics/BlockLength, Metrics/LineLength
+  # rubocop:enable Metrics/LineLength
 
   optparse.parse!
 

--- a/bin/summarize-user-events
+++ b/bin/summarize-user-events
@@ -50,6 +50,11 @@ class SummarizeUserEvents
     find_cloudwatch_events do |event|
       Time.zone ||= zone
 
+      # Timestamps coming from cloudwatch are in UTC but don't include any zone
+      # information. Here we parse them as UTC.
+      if event['@timestamp'].is_a?(String)
+        event['@timestamp'] = Time.zone.parse("#{event['@timestamp']} UTC")
+      end
       event['@message'] = JSON.parse(event['@message']) if event['@message'].is_a?(String)
 
       matchers.each do |matcher|

--- a/lib/event_summarizer/idv_matcher.rb
+++ b/lib/event_summarizer/idv_matcher.rb
@@ -417,6 +417,7 @@ module EventSummarizer
       attributes = attempt.significant_events.map do |e|
         {
           type: e.type,
+          timestamp: e.timestamp,
           description: e.description,
         }
       end

--- a/lib/event_summarizer/idv_matcher.rb
+++ b/lib/event_summarizer/idv_matcher.rb
@@ -150,7 +150,7 @@ module EventSummarizer
 
     # @return {Hash,nil}
     def handle_final_resolution_event(event:)
-      timestamp = Time.zone.parse(event['@timestamp'])
+      timestamp = event['@timestamp']
 
       gpo_pending = !!event.dig(
         *EVENT_PROPERTIES,
@@ -208,7 +208,7 @@ module EventSummarizer
     end
 
     def handle_gpo_code_submission(event:)
-      timestamp = Time.zone.parse(event['@timestamp'])
+      timestamp = event['@timestamp']
       success = event.dig(*EVENT_PROPERTIES, 'success')
 
       if !success
@@ -257,7 +257,7 @@ module EventSummarizer
     end
 
     def handle_ipp_enrollment_status_update(event:)
-      timestamp = Time.zone.parse(event['@timestamp'])
+      timestamp = event['@timestamp']
       passed = event.dig(*EVENT_PROPERTIES, 'passed')
       tmx_status = event.dig(*EVENT_PROPERTIES, 'tmx_status')
 
@@ -289,7 +289,7 @@ module EventSummarizer
 
       add_significant_event(
         type: :password_reset,
-        timestamp: Time.zone.parse(event['@timestamp']),
+        timestamp: event['@timestamp'],
         description: [
           'The user reset their password and did not provide their personal key.',
           caveats.length > 0 ?
@@ -310,7 +310,7 @@ module EventSummarizer
 
       return if limit_name.blank?
 
-      timestamp = Time.zone.parse(event['@timestamp'])
+      timestamp = event['@timestamp']
 
       for_current_idv_attempt(event:) do
         add_significant_event(
@@ -322,7 +322,7 @@ module EventSummarizer
     end
 
     def handle_verify_proofing_results_event(event:)
-      timestamp = Time.zone.parse(event['@timestamp'])
+      timestamp = event['@timestamp']
       success = event.dig(*EVENT_PROPERTIES, 'success')
 
       if success
@@ -407,7 +407,7 @@ module EventSummarizer
       finish_current_idv_attempt if current_idv_attempt
 
       @current_idv_attempt = IdvAttempt.new(
-        started_at: Time.zone.parse(event['@timestamp']),
+        started_at: event['@timestamp'],
       )
     end
 


### PR DESCRIPTION
Add timestamps to output so you can actually tell when something happened.

Example:

## Identity verification started (December 06, 2024 at 08:50 PM UTC)
* (08:57 PM) AAMVA request failed. The ID # from the user's non-driving ID card was invalid according to the state of OR
* (09:03 PM) AAMVA request failed. The ID # from the user's non-driving ID card was invalid according to the state of OR

## Identity verification started (December 09, 2024 at 08:54 PM UTC)
* (09:06 PM) Instant Verify request failed. 1 check failed: AddrNotHighRisk (addr_highrisk_fail)
* (09:06 PM) AAMVA request failed. The ID # from the user's non-driving ID card was invalid according to the state of OR
* (09:13 PM) AAMVA request failed. The ID # from the user's non-driving ID card was invalid according to the state of OR