### PR TITLE
Fix documentation formatting for Analytics Events

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1855,7 +1855,7 @@ module AnalyticsEvents
   # @param [String] state_id_type
   # @param [Boolean] async
   # @param [Integer] submit_attempts Times that user has tried submitting (previously called
-  # "attempts")
+  #   "attempts")
   # @param [Integer] remaining_submit_attempts (previously called "remaining_attempts")
   # @param [Hash] client_image_metrics
   # @param ["hybrid","standard"] flow_path Document capture user flow
@@ -1890,10 +1890,10 @@ module AnalyticsEvents
   # @param [String] birth_year Birth year from document
   # @param [Integer] issue_year Year document was issued
   # @param [Hash] failed_image_fingerprints Hash of document field with an array of failed image
-  # fingerprints for that field.
+  #   fingerprints for that field.
   # @param [Integer] selfie_attempts number of selfie attempts the user currently has processed
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
+  #   SDK upgrades
   # @option extra [String] 'DocumentName'
   # @option extra [String] 'DocAuthResult'
   # @option extra [String] 'DocIssuerCode'

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1236,7 +1236,7 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
+  #   SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_agreement_submitted(
@@ -1268,7 +1268,7 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
+  #   SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_agreement_visited(
@@ -1321,7 +1321,7 @@ module AnalyticsEvents
   # @param [Boolean] selfie_check_required Whether facial match check is required
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
+  #   SDK upgrades
   def idv_doc_auth_document_capture_polling_wait_visited(
     flow_path:,
     step:,
@@ -1358,10 +1358,10 @@ module AnalyticsEvents
   # @param [Boolean] selfie_check_required Whether facial match check is required
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
-  # warning
+  #   warning
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
+  #   SDK upgrades
   # @param [Boolean] stored_result_present Whether a stored result was present
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_document_capture_submitted(
@@ -1401,12 +1401,12 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
-  # warning
+  #   warning
   # @param [Boolean] liveness_checking_required Whether facial match check is required
   # @param [Boolean] selfie_check_required Whether facial match check is required
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
+  #   SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_document_capture_visited(
@@ -1546,12 +1546,12 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
-  # warning
+  #   warning
   # @param [Boolean] selfie_check_required Whether facial match check is required
   # @param ["document_capture","send_link"] destination Where user is sent after submission
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
+  #   SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Hash] telephony_response Response from Telephony gem
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
@@ -1593,10 +1593,10 @@ module AnalyticsEvents
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
   # @param [Boolean] redo_document_capture Whether user is redoing document capture after barcode
-  # warning
+  #   warning
   # @param [Boolean] selfie_check_required Whether facial match check is required
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
+  #   SDK upgrades
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_hybrid_handoff_visited(
@@ -1802,7 +1802,7 @@ module AnalyticsEvents
   # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Integer] submit_attempts Times that user has tried submitting (previously called
-  # "attempts")
+  #   "attempts")
   # @param [Integer] remaining_submit_attempts (previously called "remaining_attempts")
   # @param [String] user_id
   # @param ["hybrid","standard"] flow_path Document capture user flow
@@ -1811,7 +1811,7 @@ module AnalyticsEvents
   # @param [String] back_image_fingerprint Fingerprint of back image data
   # @param [String] selfie_image_fingerprint Fingerprint of selfie image data
   # @param [String] acuant_sdk_upgrade_ab_test_bucket A/B test bucket for Acuant document capture
-  # SDK upgrades
+  #   SDK upgrades
   # The document capture image uploaded was locally validated during the IDV process
   def idv_doc_auth_submitted_image_upload_form(
     success:,
@@ -4215,7 +4215,7 @@ module AnalyticsEvents
   # @param [Hash] vendor Vendor response payload
   # @param [Boolean] new_phone_added Whether phone number was added to account in submission
   # @param [Boolean] hybrid_handoff_phone_used Whether phone is the same as what was used for hybrid
-  # document capture
+  #   document capture
   # @param [String] area_code Area code of phone number
   # @param [String] country_code Abbreviated 2-letter country code associated with phone number
   # @param [String] phone_fingerprint HMAC fingerprint of the phone number formatted as E.164
@@ -4864,7 +4864,7 @@ module AnalyticsEvents
   # @param [String] state_id_type type of state issued ID
   # @param [Boolean] async whether or not this worker is running asynchronously
   # @param [Integer] submit_attempts Times that user has tried submitting (previously called
-  # "attempts")
+  #   "attempts")
   # @param [Integer] remaining_submit_attempts (previously called "remaining_attempts")
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Float] vendor_request_time_in_ms Time it took to upload images & get a response.
@@ -5471,8 +5471,8 @@ module AnalyticsEvents
 
   # @param ["authentication", "reauthentication", "confirmation"] context User session context
   # @param ["webauthn","webauthn_platform"] multi_factor_auth_method which webauthn method was used,
-  # webauthn means a roaming authenticator like a yubikey, webauthn_platform means a platform
-  # authenticator like face or touch ID
+  #   webauthn means a roaming authenticator like a yubikey, webauthn_platform means a platform
+  #   authenticator like face or touch ID
   # @param [Integer, nil] webauthn_configuration_id webauthn database ID
   # @param [String] multi_factor_auth_method_created_at When the authentication method was created
   # User visited the page to authenticate with webauthn (yubikey, face ID or touch ID)
@@ -5596,7 +5596,7 @@ module AnalyticsEvents
   # @param [Integer] attempts number of MFA setup attempts
   # @param [String, nil] aaguid AAGUID value of WebAuthn device
   # @param [String[], nil] unknown_transports Array of unrecognized WebAuthn transports, intended to
-  # be used in case of future specification changes.
+  #   be used in case of future specification changes.
   # @param [:authentication, :account_creation, nil] webauthn_platform_recommended A/B test for
   # recommended Face or Touch Unlock setup, if applicable.
   def multi_factor_auth_setup(
@@ -5979,7 +5979,7 @@ module AnalyticsEvents
   # @param [Boolean] active_profile_present Whether active profile existed at time of change
   # @param [Boolean] pending_profile_present Whether pending profile existed at time of change
   # @param [Boolean] required_password_change Whether password change was forced due to compromised
-  # password
+  #   password
   # The user updated their password
   def password_changed(
     success:,
@@ -6035,9 +6035,9 @@ module AnalyticsEvents
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation
   # @param [Boolean, nil] confirmed if the account the reset is being requested for has a
-  # confirmed email
+  #   confirmed email
   # @param [Boolean, nil] active_profile if the account the reset is being requested for has an
-  # active proofed profile
+  #   active proofed profile
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # The user entered an email address to request a password reset
   def password_reset_email(
@@ -6062,11 +6062,11 @@ module AnalyticsEvents
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] errors Errors resulting from form validation
   # @param [Boolean] profile_deactivated if the active profile for the account was deactivated
-  # (the user will need to use their personal key to reactivate their profile)
+  #   (the user will need to use their personal key to reactivate their profile)
   # @param [Boolean] pending_profile_invalidated Whether a pending profile was invalidated as a
-  # result of the password reset
+  #   result of the password reset
   # @param [String] pending_profile_pending_reasons Comma-separated list of the pending states
-  # associated with the associated profile.
+  #   associated with the associated profile.
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # The user changed the password for their account via the password reset flow
   def password_reset_password(
@@ -6126,7 +6126,7 @@ module AnalyticsEvents
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Integer] emails Number of email addresses the notification was sent to
   # @param [Array<String>] sms_message_ids AWS Pinpoint SMS message IDs for each phone number that
-  # was notified
+  #   was notified
   # Alert user if a personal key was used to sign in
   def personal_key_alert_about_sign_in(
     success:,
@@ -6386,7 +6386,7 @@ module AnalyticsEvents
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Integer] emails Number of email addresses the notification was sent to
   # @param [Array<String>] sms_message_ids AWS Pinpoint SMS message IDs for each phone number that
-  # was notified
+  #   was notified
   # User has chosen to receive a new personal key, contains stats about notifications that
   # were sent to phone numbers and email addresses for the user
   def profile_personal_key_create_notifications(
@@ -6680,14 +6680,14 @@ module AnalyticsEvents
   # @param [Boolean] finish_profile
   # @param [String] requested_ial
   # @param [Boolean] request_signed
-  # @param [String] matching_cert_serial
-  # matches the request certificate in a successful, signed request
+  # @param [String] matching_cert_serial matches the request certificate in a successful, signed
+  #  request
   # @param [Boolean] certs_different Whether the matching cert changes when SHA256 validations
-  # are turned on in the saml_idp gem
+  #   are turned on in the saml_idp gem
   # @param [Hash] cert_error_details Details for errors that occurred because of an invalid
-  # signature
+  #   signature
   # @param [String] sha256_matching_cert serial of the cert that matches when sha256 validations
-  # are turned on
+  #   are turned on
   # @param [String] unknown_authn_contexts space separated list of unknown contexts
   def saml_auth(
     success:,
@@ -6994,7 +6994,7 @@ module AnalyticsEvents
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Integer] selected_email_id Selected email address record ID
   # @param [String, nil] needs_completion_screen_reason Reason for the consent screen being shown,
-  # if user is changing email in consent flow
+  #   if user is changing email in consent flow
   def sp_select_email_submitted(
     success:,
     selected_email_id:,
@@ -7014,7 +7014,7 @@ module AnalyticsEvents
 
   # User visited form to change email shared with service provider
   # @param [String, nil] needs_completion_screen_reason Reason for the consent screen being shown,
-  # if user is changing email in consent flow
+  #   if user is changing email in consent flow
   def sp_select_email_visited(needs_completion_screen_reason: nil, **extra)
     track_event(:sp_select_email_visited, needs_completion_screen_reason:, **extra)
   end
@@ -7174,7 +7174,7 @@ module AnalyticsEvents
   # @param [String] service_provider_name The friendly name of the service provider
   # @param ['account-page','agency-page'] page_occurence Where the user concluded registration
   # @param ['new_sp','new_attributes','reverified_after_consent'] needs_completion_screen_reason The
-  # reason for the consent screen being shown
+  #   reason for the consent screen being shown
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation
   # @param [Array] sp_session_requested_attributes Attributes requested by the service provider
   # @param [String, nil] in_person_proofing_status In person proofing status
@@ -7222,7 +7222,7 @@ module AnalyticsEvents
   # @param [String] service_provider_name The friendly name of the service provider
   # @param ['account-page','agency-page'] page_occurence Where the user concluded registration
   # @param ['new_sp','new_attributes','reverified_after_consent'] needs_completion_screen_reason The
-  # reason for the consent screen being shown
+  #   reason for the consent screen being shown
   # @param [Array] sp_session_requested_attributes Attributes requested by the service provider
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation flow
   # @param [String, nil] disposable_email_domain Disposable email domain used for registration

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6681,7 +6681,7 @@ module AnalyticsEvents
   # @param [String] requested_ial
   # @param [Boolean] request_signed
   # @param [String] matching_cert_serial matches the request certificate in a successful, signed
-  #  request
+  #   request
   # @param [Boolean] certs_different Whether the matching cert changes when SHA256 validations
   #   are turned on in the saml_idp gem
   # @param [Hash] cert_error_details Details for errors that occurred because of an invalid


### PR DESCRIPTION
## 🛠 Summary of changes

The YARD documentation gets scraped and use in internal documentation. We have a few cases where per-param text was being "globbed" into the method-wide description, creating some confusing docs (see screenshot below).

I started out fixing the "vendor submitted" image event but then found a few more, by searching around with `/# [^@ ]/` regex.

## 📜 Testing Plan

Confirm that YARD parses descriptions of event as expected, confirm it in our analytics events JSON file

**Before**
```
> make analytics_events
> jq -r '.events[] | select( .event_name | contains("vendor submitted")) | .description' < public/api/_analytics-events.json
"attempts")
fingerprints for that field.
SDK upgrades
The document capture image was uploaded to vendor during the IDV process

```

**After**
```
> make analytics_events
> jq -r '.events[] | select( .event_name | contains("vendor submitted")) | .description' < public/api/_analytics-events.json
The document capture image was uploaded to vendor during the IDV process
```


## 👀 Screenshots

Example of incorrect documentation

<img width="657" alt="Screenshot 2024-12-12 at 1 17 42 PM" src="https://github.com/user-attachments/assets/09184cd1-6a9c-412e-b65d-1ffae702e86e" />


