### PR TITLE
Fix mail_later Rubocop cop when method called on variable reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ lint: ## Runs all lint tests
 	@echo "--- rubocop ---"
 	mkdir -p tmp
 ifdef JUNIT_OUTPUT
-	bundle exec rubocop --parallel --format progress --format junit --out rubocop.xml --display-only-failed --color 2> tmp/rubocop.txt
+	bundle exec rubocop --parallel --format progress --format junit --out rubocop.xml --display-only-failed --color 2> tmp/rubocop.txt || (cat tmp/rubocop.txt; exit 1)
 else
-	bundle exec rubocop --parallel --color 2> tmp/rubocop.txt
+	bundle exec rubocop --parallel --color 2> tmp/rubocop.txt || (cat tmp/rubocop.txt; exit 1)
 endif
 	awk 'NF {exit 1}' tmp/rubocop.txt || (printf "Error: Unexpected stderr output from Rubocop\n"; cat tmp/rubocop.txt; exit 1)
 	@echo "--- analytics_events ---"

--- a/lib/linters/mail_later_linter.rb
+++ b/lib/linters/mail_later_linter.rb
@@ -28,12 +28,12 @@ module RuboCop
           mailer_name = if receiver.const_type?
                           # MailerClass.email.send_later
                           receiver.const_name
-                        elsif receiver.method_name == :with
+                        elsif receiver.send_type? && receiver.method_name == :with
                           # MailerClass.with(...).email.send_later
                           receiver.receiver.const_name
                         end
 
-          add_offense(node) if mailer_name == 'UserMailer'
+          add_offense(node) if mailer_name.nil? || mailer_name == 'UserMailer'
         end
       end
     end

--- a/spec/lib/linters/mail_later_linter_spec.rb
+++ b/spec/lib/linters/mail_later_linter_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe RuboCop::Cop::IdentityIdp::MailLaterLinter do
     RUBY
   end
 
+  it 'registers offense when calling .with(...).deliver_now method with variable mailer' do
+    expect_offense(<<~RUBY)
+      mailer = UserMailer.with(user)
+      mailer.send_email(params).deliver_later
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ IdentityIdp/MailLaterLinter: Please send mail using deliver_now_or_later instead
+    RUBY
+  end
+
   it 'does not register offenses for the ReportMailer' do
     expect_no_offenses(<<~RUBY)
       ReportMailer.send_email(foobar).deliver_now

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1465,6 +1465,11 @@ RSpec.describe UserMailer, type: :mailer do
   end
 
   describe '#deliver_later' do
+    it 'queues email without raising' do
+      mailer = UserMailer.with(user:, email_address: user.email_addresses.first)
+      mailer.suspended_create_account.deliver_later
+    end
+
     it 'does not queue email if it potentially contains sensitive value' do
       user = create(:user)
       mailer = UserMailer.with(

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1466,8 +1466,10 @@ RSpec.describe UserMailer, type: :mailer do
 
   describe '#deliver_later' do
     it 'queues email without raising' do
+      # rubocop:disable IdentityIdp/MailLaterLinter
       mailer = UserMailer.with(user:, email_address: user.email_addresses.first)
       mailer.suspended_create_account.deliver_later
+      # rubocop:enable IdentityIdp/MailLaterLinter
     end
 
     it 'does not queue email if it potentially contains sensitive value' do


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where the custom `mail_later` Rubocop cop will fail if checking a method call on a variable reference to a mailer.

In doing so, it fixes a separate issue where errors raised in the course of performing Rubocop lint check are not output in the build output.

Previously: https://github.com/18F/identity-idp/pull/11458#issuecomment-2524146499

## 📜 Testing Plan

Verify that the build output now displays errors occurring during Rubocop check: https://gitlab.login.gov/lg/identity-idp/-/jobs/1577667

Verify that the lint checks pass.