### PR TITLE
Remove support for wildcard allowed_extra_analytics

### DIFF
--- a/spec/support/fake_analytics.rb
+++ b/spec/support/fake_analytics.rb
@@ -102,7 +102,7 @@ class FakeAnalytics < Analytics
 
           extra_keywords -= Array(allowed_extra_analytics)
 
-          if extra_keywords.present? && !allowed_extra_analytics.include?(:*)
+          if extra_keywords.present?
             raise UndocumentedParams, <<~ERROR
               event :#{method_name} called with undocumented params #{extra_keywords.inspect}
               (if these params are for specs only, use :allowed_extra_analytics metadata)
@@ -193,30 +193,5 @@ RSpec.configure do |c|
   ensure
     FakeAnalytics::UndocumentedParamsChecker.allowed_extra_analytics = []
     FakeAnalytics::UndocumentedParamsChecker.checked_extra_analytics = []
-  end
-
-  c.after(:all) do |_ex|
-    next if c.world.all_examples.count != c.world.example_count
-
-    groups.group_by(&:first).each do |group, pairs|
-      allowed_extra_analytics = group.metadata[:allowed_extra_analytics]
-      next if allowed_extra_analytics.blank?
-      all_checked_extra_analytics = pairs.map(&:last).flatten.uniq
-      if allowed_extra_analytics.include?(:*)
-        expect(all_checked_extra_analytics).to(
-          be_present,
-          "Unnecessary allowed_extra_analytics on example group #{group} (in #{group.id})",
-        )
-      else
-        unchecked_extra_analytics = allowed_extra_analytics - all_checked_extra_analytics
-        expect(unchecked_extra_analytics).to(
-          be_blank,
-          "Unnecessary allowed_extra_analytics keywords on example group #{group}: " \
-            "#{unchecked_extra_analytics} (in #{group.id})",
-        )
-      end
-    end
-  ensure
-    groups = []
   end
 end

--- a/spec/support/fake_analytics_spec.rb
+++ b/spec/support/fake_analytics_spec.rb
@@ -605,25 +605,6 @@ RSpec.describe FakeAnalytics do
       )
     end
 
-    it 'does not error when undocumented params are allowed via *', allowed_extra_analytics: [:*] do
-      analytics.idv_phone_confirmation_otp_submitted(
-        success: true,
-        errors: true,
-        code_expired: true,
-        code_matches: true,
-        otp_delivery_preference: :sms,
-        second_factor_attempts_count: true,
-        second_factor_locked_at: true,
-        proofing_components: true,
-        fun_level: 1000,
-      )
-
-      expect(analytics).to have_logged_event(
-        'IdV: phone confirmation otp submitted',
-        hash_including(:fun_level),
-      )
-    end
-
     it 'does not error when string tags are documented as options' do
       analytics.idv_doc_auth_submitted_image_upload_vendor(
         success: nil,


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the behavior of `FakeAnalytics` extra analytics checker to only support individually allowlisted properties and not blanket wildcard exceptions.

As of #11634, we have complete documentation coverage for every analytics event, thus removing the need for this override, which was introduced as a temporary solution when introducing the check, due to the level of effort in documenting existing analytics events.

## 📜 Testing Plan

Verify build passes.