### PR TITLE
Simplify OIDC Logout validation

### DIFF
--- a/app/controllers/openid_connect/certs_controller.rb
+++ b/app/controllers/openid_connect/certs_controller.rb
@@ -6,10 +6,12 @@ module OpenidConnect
     prepend_before_action :skip_session_expiration
     skip_before_action :disable_caching
 
+    JSON = OpenidConnectCertsPresenter.new.certs.freeze
+
     def index
       expires_in 1.week, public: true
 
-      render json: OpenidConnectCertsPresenter.new.certs
+      render json: JSON
     end
   end
 end

--- a/app/forms/openid_connect_logout_form.rb
+++ b/app/forms/openid_connect_logout_form.rb
@@ -94,14 +94,13 @@ class OpenidConnectLogoutForm
     return nil if id_token_hint.blank?
     payload, _headers = nil
 
-    Rails.application.config.oidc_public_key_queue.compact.find do |key|
+    begin
       payload, _headers = JWT.decode(
-        id_token_hint, key, true,
+        id_token_hint, Rails.application.config.oidc_public_key_queue, true,
         algorithm: 'RS256',
         leeway: Float::INFINITY
       ).map(&:with_indifferent_access)
     rescue JWT::DecodeError
-      next
     end
 
     if payload

--- a/spec/forms/openid_connect_logout_form_spec.rb
+++ b/spec/forms/openid_connect_logout_form_spec.rb
@@ -162,6 +162,19 @@ RSpec.describe OpenidConnectLogoutForm do
           end
         end
 
+        context 'with a payload that was signed with an invalid key' do
+          let(:id_token_hint) do
+            JWT.encode(
+              { sub: identity.uuid, aud: identity.service_provider },
+              OpenSSL::PKey::RSA.new(2048), 'RS256'
+            )
+          end
+
+          it 'is valid' do
+            expect(valid?).to eq(false)
+          end
+        end
+
         context 'with a payload that does not correspond to an identity' do
           let(:id_token_hint) do
             JWT.encode(


### PR DESCRIPTION
## 🛠 Summary of changes

In working on https://github.com/18F/omniauth_login_dot_gov/pull/37, I noticed `JWT::decode` accepts an array of certs for verification. Since we don't keep track of which cert is used here, we can avoid iterating and just pass the array.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
