### PR TITLE
Remove all supports for allowed extra analytics

### DIFF
--- a/spec/forms/recaptcha_enterprise_form_spec.rb
+++ b/spec/forms/recaptcha_enterprise_form_spec.rb
@@ -390,8 +390,8 @@ RSpec.describe RecaptchaEnterpriseForm do
         end
       end
 
-      context 'with extra analytics properties', allowed_extra_analytics: [:extra] do
-        let(:extra_analytics_properties) { { extra: true } }
+      context 'with extra analytics properties' do
+        let(:extra_analytics_properties) { { phone_country_code: true } }
 
         it 'logs analytics of the body' do
           result
@@ -409,7 +409,7 @@ RSpec.describe RecaptchaEnterpriseForm do
             score_threshold: score_threshold,
             form_class: 'RecaptchaEnterpriseForm',
             recaptcha_action:,
-            extra: true,
+            phone_country_code: true,
           )
         end
       end

--- a/spec/forms/recaptcha_form_spec.rb
+++ b/spec/forms/recaptcha_form_spec.rb
@@ -309,8 +309,8 @@ RSpec.describe RecaptchaForm do
         )
       end
 
-      context 'with extra analytics properties', allowed_extra_analytics: [:extra] do
-        let(:extra_analytics_properties) { { extra: true } }
+      context 'with extra analytics properties' do
+        let(:extra_analytics_properties) { { phone_country_code: true } }
 
         it 'logs analytics of the body' do
           result
@@ -328,7 +328,7 @@ RSpec.describe RecaptchaForm do
             score_threshold: score_threshold,
             form_class: 'RecaptchaForm',
             recaptcha_action:,
-            extra: true,
+            phone_country_code: true,
           )
         end
       end

--- a/spec/support/fake_analytics_spec.rb
+++ b/spec/support/fake_analytics_spec.rb
@@ -585,26 +585,6 @@ RSpec.describe FakeAnalytics do
       end.to raise_error(FakeAnalytics::UndocumentedParams, /some_new_undocumented_keyword/)
     end
 
-    it 'does not error when undocumented params are allowed',
-       allowed_extra_analytics: [:fun_level] do
-      analytics.idv_phone_confirmation_otp_submitted(
-        success: true,
-        errors: true,
-        code_expired: true,
-        code_matches: true,
-        otp_delivery_preference: :sms,
-        second_factor_attempts_count: true,
-        second_factor_locked_at: true,
-        proofing_components: true,
-        fun_level: 1000,
-      )
-
-      expect(analytics).to have_logged_event(
-        'IdV: phone confirmation otp submitted',
-        hash_including(:fun_level),
-      )
-    end
-
     it 'does not error when string tags are documented as options' do
       analytics.idv_doc_auth_submitted_image_upload_vendor(
         success: nil,


### PR DESCRIPTION
## 🛠 Summary of changes

Removes all support for `allowed_extra_analytics`.

Follows #11643, addressing the one remaining use-case of reCAPTCHA forms, which passthrough extra analytics, currently used to support optional `phone_country_code` logging. Testing with this property allows coverage for the behavior while avoiding flagging the extra analytics check.

This is also meant to support #11605, which currently has some flakey test failures within the extra analytics checking global RSpec configuration.

## 📜 Testing Plan

Verify build passes.