### PR TITLE
LG-15280 Update the alert for successful document capture

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -590,7 +590,7 @@ doc_auth.headers.underage: Age requirement not met
 doc_auth.headers.unreadable_id: We could not read your ID
 doc_auth.headings.address: Update your mailing address
 doc_auth.headings.back: Back of your driver’s license or state ID
-doc_auth.headings.capture_complete: We verified your ID
+doc_auth.headings.capture_complete: We verified your identity document
 doc_auth.headings.capture_scan_warning_html: We couldn’t read the barcode on your ID. If the information below is incorrect, please %{link_html} of your state‑issued ID.
 doc_auth.headings.capture_scan_warning_link: upload new photos
 doc_auth.headings.document_capture: Add photos of your driver’s license or state ID card

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -601,7 +601,7 @@ doc_auth.headers.underage: No se cumplió con el requisito de edad
 doc_auth.headers.unreadable_id: No pudimos leer su identificación
 doc_auth.headings.address: Actualice su dirección postal
 doc_auth.headings.back: Reverso de su licencia de conducir o identificación estatal
-doc_auth.headings.capture_complete: Verificamos su identificación
+doc_auth.headings.capture_complete: Verificamos su documento de identidad
 doc_auth.headings.capture_scan_warning_html: No pudimos leer el código de barras en su identificación. Si la información que aparece a continuación es incorrecta, %{link_html} de su identificación emitida por el estado.
 doc_auth.headings.capture_scan_warning_link: cargue nuevas fotos
 doc_auth.headings.document_capture: Añade fotos de tu licencia de conducir o credencial de identificación oficial

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -590,7 +590,7 @@ doc_auth.headers.underage: Condition d’âge non remplie
 doc_auth.headers.unreadable_id: Nous n’avons pas pu lire votre pièce d’identité
 doc_auth.headings.address: Mettre à jour votre adresse postale
 doc_auth.headings.back: Verso de votre permis de conduire ou de votre carte d’identité d’un État
-doc_auth.headings.capture_complete: Nous avons vérifié votre pièce d'identité
+doc_auth.headings.capture_complete: Nous avons vérifié votre pièce d’identité
 doc_auth.headings.capture_scan_warning_html: Nous n’avons pas pu lire le code-barres de votre pièce d’identité. Si les informations ci-dessous ne sont pas correctes, veuillez %{link_html} de votre carte d’identité délivrée par l’État.
 doc_auth.headings.capture_scan_warning_link: télécharger de nouvelles photos
 doc_auth.headings.document_capture: Ajoutez des photos de votre permis de conduire ou de votre carte d’identité nationale

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -590,7 +590,7 @@ doc_auth.headers.underage: Condition d’âge non remplie
 doc_auth.headers.unreadable_id: Nous n’avons pas pu lire votre pièce d’identité
 doc_auth.headings.address: Mettre à jour votre adresse postale
 doc_auth.headings.back: Verso de votre permis de conduire ou de votre carte d’identité d’un État
-doc_auth.headings.capture_complete: Nous avons vérifié votre pièce d’identité
+doc_auth.headings.capture_complete: Nous avons vérifié votre pièce d'identité
 doc_auth.headings.capture_scan_warning_html: Nous n’avons pas pu lire le code-barres de votre pièce d’identité. Si les informations ci-dessous ne sont pas correctes, veuillez %{link_html} de votre carte d’identité délivrée par l’État.
 doc_auth.headings.capture_scan_warning_link: télécharger de nouvelles photos
 doc_auth.headings.document_capture: Ajoutez des photos de votre permis de conduire ou de votre carte d’identité nationale

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -601,7 +601,7 @@ doc_auth.headers.underage: 不符合年龄规定
 doc_auth.headers.unreadable_id: 我们无法读取你的身份证件
 doc_auth.headings.address: 更新你的邮政地址
 doc_auth.headings.back: 驾照或州政府颁发身份证件的背面。
-doc_auth.headings.capture_complete: 我们验证了你的身份证件
+doc_auth.headings.capture_complete: 我们验证了你的身份文件
 doc_auth.headings.capture_scan_warning_html: 我们读取不到你身份证件上的条形码。如果以下信息不正确，请将州政府颁发的身份证件%{link_html}。
 doc_auth.headings.capture_scan_warning_link: 上传新照片
 doc_auth.headings.document_capture: 添加你身份证件的照片


### PR DESCRIPTION
When a user successfully complete document capture we showed an alert on the next screen that says "We successfully verified your ID". We received feedback that this may lead people to believe that they are finished with IdV. This commit updates the language to prevent any confusion.
