### PR TITLE
[HACKATHON] Enable user narrative script to work with `binding.pry`

### DIFF
--- a/bin/summarize-user-events
+++ b/bin/summarize-user-events
@@ -23,13 +23,13 @@ Dir[File.expand_path(
 end
 
 class SummarizeUserEvents
-  attr_reader :uuid, :from_date, :to_date, :zone
+  attr_reader :file_name, :uuid, :from_date, :to_date, :zone
 
   NICE_DATE_AND_TIME_FORMAT = '%B %d, %Y at %I:%M %p %Z'
   TIME_ONLY_FORMAT = '%I:%M %p'
 
-  def initialize(user_uuid: nil, start_time: nil, end_time: nil, zone: 'UTC')
-    @zone = zone
+  def initialize(file_name: nil, user_uuid: nil, start_time: nil, end_time: nil, zone: 'UTC')
+    @file_name = file_name
     Time.zone = zone
     @uuid = user_uuid
     @from_date = parse_time(start_time) || 1.week.ago
@@ -146,18 +146,18 @@ class SummarizeUserEvents
   end
 
   def find_cloudwatch_events(&block)
-    if $stdin.tty?
+    unless file_name.nil?
+      warn 'Reading Cloudwatch events as newline-delimited JSON (ndjson) a file'
+      file_source(&block)
+    else 
       cloudwatch_source(&block)
-    else
-      warn 'Reading Cloudwatch events as newline-delimited JSON (ndjson) from stdin'
-      stdin_source(&block)
     end
   end
 
-  def stdin_source(&block)
+  def file_source(&block)
     events = []
 
-    $stdin.each_line do |line|
+    File.read(file_name).each_line do |line|
       next if line.blank?
       events << JSON.parse(line)
     end
@@ -200,6 +200,10 @@ def main
 
     EOM
 
+    opts.on('-f', '--file_name FILE_NAME', 'filename from which to read the events') do |val|
+      options[:file_name] = val
+    end
+
     opts.on('-h', '--help', 'Display this message') do
       warn opts
       exit
@@ -224,7 +228,7 @@ def main
   # rubocop:enable Metrics/LineLength
 
   optparse.parse!
-
+  
   SummarizeUserEvents.new(**options).run
 end
 

--- a/bin/summarize-user-events
+++ b/bin/summarize-user-events
@@ -30,6 +30,7 @@ class SummarizeUserEvents
 
   def initialize(file_name: nil, user_uuid: nil, start_time: nil, end_time: nil, zone: 'UTC')
     @file_name = file_name
+    @zone = zone
     Time.zone = zone
     @uuid = user_uuid
     @from_date = parse_time(start_time) || 1.week.ago
@@ -189,13 +190,13 @@ def main
 
     Summarize user events in a human-readable format
 
-    Cloudwatch logs can be read from stdin as newline-delimited JSON (ndjson),
+    Cloudwatch logs can be read from a file as newline-delimited JSON (ndjson),
     or fetched directly via aws-vault.
 
     usage: #{basename} [OPTIONS]
 
     Examples:
-      #{basename} << events.ndjson
+      #{basename} -f events.ndjson
       aws-vault exec prod-power -- #{basename} -u 1234-5678-90ab-cdef -s 2024-12-09T10:00:00 -e 2024-12-09T14:30:00 -z America/New_York
 
     EOM

--- a/bin/summarize-user-events
+++ b/bin/summarize-user-events
@@ -228,7 +228,7 @@ def main
   # rubocop:enable Metrics/LineLength
 
   optparse.parse!
-  
+
   SummarizeUserEvents.new(**options).run
 end
 

--- a/lib/event_summarizer/idv_matcher.rb
+++ b/lib/event_summarizer/idv_matcher.rb
@@ -231,7 +231,7 @@ module EventSummarizer
         add_significant_event(
           type: :start_gpo,
           timestamp:,
-          description: 'User requested a letter to verfy by mail',
+          description: 'User requested a letter to verify by mail',
         )
       end
 

--- a/lib/event_summarizer/idv_matcher.rb
+++ b/lib/event_summarizer/idv_matcher.rb
@@ -290,24 +290,14 @@ module EventSummarizer
         return
       end
 
-      # User successfully entered GPO code. If nothing else is pending,
+      # User successfully entered GPO code. If fraud review is not pending,
       # then they are fully verified
-
-      ipp_pending = !!event.dig(
-        *EVENT_PROPERTIES,
-        'pending_in_person_enrollment',
-      )
-
       fraud_review_pending = !!event.dig(
         *EVENT_PROPERTIES,
         'fraud_check_failed',
       )
 
-      fully_verified = !(ipp_pending || fraud_review_pending)
-
-      description = ipp_pending ?
-        'User successfully entered a GPO code, but is still pending in-person proofing'
-        : 'User successfully entered a GPO code'
+      fully_verified = !fraud_review_pending
 
       add_significant_event(
         type: :gpo_code_success,


### PR DESCRIPTION
## 🛠 Summary of changes
- I added a command line flag, `-f`, for passing in a file that contains ndjson.  I made this change to enable using `binding.pry` with the script.  Previously, the script regarded the piped-in file as `stdin`, which made it impossible to interact with `binding.pry` breakpoints via the terminal.
- Since gpo was ripped out of the ipp flow, I removed the handling of the ipp + gpo flow.


## 📜 Testing Plan
- Drop a `binding.pry` somewhere in the script.
- Run the script and interact with the breakpoint via the CLI.