### PR TITLE
Add a big "Approve" button for pending in-person proofing enrollments

### DIFF
--- a/app/controllers/test/ipp_controller.rb
+++ b/app/controllers/test/ipp_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Test
+  class IppController < ApplicationController
+    layout 'no_card'
+
+    before_action :render_not_found_in_production
+
+    def index
+      @enrollments = InPersonEnrollment
+        .order(created_at: :desc)
+        .limit(10)
+
+      @enrollments_with_actions = @enrollments.map do |e|
+        case e.status
+        when 'pending' then [e, :approve]
+        else [e]
+        end
+      end
+    end
+
+    def update
+      enrollment_id = params['enrollment'].to_i
+      enrollment = InPersonEnrollment.find(enrollment_id)
+
+      if enrollment.present?
+        approve_enrollment(enrollment)
+      end
+
+      redirect_to test_ipp_url
+    end
+
+    private
+
+    def approve_enrollment(enrollment)
+      return if !enrollment.pending?
+
+      res = JSON.parse(
+        UspsInPersonProofing::Mock::Fixtures.request_passed_proofing_results_response,
+      )
+
+      job = GetUspsProofingResultsJob.new
+      job.instance_variable_set(
+        :@enrollment_outcomes,
+        { enrollments_passed: 0,
+          enrollments_failed: 0,
+          enrollments_errored: 0,
+          enrollments_expired: 0,
+          enrollments_checked: 0 },
+      )
+
+      job.send(:process_enrollment_response, enrollment, res)
+    end
+
+    def render_not_found_in_production
+      return unless Rails.env.production?
+      render_not_found
+    end
+  end
+end

--- a/app/views/test/ipp/index.html.erb
+++ b/app/views/test/ipp/index.html.erb
@@ -21,9 +21,9 @@
       <table class="bg-white" border="0" cellpadding="0" cellspacing="0">
         <thead>
           <tr>
-            <th class="border-bottom bg-base-lightest padding-x-2 padding-y-1 text-no-wrap"></th>
-            <th class="border-bottom bg-base-lightest padding-x-2 padding-y-1 text-no-wrap">UUID</th>
-            <th class="border-bottom bg-base-lightest padding-x-2 padding-y-1 text-no-wrap" colspan="2">Status</th>
+            <th class="border-bottom bg-base-lightest padding-x-2 padding-y-1 text-left text-no-wrap"></th>
+            <th class="border-bottom bg-base-lightest padding-x-2 padding-y-1 text-left text-no-wrap">UUID</th>
+            <th class="border-bottom bg-base-lightest padding-x-2 padding-y-1 text-left text-no-wrap" colspan="2">Status</th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/test/ipp/index.html.erb
+++ b/app/views/test/ipp/index.html.erb
@@ -1,0 +1,67 @@
+<% self.title = 'In-person proofing enrollments' %>
+
+<%= content_for(:meta_refresh) { '15' } %>
+
+<h1>In-person proofing enrollments</h1>
+
+<div class="grid-row grid-gap margin-top-2 flex-align-stretch">
+  <div class="tablet:grid-col-12">
+    <% if @enrollments.count == 0 %>
+      <p>
+          There are no recent in-person enrollments.
+      </p>
+    <% else %>
+      <p>
+        Listed below 
+        <%= @enrollments.count == 1 ? 'is' : 'are' %> 
+        the <%= @enrollments.count %> most recent 
+        in-person enrollment<%= @enrollments.count == 1 ? '' : 's' %>.
+      </p>
+
+      <table class="bg-white" border="0" cellpadding="0" cellspacing="0">
+        <thead>
+          <tr>
+            <th class="border-bottom bg-base-lightest padding-x-2 padding-y-1 text-no-wrap"></th>
+            <th class="border-bottom bg-base-lightest padding-x-2 padding-y-1 text-no-wrap">UUID</th>
+            <th class="border-bottom bg-base-lightest padding-x-2 padding-y-1 text-no-wrap" colspan="2">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @enrollments_with_actions.each_with_index do |(e, action), index| %>
+            <tr class="<%= index % 2 == 1 ? 'bg-base-lightest' : '' %>">
+              <td class="border-bottom padding-x-2 padding-y-1 text-no-wrap">
+                <small>
+                  <time datetime="<%= e.created_at %>" title="<%= e.created_at %>">
+                    <%= time_ago_in_words(e.created_at) %> ago
+                  </time>
+                </small>
+              </td>
+              <td class="border-bottom padding-x-2 padding-y-1"><code><%= e.user.uuid %></code></td>
+              <td class="border-bottom padding-x-2 padding-y-1 text-no-wrap">
+                <%= case e.status
+                  when 'pending' then '🤔'
+                  when 'passed' then '✅'
+                  when 'failed' then '🙀'
+                  else '⚪️'
+                  end %>
+                <%= e.status %>
+              </td>
+              <td class="border-bottom padding-x-2 padding-y-1">
+                  <%= case action
+                      when :approve
+                        button_to(
+                          '👍 Approve',
+                          test_ipp_path(enrollment: e.id),
+                          method: 'put',
+                          class: 'usa-button usa-button-small',
+                          title: 'Simulate the user passing the check at the post office',
+                        )
+                      end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,9 @@ Rails.application.routes.draw do
 
     if IdentityConfig.store.enable_test_routes
       namespace :test do
+        get '/ipp' => 'ipp#index'
+        put '/ipp' => 'ipp#update'
+
         # Assertion granting test start + return.
         get '/saml/login' => 'saml_test#index'
         get '/saml' => 'saml_test#start'


### PR DESCRIPTION
## 🎫 Ticket

Related to work for
[LG-15000](https://cm-jira.usa.gov/browse/LG-15000)

## 🛠 Summary of changes

Adds a new `/test/ipp` route, **accessible only for local development**, that will show the most recent in-person proofing enrollments, for `pending` ones, provide a big "Approve" button.

If you click Approve, it will then call the part of `GetUspsProofingResultsJob` that processes a successful response from USPS, and move the associated profile out of IPP.

The code to actually do the approving was sourced from the test instructions from #11261.


## 👀 Screenshots

BEHOLD

![Screenshot 2024-12-16 at 4 07 27 PM](https://github.com/user-attachments/assets/11324238-d4b1-4f46-9d6d-9395276bd1f4)

