### PR TITLE
Jmax/lg 14973 check socure pii verdict

### DIFF
--- a/app/controllers/concerns/idv/socure_errors_concern.rb
+++ b/app/controllers/concerns/idv/socure_errors_concern.rb
@@ -26,7 +26,9 @@ module Idv
     end
 
     def error_code_for(result)
-      if result.errors[:socure]
+      if result.errors[:validation_failed]
+        :validation_failed
+      elsif result.errors[:socure]
         result.errors.dig(:socure, :reason_codes).first
       elsif result.errors[:network]
         :network

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -132,7 +132,11 @@ class SocureErrorPresenter
   }.freeze
 
   def remapped_error(error_code)
-    SOCURE_ERROR_MAP[error_code] || 'unreadable_id'
+    if error_code == :validation_failed
+      'unreadable_id'
+    else
+      SOCURE_ERROR_MAP[error_code] || 'unreadable_id'
+    end
   end
 
   def heading_string_for(error_code)

--- a/app/services/doc_auth/socure/responses/docv_result_response.rb
+++ b/app/services/doc_auth/socure/responses/docv_result_response.rb
@@ -78,7 +78,7 @@ module DocAuth
             flow_path: nil,
             liveness_checking_required: @biometric_comparison_required,
             issue_year: state_id_issued&.year,
-            doc_auth_success: doc_auth_success?,
+            doc_auth_success: successful_result?,
             vendor: 'Socure',
             address_line2_present: address2.present?,
             zip_code: zipcode,
@@ -153,7 +153,7 @@ module DocAuth
             ).with_indifferent_access : {}
           rescue JSON::JSONError
             {}
-          end
+          end.symbolize_keys
           @parsed_response_body
         end
 

--- a/app/services/doc_auth/socure/responses/docv_result_response.rb
+++ b/app/services/doc_auth/socure/responses/docv_result_response.rb
@@ -112,7 +112,7 @@ module DocAuth
           return {} if successful_result?
 
           {
-            pii_invalid: !pii_valid?,
+            validation_failed: !pii_valid?,
             socure: { reason_codes: get_data(DATA_PATHS[:reason_codes]) },
           }
         end

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -94,7 +94,6 @@ RSpec.feature 'document capture step', :js do
       context 'shows the correct attempts on error pages' do
         before do
           stub_docv_verification_data_fail_with(
-            docv_transaction_token: @docv_transaction_token,
             errors: ['XXXX'],
           )
         end

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'document capture step', :js do
 
   context 'happy path', allow_browser_log: true do
     before do
-      @pass_stub = stub_docv_verification_data_pass(docv_transaction_token: @docv_transaction_token)
+      @pass_stub = stub_docv_verification_data_pass
     end
 
     context 'standard desktop flow' do
@@ -253,7 +253,7 @@ RSpec.feature 'document capture step', :js do
           it 'fetches verificationdata using override docvToken in request',
              allow_browser_log: true do
             remove_request_stub(@pass_stub)
-            stub_docv_verification_data_pass(docv_transaction_token: test_token)
+            stub_docv_verification_data_pass
 
             visit idv_socure_document_capture_update_path(docv_token: test_token)
             expect(page).to have_current_path(idv_ssn_url)
@@ -325,11 +325,6 @@ RSpec.feature 'document capture step', :js do
 
   shared_examples 'a properly categorized error' do |expected_header_key|
     before do
-      stub_docv_verification_data_fail_with(
-        docv_transaction_token: @docv_transaction_token,
-        errors: [socure_error_code],
-      )
-
       visit_idp_from_oidc_sp_with_ial2
       @user = sign_in_and_2fa_user
 
@@ -356,7 +351,7 @@ RSpec.feature 'document capture step', :js do
         .and_raise(Faraday::ConnectionFailed)
 
       visit_idp_from_oidc_sp_with_ial2
-      sign_in_and_2fa_user(@user)
+      @user = sign_in_and_2fa_user
 
       complete_doc_auth_steps_before_document_capture_step
     end
@@ -369,7 +364,7 @@ RSpec.feature 'document capture step', :js do
 
   context 'a type 1 error (because we do not recognize the code)' do
     before do
-      stub_docv_verification_data_fail_with(['XXXX'])
+      stub_docv_verification_data_fail_with(errors: ['XXXX'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.unreadable_id'
@@ -377,7 +372,7 @@ RSpec.feature 'document capture step', :js do
 
   context 'a type 1 error' do
     before do
-      stub_docv_verification_data_fail_with(['I848'])
+      stub_docv_verification_data_fail_with(errors: ['I848'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.unreadable_id'
@@ -385,7 +380,7 @@ RSpec.feature 'document capture step', :js do
 
   context 'a type 2 error' do
     before do
-      stub_docv_verification_data_fail_with(['I849'])
+      stub_docv_verification_data_fail_with(errors: ['I849'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.unaccepted_id_type'
@@ -393,7 +388,7 @@ RSpec.feature 'document capture step', :js do
 
   context 'a type 3 error' do
     before do
-      stub_docv_verification_data_fail_with(['R827'])
+      stub_docv_verification_data_fail_with(errors: ['R827'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.expired_id'
@@ -401,7 +396,7 @@ RSpec.feature 'document capture step', :js do
 
   context 'a type 4 error' do
     before do
-      stub_docv_verification_data_fail_with(['I808'])
+      stub_docv_verification_data_fail_with(errors: ['I808'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.low_resolution'
@@ -409,7 +404,7 @@ RSpec.feature 'document capture step', :js do
 
   context 'a type 5 error' do
     before do
-      stub_docv_verification_data_fail_with(['R845'])
+      stub_docv_verification_data_fail_with(errors: ['R845'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.underage'
@@ -417,7 +412,7 @@ RSpec.feature 'document capture step', :js do
 
   context 'a type 6 error' do
     before do
-      stub_docv_verification_data_fail_with(['I856'])
+      stub_docv_verification_data_fail_with(errors: ['I856'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.id_not_found'

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -352,8 +352,8 @@ RSpec.feature 'document capture step', :js do
 
   context 'a network error getting the capture path' do
     before do
-      allow_any_instance_of(Faraday::Connection).to receive(:post).
-        and_raise(Faraday::ConnectionFailed)
+      allow_any_instance_of(Faraday::Connection).to receive(:post)
+        .and_raise(Faraday::ConnectionFailed)
 
       visit_idp_from_oidc_sp_with_ial2
       sign_in_and_2fa_user(@user)

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Hybrid Flow' do
 
   context 'happy path', allow_browser_log: true do
     before do
-      @pass_stub = stub_docv_verification_data_pass(docv_transaction_token: @docv_transaction_token)
+      @pass_stub = stub_docv_verification_data_pass
     end
     it 'proofs and hands off to mobile', js: true do
       user = nil
@@ -284,7 +284,7 @@ RSpec.describe 'Hybrid Flow' do
 
           perform_in_browser(:mobile) do
             remove_request_stub(@pass_stub)
-            stub_docv_verification_data_pass(docv_transaction_token: test_token)
+            stub_docv_verification_data_pass
 
             visit @sms_link
 
@@ -365,11 +365,6 @@ RSpec.describe 'Hybrid Flow' do
       perform_in_browser(:mobile) do
         visit @sms_link
 
-        stub_docv_verification_data_fail_with(
-          docv_transaction_token: @docv_transaction_token,
-          errors: [socure_error_code],
-        )
-
         click_idv_continue
 
         socure_docv_upload_documents(docv_transaction_token: @docv_transaction_token)
@@ -390,15 +385,15 @@ RSpec.describe 'Hybrid Flow' do
 
   context 'a type 1 error (because we do not recognize the code)' do
     before do
-      stub_docv_verification_data_fail_with(['XXXX'])
+      stub_docv_verification_data_fail_with(errors: ['XXXX'])
     end
 
-    it_behaves_like 'a properly categorized error', 'doc_auth.headers.unreadable_id'
+     it_behaves_like 'a properly categorized error', 'doc_auth.headers.unreadable_id'
   end
 
   context 'a type 1 error' do
     before do
-      stub_docv_verification_data_fail_with(['I848'])
+      stub_docv_verification_data_fail_with(errors: ['I848'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.unreadable_id'
@@ -406,7 +401,7 @@ RSpec.describe 'Hybrid Flow' do
 
   context 'a type 2 error' do
     before do
-      stub_docv_verification_data_fail_with(['I849'])
+      stub_docv_verification_data_fail_with(errors: ['I849'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.unaccepted_id_type'
@@ -414,7 +409,7 @@ RSpec.describe 'Hybrid Flow' do
 
   context 'a type 3 error' do
     before do
-      stub_docv_verification_data_fail_with(['R827'])
+      stub_docv_verification_data_fail_with(errors: ['R827'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.expired_id'
@@ -422,7 +417,7 @@ RSpec.describe 'Hybrid Flow' do
 
   context 'a type 4 error' do
     before do
-      stub_docv_verification_data_fail_with(['I808'])
+      stub_docv_verification_data_fail_with(errors: ['I808'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.low_resolution'
@@ -430,7 +425,7 @@ RSpec.describe 'Hybrid Flow' do
 
   context 'a type 5 error' do
     before do
-      stub_docv_verification_data_fail_with(['R845'])
+      stub_docv_verification_data_fail_with(errors: ['R845'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.underage'
@@ -438,7 +433,7 @@ RSpec.describe 'Hybrid Flow' do
 
   context 'a type 6 error' do
     before do
-      stub_docv_verification_data_fail_with(['I856'])
+      stub_docv_verification_data_fail_with(errors: ['I856'])
     end
 
     it_behaves_like 'a properly categorized error', 'doc_auth.headers.id_not_found'

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -340,7 +340,7 @@ RSpec.describe 'Hybrid Flow' do
     end
   end
 
-  shared_examples 'a properly categorized Socure error' do |socure_error_code, expected_header_key|
+  shared_examples 'a properly categorized error' do |expected_header_key|
     it 'shows the correct error page', js: true do
       user = nil
 
@@ -389,33 +389,59 @@ RSpec.describe 'Hybrid Flow' do
   end
 
   context 'a type 1 error (because we do not recognize the code)' do
-    it_behaves_like 'a properly categorized Socure error', 'XXXX', 'doc_auth.headers.unreadable_id'
+    before do
+      stub_docv_verification_data_fail_with(['XXXX'])
+    end
+
+    it_behaves_like 'a properly categorized error', 'doc_auth.headers.unreadable_id'
   end
 
   context 'a type 1 error' do
-    it_behaves_like 'a properly categorized Socure error', 'I848', 'doc_auth.headers.unreadable_id'
+    before do
+      stub_docv_verification_data_fail_with(['I848'])
+    end
+
+    it_behaves_like 'a properly categorized error', 'doc_auth.headers.unreadable_id'
   end
 
   context 'a type 2 error' do
-    it_behaves_like 'a properly categorized Socure error',
-                    'I849',
-                    'doc_auth.headers.unaccepted_id_type'
+    before do
+      stub_docv_verification_data_fail_with(['I849'])
+    end
+
+    it_behaves_like 'a properly categorized error', 'doc_auth.headers.unaccepted_id_type'
   end
 
   context 'a type 3 error' do
-    it_behaves_like 'a properly categorized Socure error', 'R827', 'doc_auth.headers.expired_id'
+    before do
+      stub_docv_verification_data_fail_with(['R827'])
+    end
+
+    it_behaves_like 'a properly categorized error', 'doc_auth.headers.expired_id'
   end
 
   context 'a type 4 error' do
-    it_behaves_like 'a properly categorized Socure error', 'I808', 'doc_auth.headers.low_resolution'
+    before do
+      stub_docv_verification_data_fail_with(['I808'])
+    end
+
+    it_behaves_like 'a properly categorized error', 'doc_auth.headers.low_resolution'
   end
 
   context 'a type 5 error' do
-    it_behaves_like 'a properly categorized Socure error', 'R845', 'doc_auth.headers.underage'
+    before do
+      stub_docv_verification_data_fail_with(['R845'])
+    end
+
+    it_behaves_like 'a properly categorized error', 'doc_auth.headers.underage'
   end
 
   context 'a type 6 error' do
-    it_behaves_like 'a properly categorized Socure error', 'I856', 'doc_auth.headers.id_not_found'
+    before do
+      stub_docv_verification_data_fail_with(['I856'])
+    end
+
+    it_behaves_like 'a properly categorized error', 'doc_auth.headers.id_not_found'
   end
 
   context 'with a network error requesting the capture app url' do

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe 'Hybrid Flow' do
       stub_docv_verification_data_fail_with(errors: ['XXXX'])
     end
 
-     it_behaves_like 'a properly categorized error', 'doc_auth.headers.unreadable_id'
+    it_behaves_like 'a properly categorized error', 'doc_auth.headers.unreadable_id'
   end
 
   context 'a type 1 error' do

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -116,8 +116,7 @@ RSpec.describe SocureDocvResultsJob do
       perform
       expect(fake_analytics).to have_logged_event(
         :idv_socure_verification_data_requested,
-          hash_including(expected_socure_log.merge({ async: true }),
-        ),
+        hash_including(expected_socure_log.merge({ async: true })),
       )
     end
 

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -116,8 +116,7 @@ RSpec.describe SocureDocvResultsJob do
       perform
       expect(fake_analytics).to have_logged_event(
         :idv_socure_verification_data_requested,
-        hash_including(
-          expected_socure_log.merge({ async: true }),
+          hash_including(expected_socure_log.merge({ async: true }),
         ),
       )
     end

--- a/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
+++ b/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe DocAuth::Socure::Responses::DocvResultResponse do
     it 'doc_type is supported' do
       expect(subject.doc_type_supported?).to eq(true)
     end
-
-    it 'doc_auth_success? is true' do
-      expect(subject.doc_auth_success?).to eq(true)
-    end
   end
 
   context 'with a Socure error' do

--- a/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
+++ b/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe DocAuth::Socure::Responses::DocvResultResponse do
+  subject(:response) do
+    described_class.new(http_response:, biometric_comparison_required:)
+  end
+
+  let(:http_response) { double('fake faraday response') }
+  let(:biometric_comparison_required) { false }
+  let(:response_json) { SocureDocvFixtures.pass_json }
+
+  before do
+    allow(http_response).to receive(:body).and_return(response_json)
+  end
+
+  context 'happy path' do
+    it 'success? is true' do
+      expect(subject.success?).to eq(true)
+    end
+
+    it 'doc_type is supported' do
+      expect(subject.doc_type_supported?).to eq(true)
+    end
+
+    it 'doc_auth_success? is true' do
+      expect(subject.doc_auth_success?).to eq(true)
+    end
+  end
+
+  context 'with a Socure error' do
+    let(:response_json) { SocureDocvFixtures.fail_json(['I808']) }
+
+    it 'fails' do
+      expect(subject.success?).to eq(false)
+    end
+
+    it 'adds the socure error to the errors' do
+      expect(subject.errors.dig(:socure, :reason_codes)).to eq(['I808'])
+    end
+  end
+
+  context 'when the PII is not satisfactory' do
+    before do
+      allow_any_instance_of(Idv::DocAuthFormResponse).to receive(:success?).and_return(false)
+    end
+
+    it 'fails' do
+      expect(subject.success?).to eq(false)
+    end
+
+    it 'adds the pii error to the errors' do
+      expect(subject.errors).to have_key(:pii_invalid)
+    end
+  end
+end

--- a/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
+++ b/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe DocAuth::Socure::Responses::DocvResultResponse do
     end
 
     it 'adds the pii error to the errors' do
-      expect(subject.errors).to have_key(:pii_invalid)
+      expect(subject.errors).to have_key(:validation_failed)
     end
   end
 end

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -103,12 +103,12 @@ module DocumentCaptureStepHelper
     end
   end
 
-  def stub_docv_verification_data_pass(docv_transaction_token:)
-    stub_docv_verification_data(body: SocureDocvFixtures.pass_json, docv_transaction_token:)
+  def stub_docv_verification_data_pass()
+    stub_docv_verification_data(body: SocureDocvFixtures.pass_json)
   end
 
-  def stub_docv_verification_data_fail_with(docv_transaction_token:, errors:)
-    stub_docv_verification_data(body: SocureDocvFixtures.fail_json(errors), docv_transaction_token:)
+  def stub_docv_verification_data_fail_with(errors:)
+    stub_docv_verification_data(body: SocureDocvFixtures.fail_json(errors))
   end
 
   def stub_docv_verification_pii_validation_fail
@@ -125,6 +125,7 @@ module DocumentCaptureStepHelper
       to_return(
         headers: {
           'Content-Type' => 'application/json',
+
         },
         body:,
       )

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -111,15 +111,18 @@ module DocumentCaptureStepHelper
     stub_docv_verification_data(body: SocureDocvFixtures.fail_json(errors), docv_transaction_token:)
   end
 
-  def stub_docv_verification_data(docv_transaction_token:, body:)
-    request_body = {
-      modules: ['documentverification'],
-      docvTransactionToken: docv_transaction_token,
-    }
+  def stub_docv_verification_pii_validation_fail
+    stub_docv_verification_data(body: SocureDocvFixtures.pass_json)
+    allow_any_instance_of(Idv::DocPiiForm).to receive(:valid?).and_return(false)
+  end
 
-    stub_request(:post, "#{IdentityConfig.store.socure_idplus_base_url}/api/3.0/EmailAuthScore")
-      .with(body: request_body.to_json)
-      .to_return(
+  def stub_docv_verification_data_fail_with(errors)
+    stub_docv_verification_data(body: SocureDocvFixtures.fail_json(errors))
+  end
+
+  def stub_docv_verification_data(body:)
+    stub_request(:post, "#{IdentityConfig.store.socure_idplus_base_url}/api/3.0/EmailAuthScore").
+      to_return(
         headers: {
           'Content-Type' => 'application/json',
         },

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -103,7 +103,7 @@ module DocumentCaptureStepHelper
     end
   end
 
-  def stub_docv_verification_data_pass()
+  def stub_docv_verification_data_pass
     stub_docv_verification_data(body: SocureDocvFixtures.pass_json)
   end
 
@@ -116,13 +116,9 @@ module DocumentCaptureStepHelper
     allow_any_instance_of(Idv::DocPiiForm).to receive(:valid?).and_return(false)
   end
 
-  def stub_docv_verification_data_fail_with(errors)
-    stub_docv_verification_data(body: SocureDocvFixtures.fail_json(errors))
-  end
-
   def stub_docv_verification_data(body:)
-    stub_request(:post, "#{IdentityConfig.store.socure_idplus_base_url}/api/3.0/EmailAuthScore").
-      to_return(
+    stub_request(:post, "#{IdentityConfig.store.socure_idplus_base_url}/api/3.0/EmailAuthScore")
+      .to_return(
         headers: {
           'Content-Type' => 'application/json',
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14973](https://cm-jira.usa.gov/browse/LG-14973)

## 🛠 Summary of changes
Add our basic PII validation in to the Socure authorization flow.

## 📜 Testing Plan

(this plan requires modifying the code to simulate a PII validation failure)

- [ ] Configure your system to use the Socure sandbox.
- [ ] Modify `app/services/doc_auth/socure/responses/docv_result_response.rb`. Change the `pii_valid?` method to always return `false`
- [ ] Start the app and proceed through IdV. Verify that you end up on the default error page