### PR TITLE
LG-15000: Remove in_person_please_call email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -263,8 +263,6 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  alias_method :in_person_please_call, :idv_please_call
-
   def in_person_completion_survey
     with_user_locale(user) do
       @header = t('user_mailer.in_person_completion_survey.header')

--- a/spec/mailers/previews/user_mailer_preview_spec.rb
+++ b/spec/mailers/previews/user_mailer_preview_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require_relative './user_mailer_preview'
 
 RSpec.describe UserMailerPreview do
-  it_behaves_like 'a mailer preview', preview_methods_that_can_be_missing: [:in_person_please_call]
+  it_behaves_like 'a mailer preview'
 
   it 'uses user and email records that cannot be saved' do
     expect(User.count).to eq(0)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1319,37 +1319,6 @@ RSpec.describe UserMailer, type: :mailer do
       end
     end
 
-    describe '#in_person_please_call' do
-      let(:mail) do
-        UserMailer.with(user: user, email_address: email_address).in_person_please_call(
-          enrollment: enrollment,
-          visited_location_name: visited_location_name,
-        )
-      end
-
-      it_behaves_like 'a system email'
-      it_behaves_like 'an email that respects user email locale preference'
-
-      it 'renders the idv_please_call template' do
-        expect_any_instance_of(ActionMailer::Base).to receive(:mail)
-          .with(hash_including(template_name: 'idv_please_call'))
-          .and_call_original
-
-        mail.deliver_later
-      end
-
-      context 'when the keyword argument visited_location_name is missing' do
-        let(:mail) do
-          UserMailer.with(user: user, email_address: email_address).in_person_please_call(
-            enrollment: enrollment,
-          )
-        end
-        it 'sends the email successfully' do
-          mail.deliver_later
-        end
-      end
-    end
-
     describe '#in_person_completion_survey' do
       let(:mail) do
         UserMailer.with(user: user, email_address: email_address).in_person_completion_survey


### PR DESCRIPTION
**(This PR is 3 of 3. It can't be merged until #11604 and #11662 are in production)**


## 🎫 Ticket

Link to the relevant ticket:
[LG-15000](https://cm-jira.usa.gov/browse/LG-15000)

## 🛠 Summary of changes

#11604 added a new `idv_please_call` email, which is identical to `in_person_please_call`.

#11662 started sending that email from other parts of IDV and updated the in-person code to send `idv_please_call` instead of `in_person_please_call`

This PR removes references to `in_person_please_call`.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
