### PR TITLE
mailer_helper update

### DIFF
--- a/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe UserAlerts::AlertUserAboutAccountVerified do
         expect_delivered_email(
           to: [user.confirmed_email_addresses.first.email],
           subject: t('user_mailer.account_verified.subject', app_name: APP_NAME),
-          body: ['<table class="button expanded large radius">', 'localhost:3000'],
+          body: [
+            'http://www.example.com/redirect/return_to_sp/account_verified_cta',
+          ],
         )
       end
     end
@@ -50,7 +52,9 @@ RSpec.describe UserAlerts::AlertUserAboutAccountVerified do
         described_class.call(profile: profile)
 
         email_body = last_email.text_part.decoded.squish
-        expect(email_body).to_not include('<table class="button expanded large radius">')
+        expect(email_body).to_not include(
+          'http://www.example.com/redirect/return_to_sp/account_verified_cta',
+        )
       end
     end
 
@@ -69,7 +73,7 @@ RSpec.describe UserAlerts::AlertUserAboutAccountVerified do
         expect_delivered_email(
           to: [user.confirmed_email_addresses.first.email],
           subject: t('user_mailer.account_verified.subject', app_name: APP_NAME),
-          body: ['<table class="button expanded large radius">', 'http://example.com'],
+          body: ['http://example.com'],
         )
       end
     end

--- a/spec/support/mailer_helper.rb
+++ b/spec/support/mailer_helper.rb
@@ -15,26 +15,88 @@ module MailerHelper
     ActionController::Base.helpers.strip_tags(str)
   end
 
+  # @param [String,String[],nil] to The email address(es) the message must've been sent to.
+  # @param [String,nil] subject The subject the email must've had
+  # @param [String[],nil] Array of substrings that must appear in body.
   def expect_delivered_email(to: nil, subject: nil, body: nil)
-    email = ActionMailer::Base.deliveries.find do |sent_mail|
-      next unless to.present? && sent_mail.to == to
-      next unless subject.present? && sent_mail.subject == subject
-      if body.present?
-        delivered_body = sent_mail.text_part.decoded.squish
-        body.to_a.each do |expected_body|
-          next unless delivered_body.include?(expected_body)
-        end
-      end
-      true
-    end
+    email = find_sent_email(to:, subject:, body:)
 
     error_message = <<~ERROR
       Unable to find email matching args:
         to: #{to}
         subject: #{subject}
         body: #{body}
-      Sent mails: #{ActionMailer::Base.deliveries}
+      Sent mails:
+      #{summarize_all_deliveries(to:, subject:, body:).indent(2)}
     ERROR
+
     expect(email).to_not be(nil), error_message
+  end
+
+  private
+
+  def body_matches(email:, body:)
+    return true if body.nil?
+
+    delivered_body = email.text_part.decoded.squish
+
+    Array.wrap(body).all? do |expected_substring|
+      delivered_body.include?(expected_substring)
+    end
+  end
+
+  def to_matches(email:, to:)
+    return true if to.nil?
+
+    to = Array.wrap(to).to_set
+
+    (email.to.to_set - to).empty?
+  end
+
+  def find_sent_email(
+    to:,
+    subject:,
+    body:
+  )
+    ActionMailer::Base.deliveries.find do |email|
+      to_ok = to_matches(email:, to:)
+      subject_ok = subject.nil? || email.subject == subject
+      body_ok = body_matches(email:, body:)
+
+      to_ok && subject_ok && body_ok
+    end
+  end
+
+  def summarize_delivery(
+    email:,
+    to:,
+    subject:,
+    body:
+  )
+    body_text = email.text_part.decoded.squish
+
+    body_summary = body.presence && Array.wrap(body).map do |substring|
+      found = body_text.include?(substring)
+      "- #{substring.inspect} (#{found ? 'found' : 'not found'})"
+    end.join("\n")
+
+    to_ok = to_matches(email:, to:)
+    subject_ok = subject.nil? || subject == email.subject
+
+    [
+      "To:      #{email.to}#{to_ok ? '' : ' (did not match)'}",
+      "Subject: #{email.subject}#{subject_ok ? '' : ' (did not match)'}",
+      body.presence && "Body:\n#{body_summary.indent(2)}",
+    ].compact.join("\n")
+  end
+
+  def summarize_all_deliveries(query)
+    ActionMailer::Base.deliveries.map do |email|
+      summary = summarize_delivery(email:, **query)
+      [
+        "- #{summary.lines.first.chomp}",
+        *summary.lines.drop(1).map { |l| l.chomp.indent(2) },
+      ].join("\n")
+    end.join("\n")
   end
 end

--- a/spec/support/mailer_helper.rb
+++ b/spec/support/mailer_helper.rb
@@ -33,6 +33,24 @@ module MailerHelper
     expect(email).to_not be(nil), error_message
   end
 
+  # @param [String,nil] to If provided, the email address the message must've been sent to
+  # @param [String,nil] subject If provided, the subject the email must've had
+  # @param [String[],nil] Array of substrings that must appear in body.
+  def expect_email_not_delivered(to: nil, subject: nil, body: nil)
+    email = find_sent_email(to:, subject:, body:)
+
+    error_message = <<~ERROR
+      Found an email matching the below (but shouldn't have):
+        to: #{to}
+        subject: #{subject}
+        body: #{body}
+      Sent mails:
+      #{summarize_all_deliveries(to:, subject:, body:).indent(2)}
+    ERROR
+
+    expect(email).to be(nil), error_message
+  end
+
   private
 
   def body_matches(email:, body:)

--- a/spec/support/mailer_helper_spec.rb
+++ b/spec/support/mailer_helper_spec.rb
@@ -1,0 +1,206 @@
+require 'rails_helper'
+
+RSpec.describe 'mailer_helper' do
+  def mail_double(to:, subject:, body:)
+    instance_double(
+      Mail::Message,
+      to:,
+      subject:,
+      text_part: instance_double(
+        Mail::Part,
+        decoded: body,
+      ),
+    )
+  end
+
+  let(:all_deliveries) do
+    [
+      mail_double(
+        to: ['user@example.com'],
+        subject: 'Test subject 1',
+        body: 'Hello world!',
+      ),
+    ]
+  end
+
+  before do
+    allow(ActionMailer::Base).to receive(:deliveries).and_return(all_deliveries)
+  end
+
+  describe '#expect_delivered_email' do
+    context 'when searching by to' do
+      context 'and found' do
+        it 'does not raise' do
+          expect do
+            expect_delivered_email(to: 'user@example.com')
+          end.not_to raise_error
+        end
+      end
+      context 'and not found' do
+        it 'raises an appropriate error' do
+          expect do
+            expect_delivered_email(to: 'otheruser@example.com')
+          end.to raise_error(
+            satisfy do |err|
+              expect(err.message).to eql(
+                <<~END,
+                  Unable to find email matching args:
+                    to: otheruser@example.com
+                    subject: 
+                    body: 
+                  Sent mails:
+                    - To:      [\"user@example.com\"] (did not match)
+                      Subject: Test subject 1
+                END
+              )
+            end,
+          )
+        end
+      end
+    end
+
+    context 'when searching by subject' do
+      context 'and found' do
+        it 'does not raise' do
+          expect do
+            expect_delivered_email(subject: 'Test subject 1')
+          end.not_to raise_error
+        end
+        context 'and not found' do
+          it 'raises an appropriate error' do
+            expect do
+              expect_delivered_email(subject: 'Another unrelated subject')
+            end.to raise_error(
+              satisfy do |err|
+                expect(err.message).to eql(
+                  <<~END,
+                    Unable to find email matching args:
+                      to: 
+                      subject: Another unrelated subject
+                      body: 
+                    Sent mails:
+                      - To:      [\"user@example.com\"]
+                        Subject: Test subject 1 (did not match)
+                  END
+                )
+              end,
+            )
+          end
+        end
+      end
+    end
+
+    context 'when searching by body' do
+      context 'with string' do
+        context 'when found' do
+          it 'does not raise' do
+            expect do
+              expect_delivered_email(
+                body: 'Hello',
+              )
+            end.not_to raise_error
+          end
+        end
+        context 'and not found' do
+          it 'raises an appropriate error' do
+            expect do
+              expect_delivered_email(body: 'Hellow')
+            end.to raise_error(
+              satisfy do |err|
+                expect(err.message).to eql(
+                  <<~END,
+                    Unable to find email matching args:
+                      to: 
+                      subject: 
+                      body: Hellow
+                    Sent mails:
+                      - To:      [\"user@example.com\"]
+                        Subject: Test subject 1
+                        Body:
+                          - "Hellow" (not found)
+                  END
+                )
+              end,
+            )
+          end
+        end
+      end
+      context 'with array' do
+        context 'when found' do
+          it 'does not raise' do
+            expect do
+              expect_delivered_email(
+                body: ['Hello', 'world'],
+              )
+            end.not_to raise_error
+          end
+        end
+        context 'and not found' do
+          it 'raises an appropriate error' do
+            expect do
+              expect_delivered_email(body: ['Hellow', 'world'])
+            end.to raise_error(
+              satisfy do |err|
+                expect(err.message).to eql(
+                  <<~END,
+                    Unable to find email matching args:
+                      to: 
+                      subject: 
+                      body: ["Hellow", "world"]
+                    Sent mails:
+                      - To:      [\"user@example.com\"]
+                        Subject: Test subject 1
+                        Body:
+                          - "Hellow" (not found)
+                          - "world" (found)
+                  END
+                )
+              end,
+            )
+          end
+        end
+      end
+    end
+
+    context 'when searching by to + subject + body' do
+      context 'and found' do
+        it 'does not raise' do
+          expect do
+            expect_delivered_email(
+              to: 'user@example.com',
+              subject: 'Test subject 1',
+              body: 'Hello',
+            )
+          end.not_to raise_error
+        end
+        context 'and to does not match any' do
+          it 'raises an appropriate error' do
+            expect do
+              expect_delivered_email(
+                to: 'otheruser@example.com',
+                subject: 'Unrelated subject',
+                body: 'Hellow',
+              )
+            end.to raise_error(
+              satisfy do |err|
+                expect(err.message).to eql(
+                  <<~END,
+                    Unable to find email matching args:
+                      to: otheruser@example.com
+                      subject: Unrelated subject
+                      body: Hellow
+                    Sent mails:
+                      - To:      [\"user@example.com\"] (did not match)
+                        Subject: Test subject 1 (did not match)
+                        Body:
+                          - "Hellow" (not found)
+                  END
+                )
+              end,
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🛠 Summary of changes

mailer_helper.rb provides the `expect_delivered_email` helper, which we use in our specs to assert that an email was sent.

This PR:

1. Adds the inverse `expect_email_not_delivered`
2. Adds a spec to capture the expected behavior
3. Updates some places where body matching was previously incorrectly passing

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
