### PR TITLE
Use Promise.withResolvers to simplify promise handling

### DIFF
--- a/app/javascript/packages/analytics/digital-analytics-program.spec.ts
+++ b/app/javascript/packages/analytics/digital-analytics-program.spec.ts
@@ -4,12 +4,7 @@ import { pathToFileURL } from 'node:url';
 
 describe('digital analytics program', () => {
   it('parses without syntax error', async () => {
-    // Future: Replace with Promise.withResolvers once supported
-    // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers
-    let resolve;
-    const promise = new Promise((_resolve) => {
-      resolve = _resolve;
-    });
+    const { promise, resolve } = Promise.withResolvers<void>();
 
     // Reference: https://github.com/nodejs/node/issues/30682
     const toDataURL = (source: string) =>

--- a/spec/javascript/packages/document-capture/hooks/use-async-spec.jsx
+++ b/spec/javascript/packages/document-capture/hooks/use-async-spec.jsx
@@ -43,7 +43,7 @@ describe('document-capture/hooks/use-async', () => {
 
     expect(container.textContent).to.equal('Loading');
 
-    reject();
+    reject(new Error());
 
     expect(await findByText('Error')).to.be.ok();
     expect(console).to.have.loggedError();

--- a/spec/javascript/packages/document-capture/hooks/use-async-spec.jsx
+++ b/spec/javascript/packages/document-capture/hooks/use-async-spec.jsx
@@ -23,19 +23,8 @@ describe('document-capture/hooks/use-async', () => {
   }
 
   it('returns suspense resource that renders fallback', async () => {
-    let resolve;
-    const createPromise = sinon
-      .stub()
-      .onCall(0)
-      .returns(
-        new Promise((_resolve) => {
-          resolve = () => {
-            _resolve();
-          };
-        }),
-      )
-      .onCall(1)
-      .throws();
+    const { promise, resolve } = Promise.withResolvers();
+    const createPromise = sinon.stub().onCall(0).returns(promise).onCall(1).throws();
 
     const { container, findByText } = render(<Parent createPromise={createPromise} />);
 
@@ -47,19 +36,8 @@ describe('document-capture/hooks/use-async', () => {
   });
 
   it('returns suspense resource that renders error fallback', async () => {
-    let reject;
-    const createPromise = sinon
-      .stub()
-      .onCall(0)
-      .returns(
-        new Promise((_resolve, _reject) => {
-          reject = () => {
-            _reject(new Error());
-          };
-        }),
-      )
-      .onCall(1)
-      .throws();
+    const { promise, reject } = Promise.withResolvers();
+    const createPromise = sinon.stub().onCall(0).returns(promise).onCall(1).throws();
 
     const { container, findByText } = render(<Parent createPromise={createPromise} />);
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates a few instances of JavaScript behavior now able to be simplified using [`Promise.withResolvers`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers), available as of Node.js v22.

See [MDN "Description" documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers#description) for an explanation of the exact type of code this feature seeks to replace.

This builds upon #11605 and #11648, leveraging newly-available features.

## 📜 Testing Plan

Since the changes only affect specs, it should be sufficient to verify that tests pass:

```
yarn test
```