### PR TITLE
Enable Chinese in all production environments

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -512,7 +512,6 @@ production:
   aamva_send_id_type: false
   aamva_send_middle_name: false
   aamva_verification_url: 'https://verificationservices-cert.aamva.org:18449/dldv/2.1/online'
-  available_locales: 'en,es,fr'
   disable_email_sending: false
   disable_logout_get_request: false
   email_registrations_per_ip_track_only_mode: true


### PR DESCRIPTION
## 🎫 Ticket

No ticket but discovered Chinese was not enabled in staging [here](https://cm-jira.usa.gov/browse/LG-15148) and Slack conversation [here](https://gsa-tts.slack.com/archives/C0NGESUN5/p1734537094308409).   


## 🛠 Summary of changes
- Removed `available_locales` from production list so that the default would be used (which includes zh)

## 📜 Testing Plan
- [ ] Step 1 Ensure `available_locale` is not set in application.yml file (we don't want to override what we are testing)
- [ ] Step 2 Spin up app, confirm Chinese is available as a language

