### PR TITLE
Add rubocop-capybara to require using path matching helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance
+  - rubocop-capybara
   - ./lib/linters/i18n_helper_html_linter.rb
   - ./lib/linters/analytics_event_name_linter.rb
   - ./lib/linters/localized_validation_message_linter.rb
@@ -41,6 +42,9 @@ Bundler/DuplicatedGem:
   Enabled: true
 
 Bundler/InsecureProtocolSource:
+  Enabled: true
+
+Capybara/CurrentPathExpectation:
   Enabled: true
 
 Gemspec/DuplicatedAssignment:

--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,7 @@ group :development, :test do
   gem 'rubocop-performance', '~> 1.23.0', require: false
   gem 'rubocop-rails', '~> 2.27.0', require: false
   gem 'rubocop-rspec', '~> 3.2.0', require: false
+  gem 'rubocop-capybara', require: false
   gem 'sqlite3', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -635,6 +635,8 @@ GEM
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.36.2)
       parser (>= 3.3.1.0)
+    rubocop-capybara (2.21.0)
+      rubocop (~> 1.41)
     rubocop-performance (1.23.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
@@ -853,6 +855,7 @@ DEPENDENCIES
   rspec-retry
   rspec_junit_formatter
   rubocop (~> 1.69.1)
+  rubocop-capybara
   rubocop-performance (~> 1.23.0)
   rubocop-rails (~> 2.27.0)
   rubocop-rspec (~> 3.2.0)

--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Accessibility on IDV pages', :js do
       complete_welcome_step
       complete_agreement_step
 
-      expect(current_path).to eq idv_how_to_verify_path
+      expect(page).to have_current_path idv_how_to_verify_path
       expect(page).to have_unique_form_landmark_labels
       expect_page_to_have_no_accessibility_violations(page)
     end
@@ -28,7 +28,7 @@ RSpec.feature 'Accessibility on IDV pages', :js do
       sign_in_and_2fa_user
 
       visit idv_cancel_path
-      expect(current_path).to eq idv_cancel_path
+      expect(page).to have_current_path idv_cancel_path
       expect_page_to_have_no_accessibility_violations(page)
 
       visit idv_path
@@ -37,7 +37,7 @@ RSpec.feature 'Accessibility on IDV pages', :js do
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_personal_key_path
+      expect(page).to have_current_path idv_personal_key_path
       expect_page_to_have_no_accessibility_violations(page)
     end
 
@@ -48,7 +48,7 @@ RSpec.feature 'Accessibility on IDV pages', :js do
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
-      expect(current_path).to eq idv_personal_key_path
+      expect(page).to have_current_path idv_personal_key_path
       expect_page_to_have_no_accessibility_violations(page)
     end
   end

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
     email = 'test@example.com'
     sign_up_with(email)
 
-    expect(current_path).to eq(sign_up_verify_email_path)
+    expect(page).to have_current_path(sign_up_verify_email_path)
     # We can't validate markup here, since markup validation requires a page reload when using the
     # JS driver, but the sign up verify email path can only be visited once before redirecting to
     # the account creation form. Instead, we validate markup separately with the non-JS driver.
@@ -18,7 +18,7 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
       email = 'test@example.com'
       sign_up_with(email)
 
-      expect(current_path).to eq(sign_up_verify_email_path)
+      expect(page).to have_current_path(sign_up_verify_email_path)
       expect(page).to have_valid_markup
     end
   end
@@ -28,14 +28,14 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
       create(:user, :unconfirmed)
       confirm_last_user
 
-      expect(current_path).to eq(sign_up_enter_password_path)
+      expect(page).to have_current_path(sign_up_enter_password_path, ignore_query: true)
       expect_page_to_have_no_accessibility_violations(page)
     end
 
     scenario 'invalid confirmation token' do
       visit sign_up_create_email_confirmation_path(confirmation_token: '123456')
 
-      expect(current_path).to eq(sign_up_register_path)
+      expect(page).to have_current_path(sign_up_register_path)
       expect(page).to have_content(t('errors.messages.confirmation_invalid_token'))
       expect_page_to_have_no_accessibility_violations(page)
     end
@@ -45,7 +45,7 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
     scenario 'two factor options page' do
       sign_up_and_set_password
 
-      expect(current_path).to eq(authentication_methods_setup_path)
+      expect(page).to have_current_path(authentication_methods_setup_path)
       expect_page_to_have_no_accessibility_violations(page)
       phone_checkbox = page.find_field('two_factor_options_form_selection_phone', visible: :all)
       expect(phone_checkbox).to have_name(
@@ -61,7 +61,7 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
       find("label[for='two_factor_options_form_selection_phone']").click
       click_button t('forms.buttons.continue')
 
-      expect(current_path).to eq(phone_setup_path)
+      expect(page).to have_current_path(phone_setup_path)
       expect_page_to_have_no_accessibility_violations(page)
     end
 
@@ -69,7 +69,7 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
       user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
 
-      expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: 'sms'))
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
       expect_page_to_have_no_accessibility_violations(page)
     end
 
@@ -79,7 +79,7 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
         sign_in_before_2fa(user)
         visit login_two_factor_path(otp_delivery_preference: 'sms')
 
-        expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+        expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
         expect_page_to_have_no_accessibility_violations(page)
       end
     end
@@ -90,7 +90,7 @@ RSpec.feature 'Accessibility on pages that require authentication', :js do
         sign_in_before_2fa(user)
         visit login_two_factor_path(otp_delivery_preference: 'voice')
 
-        expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'voice')
+        expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'voice')
         expect_page_to_have_no_accessibility_violations(page)
       end
     end

--- a/spec/features/account/backup_codes_spec.rb
+++ b/spec/features/account/backup_codes_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Backup codes' do
     let(:user) { create(:user, :with_backup_code) }
 
     it 'the user is not prompted to set up another MFA upon login' do
-      expect(current_path).to eq account_two_factor_authentication_path
+      expect(page).to have_current_path account_two_factor_authentication_path
     end
   end
 end

--- a/spec/features/account_creation/completions_cancel_spec.rb
+++ b/spec/features/account_creation/completions_cancel_spec.rb
@@ -9,17 +9,17 @@ RSpec.feature 'canceling at the completions screen' do
     select_2fa_option('backup_code')
     click_continue
 
-    expect(current_path).to eq(sign_up_completed_path)
+    expect(page).to have_current_path(sign_up_completed_path)
 
     click_on t('links.cancel')
 
-    expect(current_path).to eq(sign_up_completed_cancel_path)
+    expect(page).to have_current_path(sign_up_completed_cancel_path)
     click_on t('login_cancel.keep_going')
 
-    expect(current_path).to eq(sign_up_completed_path)
+    expect(page).to have_current_path(sign_up_completed_path)
     click_on t('links.cancel')
 
-    expect(current_path).to eq(sign_up_completed_cancel_path)
+    expect(page).to have_current_path(sign_up_completed_cancel_path)
     click_on t('login_cancel.exit', app_name: APP_NAME)
 
     expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')

--- a/spec/features/event_disavowal_spec.rb
+++ b/spec/features/event_disavowal_spec.rb
@@ -172,7 +172,9 @@ RSpec.feature 'disavowing an action' do
 
     # We should be on the MFA screen because we logged in with the new password
     expect(page).to have_content(t('two_factor_authentication.header_text'))
-    expect(page.current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+    expect(page).to have_current_path(
+      login_two_factor_path(otp_delivery_preference: :sms),
+    )
   end
 
   scenario 'disavowing an event with javascript enabled', :js do
@@ -194,8 +196,10 @@ RSpec.feature 'disavowing an action' do
   end
 
   def submit_prefilled_otp_code(user, delivery_preference)
-    expect(current_path)
-      .to eq login_two_factor_path(otp_delivery_preference: delivery_preference)
+    expect(page).to have_current_path(
+      login_two_factor_path(otp_delivery_preference: delivery_preference),
+      ignore_query: true,
+    )
     fill_in('code', with: user.reload.direct_otp)
     click_button t('forms.buttons.submit.default')
   end
@@ -232,7 +236,9 @@ RSpec.feature 'disavowing an action' do
       expect(page).to have_current_path(login_two_factor_piv_cac_path)
     else
       expect(page).to have_content(t('two_factor_authentication.header_text'))
-      expect(page.current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+      expect(page).to have_current_path(
+        login_two_factor_path(otp_delivery_preference: :sms),
+      )
     end
   end
 end

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'cancel IdV' do
     click_link t('links.cancel')
 
     expect(page).to have_content(t('idv.cancel.headings.prompt.standard'))
-    expect(current_path).to eq(idv_cancel_path)
+    expect(page).to have_current_path(idv_cancel_path, ignore_query: true)
     expect(fake_analytics).to have_logged_event(
       'IdV: cancellation visited',
       hash_including(step: 'agreement'),
@@ -40,7 +40,7 @@ RSpec.describe 'cancel IdV' do
 
     click_on(t('idv.cancel.actions.keep_going'))
 
-    expect(current_path).to eq(original_path)
+    expect(page).to have_current_path(original_path)
     expect(fake_analytics).to have_logged_event(
       'IdV: cancellation go back',
       hash_including(step: 'agreement'),
@@ -51,7 +51,7 @@ RSpec.describe 'cancel IdV' do
     click_link t('links.cancel')
 
     expect(page).to have_content(t('idv.cancel.headings.prompt.standard'))
-    expect(current_path).to eq(idv_cancel_path)
+    expect(page).to have_current_path(idv_cancel_path, ignore_query: true)
     expect(fake_analytics).to have_logged_event(
       'IdV: cancellation visited',
       hash_including(step: 'agreement'),
@@ -65,7 +65,7 @@ RSpec.describe 'cancel IdV' do
 
     click_on t('idv.cancel.actions.start_over')
 
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
     expect(fake_analytics).to have_logged_event(
       'IdV: start over',
       hash_including(step: 'agreement'),
@@ -76,7 +76,7 @@ RSpec.describe 'cancel IdV' do
     click_link t('links.cancel')
 
     expect(page).to have_content(t('idv.cancel.headings.prompt.standard'))
-    expect(current_path).to eq(idv_cancel_path)
+    expect(page).to have_current_path(idv_cancel_path, ignore_query: true)
     expect(fake_analytics).to have_logged_event(
       'IdV: cancellation visited',
       hash_including(step: 'agreement'),
@@ -90,7 +90,7 @@ RSpec.describe 'cancel IdV' do
 
     click_spinner_button_and_wait t('idv.cancel.actions.account_page')
 
-    expect(current_path).to eq(account_path)
+    expect(page).to have_current_path(account_path)
     expect(fake_analytics).to have_logged_event(
       'IdV: cancellation confirmed',
       hash_including(step: 'agreement'),
@@ -98,7 +98,7 @@ RSpec.describe 'cancel IdV' do
 
     # After visiting /verify, expect to redirect to the first step in the IdV flow.
     visit idv_path
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
   end
 
   context 'when user has recorded proofing components' do
@@ -173,7 +173,7 @@ RSpec.describe 'cancel IdV' do
       click_link t('links.cancel')
 
       expect(page).to have_content(t('idv.cancel.headings.prompt.standard'))
-      expect(current_path).to eq(idv_cancel_path)
+      expect(page).to have_current_path(idv_cancel_path, ignore_query: true)
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation visited',
         hash_including(step: 'agreement'),
@@ -194,7 +194,7 @@ RSpec.describe 'cancel IdV' do
       )
 
       start_idv_from_sp(sp)
-      expect(current_path).to eq(idv_welcome_path)
+      expect(page).to have_current_path(idv_welcome_path)
     end
   end
 end

--- a/spec/features/idv/confirm_start_over_spec.rb
+++ b/spec/features/idv/confirm_start_over_spec.rb
@@ -34,13 +34,13 @@ RSpec.feature 'idv gpo confirm start over', js: true do
       complete_idv_steps_before_gpo_step
       click_on t('idv.messages.gpo.start_over_link_text')
 
-      expect(current_path).to eq idv_confirm_start_over_before_letter_path
+      expect(page).to have_current_path idv_confirm_start_over_before_letter_path
       expect(page).to have_content(t('idv.cancel.description.gpo.start_over_new_address'))
       expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_phone'))
       expect(fake_analytics).to have_logged_event(:idv_gpo_confirm_start_over_before_letter_visited)
       click_idv_continue
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
     end
   end
 
@@ -50,19 +50,19 @@ RSpec.feature 'idv gpo confirm start over', js: true do
     end
 
     it 'can cancel from confirmation screen' do
-      expect(current_path).to eq idv_verify_by_mail_enter_code_path
+      expect(page).to have_current_path idv_verify_by_mail_enter_code_path
 
       click_on t('idv.gpo.address_accordion.title')
       click_on t('idv.gpo.address_accordion.cta_link')
 
-      expect(current_path).to eq idv_confirm_start_over_path
+      expect(page).to have_current_path idv_confirm_start_over_path
       expect(page).to have_content(t('idv.cancel.description.gpo.start_over'))
       expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_address'))
       expect(fake_analytics).to have_logged_event('IdV: gpo confirm start over visited')
 
       click_idv_continue
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
     end
 
     it 'can return back to verify screen from confirm screen' do
@@ -71,7 +71,7 @@ RSpec.feature 'idv gpo confirm start over', js: true do
       click_on t('forms.buttons.back')
 
       expect(fake_analytics).to have_logged_event('IdV: gpo confirm start over visited')
-      expect(current_path).to eq idv_verify_by_mail_enter_code_path
+      expect(page).to have_current_path idv_verify_by_mail_enter_code_path
     end
   end
 end

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'hybrid_handoff step send link and errors', :js do
       fill_in :doc_auth_phone, with: ''
       click_send_link
 
-      expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
+      expect(page).to have_current_path(idv_hybrid_handoff_path)
     end
 
     it 'sends a link that does not contain any underscores' do
@@ -82,7 +82,7 @@ RSpec.feature 'hybrid_handoff step send link and errors', :js do
 
       click_send_link
 
-      expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
+      expect(page).to have_current_path(idv_hybrid_handoff_path)
       expect(page).to have_content I18n.t('telephony.error.friendly_message.generic')
     end
 
@@ -136,7 +136,7 @@ RSpec.feature 'hybrid_handoff step send link and errors', :js do
         fill_in :doc_auth_phone, with: '415-555-0199'
 
         click_send_link
-        expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
+        expect(page).to have_current_path(idv_hybrid_handoff_path)
         expect(page).to have_content(
           I18n.t(
             'doc_auth.errors.send_link_limited',
@@ -308,7 +308,7 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
 
     click_link t('links.cancel')
     expect(page).to have_content(t('idv.cancel.headings.prompt.standard'))
-    expect(current_path).to eq(idv_cancel_path)
+    expect(page).to have_current_path(idv_cancel_path, ignore_query: true)
   end
 
   def verify_no_upload_photos_section_and_link(page)

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe 'Identity verification', :js do
     test_go_back_from_phone
     complete_otp_verification_page(user)
 
+    expect(page).to have_current_path(idv_enter_password_path)
     test_go_back_from_enter_password
     complete_enter_password_step(user)
 
@@ -353,12 +354,12 @@ RSpec.describe 'Identity verification', :js do
   end
 
   def validate_personal_key_page
-    expect(current_path).to eq idv_personal_key_path
+    expect(page).to have_current_path idv_personal_key_path
 
     # Clicking acknowledge checkbox is required to continue
     click_continue
     expect(page).to have_content(t('forms.validation.required_checkbox'))
-    expect(current_path).to eq(idv_personal_key_path)
+    expect(page).to have_current_path(idv_personal_key_path)
 
     expect(page).to have_content(t('forms.personal_key_partial.acknowledgement.header'))
     expect(page).to have_content(t('forms.personal_key_partial.acknowledgement.text'))
@@ -382,7 +383,7 @@ RSpec.describe 'Identity verification', :js do
 
   def try_to_skip_ahead_before_signing_in
     visit idv_enter_password_path
-    expect(current_path).to eq(root_path)
+    expect(page).to have_current_path(root_path)
   end
 
   def try_to_skip_ahead_from_welcome
@@ -438,7 +439,7 @@ RSpec.describe 'Identity verification', :js do
       visible: :all,
     )
     visit idv_welcome_path
-    expect(current_path).to eql(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
     complete_welcome_step
     expect(page).to have_current_path(idv_agreement_path)
     expect(page).not_to have_checked_field(

--- a/spec/features/idv/get_proofing_results_job_scenarios_spec.rb
+++ b/spec/features/idv/get_proofing_results_job_scenarios_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
       login(@user, @new_password)
 
       # Then the user is taken to the /verify/welcome page
-      expect(current_path).to eq(idv_welcome_path)
+      expect(page).to have_current_path(idv_welcome_path)
       # And the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
         status: 'cancelled',
@@ -85,7 +85,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
       login(@user, @new_password)
 
       # Then the user is taken to the /verify/welcome page
-      expect(current_path).to eq(idv_welcome_path)
+      expect(page).to have_current_path(idv_welcome_path)
       # And the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
         status: 'cancelled',
@@ -129,7 +129,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
         login(@user, @new_password)
 
         # Then the user is taken to the /verify/welcome page
-        expect(current_path).to eq(idv_welcome_path)
+        expect(page).to have_current_path(idv_welcome_path)
         # And the user has an InPersonEnrollment with status "cancelled"
         expect(@user.in_person_enrollments.first).to have_attributes(
           status: 'cancelled',
@@ -164,7 +164,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
         login(@user, @new_password)
 
         # Then the user is taken to the /verify/welcome page
-        expect(current_path).to eq(idv_welcome_path)
+        expect(page).to have_current_path(idv_welcome_path)
         # And the user has an InPersonEnrollment with status "cancelled"
         expect(@user.in_person_enrollments.first).to have_attributes(
           status: 'cancelled',
@@ -225,7 +225,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
       login(@user, @new_password)
 
       # Then the user is taken to the /verify/welcome page
-      expect(current_path).to eq(idv_welcome_path)
+      expect(page).to have_current_path(idv_welcome_path)
       # And the user has an InPersonEnrollment with status "passed"
       expect(@user.in_person_enrollments.first).to have_attributes(
         status: 'passed',
@@ -286,7 +286,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
         login(@user, @new_password)
 
         # Then the user is taken to the /verify/welcome page
-        expect(current_path).to eq(idv_welcome_path)
+        expect(page).to have_current_path(idv_welcome_path)
         # And the user has an InPersonEnrollment with status "failed|cancelled|expired"
         expect(@user.in_person_enrollments.first).to have_attributes(
           status: status,
@@ -346,13 +346,13 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
       # When the user logs in
       login(@user, @new_password)
       # Then the user is taken to the /account/reactivate/start page
-      expect(current_path).to eq(reactivate_account_path)
+      expect(page).to have_current_path(reactivate_account_path)
 
       # When the user attempts to reactivate account without their personal key
       account_reactivation_with_personal_key(@user, @new_password)
 
       # Then the user is taken to the /sign_up/completed page
-      expect(current_path).to eq(sign_up_completed_path)
+      expect(page).to have_current_path(sign_up_completed_path)
       # And the user has an InPersonEnrollment with status "passed"
       expect(@user.in_person_enrollments.first).to have_attributes(
         status: 'passed',
@@ -411,13 +411,13 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
       # When the user logs in
       login(@user, @new_password)
       # Then the user is taken to the /account/reactivate/start page
-      expect(current_path).to eq(reactivate_account_path)
+      expect(page).to have_current_path(reactivate_account_path)
 
       # When the user attempts to reactivate account without their personal key
       account_reactivation_without_personal_key
 
       # Then the user is taken to the /verify/welcome page
-      expect(current_path).to eq(idv_welcome_path)
+      expect(page).to have_current_path(idv_welcome_path)
       # And the user has an InPersonEnrollment with status "passed"
       expect(@user.in_person_enrollments.first).to have_attributes(
         status: 'passed',
@@ -478,7 +478,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
         login(@user, @new_password)
 
         # Then the user is taken to the /verify/welcome page
-        expect(current_path).to eq(idv_welcome_path)
+        expect(page).to have_current_path(idv_welcome_path)
         # And the user has an InPersonEnrollment with status "failed|cancelled|expired"
         expect(@user.in_person_enrollments.first).to have_attributes(
           status: status,
@@ -536,7 +536,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
       login(@user, @new_password)
 
       # Then the user is taken to the /verify/welcome page
-      expect(current_path).to eq(idv_welcome_path)
+      expect(page).to have_current_path(idv_welcome_path)
       # And the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
         status: 'cancelled',
@@ -577,7 +577,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
       login(@user, @new_password)
 
       # Then the user is taken to the /verify/welcome page
-      expect(current_path).to eq(idv_welcome_path)
+      expect(page).to have_current_path(idv_welcome_path)
       # And the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
         status: 'cancelled',
@@ -656,7 +656,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
       login(@user, @new_password)
 
       # Then the user is taken to the /verify/welcome page
-      expect(current_path).to eq(idv_welcome_path)
+      expect(page).to have_current_path(idv_welcome_path)
       # And the user has an InPersonEnrollment with status "passed"
       expect(@user.in_person_enrollments.first).to have_attributes(
         status: 'passed',

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -329,7 +329,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
         warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
         click_link warning_link_text
 
-        expect(current_path).to eq(idv_hybrid_handoff_path)
+        expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
         clear_and_fill_in(:doc_auth_phone, phone_number)
         click_send_link
       end
@@ -387,7 +387,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
         warning_link_text = t('doc_auth.headings.capture_scan_warning_link')
         click_link warning_link_text
 
-        expect(current_path).to eq(idv_hybrid_handoff_path)
+        expect(page).to have_current_path(idv_hybrid_handoff_path, ignore_query: true)
         clear_and_fill_in(:doc_auth_phone, phone_number)
         click_send_link
       end

--- a/spec/features/idv/outage_spec.rb
+++ b/spec/features/idv/outage_spec.rb
@@ -68,24 +68,24 @@ RSpec.feature 'IdV Outage Spec' do
     it 'takes the user through the mail only flow, allowing hybrid', js: true do
       sign_in_with_idv_required(user: user)
 
-      expect(current_path).to eq idv_mail_only_warning_path
+      expect(page).to have_current_path idv_mail_only_warning_path
 
       click_idv_continue
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
 
       complete_welcome_step
       complete_agreement_step
 
       # Still offer the option for hybrid flow
-      expect(current_path).to eq idv_hybrid_handoff_path
+      expect(page).to have_current_path idv_hybrid_handoff_path
 
       complete_hybrid_handoff_step
       complete_document_capture_step
       complete_ssn_step
       complete_verify_step
 
-      expect(current_path).to eq idv_request_letter_path
+      expect(page).to have_current_path idv_request_letter_path
     end
   end
 
@@ -95,13 +95,13 @@ RSpec.feature 'IdV Outage Spec' do
     it 'shows mail only warning page before idv welcome page', js: true do
       sign_in_with_idv_required(user: user)
 
-      expect(current_path).to eq idv_mail_only_warning_path
+      expect(page).to have_current_path idv_mail_only_warning_path
 
       complete_doc_auth_steps_before_document_capture_step
       click_on t('links.cancel')
       click_on t('idv.cancel.actions.start_over')
 
-      expect(current_path).to eq idv_mail_only_warning_path
+      expect(page).to have_current_path idv_mail_only_warning_path
     end
   end
 
@@ -111,11 +111,11 @@ RSpec.feature 'IdV Outage Spec' do
     it 'shows mail only warning page before idv welcome page' do
       sign_in_with_idv_required(user: user)
 
-      expect(current_path).to eq idv_mail_only_warning_path
+      expect(page).to have_current_path idv_mail_only_warning_path
 
       click_idv_continue
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
     end
   end
 
@@ -126,7 +126,7 @@ RSpec.feature 'IdV Outage Spec' do
     it 'shows mail only warning page before idv welcome page' do
       sign_in_with_idv_required(user: user)
 
-      expect(current_path).to eq vendor_outage_path
+      expect(page).to have_current_path vendor_outage_path
     end
   end
 
@@ -140,11 +140,11 @@ RSpec.feature 'IdV Outage Spec' do
         it 'shows mail only warning page before idv welcome page' do
           sign_in_with_idv_required(user: user, sms_or_totp: :totp)
 
-          expect(current_path).to eq idv_mail_only_warning_path
+          expect(page).to have_current_path idv_mail_only_warning_path
 
           click_idv_continue
 
-          expect(current_path).to eq idv_welcome_path
+          expect(page).to have_current_path idv_welcome_path
         end
 
         it 'returns to the correct page when clicking to exit' do
@@ -161,7 +161,7 @@ RSpec.feature 'IdV Outage Spec' do
           click_idv_continue
           complete_agreement_step
 
-          expect(current_path).to eq idv_document_capture_path
+          expect(page).to have_current_path idv_document_capture_path
         end
       end
     end
@@ -174,11 +174,11 @@ RSpec.feature 'IdV Outage Spec' do
     it 'shows mail only warning page before idv welcome page' do
       sign_in_with_idv_required(user: user, sms_or_totp: :sms)
 
-      expect(current_path).to eq idv_mail_only_warning_path
+      expect(page).to have_current_path idv_mail_only_warning_path
 
       click_idv_continue
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
     end
 
     it 'still allows the hybrid handoff screen' do
@@ -187,7 +187,7 @@ RSpec.feature 'IdV Outage Spec' do
       click_idv_continue
       complete_agreement_step
 
-      expect(current_path).to eq idv_hybrid_handoff_path
+      expect(page).to have_current_path idv_hybrid_handoff_path
     end
   end
 
@@ -198,7 +198,7 @@ RSpec.feature 'IdV Outage Spec' do
     it 'does not show the mail only warning page before idv welcome page' do
       sign_in_with_idv_required(user: user, sms_or_totp: :sms)
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
     end
 
     it 'does not show the hybrid handoff screen' do
@@ -207,7 +207,7 @@ RSpec.feature 'IdV Outage Spec' do
       click_idv_continue
       complete_agreement_step
 
-      expect(current_path).to eq idv_document_capture_path
+      expect(page).to have_current_path idv_document_capture_path
     end
   end
 

--- a/spec/features/idv/pending_profile_password_reset_spec.rb
+++ b/spec/features/idv/pending_profile_password_reset_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Resetting password with a pending profile' do
     sign_in_live_with_2fa(user)
 
     expect(page).to have_content t('doc_auth.headings.welcome', sp_name: sp_name)
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
 
     expect(user.reload.active_or_pending_profile).to be_nil
   end
@@ -50,7 +50,7 @@ RSpec.describe 'Resetting password with a pending profile' do
     sign_in_live_with_2fa(user)
 
     expect(page).to have_content(t('doc_auth.headings.welcome', sp_name: sp_name))
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
 
     expect(user.reload.active_or_pending_profile).to be_nil
   end
@@ -72,7 +72,7 @@ RSpec.describe 'Resetting password with a pending profile' do
     sign_in_live_with_2fa(user)
 
     expect(page).to have_content(t('doc_auth.headings.welcome', sp_name: sp_name))
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
 
     expect(user.reload.active_or_pending_profile).to be_nil
   end

--- a/spec/features/idv/phone_errors_spec.rb
+++ b/spec/features/idv/phone_errors_spec.rb
@@ -25,37 +25,37 @@ RSpec.feature 'phone errors', :js do
 
   def verify_phone_submitted(phone_errors_url, phone_errors_path)
     visit(phone_errors_url)
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
 
     complete_welcome_step
     visit(phone_errors_url)
-    expect(current_path).to eq(idv_agreement_path)
+    expect(page).to have_current_path(idv_agreement_path)
 
     complete_agreement_step
     visit(phone_errors_url)
-    expect(current_path).to eq(idv_hybrid_handoff_path)
+    expect(page).to have_current_path(idv_hybrid_handoff_path)
 
     complete_hybrid_handoff_step # upload photos
     visit(phone_errors_url)
-    expect(current_path).to eq(idv_document_capture_path)
+    expect(page).to have_current_path(idv_document_capture_path)
 
     complete_document_capture_step
     visit(phone_errors_url)
-    expect(current_path).to eq(idv_ssn_path)
+    expect(page).to have_current_path(idv_ssn_path)
 
     complete_ssn_step
     visit(phone_errors_url)
-    expect(current_path).to eq(idv_verify_info_path)
+    expect(page).to have_current_path(idv_verify_info_path)
 
     complete_verify_step
     visit(phone_errors_url)
-    expect(current_path).to eq(idv_phone_path)
+    expect(page).to have_current_path(idv_phone_path)
 
     fill_out_phone_form_fail
     click_idv_send_security_code
-    expect(current_path).to eq(idv_phone_errors_warning_path)
+    expect(page).to have_current_path(idv_phone_errors_warning_path)
 
     visit(phone_errors_url)
-    expect(current_path).to eq(phone_errors_path)
+    expect(page).to have_current_path(phone_errors_path)
   end
 end

--- a/spec/features/idv/phone_otp_rate_limiting_spec.rb
+++ b/spec/features/idv/phone_otp_rate_limiting_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature 'phone otp rate limiting', :js do
       click_submit_default
 
       expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-      expect(current_path).to eq(idv_enter_password_path)
+      expect(page).to have_current_path(idv_enter_password_path)
     end
   end
 end

--- a/spec/features/idv/proof_address_rate_limit_spec.rb
+++ b/spec/features/idv/proof_address_rate_limit_spec.rb
@@ -12,11 +12,11 @@ RSpec.feature 'address proofing rate limit' do
       start_idv_from_sp
       complete_idv_steps_before_phone_step(user)
 
-      expect(current_path).to eq(idv_phone_errors_failure_path)
+      expect(page).to have_current_path(idv_phone_errors_failure_path)
 
       # Cancel is available
       click_on 'Cancel'
-      expect(current_path).to eq(idv_cancel_path)
+      expect(page).to have_current_path(idv_cancel_path, ignore_query: true)
       click_on(t('idv.cancel.actions.keep_going'))
 
       # Can continue with Verify by mail
@@ -24,7 +24,7 @@ RSpec.feature 'address proofing rate limit' do
       click_on t('idv.buttons.mail.send')
 
       expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-      expect(current_path).to eq(idv_enter_password_path)
+      expect(page).to have_current_path(idv_enter_password_path)
       fill_in 'Password', with: user.password
       click_idv_continue
       expect(page).to have_current_path(idv_letter_enqueued_path)
@@ -52,12 +52,12 @@ RSpec.feature 'address proofing rate limit' do
       click_idv_send_security_code
 
       # There should be no option to verify by mail on the warning page
-      expect(current_path).to eq(idv_phone_errors_warning_path)
+      expect(page).to have_current_path(idv_phone_errors_warning_path)
       expect(page).to_not have_content(t('idv.failure.phone.warning.gpo.button'))
 
       # Visiting the letter request URL should redirect to phone
       visit idv_request_letter_path
-      expect(current_path).to eq(idv_phone_path)
+      expect(page).to have_current_path(idv_phone_path)
 
       fill_out_phone_form_ok
       click_idv_send_security_code
@@ -65,10 +65,10 @@ RSpec.feature 'address proofing rate limit' do
       click_submit_default
 
       expect(page).to have_content(t('idv.titles.session.enter_password', app_name: APP_NAME))
-      expect(current_path).to eq(idv_enter_password_path)
+      expect(page).to have_current_path(idv_enter_password_path)
       fill_in 'Password', with: user.password
       click_idv_continue
-      expect(current_path).to eq(idv_personal_key_path)
+      expect(page).to have_current_path(idv_personal_key_path)
       expect(user.reload.active_profile.present?).to eq(true)
     end
   end
@@ -87,12 +87,12 @@ RSpec.feature 'address proofing rate limit' do
       start_idv_from_sp
       sign_in_live_with_2fa(user)
 
-      expect(current_path).to eq(idv_phone_errors_failure_path)
+      expect(page).to have_current_path(idv_phone_errors_failure_path)
       expect(page).to_not have_content(t('idv.failure.phone.warning.gpo.button'))
 
       # Visiting the letter request URL should redirect to phone failure
       visit idv_request_letter_path
-      expect(current_path).to eq(idv_phone_errors_failure_path)
+      expect(page).to have_current_path(idv_phone_errors_failure_path)
     end
   end
 end

--- a/spec/features/idv/proofing_components_spec.rb
+++ b/spec/features/idv/proofing_components_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'proofing components' do
       visit_idp_from_sp_with_ial2(:oidc)
       register_user(email)
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
 
       complete_all_doc_auth_steps_before_password_step
       fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD

--- a/spec/features/idv/puerto_rican_address_spec.rb
+++ b/spec/features/idv/puerto_rican_address_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe 'proofing flow with a Puerto Rican document', :js do
     complete_ssn_step
 
     expect(page).to have_content(t('doc_auth.headings.address'))
-    expect(current_path).to eq(idv_address_path)
+    expect(page).to have_current_path(idv_address_path)
 
     click_button t('forms.buttons.submit.update')
 
     expect(page).to have_content(t('headings.verify'))
-    expect(current_path).to eq(idv_verify_info_path)
+    expect(page).to have_current_path(idv_verify_info_path)
   end
 
   it 'does not redirect to the user to the address step after they update their SSN' do
@@ -27,7 +27,7 @@ RSpec.describe 'proofing flow with a Puerto Rican document', :js do
     click_button t('forms.buttons.submit.update')
 
     expect(page).to have_content(t('headings.verify'))
-    expect(current_path).to eq(idv_verify_info_path)
+    expect(page).to have_current_path(idv_verify_info_path)
 
     click_link t('idv.buttons.change_ssn_label')
 

--- a/spec/features/idv/sp_follow_up_spec.rb
+++ b/spec/features/idv/sp_follow_up_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'returning to an SP after out-of-band proofing' do
 
     sign_in_live_with_2fa(user)
 
-    expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
+    expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
 
     fill_in t('idv.gpo.form.otp_label'), with: otp
     click_button t('idv.gpo.form.submit')
@@ -63,13 +63,13 @@ RSpec.feature 'returning to an SP after out-of-band proofing' do
 
       sign_in_live_with_2fa(user)
 
-      expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
+      expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
 
       fill_in t('idv.gpo.form.otp_label'), with: otp
       click_button t('idv.gpo.form.submit')
       acknowledge_and_confirm_personal_key
 
-      expect(current_path).to eq(idv_sp_follow_up_path)
+      expect(page).to have_current_path(idv_sp_follow_up_path)
       click_on t('idv.by_mail.sp_follow_up.connect_account')
 
       expect(current_url).to eq(post_idv_follow_up_url)
@@ -91,13 +91,13 @@ RSpec.feature 'returning to an SP after out-of-band proofing' do
 
       sign_in_live_with_2fa(user)
 
-      expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
+      expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
 
       fill_in t('idv.gpo.form.otp_label'), with: otp
       click_button t('idv.gpo.form.submit')
       acknowledge_and_confirm_personal_key
 
-      expect(current_path).to eq(idv_sp_follow_up_path)
+      expect(page).to have_current_path(idv_sp_follow_up_path)
       click_on t('idv.by_mail.sp_follow_up.go_to_account')
 
       expect(current_url).to eq(account_url)

--- a/spec/features/idv/steps/enter_code_step_spec.rb
+++ b/spec/features/idv/steps/enter_code_step_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature 'idv enter letter code step' do
     fill_in_code_with_last_phone_otp
     click_submit_default
 
-    expect(current_path).to eq idv_verify_by_mail_enter_code_path
+    expect(page).to have_current_path idv_verify_by_mail_enter_code_path
     expect(page).to have_css('h1', text: t('idv.gpo.title'))
 
     fill_in t('idv.gpo.form.otp_label'), with: 'incorrect1'
@@ -107,7 +107,7 @@ RSpec.feature 'idv enter letter code step' do
     it 'renders an alternate ui that remains after failed submission', :js do
       visit idv_verify_by_mail_enter_code_url(did_not_receive_letter: 1)
       verify_no_rate_limit_banner
-      expect(current_path).to eql(new_user_session_path)
+      expect(page).to have_current_path(new_user_session_path)
 
       fill_in_credentials_and_submit(user.email, user.password)
       continue_as(user.email, user.password)
@@ -115,13 +115,13 @@ RSpec.feature 'idv enter letter code step' do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_path).to eq idv_verify_by_mail_enter_code_path
+      expect(page).to have_current_path(idv_verify_by_mail_enter_code_path, ignore_query: true)
       expect(page).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
 
       fill_in t('idv.gpo.form.otp_label'), with: 'incorrect1'
       click_button t('idv.gpo.form.submit')
 
-      expect(current_path).to eq idv_verify_by_mail_enter_code_path
+      expect(page).to have_current_path idv_verify_by_mail_enter_code_path
       expect(page).to have_css('h1', text: t('idv.gpo.did_not_receive_letter.title'))
       expect(page).to have_content(t('errors.messages.confirmation_code_incorrect'))
     end
@@ -135,7 +135,7 @@ RSpec.feature 'idv enter letter code step' do
       it 'shows the user a personal key after verification' do
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq idv_verify_by_mail_enter_code_path
+        expect(page).to have_current_path idv_verify_by_mail_enter_code_path
         verify_no_rate_limit_banner
         expect(page).to have_content t('idv.messages.gpo.resend')
 
@@ -163,7 +163,7 @@ RSpec.feature 'idv enter letter code step' do
       it 'allows a user to verify their account for an existing pending profile' do
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq idv_verify_by_mail_enter_code_path
+        expect(page).to have_current_path idv_verify_by_mail_enter_code_path
         expect(page).to have_content t('idv.messages.gpo.resend')
 
         verify_no_rate_limit_banner
@@ -178,7 +178,7 @@ RSpec.feature 'idv enter letter code step' do
     it 'allows a user to cancel and start over within the banner' do
       sign_in_live_with_2fa(user)
 
-      expect(current_path).to eq idv_verify_by_mail_enter_code_path
+      expect(page).to have_current_path idv_verify_by_mail_enter_code_path
       expect(page).to have_content t('idv.gpo.intro')
       expect(page).to have_content(
         strip_tags(
@@ -193,11 +193,11 @@ RSpec.feature 'idv enter letter code step' do
 
       click_on t('idv.gpo.address_accordion.cta_link')
 
-      expect(current_path).to eq idv_confirm_start_over_path
+      expect(page).to have_current_path idv_confirm_start_over_path
 
       click_idv_continue
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
     end
   end
 
@@ -209,16 +209,16 @@ RSpec.feature 'idv enter letter code step' do
     )
     sign_in_live_with_2fa(user)
 
-    expect(current_path).to eq idv_verify_by_mail_enter_code_path
+    expect(page).to have_current_path idv_verify_by_mail_enter_code_path
     verify_rate_limit_banner_present(another_gpo_confirmation_code.updated_at)
 
     click_on t('idv.gpo.address_accordion.cta_link')
 
-    expect(current_path).to eq idv_confirm_start_over_path
+    expect(page).to have_current_path idv_confirm_start_over_path
 
     click_idv_continue
 
-    expect(current_path).to eq idv_welcome_path
+    expect(page).to have_current_path idv_welcome_path
   end
 
   context 'user is rate limited', :js do
@@ -235,7 +235,7 @@ RSpec.feature 'idv enter letter code step' do
       fill_in t('idv.gpo.form.otp_label'), with: wrong_otp
       click_button t('idv.gpo.form.submit')
 
-      expect(current_path).to eq(idv_enter_code_rate_limited_path)
+      expect(page).to have_current_path(idv_enter_code_rate_limited_path)
     end
   end
 
@@ -247,10 +247,10 @@ RSpec.feature 'idv enter letter code step' do
 
       click_on t('idv.gpo.address_accordion.title')
       click_on t('idv.gpo.address_accordion.cta_link')
-      expect(current_path).to eq idv_confirm_start_over_path
+      expect(page).to have_current_path idv_confirm_start_over_path
       click_idv_continue
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
     end
   end
 

--- a/spec/features/idv/steps/enter_password_step_spec.rb
+++ b/spec/features/idv/steps/enter_password_step_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'idv enter password step', :js do
       click_continue
 
       expect(page).to have_content(t('idv.titles.come_back_later'))
-      expect(current_path).to eq idv_letter_enqueued_path
+      expect(page).to have_current_path idv_letter_enqueued_path
     end
 
     context 'with an sp' do
@@ -94,14 +94,14 @@ RSpec.feature 'idv enter password step', :js do
 
     it 'allows the user to submit password and proceed to obtain a personal key' do
       visit(idv_hybrid_handoff_url(redo: true))
-      expect(current_path).to eq idv_hybrid_handoff_path
+      expect(page).to have_current_path(idv_hybrid_handoff_path(redo: true))
       complete_hybrid_handoff_step
       complete_document_capture_step
       complete_ssn_step
       complete_verify_step
       complete_phone_step(user)
       complete_enter_password_step(user)
-      expect(current_path).to eq idv_personal_key_path
+      expect(page).to have_current_path idv_personal_key_path
     end
   end
 end

--- a/spec/features/idv/steps/forgot_password_step_spec.rb
+++ b/spec/features/idv/steps/forgot_password_step_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'forgot password step', :js do
 
     click_link t('idv.forgot_password.link_text')
 
-    expect(page.current_path).to eq(idv_forgot_password_path)
+    expect(page).to have_current_path(idv_forgot_password_path)
   end
 
   it 'goes back to the enter password page from the forgot password page' do
@@ -19,7 +19,7 @@ RSpec.feature 'forgot password step', :js do
     click_link t('idv.forgot_password.link_text')
     click_link t('idv.forgot_password.try_again')
 
-    expect(page.current_path).to eq(idv_enter_password_path)
+    expect(page).to have_current_path(idv_enter_password_path)
   end
 
   it 'allows the user to reset their password' do
@@ -29,11 +29,11 @@ RSpec.feature 'forgot password step', :js do
     click_link t('idv.forgot_password.link_text')
     click_button t('idv.forgot_password.reset_password')
 
-    expect(page.current_path).to eq(forgot_password_path)
+    expect(page).to have_current_path(forgot_password_path, ignore_query: true)
 
     open_last_email
     click_email_link_matching(/reset_password_token/)
 
-    expect(current_path).to eq edit_user_password_path
+    expect(page).to have_current_path edit_user_password_path
   end
 end

--- a/spec/features/idv/steps/phone_otp_verification_step_spec.rb
+++ b/spec/features/idv/steps/phone_otp_verification_step_spec.rb
@@ -11,14 +11,14 @@ RSpec.feature 'phone otp verification step spec', :js do
 
     # Attempt to bypass the step
     visit idv_enter_password_path
-    expect(current_path).to eq(idv_otp_verification_path)
+    expect(page).to have_current_path(idv_otp_verification_path)
 
     # Enter an incorrect otp
     fill_in 'code', with: '000000'
     click_submit_default
 
     expect(page).to have_content(t('two_factor_authentication.invalid_otp'))
-    expect(current_path).to eq(idv_otp_verification_path)
+    expect(page).to have_current_path(idv_otp_verification_path)
 
     # Enter the correct code
     fill_in_code_with_last_phone_otp
@@ -52,7 +52,7 @@ RSpec.feature 'phone otp verification step spec', :js do
     click_on t('links.two_factor_authentication.send_another_code')
 
     expect(Telephony::Test::Message.messages.count).to eq(sent_message_count + 1)
-    expect(current_path).to eq(idv_otp_verification_path)
+    expect(page).to have_current_path(idv_otp_verification_path)
 
     fill_in_code_with_last_phone_otp
     click_submit_default

--- a/spec/features/idv/threat_metrix_pending_spec.rb
+++ b/spec/features/idv/threat_metrix_pending_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Users pending ThreatMetrix review', :js do
     sign_in_live_with_2fa(user)
     click_agree_and_continue
 
-    expect(current_path).to eq('/auth/result')
+    expect(page).to have_current_path('/auth/result', ignore_query: true)
   end
 
   scenario 'users rejected from fraud review cannot perform idv' do
@@ -83,7 +83,7 @@ RSpec.feature 'Users pending ThreatMetrix review', :js do
     sign_in_live_with_2fa(user)
     click_agree_and_continue
 
-    expect(current_path).to eq('/auth/result')
+    expect(page).to have_current_path('/auth/result', ignore_query: true)
   end
 
   scenario 'users ThreatMetrix Pass, it logs idv_tmx_fraud_check event' do

--- a/spec/features/idv/verify_by_mail_pending_spec.rb
+++ b/spec/features/idv/verify_by_mail_pending_spec.rb
@@ -11,17 +11,17 @@ RSpec.feature 'a user that is pending verify by mail' do
     start_idv_from_sp(facial_match_required: false)
     sign_in_live_with_2fa(user)
 
-    expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
+    expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
 
     # Attempting to start IdV should require enter-code to be completed
     visit idv_welcome_path
-    expect(current_path).to eq(idv_verify_by_mail_enter_code_path)
+    expect(page).to have_current_path(idv_verify_by_mail_enter_code_path)
 
     # Cancelling redirects to IdV flow start
     click_on t('idv.gpo.address_accordion.cta_link')
     click_idv_continue
 
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
   end
 
   it 'does not require them to enter their code if they are upgrading to facial match' do
@@ -34,6 +34,6 @@ RSpec.feature 'a user that is pending verify by mail' do
 
     # The user is redirected to proofing since their pending profile does not meet
     # the facial match comparison requirement
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
   end
 end

--- a/spec/features/load_testing/email_sign_up_spec.rb
+++ b/spec/features/load_testing/email_sign_up_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Email sign up' do
     sign_up_with(email)
     click_link('CONFIRM NOW')
 
-    expect(current_path).to eq sign_up_enter_password_path
+    expect(page).to have_current_path(sign_up_enter_password_path, ignore_query: true)
     expect(page).to have_content t('devise.confirmations.confirmed_but_must_set_password')
   end
 end

--- a/spec/features/multiple_emails/sp_sign_in_spec.rb
+++ b/spec/features/multiple_emails/sp_sign_in_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
 
       click_button(t('help_text.requested_attributes.select_email_link'))
 
-      expect(current_path).to eq(sign_up_completed_path)
+      expect(page).to have_current_path(sign_up_completed_path)
       click_agree_and_continue
       expect(oidc_decoded_id_token[:email]).to eq(emails.second)
     end
@@ -56,7 +56,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       click_link(t('help_text.requested_attributes.change_email_link'))
       choose email2.email
       click_button(t('help_text.requested_attributes.select_email_link'))
-      expect(current_path).to eq(sign_up_completed_path)
+      expect(page).to have_current_path(sign_up_completed_path)
       click_agree_and_continue
       click_submit_default
 
@@ -105,7 +105,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       choose emails.second
       click_button(t('help_text.requested_attributes.select_email_link'))
 
-      expect(current_path).to eq(sign_up_completed_path)
+      expect(page).to have_current_path(sign_up_completed_path)
 
       click_agree_and_continue
       click_submit_default
@@ -128,7 +128,7 @@ RSpec.feature 'signing into an SP with multiple emails enabled' do
       click_link(t('help_text.requested_attributes.change_email_link'))
       choose email2.email
       click_button(t('help_text.requested_attributes.select_email_link'))
-      expect(current_path).to eq(sign_up_completed_path)
+      expect(page).to have_current_path(sign_up_completed_path)
       click_agree_and_continue
       click_submit_default
 

--- a/spec/features/new_device_tracking_spec.rb
+++ b/spec/features/new_device_tracking_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'New device tracking' do
 
       travel_to 16.minutes.from_now do
         visit root_url
-        expect(current_path).to eq(new_user_session_path)
+        expect(page).to have_current_path(new_user_session_path)
         sign_in_user(user)
       end
 
@@ -62,7 +62,7 @@ RSpec.describe 'New device tracking' do
       # Notified after session expired, user returned for successful email password and MFA
       travel_to 38.minutes.from_now do
         visit root_url
-        expect(current_path).to eq(new_user_session_path)
+        expect(page).to have_current_path(new_user_session_path)
 
         # Regression: LG-13221: Ensure that the successful authentication email lists failed MFA.
         sign_in_user(user)

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -94,13 +94,13 @@ RSpec.feature 'OIDC Authorization Confirmation' do
       sign_in_user(user1)
       visit_idp_from_ial1_oidc_sp
 
-      expect(current_path).to eq(user_authorization_confirmation_path)
+      expect(page).to have_current_path(user_authorization_confirmation_path)
 
       click_button t('user_authorization_confirmation.sign_in')
       # Simulate clicking the back button by going right back to the original path
       visit user_authorization_confirmation_path
 
-      expect(current_path).to eq(new_user_session_path)
+      expect(page).to have_current_path(new_user_session_path)
     end
   end
 
@@ -115,7 +115,7 @@ RSpec.feature 'OIDC Authorization Confirmation' do
 
       perform_in_browser(:two) do
         confirm_email_in_a_different_browser(email)
-        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_current_path sign_up_completed_path
         expect(page).to have_content t('help_text.requested_attributes.email')
         expect(page).to have_content email
 

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'OpenID Connect' do
         client_id: 'urn:gov:gsa:openidconnect:test_prompt_login_banned',
       )
 
-      expect(current_path).to eq(openid_connect_authorize_path)
+      expect(page).to have_current_path(openid_connect_authorize_path, ignore_query: true)
       expect(page).to have_content(t('openid_connect.authorization.errors.prompt_invalid'))
     end
 
@@ -110,7 +110,7 @@ RSpec.describe 'OpenID Connect' do
         client_id: 'urn:gov:gsa:openidconnect:test_prompt_login_banned',
       )
 
-      expect(current_path).to eq(openid_connect_authorize_path)
+      expect(page).to have_current_path(openid_connect_authorize_path, ignore_query: true)
       expect(page).to have_content(t('openid_connect.authorization.errors.prompt_invalid'))
     end
 
@@ -1179,7 +1179,7 @@ RSpec.describe 'OpenID Connect' do
       expect(URI(oidc_redirect_url).path).to eq(redirs_to)
       return
     end
-    expect(current_path).to eq('/')
+    expect(page).to have_current_path('/')
 
     user ||= create(
       :profile, :active, :verified,

--- a/spec/features/openid_connect/vtr_spec.rb
+++ b/spec/features/openid_connect/vtr_spec.rb
@@ -107,7 +107,7 @@ RSpec.feature 'OIDC requests using VTR' do
 
     sign_in_live_with_2fa(user)
 
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
   end
 
   scenario 'sign in with VTR request for idv with facial match requires idv with facial match',
@@ -120,7 +120,7 @@ RSpec.feature 'OIDC requests using VTR' do
 
     sign_in_live_with_2fa(user)
 
-    expect(current_path).to eq(idv_welcome_path)
+    expect(page).to have_current_path(idv_welcome_path)
 
     click_continue
     check t('doc_auth.instructions.consent', app_name: APP_NAME)

--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'phone otp confirmation' do
     def expect_failed_otp_confirmation(_delivery_method)
       visit account_path
 
-      expect(current_path).to eq(authentication_methods_setup_path)
+      expect(page).to have_current_path(authentication_methods_setup_path)
       expect(phone_configuration).to be_nil
     end
   end
@@ -52,7 +52,9 @@ RSpec.describe 'phone otp confirmation' do
     def expect_failed_otp_confirmation(delivery_method)
       visit account_path
 
-      expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: delivery_method))
+      expect(page).to have_current_path(
+        login_two_factor_path(otp_delivery_preference: delivery_method),
+      )
     end
   end
 

--- a/spec/features/phone/default_phone_selection_spec.rb
+++ b/spec/features/phone/default_phone_selection_spec.rb
@@ -129,8 +129,10 @@ RSpec.describe 'default phone selection' do
   end
 
   def submit_prefilled_otp_code(user, delivery_preference)
-    expect(current_path)
-      .to eq login_two_factor_path(otp_delivery_preference: delivery_preference)
+    expect(page).to have_current_path(
+      login_two_factor_path(otp_delivery_preference: delivery_preference),
+      ignore_query: true,
+    )
     fill_in('code', with: user.reload.direct_otp)
     click_button t('forms.buttons.submit.default')
   end

--- a/spec/features/phone/edit_phone_spec.rb
+++ b/spec/features/phone/edit_phone_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe 'editing a phone' do
     visit(manage_phone_path(id: phone_configuration.id))
 
     expect(page).to have_content(t('headings.edit_info.phone'))
-    expect(current_path).to eq(manage_phone_path(id: phone_configuration.id))
+    expect(page).to have_current_path(
+      manage_phone_path(id: phone_configuration.id),
+    )
   end
 
   it "does not allow a user to edit another user's phone number" do

--- a/spec/features/remember_device/signed_in_sp_expiration_spec.rb
+++ b/spec/features/remember_device/signed_in_sp_expiration_spec.rb
@@ -27,7 +27,9 @@ RSpec.feature 'SP expiration while signed in' do
     travel_to(5.seconds.from_now) do
       visit_idp_from_sp_with_ial1_aal2(:oidc)
 
-      expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+      expect(page).to have_current_path(
+        login_two_factor_path(otp_delivery_preference: :sms),
+      )
       expect(page).to have_content(t('two_factor_authentication.header_text'))
 
       fill_in_code_with_last_phone_otp

--- a/spec/features/remember_device/sp_expiration_spec.rb
+++ b/spec/features/remember_device/sp_expiration_spec.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples 'expiring remember device for an sp config' do |expiration
         sign_in_user(user)
 
         expect(page).to have_content(t('two_factor_authentication.header_text'))
-        expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+        expect(page).to have_current_path(login_two_factor_path(otp_delivery_preference: :sms))
 
         fill_in_code_with_last_phone_otp
         protocol == :saml ? click_submit_default_twice : click_submit_default
@@ -55,7 +55,7 @@ RSpec.shared_examples 'expiring remember device for an sp config' do |expiration
           sign_in_user(user)
           visit_sp(protocol, aal)
 
-          expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+          expect(page).to have_current_path(login_two_factor_path(otp_delivery_preference: :sms))
           expect(page).to have_content(t('two_factor_authentication.header_text'))
 
           fill_in_code_with_last_phone_otp
@@ -71,7 +71,7 @@ RSpec.shared_examples 'expiring remember device for an sp config' do |expiration
           sign_in_user(user)
 
           expect(page).to have_content(t('two_factor_authentication.header_text'))
-          expect(current_path).to eq(login_two_factor_path(otp_delivery_preference: :sms))
+          expect(page).to have_current_path(login_two_factor_path(otp_delivery_preference: :sms))
 
           fill_in_code_with_last_phone_otp
           protocol == :saml ? click_submit_default_twice : click_submit_default

--- a/spec/features/remember_device/webauthn_spec.rb
+++ b/spec/features/remember_device/webauthn_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'Remembering a webauthn device' do
         expect(page)
           .to have_content t('headings.add_info.phone')
 
-        expect(current_path).to eq phone_setup_path
+        expect(page).to have_current_path phone_setup_path
 
         fill_in 'new_phone_form_phone', with: '703-555-1212'
         click_send_one_time_code

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -63,13 +63,13 @@ RSpec.feature 'SAML Authorization Confirmation' do
       sign_in_user(user1)
       visit request_url
 
-      expect(current_path).to eq(user_authorization_confirmation_path)
+      expect(page).to have_current_path(user_authorization_confirmation_path)
 
       click_button t('user_authorization_confirmation.sign_in')
       # Simulate clicking the back button by going right back to the original path
       visit user_authorization_confirmation_path
 
-      expect(current_path).to eq(new_user_session_path)
+      expect(page).to have_current_path(new_user_session_path)
     end
 
     it 'does not render the confirmation screen on a return visit to the SP by default' do
@@ -89,7 +89,7 @@ RSpec.feature 'SAML Authorization Confirmation' do
       sign_in_user(user1)
       visit user_authorization_confirmation_path
 
-      expect(current_path).to eq(account_path)
+      expect(page).to have_current_path(account_path)
     end
   end
 
@@ -106,7 +106,7 @@ RSpec.feature 'SAML Authorization Confirmation' do
 
       perform_in_browser(:two) do
         confirm_email_in_a_different_browser(email)
-        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_current_path sign_up_completed_path
         expect(page).to have_content t('help_text.requested_attributes.email')
         expect(page).to have_content email
 

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'IAL1 Single Sign On' do
 
       perform_in_browser(:two) do
         confirm_email_in_a_different_browser(email)
-        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_current_path sign_up_completed_path
         expect(page).to have_content t('help_text.requested_attributes.email')
         expect(page).to have_content email
         expect(page).to_not have_content t('help_text.requested_attributes.address')
@@ -43,7 +43,7 @@ RSpec.feature 'IAL1 Single Sign On' do
       expect(current_url).to eq complete_saml_url
 
       visit root_path
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
 
     it 'shows user the start page without accordion' do
@@ -152,7 +152,7 @@ RSpec.feature 'IAL1 Single Sign On' do
 
       visit saml_authn_request_url
 
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
     end
   end
 
@@ -162,7 +162,7 @@ RSpec.feature 'IAL1 Single Sign On' do
 
       visit saml_authn_request_url
 
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
     end
   end
 

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'IAL2 Single Sign On' do
 
       visit saml_ial2_request_url
 
-      expect(current_path).to match new_user_session_path
+      expect(page).to have_current_path(new_user_session_path)
       expect(page).to have_content(sp_content)
     end
 
@@ -101,7 +101,7 @@ RSpec.feature 'IAL2 Single Sign On' do
           visit account_path
           click_link(t('account.index.verification.reactivate_button'))
 
-          expect(current_path).to eq idv_verify_by_mail_enter_code_path
+          expect(page).to have_current_path idv_verify_by_mail_enter_code_path
           expect(page).not_to have_link(t('idv.messages.gpo.resend'))
         end
 
@@ -114,7 +114,7 @@ RSpec.feature 'IAL2 Single Sign On' do
 
           sign_in_live_with_2fa(user)
 
-          expect(current_path).to eq idv_verify_by_mail_enter_code_path
+          expect(page).to have_current_path idv_verify_by_mail_enter_code_path
           expect(page).not_to have_link(t('idv.messages.gpo.resend'))
         end
       end
@@ -132,16 +132,16 @@ RSpec.feature 'IAL2 Single Sign On' do
 
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq idv_verify_by_mail_enter_code_path
+        expect(page).to have_current_path idv_verify_by_mail_enter_code_path
 
         click_link(t('idv.messages.gpo.resend'))
 
         expect(user.events.account_verified.size).to be(0)
-        expect(current_path).to eq(idv_resend_letter_path)
+        expect(page).to have_current_path(idv_resend_letter_path)
 
         click_button(t('idv.gpo.request_another_letter.button'))
 
-        expect(current_path).to eq(idv_letter_enqueued_path)
+        expect(page).to have_current_path(idv_letter_enqueued_path)
       end
     end
   end
@@ -158,7 +158,7 @@ RSpec.feature 'IAL2 Single Sign On' do
       )
       visit sign_up_completed_path
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
     end
   end
 end

--- a/spec/features/saml/saml_logout_spec.rb
+++ b/spec/features/saml/saml_logout_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'SAML logout' do
         # Sign out of the IDP
         visit account_path
         first(:button, t('links.sign_out')).click
-        expect(current_path).to eq root_path
+        expect(page).to have_current_path root_path
 
         # SAML logout request
         visit_saml_logout_request_url(
@@ -84,7 +84,7 @@ RSpec.feature 'SAML logout' do
 
         # The user should be signed out
         visit account_path
-        expect(current_path).to eq root_path
+        expect(page).to have_current_path root_path
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.feature 'SAML logout' do
 
         # The user should be signed out
         visit account_path
-        expect(current_path).to eq root_path
+        expect(page).to have_current_path root_path
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.feature 'SAML logout' do
 
           # The user should be signed out
           visit account_path
-          expect(current_path).to eq root_path
+          expect(page).to have_current_path root_path
         end
       end
     end
@@ -151,7 +151,10 @@ RSpec.feature 'SAML logout' do
           },
         )
 
-        expect(current_path).to eq(api_saml_logout_path(path_year: SamlAuthHelper::PATH_YEAR))
+        expect(page).to have_current_path(
+          api_saml_logout_path(path_year: SamlAuthHelper::PATH_YEAR),
+          ignore_query: true,
+        )
         expect(page.driver.status_code).to eq(400)
 
         # The user should be signed in

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -53,14 +53,14 @@ RSpec.feature 'saml api' do
       it 'directs users to the start page' do
         visit_saml_authn_request_url
 
-        expect(current_path).to eq new_user_session_path
+        expect(page).to have_current_path new_user_session_path
       end
 
       it 'prompts the user to enter OTP' do
         sign_in_before_2fa(user)
         visit_saml_authn_request_url
 
-        expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+        expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.feature 'saml api' do
       end
 
       it 'prompts the user to set up 2FA' do
-        expect(current_path).to eq authentication_methods_setup_path
+        expect(page).to have_current_path authentication_methods_setup_path
       end
 
       it 'prompts the user to confirm phone after setting up 2FA' do
@@ -79,7 +79,10 @@ RSpec.feature 'saml api' do
         fill_in 'new_phone_form_phone', with: '202-555-1212'
         click_send_one_time_code
 
-        expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+        expect(page).to have_current_path(
+          login_two_factor_path(otp_delivery_preference: 'sms'),
+          ignore_query: true,
+        )
       end
     end
 
@@ -223,7 +226,7 @@ RSpec.feature 'saml api' do
       it 'redirects to root' do
         travel(Devise.timeout_in + 1.second) do
           visit api_saml_logout_url(path_year: SamlAuthHelper::PATH_YEAR)
-          expect(page.current_path).to eq('/')
+          expect(page).to have_current_path('/')
         end
       end
     end

--- a/spec/features/session/decryption_spec.rb
+++ b/spec/features/session/decryption_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Session decryption' do
       visit account_path
 
       # Should redirect to root since the user has been logged out
-      expect(current_path).to eq(root_path)
+      expect(page).to have_current_path(root_path)
     end
   end
 end

--- a/spec/features/sign_in/banned_users_spec.rb
+++ b/spec/features/sign_in/banned_users_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Banning users for an SP' do
       SignInRestriction.create(user: user, service_provider: 'http://localhost:3000')
 
       sign_in_live_with_2fa(user)
-      expect(current_path).to eq(account_path)
+      expect(page).to have_current_path(account_path)
 
       visit_idp_from_sp_with_ial1(:saml)
       expect_user_to_be_banned
@@ -49,7 +49,7 @@ RSpec.feature 'Banning users for an SP' do
       SignInRestriction.create(user: user, service_provider: OidcAuthHelper::OIDC_IAL1_ISSUER)
 
       sign_in_live_with_2fa(user)
-      expect(current_path).to eq(account_path)
+      expect(page).to have_current_path(account_path)
 
       visit_idp_from_sp_with_ial1(:oidc)
       expect_user_to_be_banned
@@ -58,15 +58,15 @@ RSpec.feature 'Banning users for an SP' do
       sign_in_live_with_2fa(user)
       click_submit_default
       click_agree_and_continue
-      expect(current_path).to eq(complete_saml_path)
+      expect(page).to have_current_path(complete_saml_path)
     end
   end
 
   def expect_user_to_be_banned
-    expect(current_path).to eq(banned_user_path)
+    expect(page).to have_current_path(banned_user_path)
     expect(page).to have_content(I18n.t('banned_user.title'))
 
     visit account_path
-    expect(current_path).to eq(new_user_session_path)
+    expect(page).to have_current_path(new_user_session_path)
   end
 end

--- a/spec/features/sign_in/multiple_vot_spec.rb
+++ b/spec/features/sign_in/multiple_vot_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         visit_idp_from_oidc_sp_with_vtr(vtr: ['C1.C2.P1.Pb', 'C1.C2.P1'])
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
 
         user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
@@ -29,7 +29,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         visit_idp_from_oidc_sp_with_vtr(vtr: ['C1.C2.P1.Pb', 'C1.C2.P1'])
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
 
         user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
@@ -44,13 +44,13 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         visit_idp_from_oidc_sp_with_vtr(vtr: ['C1.C2.P1.Pb', 'C1.C2.P1'])
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq(idv_welcome_path)
+        expect(page).to have_current_path(idv_welcome_path)
         complete_all_doc_auth_steps_before_password_step(with_selfie: true)
         fill_in 'Password', with: user.password
         click_continue
         acknowledge_and_confirm_personal_key
 
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
 
         user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
@@ -70,7 +70,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         )
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
 
         user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
@@ -88,7 +88,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         )
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
 
         user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
@@ -109,7 +109,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         user.password = 'new even better password'
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
 
         user_info = OpenidConnectUserInfoPresenter.new(user.identities.last).user_info
@@ -141,7 +141,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         sign_in_live_with_2fa(user)
 
         click_submit_default
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
         click_submit_default
 
@@ -162,7 +162,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         sign_in_live_with_2fa(user)
 
         click_submit_default
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
         click_submit_default
 
@@ -182,13 +182,13 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         )
         sign_in_live_with_2fa(user)
 
-        expect(current_path).to eq(idv_welcome_path)
+        expect(page).to have_current_path(idv_welcome_path)
         complete_all_doc_auth_steps_before_password_step(with_selfie: true)
         fill_in 'Password', with: user.password
         click_continue
         acknowledge_and_confirm_personal_key
 
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
 
         xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
@@ -217,7 +217,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         sign_in_live_with_2fa(user)
 
         click_submit_default
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
         click_submit_default
 
@@ -245,7 +245,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         sign_in_live_with_2fa(user)
 
         click_submit_default
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
         click_submit_default
 
@@ -276,7 +276,7 @@ RSpec.feature 'Sign in with multiple vectors of trust' do
         sign_in_live_with_2fa(user)
 
         click_submit_default
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
         click_agree_and_continue
         click_submit_default
 

--- a/spec/features/sign_in/setup_piv_cac_after_sign_in_spec.rb
+++ b/spec/features/sign_in/setup_piv_cac_after_sign_in_spec.rb
@@ -83,14 +83,14 @@ RSpec.describe 'Setup PIV/CAC after sign-in' do
     click_submit_default
 
     # Add PIV/CAC after sign-in
-    expect(current_path).to eq login_add_piv_cac_prompt_path
+    expect(page).to have_current_path login_add_piv_cac_prompt_path
     stub_piv_cac_service
     fill_in 'name', with: 'Card 1'
     click_on t('forms.piv_cac_setup.submit')
     follow_piv_cac_redirect
 
     expect(page).to have_content(t('notices.piv_cac_configured'))
-    expect(current_path).to eq sign_up_completed_path
+    expect(page).to have_current_path sign_up_completed_path
   end
 
   def perform_steps_to_get_to_add_piv_cac_during_sign_up(sp: :oidc)
@@ -100,7 +100,7 @@ RSpec.describe 'Setup PIV/CAC after sign-in' do
     fill_in_credentials_and_submit(user.email, user.password)
     fill_in_code_with_last_phone_otp
     click_submit_default
-    expect(current_path).to eq login_add_piv_cac_prompt_path
+    expect(page).to have_current_path login_add_piv_cac_prompt_path
     fill_in 'name', with: 'Card 1'
   end
 

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'sign up with backup code' do
       select_2fa_option('backup_code')
 
       expect(page).to have_link(t('components.download_button.label'))
-      expect(current_path).to eq backup_code_setup_path
+      expect(page).to have_current_path backup_code_setup_path
 
       click_continue
       click_continue
@@ -29,7 +29,7 @@ RSpec.feature 'sign up with backup code' do
       click_continue
 
       expect(page).to have_content(t('notices.backup_codes_configured'))
-      expect(current_path).to eq confirm_backup_codes_path
+      expect(page).to have_current_path confirm_backup_codes_path
       expect(user.backup_code_configurations.count).to eq(BackupCodeGenerator::NUMBER_OF_CODES)
 
       click_continue
@@ -54,17 +54,17 @@ RSpec.feature 'sign up with backup code' do
       fill_in :backup_code_verification_form_backup_code, with: codes[index]
       click_on 'Submit'
       if index == BackupCodeGenerator::NUMBER_OF_CODES - 1
-        expect(current_path).to eq backup_code_refreshed_path
+        expect(page).to have_current_path backup_code_refreshed_path
         expect(page).to have_content(t('forms.backup_code.title'))
         expect(page).to have_content(t('forms.backup_code.last_code'))
         expect(user.backup_code_configurations.count).to eq(BackupCodeGenerator::NUMBER_OF_CODES)
         click_continue
 
         expect(page).to have_content(t('notices.backup_codes_configured'))
-        expect(current_path).to eq account_path
+        expect(page).to have_current_path account_path
         expect(user.backup_code_configurations.count).to eq(BackupCodeGenerator::NUMBER_OF_CODES)
       else
-        expect(current_path).to eq account_path
+        expect(page).to have_current_path account_path
         sign_out_user
       end
     end
@@ -79,7 +79,7 @@ RSpec.feature 'sign up with backup code' do
 
     click_continue
 
-    expect(current_path).to eq(sign_up_completed_path)
+    expect(page).to have_current_path(sign_up_completed_path)
   end
 
   context 'when the user needs a backup code reminder' do
@@ -93,7 +93,7 @@ RSpec.feature 'sign up with backup code' do
       fill_in_code_with_last_totp(user)
       click_submit_default
 
-      expect(current_path).to eq backup_code_reminder_path
+      expect(page).to have_current_path backup_code_reminder_path
     end
   end
 

--- a/spec/features/two_factor_authentication/change_factor_spec.rb
+++ b/spec/features/two_factor_authentication/change_factor_spec.rb
@@ -12,11 +12,11 @@ RSpec.feature 'Changing authentication factor' do
     scenario 'editing password' do
       visit manage_password_path
 
-      expect(current_path).to eq login_two_factor_options_path
+      expect(page).to have_current_path login_two_factor_options_path
 
       complete_2fa_confirmation
 
-      expect(current_path).to eq manage_password_path
+      expect(page).to have_current_path manage_password_path
     end
 
     context 'resending OTP code to old phone' do
@@ -48,8 +48,9 @@ RSpec.feature 'Changing authentication factor' do
           },
         ).once
 
-        expect(current_path)
-          .to eq login_two_factor_path(otp_delivery_preference: 'sms')
+        expect(page).to have_current_path(
+          login_two_factor_path(otp_delivery_preference: 'sms'),
+        )
       end
     end
 
@@ -62,14 +63,14 @@ RSpec.feature 'Changing authentication factor' do
 
         # Canceling from MFA prompt
         click_on t('links.cancel')
-        expect(current_path).to eq account_path
+        expect(page).to have_current_path account_path
 
         # Canceling from MFA selection
         visit manage_password_path
         complete_2fa_confirmation_without_entering_otp
         click_on t('two_factor_authentication.login_options_link_text')
         click_on t('links.cancel')
-        expect(current_path).to eq account_path
+        expect(page).to have_current_path account_path
       end
     end
   end
@@ -81,19 +82,19 @@ RSpec.feature 'Changing authentication factor' do
 
       # Ensure reauthentication context does not prompt incorrectly
       visit webauthn_setup_path
-      expect(current_path).to eq login_two_factor_options_path
+      expect(page).to have_current_path login_two_factor_options_path
 
       visit phone_setup_path
-      expect(current_path).to eq login_two_factor_options_path
+      expect(page).to have_current_path login_two_factor_options_path
 
       find("label[for='two_factor_options_form_selection_sms']").click
       click_on t('forms.buttons.continue')
       fill_in_code_with_last_phone_otp
       click_submit_default
-      expect(current_path).to eq phone_setup_path
+      expect(page).to have_current_path phone_setup_path
 
       visit phone_setup_path
-      expect(current_path).to eq phone_setup_path
+      expect(page).to have_current_path phone_setup_path
     end
   end
 
@@ -104,12 +105,12 @@ RSpec.feature 'Changing authentication factor' do
   end
 
   def complete_2fa_confirmation_without_entering_otp
-    expect(current_path).to eq login_two_factor_options_path
+    expect(page).to have_current_path login_two_factor_options_path
 
     find("label[for='two_factor_options_form_selection_sms']").click
     click_on t('forms.buttons.continue')
 
-    expect(current_path).to eq login_two_factor_path(
+    expect(page).to have_current_path login_two_factor_path(
       otp_delivery_preference: user.otp_delivery_preference,
     )
   end
@@ -123,7 +124,7 @@ RSpec.feature 'Changing authentication factor' do
     fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
     click_button t('forms.buttons.continue')
 
-    expect(current_path).to eq login_two_factor_authenticator_path
+    expect(page).to have_current_path login_two_factor_authenticator_path
 
     fill_in 'code', with: generate_totp_code(@secret)
     click_submit_default

--- a/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/multiple_mfa_sign_up_spec.rb
@@ -258,7 +258,7 @@ RSpec.feature 'Multi Two Factor Authentication' do
 
     it 'returns to setup mfa page when user clicks Choose another option' do
       click_on(t('two_factor_authentication.choose_another_option'))
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
       expect(mfa.backup_code_configurations).to be_empty
     end
   end

--- a/spec/features/two_factor_authentication/piv_cac_sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/piv_cac_sign_in_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature 'sign in with piv/cac' do
         click_on t('forms.piv_cac_setup.submit')
         follow_piv_cac_redirect
 
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
 
         click_agree_and_continue
         expect(oidc_decoded_id_token[:x509_presented]).to eq(true)

--- a/spec/features/two_factor_authentication/sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Two Factor Authentication' do
 
       attempt_to_bypass_2fa_setup
 
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
 
       select_2fa_option('phone')
 
@@ -18,7 +18,7 @@ RSpec.feature 'Two Factor Authentication' do
 
       send_one_time_code_without_entering_phone_number
 
-      expect(current_path).to eq phone_setup_path
+      expect(page).to have_current_path phone_setup_path
 
       submit_2fa_setup_form_with_empty_string_phone
 
@@ -31,7 +31,10 @@ RSpec.feature 'Two Factor Authentication' do
       submit_2fa_setup_form_with_valid_phone
 
       expect(page).to_not have_content t('errors.messages.improbable_phone')
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+      expect(page).to have_current_path(
+        login_two_factor_path(otp_delivery_preference: 'sms'),
+        ignore_query: true,
+      )
       expect(MfaContext.new(user).phone_configurations).to be_empty
       expect(user.sms?).to eq true
     end
@@ -47,7 +50,7 @@ RSpec.feature 'Two Factor Authentication' do
         fill_in 'new_phone_form_phone', with: unsupported_phone
         click_send_one_time_code
 
-        expect(current_path).to eq phone_setup_path
+        expect(page).to have_current_path phone_setup_path
         expect(page).to have_content t(
           'two_factor_authentication.otp_delivery_preference.voice_unsupported',
           location: 'Bahamas',
@@ -55,7 +58,7 @@ RSpec.feature 'Two Factor Authentication' do
 
         click_on t('two_factor_authentication.choose_another_option')
 
-        expect(current_path).to eq authentication_methods_setup_path
+        expect(page).to have_current_path authentication_methods_setup_path
       end
     end
 
@@ -285,19 +288,19 @@ RSpec.feature 'Two Factor Authentication' do
       user = create(:user, :fully_registered)
       sign_in_before_2fa(user)
 
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
       expect(page)
         .to have_content t('two_factor_authentication.header_text')
 
       attempt_to_bypass_2fa
 
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
 
       check 'remember_device'
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
 
     def attempt_to_bypass_2fa
@@ -309,7 +312,7 @@ RSpec.feature 'Two Factor Authentication' do
       sign_in_before_2fa(user)
       click_link t('links.cancel')
 
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'user does not have to focus on OTP field', js: true do
@@ -370,38 +373,38 @@ RSpec.feature 'Two Factor Authentication' do
       user = user_with_piv_cac
       sign_in_before_2fa(user)
 
-      expect(current_path).to eq login_two_factor_piv_cac_path
+      expect(page).to have_current_path login_two_factor_piv_cac_path
 
       choose_another_security_option('sms')
 
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
 
       visit login_two_factor_piv_cac_path
 
       choose_another_security_option('voice')
 
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'voice')
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'voice')
     end
 
     it 'allows totp fallback when configured' do
       user = create(:user, :fully_registered, :with_piv_or_cac, :with_authentication_app)
       sign_in_before_2fa(user)
 
-      expect(current_path).to eq login_two_factor_piv_cac_path
+      expect(page).to have_current_path login_two_factor_piv_cac_path
 
       choose_another_security_option('auth_app')
 
-      expect(current_path).to eq login_two_factor_authenticator_path
+      expect(page).to have_current_path login_two_factor_authenticator_path
     end
 
     scenario 'user can cancel PIV/CAC process' do
       user = create(:user, :fully_registered, :with_piv_or_cac)
       sign_in_before_2fa(user)
 
-      expect(current_path).to eq login_two_factor_piv_cac_path
+      expect(page).to have_current_path login_two_factor_piv_cac_path
       click_link t('links.cancel')
 
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'user uses PIV/CAC as their second factor' do
@@ -412,7 +415,7 @@ RSpec.feature 'Two Factor Authentication' do
       click_on t('forms.piv_cac_mfa.submit')
       follow_piv_cac_redirect
 
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
 
     context 'user with Voice preference sends SMS, causing a Telephony error' do
@@ -434,7 +437,7 @@ RSpec.feature 'Two Factor Authentication' do
 
         sign_in_user(user)
 
-        expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'voice')
+        expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'voice')
 
         choose_another_security_option('sms')
 
@@ -451,13 +454,13 @@ RSpec.feature 'Two Factor Authentication' do
 
       choose_another_security_option('sms')
 
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
 
       visit login_two_factor_authenticator_path
 
       choose_another_security_option('voice')
 
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'voice')
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'voice')
     end
 
     scenario 'user can cancel TOTP process' do
@@ -465,7 +468,7 @@ RSpec.feature 'Two Factor Authentication' do
       sign_in_before_2fa(user)
       click_link t('links.cancel')
 
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
 
     scenario 'attempting to reuse a TOTP code results in an error' do
@@ -479,14 +482,14 @@ RSpec.feature 'Two Factor Authentication' do
         fill_in 'code', with: otp
         click_submit_default
 
-        expect(current_path).to eq(account_path)
+        expect(page).to have_current_path(account_path)
 
         set_new_browser_session
         sign_in_user(user)
         fill_in 'code', with: otp
         click_submit_default
 
-        expect(current_path).to eq login_two_factor_authenticator_path
+        expect(page).to have_current_path login_two_factor_authenticator_path
       end
     end
   end
@@ -503,11 +506,11 @@ RSpec.feature 'Two Factor Authentication' do
       sign_in_and_2fa_user
       visit login_two_factor_path(otp_delivery_preference: 'sms')
 
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
 
       visit user_two_factor_authentication_path
 
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
   end
 
@@ -516,7 +519,7 @@ RSpec.feature 'Two Factor Authentication' do
       user = create(:user, :fully_registered)
       sign_in_user(user)
       click_link 'Login.gov'
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: :sms)
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: :sms)
     end
   end
 

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Signing in via one-time use personal key' do
     enter_personal_key(personal_key: raw_key)
     click_submit_default
     expect(user.reload.encrypted_recovery_code_digest).to_not eq old_key
-    expect(current_path).to eq account_path
+    expect(page).to have_current_path account_path
 
     last_message = Telephony::Test::Message.messages.last
     expect(last_message.body).to eq t('telephony.personal_key_sign_in_notice', app_name: APP_NAME)

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Password recovery via personal key' do
     fill_in_code_with_last_phone_otp
     click_submit_default
 
-    expect(current_path).to eq reactivate_account_path
+    expect(page).to have_current_path reactivate_account_path
 
     reactivate_profile(new_password, personal_key)
 
@@ -39,7 +39,7 @@ RSpec.feature 'Password recovery via personal key' do
     fill_in_code_with_last_phone_otp
     click_submit_default
 
-    expect(current_path).to eq(reactivate_account_path)
+    expect(page).to have_current_path(reactivate_account_path)
 
     visit account_path
 
@@ -59,7 +59,7 @@ RSpec.feature 'Password recovery via personal key' do
     visit account_path
 
     expect(page).to have_content(t('account.index.verification.verified_badge'))
-    expect(current_path).to eq(account_path)
+    expect(page).to have_current_path(account_path)
   end
 
   scenario 'resets password, not allowed to use personal key as 2fa', email: true do
@@ -86,7 +86,7 @@ RSpec.feature 'Password recovery via personal key' do
       click_on t('links.account.reactivate.with_key')
       click_on t('links.reverify')
 
-      expect(current_path).to eq(idv_welcome_path)
+      expect(page).to have_current_path(idv_welcome_path)
     end
 
     scenario 'resets password, view modal and close it', email: true do
@@ -124,12 +124,12 @@ RSpec.feature 'Password recovery via personal key' do
   def reactivate_profile(password, personal_key)
     click_on t('links.account.reactivate.with_key')
 
-    expect(current_path).to eq verify_personal_key_path
+    expect(page).to have_current_path verify_personal_key_path
 
     fill_in 'personal_key', with: personal_key
     click_continue
 
-    expect(current_path).to eq verify_password_path
+    expect(page).to have_current_path verify_password_path
 
     fill_in 'Password', with: password
     click_continue

--- a/spec/features/users/piv_cac_management_spec.rb
+++ b/spec/features/users/piv_cac_management_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'PIV/CAC Management' do
       click_on t('forms.piv_cac_setup.submit')
       follow_piv_cac_redirect
 
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
       visit account_two_factor_authentication_path
       user.reload
       expect(page).to have_link(href: edit_piv_cac_path(id: user.piv_cac_configurations.first.id))
@@ -47,7 +47,7 @@ RSpec.feature 'PIV/CAC Management' do
       expect(page).to_not have_link(t('account.index.piv_cac_add'), href: setup_piv_cac_url)
 
       visit setup_piv_cac_path
-      expect(current_path).to eq account_two_factor_authentication_path
+      expect(page).to have_current_path account_two_factor_authentication_path
     end
 
     scenario 'disallows association of a piv/cac with the same name' do
@@ -61,7 +61,7 @@ RSpec.feature 'PIV/CAC Management' do
       click_on t('forms.piv_cac_setup.submit')
       follow_piv_cac_redirect
 
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
 
       visit account_two_factor_authentication_path
       click_link t('account.index.piv_cac_add'), href: setup_piv_cac_url
@@ -83,7 +83,7 @@ RSpec.feature 'PIV/CAC Management' do
       click_on t('forms.piv_cac_setup.submit')
       follow_piv_cac_redirect
 
-      expect(current_path).to eq setup_piv_cac_error_path
+      expect(page).to have_current_path(setup_piv_cac_error_path, ignore_query: true)
       expect(page).to have_link(t('instructions.mfa.piv_cac.try_again'), href: setup_piv_cac_url)
       expect(page).to have_content(
         t(
@@ -104,7 +104,7 @@ RSpec.feature 'PIV/CAC Management' do
       click_on t('forms.piv_cac_setup.submit')
       follow_piv_cac_redirect
 
-      expect(current_path).to eq setup_piv_cac_error_path
+      expect(page).to have_current_path(setup_piv_cac_error_path, ignore_query: true)
       expect(page).to have_link(
         t('instructions.mfa.piv_cac.please_try_again'),
         href: setup_piv_cac_url,
@@ -155,7 +155,9 @@ RSpec.feature 'PIV/CAC Management' do
         ),
       )
 
-      expect(current_path).to eq(edit_piv_cac_path(id: user.piv_cac_configurations.first.id))
+      expect(page).to have_current_path(
+        edit_piv_cac_path(id: user.piv_cac_configurations.first.id),
+      )
       click_button t('two_factor_authentication.piv_cac.delete')
 
       expect(page).to have_content(t('two_factor_authentication.piv_cac.deleted'))

--- a/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
+++ b/spec/features/users/profile_recovery_for_gpo_verified_spec.rb
@@ -28,11 +28,11 @@ RSpec.feature 'Password recovery via personal key for a GPO-verified user' do
 
     click_on t('links.account.reactivate.with_key')
 
-    expect(current_path).to eq verify_personal_key_path
+    expect(page).to have_current_path verify_personal_key_path
     fill_in 'personal_key', with: personal_key
     click_continue
 
-    expect(current_path).to eq verify_password_path
+    expect(page).to have_current_path verify_password_path
     fill_in 'Password', with: new_password
     click_continue
 

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'View personal key' do
         click_on(t('account.links.regenerate_personal_key'), match: :prefer_exact)
 
         # reauthn
-        expect(current_path).to eq login_two_factor_options_path
+        expect(page).to have_current_path login_two_factor_options_path
         find("label[for='two_factor_options_form_selection_sms']").click
         click_on t('forms.buttons.continue')
         fill_in_code_with_last_phone_otp

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Sign in' do
     fill_in_code_with_last_phone_otp
     click_submit_default
 
-    expect(current_path).to eq(user_please_call_path)
+    expect(page).to have_current_path(user_please_call_path)
   end
 
   scenario 'user with old terms of use can accept and continue to IAL1 SP' do
@@ -165,12 +165,12 @@ RSpec.feature 'Sign in' do
     sign_in_and_2fa_user
 
     visit account_path
-    expect(current_path).to eq account_path
+    expect(page).to have_current_path account_path
 
     travel(Devise.timeout_in + 1.minute)
 
     visit account_path
-    expect(current_path).to eq root_path
+    expect(page).to have_current_path root_path
 
     travel_back
   end
@@ -231,7 +231,7 @@ RSpec.feature 'Sign in' do
       click_button(t('notices.timeout_warning.signed_in.sign_out'))
 
       expect(page).to have_content t('devise.sessions.signed_out')
-      expect(current_path).to eq new_user_session_path
+      expect(page).to have_current_path new_user_session_path
     end
   end
 
@@ -292,7 +292,7 @@ RSpec.feature 'Sign in' do
         expect(page).to have_content t('errors.general')
 
         fill_in_credentials_and_submit(user.email, user.password)
-        expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+        expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
       end
     end
 
@@ -323,19 +323,19 @@ RSpec.feature 'Sign in' do
         perform_in_browser(:one) do
           sign_in_live_with_2fa(user)
 
-          expect(current_path).to eq account_path
+          expect(page).to have_current_path account_path
         end
 
         perform_in_browser(:two) do
           sign_in_live_with_2fa(user)
 
-          expect(current_path).to eq account_path
+          expect(page).to have_current_path account_path
         end
 
         perform_in_browser(:one) do
           visit account_path
 
-          expect(current_path).to eq new_user_session_path
+          expect(page).to have_current_path new_user_session_path
           expect(page).to have_content(t('devise.failure.session_limited'))
 
           expect(analytics.events[:concurrent_session_logout].count).to eq 1
@@ -350,19 +350,19 @@ RSpec.feature 'Sign in' do
         perform_in_browser(:one) do
           sign_in_user_with_piv(user)
 
-          expect(current_path).to eq account_path
+          expect(page).to have_current_path account_path
         end
 
         perform_in_browser(:two) do
           sign_in_user_with_piv(user)
 
-          expect(current_path).to eq account_path
+          expect(page).to have_current_path account_path
         end
 
         perform_in_browser(:one) do
           visit account_path
 
-          expect(current_path).to eq new_user_session_path
+          expect(page).to have_current_path new_user_session_path
           expect(page).to have_content(t('devise.failure.session_limited'))
         end
       end
@@ -389,7 +389,7 @@ RSpec.feature 'Sign in' do
         perform_in_browser(:one) do
           visit account_path
 
-          expect(current_path).to eq new_user_session_path
+          expect(page).to have_current_path new_user_session_path
           expect(page).to have_content(t('devise.failure.session_limited'))
           expect_branded_experience
         end
@@ -451,7 +451,7 @@ RSpec.feature 'Sign in' do
 
       expect(page)
         .to have_link t('devise.failure.invalid_link_text', href: link_url)
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -463,7 +463,7 @@ RSpec.feature 'Sign in' do
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
       click_submit_default
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
 
     context 'with email and password' do
@@ -475,7 +475,7 @@ RSpec.feature 'Sign in' do
         fill_in_credentials_and_submit(user.email, user.password)
         click_submit_default
 
-        expect(current_path).to eq account_path
+        expect(page).to have_current_path account_path
       end
     end
 
@@ -486,7 +486,7 @@ RSpec.feature 'Sign in' do
         visit new_user_session_path(request_id: 'invalid')
         signin_with_piv(user)
 
-        expect(current_path).to eq account_path
+        expect(page).to have_current_path account_path
       end
     end
   end
@@ -641,7 +641,7 @@ RSpec.feature 'Sign in' do
       click_link t('two_factor_authentication.login_options_link_text')
       click_on t('links.cancel')
 
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
       expect(page).to have_content(t('devise.sessions.signed_out'))
     end
   end
@@ -657,7 +657,7 @@ RSpec.feature 'Sign in' do
       check 'rules_of_use_form[terms_accepted]'
 
       click_button t('forms.buttons.continue')
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
     end
   end
 
@@ -701,7 +701,7 @@ RSpec.feature 'Sign in' do
       click_agree_and_continue
 
       visit_idp_from_oidc_sp_with_loa1_prompt_login
-      expect(current_path).to eq(bounced_path)
+      expect(page).to have_current_path(bounced_path)
     end
   end
 
@@ -743,7 +743,7 @@ RSpec.feature 'Sign in' do
         fill_in_code_with_last_phone_otp
         click_submit_default
 
-        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_current_path sign_up_completed_path
         expect(page).to have_content(user.email)
 
         click_agree_and_continue
@@ -761,7 +761,7 @@ RSpec.feature 'Sign in' do
         fill_in_code_with_last_phone_otp
         click_submit_default
 
-        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_current_path sign_up_completed_path
         expect(page).to have_content('1**-**-***3')
 
         click_agree_and_continue
@@ -803,7 +803,7 @@ RSpec.feature 'Sign in' do
         fill_in_code_with_last_phone_otp
         click_submit_default_twice
 
-        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_current_path sign_up_completed_path
         expect(page).to have_content(user.email)
 
         click_agree_and_continue
@@ -832,7 +832,7 @@ RSpec.feature 'Sign in' do
         click_submit_default
         click_submit_default
 
-        expect(current_path).to eq sign_up_completed_path
+        expect(page).to have_current_path sign_up_completed_path
         expect(page).to have_content('1**-**-***3')
 
         click_agree_and_continue
@@ -928,7 +928,7 @@ RSpec.feature 'Sign in' do
           fill_in_code_with_last_phone_otp
           click_submit_default
 
-          expect(current_path).to eq manage_password_path
+          expect(page).to have_current_path manage_password_path
         end
 
         it 'should redirect user to after_sign_in_path after editing password' do
@@ -937,7 +937,7 @@ RSpec.feature 'Sign in' do
           fill_in_code_with_last_phone_otp
           click_submit_default
 
-          expect(current_path).to eq manage_password_path
+          expect(page).to have_current_path manage_password_path
 
           password = 'salty pickles'
           fill_in t('forms.passwords.edit.labels.password'), with: password
@@ -962,7 +962,7 @@ RSpec.feature 'Sign in' do
           fill_in_code_with_last_phone_otp
           click_submit_default
 
-          expect(current_path).to eq account_path
+          expect(page).to have_current_path account_path
         end
       end
     end
@@ -981,7 +981,7 @@ RSpec.feature 'Sign in' do
           fill_in_code_with_last_phone_otp
           click_submit_default
 
-          expect(current_path).to eq account_path
+          expect(page).to have_current_path account_path
           user.reload
           expect(user.password_compromised_checked_at).to be_truthy
         end
@@ -999,7 +999,7 @@ RSpec.feature 'Sign in' do
           fill_in_code_with_last_phone_otp
           click_submit_default
 
-          expect(current_path).to eq account_path
+          expect(page).to have_current_path account_path
           user.reload
           expect(user.password_compromised_checked_at).to be_falsey
         end
@@ -1018,7 +1018,7 @@ RSpec.feature 'Sign in' do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
       select_2fa_option('piv_cac')
 
       expect(page).to have_current_path setup_piv_cac_path
@@ -1028,7 +1028,7 @@ RSpec.feature 'Sign in' do
       user = create(:user, :with_phone, :with_piv_or_cac)
       fill_in_credentials_and_submit(user.email, user.password)
 
-      expect(current_path).to eq login_two_factor_piv_cac_path
+      expect(page).to have_current_path login_two_factor_piv_cac_path
     end
   end
 
@@ -1040,7 +1040,7 @@ RSpec.feature 'Sign in' do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_path).to eq sign_up_completed_path
+      expect(page).to have_current_path sign_up_completed_path
       expect(page).to have_content(user.email)
 
       agree_and_continue_button = find_button(t('sign_up.agree_and_continue'))

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Sign Up' do
     end
 
     it 'redirects user to the home page' do
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
     end
   end
 
@@ -69,7 +69,7 @@ RSpec.feature 'Sign Up' do
     end
 
     it 'sends them to the cancel page' do
-      expect(current_path).to eq sign_up_cancel_path
+      expect(page).to have_current_path sign_up_cancel_path
     end
   end
 
@@ -81,7 +81,7 @@ RSpec.feature 'Sign Up' do
     end
 
     it 'sends them to the cancel page' do
-      expect(current_path).to eq sign_up_cancel_path
+      expect(page).to have_current_path sign_up_cancel_path
     end
   end
 
@@ -89,7 +89,7 @@ RSpec.feature 'Sign Up' do
     it 'redirects user to the translated home page' do
       visit sign_up_email_path(locale: 'es')
       click_on t('links.cancel')
-      expect(current_path).to eq '/es'
+      expect(page).to have_current_path '/es'
     end
   end
 
@@ -110,7 +110,7 @@ RSpec.feature 'Sign Up' do
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_path).to eq backup_code_setup_path
+      expect(page).to have_current_path backup_code_setup_path
 
       expect(page).to have_link(t('components.download_button.label'))
 
@@ -140,7 +140,7 @@ RSpec.feature 'Sign Up' do
     fill_in 'new_phone_form_phone', with: '225-555-1000'
     click_send_one_time_code
 
-    expect(current_path).to eq(phone_setup_path)
+    expect(page).to have_current_path(phone_setup_path)
     expect(page).to have_content(I18n.t('telephony.error.friendly_message.generic'))
   end
 
@@ -163,7 +163,7 @@ RSpec.feature 'Sign Up' do
       timeout: '(10|9) minutes',
     )
 
-    expect(current_path).to eq(authentication_methods_setup_path)
+    expect(page).to have_current_path(authentication_methods_setup_path)
 
     expect(page).to have_content(/#{rate_limited_message}/)
   end
@@ -398,12 +398,12 @@ RSpec.feature 'Sign Up' do
       )
       click_button t('forms.buttons.continue')
 
-      expect(current_path).to eq rules_of_use_path
+      expect(page).to have_current_path rules_of_use_path
       check 'rules_of_use_form[terms_accepted]'
 
       freeze_time do
         click_button t('forms.buttons.continue')
-        expect(current_path).to eq authentication_methods_setup_path
+        expect(page).to have_current_path authentication_methods_setup_path
         expect(user.reload.accepted_terms_at).to eq Time.zone.now
       end
     end
@@ -493,7 +493,7 @@ RSpec.feature 'Sign Up' do
       it 'returns them to the homepage' do
         click_link APP_NAME, href: new_user_session_path
 
-        expect(current_path).to eq new_user_session_path
+        expect(page).to have_current_path new_user_session_path
       end
     end
 
@@ -506,7 +506,7 @@ RSpec.feature 'Sign Up' do
       it 'returns them to the MFA setup screen' do
         click_link APP_NAME, href: new_user_session_path
 
-        expect(current_path).to eq authentication_methods_setup_path
+        expect(page).to have_current_path authentication_methods_setup_path
       end
     end
   end
@@ -519,17 +519,17 @@ RSpec.feature 'Sign Up' do
       it 'should land user on piv cac suggestion page' do
         confirm_email(email)
         submit_form_with_valid_password
-        expect(current_path).to eq login_piv_cac_recommended_path
+        expect(page).to have_current_path login_piv_cac_recommended_path
       end
 
       context 'when the user chooses to skip adding piv' do
         it 'should land on mfa screen' do
           confirm_email(email)
           submit_form_with_valid_password
-          expect(current_path).to eq login_piv_cac_recommended_path
+          expect(page).to have_current_path login_piv_cac_recommended_path
           click_button t('two_factor_authentication.piv_cac_upsell.choose_other_method')
 
-          expect(current_path).to eq authentication_methods_setup_path
+          expect(page).to have_current_path authentication_methods_setup_path
         end
       end
 
@@ -537,10 +537,10 @@ RSpec.feature 'Sign Up' do
         it 'should land on piv add screen' do
           confirm_email(email)
           submit_form_with_valid_password
-          expect(current_path).to eq login_piv_cac_recommended_path
+          expect(page).to have_current_path login_piv_cac_recommended_path
           click_button t('two_factor_authentication.piv_cac_upsell.add_piv')
 
-          expect(current_path).to eq setup_piv_cac_path
+          expect(page).to have_current_path setup_piv_cac_path
         end
       end
     end
@@ -550,17 +550,17 @@ RSpec.feature 'Sign Up' do
       it 'should land user on piv cac suggestion page' do
         confirm_email(email)
         submit_form_with_valid_password
-        expect(current_path).to eq login_piv_cac_recommended_path
+        expect(page).to have_current_path login_piv_cac_recommended_path
       end
 
       context 'when the user chooses to skip adding piv' do
         it 'should land on mfa screen' do
           confirm_email(email)
           submit_form_with_valid_password
-          expect(current_path).to eq login_piv_cac_recommended_path
+          expect(page).to have_current_path login_piv_cac_recommended_path
           click_button t('two_factor_authentication.piv_cac_upsell.choose_other_method')
 
-          expect(current_path).to eq authentication_methods_setup_path
+          expect(page).to have_current_path authentication_methods_setup_path
         end
       end
 
@@ -568,10 +568,10 @@ RSpec.feature 'Sign Up' do
         it 'should land on piv add screen' do
           confirm_email(email)
           submit_form_with_valid_password
-          expect(current_path).to eq login_piv_cac_recommended_path
+          expect(page).to have_current_path login_piv_cac_recommended_path
           click_button t('two_factor_authentication.piv_cac_upsell.add_piv')
 
-          expect(current_path).to eq setup_piv_cac_path
+          expect(page).to have_current_path setup_piv_cac_path
         end
       end
     end
@@ -581,7 +581,7 @@ RSpec.feature 'Sign Up' do
       it 'should skip piv cac recommendation page' do
         confirm_email(email)
         submit_form_with_valid_password
-        expect(current_path).to eq authentication_methods_setup_path
+        expect(page).to have_current_path authentication_methods_setup_path
       end
     end
   end

--- a/spec/features/users/totp_management_spec.rb
+++ b/spec/features/users/totp_management_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'totp management' do
         ),
       )
 
-      expect(current_path).to eq(edit_auth_app_path(id: auth_app_config.id))
+      expect(page).to have_current_path(edit_auth_app_path(id: auth_app_config.id))
 
       click_button t('two_factor_authentication.auth_app.delete')
 
@@ -47,7 +47,7 @@ RSpec.describe 'totp management' do
         ),
       )
 
-      expect(current_path).to eq(edit_auth_app_path(id: auth_app_configuration.id))
+      expect(page).to have_current_path(edit_auth_app_path(id: auth_app_configuration.id))
       expect(page).to have_field(
         t('two_factor_authentication.auth_app.nickname'),
         with: name,
@@ -79,7 +79,7 @@ RSpec.describe 'totp management' do
         ),
       )
 
-      expect(current_path).to eq(edit_auth_app_path(id: existing_auth_app_configuration.id))
+      expect(page).to have_current_path(edit_auth_app_path(id: existing_auth_app_configuration.id))
       expect(page).to have_field(
         t('two_factor_authentication.auth_app.nickname'),
         with: name,
@@ -90,7 +90,7 @@ RSpec.describe 'totp management' do
 
       click_button t('two_factor_authentication.auth_app.change_nickname')
 
-      expect(current_path).to eq(edit_auth_app_path(id: existing_auth_app_configuration.id))
+      expect(page).to have_current_path(edit_auth_app_path(id: existing_auth_app_configuration.id))
 
       expect(page).to have_content(t('errors.manage_authenticator.unique_name_error'))
     end

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'User profile' do
       fill_in(t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD)
       click_button t('users.delete.actions.delete')
       expect(page).to have_content t('devise.registrations.destroyed')
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
       expect(User.count).to eq 0
       expect(AgencyIdentity.count).to eq 0
     end
@@ -84,7 +84,7 @@ RSpec.feature 'User profile' do
       fill_in(t('idv.form.password'), with: profile.user.password)
       click_button t('users.delete.actions.delete')
       expect(page).to have_content t('devise.registrations.destroyed')
-      expect(current_path).to eq root_path
+      expect(page).to have_current_path root_path
       expect(User.count).to eq 0
       expect(Profile.count).to eq 0
     end
@@ -132,7 +132,7 @@ RSpec.feature 'User profile' do
 
       click_button 'Update'
 
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
 
     context 'IAL2 user' do
@@ -155,7 +155,7 @@ RSpec.feature 'User profile' do
 
         click_continue
 
-        expect(current_path).to eq(account_path)
+        expect(page).to have_current_path(account_path)
       end
 
       it 'allows the user reactivate their profile by reverifying', :js do
@@ -173,7 +173,7 @@ RSpec.feature 'User profile' do
         click_idv_continue
         acknowledge_and_confirm_personal_key
 
-        expect(current_path).to eq(sign_up_completed_path)
+        expect(page).to have_current_path(sign_up_completed_path)
 
         click_agree_and_continue
 
@@ -191,7 +191,7 @@ RSpec.feature 'User profile' do
       click_on t('account.navigation.menu')
       click_link t('account.navigation.history')
 
-      expect(current_path).to eq(account_history_path)
+      expect(page).to have_current_path(account_history_path)
     end
   end
 

--- a/spec/features/users/verify_profile_spec.rb
+++ b/spec/features/users/verify_profile_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'verify profile with OTP' do
       click_button t('idv.gpo.form.submit')
 
       expect(page).to have_content t('errors.messages.gpo_otp_expired_and_cannot_request_another')
-      expect(current_path).to eq idv_verify_by_mail_enter_code_path
+      expect(page).to have_current_path idv_verify_by_mail_enter_code_path
     end
 
     scenario 'wrong OTP used' do
@@ -51,7 +51,7 @@ RSpec.feature 'verify profile with OTP' do
       fill_in t('idv.gpo.form.otp_label'), with: 'the wrong code'
       click_button t('idv.gpo.form.submit')
 
-      expect(current_path).to eq idv_verify_by_mail_enter_code_path
+      expect(page).to have_current_path idv_verify_by_mail_enter_code_path
       expect(page).to have_content(t('errors.messages.confirmation_code_incorrect'))
       expect(page.body).to_not match('the wrong code')
     end

--- a/spec/features/visitors/i18n_spec.rb
+++ b/spec/features/visitors/i18n_spec.rb
@@ -119,7 +119,7 @@ RSpec.feature 'Internationalization' do
         click_submit_default
       end
 
-      expect(current_path).to eq idv_welcome_path(locale: :es)
+      expect(page).to have_current_path idv_welcome_path(locale: :es)
       expect(page.document.find('html')['lang']).to eq('es')
     end
   end

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Password Recovery' do
 
       click_button t('forms.buttons.continue')
 
-      expect(current_path).to eq forgot_password_path
+      expect(page).to have_current_path forgot_password_path
 
       expect(last_email.subject).to eq t('user_mailer.reset_password_instructions.subject')
       expect(last_email.html_part.body).to include MarketingSite.help_url
@@ -33,7 +33,7 @@ RSpec.feature 'Password Recovery' do
       open_last_email
       click_email_link_matching(/reset_password_token/)
 
-      expect(current_path).to eq edit_user_password_path
+      expect(page).to have_current_path edit_user_password_path
     end
   end
 
@@ -85,13 +85,13 @@ RSpec.feature 'Password Recovery' do
       fill_in t('components.password_confirmation.confirm_label'), with: password
       click_button t('forms.passwords.edit.buttons.submit')
 
-      expect(current_path).to eq new_user_session_path
+      expect(page).to have_current_path new_user_session_path
     end
 
     it 'prompts user to set up their 2FA options after signing back in' do
       reset_password_and_sign_back_in(@user)
 
-      expect(current_path).to eq authentication_methods_setup_path
+      expect(page).to have_current_path authentication_methods_setup_path
     end
   end
 
@@ -105,7 +105,7 @@ RSpec.feature 'Password Recovery' do
     end
 
     it 'redirects to new user password form' do
-      expect(current_path).to eq new_user_password_path
+      expect(page).to have_current_path new_user_password_path
     end
 
     it 'displays a flash error message' do
@@ -130,7 +130,7 @@ RSpec.feature 'Password Recovery' do
       fill_in 'code', with: @user.reload.direct_otp
       click_button t('forms.buttons.submit.default')
 
-      expect(current_path).to eq account_path
+      expect(page).to have_current_path account_path
     end
   end
 
@@ -157,7 +157,7 @@ RSpec.feature 'Password Recovery' do
     end
 
     it 'lands on the reset password page' do
-      expect(current_path).to eq edit_user_password_path
+      expect(page).to have_current_path edit_user_password_path
     end
 
     context 'when password form values are valid' do
@@ -177,7 +177,7 @@ RSpec.feature 'Password Recovery' do
         ).to eq('password_changed')
 
         visit account_path
-        expect(current_path).to eq new_user_session_path
+        expect(page).to have_current_path new_user_session_path
       end
 
       it 'allows the user to continue to the service provider' do
@@ -234,7 +234,7 @@ RSpec.feature 'Password Recovery' do
         click_button t('forms.passwords.edit.buttons.submit')
 
         signin(@user.email, '1234')
-        expect(current_path).to eq new_user_session_path
+        expect(page).to have_current_path new_user_session_path
       end
 
       it 'allows multiple attempts with invalid password' do
@@ -276,7 +276,7 @@ RSpec.feature 'Password Recovery' do
 
     expect(page).to have_content t('devise.passwords.token_expired')
 
-    expect(current_path).to eq new_user_password_path
+    expect(page).to have_current_path new_user_password_path
   end
 
   it 'rate limits reset passwords requests' do

--- a/spec/features/visitors/sign_up_with_email_spec.rb
+++ b/spec/features/visitors/sign_up_with_email_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Visitor signs up with email address' do
     sign_up_and_2fa_ial1_user
 
     expect(Funnel::Registration::TotalRegisteredCount.call).to eq(1)
-    expect(current_path).to eq account_path
+    expect(page).to have_current_path account_path
   end
 
   it 'returns a bad request if the email contains invalid bytes' do

--- a/spec/features/webauthn/hidden_spec.rb
+++ b/spec/features/webauthn/hidden_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'webauthn hide' do
             fill_in_credentials_and_submit(user.email, user.password)
 
             # Redirected to options page
-            expect(current_path).to eq(login_two_factor_options_path)
+            expect(page).to have_current_path(login_two_factor_options_path)
 
             # Can choose authenticator
             expect(webauthn_option_hidden?).to eq(false)
@@ -150,7 +150,7 @@ RSpec.describe 'webauthn hide' do
               fill_in_credentials_and_submit(user.email, user.password)
 
               # Redirected to default MFA method
-              expect(current_path).to eq(login_two_factor_piv_cac_path)
+              expect(page).to have_current_path(login_two_factor_piv_cac_path)
 
               # Can change to authenticator if they choose
               click_on t('two_factor_authentication.login_options_link_text')

--- a/spec/features/webauthn/management_spec.rb
+++ b/spec/features/webauthn/management_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'webauthn management' do
       'errors.webauthn_setup.general_error_html',
       link_html: t('errors.webauthn_setup.additional_methods_link'),
     )
-    expect(current_path).to eq webauthn_setup_path
+    expect(page).to have_current_path webauthn_setup_path
   end
 
   def visit_webauthn_platform_setup
@@ -44,7 +44,7 @@ RSpec.describe 'webauthn management' do
 
   def expect_webauthn_platform_setup_error
     expect(page).to have_content t('errors.webauthn_platform_setup.general_error')
-    expect(current_path).to eq webauthn_setup_path
+    expect(page).to have_current_path webauthn_setup_path
   end
 
   context 'with webauthn roaming associations' do
@@ -91,7 +91,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
 
       click_button t('two_factor_authentication.webauthn_roaming.delete')
 
@@ -116,7 +116,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
       expect(page).to have_field(
         t('two_factor_authentication.webauthn_roaming.nickname'),
         with: name,
@@ -146,7 +146,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
 
       click_link t('links.cancel')
 
@@ -170,7 +170,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
 
       click_button t('two_factor_authentication.webauthn_roaming.delete')
 
@@ -195,7 +195,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
       expect(page).to have_field(
         t('two_factor_authentication.webauthn_roaming.nickname'),
         with: name,
@@ -205,7 +205,7 @@ RSpec.describe 'webauthn management' do
 
       click_button t('two_factor_authentication.webauthn_roaming.change_nickname')
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
       expect(page).to have_field(
         t('two_factor_authentication.webauthn_roaming.nickname'),
         with: 'existing',
@@ -221,15 +221,15 @@ RSpec.describe 'webauthn management' do
       sign_in_and_2fa_user(user)
 
       visit account_two_factor_authentication_path
-      expect(current_path).to eq account_two_factor_authentication_path
+      expect(page).to have_current_path account_two_factor_authentication_path
 
       first(:link, t('account.index.webauthn_add'), href: webauthn_setup_path).click
-      expect(current_path).to eq webauthn_setup_path
+      expect(page).to have_current_path webauthn_setup_path
 
       fill_in_nickname_and_click_continue(nickname: webauthn_config.name)
       mock_press_button_on_hardware_key_on_setup
 
-      expect(current_path).to eq webauthn_setup_path
+      expect(page).to have_current_path webauthn_setup_path
       expect(page).to have_content t('errors.webauthn_setup.unique_name')
     end
 
@@ -401,7 +401,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
 
       click_button t('two_factor_authentication.webauthn_platform.delete')
 
@@ -426,7 +426,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
       expect(page).to have_field(
         t('two_factor_authentication.webauthn_platform.nickname'),
         with: name,
@@ -456,7 +456,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
 
       click_link t('links.cancel')
 
@@ -480,7 +480,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
 
       click_button t('two_factor_authentication.webauthn_platform.delete')
 
@@ -505,7 +505,7 @@ RSpec.describe 'webauthn management' do
         ].join(': '),
       )
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
       expect(page).to have_field(
         t('two_factor_authentication.webauthn_platform.nickname'),
         with: name,
@@ -515,7 +515,7 @@ RSpec.describe 'webauthn management' do
 
       click_button t('two_factor_authentication.webauthn_platform.change_nickname')
 
-      expect(current_path).to eq(edit_webauthn_path(id: webauthn_config.id))
+      expect(page).to have_current_path(edit_webauthn_path(id: webauthn_config.id))
       expect(page).to have_field(
         t('two_factor_authentication.webauthn_platform.nickname'),
         with: 'existing',
@@ -531,15 +531,15 @@ RSpec.describe 'webauthn management' do
       sign_in_and_2fa_user(user)
 
       visit account_two_factor_authentication_path
-      expect(current_path).to eq account_two_factor_authentication_path
+      expect(page).to have_current_path account_two_factor_authentication_path
 
       first(:link, t('account.index.webauthn_add'), href: webauthn_setup_path).click
-      expect(current_path).to eq webauthn_setup_path
+      expect(page).to have_current_path webauthn_setup_path
 
       fill_in_nickname_and_click_continue(nickname: webauthn_config.name)
       mock_press_button_on_hardware_key_on_setup
 
-      expect(current_path).to eq webauthn_setup_path
+      expect(page).to have_current_path webauthn_setup_path
       expect(page).to have_content t('errors.webauthn_setup.unique_name')
     end
 

--- a/spec/features/webauthn/sign_in_spec.rb
+++ b/spec/features/webauthn/sign_in_spec.rb
@@ -97,11 +97,11 @@ RSpec.feature 'webauthn sign in' do
       end
 
       it 'redirects to options page on sign in' do
-        expect(current_path).to eq(login_two_factor_options_path)
+        expect(page).to have_current_path(login_two_factor_options_path)
       end
 
       it 'allows user to go to options page and still select webauthn as their option' do
-        expect(current_path).to eq(login_two_factor_options_path)
+        expect(page).to have_current_path(login_two_factor_options_path)
         select_2fa_option('webauthn_platform', visible: :all)
         click_continue
         expect(current_url).to eq(login_two_factor_webauthn_url(platform: true))

--- a/spec/features/webauthn/sign_up_spec.rb
+++ b/spec/features/webauthn/sign_up_spec.rb
@@ -33,13 +33,13 @@ RSpec.feature 'webauthn sign up' do
       visit_idp_from_ial1_oidc_sp_requesting_phishing_resistant(prompt: 'select_account')
       select_2fa_option('webauthn', visible: :all)
 
-      expect(current_path).to eq webauthn_setup_path
+      expect(page).to have_current_path webauthn_setup_path
 
       fill_in_nickname_and_click_continue
       mock_press_button_on_hardware_key_on_setup
       skip_second_mfa_prompt
 
-      expect(current_path).to eq(sign_up_completed_path)
+      expect(page).to have_current_path(sign_up_completed_path)
     end
   end
 end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -111,6 +111,7 @@ module DocAuthHelper
     if with_selfie
       attach_liveness_images
     else
+      expect(page).to have_current_path(idv_document_capture_path)
       attach_images
     end
 

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -199,7 +199,7 @@ module IdvHelper
 
   def validate_idv_completed_page(user)
     expect(user.identity_verified?).to be(true)
-    expect(current_path).to eq sign_up_completed_path
+    expect(page).to have_current_path sign_up_completed_path
     expect(page).to have_content t(
       'titles.sign_up.completion_ial2',
       sp: 'Test SP',
@@ -207,7 +207,10 @@ module IdvHelper
   end
 
   def validate_return_to_sp
-    expect(page).to have_current_path('/auth/result', ignore_query: true)
-    expect(current_url).to start_with('http://localhost:7654/auth/result')
+    expect(page).to have_current_path(
+      'http://localhost:7654/auth/result',
+      url: true,
+      ignore_query: true,
+    )
   end
 end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -21,7 +21,7 @@ module Features
 
       click_link t('two_factor_authentication.login_options_link_text')
 
-      expect(current_path).to eq login_two_factor_options_path
+      expect(page).to have_current_path login_two_factor_options_path
 
       select_2fa_option(option)
     end
@@ -602,7 +602,7 @@ module Features
       fill_in t('account.index.email'), with: user.email
       click_button t('forms.buttons.continue')
 
-      expect(current_path).to eq forgot_password_path
+      expect(page).to have_current_path forgot_password_path
     end
 
     def click_reset_password_link_from_email
@@ -617,7 +617,7 @@ module Features
       open_last_email
       click_email_link_matching(/reset_password_token/)
 
-      expect(current_path).to eq edit_user_password_path
+      expect(page).to have_current_path edit_user_password_path
     end
 
     def expect_branded_experience

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       visit_idp_from_sp_with_ial2(sp)
       register_user(email)
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
 
       complete_all_doc_auth_steps_before_password_step
       fill_in 'Password', with: Features::SessionHelper::VALID_PASSWORD
@@ -43,7 +43,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       fill_in_code_with_last_totp(user)
       click_submit_default
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
 
       complete_all_doc_auth_steps_before_password_step
       fill_in 'Password', with: user.password
@@ -171,7 +171,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
 
     expect(AgencyIdentity.where(user_id: user.id, agency_id: 2).first.uuid).to eq(xmldoc.uuid)
     if javascript_enabled?
-      expect(current_path).to eq test_saml_decode_assertion_path
+      expect(page).to have_current_path test_saml_decode_assertion_path
     else
       expect(current_url).to eq @saml_authn_request
     end

--- a/spec/support/idv_examples/sp_requested_attributes.rb
+++ b/spec/support/idv_examples/sp_requested_attributes.rb
@@ -13,14 +13,14 @@ RSpec.shared_examples 'sp requesting attributes' do |sp|
       fill_in_code_with_last_phone_otp
       click_submit_default
 
-      expect(current_path).to eq idv_welcome_path
+      expect(page).to have_current_path idv_welcome_path
 
       complete_all_doc_auth_steps_before_password_step
       fill_in 'Password', with: user.password
       click_continue
       acknowledge_and_confirm_personal_key
 
-      expect(current_path).to eq(sign_up_completed_path)
+      expect(page).to have_current_path(sign_up_completed_path)
 
       expect(page).to have_content t('help_text.requested_attributes.email')
       expect(page).to have_content user.email
@@ -84,7 +84,7 @@ RSpec.shared_examples 'sp requesting attributes' do |sp|
       fill_in_code_with_last_phone_otp
       sp == :saml ? click_submit_default_twice : click_submit_default
 
-      expect(current_path).to eq(sign_up_completed_path)
+      expect(page).to have_current_path(sign_up_completed_path)
 
       expect(page).to have_content t('help_text.requested_attributes.email')
       expect(page).to have_content user.email

--- a/spec/support/idv_examples/verification_code_entry.rb
+++ b/spec/support/idv_examples/verification_code_entry.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'verification code entry' do
   it 'prompts for verification code at sign in' do
     sign_in_live_with_2fa(user)
 
-    expect(current_path).to eq idv_verify_by_mail_enter_code_path
+    expect(page).to have_current_path idv_verify_by_mail_enter_code_path
     expect(page).to have_content t('idv.messages.gpo.resend')
 
     gpo_confirmation_code
@@ -35,7 +35,7 @@ RSpec.shared_examples 'verification code entry' do
     fill_in t('idv.gpo.form.otp_label'), with: otp
     click_button t('idv.gpo.form.submit')
 
-    expect(current_path).to eq idv_verify_by_mail_enter_code_path
+    expect(page).to have_current_path idv_verify_by_mail_enter_code_path
     expect(page).to have_content t('errors.messages.gpo_otp_expired_and_cannot_request_another')
 
     user.reload
@@ -59,7 +59,7 @@ RSpec.shared_examples 'verification code entry' do
 
     expect(GpoConfirmation.count).to eq(1)
     expect(GpoConfirmationCode.count).to eq(2)
-    expect(current_path).to eq idv_letter_enqueued_path
+    expect(page).to have_current_path idv_letter_enqueued_path
 
     confirmation_code = GpoConfirmationCode.first
     otp_fingerprint = Pii::Fingerprinter.fingerprint(otp)

--- a/spec/support/shared_examples/account_creation.rb
+++ b/spec/support/shared_examples/account_creation.rb
@@ -46,7 +46,9 @@ RSpec.shared_examples 'creating an IAL2 account using authenticator app for 2FA'
     acknowledge_and_confirm_personal_key
 
     click_agree_and_continue
-    expect(current_path).to eq test_saml_decode_assertion_path if sp == :saml
+    if sp == :saml
+      expect(page).to have_current_path test_saml_decode_assertion_path
+    end
 
     if sp == :oidc
       redirect_uri = URI(current_url)
@@ -92,7 +94,9 @@ RSpec.shared_examples 'creating an IAL2 account using webauthn for 2FA' do |sp|
     acknowledge_and_confirm_personal_key
 
     click_agree_and_continue
-    expect(current_path).to eq test_saml_decode_assertion_path if sp == :saml
+    if sp == :saml
+      expect(page).to have_current_path test_saml_decode_assertion_path
+    end
 
     if sp == :oidc
       redirect_uri = URI(current_url)

--- a/spec/support/shared_examples/phone/rate_limiting.rb
+++ b/spec/support/shared_examples/phone/rate_limiting.rb
@@ -71,7 +71,9 @@ RSpec.shared_examples 'phone rate limiting' do |delivery_method|
           ),
         )
       end
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: delivery_method)
+      expect(page).to have_current_path(
+        login_two_factor_path(otp_delivery_preference: delivery_method),
+      )
     end
     fill_in :code, with: '123456'
     click_submit_default

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -164,7 +164,7 @@ RSpec.shared_examples 'signing in as IAL2 after resetting password' do |sp|
     click_submit_default
     click_submit_default if current_path == complete_saml_path
 
-    expect(current_path).to eq reactivate_account_path
+    expect(page).to have_current_path reactivate_account_path
 
     reactivate_profile(new_password, user.personal_key)
 
@@ -378,9 +378,9 @@ RSpec.shared_examples 'logs reCAPTCHA event and redirects appropriately' do |suc
       ),
     )
     if successful_sign_in
-      expect(current_path).to eq login_two_factor_path(otp_delivery_preference: 'sms')
+      expect(page).to have_current_path login_two_factor_path(otp_delivery_preference: 'sms')
     else
-      expect(current_path).to eq sign_in_security_check_failed_path
+      expect(page).to have_current_path sign_in_security_check_failed_path
     end
   end
 end

--- a/spec/support/shared_examples/webauthn_setup.rb
+++ b/spec/support/shared_examples/webauthn_setup.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples 'webauthn setup' do
     mock_webauthn_setup_challenge
     visit_webauthn_setup
 
-    expect(current_path).to eq webauthn_setup_path
+    expect(page).to have_current_path webauthn_setup_path
 
     fill_in_nickname_and_click_continue
     mock_press_button_on_hardware_key_on_setup
@@ -32,7 +32,7 @@ RSpec.shared_examples 'webauthn setup' do
     mock_webauthn_setup_challenge
     visit_webauthn_setup
 
-    expect(current_path).to eq webauthn_setup_path
+    expect(page).to have_current_path webauthn_setup_path
 
     mock_submit_without_pressing_button_on_hardware_key_on_setup
 

--- a/spec/support/sp_auth_helper.rb
+++ b/spec/support/sp_auth_helper.rb
@@ -43,7 +43,7 @@ module SpAuthHelper
     fill_in_code_with_last_totp(user)
     click_submit_default
 
-    expect(current_path).to eq(sign_up_completed_path)
+    expect(page).to have_current_path(sign_up_completed_path)
     click_agree_and_continue
 
     visit sign_out_url


### PR DESCRIPTION
## 🛠 Summary of changes

We've had some flakier feature tests recently following #11605, and some of them have been alleviated by doing replacements like:

```diff
-    expect(current_path).to eq sign_up_completed_path
+    expect(page).to have_current_path sign_up_completed_path
```

The second line uses the Capybara [has_current_path?](https://www.rubydoc.info/gems/capybara/Capybara/SessionMatchers#has_current_path%3F-instance_method) helper, which includes a timeout to wait for page loads rather than asserting the current_path in that moment in time. This will hopefully make some of the longer or more complicated feature test steps more reliable. There may still be places where we're missing an assertion and should add it before trying to take other actions like clicking on a button.

This PR adds `rubocop-capybara` and enables [Capybara/CurrentPathExpectation](https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaracurrentpathexpectation) to require usage of the `have_current_path` helper.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
