### PR TITLE
Add additional path expectations in end to end specs to reduce test flakiness

### DIFF
--- a/spec/features/account_creation/completions_cancel_spec.rb
+++ b/spec/features/account_creation/completions_cancel_spec.rb
@@ -22,6 +22,11 @@ RSpec.feature 'canceling at the completions screen' do
     expect(page).to have_current_path(sign_up_completed_cancel_path)
     click_on t('login_cancel.exit', app_name: APP_NAME)
 
+    expect(page).to have_current_path(
+      'http://localhost:7654/auth/result',
+      url: true,
+      ignore_query: true,
+    )
     expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
   end
 end

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -187,6 +187,11 @@ RSpec.describe 'cancel IdV' do
 
       click_spinner_button_and_wait t('idv.cancel.actions.exit', app_name: APP_NAME)
 
+      expect(page).to have_current_path(
+        'http://localhost:7654/auth/result',
+        url: true,
+        ignore_query: true,
+      )
       expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation confirmed',

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -71,12 +71,15 @@ RSpec.describe 'Identity verification', :js do
     test_go_back_from_document_capture
     complete_document_capture_step
 
+    expect(page).to have_current_path(idv_ssn_path)
     test_go_back_from_ssn_page
     complete_ssn_step
 
+    expect(page).to have_current_path(idv_verify_info_path)
     test_go_back_from_verify_info
     complete_verify_step
 
+    expect(page).to have_current_path(idv_phone_path)
     test_go_back_from_phone
     complete_otp_verification_page(user)
 
@@ -97,6 +100,7 @@ RSpec.describe 'Identity verification', :js do
     complete_all_doc_auth_steps
 
     enter_gpo_flow
+    expect(page).to have_current_path(idv_request_letter_path)
     test_go_back_from_request_letter
     complete_request_letter
     complete_enter_password_step(user)

--- a/spec/features/idv/uak_password_spec.rb
+++ b/spec/features/idv/uak_password_spec.rb
@@ -18,6 +18,10 @@ RSpec.feature 'A user with a UAK passwords attempts IdV' do
 
     click_agree_and_continue
 
-    expect(current_url).to start_with('http://localhost:7654/auth/result')
+    expect(page).to have_current_path(
+      'http://localhost:7654/auth/result',
+      url: true,
+      ignore_query: true,
+    )
   end
 end

--- a/spec/features/two_factor_authentication/second_mfa_reminder_spec.rb
+++ b/spec/features/two_factor_authentication/second_mfa_reminder_spec.rb
@@ -40,7 +40,11 @@ RSpec.feature 'Second MFA Reminder' do
 
         click_on t('users.second_mfa_reminder.continue', sp_name: service_provider.friendly_name)
 
-        expect(current_url).to start_with(service_provider.redirect_uris.first)
+        expect(page).to have_current_path(
+          service_provider.redirect_uris.first,
+          url: true,
+          ignore_query: true,
+        )
       end
     end
 

--- a/spec/features/users/password_recovery_via_recovery_code_spec.rb
+++ b/spec/features/users/password_recovery_via_recovery_code_spec.rb
@@ -54,7 +54,11 @@ RSpec.feature 'Password recovery via personal key' do
     acknowledge_and_confirm_personal_key
     click_agree_and_continue
 
-    expect(current_url).to start_with('http://localhost:7654/auth/result')
+    expect(page).to have_current_path(
+      'http://localhost:7654/auth/result',
+      url: true,
+      ignore_query: true,
+    )
 
     visit account_path
 

--- a/spec/features/users/user_profile_spec.rb
+++ b/spec/features/users/user_profile_spec.rb
@@ -177,7 +177,11 @@ RSpec.feature 'User profile' do
 
         click_agree_and_continue
 
-        expect(current_url).to start_with('http://localhost:7654/auth/result')
+        expect(page).to have_current_path(
+          'http://localhost:7654/auth/result',
+          url: true,
+          ignore_query: true,
+        )
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Following #11669, I've been monitoring a few other areas where tests seem to be a bit flakey. This PR adds some path expectations to try to address them.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
