### PR TITLE
LG-15051: Record correct resolution vendor in proofing components

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -233,6 +233,7 @@ module Idv
       if form_response.success?
         save_threatmetrix_status(form_response)
         save_source_check_vendor(form_response)
+        save_resolution_vendors(form_response)
         move_applicant_to_idv_session
         idv_session.mark_verify_info_step_complete!
 
@@ -245,6 +246,24 @@ module Idv
     def next_step_url
       return idv_request_letter_url if FeatureManagement.idv_by_mail_only?
       idv_phone_url
+    end
+
+    def save_resolution_vendors(form_response)
+      idv_session.resolution_vendor = form_response.extra.dig(
+        :proofing_results,
+        :context,
+        :stages,
+        :resolution,
+        :vendor_name,
+      )
+
+      idv_session.residential_resolution_vendor = form_response.extra.dig(
+        :proofing_results,
+        :context,
+        :stages,
+        :residential_address,
+        :vendor_name,
+      )
     end
 
     def save_threatmetrix_status(form_response)

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -43,7 +43,9 @@ module Idv
             idv_session.ssn && idv_session.ipp_document_capture_complete?
           end,
           undo_step: ->(idv_session:, user:) do
+            idv_session.residential_resolution_vendor = nil
             idv_session.resolution_successful = nil
+            idv_session.resolution_vendor = nil
             idv_session.verify_info_step_document_capture_session_uuid = nil
             idv_session.threatmetrix_review_status = nil
             idv_session.source_check_vendor = nil

--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -51,7 +51,9 @@ module Idv
               threatmetrix_session_id_present_or_not_required?(idv_session:)
         end,
         undo_step: ->(idv_session:, user:) do
+          idv_session.residential_resolution_vendor = nil
           idv_session.resolution_successful = nil
+          idv_session.resolution_vendor = nil
           idv_session.source_check_vendor = nil
           idv_session.address_edited = nil
           idv_session.verify_info_step_document_capture_session_uuid = nil

--- a/app/services/idv/proofing_components.rb
+++ b/app/services/idv/proofing_components.rb
@@ -32,8 +32,15 @@ module Idv
         (idv_session.verify_info_step_complete? && Idp::Constants::Vendors::AAMVA)
     end
 
+    def residential_resolution_check
+      idv_session.residential_resolution_vendor if idv_session.verify_info_step_complete?
+    end
+
     def resolution_check
-      Idp::Constants::Vendors::LEXIS_NEXIS if idv_session.verify_info_step_complete?
+      if idv_session.verify_info_step_complete?
+        # NOTE: Fallback to LexisNexis to handle 50/50 state, will be removed later
+        idv_session.resolution_vendor || Idp::Constants::Vendors::LEXIS_NEXIS
+      end
     end
 
     def address_check
@@ -59,6 +66,7 @@ module Idv
         document_check:,
         document_type:,
         source_check:,
+        residential_resolution_check:,
         resolution_check:,
         address_check:,
         threatmetrix:,

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -23,7 +23,9 @@ module Idv
   # @attr profile_id [String, nil]
   # @attr proofing_started_at [String, nil]
   # @attr redo_document_capture [Boolean, nil]
+  # @attr residential_resolution_vendor [String, nil]
   # @attr resolution_successful [Boolean, nil]
+  # @attr resolution_vendor [String,nil]
   # @attr selfie_check_performed [Boolean, nil]
   # @attr selfie_check_required [Boolean, nil]
   # @attr skip_doc_auth_from_handoff [Boolean, nil]
@@ -65,7 +67,9 @@ module Idv
       proofing_started_at
       redo_document_capture
       source_check_vendor
+      residential_resolution_vendor
       resolution_successful
+      resolution_vendor
       selfie_check_performed
       selfie_check_required
       skip_doc_auth_from_handoff

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -21,6 +21,37 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
     it 'returns a valid StepInfo object' do
       expect(Idv::InPerson::VerifyInfoController.step_info).to be_valid
     end
+
+    describe '#undo_step' do
+      let(:idv_session) do
+        Idv::Session.new(
+          user_session: {},
+          current_user: user,
+          service_provider: nil,
+        ).tap do |idv_session|
+          idv_session.residential_resolution_vendor = 'ResidentialResolutionVendor'
+          idv_session.resolution_successful = true
+          idv_session.resolution_vendor = 'ResolutionVendor'
+          idv_session.verify_info_step_document_capture_session_uuid = 'abcd-1234'
+          idv_session.threatmetrix_review_status = 'pass'
+          idv_session.source_check_vendor = 'aamva'
+          idv_session.applicant = { first_name: 'Joe ' }
+        end
+      end
+
+      it 'resets relevant fields on idv_session to nil' do
+        described_class.step_info.undo_step.call(idv_session:, user:)
+        aggregate_failures do
+          expect(idv_session.applicant).to be(nil)
+          expect(idv_session.residential_resolution_vendor).to be(nil)
+          expect(idv_session.resolution_successful).to be(nil)
+          expect(idv_session.resolution_vendor).to be(nil)
+          expect(idv_session.source_check_vendor).to be(nil)
+          expect(idv_session.threatmetrix_review_status).to be(nil)
+          expect(idv_session.verify_info_step_document_capture_session_uuid).to be(nil)
+        end
+      end
+    end
   end
 
   describe 'before_actions' do

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -304,7 +304,9 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
 
       it 'sets residential_resolution_vendor on idv_session' do
         get :show
-        expect(controller.idv_session.residential_resolution_vendor).to eql(residential_resolution_vendor_name)
+        expect(controller.idv_session.residential_resolution_vendor).to(
+          eql(residential_resolution_vendor_name),
+        )
       end
     end
   end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -678,7 +678,9 @@ RSpec.describe Idv::VerifyInfoController do
 
       it 'sets residential_resolution_vendor on idv_session' do
         get :show
-        expect(controller.idv_session.residential_resolution_vendor).to eql(residential_resolution_vendor_name)
+        expect(controller.idv_session.residential_resolution_vendor).to(
+          eql(residential_resolution_vendor_name),
+        )
       end
     end
   end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -23,6 +23,39 @@ RSpec.describe Idv::VerifyInfoController do
     it 'returns a valid StepInfo object' do
       expect(Idv::VerifyInfoController.step_info).to be_valid
     end
+
+    describe '#undo_step' do
+      let(:idv_session) do
+        Idv::Session.new(
+          user_session: {},
+          current_user: user,
+          service_provider: nil,
+        ).tap do |idv_session|
+          idv_session.address_edited = false
+          idv_session.applicant = { first_name: 'Joe' }
+          idv_session.residential_resolution_vendor = 'ResidentialResolutionVendor'
+          idv_session.resolution_successful = true
+          idv_session.resolution_vendor = 'ResolutionVendor'
+          idv_session.source_check_vendor = 'aamva'
+          idv_session.threatmetrix_review_status = 'pass'
+          idv_session.verify_info_step_document_capture_session_uuid = 'abcd-1234'
+        end
+      end
+
+      it 'resets relevant fields on idv_session to nil' do
+        described_class.step_info.undo_step.call(idv_session:, user:)
+        aggregate_failures do
+          expect(idv_session.address_edited).to be(nil)
+          expect(idv_session.applicant).to be(nil)
+          expect(idv_session.residential_resolution_vendor).to be(nil)
+          expect(idv_session.resolution_successful).to be(nil)
+          expect(idv_session.resolution_vendor).to be(nil)
+          expect(idv_session.source_check_vendor).to be(nil)
+          expect(idv_session.threatmetrix_review_status).to be(nil)
+          expect(idv_session.verify_info_step_document_capture_session_uuid).to be(nil)
+        end
+      end
+    end
   end
 
   describe 'before_actions' do

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -591,6 +591,63 @@ RSpec.describe Idv::VerifyInfoController do
         expect(@analytics).to have_logged_event('IdV: proofing resolution result missing')
       end
     end
+
+    context 'when the resolution proofing job completed successfully' do
+      let(:document_capture_session) do
+        DocumentCaptureSession.create(user:)
+      end
+
+      let(:resolution_vendor_name) { 'ResolutionVendor' }
+
+      let(:residential_resolution_vendor_name) { 'ResidentialResolutionVendor' }
+
+      let(:async_state) do
+        # Here we're trying to match the store to redis -> read from redis flow this data travels
+        adjudicated_result = Proofing::Resolution::ResultAdjudicator.new(
+          state_id_result: Proofing::StateIdResult.new(
+            success: true,
+            errors: {},
+            exception: nil,
+            vendor_name: :aamva,
+            transaction_id: 'abc123',
+            verified_attributes: [],
+          ),
+          device_profiling_result: Proofing::DdpResult.new(success: true),
+          ipp_enrollment_in_progress: true,
+          residential_resolution_result: Proofing::Resolution::Result.new(
+            success: true,
+            vendor_name: residential_resolution_vendor_name,
+          ),
+          resolution_result: Proofing::Resolution::Result.new(
+            success: true,
+            vendor_name: resolution_vendor_name,
+          ),
+          same_address_as_id: true,
+          should_proof_state_id: true,
+          applicant_pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN,
+        ).adjudicated_result.to_h
+
+        document_capture_session.create_proofing_session
+
+        document_capture_session.store_proofing_result(adjudicated_result)
+
+        document_capture_session.load_proofing_result
+      end
+
+      before do
+        allow(controller).to receive(:load_async_state).and_return(async_state)
+      end
+
+      it 'sets resolution_vendor on idv_session' do
+        get :show
+        expect(controller.idv_session.resolution_vendor).to eql(resolution_vendor_name)
+      end
+
+      it 'sets residential_resolution_vendor on idv_session' do
+        get :show
+        expect(controller.idv_session.residential_resolution_vendor).to eql(residential_resolution_vendor_name)
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -45,7 +45,8 @@ RSpec.feature 'Analytics Regression', :js do
       document_check: 'mock',
       document_type: 'state_id',
       source_check: 'StateIdMock',
-      resolution_check: 'lexis_nexis',
+      resolution_check: 'ResolutionMock',
+      residential_resolution_check: 'ResidentialAddressNotRequired',
       threatmetrix: threatmetrix,
       threatmetrix_review_status: 'pass',
     }
@@ -614,58 +615,58 @@ RSpec.feature 'Analytics Regression', :js do
       'IdV: doc auth verify proofing results' => {
         success: true, errors: {}, flow_path: 'standard', address_edited: false, address_line2_present: false, analytics_id: 'In Person Proofing', step: 'verify',
         proofing_results: in_person_path_proofing_results,
-        proofing_components: { document_check: 'usps', resolution_check: 'lexis_nexis', source_check: 'StateIdMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
+        proofing_components: { document_check: 'usps', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', source_check: 'StateIdMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass' }
       },
       'IdV: phone confirmation form' => {
         success: true, errors: {}, phone_type: :mobile, types: [:fixed_or_mobile], carrier: 'Test Mobile Carrier', country_code: 'US', area_code: '202', otp_delivery_preference: 'sms',
-        proofing_components: { document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'StateIdMock' }
+        proofing_components: { document_check: 'usps', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'StateIdMock' }
       },
       'IdV: phone confirmation vendor' => {
         success: true, errors: {}, vendor: { exception: nil, vendor_name: 'AddressMock', transaction_id: 'address-mock-transaction-id-123', timed_out: false, reference: '' }, new_phone_added: false, hybrid_handoff_phone_used: false, area_code: '202', country_code: 'US', phone_fingerprint: anything,
-        proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'StateIdMock' }
+        proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'StateIdMock' }
       },
       'IdV: phone confirmation otp sent' => {
         success: true, otp_delivery_preference: :sms, country_code: 'US', area_code: '202', adapter: :test, errors: {}, phone_fingerprint: anything, rate_limit_exceeded: false, telephony_response: anything,
-        proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'StateIdMock' }
+        proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'StateIdMock' }
       },
       'IdV: phone confirmation otp visited' => {
-        proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'StateIdMock' },
+        proofing_components: { address_check: 'lexis_nexis_address', document_check: 'usps', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', source_check: 'StateIdMock' },
       },
       'IdV: phone confirmation otp submitted' => {
         success: true, code_expired: false, code_matches: true, otp_delivery_preference: :sms, second_factor_attempts_count: 0, errors: {},
-        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       :idv_enter_password_visited => {
         address_verification_method: 'phone',
-        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       :idv_enter_password_submitted => {
         success: true, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, proofing_workflow_time_in_seconds: 0.0,
-        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: final resolution' => {
         success: true, fraud_review_pending: false, fraud_rejection: false, gpo_verification_pending: false, in_person_verification_pending: true, proofing_workflow_time_in_seconds: 0.0,
         # NOTE: pending_profile_idv_level should be set here, a nil value is cached for current_user.pending_profile.
         profile_history: match_array(kind_of(Idv::ProfileLogging)),
-        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key visited' => {
         in_person_verification_pending: true,
         address_verification_method: 'phone',
         encrypted_profiles_missing: false, pending_profile_idv_level: idv_level,
-        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key acknowledgment toggled' => {
         checked: true, pending_profile_idv_level: idv_level,
-        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: personal key submitted' => {
         address_verification_method: 'phone', fraud_review_pending: false, fraud_rejection: false, in_person_verification_pending: true, pending_profile_idv_level: idv_level,
-        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
+        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' }
       },
       'IdV: in person ready to verify visited' => {
         pending_profile_idv_level: idv_level,
-        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'lexis_nexis', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
+        proofing_components: { document_check: 'usps', source_check: 'StateIdMock', resolution_check: 'ResolutionMock', residential_resolution_check: 'ResolutionMock', threatmetrix: threatmetrix, threatmetrix_review_status: 'pass', address_check: 'lexis_nexis_address' },
       },
       'IdV: user clicked what to bring link on ready to verify page' => {},
       'IdV: user clicked sp link on ready to verify page' => {},

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -344,7 +344,8 @@ RSpec.describe 'Identity verification', :js do
       'address_check' => 'lexis_nexis_address',
       'document_type' => 'state_id',
       'document_check' => 'mock',
-      'resolution_check' => 'lexis_nexis',
+      'residential_resolution_check' => 'ResidentialAddressNotRequired',
+      'resolution_check' => 'ResolutionMock',
       'threatmetrix_review_status' => 'pass',
     )
     expect(GpoConfirmation.count).to eq(0)

--- a/spec/services/idv/proofing_components_spec.rb
+++ b/spec/services/idv/proofing_components_spec.rb
@@ -153,18 +153,56 @@ RSpec.describe Idv::ProofingComponents do
     end
   end
 
+  describe '#residential_resolution_check' do
+    it 'returns nil by default' do
+      expect(subject.residential_resolution_check).to be_nil
+    end
+
+    context 'when resolution_vendor is set on idv_session' do
+      before do
+        idv_session.mark_verify_info_step_complete!
+        idv_session.residential_resolution_vendor = 'AReallyGoodVendor'
+      end
+
+      it 'returns the vendor we set' do
+        expect(subject.residential_resolution_check).to eql('AReallyGoodVendor')
+      end
+    end
+
+    context 'when resolution done but residential_resolution_vendor nil because of 50/50 state' do
+      before do
+        idv_session.mark_verify_info_step_complete!
+      end
+
+      it 'returns nil to match previous behavior' do
+        expect(subject.residential_resolution_check).to be(nil)
+      end
+    end
+  end
+
   describe '#resolution_check' do
     it 'returns nil by default' do
       expect(subject.resolution_check).to be_nil
     end
 
-    context 'after verification' do
+    context 'when resolution_vendor is set on idv_session' do
+      before do
+        idv_session.mark_verify_info_step_complete!
+        idv_session.resolution_vendor = 'AReallyGoodVendor'
+      end
+
+      it 'returns the vendor we set' do
+        expect(subject.resolution_check).to eql('AReallyGoodVendor')
+      end
+    end
+
+    context 'when resolution done but resolution_vendor nil because of 50/50 state' do
       before do
         idv_session.mark_verify_info_step_complete!
       end
 
-      it 'returns LexisNexis' do
-        expect(subject.resolution_check).to eql(Idp::Constants::Vendors::LEXIS_NEXIS)
+      it 'returns LexisNexis to match previous behavior' do
+        expect(subject.resolution_check).to eql('lexis_nexis')
       end
     end
   end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15051](https://cm-jira.usa.gov/browse/LG-15051)

## 🛠 Summary of changes

Prior to this PR, we always said (in proofing components) that the resolution check was done via LexisNexis.

This PR:

- Starts tracking the actual vendor used for identity resolution in idv_session
- Uses that data to set the resolution_check value in ProofingComponents
- ALSO starts tracking residential_resolution_check in ProofingComponents for the check done with the residential address (for the IPP case)

## 📜 Testing Plan

1. Run through IdV (remote). At the end, look at the Profile record that was generated. Verify that `resolution_check` is set to `ResolutionMock` and that `residential_resolution_check` is set to `ResidentialAddressNotRequired`
2. Run through IdV (IPP). At the end, look at the Profile record that was generated. Verify that `resolution_check` is set to `ResolutionMock` and that `residential_resolution_check` is **also** set to `ResolutionMock`

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
