### PR TITLE
LG-15265 | Work around "content" blocking content

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -10,3 +10,10 @@
     @include u-height(9);
   }
 }
+
+/*
+  Workaround for https://github.com/uswds/uswds/issues/6260
+ */
+.usa-skipnav {
+  top: -5rem;
+}


### PR DESCRIPTION
changelog: User-Facing Improvements, Accessibility, skipnav container no longer blocks content at large zoom levels

## 🎫 Ticket

Link to the relevant ticket:
[LG-15265](https://cm-jira.usa.gov/browse/LG-15265)

See also https://github.com/uswds/uswds/issues/6260

## 🛠 Summary of changes

Works around an irksome bug where high zoom levels caused part of "Skip to main content" to overlap the actual content.



## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

<img width="562" alt="Screenshot 2024-12-19 at 2 18 34 PM" src="https://github.com/user-attachments/assets/b429f805-c250-4f61-b28f-ac4fd8184a91" />

</details>

<details>
<summary>After:</summary>

<img width="562" alt="Screenshot 2024-12-19 at 2 18 43 PM" src="https://github.com/user-attachments/assets/f25289ee-791b-49b3-a029-a5f4350d64bc" />

<img width="562" alt="Screenshot 2024-12-19 at 2 18 47 PM" src="https://github.com/user-attachments/assets/d30a8ec6-011d-400e-b38b-895908dcb865" />

</details>