### PR TITLE
Override CSP for ThreatMetrix based on feature-specific config

### DIFF
--- a/app/controllers/concerns/threat_metrix_concern.rb
+++ b/app/controllers/concerns/threat_metrix_concern.rb
@@ -5,12 +5,6 @@ module ThreatMetrixConcern
   THREAT_METRIX_WILDCARD_DOMAIN = '*.online-metrix.net'
 
   def override_csp_for_threat_metrix
-    return unless FeatureManagement.proofing_device_profiling_collecting_enabled?
-
-    threat_metrix_csp_overrides
-  end
-
-  def threat_metrix_csp_overrides
     policy = current_content_security_policy
 
     # ThreatMetrix requires additional Content Security Policy (CSP)

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -12,7 +12,8 @@ module Idv
       before_action :confirm_not_rate_limited_after_doc_auth
       before_action :confirm_in_person_address_step_complete
       before_action :confirm_repeat_ssn, only: :show
-      before_action :override_csp_for_threat_metrix
+      before_action :override_csp_for_threat_metrix,
+                    if: -> { FeatureManagement.proofing_device_profiling_collecting_enabled? }
 
       attr_reader :ssn_presenter
 

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -10,7 +10,8 @@ module Idv
 
     before_action :confirm_not_rate_limited_after_doc_auth
     before_action :confirm_step_allowed
-    before_action :override_csp_for_threat_metrix
+    before_action :override_csp_for_threat_metrix,
+                  if: -> { FeatureManagement.proofing_device_profiling_collecting_enabled? }
 
     attr_reader :ssn_presenter
 

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -12,7 +12,8 @@ module Users
     before_action :authenticate_user
     before_action :confirm_user_authenticated_for_2fa_setup
     before_action :check_if_possible_piv_user
-    before_action :override_csp_for_threat_metrix
+    before_action :override_csp_for_threat_metrix,
+                  if: -> { FeatureManagement.account_creation_device_profiling_collecting_enabled? }
 
     delegate :enabled_mfa_methods_count, to: :mfa_context
 

--- a/spec/controllers/concerns/threat_metrix_concern_spec.rb
+++ b/spec/controllers/concerns/threat_metrix_concern_spec.rb
@@ -12,60 +12,42 @@ RSpec.describe ThreatMetrixConcern, type: :controller do
   end
 
   describe '#override_csp_for_threat_metrix' do
-    let(:ff_enabled) { true }
+    it 'modifies CSP headers' do
+      get :index
 
-    before do
-      allow(IdentityConfig.store).to receive(:proofing_device_profiling)
-        .and_return(ff_enabled ? :enabled : :disabled)
-    end
+      csp = response.request.content_security_policy
 
-    context 'ff is set' do
-      it 'modifies CSP headers' do
-        get :index
+      aggregate_failures do
+        expect(csp.directives['script-src']).to include('h.online-metrix.net')
+        expect(csp.directives['script-src']).to include("'unsafe-eval'")
 
-        csp = response.request.content_security_policy
+        expect(csp.directives['style-src']).to include("'unsafe-inline'")
 
-        aggregate_failures do
-          expect(csp.directives['script-src']).to include('h.online-metrix.net')
-          expect(csp.directives['script-src']).to include("'unsafe-eval'")
+        expect(csp.directives['child-src']).to include('h.online-metrix.net')
 
-          expect(csp.directives['style-src']).to include("'unsafe-inline'")
+        expect(csp.directives['connect-src']).to include('h.online-metrix.net')
 
-          expect(csp.directives['child-src']).to include('h.online-metrix.net')
-
-          expect(csp.directives['connect-src']).to include('h.online-metrix.net')
-
-          expect(csp.directives['img-src']).to include('*.online-metrix.net')
-        end
-      end
-
-      context 'with content security policy directives for style-src' do
-        let(:csp_nonce_directives) { ['style-src'] }
-
-        before do
-          request.content_security_policy_nonce_directives = csp_nonce_directives
-        end
-
-        it 'removes style-src nonce directive to allow all unsafe inline styles' do
-          get :index
-
-          csp = parse_content_security_policy
-
-          expect(csp['style-src']).to_not include(/'nonce-.+'/)
-
-          # Ensure that the default configuration is not mutated as a result of the request-specific
-          # revisions to the content security policy.
-          expect(csp_nonce_directives).to eq(['style-src'])
-        end
+        expect(csp.directives['img-src']).to include('*.online-metrix.net')
       end
     end
 
-    context 'ff is not set' do
-      let(:ff_enabled) { false }
-      it 'does not modify CSP headers' do
+    context 'with content security policy directives for style-src' do
+      let(:csp_nonce_directives) { ['style-src'] }
+
+      before do
+        request.content_security_policy_nonce_directives = csp_nonce_directives
+      end
+
+      it 'removes style-src nonce directive to allow all unsafe inline styles' do
         get :index
-        secure_header_config = response.request.headers.env['secure_headers_request_config']
-        expect(secure_header_config).to be_nil
+
+        csp = parse_content_security_policy
+
+        expect(csp['style-src']).to_not include(/'nonce-.+'/)
+
+        # Ensure that the default configuration is not mutated as a result of the request-specific
+        # revisions to the content security policy.
+        expect(csp_nonce_directives).to eq(['style-src'])
       end
     end
   end

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Idv::InPerson::SsnController do
 
   before do
     stub_sign_in(user)
-    subject.user_session['idv/in_person'] = flow_session
+    controller.user_session['idv/in_person'] = flow_session
     stub_analytics
-    subject.idv_session.flow_path = 'standard'
+    controller.idv_session.flow_path = 'standard'
   end
 
   describe '#step_info' do
@@ -36,6 +36,8 @@ RSpec.describe Idv::InPerson::SsnController do
   end
 
   describe '#show' do
+    subject(:response) { get :show }
+
     let(:analytics_name) { 'IdV: doc auth ssn visited' }
     let(:analytics_args) do
       {
@@ -66,18 +68,18 @@ RSpec.describe Idv::InPerson::SsnController do
     end
 
     it 'adds a threatmetrix session id to idv_session' do
-      expect { get :show }.to change { subject.idv_session.threatmetrix_session_id }.from(nil)
+      expect { get :show }.to change { controller.idv_session.threatmetrix_session_id }.from(nil)
     end
 
     it 'does not change threatmetrix_session_id when updating ssn' do
-      subject.idv_session.ssn = ssn
-      expect { get :show }.not_to change { subject.idv_session.threatmetrix_session_id }
+      controller.idv_session.ssn = ssn
+      expect { get :show }.not_to change { controller.idv_session.threatmetrix_session_id }
     end
 
     context 'with an ssn in idv_session' do
       let(:referer) { idv_in_person_address_url }
       before do
-        subject.idv_session.ssn = ssn
+        controller.idv_session.ssn = ssn
         request.env['HTTP_REFERER'] = referer
       end
 
@@ -96,6 +98,32 @@ RSpec.describe Idv::InPerson::SsnController do
 
           expect(response).to render_template 'idv/shared/ssn'
         end
+      end
+    end
+
+    context 'with ThreatMetrix profiling disabled' do
+      before do
+        allow(FeatureManagement).to receive(:proofing_device_profiling_collecting_enabled?)
+          .and_return(false)
+      end
+
+      it 'does not override CSPs for ThreatMetrix' do
+        expect(controller).not_to receive(:override_csp_for_threat_metrix)
+
+        response
+      end
+    end
+
+    context 'with ThreatMetrix profiling enabled' do
+      before do
+        allow(FeatureManagement).to receive(:proofing_device_profiling_collecting_enabled?)
+          .and_return(true)
+      end
+
+      it 'overrides CSPs for ThreatMetrix' do
+        expect(controller).to receive(:override_csp_for_threat_metrix)
+
+        response
       end
     end
   end

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Idv::SsnController do
 
   before do
     stub_sign_in(user)
-    stub_up_to(:document_capture, idv_session: subject.idv_session)
+    stub_up_to(:document_capture, idv_session: controller.idv_session)
     stub_analytics
   end
 
@@ -33,16 +33,11 @@ RSpec.describe Idv::SsnController do
         :check_for_mail_only_outage,
       )
     end
-
-    it 'overrides CSPs for ThreatMetrix' do
-      expect(subject).to have_actions(
-        :before,
-        :override_csp_for_threat_metrix,
-      )
-    end
   end
 
   describe '#show' do
+    subject(:response) { get :show }
+
     let(:analytics_name) { 'IdV: doc auth ssn visited' }
     let(:analytics_args) do
       {
@@ -73,25 +68,25 @@ RSpec.describe Idv::SsnController do
     end
 
     it 'adds a threatmetrix session id to idv_session' do
-      expect { get :show }.to change { subject.idv_session.threatmetrix_session_id }.from(nil)
+      expect { get :show }.to change { controller.idv_session.threatmetrix_session_id }.from(nil)
     end
 
     context 'when updating ssn' do
       let(:threatmetrix_session_id) { 'original-session-id' }
 
       before do
-        subject.idv_session.ssn = ssn
-        subject.idv_session.threatmetrix_session_id = threatmetrix_session_id
+        controller.idv_session.ssn = ssn
+        controller.idv_session.threatmetrix_session_id = threatmetrix_session_id
       end
       it 'does not change threatmetrix_session_id' do
-        expect { get :show }.not_to change { subject.idv_session.threatmetrix_session_id }
+        expect { get :show }.not_to change { controller.idv_session.threatmetrix_session_id }
       end
 
       context 'but there is no threatmetrix_session_id in the session' do
         let(:threatmetrix_session_id) { nil }
 
         it 'sets a threatmetrix_session_id' do
-          expect { get :show }.to change { subject.idv_session.threatmetrix_session_id }
+          expect { get :show }.to change { controller.idv_session.threatmetrix_session_id }
         end
       end
     end
@@ -102,22 +97,22 @@ RSpec.describe Idv::SsnController do
       end
 
       it 'still add a threatmetrix session id to idv_session' do
-        expect { get :show }.to change { subject.idv_session.threatmetrix_session_id }.from(nil)
+        expect { get :show }.to change { controller.idv_session.threatmetrix_session_id }.from(nil)
       end
 
       context 'when idv_session has a threatmetrix_session_id' do
         before do
-          subject.idv_session.threatmetrix_session_id = 'fake-session-id'
+          controller.idv_session.threatmetrix_session_id = 'fake-session-id'
         end
         it 'changes the threatmetrix_session_id' do
-          expect { get :show }.to change { subject.idv_session.threatmetrix_session_id }
+          expect { get :show }.to change { controller.idv_session.threatmetrix_session_id }
         end
       end
     end
 
     context 'with an ssn in idv_session' do
       before do
-        subject.idv_session.ssn = ssn
+        controller.idv_session.ssn = ssn
       end
 
       it 'does not redirect and allows the back button' do
@@ -127,24 +122,29 @@ RSpec.describe Idv::SsnController do
       end
     end
 
-    it 'overrides Content Security Policies for ThreatMetrix' do
-      allow(IdentityConfig.store).to receive(:proofing_device_profiling)
-        .and_return(:enabled)
-      get :show
+    context 'with ThreatMetrix profiling disabled' do
+      before do
+        allow(FeatureManagement).to receive(:proofing_device_profiling_collecting_enabled?)
+          .and_return(false)
+      end
 
-      csp = response.request.content_security_policy
+      it 'does not override CSPs for ThreatMetrix' do
+        expect(controller).not_to receive(:override_csp_for_threat_metrix)
 
-      aggregate_failures do
-        expect(csp.directives['script-src']).to include('h.online-metrix.net')
-        expect(csp.directives['script-src']).to include("'unsafe-eval'")
+        response
+      end
+    end
 
-        expect(csp.directives['style-src']).to include("'unsafe-inline'")
+    context 'with ThreatMetrix profiling enabled' do
+      before do
+        allow(FeatureManagement).to receive(:proofing_device_profiling_collecting_enabled?)
+          .and_return(true)
+      end
 
-        expect(csp.directives['child-src']).to include('h.online-metrix.net')
+      it 'overrides CSPs for ThreatMetrix' do
+        expect(controller).to receive(:override_csp_for_threat_metrix)
 
-        expect(csp.directives['connect-src']).to include('h.online-metrix.net')
-
-        expect(csp.directives['img-src']).to include('*.online-metrix.net')
+        response
       end
     end
   end

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe Users::TwoFactorAuthenticationSetupController do
       expect(assigns(:presenter).desktop_ft_ab_test).to be false
     end
 
+    context 'with threatmetrix disabled' do
+      before do
+        allow(FeatureManagement).to receive(:proofing_device_profiling_collecting_enabled?)
+          .and_return(false)
+      end
+
+      it 'does not override CSPs for ThreatMetrix' do
+        expect(controller).not_to receive(:override_csp_for_threat_metrix)
+
+        response
+      end
+    end
+
     context 'with threatmetrix enabled' do
       let(:tmx_session_id) { '1234' }
 
@@ -51,6 +64,12 @@ RSpec.describe Users::TwoFactorAuthenticationSetupController do
         ).and_call_original
 
         expect(response).to render_template(:index)
+      end
+
+      it 'overrides CSPs for ThreatMetrix' do
+        expect(controller).to receive(:override_csp_for_threat_metrix)
+
+        response
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-15302](https://cm-jira.usa.gov/browse/LG-15302)

## 🛠 Summary of changes

Moves feature flag check from shared `ThreatMetrixConcern` to individual controllers, so that overriding CSP for account creation is not dependent on profiling collection being enabled for identity proofing.

## 📜 Testing Plan

Verify build passes.

Verify that CSP override occurs on MFA setup screen when account creation profiling collection is enabled and identity proofing device profiling collection is disabled.

```yaml
# config/application.yml
development:
  account_creation_device_profiling: collect_only
  proofing_device_profiling: disabled
```