### PR TITLE
Remove unused method checking enabled ThreatMetrix

### DIFF
--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -138,10 +138,6 @@ module Idv
         redirect_to account_url
       end
 
-      def threatmetrix_enabled?
-        FeatureManagement.proofing_device_profiling_decisioning_enabled?
-      end
-
       def pii_locked?
         !Pii::Cacher.new(current_user, user_session).exists_in_session?
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Removes an unused method `Idv::ByMail::EnterCodeController#threatmetrix_enabled?`

Last reference removed in #8397

## 📜 Testing Plan

Verify build passes.