### PR TITLE
Allow passing PR url to create-release script

### DIFF
--- a/scripts/create-release
+++ b/scripts/create-release
@@ -6,7 +6,7 @@ DEPLOY_BRANCH=stages/prod
 DRY_RUN=${DRY_RUN:-0}
 PR_JSON_FILE=${PR_JSON_FILE:-tmp/.pr.json}
 CHANGELOG_FILE=${CHANGELOG_FILE:-tmp/.changelog.md}
-GH_REPO=${GH_REPO:-18f/identity-idp}
+GH_REPO=${GH_REPO:-18F/identity-idp}
 
 USAGE="
 ${0} [PULL_REQUEST_URL]
@@ -22,7 +22,7 @@ fi
 PR="$1"; shift
 
 # Allow just pasting the PR URL
-PR=$(echo "$PR" | sed -E 's#https://github.com/18F/identity-idp/pull/([0-9]+).*#\1#')
+PR=$(echo "$PR" | sed -E "s#https://github.com/${GH_REPO}/pull/([0-9]+).*#\1#i")
 
 if ! which gh > /dev/null 2>&1; then
     echo "Github CLI (gh) is not installed. You can install it with: brew install gh"

--- a/scripts/create-release
+++ b/scripts/create-release
@@ -9,7 +9,7 @@ CHANGELOG_FILE=${CHANGELOG_FILE:-tmp/.changelog.md}
 GH_REPO=${GH_REPO:-18f/identity-idp}
 
 USAGE="
-${0} [PULL_REQUEST_NUMBER]
+${0} [PULL_REQUEST_URL]
 
 Creates a new release based on the given PR having been merged.
 "
@@ -20,6 +20,9 @@ if [ $# -eq 0 ]; then
 fi
 
 PR="$1"; shift
+
+# Allow just pasting the PR URL
+PR=$(echo "$PR" | sed -E 's#https://github.com/18F/identity-idp/pull/([0-9]+).*#\1#')
 
 if ! which gh > /dev/null 2>&1; then
     echo "Github CLI (gh) is not installed. You can install it with: brew install gh"


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

`scripts/create-release` is used to tag a release after it is deployed. Previously this script required you to pass in the actual PR ID. This update allows you to just pass in the PR URL directly, which is ever so slightly faster.

Before:

```shell
scripts/create-release 1234
```

After:

```shell
scripts/create-release https://github.com/18F/identity-idp/pull/1234
```

(The old way still works too.)


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
