### PR TITLE
LG-15217 Add submit_attempts property to doc auth troubleshooting option actions

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture.tsx
@@ -77,6 +77,7 @@ function DocumentCapture({ onStepChange = () => {} }: DocumentCaptureProps) {
       submissionError instanceof UploadFormEntriesError
         ? withProps({
             remainingSubmitAttempts: submissionError.remainingSubmitAttempts,
+            submitAttempts: submissionError.submitAttempts,
             isResultCodeInvalid: submissionError.isResultCodeInvalid,
             isFailedResult: submissionError.isFailedResult,
             isFailedDocType: submissionError.isFailedDocType,

--- a/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
@@ -3,10 +3,12 @@ import { Button } from '@18f/identity-components';
 import { useInstanceId } from '@18f/identity-react-hooks';
 import { t } from '@18f/identity-i18n';
 import AnalyticsContext from '../context/analytics';
+import UploadContext from '../context/upload';
 
 function InPersonCallToAction() {
   const instanceId = useInstanceId();
   const { trackEvent } = useContext(AnalyticsContext);
+  const { submitAttempts } = useContext(UploadContext);
 
   return (
     <section
@@ -25,7 +27,7 @@ function InPersonCallToAction() {
         isWide
         className="margin-top-3 margin-bottom-1"
         onClick={() => {
-          trackEvent('IdV: verify in person troubleshooting option clicked');
+          trackEvent('IdV: verify in person troubleshooting option clicked', {submit_attempts: submitAttempts});
         }}
       >
         {t('in_person_proofing.body.cta.button')}

--- a/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-call-to-action.tsx
@@ -27,7 +27,9 @@ function InPersonCallToAction() {
         isWide
         className="margin-top-3 margin-bottom-1"
         onClick={() => {
-          trackEvent('IdV: verify in person troubleshooting option clicked', {submit_attempts: submitAttempts});
+          trackEvent('IdV: verify in person troubleshooting option clicked', {
+            submit_attempts: submitAttempts,
+          });
         }}
       >
         {t('in_person_proofing.body.cta.button')}

--- a/app/javascript/packages/document-capture/components/review-issues-step.tsx
+++ b/app/javascript/packages/document-capture/components/review-issues-step.tsx
@@ -38,6 +38,7 @@ export interface ReviewIssuesStepValue {
 
 interface ReviewIssuesStepProps extends FormStepComponentProps<ReviewIssuesStepValue> {
   remainingSubmitAttempts?: number;
+  submitAttempts?: number;
   isResultCodeInvalid?: boolean;
   isFailedResult?: boolean;
   isFailedSelfie?: boolean;
@@ -57,6 +58,7 @@ function ReviewIssuesStep({
   registerField = () => undefined,
   toPreviousStep = () => undefined,
   remainingSubmitAttempts = Infinity,
+  submitAttempts,
   isResultCodeInvalid = false,
   isFailedResult = false,
   isFailedDocType = false,
@@ -106,6 +108,7 @@ function ReviewIssuesStep({
   function onWarningPageDismissed() {
     trackEvent('IdV: Capture troubleshooting dismissed', {
       liveness_checking_required: isSelfieCaptureEnabled,
+      submit_attempts: submitAttempts,
     });
 
     setHasDismissed(true);

--- a/app/javascript/packages/document-capture/context/upload.tsx
+++ b/app/javascript/packages/document-capture/context/upload.tsx
@@ -82,7 +82,7 @@ export interface UploadErrorResponse {
   remaining_submit_attempts?: number;
 
   /**
-   * Number of submit attempts for user.
+   * Number of submitted doc capture attempts for user
    */
   submit_attempts?: number;
 

--- a/app/javascript/packages/document-capture/context/upload.tsx
+++ b/app/javascript/packages/document-capture/context/upload.tsx
@@ -1,9 +1,8 @@
 import { createContext, useState } from 'react';
 import { useObjectMemo } from '@18f/identity-react-hooks';
 import type { ReactNode } from 'react';
-import defaultUpload from '../services/upload';
+import defaultUpload, { UploadFormEntriesError } from '../services/upload';
 import type { PII } from '../services/upload';
-import { UploadFormEntriesError } from '../services/upload';
 
 const UploadContext = createContext({
   upload: defaultUpload,

--- a/app/javascript/packages/document-capture/services/upload.ts
+++ b/app/javascript/packages/document-capture/services/upload.ts
@@ -38,6 +38,8 @@ export class UploadFormEntriesError extends FormError {
 
   remainingSubmitAttempts = Infinity;
 
+  submitAttempts = 0;
+
   isResultCodeInvalid = false;
 
   isFailedResult = false;
@@ -118,6 +120,10 @@ const upload: UploadImplementation = async function (payload, { method = 'POST',
 
     if (result.remaining_submit_attempts) {
       error.remainingSubmitAttempts = result.remaining_submit_attempts;
+    }
+
+    if (result.submit_attempts) {
+      error.submitAttempts = result.submit_attempts;
     }
 
     if (result.ocr_pii) {

--- a/app/presenters/image_upload_response_presenter.rb
+++ b/app/presenters/image_upload_response_presenter.rb
@@ -24,6 +24,10 @@ class ImageUploadResponsePresenter
     @form_response.to_h[:remaining_submit_attempts]
   end
 
+  def submit_attempts
+    @form_response.to_h[:submit_attempts]
+  end
+
   def status
     if success?
       :ok
@@ -41,6 +45,7 @@ class ImageUploadResponsePresenter
       json = { success: false,
                errors: errors,
                remaining_submit_attempts: remaining_submit_attempts,
+               submit_attempts: submit_attempts,
                doc_type_supported: doc_type_supported? }
       if remaining_submit_attempts&.zero?
         if @form_response.extra[:flow_path] == 'standard'

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1198,7 +1198,7 @@ module AnalyticsEvents
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] use_alternate_sdk
   # @param [Boolean] liveness_checking_required
-  # @param [Integer] submit_attempts Times that user has tried submitting
+  # @param [Integer] submit_attempts Times that user has tried submitting document capture
   def idv_capture_troubleshooting_dismissed(
     acuant_sdk_upgrade_a_b_testing_enabled:,
     acuant_version:,
@@ -5312,7 +5312,7 @@ module AnalyticsEvents
 
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
-  # @param [Integer] submit_attempts Times that user has tried submitting
+  # @param [Integer] submit_attempts Times that user has tried submitting document capture
   # The user clicked the troubleshooting option to start in-person proofing
   def idv_verify_in_person_troubleshooting_option_clicked(
     flow_path:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1198,12 +1198,14 @@ module AnalyticsEvents
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] use_alternate_sdk
   # @param [Boolean] liveness_checking_required
+  # @param [Integer] submit_attempts Times that user has tried submitting
   def idv_capture_troubleshooting_dismissed(
     acuant_sdk_upgrade_a_b_testing_enabled:,
     acuant_version:,
     flow_path:,
     use_alternate_sdk:,
     liveness_checking_required:,
+    submit_attempts:,
     **extra
   )
     track_event(
@@ -1213,6 +1215,7 @@ module AnalyticsEvents
       flow_path: flow_path,
       use_alternate_sdk: use_alternate_sdk,
       liveness_checking_required: liveness_checking_required,
+      submit_attempts: submit_attempts,
       **extra,
     )
   end
@@ -5309,16 +5312,19 @@ module AnalyticsEvents
 
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
+  # @param [Integer] submit_attempts Times that user has tried submitting
   # The user clicked the troubleshooting option to start in-person proofing
   def idv_verify_in_person_troubleshooting_option_clicked(
     flow_path:,
     opted_in_to_in_person_proofing:,
+    submit_attempts:,
     **extra
   )
     track_event(
       'IdV: verify in person troubleshooting option clicked',
       flow_path: flow_path,
       opted_in_to_in_person_proofing: opted_in_to_in_person_proofing,
+      submit_attempts: submit_attempts,
       **extra,
     )
   end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -165,6 +165,7 @@ RSpec.describe Idv::ImageUploadsController do
             ocr_pii: nil,
             doc_type_supported: true,
             failed_image_fingerprints: { front: [], back: [], selfie: [] },
+            submit_attempts: 2,
           },
         )
       end
@@ -182,6 +183,7 @@ RSpec.describe Idv::ImageUploadsController do
             ocr_pii: nil,
             doc_type_supported: true,
             failed_image_fingerprints: { front: [], back: [], selfie: [] },
+            submit_attempts: 4,
           }
         end
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Idv::ImageUploadsController do
             ocr_pii: nil,
             doc_type_supported: true,
             failed_image_fingerprints: { front: [], back: [], selfie: [] },
-            submit_attempts: 4,
+            submit_attempts: IdentityConfig.store.doc_auth_max_attempts,
           }
         end
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -569,7 +569,7 @@ RSpec.feature 'Analytics Regression', :js do
       },
       'IdV: doc auth image upload vendor submitted' => hash_including(success: true, flow_path: 'standard', attention_with_barcode: true, doc_auth_result: 'Attention', liveness_checking_required: boolean),
       'IdV: verify in person troubleshooting option clicked' => {
-        flow_path: 'standard', opted_in_to_in_person_proofing: false
+        flow_path: 'standard', opted_in_to_in_person_proofing: false, submit_attempts: 1
       },
       'IdV: in person proofing location visited' => {
         flow_path: 'standard', opted_in_to_in_person_proofing: false

--- a/spec/javascript/packages/document-capture/context/upload-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/upload-spec.jsx
@@ -19,6 +19,7 @@ describe('document-capture/context/upload', () => {
       'getStatus',
       'flowPath',
       'formData',
+      'submitAttempts',
     ]);
 
     expect(result.current.upload).to.equal(defaultUpload);
@@ -26,6 +27,7 @@ describe('document-capture/context/upload', () => {
     expect(result.current.statusPollInterval).to.be.undefined();
     expect(result.current.isMockClient).to.be.false();
     expect(await result.current.getStatus()).to.deep.equal({});
+    expect(result.current.submitAttempts).to.equal(0);
   });
 
   it('can be overridden with custom upload behavior', async () => {

--- a/spec/presenters/image_upload_response_presenter_spec.rb
+++ b/spec/presenters/image_upload_response_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ImageUploadResponsePresenter do
   include Rails.application.routes.url_helpers
 
   let(:extra_attributes) do
-    { remaining_submit_attempts: 3, flow_path: 'standard' }
+    { remaining_submit_attempts: 3, flow_path: 'standard', submit_attempts: 2 }
   end
 
   let(:form_response) do
@@ -109,7 +109,8 @@ RSpec.describe ImageUploadResponsePresenter do
       let(:extra_attributes) do
         { remaining_submit_attempts: 0,
           flow_path: 'standard',
-          failed_image_fingerprints: { back: [], front: ['12345'], selfie: [] } }
+          failed_image_fingerprints: { back: [], front: ['12345'], selfie: [] },
+          submit_attempts: 5 }
       end
       let(:form_response) do
         FormResponse.new(
@@ -132,6 +133,7 @@ RSpec.describe ImageUploadResponsePresenter do
           ocr_pii: nil,
           doc_type_supported: true,
           failed_image_fingerprints: { back: [], front: ['12345'], selfie: [] },
+          submit_attempts: 5,
         }
 
         expect(presenter.as_json).to eq expected
@@ -141,7 +143,8 @@ RSpec.describe ImageUploadResponsePresenter do
         let(:extra_attributes) do
           { remaining_submit_attempts: 0,
             flow_path: 'hybrid',
-            failed_image_fingerprints: { back: [], front: ['12345'], selfie: [] } }
+            failed_image_fingerprints: { back: [], front: ['12345'], selfie: [] },
+            submit_attempts: 5 }
         end
 
         it 'returns hash of properties redirecting to capture_complete' do
@@ -155,6 +158,7 @@ RSpec.describe ImageUploadResponsePresenter do
             ocr_pii: nil,
             doc_type_supported: true,
             failed_image_fingerprints: { back: [], front: ['12345'], selfie: [] },
+            submit_attempts: 5,
           }
 
           expect(presenter.as_json).to eq expected
@@ -185,6 +189,7 @@ RSpec.describe ImageUploadResponsePresenter do
           ocr_pii: nil,
           doc_type_supported: true,
           failed_image_fingerprints: { back: [], front: [], selfie: [] },
+          submit_attempts: 2,
         }
 
         expect(presenter.as_json).to eq expected
@@ -198,7 +203,7 @@ RSpec.describe ImageUploadResponsePresenter do
               front: t('doc_auth.errors.not_a_file'),
               hints: true,
             },
-            extra: { doc_auth_result: 'Failed', remaining_submit_attempts: 3 },
+            extra: { doc_auth_result: 'Failed', remaining_submit_attempts: 3, submit_attempts: 2 },
           )
         end
 
@@ -213,6 +218,7 @@ RSpec.describe ImageUploadResponsePresenter do
             ocr_pii: nil,
             doc_type_supported: true,
             failed_image_fingerprints: { front: [], back: [], selfie: [] },
+            submit_attempts: 2,
           }
 
           expect(presenter.as_json).to eq expected
@@ -221,7 +227,7 @@ RSpec.describe ImageUploadResponsePresenter do
 
       context 'no remaining attempts' do
         let(:extra_attributes) do
-          { remaining_submit_attempts: 0, flow_path: 'standard' }
+          { remaining_submit_attempts: 0, flow_path: 'standard', submit_attempts: 5 }
         end
         let(:form_response) do
           FormResponse.new(
@@ -236,7 +242,7 @@ RSpec.describe ImageUploadResponsePresenter do
 
         context 'hybrid flow' do
           let(:extra_attributes) do
-            { remaining_submit_attempts: 0, flow_path: 'hybrid' }
+            { remaining_submit_attempts: 0, flow_path: 'hybrid', submit_attempts: 5 }
           end
 
           it 'returns hash of properties' do
@@ -251,6 +257,7 @@ RSpec.describe ImageUploadResponsePresenter do
               ocr_pii: nil,
               doc_type_supported: true,
               failed_image_fingerprints: { front: [], back: [], selfie: [] },
+              submit_attempts: 5,
             }
 
             expect(presenter.as_json).to eq expected
@@ -269,6 +276,7 @@ RSpec.describe ImageUploadResponsePresenter do
             ocr_pii: nil,
             doc_type_supported: true,
             failed_image_fingerprints: { back: [], front: [], selfie: [] },
+            submit_attempts: 5,
           }
 
           expect(presenter.as_json).to eq expected
@@ -325,7 +333,7 @@ RSpec.describe ImageUploadResponsePresenter do
       let(:form_response) do
         response = DocAuth::Response.new(
           success: true,
-          extra: { remaining_submit_attempts: 3 },
+          extra: { remaining_submit_attempts: 3, submit_attempts: 2 },
           pii_from_doc: Idp::Constants::MOCK_IDV_APPLICANT,
         )
         allow(response).to receive(:attention_with_barcode?).and_return(true)
@@ -343,6 +351,7 @@ RSpec.describe ImageUploadResponsePresenter do
           result_code_invalid: false,
           doc_type_supported: true,
           failed_image_fingerprints: { back: [], front: [], selfie: [] },
+          submit_attempts: 2,
         }
 
         expect(presenter.as_json).to eq expected
@@ -352,7 +361,7 @@ RSpec.describe ImageUploadResponsePresenter do
         let(:form_response) do
           response = DocAuth::Response.new(
             success: true,
-            extra: { remaining_submit_attempts: 3 },
+            extra: { remaining_submit_attempts: 3, submit_attempts: 2 },
             pii_from_doc: Idp::Constants::MOCK_IDV_APPLICANT,
           )
           allow(response).to receive(:attention_with_barcode?).and_return(true)
@@ -370,6 +379,7 @@ RSpec.describe ImageUploadResponsePresenter do
             ocr_pii: Idp::Constants::MOCK_IDV_APPLICANT.slice(:first_name, :last_name, :dob),
             doc_type_supported: true,
             failed_image_fingerprints: { back: [], front: [], selfie: [] },
+            submit_attempts: 2,
           }
 
           expect(presenter.as_json).to eq expected


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15217](https://cm-jira.usa.gov/browse/LG-15217)


## 🛠 Summary of changes

We want to be able to track metrics for users who choose to "try again online" or fall back to "try in person" after not being able to verify their ID in the remote flow. In particular we want to know how many submission attempts they've made before eventually trying in person. This PR adds `submit_attempts` to the analytics for these events: "Frontend: IdV: Capture troubleshooting dismissed" and "Frontend: IdV: Verify in person troubleshooting option clicked"


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Run `make watch_events` in your terminal to view the analytics events

- [ ] Enter the application through Sinatra, choosing "identity-verified"
- [ ] Begin the remote flow by choosing "Continue online" on /verify/how_to_verify
- [ ] Choose "upload photos" to reach the document capture step
- [ ] Upload failing images and submit
- [ ] Choose "Try Again"
- [ ] Observe that the event "Frontend: IdV: Capture troubleshooting **dismissed**" has been logged, with `submit_attempts` included under event_properties. It should accurately reflect how many times you've tried to submit the doc. (So far, 1)
- [ ] Back on the document capture page, upload another erroring/failing ID (you may need a separate failing YML or reload the page to upload the same ones you just uploaded)
- [ ] This time, choose "Try in person"
- [ ] Observe that the event "IdV: verify in person troubleshooting **option clicked**" has been logged, with `submit_attempts` included under event_properties. It should accurately reflect how many times you've tried to submit the doc (This time, 2)


## 👀 Screenshots

https://github.com/user-attachments/assets/e0fffbe8-91b7-4aee-80fe-c8059a8392da


