### PR TITLE
LG-15187: Update Socure Idv A/B test logic, pt.1

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -25,7 +25,7 @@ class ResolutionProofingJob < ApplicationJob
     service_provider_issuer: nil,
     threatmetrix_session_id: nil,
     request_ip: nil,
-    proofing_components: nil,
+    proofing_components: nil, # rubocop:disable Lint/UnusedMethodArgument
     # DEPRECATED ARGUMENTS
     should_proof_state_id: false # rubocop:disable Lint/UnusedMethodArgument
   )

--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -25,6 +25,7 @@ class ResolutionProofingJob < ApplicationJob
     service_provider_issuer: nil,
     threatmetrix_session_id: nil,
     request_ip: nil,
+    proofing_components: nil,
     # DEPRECATED ARGUMENTS
     should_proof_state_id: false # rubocop:disable Lint/UnusedMethodArgument
   )


### PR DESCRIPTION
Part 1 of 2 for [LG-15187](https://cm-jira.usa.gov/browse/LG-15187)

Adds a new parameter to ResolutionProofingJob prior to implementation, so that the new signature method can be used once all job queues are running the same code.

See: #11685 for implementation