### PR TITLE
LG-15314 | Replace 'partner agency' with SP name

### DIFF
--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -82,18 +82,24 @@ class AccountShowPresenter
     I18n.l(user.active_profile.created_at, format: :event_date)
   end
 
-  def connect_to_initiating_idv_sp_url
-    initiating_service_provider = user.active_profile&.initiating_service_provider
-    return nil if !initiating_service_provider.present?
+  def initiating_idv_sp
+    @initiating_idv_sp ||= user.active_profile&.initiating_service_provider
+  end
 
-    SpReturnUrlResolver.new(service_provider: initiating_service_provider).post_idv_follow_up_url
+  def initiating_idv_sp_name
+    initiating_idv_sp&.friendly_name
+  end
+
+  def connect_to_initiating_idv_sp_url
+    return nil if !initiating_idv_sp.present?
+
+    SpReturnUrlResolver.new(service_provider: initiating_idv_sp).post_idv_follow_up_url
   end
 
   def connected_to_initiating_idv_sp?
-    initiating_service_provider = user.active_profile&.initiating_service_provider
-    return false if !initiating_service_provider.present?
+    return false if !initiating_idv_sp.present?
 
-    identity = user.identities.find_by(service_provider: initiating_service_provider.issuer)
+    identity = user.identities.find_by(service_provider: initiating_idv_sp.issuer)
     !!identity&.last_ial2_authenticated_at.present?
   end
 

--- a/app/views/accounts/_identity_verification.html.erb
+++ b/app/views/accounts/_identity_verification.html.erb
@@ -19,13 +19,13 @@
   </div>
 </div>
 
-<% if @presenter.active_profile? && !@presenter.connected_to_initiating_idv_sp? && @presenter.sp_name %>
+<% if @presenter.active_profile? && !@presenter.connected_to_initiating_idv_sp? && @presenter.initiating_idv_sp_name %>
   <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-2') do %>
-    <%= t('account.index.verification.connect_idv_account.intro', sp_name: @presenter.sp_name) %><br />
+    <%= t('account.index.verification.connect_idv_account.intro', sp_name: @presenter.initiating_idv_sp_name) %><br />
     <% if @presenter.connect_to_initiating_idv_sp_url.present? %>
-      <%= link_to(t('account.index.verification.connect_idv_account.cta', sp_name: @presenter.sp_name), @presenter.connect_to_initiating_idv_sp_url) %>
+      <%= link_to(t('account.index.verification.connect_idv_account.cta', sp_name: @presenter.initiating_idv_sp_name), @presenter.connect_to_initiating_idv_sp_url) %>
     <% else %>
-      <%= t('account.index.verification.connect_idv_account.cta', sp_name: @presenter.sp_name) %>
+      <%= t('account.index.verification.connect_idv_account.cta', sp_name: @presenter.initiating_idv_sp_name) %>
     <% end %>
   <% end %>
 <% end %>
@@ -36,7 +36,7 @@
       <% if @presenter.identity_verified_with_facial_match? %>
         <%= t('account.index.verification.you_verified_your_facial_match_identity', app_name: APP_NAME) %>
       <% else %>
-        <%= t('account.index.verification.you_verified_your_identity_html', sp_name: @presenter.user.active_profile.initiating_service_provider&.friendly_name || APP_NAME) %>
+        <%= t('account.index.verification.you_verified_your_identity_html', sp_name: @presenter.initiating_idv_sp_name || APP_NAME) %>
       <% end %>
     <% elsif @presenter.active_profile? %>
       <%= t('account.index.verification.legacy_verified_html', app_name: APP_NAME, date: @presenter.formatted_legacy_idv_date) %>

--- a/app/views/accounts/_identity_verification.html.erb
+++ b/app/views/accounts/_identity_verification.html.erb
@@ -19,13 +19,13 @@
   </div>
 </div>
 
-<% if @presenter.active_profile? && !@presenter.connected_to_initiating_idv_sp? %>
+<% if @presenter.active_profile? && !@presenter.connected_to_initiating_idv_sp? && @presenter.sp_name %>
   <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-2') do %>
-    <%= t('account.index.verification.connect_idv_account.intro') %><br />
+    <%= t('account.index.verification.connect_idv_account.intro', sp_name: @presenter.sp_name) %><br />
     <% if @presenter.connect_to_initiating_idv_sp_url.present? %>
-      <%= link_to(t('account.index.verification.connect_idv_account.cta'), @presenter.connect_to_initiating_idv_sp_url) %>
+      <%= link_to(t('account.index.verification.connect_idv_account.cta', sp_name: @presenter.sp_name), @presenter.connect_to_initiating_idv_sp_url) %>
     <% else %>
-      <%= t('account.index.verification.connect_idv_account.cta') %>
+      <%= t('account.index.verification.connect_idv_account.cta', sp_name: @presenter.sp_name) %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,8 +75,8 @@ account.index.reactivation.instructions: Your profile was recently deactivated d
 account.index.reactivation.link: Reactivate your profile now.
 account.index.sign_in_location_and_ip: From %{ip} (IP address potentially located in %{location})
 account.index.unknown_location: unknown location
-account.index.verification.connect_idv_account.cta: Sign in to partner agency to access services.
-account.index.verification.connect_idv_account.intro: Connect your account to the partner agency.
+account.index.verification.connect_idv_account.cta: Sign in to %{sp_name} to access services.
+account.index.verification.connect_idv_account.intro: Connect your account to %{sp_name}.
 account.index.verification.continue_idv: Continue identity verification
 account.index.verification.finish_verifying_html: Finish verifying your identity to access <strong>%{sp_name}</strong>.
 account.index.verification.finish_verifying_no_sp: Finish the identity verification process to gain access to all %{app_name} partners.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -75,8 +75,8 @@ account.index.reactivation.instructions: Su perfil fue desactivado recientemente
 account.index.reactivation.link: Reactive su perfil ahora.
 account.index.sign_in_location_and_ip: Desde %{ip} (la dirección IP se encuentra posiblemente en %{location})
 account.index.unknown_location: ubicación desconocida
-account.index.verification.connect_idv_account.cta: Inicie sesión en la agencia asociada para acceder a los servicios.
-account.index.verification.connect_idv_account.intro: Conecte su cuenta a la agencia asociada.
+account.index.verification.connect_idv_account.cta: Inicie sesión en %{sp_name} para acceder a los servicios.
+account.index.verification.connect_idv_account.intro: Conecte su cuenta a %{sp_name}.
 account.index.verification.continue_idv: Continuar la verificación de identidad
 account.index.verification.finish_verifying_html: Termine de verificar su identidad para acceder a la <strong>%{sp_name}</strong>.
 account.index.verification.finish_verifying_no_sp: Termine el proceso de verificación de identidad para obtener acceso a todos los asociados de %{app_name}.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -75,8 +75,8 @@ account.index.reactivation.instructions: Votre profil a été récemment désact
 account.index.reactivation.link: Réactiver votre profil maintenant.
 account.index.sign_in_location_and_ip: De %{ip} (adresse IP éventuellement située dans %{location})
 account.index.unknown_location: lieu inconnu
-account.index.verification.connect_idv_account.cta: Connectez-vous à l’organisme partenaire pour accéder à ses services.
-account.index.verification.connect_idv_account.intro: Associer votre compte à l’organisme partenaire.
+account.index.verification.connect_idv_account.cta: Connectez-vous à %{sp_name} pour accéder à ses services.
+account.index.verification.connect_idv_account.intro: Associer votre compte à %{sp_name}.
 account.index.verification.continue_idv: Poursuivre la vérification d’identité
 account.index.verification.finish_verifying_html: Terminez la procédure de vérification d’identité pour pouvoir accéder à <strong>%{sp_name}</strong>.
 account.index.verification.finish_verifying_no_sp: Terminer la procédure de vérification d’identité pour pouvoir accéder à tous les organismes partenaires de %{app_name}.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -75,8 +75,8 @@ account.index.reactivation.instructions: 你的用户资料因为重设密码最
 account.index.reactivation.link: 现在重新激活你的用户资料。
 account.index.sign_in_location_and_ip: 从 %{ip}（IP 地址可能位于 %{location}）。
 account.index.unknown_location: 未知地点
-account.index.verification.connect_idv_account.cta: 登录合作伙伴机构来获得服务。
-account.index.verification.connect_idv_account.intro: 把你的账户连接到合作伙伴机构。
+account.index.verification.connect_idv_account.cta: 登录%{sp_name}来获得服务。
+account.index.verification.connect_idv_account.intro: 把你的账户连接到%{sp_name}。
 account.index.verification.continue_idv: 继续身份验证
 account.index.verification.finish_verifying_html: 完成身份验证流程来获得访问 <strong>%{sp_name}</strong> 的权限。
 account.index.verification.finish_verifying_no_sp: 完成身份验证流程来获得访问%{app_name} 合作伙伴机构的权限。

--- a/spec/features/idv/sp_follow_up_spec.rb
+++ b/spec/features/idv/sp_follow_up_spec.rb
@@ -102,8 +102,18 @@ RSpec.feature 'returning to an SP after out-of-band proofing' do
 
       expect(current_url).to eq(account_url)
 
-      expect(page).to have_content(t('account.index.verification.connect_idv_account.intro'))
-      click_on(t('account.index.verification.connect_idv_account.cta'))
+      expect(page).to have_content(
+        t(
+          'account.index.verification.connect_idv_account.intro',
+          sp_name: initiating_service_provider.friendly_name,
+        ),
+      )
+      click_on(
+        t(
+          'account.index.verification.connect_idv_account.cta',
+          sp_name: initiating_service_provider.friendly_name,
+        ),
+      )
 
       expect(current_url).to eq(post_idv_follow_up_url)
     end

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -646,7 +646,7 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
         let(:initiating_sp_name) { nil }
 
         context 'the service provider has a post-idv follow-up url' do
-          it 'renders a link but not the intro' do
+          it 'does not render the alert' do
             expect(rendered).not_to have_content(
               t(
                 'account.index.verification.connect_idv_account.intro',

--- a/spec/views/accounts/_identity_verification.html.erb_spec.rb
+++ b/spec/views/accounts/_identity_verification.html.erb_spec.rb
@@ -602,10 +602,16 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
       context 'the service provider has a post-idv follow-up url' do
         it 'renders an alert to connect to IdV SP with a link' do
           expect(rendered).to have_content(
-            t('account.index.verification.connect_idv_account.intro'),
+            t(
+              'account.index.verification.connect_idv_account.intro',
+              sp_name: initiating_sp_name,
+            ),
           )
           expect(rendered).to have_link(
-            t('account.index.verification.connect_idv_account.cta'),
+            t(
+              'account.index.verification.connect_idv_account.cta',
+              sp_name: initiating_sp_name,
+            ),
             href: post_idv_follow_up_url,
           )
         end
@@ -616,14 +622,45 @@ RSpec.describe 'accounts/_identity_verification.html.erb' do
 
         it 'renders an alert to connect to IdV SP without a link' do
           expect(rendered).to have_content(
-            t('account.index.verification.connect_idv_account.intro'),
+            t(
+              'account.index.verification.connect_idv_account.intro',
+              sp_name: initiating_sp_name,
+            ),
           )
           expect(rendered).to have_content(
-            t('account.index.verification.connect_idv_account.cta'),
+            t(
+              'account.index.verification.connect_idv_account.cta',
+              sp_name: initiating_sp_name,
+            ),
           )
           expect(rendered).to_not have_link(
-            t('account.index.verification.connect_idv_account.cta'),
+            t(
+              'account.index.verification.connect_idv_account.cta',
+              sp_name: initiating_sp_name,
+            ),
           )
+        end
+      end
+
+      context 'the service provider does not have a name' do
+        let(:initiating_sp_name) { nil }
+
+        context 'the service provider has a post-idv follow-up url' do
+          it 'renders a link but not the intro' do
+            expect(rendered).not_to have_content(
+              t(
+                'account.index.verification.connect_idv_account.intro',
+                sp_name: initiating_sp_name,
+              ),
+            )
+            expect(rendered).not_to have_link(
+              t(
+                'account.index.verification.connect_idv_account.cta',
+                sp_name: initiating_sp_name,
+              ),
+              href: post_idv_follow_up_url,
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15314](https://cm-jira.usa.gov/browse/LG-15314)

## 🛠 Summary of changes

Due to a misunderstanding with the Department of State, the strings for a prompt redirecting users to their service provider when they hadn't connected their account to them used "partner agency" as a literal string rather than an interpolation.

This fixes that, and also omits the message in the case that the name is nil since it is otherwise incomprehensible and contains no link.

That required some test changes, and also led to a bit of refactoring. Shoutout to @jmhooper for encouraging that part.


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

![Screenshot 2024-12-20 at 2 38 10 PM](https://github.com/user-attachments/assets/45219cb9-1f9c-4b6c-af53-cec01af675e3)
</details>

<details>
<summary>After:</summary>

No SP name, so CTA not displayed:
(Otherwise it would read "Connect your account to. Sign in to  to access services.")
![Screenshot 2024-12-20 at 5 10 03 PM](https://github.com/user-attachments/assets/dbe908e9-49f2-47f0-a03e-81b3f26ccb60)

English:
![Screenshot 2024-12-20 at 5 14 02 PM](https://github.com/user-attachments/assets/a9021773-f1e7-4e5e-ac31-4d905e9ccf7d)

Spanish:
![Screenshot 2024-12-20 at 5 14 21 PM](https://github.com/user-attachments/assets/04660258-ade3-419d-a1b1-1532e3e54693)

French:
![Screenshot 2024-12-20 at 5 14 15 PM](https://github.com/user-attachments/assets/a686eac4-4671-4bd0-a5bf-6b659e173413)

Chinese (simplified):
![Screenshot 2024-12-20 at 5 14 09 PM](https://github.com/user-attachments/assets/929e38c8-e0ed-4ea5-a20e-a34ad9ad8188)



</details>

