### PR TITLE
Refactor Idv::Agent spec

### DIFF
--- a/spec/services/idv/agent_spec.rb
+++ b/spec/services/idv/agent_spec.rb
@@ -4,10 +4,6 @@ require 'ostruct'
 RSpec.describe Idv::Agent do
   let(:user) { create(:user) }
 
-  let(:bad_phone) do
-    Proofing::Mock::AddressMockClient::UNVERIFIABLE_PHONE_NUMBER
-  end
-
   describe 'instance' do
     let(:trace_id) { SecureRandom.uuid }
     let(:request_ip) { Faker::Internet.ip_v4_address }
@@ -15,6 +11,12 @@ RSpec.describe Idv::Agent do
     let(:friendly_name) { 'fake-name' }
     let(:app_id) { 'fake-app-id' }
     let(:ipp_enrollment_in_progress) { false }
+    let(:applicant) do
+      Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN
+    end
+    let(:document_capture_session) { DocumentCaptureSession.new(result_id: SecureRandom.hex) }
+
+    subject(:agent) { Idv::Agent.new(applicant) }
 
     before do
       ServiceProvider.create(
@@ -25,97 +27,7 @@ RSpec.describe Idv::Agent do
     end
 
     describe '#proof_resolution' do
-      let(:document_capture_session) { DocumentCaptureSession.new(result_id: SecureRandom.hex) }
-
-      context 'proofing in an AAMVA state' do
-        it 'does not proof state_id if resolution fails' do
-          agent = Idv::Agent.new(
-            Idp::Constants::MOCK_IDV_APPLICANT.merge(ssn: '444-55-6666'),
-          )
-          agent.proof_resolution(
-            document_capture_session,
-            trace_id: trace_id,
-            user_id: user.id,
-            threatmetrix_session_id: nil,
-            request_ip: request_ip,
-            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-          )
-
-          result = document_capture_session.load_proofing_result.result
-          expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
-          expect(result[:context][:stages][:state_id][:vendor_name]).to eq 'UnsupportedJurisdiction'
-        end
-
-        it 'does proof state_id if resolution succeeds' do
-          agent = Idv::Agent.new(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN)
-          agent.proof_resolution(
-            document_capture_session,
-            trace_id: trace_id,
-            user_id: user.id,
-            threatmetrix_session_id: nil,
-            request_ip: request_ip,
-            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-          )
-          result = document_capture_session.load_proofing_result.result
-          expect(result[:context][:stages][:state_id]).to include(
-            transaction_id: Proofing::Mock::StateIdMockClient::TRANSACTION_ID,
-            errors: {},
-            exception: nil,
-            success: true,
-            timed_out: false,
-            vendor_name: 'StateIdMock',
-          )
-        end
-      end
-
-      context 'proofing state_id disabled' do
-        it 'does not proof state_id if resolution fails' do
-          agent = Idv::Agent.new(
-            Idp::Constants::MOCK_IDV_APPLICANT.merge(
-              ssn: '444-55-6666', state_id_jurisdiction: 'NY',
-            ),
-          )
-          agent.proof_resolution(
-            document_capture_session,
-            trace_id: trace_id,
-            user_id: user.id,
-            threatmetrix_session_id: nil,
-            request_ip: request_ip,
-            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-          )
-          result = document_capture_session.load_proofing_result.result
-          expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
-          expect(result[:context][:stages][:state_id][:vendor_name]).to eq 'UnsupportedJurisdiction'
-        end
-
-        it 'does not proof state_id if resolution succeeds' do
-          agent = Idv::Agent.new(
-            Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
-              state_id_jurisdiction: 'NY',
-            ),
-          )
-          agent.proof_resolution(
-            document_capture_session,
-            trace_id: trace_id,
-            user_id: user.id,
-            threatmetrix_session_id: nil,
-            request_ip: request_ip,
-            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-          )
-
-          result = document_capture_session.load_proofing_result.result
-          expect(result[:context][:stages]).to_not include(
-            state_id: 'StateIdMock',
-            transaction_id: Proofing::Mock::StateIdMockClient::TRANSACTION_ID,
-          )
-        end
-      end
-
-      it 'returns a successful result if SSN does not start with 900 but is in SSN allowlist' do
-        agent = Idv::Agent.new(
-          Idp::Constants::MOCK_IDV_APPLICANT.merge(ssn: '999-99-9999'),
-        )
-
+      subject(:proof_resolution) do
         agent.proof_resolution(
           document_capture_session,
           trace_id: trace_id,
@@ -124,19 +36,83 @@ RSpec.describe Idv::Agent do
           request_ip: request_ip,
           ipp_enrollment_in_progress: ipp_enrollment_in_progress,
         )
-        result = document_capture_session.load_proofing_result.result
+      end
 
-        expect(result).to include(
-          success: true,
-        )
+      subject(:result) do
+        proof_resolution
+        document_capture_session.load_proofing_result.result
+      end
+
+      context 'proofing in an AAMVA state' do
+        context 'when resolution fails' do
+          let(:applicant) do
+            super().merge(ssn: '444-55-6666')
+          end
+
+          it 'does not proof state_id' do
+            expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
+            expect(result[:context][:stages][:state_id][:vendor_name]).to(
+              eq('UnsupportedJurisdiction'),
+            )
+          end
+        end
+        context 'when resolution succeeds' do
+          it 'proofs state_id' do
+            expect(result[:context][:stages][:state_id]).to include(
+              transaction_id: Proofing::Mock::StateIdMockClient::TRANSACTION_ID,
+              errors: {},
+              exception: nil,
+              success: true,
+              timed_out: false,
+              vendor_name: 'StateIdMock',
+            )
+          end
+        end
+      end
+
+      context 'non-AAMVA state' do
+        let(:applicant) do
+          super().merge(state_id_jurisdiction: 'NY')
+        end
+
+        context 'when resolution fails' do
+          let(:applicant) do
+            super().merge(ssn: '444-55-6666')
+          end
+
+          it 'does not proof state_id' do
+            expect(result[:errors][:ssn]).to eq ['Unverified SSN.']
+            expect(result[:context][:stages][:state_id][:vendor_name]).to(
+              eq('UnsupportedJurisdiction'),
+            )
+          end
+        end
+
+        context 'when resolution succeeds' do
+          it 'does not proof state_id' do
+            expect(result[:context][:stages]).to_not include(
+              state_id: 'StateIdMock',
+              transaction_id: Proofing::Mock::StateIdMockClient::TRANSACTION_ID,
+            )
+          end
+        end
+      end
+
+      context 'when SSN does not start with 900 but is in SSN allowlist' do
+        let(:applicant) do
+          super().merge(ssn: '999-99-9999')
+        end
+
+        it 'returns a successful result' do
+          expect(result).to include(
+            success: true,
+          )
+        end
       end
 
       it 'passes the correct service provider to the ResolutionProofingJob' do
         issuer = 'https://rp1.serviceprovider.com/auth/saml/metadata'
         document_capture_session.update!(issuer: issuer)
-        agent = Idv::Agent.new(
-          Idp::Constants::MOCK_IDV_APPLICANT.merge(ssn: '999-99-9999'),
-        )
 
         expect(ResolutionProofingJob).to receive(:perform_later).with(
           hash_including(
@@ -144,52 +120,29 @@ RSpec.describe Idv::Agent do
           ),
         )
 
-        agent.proof_resolution(
-          document_capture_session,
-          trace_id: trace_id,
-          user_id: user.id,
-          threatmetrix_session_id: nil,
-          request_ip: request_ip,
-          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-        )
+        proof_resolution
       end
 
-      it 'returns an unsuccessful result and notifies exception trackers if an exception occurs' do
-        agent = Idv::Agent.new(
-          Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(first_name: 'Time Exception'),
-        )
-
-        agent.proof_resolution(
-          document_capture_session,
-          trace_id: trace_id,
-          user_id: user.id,
-          threatmetrix_session_id: nil,
-          request_ip: request_ip,
-          ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-        )
-        result = document_capture_session.load_proofing_result.result
-
-        expect(result[:exception].to_s).to include('resolution mock timeout')
-        expect(result).to include(
-          success: false,
-          timed_out: true,
-        )
+      context 'when a proofing timeout occurs' do
+        let(:applicant) do
+          super().merge(first_name: 'Time Exception')
+        end
+        it 'returns unsuccessful result and notifies exception trackers if an exception occurs' do
+          expect(result[:exception].to_s).to include('resolution mock timeout')
+          expect(result).to include(
+            success: false,
+            timed_out: true,
+          )
+        end
       end
 
       context 'in-person proofing is enabled' do
         let(:ipp_enrollment_in_progress) { true }
+        let(:applicant) do
+          Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS
+        end
 
         it 'returns a successful result if resolution passes' do
-          agent = Idv::Agent.new(Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS)
-          agent.proof_resolution(
-            document_capture_session,
-            trace_id: trace_id,
-            user_id: user.id,
-            threatmetrix_session_id: nil,
-            request_ip: request_ip,
-            ipp_enrollment_in_progress: ipp_enrollment_in_progress,
-          )
-          result = document_capture_session.load_proofing_result.result
           expect(result[:context][:stages][:state_id]).to include(
             transaction_id: Proofing::Mock::StateIdMockClient::TRANSACTION_ID,
             errors: {},
@@ -202,37 +155,42 @@ RSpec.describe Idv::Agent do
     end
 
     describe '#proof_address' do
-      let(:document_capture_session) { DocumentCaptureSession.new(result_id: SecureRandom.hex) }
-      let(:user_id) { SecureRandom.random_number(1000) }
-      let(:issuer) { build(:service_provider).issuer }
-
-      it 'proofs addresses successfully with valid information' do
-        agent = Idv::Agent.new(
-          first_name: 'Fakey',
-          last_name: 'Fakersgerald',
-          dob: 50.years.ago.to_date.to_s,
-          ssn: '666-12-1234',
+      let(:applicant) do
+        super().merge(
           phone: Faker::PhoneNumber.cell_phone,
         )
+      end
+
+      subject(:proof_address) do
         agent.proof_address(
           document_capture_session,
           trace_id: trace_id,
-          user_id: user_id,
+          user_id: user.id,
           issuer: issuer,
         )
-        result = document_capture_session.load_proofing_result[:result]
+      end
+
+      subject(:result) do
+        proof_address
+        document_capture_session.load_proofing_result[:result]
+      end
+
+      it 'proofs addresses successfully with valid information' do
         expect(result[:vendor_name]).to eq('AddressMock')
         expect(result[:success]).to eq true
       end
 
-      it 'fails to proof addresses with invalid information' do
-        agent = Idv::Agent.new(phone: bad_phone)
-        agent.proof_address(
-          document_capture_session, trace_id: trace_id, user_id: user_id, issuer: issuer
-        )
-        result = document_capture_session.load_proofing_result[:result]
-        expect(result[:vendor_name]).to eq('AddressMock')
-        expect(result[:success]).to eq false
+      context 'when address has invalid information' do
+        let(:applicant) do
+          super().merge(
+            phone: Proofing::Mock::AddressMockClient::UNVERIFIABLE_PHONE_NUMBER,
+          )
+        end
+
+        it 'fails to proof address' do
+          expect(result[:vendor_name]).to eq('AddressMock')
+          expect(result[:success]).to eq false
+        end
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Supports work for 
[LG-15187](https://cm-jira.usa.gov/browse/LG-15187)

## 🛠 Summary of changes

This PR just refactors the `Idv::Agent` spec to use more `let` and `subject` blocks. This will make future changes I want to make for LG-15187 a little cleaner.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
