### PR TITLE
Aggressively reload A/B tests during spec runs

### DIFF
--- a/spec/config/initializers/ab_tests_spec.rb
+++ b/spec/config/initializers/ab_tests_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe AbTests do
-  include AbTestsHelper
-
-  after :suite do
-    reload_ab_tests
-  end
-
   describe '#all' do
     it 'returns all registered A/B tests' do
       expect(AbTests.all.values).to all(be_kind_of(AbTest))

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include AbTestsHelper
   config.include EmailSpec::Helpers
   config.include EmailSpec::Matchers
   config.include AbstractController::Translation
@@ -164,5 +165,9 @@ RSpec.configure do |config|
         /chromedriver\.storage\.googleapis\.com/, # For fetching a chromedriver binary
       ],
     )
+  end
+
+  config.after(:context) do
+    reload_ab_tests
   end
 end


### PR DESCRIPTION
<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

## 🛠 Summary of changes

**TLDR:** This PR updates our RSpec config to reload A/B tests after each spec file in a test run. This is because by default A/B tests are initialized _once and only once_, and this makes it possible for them to "hold on" to mocked configuration data, potentially leading to flakiness.

Previously in #11583 I added a cleanup hook to the `ab_tests_spec.rb` file, but there are two problems with this:

1. Theoretically, A/B tests could get "stuck" by any spec, so it needs to be applied more broadly
2. The way I added it didn't actually work. RSpec complained:

```
WARNING: `after(:suite)` hooks are only supported on the RSpec configuration object. This `after(:suite)` hook, registered on an example group, will be ignored. Called from /builds/lg/identity-idp/spec/config/initializers/ab_tests_spec.rb:6:in `block in <top (required)>'.
```

Thus, this PR adds the cleanup hook to the main RSpec config. I'm adding it as an `after :context` block, which here means "after each test file". We could theoretically run the same thing after each example, but that is probably overkill.

## 📜 Testing Plan

To see an example of this causing a problem on `main`, run:

```shell
bundle exec rspec --seed 4734 --fail-fast \
spec/config/initializers/ab_tests_spec.rb \
spec/features/saml/ial2_sso_spec.rb
```

`ial2_sso_spec.rb` will fail.

Switch to this branch, and the same invocation will pass.
