### PR TITLE
LG-15362 Bug fix: Limit query for timeframe expired event

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -106,9 +106,14 @@ module TwoFactorAuthenticatableMethods
     return @sign_in_notification_timeframe_expired_event if defined?(
       @sign_in_notification_timeframe_expired_event
     )
-    @sign_in_notification_timeframe_expired_event = current_user.events.where(
-      event_type: 'sign_in_notification_timeframe_expired',
-    ).order(created_at: :desc).limit(1).take
+    @sign_in_notification_timeframe_expired_event = current_user.events
+      .limit(3000)
+      .where(
+        event_type: 'sign_in_notification_timeframe_expired',
+      )
+      .order(created_at: :desc)
+      .limit(1)
+      .take
   end
 
   def handle_remember_device_preference(remember_device_preference)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -107,9 +107,9 @@ module TwoFactorAuthenticatableMethods
       @sign_in_notification_timeframe_expired_event
     )
     @sign_in_notification_timeframe_expired_event = current_user.events
-      .limit(3000)
       .where(
         event_type: 'sign_in_notification_timeframe_expired',
+        created_at: (IdentityConfig.store.session_total_duration_timeout_in_minutes.minutes.ago..),
       )
       .order(created_at: :desc)
       .limit(1)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-15362](https://cm-jira.usa.gov/browse/LG-15362)



## 🛠 Summary of changes

As discussed in [slack](https://gsa-tts.slack.com/archives/C05MGJ72GU9/p1735663969801249) check for timeframe expired event for new device email was causing a lengthy query in many cases. @mitchellhenke added a maximum time window for the events that would limit those searches.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
