### PR TITLE
Fix a feature test that breaks around New Year

### DIFF
--- a/spec/features/idv/steps/in_person/state_id_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_spec.rb
@@ -286,9 +286,14 @@ RSpec.describe 'state id controller enabled', :js do
     it 'shows error for dob under minimum age', allow_browser_log: true do
       complete_steps_before_state_id_controller
 
-      fill_in t('components.memorable_date.month'), with: '1'
-      fill_in t('components.memorable_date.day'), with: '1'
-      fill_in t('components.memorable_date.year'), with: Time.zone.now.strftime('%Y')
+      buffer_to_avoid_test_flakiness = 2.days
+
+      less_than_13_years_ago = Time.zone.now - (13.years - buffer_to_avoid_test_flakiness)
+
+      fill_in t('components.memorable_date.month'), with: less_than_13_years_ago.month
+      fill_in t('components.memorable_date.day'), with: less_than_13_years_ago.day
+      fill_in t('components.memorable_date.year'), with: less_than_13_years_ago.year
+
       click_idv_continue
       expect(page).to have_content(
         t(
@@ -297,8 +302,11 @@ RSpec.describe 'state id controller enabled', :js do
         ),
       )
 
-      year = (Time.zone.now - 13.years).strftime('%Y')
-      fill_in t('components.memorable_date.year'), with: year
+      thirteenish_years_ago = Time.zone.now - (13.years + buffer_to_avoid_test_flakiness)
+      fill_in t('components.memorable_date.month'), with: thirteenish_years_ago.month
+      fill_in t('components.memorable_date.day'), with: thirteenish_years_ago.day
+      fill_in t('components.memorable_date.year'), with: thirteenish_years_ago.year
+
       click_idv_continue
       expect(page).not_to have_content(
         t(


### PR DESCRIPTION
This test is checking validation around when the user reports they are under 13 years of age.  Around New Year, it's possible that the year for the Rails app and the year for the browser might differ. So this PR adds in a little bit of wiggle room to the calculation.