### PR TITLE
Add a mocked version of Socure docauth

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -68,6 +68,8 @@ module Idv
         when Idp::Constants::Vendors::SOCURE
           in_hybrid_mobile ? idv_hybrid_mobile_socure_document_capture_path
                            : idv_socure_document_capture_path
+        when Idp::Constants::Vendors::MOCK_SOCURE
+          test_mock_socure_url(hybrid: in_hybrid_mobile ? 1 : 0)
         when Idp::Constants::Vendors::LEXIS_NEXIS, Idp::Constants::Vendors::MOCK
           in_hybrid_mobile ? idv_hybrid_mobile_document_capture_path
                            : idv_document_capture_path

--- a/app/controllers/idv/hybrid_mobile/entry_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/entry_controller.rb
@@ -17,6 +17,8 @@ module Idv
         case doc_auth_vendor
         when Idp::Constants::Vendors::SOCURE
           redirect_to idv_hybrid_mobile_socure_document_capture_url
+        when Idp::Constants::Vendors::MOCK_SOCURE
+          redirect_to test_mock_socure_url(hybrid: 1)
         when Idp::Constants::Vendors::MOCK, Idp::Constants::Vendors::LEXIS_NEXIS
           redirect_to idv_hybrid_mobile_document_capture_url
         end

--- a/app/controllers/test/mock_socure_document_capture_controller.rb
+++ b/app/controllers/test/mock_socure_document_capture_controller.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Test
+  class MockSocureDocumentCaptureController < ApplicationController
+    before_action :check_not_in_prod
+
+    def show
+      if verify?
+        simulate_socure_docv
+        return
+      end
+
+      @url = test_mock_socure_url(verify: 1, hybrid: hybrid? ? 1 : 0)
+    end
+
+    private
+
+    def check_not_in_prod
+      render_not_found if Rails.env.production?
+    end
+
+    def build_fake_docv_result_response
+      DocAuth::Socure::Responses::DocvResultResponse.new(
+        http_response: Struct.new(:body, keyword_init: true).new(
+          body: JSON.generate(
+            {
+              referenceId: SecureRandom.uuid,
+              documentVerification: {
+                customerProfile: {
+                  customerUserId: '',
+                  userId: SecureRandom.uuid,
+                },
+                decision: {
+                  name: '',
+                  value: 'accept',
+                },
+                documentData: {
+                  dob: '1938-01-01',
+                  documentNumber: 'ABCD-1234',
+                  expirationDate: (Time.zone.now + 1.year).to_date,
+                  firstName: 'Joey',
+                  issueDate: 3.years.ago.to_date,
+                  middleName: 'Joe-Joe',
+                  surName: 'Junior Shabbadoo',
+                  parsedAddress: {
+                    physicalAddress: '1234 Fake St.',
+                    physicalAddress2: 'Unit 99',
+                    city: 'Fakeville',
+                    state: 'CA',
+                    zip: '90210',
+                  },
+                },
+                documentType: {
+                  state: 'WA',
+                  country: 'US',
+                },
+                reasonCodes: [],
+              },
+
+            },
+          ),
+        ),
+      )
+    end
+
+    def document_capture_session
+      DocumentCaptureSession.find_by(
+        uuid: if idv_session.present?
+                idv_session.document_capture_session_uuid
+              else
+                session[:document_capture_session_uuid]
+              end,
+      )
+    end
+
+    def hybrid?
+      params[:hybrid].to_i == 1
+    end
+
+    def idv_session
+      return nil if user_session.nil?
+
+      @idv_session ||= Idv::Session.new(
+        user_session: user_session,
+        current_user: current_user,
+        service_provider: current_sp,
+      )
+    end
+
+    def simulate_socure_docv
+      # Fake what the Socure webhook processor would've done.
+      # TODO: It'd be cool to just call the webhook processing code here
+
+      document_capture_session.store_result_from_response(
+        build_fake_docv_result_response,
+      )
+
+      if hybrid?
+        redirect_to idv_hybrid_mobile_capture_complete_url
+      else
+        redirect_to idv_socure_document_capture_update_url
+      end
+    end
+
+    def verify?
+      params[:verify].to_i == 1
+    end
+  end
+end

--- a/app/views/idv/shared/_doc_capture_interstitial.html.erb
+++ b/app/views/idv/shared/_doc_capture_interstitial.html.erb
@@ -8,6 +8,12 @@
       ) %>
 <% end %>
 
+<% if local_assigns.fetch(:show_test_mode_warning, false) %>
+  <p>
+    <marquee class="bg-accent-warm" ><strong>FOR TESTING ONLY.</strong> This will only <strong>simulate</strong> verifying your documents.</marquee>
+  </p>
+<% end %>
+
 <%= render PageHeadingComponent.new do %>
   <%= t('doc_auth.headings.verify_with_phone') %>
 <% end %>

--- a/app/views/test/mock_socure_document_capture/show.html.erb
+++ b/app/views/test/mock_socure_document_capture/show.html.erb
@@ -1,0 +1,1 @@
+<%= render 'idv/shared/doc_capture_interstitial', show_test_mode_warning: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,8 @@ Rails.application.routes.draw do
         put '/s3/:key' => 'fake_s3#update'
 
         get '/session_data' => 'session_data#index'
+
+        get '/mock_socure' => 'mock_socure_document_capture#show'
       end
     end
 

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -14,6 +14,7 @@ module Idp
       LEXIS_NEXIS = 'lexis_nexis'
       SOCURE = 'socure'
       MOCK = 'mock'
+      MOCK_SOCURE = 'mock_socure'
       USPS = 'usps'
       AAMVA = 'aamva'
       AAMVA_UNSUPPORTED_JURISDICTION = 'UnsupportedJurisdiction'


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Supports work for 
[LG-15187](https://cm-jira.usa.gov/browse/LG-15187)

## 🛠 Summary of changes

Adds a new doc auth vendor, `mock_socure` that allows pretending that the user went through a Socure-like doc auth experience.

This mock vendor:

  - Is not enabled by default
  - Only works when `socure_docv_enabled` is set to `true`
  - Only works in non-prod environments (in deployed envs, you should use the Socure sandbox)

## 📜 Testing Plan

Enable the new vendor:

```yaml
  socure_docv_enabled: true
  doc_auth_vendor_default: 'mock_socure'
```

Then, go through IdV. Socure docv only works on mobile phones, so you need to either:

1. Use hybrid handoff to complete doc auth on a mobile device
2. Use your browser's developer tools to simulate a mobile device

## 👀 Screenshots

![test-mock_socure-en](https://github.com/user-attachments/assets/5ed60320-a3aa-4338-9c7f-0c7a22833ff4)