### PR TITLE
Update newrelic_rpm gem to fix Bundler deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,7 +458,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     net-ssh (6.1.0)
-    newrelic_rpm (9.7.0)
+    newrelic_rpm (9.16.1)
     nio4r (2.7.4)
     nokogiri (1.16.8)
       mini_portile2 (~> 2.8.2)


### PR DESCRIPTION
## 🛠 Summary of changes

When running scripts or similar with NewRelic enabled, we get a deprecation warning:

```
[DEPRECATED] Bundler.rubygems.all_specs has been removed in favor of Bundler.rubygems.installed_specs
```

This was addressed in NewRelic [here](https://github.com/newrelic/newrelic-ruby-agent/pull/2823), and this PR updates the gem to fix the warning.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
