### PR TITLE
Include jurisdiction_in_maintenance_window in result when AAMVA raises exception

### DIFF
--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -62,7 +62,10 @@ module Proofing
       rescue => exception
         failed_result = Proofing::StateIdResult.new(
           success: false, errors: {}, exception: exception, vendor_name: 'aamva:state_id',
-          transaction_id: nil, verified_attributes: []
+          transaction_id: nil, verified_attributes: [],
+          jurisdiction_in_maintenance_window: jurisdiction_in_maintenance_window?(
+            applicant[:state],
+          )
         )
         send_to_new_relic(failed_result)
         failed_result

--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -58,13 +58,13 @@ module Proofing
           applicant: aamva_applicant,
         )
 
-        build_result_from_response(response, applicant[:state])
+        build_result_from_response(response, applicant[:state_id_jurisdiction])
       rescue => exception
         failed_result = Proofing::StateIdResult.new(
           success: false, errors: {}, exception: exception, vendor_name: 'aamva:state_id',
           transaction_id: nil, verified_attributes: [],
           jurisdiction_in_maintenance_window: jurisdiction_in_maintenance_window?(
-            applicant[:state],
+            applicant[:state_id_jurisdiction],
           )
         )
         send_to_new_relic(failed_result)

--- a/spec/services/proofing/aamva/proofer_spec.rb
+++ b/spec/services/proofing/aamva/proofer_spec.rb
@@ -737,6 +737,18 @@ RSpec.describe Proofing::Aamva::Proofer do
           expect(result.mva_timeout?).to eq(true)
           expect(result.mva_exception?).to eq(true)
         end
+
+        context 'when the DMV is in a defined maintenance window' do
+          before do
+            expect(Idv::AamvaStateMaintenanceWindow).to receive(:in_maintenance_window?)
+              .and_return(true)
+          end
+
+          it 'sets jurisdiction_in_maintenance_window to true' do
+            result = subject.proof(state_id_data)
+            expect(result.jurisdiction_in_maintenance_window?).to eq(true)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

While investigating a support case [here](https://gsa-tts.slack.com/archives/C20J64X6V/p1735908075619039), I noticed that we didn't seem to be logging AAMVA maintenance windows as expected. Following some discussion [here](https://gsa-tts.slack.com/archives/C03DCUECFH7/p1735926961106209), the issue is that we only include the attribute if the call does not raise an exception.

This PR includes the `jurisdiction_in_maintenance_window` attribute in both cases.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
