### PR TITLE
LG-15377 Add in-person post office closed email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -441,6 +441,16 @@ class UserMailer < ActionMailer::Base
     end
   end
 
+  def in_person_post_office_closed
+    with_user_locale(user) do
+      @hide_title = true
+      mail(
+        to: email_address.email,
+        subject: t('in_person_proofing.post_office_closed.email.subject'),
+      )
+    end
+  end
+
   private
 
   attr_reader :user, :email_address

--- a/app/views/user_mailer/in_person_post_office_closed.html.erb
+++ b/app/views/user_mailer/in_person_post_office_closed.html.erb
@@ -1,0 +1,2 @@
+<h1><%= t('in_person_proofing.post_office_closed.email.heading') %></h1>
+<p><%= t('in_person_proofing.post_office_closed.email.body_html') %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1328,6 +1328,9 @@ in_person_proofing.headings.switch_back: Switch back to your computer to prepare
 in_person_proofing.headings.update_address: Update your current address
 in_person_proofing.headings.update_state_id: Update the information on your ID
 in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.email.body_html: <strong>You will not be able to visit a Post Office on Thursday, January 9, 2025 to finish verifying your identity.</strong> Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.email.heading: All Post Offices will be closed on January 9, 2025 to honor former President Jimmy Carter
+in_person_proofing.post_office_closed.email.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
 in_person_proofing.process.barcode.caption_label: Enrollment code
 in_person_proofing.process.barcode.heading: Show your %{app_name} barcode

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1339,6 +1339,9 @@ in_person_proofing.headings.switch_back: Vuelva a su computadora para preparar l
 in_person_proofing.headings.update_address: Actualice su dirección actual
 in_person_proofing.headings.update_state_id: Actualice la información de su identificación
 in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.email.body_html: <strong>You will not be able to visit a Post Office on Thursday, January 9, 2025 to finish verifying your identity.</strong> Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.email.heading: All Post Offices will be closed on January 9, 2025 to honor former President Jimmy Carter
+in_person_proofing.post_office_closed.email.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
 in_person_proofing.process.barcode.caption_label: Código de registro
 in_person_proofing.process.barcode.heading: Muestre su código de barras de %{app_name}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1328,6 +1328,9 @@ in_person_proofing.headings.switch_back: Revenez à votre ordinateur pour vous p
 in_person_proofing.headings.update_address: Mettez à jour votre adresse actuelle
 in_person_proofing.headings.update_state_id: Mettez à jour les informations figurant sur votre document d’identité
 in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.email.body_html: <strong>You will not be able to visit a Post Office on Thursday, January 9, 2025 to finish verifying your identity.</strong> Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.email.heading: All Post Offices will be closed on January 9, 2025 to honor former President Jimmy Carter
+in_person_proofing.post_office_closed.email.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
 in_person_proofing.process.barcode.caption_label: Code d’inscription
 in_person_proofing.process.barcode.heading: Montrez votre code-barres %{app_name}

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1341,6 +1341,9 @@ in_person_proofing.headings.switch_back: 切换回你的电脑，来准备亲身
 in_person_proofing.headings.update_address: 更新你当前地址
 in_person_proofing.headings.update_state_id: 更新你身份证件上的信息
 in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.email.body_html: <strong>You will not be able to visit a Post Office on Thursday, January 9, 2025 to finish verifying your identity.</strong> Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.email.heading: All Post Offices will be closed on January 9, 2025 to honor former President Jimmy Carter
+in_person_proofing.post_office_closed.email.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
 in_person_proofing.process.barcode.caption_label: 注册代码
 in_person_proofing.process.barcode.heading: 出示你的 %{app_name} 条形码

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -68,6 +68,9 @@ module I18n
         { key: 'in_person_proofing.post_office_closed.heading', locales: %i[es fr zh] }, # temp, waiting on translations 01/03/25
         { key: 'in_person_proofing.process.eipp_bring_id.image_alt_text', locales: %i[fr es zh] }, # Real ID is considered a proper noun in this context, ID translated to ID Card in Chinese
         { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
+        { key: 'in_person_proofing.post_office_closed.email.body_html', locales: %i[fr es zh] }, # Temporary email for post office closures
+        { key: 'in_person_proofing.post_office_closed.email.heading', locales: %i[fr es zh] }, # Temporary email for post office closures
+        { key: 'in_person_proofing.post_office_closed.email.subject', locales: %i[fr es zh] }, # Temporary email for post office closures
         { key: 'saml_idp.auth.error.title', locales: %i[es] }, # "Error" is "Error" in Spanish
         { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
         { key: 'telephony.format_length.six', locales: %i[zh] }, # numeral is not translated

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -286,6 +286,10 @@ class UserMailerPreview < ActionMailer::Preview
     ).account_reinstated
   end
 
+  def in_person_post_office_closed
+    UserMailer.with(user: user, email_address: email_address_record).in_person_post_office_closed
+  end
+
   private
 
   def user

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1654,4 +1654,23 @@ RSpec.describe UserMailer, type: :mailer do
     it_behaves_like 'a system email'
     it_behaves_like 'an email that respects user email locale preference'
   end
+
+  describe '#in_person_post_office_closed' do
+    let(:mail) do
+      UserMailer.with(user: user, email_address: email_address).in_person_post_office_closed
+    end
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
+
+    it 'includes a translated header' do
+      expect(mail.html_part.body)
+        .to include(t('in_person_proofing.post_office_closed.email.heading', locale: :en))
+    end
+
+    it 'includes a translated body' do
+      expect(mail.html_part.body)
+        .to include(t('in_person_proofing.post_office_closed.email.body_html', locale: :en))
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15377](https://cm-jira.usa.gov/browse/LG-15377)

## 🛠 Summary of changes

Added an in-person post office closed email template.



## 📜 Testing Plan

- [ ] Navigate to [in-person post office closed email preview](http://localhost:3000/rails/mailers/user_mailer/in_person_post_office_closed.html?locale=en)
- [ ] Ensure content matches designs

## 👀 Screenshots

<img width="1721" alt="Screenshot 2025-01-06 at 10 26 00 AM" src="https://github.com/user-attachments/assets/e371b834-1676-4e02-9a58-b454c35e9add" />


