### PR TITLE
LG-15378 Add Conditional Warning Banner to Ready to Verify View and Email

### DIFF
--- a/app/controllers/idv/in_person/ready_to_verify_controller.rb
+++ b/app/controllers/idv/in_person/ready_to_verify_controller.rb
@@ -17,6 +17,7 @@ module Idv
       before_action :confirm_in_person_session
 
       def show
+        @show_closed_post_office_banner = IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
         @is_enhanced_ipp = resolved_authn_context_result.enhanced_ipp?
         analytics.idv_in_person_ready_to_verify_visit(**opt_in_analytics_properties)
         @presenter = ReadyToVerifyPresenter.new(

--- a/app/controllers/idv/in_person/ready_to_verify_controller.rb
+++ b/app/controllers/idv/in_person/ready_to_verify_controller.rb
@@ -17,8 +17,9 @@ module Idv
       before_action :confirm_in_person_session
 
       def show
-        @show_closed_post_office_banner = IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
         @is_enhanced_ipp = resolved_authn_context_result.enhanced_ipp?
+        @show_closed_post_office_banner =
+          IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
         analytics.idv_in_person_ready_to_verify_visit(**opt_in_analytics_properties)
         @presenter = ReadyToVerifyPresenter.new(
           enrollment: enrollment,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -314,6 +314,7 @@ class UserMailer < ActionMailer::Base
         is_enhanced_ipp: is_enhanced_ipp,
       )
       @is_enhanced_ipp = is_enhanced_ipp
+      @show_closed_post_office_banner = IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
       mail(
         to: email_address.email,
         subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
@@ -327,6 +328,7 @@ class UserMailer < ActionMailer::Base
     ).image_data
 
     @is_enhanced_ipp = enrollment.enhanced_ipp?
+    @show_closed_post_office_banner = IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
     with_user_locale(user) do
       @presenter = Idv::InPerson::ReadyToVerifyPresenter.new(
         enrollment: enrollment,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -314,7 +314,9 @@ class UserMailer < ActionMailer::Base
         is_enhanced_ipp: is_enhanced_ipp,
       )
       @is_enhanced_ipp = is_enhanced_ipp
-      @show_closed_post_office_banner = IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
+      @show_closed_post_office_banner =
+        IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
+
       mail(
         to: email_address.email,
         subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
@@ -328,7 +330,9 @@ class UserMailer < ActionMailer::Base
     ).image_data
 
     @is_enhanced_ipp = enrollment.enhanced_ipp?
-    @show_closed_post_office_banner = IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
+    @show_closed_post_office_banner =
+      IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
+
     with_user_locale(user) do
       @presenter = Idv::InPerson::ReadyToVerifyPresenter.new(
         enrollment: enrollment,

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -228,6 +228,13 @@
   </section>
 <% end %>
 
+<%# Alert %>
+<% if @show_closed_post_office_banner %>
+  <%= render AlertComponent.new(type: :warning, class: 'margin-y-4', text_tag: :div) do %>
+    <p class="margin-bottom-1 margin-top-0 h3"><strong><%= t('in_person_proofing.post_office_closed.heading') %></strong></p>
+    <p><%= t('in_person_proofing.post_office_closed.body') %></p>
+  <% end %>
+<% end %>
 
 <% if !@is_enhanced_ipp %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>

--- a/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
@@ -275,6 +275,21 @@
   </div>
 <% end %>
 
+<%# alert %>
+<% if @show_closed_post_office_banner %>
+  <table class="usa-alert usa-alert--warning margin-y-4">
+    <tr>
+      <td style="width:16px;">
+        <%= image_tag('email/warning.png', width: 16, height: 16, alt: '', style: 'margin-top: 4px;') %>
+      </td>
+      <td>
+        <p class="margin-bottom-1"><strong><%= t('in_person_proofing.post_office_closed.heading') %></strong></p>
+        <p class="margin-bottom-0"><%= t('in_person_proofing.post_office_closed.body') %></p>
+      </td>
+    </tr>
+  </table>
+<% end %>
+
 <% if !@is_enhanced_ipp %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
   <p class="margin-bottom-4">

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -193,6 +193,7 @@ in_person_outage_message_enabled: false
 in_person_proofing_enabled: false
 in_person_proofing_enforce_tmx: false
 in_person_proofing_opt_in_enabled: false
+in_person_proofing_post_office_closed_alert_enabled: true
 in_person_results_delay_in_hours: 1
 in_person_send_proofing_notifications_enabled: false
 in_person_stop_expiring_enrollments: false
@@ -560,6 +561,7 @@ test:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
   identity_pki_disabled: true
+  in_person_proofing_post_office_closed_alert_enabled: false
   lexisnexis_trueid_account_id: 'test_account'
   lockout_period_in_minutes: 5
   logins_per_email_and_ip_limit: 2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1329,7 +1329,6 @@ in_person_proofing.headings.update_address: Update your current address
 in_person_proofing.headings.update_state_id: Update the information on your ID
 in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
 in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
-in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.process.barcode.caption_label: Enrollment code
 in_person_proofing.process.barcode.heading: Show your %{app_name} barcode
 in_person_proofing.process.barcode.info: The retail associate needs to scan your barcode at the top of this page. You can print this page or show it on your mobile device.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1327,6 +1327,9 @@ in_person_proofing.headings.state_id_milestone_2: Enter the information on your 
 in_person_proofing.headings.switch_back: Switch back to your computer to prepare to verify your identity in person
 in_person_proofing.headings.update_address: Update your current address
 in_person_proofing.headings.update_state_id: Update the information on your ID
+in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
+in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.process.barcode.caption_label: Enrollment code
 in_person_proofing.process.barcode.heading: Show your %{app_name} barcode
 in_person_proofing.process.barcode.info: The retail associate needs to scan your barcode at the top of this page. You can print this page or show it on your mobile device.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1338,6 +1338,9 @@ in_person_proofing.headings.state_id_milestone_2: Ingrese la información de su 
 in_person_proofing.headings.switch_back: Vuelva a su computadora para preparar la verificación de su identidad en persona
 in_person_proofing.headings.update_address: Actualice su dirección actual
 in_person_proofing.headings.update_state_id: Actualice la información de su identificación
+in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
+in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.process.barcode.caption_label: Código de registro
 in_person_proofing.process.barcode.heading: Muestre su código de barras de %{app_name}
 in_person_proofing.process.barcode.info: El empleado debe escanear el código de barras que aparece en la parte superior de esta página. Puede imprimir esta página o mostrarla en su dispositivo móvil.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1340,7 +1340,6 @@ in_person_proofing.headings.update_address: Actualice su dirección actual
 in_person_proofing.headings.update_state_id: Actualice la información de su identificación
 in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
 in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
-in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.process.barcode.caption_label: Código de registro
 in_person_proofing.process.barcode.heading: Muestre su código de barras de %{app_name}
 in_person_proofing.process.barcode.info: El empleado debe escanear el código de barras que aparece en la parte superior de esta página. Puede imprimir esta página o mostrarla en su dispositivo móvil.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1327,6 +1327,9 @@ in_person_proofing.headings.state_id_milestone_2: Saisissez les informations fig
 in_person_proofing.headings.switch_back: Revenez à votre ordinateur pour vous préparer à confirmer votre identité en personne
 in_person_proofing.headings.update_address: Mettez à jour votre adresse actuelle
 in_person_proofing.headings.update_state_id: Mettez à jour les informations figurant sur votre document d’identité
+in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
+in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.process.barcode.caption_label: Code d’inscription
 in_person_proofing.process.barcode.heading: Montrez votre code-barres %{app_name}
 in_person_proofing.process.barcode.info: Le préposé doit scanner votre code-barres en haut de cette page. Vous pouvez imprimer cette page ou la montrer sur votre appareil mobile.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1329,7 +1329,6 @@ in_person_proofing.headings.update_address: Mettez à jour votre adresse actuell
 in_person_proofing.headings.update_state_id: Mettez à jour les informations figurant sur votre document d’identité
 in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
 in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
-in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.process.barcode.caption_label: Code d’inscription
 in_person_proofing.process.barcode.heading: Montrez votre code-barres %{app_name}
 in_person_proofing.process.barcode.info: Le préposé doit scanner votre code-barres en haut de cette page. Vous pouvez imprimer cette page ou la montrer sur votre appareil mobile.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1279,6 +1279,9 @@ in_person_proofing.body.location.retail_hours_sat: 周六：
 in_person_proofing.body.location.retail_hours_sun: 周日：
 in_person_proofing.body.location.retail_hours_weekday: 周一到周五：
 in_person_proofing.body.location.selection: 这是你选择的地点：
+in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
+in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.body.prepare.privacy_disclaimer: '%{app_name} 是一个安全的政府网站。我们和美国邮局使用你的数据来验证你的身份。'
 in_person_proofing.body.prepare.privacy_disclaimer_link: 了解有关隐私和安全的更多信息。
 in_person_proofing.body.prepare.privacy_disclaimer_questions: 有问题吗？

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1342,7 +1342,6 @@ in_person_proofing.headings.update_address: 更新你当前地址
 in_person_proofing.headings.update_state_id: 更新你身份证件上的信息
 in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
 in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
-in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.process.barcode.caption_label: 注册代码
 in_person_proofing.process.barcode.heading: 出示你的 %{app_name} 条形码
 in_person_proofing.process.barcode.info: 邮局工作人员需要扫描该页顶部的条形码你可以把该页打印出来，或在你的移动设备上显示。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1279,9 +1279,6 @@ in_person_proofing.body.location.retail_hours_sat: 周六：
 in_person_proofing.body.location.retail_hours_sun: 周日：
 in_person_proofing.body.location.retail_hours_weekday: 周一到周五：
 in_person_proofing.body.location.selection: 这是你选择的地点：
-in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
-in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
-in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.body.prepare.privacy_disclaimer: '%{app_name} 是一个安全的政府网站。我们和美国邮局使用你的数据来验证你的身份。'
 in_person_proofing.body.prepare.privacy_disclaimer_link: 了解有关隐私和安全的更多信息。
 in_person_proofing.body.prepare.privacy_disclaimer_questions: 有问题吗？
@@ -1343,6 +1340,9 @@ in_person_proofing.headings.state_id_milestone_2: 输入你州政府颁发身份
 in_person_proofing.headings.switch_back: 切换回你的电脑，来准备亲身去验证身份。
 in_person_proofing.headings.update_address: 更新你当前地址
 in_person_proofing.headings.update_state_id: 更新你身份证件上的信息
+in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
+in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
+in_person_proofing.post_office_closed.subject: All Post Offices will be closed on Thursday, January 9, 2025
 in_person_proofing.process.barcode.caption_label: 注册代码
 in_person_proofing.process.barcode.heading: 出示你的 %{app_name} 条形码
 in_person_proofing.process.barcode.info: 邮局工作人员需要扫描该页顶部的条形码你可以把该页打印出来，或在你的移动设备上显示。

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -217,6 +217,7 @@ module IdentityConfig
     config.add(:in_person_proofing_enabled, type: :boolean)
     config.add(:in_person_proofing_enforce_tmx, type: :boolean)
     config.add(:in_person_proofing_opt_in_enabled, type: :boolean)
+    config.add(:in_person_proofing_post_office_closed_alert_enabled, type: :boolean)
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:in_person_send_proofing_notifications_enabled, type: :boolean)
     config.add(:in_person_stop_expiring_enrollments, type: :boolean)

--- a/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
 
     context 'with in person proofing enabled' do
       let(:in_person_proofing_enabled) { true }
+      let(:ipp_post_office_closed_alert_enabled) { false }
 
       context 'authenticated' do
         before do
@@ -125,6 +126,18 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
               response
 
               expect(assigns(:is_enhanced_ipp)).to be true
+            end
+          end
+
+          context 'with in_person_proofing_post_office_closed_alert_enabled' do
+            let(:ipp_post_office_closed_alert_enabled) { true }
+            before do
+              allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
+              .and_return(ipp_post_office_closed_alert_enabled)
+            end
+  
+            it 'renders the show template' do
+              expect(response).to render_template :show
             end
           end
         end

--- a/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
@@ -132,10 +132,11 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
           context 'with in_person_proofing_post_office_closed_alert_enabled' do
             let(:ipp_post_office_closed_alert_enabled) { true }
             before do
-              allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
-              .and_return(ipp_post_office_closed_alert_enabled)
+              allow(IdentityConfig.store)
+                .to receive(:in_person_proofing_post_office_closed_alert_enabled)
+                .and_return(ipp_post_office_closed_alert_enabled)
             end
-  
+
             it 'renders the show template' do
               expect(response).to render_template :show
             end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -64,6 +64,8 @@ module I18n
         { key: 'datetime.dotiw.minutes.one' }, # "minute is minute" in French and English
         { key: 'datetime.dotiw.minutes.other' }, # "minute is minute" in French and English
         { key: 'datetime.dotiw.words_connector' }, # " , " is only punctuation and not translated
+        { key: 'in_person_proofing.post_office_closed.body', locales: %i[es fr zh] }, # temp, waiting on translations 01/03/25
+        { key: 'in_person_proofing.post_office_closed.heading', locales: %i[es fr zh] }, # temp, waiting on translations 01/03/25
         { key: 'in_person_proofing.process.eipp_bring_id.image_alt_text', locales: %i[fr es zh] }, # Real ID is considered a proper noun in this context, ID translated to ID Card in Chinese
         { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
         { key: 'saml_idp.auth.error.title', locales: %i[es] }, # "Error" is "Error" in Spanish

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -937,12 +937,13 @@ RSpec.describe UserMailer, type: :mailer do
       context 'post office closed alert' do
         context 'when the post office closed alert flag is disabled' do
           before do
-            allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
+            allow(IdentityConfig.store)
+              .to receive(:in_person_proofing_post_office_closed_alert_enabled)
               .and_return(false)
           end
-    
+
           it 'does not render the post office closed alert' do
-            aggregate_failures do 
+            aggregate_failures do
               [
                 t('in_person_proofing.post_office_closed.heading'),
                 t('in_person_proofing.post_office_closed.body'),
@@ -954,15 +955,16 @@ RSpec.describe UserMailer, type: :mailer do
             end
           end
         end
-    
+
         context 'when the post office closed alert flag is enabled' do
           before do
-            allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
+            allow(IdentityConfig.store)
+              .to receive(:in_person_proofing_post_office_closed_alert_enabled)
               .and_return(true)
           end
-    
+
           it 'renders the post office closed alert' do
-            aggregate_failures do 
+            aggregate_failures do
               [
                 t('in_person_proofing.post_office_closed.heading'),
                 t('in_person_proofing.post_office_closed.body'),

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -934,6 +934,48 @@ RSpec.describe UserMailer, type: :mailer do
         end
       end
 
+      context 'post office closed alert' do
+        context 'when the post office closed alert flag is disabled' do
+          before do
+            allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
+              .and_return(false)
+          end
+    
+          it 'does not render the post office closed alert' do
+            aggregate_failures do 
+              [
+                t('in_person_proofing.post_office_closed.heading'),
+                t('in_person_proofing.post_office_closed.body'),
+              ].each do |copy|
+                Array(copy).each do |part|
+                  expect(mail.html_part.body).to_not have_content(part)
+                end
+              end
+            end
+          end
+        end
+    
+        context 'when the post office closed alert flag is enabled' do
+          before do
+            allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
+              .and_return(true)
+          end
+    
+          it 'renders the post office closed alert' do
+            aggregate_failures do 
+              [
+                t('in_person_proofing.post_office_closed.heading'),
+                t('in_person_proofing.post_office_closed.body'),
+              ].each do |copy|
+                Array(copy).each do |part|
+                  expect(mail.html_part.body).to have_content(part)
+                end
+              end
+            end
+          end
+        end
+      end
+
       context 'Need to change location section' do
         context 'when Enhanced IPP is not enabled' do
           let(:is_enhanced_ipp) { false }

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -122,8 +122,6 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
         let(:in_person_outage_expected_update_date) { 'October 31, 2023' }
 
         before do
-          allow(IdentityConfig.store).to receive(:in_person_outage_message_enabled)
-            .and_return(true)
           allow(IdentityConfig.store).to receive(:in_person_outage_emailed_by_date)
             .and_return(in_person_outage_emailed_by_date)
           allow(IdentityConfig.store).to receive(:in_person_outage_expected_update_date)
@@ -174,6 +172,54 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
         expect(rendered).not_to have_content(
           t('idv.failure.exceptions.in_person_outage_error_message.ready_to_verify.title'),
         )
+      end
+    end
+  end
+
+  context 'post office closed alert' do
+    context 'when the post office closed alert flag is disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
+          .and_return(false)
+      end
+
+      it 'does not render the outage alert' do
+        render
+  
+        aggregate_failures do
+          [
+            t('in_person_proofing.post_office_closed.heading'),
+            t('in_person_proofing.post_office_closed.body'),
+          ].each do |copy|
+            Array(copy).each do |part|
+              expect(rendered).to_not have_content(part)
+            end
+          end
+        end
+      end
+    end
+
+    context 'when the post office closed alert flag is enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
+          .and_return(true)
+      end
+
+      it 'renders the outage alert' do
+        render
+
+        aggregate_failures do
+          [
+            t('in_person_proofing.post_office_closed.heading'),
+            t('in_person_proofing.post_office_closed.body'),
+          ].each do |copy|
+            Array(copy).each do |part|
+              puts '-----'
+              puts part
+              expect(rendered).to have_content(part)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
 
       it 'does not render the post office closed alert' do
         render
-  
+
         aggregate_failures do
           [
             t('in_person_proofing.post_office_closed.heading'),

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -176,14 +176,13 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
     end
   end
 
-  context 'post office closed alert' do
-    context 'when the post office closed alert flag is disabled' do
+  context 'post office warning' do
+    context 'when the show closed post office banner is disabled' do
       before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
-          .and_return(false)
+        @show_closed_post_office_banner = false
       end
 
-      it 'does not render the outage alert' do
+      it 'does not render the post office closed alert' do
         render
   
         aggregate_failures do
@@ -199,13 +198,12 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
       end
     end
 
-    context 'when the post office closed alert flag is enabled' do
+    context 'when the show closed post office banner is enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_post_office_closed_alert_enabled)
-          .and_return(true)
+        @show_closed_post_office_banner = true
       end
 
-      it 'renders the outage alert' do
+      it 'renders the post office closed alert' do
         render
 
         aggregate_failures do
@@ -214,8 +212,6 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
             t('in_person_proofing.post_office_closed.body'),
           ].each do |copy|
             Array(copy).each do |part|
-              puts '-----'
-              puts part
               expect(rendered).to have_content(part)
             end
           end


### PR DESCRIPTION
## 🎫 Ticket
[LG-15378](https://cm-jira.usa.gov/browse/LG-15378) Add temporary copy about post office closure to barcode email and barcode page

## 🛠 Summary of changes

- Add config `in_person_proofing_post_office_closed_alert_enabled` in the default and set it to **true** so that this banner will be displayed once it is deployed in each environment (including production) on Tuesday 01/07/25. **To my understanding, we can then use AWS secrets to disable it on Friday 01/10/25 so we don't need to wait for a deployment to hide the alert**
- Add config `in_person_proofing_post_office_closed_alert_enabled: false` in the test section 
- Add Warning Banner to conditionally display Post Office Closed Message on Ready to Verify Email (this includes email reminder and EIPP email) (aka Barcode email)
- Add Warning Banner to conditionally display Post Office Closed Message on Ready to Verify View (aka Barcode View)
- New specs to check conditionally rendering
- NOTICE: **We do not have translation in yet**. They are expected to come in on Tuesday. We will probably merge this as is and open a new PR to update translations.

You can see the warning banner here on this [Figma](https://www.figma.com/design/1lt1AsemN26fPGYpwVDs3e/LG-15367%3A-Temp-copy-about-Post-Office-closures?node-id=0-1&p=f&t=jfte8RXhxFFq6xK2-0) 

## 📜 Testing Plan

- [ ] Step 1 Come in through Sinatra. Create an account. Move through the ID-IPP flow.
- [ ] Step 2 Inspect the Ready to Verify view and email to ensure content and layout of banner is working as expected.
- [ ] Step 3 Run through step 1 and 2 for English, Spanish, French, and Chinese ensuring view and email all render for each language.
- [ ] Step 4 Inspect other emails using rails/mailers -- be sure to test that all languages are rendering even though we don't have translations in yet. 
1. http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify
2. http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify_enhanced_ipp_enabled
3. http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify_reminder
4. http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify_reminder_enhanced_ipp_enabled
- [ ] Step 5  Kill the server. Update application.yml. Set `in_person_proofing_post_office_closed_alert_enabled: false`
- [ ] Step 6 Run through step 1. Confirm that the banner does not display on the Ready to Verify view and email when the flag is disabled.

## 👀 Screenshots

|  template described | when `in_person_proofing_post_office_closed_alert_enabled: false` | when `in_person_proofing_post_office_closed_alert_enabled: true` |
| ----- | ----- | ----- |
| email: id-ipp  | <img width="195" alt="Screenshot 2025-01-03 at 3 39 49 PM" src="https://github.com/user-attachments/assets/2effffff-4ad1-4bda-8f7d-547bdeb13ecb" /> | <img width="568" alt="Screenshot 2025-01-03 at 3 37 13 PM" src="https://github.com/user-attachments/assets/3ba4d3c1-70d7-498d-9f72-01701f5767b9" />  |
| email: eipp | <img width="233" alt="Screenshot 2025-01-03 at 3 39 59 PM" src="https://github.com/user-attachments/assets/c6057684-58c6-49f6-b1f9-86deaafd1137" />  | <img width="371" alt="Screenshot 2025-01-03 at 3 37 53 PM" src="https://github.com/user-attachments/assets/b33b5586-9234-47d3-ba12-3a4fa0ff023c" />  |
| email: id-ipp reminder | <img width="219" alt="Screenshot 2025-01-03 at 3 40 10 PM" src="https://github.com/user-attachments/assets/41be8eb1-1371-458f-85bc-dd9cb9c624a2" />  | <img width="207" alt="Screenshot 2025-01-03 at 3 38 22 PM" src="https://github.com/user-attachments/assets/42554e52-b61a-463c-ad4e-47fa6a876542" />  |
| email: eipp reminder | <img width="165" alt="Screenshot 2025-01-03 at 3 40 27 PM" src="https://github.com/user-attachments/assets/86a775a5-1362-4c69-8db3-7ab9dbdf6d18" /> <img width="195" alt="Screenshot 2025-01-03 at 3 40 31 PM" src="https://github.com/user-attachments/assets/d76ca3bf-f845-4f94-9a5c-81ed1503b84a" />  | <img width="218" alt="Screenshot 2025-01-03 at 3 38 36 PM" src="https://github.com/user-attachments/assets/c3138b77-d7f4-48c5-bcc5-e915b714c387" />  |
| view id-ipp | ![Screenshot 2025-01-03 at 3 50 38 PM](https://github.com/user-attachments/assets/4afd3dec-63af-4585-a733-8aa2c34c45b9) | ![Screenshot 2025-01-03 at 3 49 41 PM](https://github.com/user-attachments/assets/26fc7586-dc8f-4c94-9207-c63ad2b6f550) ![Screenshot 2025-01-03 at 3 49 46 PM](https://github.com/user-attachments/assets/18cdf50d-07f3-43b3-a5e4-dda3d9738bab) |
| view eipp | ![Screenshot 2025-01-03 at 3 58 46 PM](https://github.com/user-attachments/assets/52dc7369-cacc-48f7-9c18-21399f308a96) ![Screenshot 2025-01-03 at 3 58 51 PM](https://github.com/user-attachments/assets/964d02e8-36eb-4942-8a7a-0ce8cdcfcac0) | ![Screenshot 2025-01-03 at 3 58 18 PM](https://github.com/user-attachments/assets/34974336-bdb0-4caf-80e4-f35859666c08) ![Screenshot 2025-01-03 at 3 58 28 PM](https://github.com/user-attachments/assets/096551d5-9557-4632-b22f-f04fd5d7266a) |



<details>
<summary>We don't have translations in yet. Here is a screenshot of ID-IPP Ready to Verify View in each language:</summary>

![Screenshot 2025-01-03 at 3 52 14 PM](https://github.com/user-attachments/assets/4b3c376a-e444-428a-aed5-cf52fb9128b1)

![Screenshot 2025-01-03 at 3 52 23 PM](https://github.com/user-attachments/assets/3587b067-3949-4d04-b12e-d10605c6f076)

![Screenshot 2025-01-03 at 3 52 30 PM](https://github.com/user-attachments/assets/1c667af5-3b7c-4e61-8795-6dda9008992e)

</details>


<details>
<summary>If we don't have selected_location_details present, this is how the view will look:</summary>


![Screenshot 2025-01-03 at 6 23 00 PM](https://github.com/user-attachments/assets/2875c847-c959-4a92-9b57-dedbdfffc37e)

</details>


