### PR TITLE
LG-15260 Add NH and OK to list of AAMVA supported states

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -21,7 +21,7 @@ aamva_private_key: ''
 aamva_public_key: ''
 aamva_send_id_type: true
 aamva_send_middle_name: true
-aamva_supported_jurisdictions: '["AL","AR","AZ","CO","CT","DC","DE","FL","GA","HI","IA","ID","IL","IN","KS","KY","MA","MD","ME","MI","MO","MS","MT","NC","ND","NE","NJ","NM","NV","OH","OR","PA","RI","SC","SD","TN","TX","VA","VT","WA","WI","WV","WY"]'
+aamva_supported_jurisdictions: '["AL","AR","AZ","CO","CT","DC","DE","FL","GA","HI","IA","ID","IL","IN","KS","KY","MA","MD","ME","MI","MO","MS","MT","NC","ND","NE","NH","NJ","NM","NV","OH","OK","OR","PA","RI","SC","SD","TN","TX","VA","VT","WA","WI","WV","WY"]'
 aamva_verification_request_timeout: 5.0
 aamva_verification_url: https://example.org:12345/verification/url
 account_creation_device_profiling: disabled


### PR DESCRIPTION
AAMVA let us know these states are now available to us through DLDV. I used the "Jonny Proofs" script in the [DLDV Outage Guide](https://gitlab.login.gov/lg/identity-devops/-/wikis/Runbook:-AAMVA-DLDV-outage) to confirm connectivity.

This commit adds these states to the list of configured states.
