### PR TITLE
Drop proofing_components table

### DIFF
--- a/db/primary_migrate/20250106232958_drop_proofing_components_table.rb
+++ b/db/primary_migrate/20250106232958_drop_proofing_components_table.rb
@@ -1,0 +1,5 @@
+class DropProofingComponentsTable < ActiveRecord::Migration[7.2]
+  def change
+    drop_table :proofing_components
+  end
+end

--- a/db/primary_migrate/20250106232958_drop_proofing_components_table.rb
+++ b/db/primary_migrate/20250106232958_drop_proofing_components_table.rb
@@ -1,5 +1,23 @@
 class DropProofingComponentsTable < ActiveRecord::Migration[7.2]
   def change
-    drop_table :proofing_components
+    drop_table :proofing_components do |t|
+      t.integer "user_id", null: false, comment: "sensitive=false"
+      t.string "document_check", comment: "sensitive=false"
+      t.string "document_type", comment: "sensitive=false"
+      t.string "source_check", comment: "sensitive=false"
+      t.string "resolution_check", comment: "sensitive=false"
+      t.string "address_check", comment: "sensitive=false"
+      t.datetime "verified_at", precision: nil, comment: "sensitive=false"
+      t.datetime "created_at", precision: nil, null: false, comment: "sensitive=false"
+      t.datetime "updated_at", precision: nil, null: false, comment: "sensitive=false"
+      t.string "liveness_check", comment: "sensitive=false"
+      t.string "device_fingerprinting_vendor", comment: "sensitive=false"
+      t.boolean "threatmetrix", comment: "sensitive=false"
+      t.string "threatmetrix_review_status", comment: "sensitive=false"
+      t.string "threatmetrix_risk_rating", comment: "sensitive=false"
+      t.string "threatmetrix_policy_score", comment: "sensitive=false"
+      t.index ["user_id"], name: "index_proofing_components_on_user_id", unique: true
+      t.index ["verified_at"], name: "index_proofing_components_on_verified_at"
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_03_163014) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_06_232958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -469,26 +469,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_03_163014) do
     t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"
     t.index ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)"
     t.index ["user_id"], name: "index_profiles_on_user_id"
-  end
-
-  create_table "proofing_components", force: :cascade do |t|
-    t.integer "user_id", null: false, comment: "sensitive=false"
-    t.string "document_check", comment: "sensitive=false"
-    t.string "document_type", comment: "sensitive=false"
-    t.string "source_check", comment: "sensitive=false"
-    t.string "resolution_check", comment: "sensitive=false"
-    t.string "address_check", comment: "sensitive=false"
-    t.datetime "verified_at", precision: nil, comment: "sensitive=false"
-    t.datetime "created_at", precision: nil, null: false, comment: "sensitive=false"
-    t.datetime "updated_at", precision: nil, null: false, comment: "sensitive=false"
-    t.string "liveness_check", comment: "sensitive=false"
-    t.string "device_fingerprinting_vendor", comment: "sensitive=false"
-    t.boolean "threatmetrix", comment: "sensitive=false"
-    t.string "threatmetrix_review_status", comment: "sensitive=false"
-    t.string "threatmetrix_risk_rating", comment: "sensitive=false"
-    t.string "threatmetrix_policy_score", comment: "sensitive=false"
-    t.index ["user_id"], name: "index_proofing_components_on_user_id", unique: true
-    t.index ["verified_at"], name: "index_proofing_components_on_verified_at"
   end
 
   create_table "registration_logs", force: :cascade do |t|


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-14367](https://cm-jira.usa.gov/browse/LG-14367)

## 🛠 Summary of changes

Since #11564 we've stopped writing to this table, so now is the time to drop it.

This table was previously used as a temporary datastore for proofing component values as a user moves through IdV. We now dynamically derive those values from the Idv::Session, so this table is not needed any longer.

## 📜 Testing Plan

- [ ] Apply the migration, then go through IdV. Observe that it works.
