### PR TITLE
LG-15396 Log the initiating SP on verify-by-mail code entry

### DIFF
--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -49,6 +49,7 @@ class GpoVerifyForm
         pii_like_keypaths: [[:errors, :otp], [:error_details, :otp]],
         pending_in_person_enrollment: !!pending_profile&.in_person_enrollment&.pending?,
         fraud_check_failed: fraud_check_failed,
+        initiating_service_provider: pending_profile&.initiating_service_provider_issuer,
       },
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5253,6 +5253,7 @@ module AnalyticsEvents
   # @param [Integer] which_letter Sorted by enqueue time, which letter had this code
   # @param [Integer] letter_count How many letters did the user enqueue for this profile
   # @param [Integer] profile_age_in_seconds How many seconds have passed since profile created
+  # @param [String] initiating_service_provider The initiating service provider issuer
   # @param [Integer] submit_attempts Number of attempts to enter a correct code
   #                  (previously called "attempts")
   # @param [Boolean] pending_in_person_enrollment
@@ -5267,6 +5268,7 @@ module AnalyticsEvents
     which_letter:,
     letter_count:,
     profile_age_in_seconds:,
+    initiating_service_provider:,
     submit_attempts:,
     pending_in_person_enrollment:,
     fraud_check_failed:,
@@ -5282,6 +5284,7 @@ module AnalyticsEvents
       which_letter:,
       letter_count:,
       profile_age_in_seconds:,
+      initiating_service_provider:,
       submit_attempts:,
       pending_in_person_enrollment:,
       fraud_check_failed:,

--- a/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
@@ -181,7 +181,10 @@ RSpec.describe Idv::ByMail::EnterCodeController do
 
       let(:user) { create(:user, :with_pending_gpo_profile, created_at: 2.days.ago) }
       let!(:pending_profile) { user.gpo_verification_pending_profile }
+      let(:initiating_service_provider) { create(:service_provider) }
       let(:success) { true }
+
+      before { pending_profile.update!(initiating_service_provider:) }
 
       it 'uses the PII from the pending profile' do
         # action will make the profile active, so grab the ID here.
@@ -202,6 +205,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
           fraud_check_failed: false,
           enqueued_at: pending_profile.gpo_confirmation_codes.last.code_sent_at,
           profile_age_in_seconds: instance_of(Integer),
+          initiating_service_provider: initiating_service_provider.issuer,
           which_letter: 1,
           letter_count: 1,
           submit_attempts: 1,
@@ -247,6 +251,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
             fraud_check_failed: false,
             enqueued_at: pending_profile.gpo_confirmation_codes.last.code_sent_at,
             profile_age_in_seconds: instance_of(Integer),
+            initiating_service_provider: initiating_service_provider.issuer,
             which_letter: 1,
             letter_count: 1,
             submit_attempts: 1,
@@ -276,6 +281,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
               fraud_check_failed: true,
               enqueued_at: pending_profile.gpo_confirmation_codes.last.code_sent_at,
               profile_age_in_seconds: instance_of(Integer),
+              initiating_service_provider: initiating_service_provider.issuer,
               which_letter: 1,
               letter_count: 1,
               submit_attempts: 1,
@@ -313,6 +319,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
               fraud_check_failed: true,
               enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
               profile_age_in_seconds: instance_of(Integer),
+              initiating_service_provider: initiating_service_provider.issuer,
               which_letter: 1,
               letter_count: 1,
               submit_attempts: 1,
@@ -355,6 +362,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
               fraud_check_failed: true,
               enqueued_at: user.pending_profile.gpo_confirmation_codes.last.code_sent_at,
               profile_age_in_seconds: instance_of(Integer),
+              initiating_service_provider: initiating_service_provider.issuer,
               which_letter: 1,
               letter_count: 1,
               submit_attempts: 1,


### PR DESCRIPTION
When a user enters a code during GPO there usually is not a service provider present in the SP session. This is because the letter we send instructs users to go directly to Login.gov to enter the code. As a result it is difficult to collect verification events for service providers in the out-of-band case since we cannot group events by `properties.service_provider`.

This commit adds the initiating service provider to the logged analytics event when a user enters a GPO code. The issuer is already logged on in-person and fraud review so this change allows us to group all out-of-band verification events by service provider.
