### PR TITLE
Add Document Encryption Service for Doc Escrow

### DIFF
--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module EncryptedDocStorage
+  class DocWriter
+    Result = Struct.new(
+      :front_uuid,
+      :back_uuid,
+      :encryption_key,
+    )
+
+    def write(front_image:, back_image:, data_store: LocalStorage)
+      front_uuid = SecureRandom.uuid
+      back_uuid = SecureRandom.uuid
+      storage = data_store.new
+
+      storage.write_image(
+        encrypted_image: encrypted_image(front_image),
+        name: front_uuid,
+      )
+      storage.write_image(
+        encrypted_image: encrypted_image(back_image),
+        name: back_uuid,
+      )
+
+      Result.new(
+        front_uuid:,
+        back_uuid:,
+        encryption_key: Base64.strict_encode64(key),
+      )
+    end
+
+    private
+
+    def aes_cipher
+      @aes_cipher ||= Encryption::AesCipher.new
+    end
+
+    def encrypted_image(image)
+      aes_cipher.encrypt(image, key)
+    end
+
+    def key
+      @key ||= SecureRandom.bytes(32)
+    end
+  end
+end

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -25,7 +25,7 @@ module EncryptedDocStorage
     private
 
     def aes_cipher
-      @aes_cipher ||= Encryption::AesCipher.new
+      @aes_cipher ||= Encryption::AesCipherV2.new
     end
 
     def key

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -3,28 +3,21 @@
 module EncryptedDocStorage
   class DocWriter
     Result = Struct.new(
-      :front_uuid,
-      :back_uuid,
+      :name,
       :encryption_key,
     )
 
-    def write(front_image:, back_image:, data_store: LocalStorage)
-      front_uuid = SecureRandom.uuid
-      back_uuid = SecureRandom.uuid
+    def write(image:, data_store: LocalStorage)
+      name = SecureRandom.uuid
       storage = data_store.new
 
       storage.write_image(
-        encrypted_image: encrypted_image(front_image),
-        name: front_uuid,
-      )
-      storage.write_image(
-        encrypted_image: encrypted_image(back_image),
-        name: back_uuid,
+        encrypted_image: aes_cipher.encrypt(image, key),
+        name:,
       )
 
       Result.new(
-        front_uuid:,
-        back_uuid:,
+        name:,
         encryption_key: Base64.strict_encode64(key),
       )
     end
@@ -33,10 +26,6 @@ module EncryptedDocStorage
 
     def aes_cipher
       @aes_cipher ||= Encryption::AesCipher.new
-    end
-
-    def encrypted_image(image)
-      aes_cipher.encrypt(image, key)
     end
 
     def key

--- a/app/services/encrypted_doc_storage/local_storage.rb
+++ b/app/services/encrypted_doc_storage/local_storage.rb
@@ -5,7 +5,9 @@ module EncryptedDocStorage
     def write_image(encrypted_image:, name:)
       FileUtils.mkdir_p(tmp_document_storage_dir)
 
-      File.write(tmp_document_storage_dir.join(name), encrypted_image)
+      File.open(tmp_document_storage_dir.join(name), 'wb') do |f|
+        f.write(encrypted_image)
+      end
     end
 
     private

--- a/app/services/encrypted_doc_storage/local_storage.rb
+++ b/app/services/encrypted_doc_storage/local_storage.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module EncryptedDocStorage
+  class LocalStorage
+    def write_image(encrypted_image:, name:)
+      FileUtils.mkdir_p(tmp_document_storage_dir)
+
+      File.write(tmp_document_storage_dir.join(name), encrypted_image)
+    end
+
+    private
+
+    def tmp_document_storage_dir
+      Rails.root.join('tmp', 'encrypted_doc_storage')
+    end
+  end
+end

--- a/app/services/encrypted_doc_storage/s3_storage.rb
+++ b/app/services/encrypted_doc_storage/s3_storage.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module EncryptedDocStorage
+  class S3Storage
+    def write_image(encrypted_image:, name:)
+      s3_client.put_object(
+        bucket:,
+        body: encrypted_image,
+        key: name,
+      )
+    end
+
+    private
+
+    def s3_client
+      Aws::S3::Client.new(
+        http_open_timeout: 5,
+        http_read_timeout: 5,
+        compute_checksums: false,
+      )
+    end
+
+    def bucket
+      IdentityConfig.store.encrypted_document_storage_s3_bucket
+    end
+  end
+end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -130,6 +130,7 @@ enable_load_testing_mode: false
 enable_rate_limiting: true
 enable_test_routes: true
 enable_usps_verification: true
+encrypted_document_storage_s3_bucket: 'test-bucket'
 event_disavowal_expiration_hours: 240
 facial_match_general_availability_enabled: true
 feature_idv_force_gpo_verification_enabled: false
@@ -522,6 +523,7 @@ production:
   email_registrations_per_ip_track_only_mode: true
   enable_test_routes: false
   enable_usps_verification: false
+  encrypted_document_storage_s3_bucket: ''
   facial_match_general_availability_enabled: false
   feature_select_email_to_share_enabled: false
   idv_sp_required: true

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -148,6 +148,7 @@ module IdentityConfig
     config.add(:enable_rate_limiting, type: :boolean)
     config.add(:enable_test_routes, type: :boolean)
     config.add(:enable_usps_verification, type: :boolean)
+    config.add(:encrypted_document_storage_s3_bucket, type: :string)
     config.add(:event_disavowal_expiration_hours, type: :integer)
     config.add(:facial_match_general_availability_enabled, type: :boolean)
     config.add(:feature_idv_force_gpo_verification_enabled, type: :boolean)

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
       result = subject.write(image:)
 
       key = Base64.strict_decode64(result.encryption_key)
-      aes_cipher = Encryption::AesCipher.new
+      aes_cipher = Encryption::AesCipherV2.new
 
       written_image = aes_cipher.decrypt(
         File.read(file_path(result.name)),

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe EncryptedDocStorage::DocWriter do
+  describe '#write' do
+    let(:front_image) { 'front_image' }
+    let(:back_image) { 'back_image' }
+
+    subject do
+      EncryptedDocStorage::DocWriter.new
+    end
+
+    it 'encrypts the document and writes it to storage' do
+      result = subject.write(
+        front_image:,
+        back_image:,
+      )
+
+      key = Base64.strict_decode64(result.encryption_key)
+      aes_cipher = Encryption::AesCipher.new
+
+      written_front_image = aes_cipher.decrypt(
+        File.read(file_path(result.front_uuid)),
+        key,
+      )
+      written_back_image = aes_cipher.decrypt(
+        File.read(file_path(result.back_uuid)),
+        key,
+      )
+
+      expect(written_front_image).to eq(front_image)
+      expect(written_back_image).to eq(back_image)
+    end
+
+    it 'uses LocalStorage by default' do
+      expect_any_instance_of(EncryptedDocStorage::LocalStorage).to receive(:write_image).twice
+      expect_any_instance_of(EncryptedDocStorage::S3Storage).to_not receive(:write_image)
+
+      subject.write(
+        front_image:,
+        back_image:,
+      )
+    end
+
+    context 'when S3Storage is passed in' do
+      it 'uses S3' do
+        expect_any_instance_of(EncryptedDocStorage::S3Storage).to receive(:write_image).twice
+        expect_any_instance_of(EncryptedDocStorage::LocalStorage).not_to receive(:write_image)
+
+        subject.write(
+          front_image:,
+          back_image:,
+          data_store: EncryptedDocStorage::S3Storage,
+        )
+      end
+    end
+
+    def file_path(uuid)
+      Rails.root.join('tmp', 'encrypted_doc_storage', uuid)
+    end
+  end
+end

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EncryptedDocStorage::DocWriter do
   describe '#write' do
-    let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg')}
+    let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg') }
     let(:image) { File.read(img_path) }
 
     subject do

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe EncryptedDocStorage::DocWriter do
   describe '#write' do
-    let(:image) { 'image' }
+    let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg')}
+    let(:image) { File.read(img_path) }
 
     subject do
       EncryptedDocStorage::DocWriter.new
@@ -18,6 +19,9 @@ RSpec.describe EncryptedDocStorage::DocWriter do
         File.read(file_path(result.name)),
         key,
       )
+
+      # cleanup
+      File.delete(file_path(result.name))
 
       expect(written_image).to eq(image)
     end

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -2,53 +2,40 @@ require 'rails_helper'
 
 RSpec.describe EncryptedDocStorage::DocWriter do
   describe '#write' do
-    let(:front_image) { 'front_image' }
-    let(:back_image) { 'back_image' }
+    let(:image) { 'image' }
 
     subject do
       EncryptedDocStorage::DocWriter.new
     end
 
     it 'encrypts the document and writes it to storage' do
-      result = subject.write(
-        front_image:,
-        back_image:,
-      )
+      result = subject.write(image:)
 
       key = Base64.strict_decode64(result.encryption_key)
       aes_cipher = Encryption::AesCipher.new
 
-      written_front_image = aes_cipher.decrypt(
-        File.read(file_path(result.front_uuid)),
-        key,
-      )
-      written_back_image = aes_cipher.decrypt(
-        File.read(file_path(result.back_uuid)),
+      written_image = aes_cipher.decrypt(
+        File.read(file_path(result.name)),
         key,
       )
 
-      expect(written_front_image).to eq(front_image)
-      expect(written_back_image).to eq(back_image)
+      expect(written_image).to eq(image)
     end
 
     it 'uses LocalStorage by default' do
-      expect_any_instance_of(EncryptedDocStorage::LocalStorage).to receive(:write_image).twice
+      expect_any_instance_of(EncryptedDocStorage::LocalStorage).to receive(:write_image).once
       expect_any_instance_of(EncryptedDocStorage::S3Storage).to_not receive(:write_image)
 
-      subject.write(
-        front_image:,
-        back_image:,
-      )
+      subject.write(image:)
     end
 
     context 'when S3Storage is passed in' do
       it 'uses S3' do
-        expect_any_instance_of(EncryptedDocStorage::S3Storage).to receive(:write_image).twice
+        expect_any_instance_of(EncryptedDocStorage::S3Storage).to receive(:write_image).once
         expect_any_instance_of(EncryptedDocStorage::LocalStorage).not_to receive(:write_image)
 
         subject.write(
-          front_image:,
-          back_image:,
+          image:,
           data_store: EncryptedDocStorage::S3Storage,
         )
       end

--- a/spec/services/encrypted_doc_storage/local_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/local_storage_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe EncryptedDocStorage::LocalStorage do
-  let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg')}
+  let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg') }
   let(:image) { File.read(img_path) }
   let(:encrypted_image) do
     Encryption::AesCipherV2.new.encrypt(image, SecureRandom.bytes(32))
@@ -20,10 +20,10 @@ RSpec.describe EncryptedDocStorage::LocalStorage do
       f = File.new(path, 'rb')
       result = f.read
       f.close
-    
+
       # cleanup
       File.delete(path)
-      
+
       expect(result).to eq(encrypted_image)
     end
   end

--- a/spec/services/encrypted_doc_storage/local_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/local_storage_spec.rb
@@ -1,19 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe EncryptedDocStorage::LocalStorage do
+  let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg')}
+  let(:image) { File.read(img_path) }
+  let(:encrypted_image) do
+    Encryption::AesCipherV2.new.encrypt(image, SecureRandom.bytes(32))
+  end
+
   describe '#write_image' do
     it 'writes the document to the disk' do
-      encrypted_image = 'encrypted document.'
       name = SecureRandom.uuid
 
       EncryptedDocStorage::LocalStorage.new.write_image(
         encrypted_image:,
         name:,
       )
+      path = Rails.root.join('tmp', 'encrypted_doc_storage', name)
 
-      result = File.read(
-        Rails.root.join('tmp', 'encrypted_doc_storage', name),
-      )
+      f = File.new(path, 'rb')
+      result = f.read
+      f.close
+    
+      # cleanup
+      File.delete(path)
+      
       expect(result).to eq(encrypted_image)
     end
   end

--- a/spec/services/encrypted_doc_storage/local_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/local_storage_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe EncryptedDocStorage::LocalStorage do
+  describe '#write_image' do
+    it 'writes the document to the disk' do
+      encrypted_image = 'encrypted document.'
+      name = SecureRandom.uuid
+
+      EncryptedDocStorage::LocalStorage.new.write_image(
+        encrypted_image:,
+        name:,
+      )
+
+      result = File.read(
+        Rails.root.join('tmp', 'encrypted_doc_storage', name),
+      )
+      expect(result).to eq(encrypted_image)
+    end
+  end
+end

--- a/spec/services/encrypted_doc_storage/s3_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/s3_storage_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EncryptedDocStorage::S3Storage do
   subject { EncryptedDocStorage::S3Storage.new }
-  let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg')}
+  let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg') }
   let(:image) { File.read(img_path) }
   let(:encrypted_image) do
     Encryption::AesCipherV2.new.encrypt(image, SecureRandom.bytes(32))

--- a/spec/services/encrypted_doc_storage/s3_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/s3_storage_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe EncryptedDocStorage::S3Storage do
   subject { EncryptedDocStorage::S3Storage.new }
+  let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg')}
+  let(:image) { File.read(img_path) }
+  let(:encrypted_image) do
+    Encryption::AesCipherV2.new.encrypt(image, SecureRandom.bytes(32))
+  end
 
   describe '#write_image' do
     let(:stubbed_s3_client) { Aws::S3::Client.new(stub_responses: true) }
@@ -12,7 +17,6 @@ RSpec.describe EncryptedDocStorage::S3Storage do
     end
 
     it 'writes the document to S3' do
-      encrypted_image = 'encrypted document.'
       name = '123abc'
 
       subject.write_image(encrypted_image:, name:)

--- a/spec/services/encrypted_doc_storage/s3_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/s3_storage_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe EncryptedDocStorage::S3Storage do
+  subject { EncryptedDocStorage::S3Storage.new }
+
+  describe '#write_image' do
+    let(:stubbed_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+
+    before do
+      allow(subject).to receive(:s3_client).and_return(stubbed_s3_client)
+      allow(stubbed_s3_client).to receive(:put_object)
+    end
+
+    it 'writes the document to S3' do
+      encrypted_image = 'encrypted document.'
+      name = '123abc'
+
+      subject.write_image(encrypted_image:, name:)
+
+      expect(stubbed_s3_client).to have_received(:put_object).with(
+        bucket: IdentityConfig.store.encrypted_document_storage_s3_bucket,
+        key: name,
+        body: encrypted_image,
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Add Document Encryption Service for Doc Escrow](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/143)

## 🛠 Summary of changes
This change adds an `EncryptedDocStorage` service that will be used for Doc Escrow.

- encrypts the front and back images of a document
- stores the images locally by default
- returns the image UUIDs and the encryption key

Open questions:
This implementation stole liberally from @jmhooper's [initial implementation of this service](https://github.com/18F/identity-idp/pull/7351/files#diff-49d7f0f1cea15bb7ca7d7c7c4108c78504fbeeae0066ae767cdd872dbf0cfaad). It currently relies on two images being passed in. Do we think that will always be the case? Is it possible that there might be single images (like a selfie?) 

I am wondering if this updated implementation should:
- Only accept a single image so that the caller of this method has to call it multiple times for each image they want encrypted, and each image has its own encryption key, OR;
- Accept an array of images and then loop over them, and return all the uuids with a single encryption key, OR;
- Make the same assumptions the first implementation made about there always being a front/back image.

I think I like the first option best, as it makes less assumptions, but does mean multiple encryption keys. Would love to hear other thoughts!

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
