### PR TITLE
Create classes for tracking Attempts API events

### DIFF
--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module AttemptsApi
+  class Tracker
+    attr_reader :session_id, :enabled_for_session, :request, :user, :sp, :cookie_device_uuid,
+                :sp_request_uri, :analytics
+
+    def initialize(session_id:, request:, user:, sp:, cookie_device_uuid:,
+                   sp_request_uri:, enabled_for_session:, analytics:)
+      @session_id = session_id
+      @request = request
+      @user = user
+      @sp = sp
+      @cookie_device_uuid = cookie_device_uuid
+      @sp_request_uri = sp_request_uri
+      @enabled_for_session = enabled_for_session
+      @analytics = analytics
+    end
+    include TrackerEvents
+
+    def track_event(event_type, metadata = {})
+      return unless enabled?
+
+      if metadata.has_key?(:failure_reason) &&
+         (metadata[:failure_reason].blank? ||
+          metadata[:success].present?)
+        metadata.delete(:failure_reason)
+      end
+
+      event_metadata = {
+        user_agent: request&.user_agent,
+        unique_session_id: hashed_session_id,
+        user_uuid: sp && AgencyIdentityLinker.for(user: user, service_provider: sp)&.uuid,
+        device_fingerprint: hashed_cookie_device_uuid,
+        user_ip_address: request&.remote_ip,
+        application_url: sp_request_uri,
+        client_port: CloudFrontHeaderParser.new(request).client_port,
+      }
+
+      event_metadata.merge!(metadata)
+
+      event = AttemptEvent.new(
+        event_type: event_type,
+        session_id: session_id,
+        occurred_at: Time.zone.now,
+        event_metadata: event_metadata,
+      )
+
+      jwe = event.to_jwe(
+        issuer: sp.issuer,
+        public_key: sp.ssl_certs.first.public_key,
+      )
+
+      redis_client.write_event(
+        event_key: event.jti,
+        jwe: jwe,
+        timestamp: event.occurred_at,
+        issuer: sp.issuer,
+      )
+
+      event
+    end
+
+    def parse_failure_reason(result)
+      return result.to_h[:error_details] || result.errors.presence
+    end
+
+    private
+
+    def hashed_session_id
+      return nil unless user&.unique_session_id
+      Digest::SHA1.hexdigest(user&.unique_session_id)
+    end
+
+    def hashed_cookie_device_uuid
+      return nil unless cookie_device_uuid
+      Digest::SHA1.hexdigest(cookie_device_uuid)
+    end
+
+    def enabled?
+      IdentityConfig.store.attempts_api_enabled && @enabled_for_session
+    end
+
+    def redis_client
+      @redis_client ||= AttemptsApi::RedisClient.new
+    end
+  end
+end

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module AttemptsApi
+  module TrackerEvents
+    # @param [String] email The submitted email address
+    # @param [Boolean] success True if the email and password matched
+    # A user has submitted an email address and password for authentication
+    def email_and_password_auth(email:, success:)
+      track_event(
+        :email_and_password_auth,
+        email: email,
+        success: success,
+      )
+    end
+  end
+end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -40,6 +40,7 @@ allowed_verified_within_providers: '[]'
 asset_host: ''
 async_stale_job_timeout_seconds: 300
 async_wait_timeout_seconds: 60
+attempts_api_enabled: false
 attempts_api_event_ttl_seconds: 3_600
 attribute_encryption_key:
 attribute_encryption_key_queue: '[]'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -59,6 +59,7 @@ module IdentityConfig
     config.add(:async_stale_job_timeout_seconds, type: :integer)
     config.add(:async_wait_timeout_seconds, type: :integer)
     config.add(:attempts_api_event_ttl_seconds, type: :integer)
+    config.add(:attempts_api_enabled, type: :boolean)
     config.add(:attribute_encryption_key, type: :string)
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:available_locales, type: :comma_separated_string_list)

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+RSpec.describe AttemptsApi::Tracker do
+  before do
+    allow(IdentityConfig.store).to receive(:attempts_api_enabled)
+      .and_return(attempts_api_enabled)
+    allow(request).to receive(:user_agent).and_return('example/1.0')
+    allow(request).to receive(:remote_ip).and_return('192.0.2.1')
+    allow(request).to receive(:headers).and_return(
+      { 'CloudFront-Viewer-Address' => '192.0.2.1:1234' },
+    )
+  end
+
+  let(:attempts_api_enabled) { true }
+  let(:session_id) { 'test-session-id' }
+  let(:enabled_for_session) { true }
+  let(:request) { instance_double(ActionDispatch::Request) }
+  let(:service_provider) { create(:service_provider) }
+  let(:cookie_device_uuid) { 'device_id' }
+  let(:sp_request_uri) { 'https://example.com/auth_page' }
+  let(:user) { create(:user) }
+  let(:analytics) { FakeAnalytics.new }
+
+  subject do
+    described_class.new(
+      session_id: session_id,
+      request: request,
+      user: user,
+      sp: service_provider,
+      cookie_device_uuid: cookie_device_uuid,
+      sp_request_uri: sp_request_uri,
+      enabled_for_session: enabled_for_session,
+      analytics: analytics,
+    )
+  end
+
+  describe '#track_event' do
+    it 'omit failure reason when success is true' do
+      freeze_time do
+        event = subject.track_event(:test_event, foo: :bar, success: true, failure_reason: nil)
+        expect(event.event_metadata).to_not have_key(:failure_reason)
+      end
+    end
+
+    it 'omit failure reason when failure_reason is blank' do
+      freeze_time do
+        event = subject.track_event(:test_event, foo: :bar, failure_reason: nil)
+        expect(event.event_metadata).to_not have_key(:failure_reason)
+      end
+    end
+
+    it 'should not omit failure reason when success is false and failure_reason is not blank' do
+      freeze_time do
+        event = subject.track_event(
+          :test_event, foo: :bar, success: false,
+                       failure_reason: { foo: [:bar] }
+        )
+        expect(event.event_metadata).to have_key(:failure_reason)
+        expect(event.event_metadata).to have_key(:success)
+      end
+    end
+
+    it 'records the event in redis' do
+      freeze_time do
+        subject.track_event(:test_event, foo: :bar)
+
+        events = AttemptsApi::RedisClient.new.read_events(
+          timestamp: Time.zone.now,
+          issuer: service_provider.issuer,
+        )
+
+        expect(events.values.length).to eq(1)
+      end
+    end
+
+    it 'does not store events in plaintext in redis' do
+      freeze_time do
+        subject.track_event(:event, first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
+
+        events = AttemptsApi::RedisClient.new.read_events(
+          timestamp: Time.zone.now,
+          issuer: service_provider.issuer,
+        )
+
+        expect(events.keys.first).to_not include('first_name')
+        expect(events.values.first).to_not include(Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
+      end
+    end
+
+    context 'the current session is not an attempts API session' do
+      let(:enabled_for_session) { false }
+
+      it 'does not record any events in redis' do
+        freeze_time do
+          subject.track_event(:test_event, foo: :bar)
+
+          events = AttemptsApi::RedisClient.new.read_events(
+            timestamp: Time.zone.now,
+            issuer: service_provider.issuer,
+          )
+
+          expect(events.values.length).to eq(0)
+        end
+      end
+    end
+
+    context 'the attempts API is not enabled' do
+      let(:attempts_api_enabled) { false }
+
+      it 'does not record any events in redis' do
+        freeze_time do
+          subject.track_event(:test_event, foo: :bar)
+
+          events = AttemptsApi::RedisClient.new.read_events(
+            timestamp: Time.zone.now,
+            issuer: service_provider.issuer,
+          )
+
+          expect(events.values.length).to eq(0)
+        end
+      end
+    end
+  end
+
+  describe '#parse_failure_reason' do
+    let(:mock_error_message) { 'failure_reason_from_error' }
+    let(:mock_error_details) { [{ mock_error: 'failure_reason_from_error_details' }] }
+
+    it 'parses failure_reason from error_details' do
+      test_failure_reason = subject.parse_failure_reason(
+        { errors: mock_error_message,
+          error_details: mock_error_details },
+      )
+
+      expect(test_failure_reason).to eq(mock_error_details)
+    end
+
+    it 'parses failure_reason from errors when no error_details present' do
+      mock_failure_reason = double(
+        'MockFailureReason',
+        errors: mock_error_message,
+        to_h: {},
+      )
+
+      test_failure_reason = subject.parse_failure_reason(mock_failure_reason)
+
+      expect(test_failure_reason).to eq(mock_error_message)
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/142

## 🛠 Summary of changes

A follow up to #11692 to create an interface to begin logging events to the previously implemented storage. This is also heavily based on the [2022 implementation](https://github.com/18F/identity-idp/tree/f93b63da072c1d45809f5c9954ecc1e2f1379ba8/app/services/irs_attempts_api) with similar changes to accommodate multiple service providers. This PR creates an initial stub module for the list of events as well.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
