### PR TITLE
LG-15051: Remove fallback to LexisNexis

### DIFF
--- a/app/services/idv/proofing_components.rb
+++ b/app/services/idv/proofing_components.rb
@@ -37,10 +37,7 @@ module Idv
     end
 
     def resolution_check
-      if idv_session.verify_info_step_complete?
-        # NOTE: Fallback to LexisNexis to handle 50/50 state, will be removed later
-        idv_session.resolution_vendor || Idp::Constants::Vendors::LEXIS_NEXIS
-      end
+      idv_session.resolution_vendor if idv_session.verify_info_step_complete?
     end
 
     def address_check

--- a/spec/services/idv/proofing_components_spec.rb
+++ b/spec/services/idv/proofing_components_spec.rb
@@ -169,16 +169,6 @@ RSpec.describe Idv::ProofingComponents do
         expect(subject.residential_resolution_check).to eql('AReallyGoodVendor')
       end
     end
-
-    context 'when resolution done but residential_resolution_vendor nil because of 50/50 state' do
-      before do
-        idv_session.mark_verify_info_step_complete!
-      end
-
-      it 'returns nil to match previous behavior' do
-        expect(subject.residential_resolution_check).to be(nil)
-      end
-    end
   end
 
   describe '#resolution_check' do

--- a/spec/services/idv/proofing_components_spec.rb
+++ b/spec/services/idv/proofing_components_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Idv::ProofingComponents do
         .and_return(true)
       idv_session.threatmetrix_review_status = 'pass'
       idv_session.source_check_vendor = 'aamva'
+      idv_session.resolution_vendor = 'lexis_nexis'
     end
 
     it 'returns expected result' do
@@ -193,16 +194,6 @@ RSpec.describe Idv::ProofingComponents do
 
       it 'returns the vendor we set' do
         expect(subject.resolution_check).to eql('AReallyGoodVendor')
-      end
-    end
-
-    context 'when resolution done but resolution_vendor nil because of 50/50 state' do
-      before do
-        idv_session.mark_verify_info_step_complete!
-      end
-
-      it 'returns LexisNexis to match previous behavior' do
-        expect(subject.resolution_check).to eql('lexis_nexis')
       end
     end
   end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15051](https://cm-jira.usa.gov/browse/LG-15051)
-->

## 🛠 Summary of changes

In #11674 we added a fallback in the case resolution_vendor was not set in IdV::Session to account for the 50/50 state.

Here we remove it, since that's been deployed.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
