### PR TITLE
Fix a feature Predictable results in nanoid generation when given non-integer values

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4445,9 +4445,9 @@ mute-stream@^2.0.0:
   integrity sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==
 
 nanoid@^3.3.6:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
-  integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
+  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
When nanoid is called with a fractional value, there were a number of undesirable effects:
- in browser and non-secure, the code infinite loops on while (size--)
- in node, the value of poolOffset becomes fractional, causing calls to nanoid to return zeroes until the pool is next filled
- if the first call in node is a fractional argument, the initial buffer allocation fails with an error

CVE-2024-55565
[CWE-835](https://cwe.mitre.org/data/definitions/835.html)
