### PR TITLE
lg-15270 disable drag and drop when selfie is required

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -141,11 +141,6 @@ interface AcuantCaptureProps {
 const NBSP_UNICODE = '\u00A0';
 
 /**
- * A noop function.
- */
-const noop = () => {};
-
-/**
  * Returns true if the given Acuant capture failure was caused by the user declining access to the
  * camera, or false otherwise.
  */
@@ -492,6 +487,16 @@ function AcuantCapture(
   }
 
   /**
+   * Responds to a drag and drop file upload by either preventing the default action
+   * or allowing the file to be uploaded
+   */
+  function startDragDropUpload(event) {
+    if (!allowUpload) {
+      event.preventDefault();
+    }
+  }
+
+  /**
    * Responds to a click by starting capture if supported in the environment, or triggering the
    * default file picker prompt. The click event may originate from the file input itself, or
    * another element which aims to trigger the prompt of the file input.
@@ -783,7 +788,7 @@ function AcuantCapture(
         errorMessage={ownErrorMessage ?? errorMessage}
         isValuePending={hasStartedCropping}
         onClick={withLoggedClick('placeholder')(startCaptureOrTriggerUpload)}
-        onDrop={withLoggedClick('placeholder', { isDrop: true })(noop)}
+        onDrop={withLoggedClick('placeholder', { isDrop: true })(startDragDropUpload)}
         onChange={onUpload}
         onError={() => setOwnErrorMessage(null)}
       />


### PR DESCRIPTION
Disable drag and drop functionality if selfie required. 

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15270](https://cm-jira.usa.gov/browse/LG-15270)

## 🛠 Summary of changes
Disable drag and drop functionality if selfie required. This functionality was already present as a part of the disable upload, doing a similar approach for the drag/drop functionality. 



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - On local machine set doc_auth_selfie_desktop_test_mode to false. 
- [ ] Step 2 - Run 'make run' and proceed to http://localhost:3000/test/oidc/login . Select 'Sign in with facial match'.
- [ ] Step 3 - Create and account and proceed to doc auth (Continue on phone)
- [ ] Step 4 - Once a phone number is entered proceed to http://localhost:3000/test/telephony to retrieve the doc auth localhost link.
- [ ] Step 5 - Once in the document capture step, try to drag and drop a file for front and back and confirm it is not allowed


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
