### PR TITLE
Revert "Update newrelic_rpm gem to fix Bundler deprecation warning"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,7 +458,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     net-ssh (6.1.0)
-    newrelic_rpm (9.16.1)
+    newrelic_rpm (9.7.0)
     nio4r (2.7.4)
     nokogiri (1.16.8)
       mini_portile2 (~> 2.8.2)


### PR DESCRIPTION
Reverts 18F/identity-idp#11699

Due to low-frequency errors that are potentially related to this upgrade, this PR reverts the original