### PR TITLE
LG-15379 removes post office closure alerts from barcode page and email

### DIFF
--- a/app/controllers/idv/in_person/ready_to_verify_controller.rb
+++ b/app/controllers/idv/in_person/ready_to_verify_controller.rb
@@ -18,8 +18,6 @@ module Idv
 
       def show
         @is_enhanced_ipp = resolved_authn_context_result.enhanced_ipp?
-        @show_closed_post_office_banner =
-          IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
         analytics.idv_in_person_ready_to_verify_visit(**opt_in_analytics_properties)
         @presenter = ReadyToVerifyPresenter.new(
           enrollment: enrollment,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -312,8 +312,6 @@ class UserMailer < ActionMailer::Base
         is_enhanced_ipp: is_enhanced_ipp,
       )
       @is_enhanced_ipp = is_enhanced_ipp
-      @show_closed_post_office_banner =
-        IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
 
       mail(
         to: email_address.email,
@@ -328,8 +326,6 @@ class UserMailer < ActionMailer::Base
     ).image_data
 
     @is_enhanced_ipp = enrollment.enhanced_ipp?
-    @show_closed_post_office_banner =
-      IdentityConfig.store.in_person_proofing_post_office_closed_alert_enabled
 
     with_user_locale(user) do
       @presenter = Idv::InPerson::ReadyToVerifyPresenter.new(

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -435,16 +435,6 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def in_person_post_office_closed
-    with_user_locale(user) do
-      @hide_title = true
-      mail(
-        to: email_address.email,
-        subject: t('in_person_proofing.post_office_closed.email.subject'),
-      )
-    end
-  end
-
   private
 
   attr_reader :user, :email_address

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -228,14 +228,6 @@
   </section>
 <% end %>
 
-<%# Alert %>
-<% if @show_closed_post_office_banner %>
-  <%= render AlertComponent.new(type: :warning, class: 'margin-y-4', text_tag: :div) do %>
-    <p class="margin-bottom-1 margin-top-0 h3"><strong><%= t('in_person_proofing.post_office_closed.heading') %></strong></p>
-    <p><%= t('in_person_proofing.post_office_closed.body') %></p>
-  <% end %>
-<% end %>
-
 <% if !@is_enhanced_ipp %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
   <p class="margin-bottom-4">

--- a/app/views/user_mailer/in_person_post_office_closed.html.erb
+++ b/app/views/user_mailer/in_person_post_office_closed.html.erb
@@ -1,2 +1,0 @@
-<h1><%= t('in_person_proofing.post_office_closed.email.heading') %></h1>
-<p><%= t('in_person_proofing.post_office_closed.email.body_html') %></p>

--- a/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
@@ -275,21 +275,6 @@
   </div>
 <% end %>
 
-<%# alert %>
-<% if @show_closed_post_office_banner %>
-  <table class="usa-alert usa-alert--warning margin-y-4">
-    <tr>
-      <td style="width:16px;">
-        <%= image_tag('email/warning.png', width: 16, height: 16, alt: '', style: 'margin-top: 4px;') %>
-      </td>
-      <td>
-        <p class="margin-bottom-1"><strong><%= t('in_person_proofing.post_office_closed.heading') %></strong></p>
-        <p class="margin-bottom-0"><%= t('in_person_proofing.post_office_closed.body') %></p>
-      </td>
-    </tr>
-  </table>
-<% end %>
-
 <% if !@is_enhanced_ipp %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
   <p class="margin-bottom-4">

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -194,7 +194,6 @@ in_person_outage_message_enabled: false
 in_person_proofing_enabled: false
 in_person_proofing_enforce_tmx: false
 in_person_proofing_opt_in_enabled: false
-in_person_proofing_post_office_closed_alert_enabled: false
 in_person_results_delay_in_hours: 1
 in_person_send_proofing_notifications_enabled: false
 in_person_stop_expiring_enrollments: false

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -194,7 +194,7 @@ in_person_outage_message_enabled: false
 in_person_proofing_enabled: false
 in_person_proofing_enforce_tmx: false
 in_person_proofing_opt_in_enabled: false
-in_person_proofing_post_office_closed_alert_enabled: true
+in_person_proofing_post_office_closed_alert_enabled: false
 in_person_results_delay_in_hours: 1
 in_person_send_proofing_notifications_enabled: false
 in_person_stop_expiring_enrollments: false

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -561,7 +561,6 @@ test:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
   identity_pki_disabled: true
-  in_person_proofing_post_office_closed_alert_enabled: false
   lexisnexis_trueid_account_id: 'test_account'
   lockout_period_in_minutes: 5
   logins_per_email_and_ip_limit: 2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1327,11 +1327,6 @@ in_person_proofing.headings.state_id_milestone_2: Enter the information on your 
 in_person_proofing.headings.switch_back: Switch back to your computer to prepare to verify your identity in person
 in_person_proofing.headings.update_address: Update your current address
 in_person_proofing.headings.update_state_id: Update the information on your ID
-in_person_proofing.post_office_closed.body: Post Office locations will resume regular hours on Friday, January 10, 2025.
-in_person_proofing.post_office_closed.email.body_html: <strong>You will not be able to visit a Post Office on Thursday, January 9, 2025 to finish verifying your identity.</strong> Post Office locations will resume regular hours on Friday, January 10, 2025.
-in_person_proofing.post_office_closed.email.heading: All Post Offices will be closed on January 9, 2025 to honor former President Jimmy Carter
-in_person_proofing.post_office_closed.email.subject: All Post Offices will be closed on Thursday, January 9, 2025
-in_person_proofing.post_office_closed.heading: All Post Offices will be closed on Thursday, January 9, 2025 to honor former President Jimmy Carter.
 in_person_proofing.process.barcode.caption_label: Enrollment code
 in_person_proofing.process.barcode.heading: Show your %{app_name} barcode
 in_person_proofing.process.barcode.info: The retail associate needs to scan your barcode at the top of this page. You can print this page or show it on your mobile device.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1338,11 +1338,6 @@ in_person_proofing.headings.state_id_milestone_2: Ingrese la información de su 
 in_person_proofing.headings.switch_back: Vuelva a su computadora para preparar la verificación de su identidad en persona
 in_person_proofing.headings.update_address: Actualice su dirección actual
 in_person_proofing.headings.update_state_id: Actualice la información de su identificación
-in_person_proofing.post_office_closed.body: Las oficinas de correos reanudarán su horario habitual el viernes 10 de enero de 2025.
-in_person_proofing.post_office_closed.email.body_html: <strong>No podrás visitar una Oficina de Correos el jueves 9 de enero de 2025 para terminar de verificar tu identidad.</strong> Las oficinas de correos reanudarán su horario habitual el viernes 10 de enero de 2025.
-in_person_proofing.post_office_closed.email.heading: Todas las oficinas de correos estarán cerradas el 9 de enero de 2025 en honor al expresidente Jimmy Carter
-in_person_proofing.post_office_closed.email.subject: Todas las oficinas de correos estarán cerradas el jueves 9 de enero de 2025
-in_person_proofing.post_office_closed.heading: Todas las oficinas de correos estarán cerradas el jueves 9 de enero de 2025 en honor al ex presidente Jimmy Carter.
 in_person_proofing.process.barcode.caption_label: Código de registro
 in_person_proofing.process.barcode.heading: Muestre su código de barras de %{app_name}
 in_person_proofing.process.barcode.info: El empleado debe escanear el código de barras que aparece en la parte superior de esta página. Puede imprimir esta página o mostrarla en su dispositivo móvil.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1327,11 +1327,6 @@ in_person_proofing.headings.state_id_milestone_2: Saisissez les informations fig
 in_person_proofing.headings.switch_back: Revenez à votre ordinateur pour vous préparer à confirmer votre identité en personne
 in_person_proofing.headings.update_address: Mettez à jour votre adresse actuelle
 in_person_proofing.headings.update_state_id: Mettez à jour les informations figurant sur votre document d’identité
-in_person_proofing.post_office_closed.body: Les bureaux de poste reprendront leurs horaires habituels le vendredi 10 janvier 2025.
-in_person_proofing.post_office_closed.email.body_html: <strong>Vous ne pourrez pas vous rendre dans un bureau de Poste le jeudi 9 janvier 2025 pour terminer la vérification de votre identité.</strong> Les bureaux de poste reprendront leurs horaires habituels le vendredi 10 janvier 2025
-in_person_proofing.post_office_closed.email.heading: Tous les bureaux de poste seront fermés le 9 janvier 2025 en l’honneur de l’ancien président Jimmy Carter
-in_person_proofing.post_office_closed.email.subject: Tous les bureaux de poste seront fermés le jeudi 9 janvier 2025
-in_person_proofing.post_office_closed.heading: Tous les bureaux de poste seront fermés le jeudi 9 janvier 2025 en l’honneur de l’ancien président Jimmy Carter.
 in_person_proofing.process.barcode.caption_label: Code d’inscription
 in_person_proofing.process.barcode.heading: Montrez votre code-barres %{app_name}
 in_person_proofing.process.barcode.info: Le préposé doit scanner votre code-barres en haut de cette page. Vous pouvez imprimer cette page ou la montrer sur votre appareil mobile.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1340,11 +1340,6 @@ in_person_proofing.headings.state_id_milestone_2: 输入你州政府颁发身份
 in_person_proofing.headings.switch_back: 切换回你的电脑，来准备亲身去验证身份。
 in_person_proofing.headings.update_address: 更新你当前地址
 in_person_proofing.headings.update_state_id: 更新你身份证件上的信息
-in_person_proofing.post_office_closed.body: 邮局地点将于 2025 年 1 月 10 日星期五恢复正常工作时间。
-in_person_proofing.post_office_closed.email.body_html: <strong>您将无法在 2025 年 1 月 9 日星期四前往邮局完成身份验证。</strong> 邮局地点将于 2025 年 1 月 10 日星期五恢复正常工作时间
-in_person_proofing.post_office_closed.email.heading: 所有邮局将于 2025 年 1 月 9 日关闭，以纪念前总统吉米·卡特
-in_person_proofing.post_office_closed.email.subject: 所有邮局将于 2025 年 1 月 9 日星期四关闭
-in_person_proofing.post_office_closed.heading: 所有邮局将于 2025 年 1 月 9 日关闭，以纪念前总统吉米·卡特。
 in_person_proofing.process.barcode.caption_label: 注册代码
 in_person_proofing.process.barcode.heading: 出示你的 %{app_name} 条形码
 in_person_proofing.process.barcode.info: 邮局工作人员需要扫描该页顶部的条形码你可以把该页打印出来，或在你的移动设备上显示。

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -218,7 +218,6 @@ module IdentityConfig
     config.add(:in_person_proofing_enabled, type: :boolean)
     config.add(:in_person_proofing_enforce_tmx, type: :boolean)
     config.add(:in_person_proofing_opt_in_enabled, type: :boolean)
-    config.add(:in_person_proofing_post_office_closed_alert_enabled, type: :boolean)
     config.add(:in_person_results_delay_in_hours, type: :integer)
     config.add(:in_person_send_proofing_notifications_enabled, type: :boolean)
     config.add(:in_person_stop_expiring_enrollments, type: :boolean)

--- a/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
@@ -128,19 +128,6 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
               expect(assigns(:is_enhanced_ipp)).to be true
             end
           end
-
-          context 'with in_person_proofing_post_office_closed_alert_enabled' do
-            let(:ipp_post_office_closed_alert_enabled) { true }
-            before do
-              allow(IdentityConfig.store)
-                .to receive(:in_person_proofing_post_office_closed_alert_enabled)
-                .and_return(ipp_post_office_closed_alert_enabled)
-            end
-
-            it 'renders the show template' do
-              expect(response).to render_template :show
-            end
-          end
         end
       end
 

--- a/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
 
     context 'with in person proofing enabled' do
       let(:in_person_proofing_enabled) { true }
-      let(:ipp_post_office_closed_alert_enabled) { false }
 
       context 'authenticated' do
         before do

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -286,10 +286,6 @@ class UserMailerPreview < ActionMailer::Preview
     ).account_reinstated
   end
 
-  def in_person_post_office_closed
-    UserMailer.with(user: user, email_address: email_address_record).in_person_post_office_closed
-  end
-
   private
 
   def user

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1580,22 +1580,4 @@ RSpec.describe UserMailer, type: :mailer do
     it_behaves_like 'an email that respects user email locale preference'
   end
 
-  describe '#in_person_post_office_closed' do
-    let(:mail) do
-      UserMailer.with(user: user, email_address: email_address).in_person_post_office_closed
-    end
-
-    it_behaves_like 'a system email'
-    it_behaves_like 'an email that respects user email locale preference'
-
-    it 'includes a translated header' do
-      expect(mail.html_part.body)
-        .to include(t('in_person_proofing.post_office_closed.email.heading', locale: :en))
-    end
-
-    it 'includes a translated body' do
-      expect(mail.html_part.body)
-        .to include(t('in_person_proofing.post_office_closed.email.body_html', locale: :en))
-    end
-  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1579,5 +1579,4 @@ RSpec.describe UserMailer, type: :mailer do
     it_behaves_like 'a system email'
     it_behaves_like 'an email that respects user email locale preference'
   end
-
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -934,50 +934,6 @@ RSpec.describe UserMailer, type: :mailer do
         end
       end
 
-      context 'post office closed alert' do
-        context 'when the post office closed alert flag is disabled' do
-          before do
-            allow(IdentityConfig.store)
-              .to receive(:in_person_proofing_post_office_closed_alert_enabled)
-              .and_return(false)
-          end
-
-          it 'does not render the post office closed alert' do
-            aggregate_failures do
-              [
-                t('in_person_proofing.post_office_closed.heading'),
-                t('in_person_proofing.post_office_closed.body'),
-              ].each do |copy|
-                Array(copy).each do |part|
-                  expect(mail.html_part.body).to_not have_content(part)
-                end
-              end
-            end
-          end
-        end
-
-        context 'when the post office closed alert flag is enabled' do
-          before do
-            allow(IdentityConfig.store)
-              .to receive(:in_person_proofing_post_office_closed_alert_enabled)
-              .and_return(true)
-          end
-
-          it 'renders the post office closed alert' do
-            aggregate_failures do
-              [
-                t('in_person_proofing.post_office_closed.heading'),
-                t('in_person_proofing.post_office_closed.body'),
-              ].each do |copy|
-                Array(copy).each do |part|
-                  expect(mail.html_part.body).to have_content(part)
-                end
-              end
-            end
-          end
-        end
-      end
-
       context 'Need to change location section' do
         context 'when Enhanced IPP is not enabled' do
           let(:is_enhanced_ipp) { false }

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -176,50 +176,6 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
     end
   end
 
-  context 'post office warning' do
-    context 'when the show closed post office banner is disabled' do
-      before do
-        @show_closed_post_office_banner = false
-      end
-
-      it 'does not render the post office closed alert' do
-        render
-
-        aggregate_failures do
-          [
-            t('in_person_proofing.post_office_closed.heading'),
-            t('in_person_proofing.post_office_closed.body'),
-          ].each do |copy|
-            Array(copy).each do |part|
-              expect(rendered).to_not have_content(part)
-            end
-          end
-        end
-      end
-    end
-
-    context 'when the show closed post office banner is enabled' do
-      before do
-        @show_closed_post_office_banner = true
-      end
-
-      it 'renders the post office closed alert' do
-        render
-
-        aggregate_failures do
-          [
-            t('in_person_proofing.post_office_closed.heading'),
-            t('in_person_proofing.post_office_closed.body'),
-          ].each do |copy|
-            Array(copy).each do |part|
-              expect(rendered).to have_content(part)
-            end
-          end
-        end
-      end
-    end
-  end
-
   context 'what to expect section' do
     context 'when Enhanced IPP is not enabled' do
       let(:is_enhanced_ipp) { false }


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15379](https://cm-jira.usa.gov/browse/LG-15379)


## 🛠 Summary of changes

Updates barcode page and email to remove the temporary alerts about the January 9th post office closure.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Enter the application via Sinatra and perform the in-person proofing flow all the way to the barcode page.
- [ ] Inspect the **barcode page** and ensure this alert is **not** present:
<img width="243" alt="image" src="https://github.com/user-attachments/assets/e24a4a53-5d88-43dd-a833-b5c5f81ea541" />

- [ ] Inspect the **email page** and ensure this alert is **not** present: 
<img width="243" alt="image" src="https://github.com/user-attachments/assets/d69851ce-2b2f-4f5f-b83c-ac4f86176ac9" />

