### PR TITLE
LG-15453: Fix issue formating heights for AAMVA DLDV

### DIFF
--- a/app/services/proofing/aamva/applicant.rb
+++ b/app/services/proofing/aamva/applicant.rb
@@ -87,10 +87,11 @@ module Proofing
         return if height.nil?
 
         # From the AAMVA DLDV guide regarding formatting the height:
-        #
-        #     The height is provided in feet-inches (i.e. 5 foot 10 inches is presented as "510").
-        #
-        [(height / 12).to_s, (height % 12).to_s].join('')
+        # > Height data should be 3 characters (i.e. 5 foot 7 inches is submitted as 507)
+        feet = (height / 12).floor
+        inches = (height % 12).floor
+
+        "#{feet}#{format('%02d', inches)}"
       end
     end.freeze
   end

--- a/spec/services/proofing/aamva/applicant_spec.rb
+++ b/spec/services/proofing/aamva/applicant_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe Proofing::Aamva::Applicant do
     proofer_applicant[:height] = 73
     aamva_applicant = Proofing::Aamva::Applicant.from_proofer_applicant(proofer_applicant)
 
-    # This is intended to describe 6'1"
-    expect(aamva_applicant[:height]).to eq('61')
+    # From the DLDV user guide:
+    # > Height data should be 3 characters (i.e. 5 foot 7 inches is submitted as 507)
+    expect(aamva_applicant[:height]).to eq('601')
   end
 end

--- a/spec/services/proofing/aamva/applicant_spec.rb
+++ b/spec/services/proofing/aamva/applicant_spec.rb
@@ -65,12 +65,22 @@ RSpec.describe Proofing::Aamva::Applicant do
     expect(aamva_applicant[:dob]).to eq('')
   end
 
-  it 'should format the height' do
-    proofer_applicant[:height] = 73
-    aamva_applicant = Proofing::Aamva::Applicant.from_proofer_applicant(proofer_applicant)
+  context 'when height includes inches >= 10' do
+    it 'formats as expected' do
+      proofer_applicant[:height] = 95
+      aamva_applicant = Proofing::Aamva::Applicant.from_proofer_applicant(proofer_applicant)
+      expect(aamva_applicant[:height]).to eq('711')
+    end
+  end
 
-    # From the DLDV user guide:
-    # > Height data should be 3 characters (i.e. 5 foot 7 inches is submitted as 507)
-    expect(aamva_applicant[:height]).to eq('601')
+  context 'when height includes inches < 10' do
+    it 'formats as expected' do
+      proofer_applicant[:height] = 67
+      aamva_applicant = Proofing::Aamva::Applicant.from_proofer_applicant(proofer_applicant)
+
+      # From the DLDV user guide:
+      # > Height data should be 3 characters (i.e. 5 foot 7 inches is submitted as 507)
+      expect(aamva_applicant[:height]).to eq('507')
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15453](https://cm-jira.usa.gov/browse/LG-15453)

## 🛠 Summary of changes

From the AAMVA DLDV guide regarding formatting the height:

> Height data should be 3 characters (i.e. 5 foot 7 inches is submitted as 507)

We were not previously zero-padding the inches, leading to us sending "57" in the 5' 7" case.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
