### PR TITLE
Account for a space in the height returned by TrueID

### DIFF
--- a/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb
+++ b/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb
@@ -106,7 +106,7 @@ module DocAuth
       end
 
       def parse_height_value(height_attribute)
-        height_match_data = height_attribute&.match(/(?<feet>\d)'(?<inches>\d{1,2})"/)
+        height_match_data = height_attribute&.match(/(?<feet>\d)' ?(?<inches>\d{1,2})"/)
 
         return unless height_match_data
 

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -251,18 +251,31 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
     end
 
     context 'when doc_auth_read_additional_pii_attributes_enabled is enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_read_additional_pii_attributes_enabled)
+          .and_return(true)
+      end
+
       let(:success_response_body) { LexisNexisFixtures.true_id_response_success }
 
       it 'reads the additional PII attributes' do
-        allow(IdentityConfig.store).to receive(:doc_auth_read_additional_pii_attributes_enabled)
-          .and_return(true)
-
         pii_from_doc = response.pii_from_doc
 
         expect(pii_from_doc.first_name).to eq('LICENSE')
         expect(pii_from_doc.name_suffix).to eq('JR')
         expect(pii_from_doc.sex).to eq('male')
         expect(pii_from_doc.height).to eq(68)
+      end
+
+      context 'when the height has a space in it' do
+        # This fixture has the height returns as "5' 9\""
+        let(:success_response_body) { LexisNexisFixtures.true_id_response_success_3 }
+
+        it 'reads parses the height correctly' do
+          pii_from_doc = response.pii_from_doc
+
+          expect(pii_from_doc.height).to eq(69)
+        end
       end
     end
   end


### PR DESCRIPTION
The regex we used to read the height from a TrueID response did not account for a space that may appear between feet and inches. As a result height values like `5' 11"` were not read. This commit updates the regex to fix that.
