### PR TITLE
LG-10965: Extract new controller for backup code reminder

### DIFF
--- a/app/controllers/concerns/backup_code_reminder_concern.rb
+++ b/app/controllers/concerns/backup_code_reminder_concern.rb
@@ -13,6 +13,7 @@ module BackupCodeReminderConcern
   end
 
   def user_last_signed_in_more_than_5_months_ago?
-    current_user.second_last_signed_in_at(since: 5.months.ago).blank?
+    current_user.created_at < 5.months.ago &&
+      current_user.second_last_signed_in_at(since: 5.months.ago).blank?
   end
 end

--- a/app/controllers/concerns/backup_code_reminder_concern.rb
+++ b/app/controllers/concerns/backup_code_reminder_concern.rb
@@ -13,7 +13,7 @@ module BackupCodeReminderConcern
   end
 
   def user_last_signed_in_more_than_5_months_ago?
-    current_user.created_at < 5.months.ago &&
+    current_user.created_at.before?(5.months.ago) &&
       current_user.second_last_signed_in_at(since: 5.months.ago).blank?
   end
 end

--- a/app/controllers/concerns/backup_code_reminder_concern.rb
+++ b/app/controllers/concerns/backup_code_reminder_concern.rb
@@ -2,15 +2,17 @@
 
 module BackupCodeReminderConcern
   def user_needs_backup_code_reminder?
+    return false if user_session[:dismissed_backup_code_reminder]
     user_backup_codes_configured? && user_last_signed_in_more_than_5_months_ago?
   end
+
+  private
 
   def user_backup_codes_configured?
     MfaContext.new(current_user).backup_code_configurations.present?
   end
 
   def user_last_signed_in_more_than_5_months_ago?
-    second_last_signed_in_at = current_user.second_last_signed_in_at
-    second_last_signed_in_at && second_last_signed_in_at < 5.months.ago
+    current_user.second_last_signed_in_at(since: 5.months.ago).blank?
   end
 end

--- a/app/controllers/users/backup_code_reminder_controller.rb
+++ b/app/controllers/users/backup_code_reminder_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Users
+  class BackupCodeReminderController < ApplicationController
+    before_action :confirm_two_factor_authenticated
+
+    def show
+      flash.now[:success] = t('notices.authenticated_successfully')
+      analytics.backup_code_reminder_visited
+    end
+
+    def update
+      user_session[:dismissed_backup_code_reminder] = true
+      analytics.backup_code_reminder_submitted(has_codes: has_codes?)
+
+      if has_codes?
+        redirect_to after_sign_in_path_for(current_user)
+      else
+        redirect_to backup_code_regenerate_path
+      end
+    end
+
+    private
+
+    def has_codes?
+      params[:has_codes].present?
+    end
+  end
+end

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -13,7 +13,7 @@ module Users
     before_action :set_backup_code_setup_presenter
     before_action :apply_secure_headers_override
     before_action :authorize_backup_code_disable, only: [:delete]
-    before_action :confirm_recently_authenticated_2fa, except: [:reminder, :continue]
+    before_action :confirm_recently_authenticated_2fa, except: [:continue]
     before_action :validate_multi_mfa_selection, only: [:index]
 
     helper_method :in_multi_mfa_selection_flow?
@@ -67,10 +67,6 @@ module Users
       else
         redirect_to account_two_factor_authentication_path
       end
-    end
-
-    def reminder
-      flash.now[:success] = t('notices.authenticated_successfully')
     end
 
     def confirm_backup_codes; end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -446,10 +446,17 @@ class User < ApplicationRecord
       .count
   end
 
-  def second_last_signed_in_at
+  # Returns the date of the last fully-authenticated sign-in before the most recent.
+  #
+  # A `since` time argument is required, to optimize performance based on database indices for
+  # querying a user's events.
+  def second_last_signed_in_at(since:)
     events
-      .where(event_type: 'sign_in_after_2fa')
-      .order(created_at: :desc).limit(2).pluck(:created_at).second
+      .where(event_type: :sign_in_after_2fa, created_at: since..)
+      .order(created_at: :desc)
+      .limit(2)
+      .pluck(:created_at)
+      .second
   end
 
   def connected_apps

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -390,17 +390,17 @@ module AnalyticsEvents
     track_event('Backup Code Regenerate Visited', in_account_creation_flow:, **extra)
   end
 
-  # Tracks when the user is prompted to confirm that they still have access to their backup codes
-  # when signing in for the first time in at least 5 months.
-  def backup_code_reminder_visited
-    track_event(:backup_code_reminder_visited)
-  end
-
   # @param [Boolean] has_codes Whether the user still has access to their backup codes.
   # Tracks when the user submits to confirm whether they still have access to their backup codes
   # when signing in for the first time in at least 5 months.
   def backup_code_reminder_submitted(has_codes:, **extra)
     track_event(:backup_code_reminder_submitted, has_codes:, **extra)
+  end
+
+  # Tracks when the user is prompted to confirm that they still have access to their backup codes
+  # when signing in for the first time in at least 5 months.
+  def backup_code_reminder_visited
+    track_event(:backup_code_reminder_visited)
   end
 
   # Track user creating new BackupCodeSetupForm, record form submission Hash

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -390,6 +390,19 @@ module AnalyticsEvents
     track_event('Backup Code Regenerate Visited', in_account_creation_flow:, **extra)
   end
 
+  # Tracks when the user is prompted to confirm that they still have access to their backup codes
+  # when signing in for the first time in at least 6 months.
+  def backup_code_reminder_visited
+    track_event(:backup_code_reminder_visited)
+  end
+
+  # @param [Boolean] has_codes Whether the user still has access to their backup codes.
+  # Tracks when the user submits to confirm whether they still have access to their backup codes
+  # when signing in for the first time in at least 6 months.
+  def backup_code_reminder_submitted(has_codes:, **extra)
+    track_event(:backup_code_reminder_submitted, has_codes:, **extra)
+  end
+
   # Track user creating new BackupCodeSetupForm, record form submission Hash
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] mfa_method_counts Hash of MFA method with the number of that method on the account

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -391,14 +391,14 @@ module AnalyticsEvents
   end
 
   # Tracks when the user is prompted to confirm that they still have access to their backup codes
-  # when signing in for the first time in at least 6 months.
+  # when signing in for the first time in at least 5 months.
   def backup_code_reminder_visited
     track_event(:backup_code_reminder_visited)
   end
 
   # @param [Boolean] has_codes Whether the user still has access to their backup codes.
   # Tracks when the user submits to confirm whether they still have access to their backup codes
-  # when signing in for the first time in at least 6 months.
+  # when signing in for the first time in at least 5 months.
   def backup_code_reminder_submitted(has_codes:, **extra)
     track_event(:backup_code_reminder_submitted, has_codes:, **extra)
   end

--- a/app/views/users/backup_code_reminder/show.html.erb
+++ b/app/views/users/backup_code_reminder/show.html.erb
@@ -1,19 +1,19 @@
-<% self.title = t('forms.backup_code.title') %>
+<% self.title = t('forms.backup_code_reminder.heading') %>
 
 <%= image_tag asset_url('user-signup.svg'), width: 107, height: 119, alt: '', class: 'margin-bottom-4', aria: { hidden: true } %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code_reminder.heading')) %>
 
-<p class='margin-top-1 margin-bottom-4'>
+<p>
   <%= t('forms.backup_code_reminder.body_info') %>
 </p>
 
-<%= button_to(
-      account_path,
-      method: :get,
-      class: 'usa-button usa-button--wide usa-button--big margin-bottom-3',
-    ) do %>
-  <%= t('forms.backup_code_reminder.have_codes') %>
-<% end %>
+<div class="margin-top-5 margin-bottom-2">
+  <%= render ButtonComponent.new(
+        url: account_path,
+        big: true,
+        wide: true,
+      ).with_content(t('forms.backup_code_reminder.have_codes')) %>
+</div>
 
 <%= link_to t('forms.backup_code_reminder.need_new_codes'), backup_code_regenerate_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,7 +299,8 @@ Rails.application.routes.draw do
     get '/users/two_factor_authentication' => 'users/two_factor_authentication#show',
         as: :user_two_factor_authentication # route name is used by two_factor_authentication gem
     get '/backup_code_refreshed' => 'users/backup_code_setup#refreshed'
-    get '/backup_code_reminder' => 'users/backup_code_setup#reminder'
+    get '/backup_code_reminder' => 'users/backup_code_reminder#show'
+    post '/backup_code_reminder' => 'users/backup_code_reminder#update'
     get '/backup_code_confirm_setup' => 'users/backup_code_setup#new'
     post '/backup_code_setup' => 'users/backup_code_setup#create'
     get '/backup_code_setup' => 'users/backup_code_setup#index'

--- a/spec/controllers/concerns/backup_code_reminder_concern_spec.rb
+++ b/spec/controllers/concerns/backup_code_reminder_concern_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe BackupCodeReminderConcern do
+  let(:user) { create(:user, :fully_registered) }
+
+  controller ApplicationController do
+    include BackupCodeReminderConcern
+  end
+
+  before do
+    stub_sign_in(user)
+  end
+
+  describe '#user_needs_backup_code_reminder?' do
+    subject(:user_needs_backup_code_reminder?) { controller.user_needs_backup_code_reminder? }
+
+    context 'if user has dismissed reminder in current session' do
+      before do
+        controller.user_session[:dismissed_backup_code_reminder] = true
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'if the user does not have backup codes' do
+      let(:user) { create(:user, :fully_registered, :with_phone) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'if the user has backup codes' do
+      let(:user) { create(:user, :fully_registered, :with_phone, :with_backup_code) }
+
+      context 'if the user has signed in more recently than 5 months ago' do
+        before do
+          create(:event, user:, event_type: :sign_in_after_2fa, created_at: 4.months.ago)
+          create(:event, user:, event_type: :sign_in_after_2fa, created_at: 1.minute.ago)
+        end
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'if the user not signed in within the past 5 months' do
+        before do
+          create(:event, user:, event_type: :sign_in_after_2fa, created_at: 6.months.ago)
+          create(:event, user:, event_type: :sign_in_after_2fa, created_at: 1.minute.ago)
+        end
+
+        it { is_expected.to eq(true) }
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/backup_code_reminder_concern_spec.rb
+++ b/spec/controllers/concerns/backup_code_reminder_concern_spec.rb
@@ -29,24 +29,48 @@ RSpec.describe BackupCodeReminderConcern do
     end
 
     context 'if the user has backup codes' do
-      let(:user) { create(:user, :fully_registered, :with_phone, :with_backup_code) }
+      context 'if the user account is less than 5 months old' do
+        let(:user) do
+          create(:user, :fully_registered, :with_phone, :with_backup_code, created_at: 1.day.ago)
+        end
 
-      context 'if the user has signed in more recently than 5 months ago' do
         before do
-          create(:event, user:, event_type: :sign_in_after_2fa, created_at: 4.months.ago)
           create(:event, user:, event_type: :sign_in_after_2fa, created_at: 1.minute.ago)
         end
 
         it { is_expected.to eq(false) }
       end
 
-      context 'if the user not signed in within the past 5 months' do
-        before do
-          create(:event, user:, event_type: :sign_in_after_2fa, created_at: 6.months.ago)
-          create(:event, user:, event_type: :sign_in_after_2fa, created_at: 1.minute.ago)
+      context 'if the user account is more than 5 months old' do
+        let(:user) do
+          create(:user, :fully_registered, :with_phone, :with_backup_code, created_at: 7.months.ago)
         end
 
-        it { is_expected.to eq(true) }
+        context 'if the user has signed in more recently than 5 months ago' do
+          before do
+            create(:event, user:, event_type: :sign_in_after_2fa, created_at: 4.months.ago)
+            create(:event, user:, event_type: :sign_in_after_2fa, created_at: 1.minute.ago)
+          end
+
+          it { is_expected.to eq(false) }
+        end
+
+        context 'if the user not signed in within the past 5 months' do
+          before do
+            create(:event, user:, event_type: :sign_in_after_2fa, created_at: 6.months.ago)
+            create(:event, user:, event_type: :sign_in_after_2fa, created_at: 1.minute.ago)
+          end
+
+          it { is_expected.to eq(true) }
+        end
+
+        context 'if the user is fully authenticating for the first time' do
+          before do
+            create(:event, user:, event_type: :sign_in_after_2fa, created_at: 1.minute.ago)
+          end
+
+          it { is_expected.to eq(true) }
+        end
       end
     end
   end

--- a/spec/controllers/users/backup_code_reminder_controller_spec.rb
+++ b/spec/controllers/users/backup_code_reminder_controller_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe Users::BackupCodeReminderController do
+  let(:user) { create(:user) }
+
+  before do
+    stub_sign_in(user) if user
+  end
+
+  describe '#show' do
+    subject(:response) { get :show }
+
+    it 'flashes successful authentication message' do
+      response
+
+      expect(flash[:success]).to eq(t('notices.authenticated_successfully'))
+    end
+
+    it 'logs analytics' do
+      stub_analytics
+
+      response
+
+      expect(@analytics).to have_logged_event(:backup_code_reminder_visited)
+    end
+
+    context 'if signed out' do
+      let(:user) { nil }
+
+      it 'redirects to sign in page' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe '#update' do
+    subject(:response) { post :update, params: params }
+    let(:params) { {} }
+
+    it 'assigns user session value acknowledging dismissed reminder' do
+      response
+
+      expect(controller.user_session[:dismissed_backup_code_reminder]).to eq(true)
+    end
+
+    context 'if user confirms they have codes' do
+      let(:params) { { has_codes: 'true' } }
+
+      it 'logs analytics' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(:backup_code_reminder_submitted, has_codes: true)
+      end
+
+      it 'redirects to after-sign-in path' do
+        expect(response).to redirect_to(account_path)
+      end
+    end
+
+    context 'if user requests new codes' do
+      let(:params) { {} }
+
+      it 'logs analytics' do
+        stub_analytics
+
+        response
+
+        expect(@analytics).to have_logged_event(:backup_code_reminder_submitted, has_codes: false)
+      end
+
+      it 'redirects to backup code regenerate path' do
+        expect(response).to redirect_to(backup_code_regenerate_path)
+      end
+    end
+
+    context 'if signed out' do
+      let(:user) { nil }
+
+      it 'redirects to sign in page' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Users::BackupCodeSetupController do
         :authenticate_user!,
         :confirm_user_authenticated_for_2fa_setup,
         :apply_secure_headers_override,
-        [:confirm_recently_authenticated_2fa, except: ['reminder', 'continue']],
+        [:confirm_recently_authenticated_2fa, except: ['continue']],
         :validate_multi_mfa_selection,
       )
     end

--- a/spec/features/two_factor_authentication/backup_code_sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_in_spec.rb
@@ -47,8 +47,13 @@ RSpec.feature 'sign in with backup code' do
   end
 
   context 'when the user needs a backup code reminder' do
+    let(:user) do
+      create(:user, created_at: 10.months.ago, second_mfa_reminder_dismissed_at: 8.months.ago)
+    end
+
     let!(:event) do
       create(:event, user:, event_type: :sign_in_after_2fa, created_at: 9.months.ago)
+      create(:event, user:, event_type: :sign_in_after_2fa, created_at: 8.months.ago)
     end
 
     it 'redirects the user to the backup code reminder url and allows user to confirm possession' do

--- a/spec/features/two_factor_authentication/backup_code_sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_in_spec.rb
@@ -45,4 +45,32 @@ RSpec.feature 'sign in with backup code' do
       assert_navigation { click_submit_default }
     end
   end
+
+  context 'when the user needs a backup code reminder' do
+    let!(:event) do
+      create(:event, user:, event_type: :sign_in_after_2fa, created_at: 9.months.ago)
+    end
+
+    it 'redirects the user to the backup code reminder url and allows user to confirm possession' do
+      fill_in t('forms.two_factor.backup_code'), with: codes.sample
+      click_submit_default
+
+      expect(page).to have_current_path(backup_code_reminder_path)
+
+      click_on t('forms.backup_code_reminder.have_codes')
+
+      expect(page).to have_current_path(account_path)
+    end
+
+    it 'redirects the user to the backup code reminder url and allows user to create new codes' do
+      fill_in t('forms.two_factor.backup_code'), with: codes.sample
+      click_submit_default
+
+      expect(page).to have_current_path(backup_code_reminder_path)
+
+      click_on t('forms.backup_code_reminder.need_new_codes')
+
+      expect(page).to have_current_path(backup_code_regenerate_path)
+    end
+  end
 end

--- a/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_up_spec.rb
@@ -82,21 +82,6 @@ RSpec.feature 'sign up with backup code' do
     expect(page).to have_current_path(sign_up_completed_path)
   end
 
-  context 'when the user needs a backup code reminder' do
-    let!(:user) { create(:user, :fully_registered, :with_authentication_app, :with_backup_code) }
-    let!(:event) do
-      create(:event, user: user, event_type: :sign_in_after_2fa, created_at: 9.months.ago)
-    end
-
-    it 'redirects the user to the backup code reminder url' do
-      sign_in_user(user)
-      fill_in_code_with_last_totp(user)
-      click_submit_default
-
-      expect(page).to have_current_path backup_code_reminder_path
-    end
-  end
-
   def sign_out_user
     first(:button, t('links.sign_out')).click
   end

--- a/spec/views/users/backup_code_reminder/show.html.erb_spec.rb
+++ b/spec/views/users/backup_code_reminder/show.html.erb_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe 'users/backup_code_setup/reminder.html.erb' do
+RSpec.describe 'users/backup_code_reminder/show.html.erb' do
   it 'has a localized title' do
-    expect(view).to receive(:title=).with(t('forms.backup_code.title'))
+    expect(view).to receive(:title=).with(t('forms.backup_code_reminder.heading'))
 
     render
   end
@@ -10,21 +10,19 @@ RSpec.describe 'users/backup_code_setup/reminder.html.erb' do
   it 'has a localized heading' do
     render
 
-    expect(rendered).to have_content \
-      t('forms.backup_code_reminder.heading')
+    expect(rendered).to have_content(t('forms.backup_code_reminder.heading'))
   end
 
   it 'has localized body info' do
     render
 
-    expect(rendered).to have_content \
-      t('forms.backup_code_reminder.body_info')
+    expect(rendered).to have_content(t('forms.backup_code_reminder.body_info'))
   end
 
   it 'has a cancel link to account path' do
     render
 
-    expect(rendered).to have_button(t('forms.backup_code_reminder.have_codes'))
+    expect(rendered).to have_link(t('forms.backup_code_reminder.have_codes'))
   end
 
   it 'has a regenerate backup code link' do


### PR DESCRIPTION
## 🎫 Ticket

Supports [LG-10965](https://cm-jira.usa.gov/browse/LG-10965)

## 🛠 Summary of changes

Refactors backup code reminder to be implemented as a standalone controller. This supports [LG-10965](https://cm-jira.usa.gov/browse/LG-10965), which expands the current reminder to apply for any sign-in, not just sign-ins without an associated service provider. 

**Why?**

- Adds missing analytics for visits and submissions to the reminder screen
- Optimizes database query on checking whether the user should be reminded for backup codes (apply timeframe on "second-last-sign-in" query)
- Avoid edge case where user may see reminder screen multiple times during same session (most notably as its usage would be extended in LG-10965)
- Incremental step toward skinny / single-responsibility controllers with [conventional action names](https://guides.rubyonrails.org/routing.html#crud-verbs-and-actions)
- Improves test coverage for affected behaviors

This the first of two pull requests. Since the new `BackupCodeReminderController#update` action will need to be fully deployed to avoid [50/50 deployment issues](https://handbook.login.gov/articles/manage-50-50-state.html#add-a-route), this does not change any existing behavior with the backup code reminder. Notably, it does not yet update links or capture users who are signing in to a partner application. These will be implemented in a follow-up pull request.

## 📜 Testing Plan

Verify that there are no regressions in the behavior of backup code reminder when signing in without an associated partner application (either confirming possession or generating new codes).

To simulate this state:

1. (Prerequisite) Have an account with backup codes
2. In a private browsing window, go to http://localhost:3000
3. Fully sign-in with MFA (you don't need to authenticate using backup codes, they just need to exist on the account)
4. In a Rails console (`rails c`), modify events to set last sign-in to more than 5 months in the past:
   - `User.find_with_email('example@example.com').events.where(event_type: 'sign_in_after_2fa').update_all(created_at: 6.months.ago)` (replace with test user email)
   - Note that this will potentially modify many events and could put the account into an invalid state. You can also do this with a new account to use as a throwaway account.
7. In the same Rails console, modify the user's creation date to more than 5 months in the past:
   - `User.find_with_email('example@example.com').update(created_at: 6.months.ago)` (replace with test user email)
9. Close all private browsing windows

To verify behaviors:

1. In a new private browsing window, go to http://localhost:3000
2. Fully sign-in with MFA (you don't need to authenticate using backup codes, they just need to exist on the account)
3. In a separate terminal process, run `make watch_events`
4. Observe that you're prompted with the "Do you still have your backup codes?" screen, and `make watch_events` output includes "
5. Click either "I have my codes" or "I need a new set of backup codes"
6. Observe that...
   - ...if you clicked "I have my codes", you're redirected to the account page
   - ...if you clicked "I need a new set of backup codes", you're redirected to the backup codes regenerate page

## 👀 Screenshots

![image](https://github.com/user-attachments/assets/80900898-7ef5-439e-ab47-44169a94835b)
