### PR TITLE
changelog: Bug Fixes, SAML Gem, Validates signature algorithm correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.4-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.5-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,10 +36,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: e5d876cf10ce9b39bba0cc523d06c4dda1af5124
-  tag: 0.23.4-18f
+  revision: bdf8e1f93707e413ecbd0f48d803e18812e19f90
+  tag: 0.23.5-18f
   specs:
-    saml_idp (0.23.4.pre.18f)
+    saml_idp (0.23.5.pre.18f)
       activesupport
       builder
       faraday

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -150,13 +150,6 @@ class SamlIdpController < ApplicationController
 
     if result.success? && saml_request.signed?
       analytics_payload[:cert_error_details] = saml_request.cert_errors
-
-      # analytics to determine if turning on SHA256 validation will break
-      # existing partners
-      if certs_different?
-        analytics_payload[:certs_different] = true
-        analytics_payload[:sha256_matching_cert] = sha256_alg_matching_cert_serial
-      end
     end
 
     analytics.saml_auth(**analytics_payload)
@@ -166,21 +159,6 @@ class SamlIdpController < ApplicationController
     saml_request.matching_cert&.serial&.to_s
   rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
     nil
-  end
-
-  def sha256_alg_matching_cert
-    # if sha256_alg_matching_cert is nil, fallback to the "first" cert
-    saml_request.sha256_validation_matching_cert ||
-      saml_request_service_provider&.ssl_certs&.first
-  rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
-  end
-
-  def sha256_alg_matching_cert_serial
-    sha256_alg_matching_cert&.serial&.to_s
-  end
-
-  def certs_different?
-    encryption_cert != sha256_alg_matching_cert
   end
 
   def log_external_saml_auth_request

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6903,12 +6903,8 @@ module AnalyticsEvents
   # @param [Boolean] request_signed
   # @param [String] matching_cert_serial matches the request certificate in a successful, signed
   #   request
-  # @param [Boolean] certs_different Whether the matching cert changes when SHA256 validations
-  #   are turned on in the saml_idp gem
   # @param [Hash] cert_error_details Details for errors that occurred because of an invalid
   #   signature
-  # @param [String] sha256_matching_cert serial of the cert that matches when sha256 validations
-  #   are turned on
   # @param [String] unknown_authn_contexts space separated list of unknown contexts
   def saml_auth(
     success:,
@@ -6926,8 +6922,6 @@ module AnalyticsEvents
     matching_cert_serial:,
     error_details: nil,
     cert_error_details: nil,
-    certs_different: nil,
-    sha256_matching_cert: nil,
     unknown_authn_contexts: nil,
     **extra
   )
@@ -6948,8 +6942,6 @@ module AnalyticsEvents
       request_signed:,
       matching_cert_serial:,
       cert_error_details:,
-      certs_different:,
-      sha256_matching_cert:,
       unknown_authn_contexts:,
       **extra,
     )

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1694,59 +1694,6 @@ RSpec.describe SamlIdpController do
             )
           end
 
-          context 'when request is using SHA1 as the signature method algorithm' do
-            let(:auth_settings) do
-              saml_settings(
-                overrides: {
-                  security: {
-                    authn_requests_signed:,
-                    signature_method: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha1',
-                  },
-                },
-              )
-            end
-
-            context 'when the certificate matches' do
-              it 'does not note that certs are different in the event' do
-                user.identities.last.update!(verified_attributes: ['email'])
-                generate_saml_response(user, auth_settings)
-
-                expect(response.status).to eq(200)
-                expect(@analytics).to have_logged_event(
-                  'SAML Auth', hash_not_including(
-                    certs_different: true,
-                    sha256_matching_cert: matching_cert_serial,
-                  )
-                )
-              end
-            end
-
-            context 'when the certificate does not match' do
-              let(:wrong_cert) do
-                OpenSSL::X509::Certificate.new(
-                  Rails.root.join('certs', 'sp', 'saml_test_sp2.crt').read,
-                )
-              end
-
-              before do
-                service_provider.update!(certs: [wrong_cert, saml_test_sp_cert])
-              end
-
-              it 'notes that certs are different in the event' do
-                user.identities.last.update!(verified_attributes: ['email'])
-                generate_saml_response(user, auth_settings)
-
-                expect(response.status).to eq(200)
-                expect(@analytics).to have_logged_event(
-                  'SAML Auth', hash_including(
-                    certs_different: true,
-                    sha256_matching_cert: wrong_cert.serial.to_s,
-                  )
-                )
-              end
-            end
-          end
-
           context 'when request is using SHA1 as the digest method algorithm' do
             let(:auth_settings) do
               saml_settings(
@@ -1754,30 +1701,56 @@ RSpec.describe SamlIdpController do
                   security: {
                     authn_requests_signed:,
                     digest_method: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha1',
+                    signature_method:,
                   },
                 },
               )
             end
 
-            it 'notes an error in the event' do
-              user.identities.last.update!(verified_attributes: ['email'])
-              generate_saml_response(user, auth_settings)
+            context 'when request is using SHA256 as the signature method algorithm' do
+              let(:signature_method) do
+                'http://www.w3.org/2001/04/xmldsig-more#rsa-sha1'
+              end
 
-              expect(response.status).to eq(200)
-              expect(@analytics).to have_logged_event(
-                'SAML Auth', hash_including(
-                  request_signed: authn_requests_signed,
-                  cert_error_details: [
-                    {
-                      cert: '16692258094164984098',
-                      error_code: :fingerprint_mismatch,
-                    },
-                    {
-                      cert: '14834808178619537243', error_code: :fingerprint_mismatch
-                    },
-                  ],
+              it 'notes an error in the event' do
+                user.identities.last.update!(verified_attributes: ['email'])
+                generate_saml_response(user, auth_settings)
+
+                expect(response.status).to eq(200)
+                expect(@analytics).to have_logged_event(
+                  'SAML Auth', hash_including(
+                    request_signed: authn_requests_signed,
+                    cert_error_details: [
+                      {
+                        cert: '16692258094164984098',
+                        error_code: :wrong_sig_algorithm,
+                      },
+                      {
+                        cert: '14834808178619537243',
+                        error_code: :request_cert_not_registered,
+                      },
+                    ],
+                  )
                 )
-              )
+              end
+            end
+
+            context 'when request is using SHA1 as the signature method algorithm' do
+              let(:signature_method) do
+                'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+              end
+
+              it 'notes an error in the event' do
+                user.identities.last.update!(verified_attributes: ['email'])
+                generate_saml_response(user, auth_settings)
+
+                expect(response.status).to eq(200)
+                expect(@analytics).to have_logged_event(
+                  'SAML Auth', hash_not_including(
+                    :cert_error_details,
+                  )
+                )
+              end
             end
           end
 
@@ -1836,7 +1809,7 @@ RSpec.describe SamlIdpController do
             cert_error_details = [
               {
                 cert: saml_test_sp_cert_serial,
-                error_code: :fingerprint_mismatch,
+                error_code: :request_cert_not_registered,
               },
             ]
 
@@ -2384,7 +2357,8 @@ RSpec.describe SamlIdpController do
         end
 
         it 'has valid signature' do
-          expect(xmldoc.saml_document.valid_signature?(idp_fingerprint)).to eq(true)
+          cert = OpenSSL::X509::Certificate.new(saml_test_idp_cert)
+          expect(xmldoc.saml_document.valid_signature?(cert)).to eq(true)
         end
 
         context 'Reference' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Add specific saml_idp error for wrong Encryption Algorithm](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/131)
-->

## 🛠 Summary of changes
This change is the follow-up to several weeks of tracking whether this change will https://github.com/18F/saml_idp/pull/126. [Running a query](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:logs-insights$3FqueryDetail$3D~(end~0~start~-1209600~timeType~'RELATIVE~tz~'LOCAL~unit~'seconds~editorString~'fields*20*40timestamp*2c*20*40message*2c*20*40logStream*2c*20*40log*0a*7c*20filter*20name*20*3d*20*27SAML*20Auth*27*0a*7c*20filter*20properties.event_properties.certs_different*0a*7c*20sort*20*40timestamp*20desc*0a*7c*20limit*2010000~queryId~'33d02f58-9385-440d-bf8f-95100245ed0e~source~(~'prod_*2fsrv*2fidp*2fshared*2flog*2fevents.log)~lang~'CWLI)) for the certs_different value does not produce any results, so it feels safe to move forward.

This change:
* Updates the saml_idp gem tag
* Removes the analytics code that is no longer needed
* Updates tests to reflect updated behavior and return a more specific cert_error in the analytics

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
