### PR TITLE
Update Rubocop to latest version (1.70.0)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
     - 'public/**/*'
-  TargetRubyVersion: 3.2.0
+  TargetRubyVersion: 3.3.0
   TargetRailsVersion: 7.2
   UseCache: true
   DisabledByDefault: true
@@ -389,6 +389,9 @@ Lint/BooleanSymbol:
   Enabled: true
 
 Lint/CircularArgumentReference:
+  Enabled: true
+
+Lint/ConstantReassignment:
   Enabled: true
 
 Lint/Debugger:

--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,7 @@ group :development, :test do
   gem 'psych'
   gem 'rspec', '~> 3.13.0'
   gem 'rspec-rails', '~> 7.0'
-  gem 'rubocop', '~> 1.69.1', require: false
+  gem 'rubocop', '~> 1.70.0', require: false
   gem 'rubocop-performance', '~> 1.23.0', require: false
   gem 'rubocop-rails', '~> 2.27.0', require: false
   gem 'rubocop-rspec', '~> 3.2.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.1.2)
       railties (>= 6.0.0)
-    json (2.9.0)
+    json (2.9.1)
     jwe (0.4.0)
     jwt (2.7.1)
     knapsack (4.0.0)
@@ -582,7 +582,7 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.23.0)
       connection_pool
-    regexp_parser (2.9.3)
+    regexp_parser (2.10.0)
     reline (0.5.12)
       io-console (~> 0.5)
     request_store (1.5.1)
@@ -623,7 +623,7 @@ GEM
     rspec-support (3.13.2)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.69.1)
+    rubocop (1.70.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -633,7 +633,7 @@ GEM
       rubocop-ast (>= 1.36.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.36.2)
+    rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
@@ -706,7 +706,7 @@ GEM
       openssl-signature_algorithm (~> 1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
     uniform_notifier (1.16.0)
     uri (0.13.0)
     useragent (0.16.11)
@@ -854,7 +854,7 @@ DEPENDENCIES
   rspec-rails (~> 7.0)
   rspec-retry
   rspec_junit_formatter
-  rubocop (~> 1.69.1)
+  rubocop (~> 1.70.0)
   rubocop-capybara
   rubocop-performance (~> 1.23.0)
   rubocop-rails (~> 2.27.0)

--- a/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/options/index.html.erb_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'two_factor_authentication/options/index.html.erb' do
   end
 
   it 'has a localized title' do
-    expect(view).to receive(:title=).with( \
+    expect(view).to receive(:title=).with(
       t('two_factor_authentication.login_options_title'),
     )
 

--- a/spec/views/users/backup_code_setup/reminder.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/reminder.html.erb_spec.rb
@@ -2,9 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'users/backup_code_setup/reminder.html.erb' do
   it 'has a localized title' do
-    expect(view).to receive(:title=).with( \
-      t('forms.backup_code.title'),
-    )
+    expect(view).to receive(:title=).with(t('forms.backup_code.title'))
 
     render
   end


### PR DESCRIPTION
## 🛠 Summary of changes

Updates Rubocop to the latest version (1.70.0).

**Why?**

- Incorporate new features and bug fixes
   - In particular, the [new support for passing target Ruby version as an environment variable](https://github.com/rubocop/rubocop/pull/13607) helps me with an issue I've been having with a local global pre-commit hook

**Included:**

- Version bump
- Fixes to affected files
- Enable new rule [`Lint/ConstantReassignment`](https://docs.rubocop.org/rubocop/cops_lint.html#lintconstantreassignment)
- Sync `TargetRubyVersion` to `.ruby-version`

## 📜 Testing Plan

Verify Rubocop lint checks all files and passes.

```
rubocop
```