### PR TITLE
LG-10965: Show backup code reminder for partner-initiated requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -238,13 +238,13 @@ class ApplicationController < ActionController::Base
       :recommend_for_authentication,
     )
     return second_mfa_reminder_url if user_needs_second_mfa_reminder?
+    return backup_code_reminder_url if user_needs_backup_code_reminder?
     return sp_session_request_url_with_updated_params if sp_session.key?(:request_url)
     signed_in_url
   end
 
   def signed_in_url
     return idv_verify_by_mail_enter_code_url if current_user.gpo_verification_pending_profile?
-    return backup_code_reminder_url if user_needs_backup_code_reminder?
     account_path
   end
 

--- a/app/controllers/concerns/backup_code_reminder_concern.rb
+++ b/app/controllers/concerns/backup_code_reminder_concern.rb
@@ -15,7 +15,7 @@ module BackupCodeReminderConcern
     auth_methods_session.auth_events.none? do |auth_event|
       # If the user authenticated using remembered device, they have signed in more recently than
       # 5 months ago. Remembered device authentications do not produce `after_sign_in_2fa` events,
-      # which is what's used to consider whether used signed in more than 5 months ago.
+      # which is what's used to consider whether user signed in more than 5 months ago.
       auth_event[:auth_method] == TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE ||
         # If the user authenticated using backup code in the same session, it can be inferred that
         # they still have possession of their backup codes

--- a/app/controllers/concerns/backup_code_reminder_concern.rb
+++ b/app/controllers/concerns/backup_code_reminder_concern.rb
@@ -2,11 +2,26 @@
 
 module BackupCodeReminderConcern
   def user_needs_backup_code_reminder?
-    return false if user_session[:dismissed_backup_code_reminder]
-    user_backup_codes_configured? && user_last_signed_in_more_than_5_months_ago?
+    user_session[:dismissed_backup_code_reminder].blank? &&
+      auth_events_valid_for_backup_code_reminder? &&
+      user_backup_codes_configured? &&
+      user_last_signed_in_more_than_5_months_ago?
   end
 
   private
+
+  def auth_events_valid_for_backup_code_reminder?
+    # Exclude backup codes and remembered device for backup code reminders.
+    auth_methods_session.auth_events.none? do |auth_event|
+      # If the user authenticated using remembered device, they have signed in more recently than
+      # 5 months ago. Remembered device authentications do not produce `after_sign_in_2fa` events,
+      # which is what's used to consider whether used signed in more than 5 months ago.
+      auth_event[:auth_method] == TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE ||
+        # If the user authenticated using backup code in the same session, it can be inferred that
+        # they still have possession of their backup codes
+        auth_event[:auth_method] == TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE
+    end
+  end
 
   def user_backup_codes_configured?
     MfaContext.new(current_user).backup_code_configurations.present?

--- a/app/views/users/backup_code_reminder/show.html.erb
+++ b/app/views/users/backup_code_reminder/show.html.erb
@@ -10,10 +10,16 @@
 
 <div class="margin-top-5 margin-bottom-2">
   <%= render ButtonComponent.new(
-        url: account_path,
+        url: backup_code_reminder_path,
+        method: :post,
+        params: { has_codes: true },
         big: true,
         wide: true,
       ).with_content(t('forms.backup_code_reminder.have_codes')) %>
 </div>
 
-<%= link_to t('forms.backup_code_reminder.need_new_codes'), backup_code_regenerate_path %>
+<%= render ButtonComponent.new(
+      url: backup_code_reminder_path,
+      method: :post,
+      unstyled: true,
+    ).with_content(t('forms.backup_code_reminder.need_new_codes')) %>

--- a/spec/controllers/concerns/backup_code_reminder_concern_spec.rb
+++ b/spec/controllers/concerns/backup_code_reminder_concern_spec.rb
@@ -62,6 +62,26 @@ RSpec.describe BackupCodeReminderConcern do
           end
 
           it { is_expected.to eq(true) }
+
+          context 'if the user authenticated with backup codes' do
+            before do
+              controller.auth_methods_session.authenticate!(
+                TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
+              )
+            end
+
+            it { is_expected.to eq(false) }
+          end
+
+          context 'if the user authenticated with remember device' do
+            before do
+              controller.auth_methods_session.authenticate!(
+                TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE,
+              )
+            end
+
+            it { is_expected.to eq(false) }
+          end
         end
 
         context 'if the user is fully authenticating for the first time' do
@@ -70,6 +90,16 @@ RSpec.describe BackupCodeReminderConcern do
           end
 
           it { is_expected.to eq(true) }
+
+          context 'if the user authenticated with backup codes' do
+            before do
+              controller.auth_methods_session.authenticate!(
+                TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
+              )
+            end
+
+            it { is_expected.to eq(false) }
+          end
         end
       end
     end

--- a/spec/features/two_factor_authentication/backup_code_sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_in_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'sign in with backup code' do
   include SamlAuthHelper
   include InteractionHelper
+  include NavigationHelper
 
   let(:user) { create(:user) }
   let!(:codes) { BackupCodeGenerator.new(user).delete_and_regenerate }
@@ -49,7 +50,7 @@ RSpec.feature 'sign in with backup code' do
 
   context 'when the user needs a backup code reminder' do
     let(:user) do
-      create(:user, created_at: 10.months.ago, second_mfa_reminder_dismissed_at: 8.months.ago)
+      create(:user, :with_phone, created_at: 10.months.ago)
     end
 
     let!(:event) do
@@ -58,7 +59,7 @@ RSpec.feature 'sign in with backup code' do
     end
 
     it 'redirects the user to the backup code reminder url and allows user to confirm possession' do
-      fill_in t('forms.two_factor.backup_code'), with: codes.sample
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect(page).to have_current_path(backup_code_reminder_path)
@@ -69,7 +70,7 @@ RSpec.feature 'sign in with backup code' do
     end
 
     it 'redirects the user to the backup code reminder url and allows user to create new codes' do
-      fill_in t('forms.two_factor.backup_code'), with: codes.sample
+      fill_in_code_with_last_phone_otp
       click_submit_default
 
       expect(page).to have_current_path(backup_code_reminder_path)
@@ -79,13 +80,61 @@ RSpec.feature 'sign in with backup code' do
       expect(page).to have_current_path(backup_code_regenerate_path)
     end
 
+    context 'authenticating with backup code' do
+      before do
+        sign_in_before_2fa(user)
+        choose_another_security_option(:backup_code)
+        fill_in t('forms.two_factor.backup_code'), with: codes.sample
+        click_submit_default
+      end
+
+      it 'does not prompt the user to confirm backup code possession' do
+        expect(page).to have_current_path(account_path)
+      end
+    end
+
+    context 'after dismissing the prompt (remembered device)' do
+      before do
+        fill_in_code_with_last_phone_otp
+        check t('forms.messages.remember_device')
+        click_submit_default
+        click_on t('forms.backup_code_reminder.have_codes')
+        click_on t('links.sign_out')
+      end
+
+      it 'does not prompt again the next sign in' do
+        sign_in_before_2fa(user)
+
+        expect(page).to have_current_path(account_path)
+      end
+    end
+
+    context 'after dismissing the prompt (non-remembered device)' do
+      before do
+        fill_in_code_with_last_phone_otp
+        uncheck t('forms.messages.remember_device')
+        click_submit_default
+        click_on t('forms.backup_code_reminder.have_codes')
+        click_on t('links.sign_out')
+      end
+
+      it 'does not prompt again the next sign in' do
+        sign_in_before_2fa(user)
+
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        expect(page).to have_current_path(account_path)
+      end
+    end
+
     context 'when signing in to partner application' do
       before do
         visit_idp_from_sp_with_ial1(:oidc)
       end
 
       it 'redirects the user to backup code reminder url and allows user to confirm possession' do
-        fill_in t('forms.two_factor.backup_code'), with: codes.sample
+        fill_in_code_with_last_phone_otp
         click_submit_default
 
         expect(page).to have_current_path(backup_code_reminder_path)
@@ -96,7 +145,7 @@ RSpec.feature 'sign in with backup code' do
       end
 
       it 'redirects the user to the backup code reminder url and allows user to create new codes' do
-        fill_in t('forms.two_factor.backup_code'), with: codes.sample
+        fill_in_code_with_last_phone_otp
         click_submit_default
 
         expect(page).to have_current_path(backup_code_reminder_path)

--- a/spec/features/two_factor_authentication/backup_code_sign_in_spec.rb
+++ b/spec/features/two_factor_authentication/backup_code_sign_in_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'sign in with backup code' do
+  include SamlAuthHelper
   include InteractionHelper
 
   let(:user) { create(:user) }
@@ -76,6 +77,38 @@ RSpec.feature 'sign in with backup code' do
       click_on t('forms.backup_code_reminder.need_new_codes')
 
       expect(page).to have_current_path(backup_code_regenerate_path)
+    end
+
+    context 'when signing in to partner application' do
+      before do
+        visit_idp_from_sp_with_ial1(:oidc)
+      end
+
+      it 'redirects the user to backup code reminder url and allows user to confirm possession' do
+        fill_in t('forms.two_factor.backup_code'), with: codes.sample
+        click_submit_default
+
+        expect(page).to have_current_path(backup_code_reminder_path)
+
+        click_on t('forms.backup_code_reminder.have_codes')
+
+        expect(page).to have_current_path(sign_up_completed_path)
+      end
+
+      it 'redirects the user to the backup code reminder url and allows user to create new codes' do
+        fill_in t('forms.two_factor.backup_code'), with: codes.sample
+        click_submit_default
+
+        expect(page).to have_current_path(backup_code_reminder_path)
+        click_on t('forms.backup_code_reminder.need_new_codes')
+
+        expect(page).to have_current_path(backup_code_regenerate_path)
+        click_on t('account.index.backup_code_confirm_regenerate')
+
+        click_continue
+
+        expect(page).to have_current_path(sign_up_completed_path)
+      end
     end
   end
 end

--- a/spec/views/users/backup_code_reminder/show.html.erb_spec.rb
+++ b/spec/views/users/backup_code_reminder/show.html.erb_spec.rb
@@ -22,15 +22,12 @@ RSpec.describe 'users/backup_code_reminder/show.html.erb' do
   it 'has a cancel link to account path' do
     render
 
-    expect(rendered).to have_link(t('forms.backup_code_reminder.have_codes'))
+    expect(rendered).to have_button(t('forms.backup_code_reminder.have_codes'))
   end
 
   it 'has a regenerate backup code link' do
     render
 
-    expect(rendered).to have_link(
-      t('forms.backup_code_reminder.need_new_codes'),
-      href: backup_code_regenerate_path,
-    )
+    expect(rendered).to have_button(t('forms.backup_code_reminder.need_new_codes'))
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-10965](https://cm-jira.usa.gov/browse/LG-10965)

## 🛠 Summary of changes

Updates backup code reminder screen to use new controller actions implemented in #11738 to support use with sign-ins associated with a partner application, and updated after-sign-in logic to include partner-associated sign-ins to be considered for backup code reminder.

## 📜 Testing Plan

Repeat testing plan from #11738, but also verify that it shows reminder when initiating sign-in from partner application (e.g. [sample OIDC application](https://github.com/18F/identity-oidc-sinatra)), and that you eventually return to the partner application after making your reminder choice.

## 👀 Screenshots

Note the partner logo in the screenshot, indicating that it is a partner-associated sign-in request:

![Screenshot 2025-01-14 at 8 34 16 AM](https://github.com/user-attachments/assets/1292d3c8-3224-4ba6-816d-b459296101f6)

