### PR TITLE
Remove unused file input styles

### DIFF
--- a/app/javascript/packages/document-capture/components/_file-input.scss
+++ b/app/javascript/packages/document-capture/components/_file-input.scss
@@ -17,18 +17,6 @@
   border-width: 3px;
 }
 
-usa-file-input:not(
-    .usa-file-input--has-value,
-    .usa-file-input--value-pending,
-    .usa-file-input--is-id-capture
-  )
-  .usa-form-group--success
-  .usa-file-input
-  .usa-file-input__target {
-  height: 21rem;
-  width: 12rem;
-}
-
 .usa-file-input:not(.usa-file-input--has-value, .usa-file-input--value-pending) {
   .usa-file-input__target {
     border-color: color('primary');
@@ -88,12 +76,8 @@ usa-file-input:not(
   }
 }
 .usa-file-input.usa-file-input--single-value:not(.usa-file-input--is-id-capture) {
-  .usa-file-input__preview {
-    width: 12rem;
-  }
-  .usa-file-input__target {
-    width: 12rem;
-  }
+  .usa-file-input__preview,
+  .usa-file-input__target,
   .usa-file-input__preview-image {
     width: 12rem;
   }


### PR DESCRIPTION
## 🛠 Summary of changes

Removes unused styles from file input component.

Repeat of #11313 

Explanation:

- The selector `usa-file-input` refers to a custom element which does not exist
- Common `width` styles can be collapsed to a single style declaration

## 📜 Testing Plan

Verify no regressions in display of file input in document capture.