### PR TITLE
LG-14973 Add PII check to Socure flow

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -33,6 +33,7 @@ module Idv
       {
         message: message || I18n.t('doc_auth.errors.general.network_error'),
         socure: stored_result&.errors&.dig(:socure),
+        pii_validation: stored_result&.errors&.dig(:pii_validation),
       }
     end
 

--- a/app/controllers/concerns/idv/socure_errors_concern.rb
+++ b/app/controllers/concerns/idv/socure_errors_concern.rb
@@ -16,6 +16,8 @@ module Idv
         result.errors.dig(:socure, :reason_codes).first
       elsif result.errors[:network]
         :network
+      elsif result.errors[:pii_validation]
+        :pii_validation
       else
         # No error information available (shouldn't happen). Default
         # to :network if it does.

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -111,6 +111,7 @@ module Idv
         skip_hybrid_handoff: idv_session.skip_hybrid_handoff,
         liveness_checking_required: resolved_authn_context_result.facial_match?,
         selfie_check_required: resolved_authn_context_result.facial_match?,
+        pii_like_keypaths: [[:pii]],
       }.merge(ab_test_analytics_buckets)
     end
 

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -79,6 +79,7 @@ module Idv
           analytics_id: 'Doc Auth',
           liveness_checking_required: resolved_authn_context_result.facial_match?,
           selfie_check_required: resolved_authn_context_result.facial_match?,
+          pii_like_keypaths: [[:pii]],
         }.merge(
           ab_test_analytics_buckets,
         )

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -126,6 +126,7 @@ module Idv
             analytics_id: 'Doc Auth',
             liveness_checking_required: false,
             selfie_check_required: false,
+            pii_like_keypaths: [[:pii]],
           }
         end
       end

--- a/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
@@ -49,6 +49,7 @@ module Idv
           attributes = {
             error_code:,
             remaining_submit_attempts:,
+            pii_like_keypaths: [[:pii]],
           }
 
           analytics.idv_doc_auth_socure_error_visited(**attributes)

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -149,6 +149,7 @@ module Idv
           skip_hybrid_handoff: idv_session.skip_hybrid_handoff,
           liveness_checking_required: resolved_authn_context_result.facial_match?,
           selfie_check_required: resolved_authn_context_result.facial_match?,
+          pii_like_keypaths: [[:pii]],
         }.merge(ab_test_analytics_buckets)
       end
     end

--- a/app/controllers/idv/socure/errors_controller.rb
+++ b/app/controllers/idv/socure/errors_controller.rb
@@ -49,6 +49,7 @@ module Idv
       def track_event(error_code:)
         attributes = { error_code: }.merge(ab_test_analytics_buckets)
         attributes[:remaining_submit_attempts] = remaining_submit_attempts
+        attributes[:pii_like_keypaths] = [[:pii]]
 
         analytics.idv_doc_auth_socure_error_visited(**attributes)
       end
@@ -71,6 +72,8 @@ module Idv
           result.errors.dig(:socure, :reason_codes).first
         elsif result.errors[:network]
           :network
+        elsif result.errors[:pii_validation]
+          :pii_validation
         else
           # No error information available (shouldn't happen). Default
           # to :network if it does.

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -44,6 +44,7 @@ class SocureDocvResultsJob < ApplicationJob
         remaining_submit_attempts: rate_limiter&.remaining_count,
         vendor_request_time_in_ms:,
         async:,
+        pii_like_keypaths: [[:pii]],
       ).except(:attention_with_barcode, :selfie_live, :selfie_quality_good,
                :selfie_status),
     )

--- a/app/services/doc_auth/socure/responses/docv_result_response.rb
+++ b/app/services/doc_auth/socure/responses/docv_result_response.rb
@@ -42,10 +42,10 @@ module DocAuth
           @pii_from_doc = read_pii
 
           super(
-            success: successful_result?,
+            success: successful_result? && pii_valid?,
             errors: error_messages,
+            pii_from_doc:,
             extra: extra_attributes,
-            pii_from_doc: @pii_from_doc,
           )
         rescue StandardError => e
           NewRelic::Agent.notice_error(e)
@@ -175,6 +175,12 @@ module DocAuth
           }.to_json
           Rails.logger.info(message)
           nil
+        end
+
+        def pii_valid?
+          return @pii_valid if !@pii_valid.nil?
+
+          @pii_valid = Idv::DocPiiForm.new(pii: pii_from_doc.to_h).submit.success?
         end
       end
     end

--- a/app/services/doc_auth/socure/responses/docv_result_response.rb
+++ b/app/services/doc_auth/socure/responses/docv_result_response.rb
@@ -96,11 +96,13 @@ module DocAuth
         end
 
         def error_messages
-          return {} if successful_result?
-
-          {
-            socure: { reason_codes: get_data(DATA_PATHS[:reason_codes]) },
-          }
+          if !successful_result?
+            { socure: { reason_codes: get_data(DATA_PATHS[:reason_codes]) } }
+          elsif !pii_valid?
+            { pii_validation: 'failed' }
+          else
+            {}
+          end
         end
 
         def read_pii

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Idv::ApiImageUploadForm do
       fileName: front_image_file_name,
     }
   end
+
   let(:back_image_metadata) do
     {
       width: 20,
@@ -732,6 +733,7 @@ RSpec.describe Idv::ApiImageUploadForm do
       end
     end
   end
+
   describe '#store_failed_images' do
     let(:doc_pii_response) { instance_double(Idv::DocAuthFormResponse) }
     let(:client_response) { instance_double(DocAuth::Response) }

--- a/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
+++ b/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe DocAuth::Socure::Responses::DocvResultResponse do
+  subject(:docv_response) do
+    http_response = Struct.new(:body).new(SocureDocvFixtures.pass_json)
+    described_class.new(http_response:)
+  end
+
+  context 'Socure says OK and the PII is valid' do
+    it 'succeeds' do
+      expect(docv_response.success?).to be(true)
+    end
+  end
+
+  context 'Socure says OK but the PII is invalid' do
+    before do
+      allow_any_instance_of(Idv::DocPiiForm).to receive(:zipcode).and_return(:invalid_junk)
+    end
+
+    it 'fails' do
+      expect(docv_response.success?).to be(false)
+    end
+  end
+end

--- a/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
+++ b/spec/services/doc_auth/socure/responses/docv_result_response_spec.rb
@@ -20,5 +20,9 @@ RSpec.describe DocAuth::Socure::Responses::DocvResultResponse do
     it 'fails' do
       expect(docv_response.success?).to be(false)
     end
+
+    it 'with a pii failure error' do
+      expect(docv_response.errors).to eq({ pii_validation: 'failed' })
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket
[LG-14973](https://cm-jira.usa.gov/browse/LG-14973)

## 🛠 Summary of changes

Add the PII checks in the `DocPiiForm` to the Socure flow.

## 📜 Testing Plan

Verify that the tests in in `spec/services/doc_auth/socure/responses/docv_result_response_spec.rb` adequately check the functionality and pass.