### PR TITLE
LG-15272 Add IdentityConfig variable for maximum allowed doc auth socure users

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -106,6 +106,7 @@ doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_redirect_to_correct_vendor_disabled: false
 doc_auth_selfie_desktop_test_mode: false
+doc_auth_socure_max_allowed_users: 10_000
 doc_auth_socure_wait_polling_refresh_max_seconds: 15
 doc_auth_socure_wait_polling_timeout_minutes: 2
 doc_auth_supported_country_codes: '["US", "GU", "VI", "AS", "MP", "PR", "USA" ,"GUM", "VIR", "ASM", "MNP", "PRI"]'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -124,6 +124,7 @@ module IdentityConfig
     config.add(:doc_auth_max_capture_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_max_submission_attempts_before_native_camera, type: :integer)
     config.add(:doc_auth_selfie_desktop_test_mode, type: :boolean)
+    config.add(:doc_auth_socure_max_allowed_users, type: :integer)
     config.add(:doc_auth_socure_wait_polling_refresh_max_seconds, type: :integer)
     config.add(:doc_auth_socure_wait_polling_timeout_minutes, type: :integer)
     config.add(:doc_auth_supported_country_codes, type: :json)


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-15272](https://cm-jira.usa.gov/browse/LG-15272)



## 🛠 Summary of changes

Added an IdentityConfig variable for the maximum allowed number of socure users.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
