### PR TITLE
LG-15391 Allow SPs to request the user's locale

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,7 @@ class ApplicationController < ActionController::Base
   prepend_before_action :set_locale
   before_action :disable_caching
   before_action :cache_issuer_in_cookie
+  after_action :store_web_locale_in_sessions
 
   def session_expires_at
     return if @skip_session_expiration || @skip_session_load
@@ -398,6 +399,12 @@ class ApplicationController < ActionController::Base
 
   def set_locale
     I18n.locale = LocaleChooser.new(params[:locale], request).locale
+  end
+
+  def store_web_locale_in_sessions
+    return unless user_signed_in?
+
+    user_session[:web_locale] = I18n.locale.to_s
   end
 
   def pii_requested_but_locked?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
   prepend_before_action :set_locale
   before_action :disable_caching
   before_action :cache_issuer_in_cookie
-  after_action :store_web_locale_in_sessions
+  after_action :store_web_locale_in_session
 
   def session_expires_at
     return if @skip_session_expiration || @skip_session_load
@@ -401,7 +401,7 @@ class ApplicationController < ActionController::Base
     I18n.locale = LocaleChooser.new(params[:locale], request).locale
   end
 
-  def store_web_locale_in_sessions
+  def store_web_locale_in_session
     return unless user_signed_in?
 
     user_session[:web_locale] = I18n.locale.to_s

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -20,6 +20,7 @@ class OpenidConnectUserInfoPresenter
     }
 
     info[:all_emails] = all_emails_from_sp_identity(identity) if scoper.all_emails_requested?
+    info[:locale] = web_locale if scoper.locale_requested?
     info.merge!(ial2_attributes) if identity_proofing_requested_for_verified_user?
     info.merge!(x509_attributes) if scoper.x509_scopes_requested?
     info[:verified_at] = verified_at if scoper.verified_at_requested?
@@ -55,6 +56,10 @@ class OpenidConnectUserInfoPresenter
 
   def all_emails_from_sp_identity(identity)
     identity.user.confirmed_email_addresses.map(&:email)
+  end
+
+  def web_locale
+    out_of_band_session_accessor.load_web_locale
   end
 
   def ial2_attributes

--- a/app/presenters/saml_requested_attributes_presenter.rb
+++ b/app/presenters/saml_requested_attributes_presenter.rb
@@ -4,6 +4,7 @@ class SamlRequestedAttributesPresenter
   ATTRIBUTE_TO_FRIENDLY_NAME_MAP = {
     email: :email,
     all_emails: :all_emails,
+    locale: :locale,
     first_name: :given_name,
     last_name: :family_name,
     dob: :birthdate,
@@ -30,6 +31,7 @@ class SamlRequestedAttributesPresenter
     else
       attrs = [:email]
       attrs << :all_emails if bundle.include?(:all_emails)
+      attrs << :locale if bundle.include?(:locale)
       attrs << :verified_at if bundle.include?(:verified_at)
       attrs
     end

--- a/app/services/attribute_asserter.rb
+++ b/app/services/attribute_asserter.rb
@@ -36,6 +36,7 @@ class AttributeAsserter
     attrs = default_attrs
     add_email(attrs) if bundle.include? :email
     add_all_emails(attrs) if bundle.include? :all_emails
+    add_locale(attrs) if bundle.include? :locale
     add_bundle(attrs) if should_add_proofed_attributes?
     add_verified_at(attrs) if bundle.include?(:verified_at) && ial2_service_provider?
     if authn_request.requested_vtr_authn_contexts.present?
@@ -206,6 +207,10 @@ class AttributeAsserter
       name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic',
       name_id_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS,
     }
+  end
+
+  def add_locale(attrs)
+    attrs[:locale] = { getter: ->(_principal) { user_session[:web_locale] } }
   end
 
   def add_all_emails(attrs)

--- a/app/services/openid_connect_attribute_scoper.rb
+++ b/app/services/openid_connect_attribute_scoper.rb
@@ -20,6 +20,7 @@ class OpenidConnectAttributeScoper
   VALID_SCOPES = (%w[
     email
     all_emails
+    locale
     openid
     profile:verified_at
   ] + X509_SCOPES + IAL2_SCOPES).freeze
@@ -27,6 +28,7 @@ class OpenidConnectAttributeScoper
   VALID_IAL1_SCOPES = (%w[
     email
     all_emails
+    locale
     openid
     profile:verified_at
   ] + X509_SCOPES).freeze
@@ -35,6 +37,7 @@ class OpenidConnectAttributeScoper
     email: %w[email],
     email_verified: %w[email],
     all_emails: %w[all_emails],
+    locale: %w[locale],
     address: %w[address],
     phone: %w[phone],
     phone_verified: %w[phone],
@@ -80,6 +83,10 @@ class OpenidConnectAttributeScoper
 
   def all_emails_requested?
     scopes.include?('all_emails')
+  end
+
+  def locale_requested?
+    scopes.include?('locale')
   end
 
   def filter(user_info)

--- a/spec/controllers/sign_up/passwords_controller_spec.rb
+++ b/spec/controllers/sign_up/passwords_controller_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe SignUp::PasswordsController do
           'last_request_at' => kind_of(Numeric),
           new_device: false,
           in_account_creation_flow: true,
+          web_locale: 'en',
         )
       end
     end

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -569,6 +569,26 @@ RSpec.describe 'OpenID Connect' do
     expect(userinfo_response[:verified_at]).to be_nil
   end
 
+  it 'returns the locale if requested', driver: :mobile_rack_test do
+    user = user_with_2fa
+
+    token_response = sign_in_get_token_response(
+      user: user,
+      scope: 'openid email locale',
+    )
+
+    access_token = token_response[:access_token]
+    expect(access_token).to be_present
+
+    page.driver.get api_openid_connect_userinfo_path,
+                    {},
+                    'HTTP_AUTHORIZATION' => "Bearer #{access_token}"
+
+    userinfo_response = JSON.parse(page.body).with_indifferent_access
+    expect(userinfo_response[:email]).to eq(user.email)
+    expect(userinfo_response[:locale]).to eq('en')
+  end
+
   it 'errors if verified_within param is too recent', driver: :mobile_rack_test do
     client_id = 'urn:gov:gsa:openidconnect:test'
     allow(IdentityConfig.store).to receive(:allowed_verified_within_providers)

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -1154,7 +1154,6 @@ RSpec.describe 'OpenID Connect' do
       sign_in_live_with_2fa(user)
     end
 
-
     proofing_steps&.call
     handoff_page_steps&.call
 

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -572,9 +572,24 @@ RSpec.describe 'OpenID Connect' do
   it 'returns the locale if requested', driver: :mobile_rack_test do
     user = user_with_2fa
 
+
+
     token_response = sign_in_get_token_response(
       user: user,
       scope: 'openid email locale',
+      sign_in_steps: proc do
+        visit root_path(locale: 'es')
+
+        fill_in_credentials_and_submit(
+          user.confirmed_email_addresses.first.email,
+          user.password,
+        )
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+      end,
+      handoff_page_steps: proc do
+        click_agree_and_continue
+      end,
     )
 
     access_token = token_response[:access_token]
@@ -586,7 +601,7 @@ RSpec.describe 'OpenID Connect' do
 
     userinfo_response = JSON.parse(page.body).with_indifferent_access
     expect(userinfo_response[:email]).to eq(user.email)
-    expect(userinfo_response[:locale]).to eq('en')
+    expect(userinfo_response[:locale]).to eq('es')
   end
 
   it 'errors if verified_within param is too recent', driver: :mobile_rack_test do
@@ -1107,6 +1122,7 @@ RSpec.describe 'OpenID Connect' do
     acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
     scope: 'openid email',
     redirect_uri: 'gov.gsa.openidconnect.test://result',
+    sign_in_steps: nil,
     handoff_page_steps: nil,
     proofing_steps: nil,
     verified_within: nil,
@@ -1134,7 +1150,12 @@ RSpec.describe 'OpenID Connect' do
       verified_within: verified_within,
     )
 
-    _user = sign_in_live_with_2fa(user)
+    if sign_in_steps.present?
+      sign_in_steps.call
+    else
+      sign_in_live_with_2fa(user)
+    end
+
 
     proofing_steps&.call
     handoff_page_steps&.call

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -572,8 +572,6 @@ RSpec.describe 'OpenID Connect' do
   it 'returns the locale if requested', driver: :mobile_rack_test do
     user = user_with_2fa
 
-
-
     token_response = sign_in_get_token_response(
       user: user,
       scope: 'openid email locale',

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -253,6 +253,7 @@ RSpec.feature 'IAL1 Single Sign On' do
       )
 
       visit saml_authn_request
+      visit root_url(locale: 'es')
       fill_in_credentials_and_submit(user.email, user.password)
       fill_in_code_with_last_phone_otp
       click_submit_default
@@ -265,7 +266,7 @@ RSpec.feature 'IAL1 Single Sign On' do
       xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
 
       expect(xmldoc.attribute_node_for('locale')).to be_present
-      expect(xmldoc.attribute_value_for('locale')).to eq('en')
+      expect(xmldoc.attribute_value_for('locale')).to eq('es')
     end
   end
 end

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -238,4 +238,34 @@ RSpec.feature 'IAL1 Single Sign On' do
       expect(xmldoc.attribute_value_for('verified_at')).to be_blank
     end
   end
+
+  context 'requesting locale' do
+    it 'includes locale in the response' do
+      user = create(:user, :fully_registered)
+      saml_authn_request = saml_authn_request_url(
+        overrides: {
+          issuer: sp1_issuer,
+          authn_context: [
+            Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}email,locale",
+          ],
+        },
+      )
+
+      visit saml_authn_request
+      fill_in_credentials_and_submit(user.email, user.password)
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+
+      expect(current_url).to match new_user_session_path
+      click_submit_default
+      click_agree_and_continue
+      click_submit_default
+
+      xmldoc = SamlResponseDoc.new('feature', 'response_assertion')
+
+      expect(xmldoc.attribute_node_for('locale')).to be_present
+      expect(xmldoc.attribute_value_for('locale')).to eq('en')
+    end
+  end
 end

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AttributeAsserter do
   let(:facial_match_verified_user) do
     create(:profile, :active, :verified, idv_level: :in_person).user
   end
-  let(:user_session) { {} }
+  let(:user_session) { { web_locale: 'en' } }
   let(:identity) do
     build(
       :service_provider_identity,
@@ -612,6 +612,19 @@ RSpec.describe AttributeAsserter do
           emails = all_emails_getter.call(user)
           expect(emails.length).to eq(2)
           expect(emails).to match_array(user.confirmed_email_addresses.map(&:email))
+        end
+      end
+
+      context 'custom bundle includes locale' do
+        let(:attribute_bundle) { %w[locale] }
+        before do
+          subject.build
+        end
+
+        it 'includes the user locale' do
+          locale_getter = user.asserted_attributes[:locale][:getter]
+          locale = locale_getter.call(user)
+          expect(locale).to eq('en')
         end
       end
 

--- a/spec/services/openid_connect_attribute_scoper_spec.rb
+++ b/spec/services/openid_connect_attribute_scoper_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe OpenidConnectAttributeScoper do
         email: 'foo@example.com',
         email_verified: true,
         all_emails: ['foo@example.com', 'bar@example.com'],
+        locale: 'es',
         given_name: 'John',
         family_name: 'Jones',
         birthdate: '1970-01-01',
@@ -86,6 +87,14 @@ RSpec.describe OpenidConnectAttributeScoper do
 
       it 'includes the all_emails attributes' do
         expect(filtered[:all_emails]).to eq(['foo@example.com', 'bar@example.com'])
+      end
+    end
+
+    context 'with the locale scope' do
+      let(:scope) { 'openid locale' }
+
+      it 'includes the locale attribute' do
+        expect(filtered[:locale]).to eq('es')
       end
     end
 


### PR DESCRIPTION
We have a service provider who would like to be able to receive the user's UI locale when they receive attributes after sign in. This partner has a `post_idv_follow_up_url` that is configured to redirect the user to Login.gov with a request for verified attributes. Since the user does not see a UI on their site and likely does not have an established session there they want to know what locale the user is using on Login.gov to provide a consistent experience.

This commit enables partners to request to user's locale using the `locale` OIDC scope. The locale is stored in the session and set to the current user's locale on every request. This ensures the latest value will be returned to service providers.
