### PR TITLE
Move Faker gem from all environments to test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'cssbundling-rails'
 gem 'devise', '~> 4.8'
 gem 'dotiw', '>= 4.0.1'
 gem 'faraday', '~> 2'
-gem 'faker'
 gem 'faraday-retry'
 gem 'fugit'
 gem 'foundation_emails'
@@ -129,6 +128,7 @@ end
 group :test do
   gem 'axe-core-rspec', '~> 4.2'
   gem 'bundler-audit', require: false
+  gem 'faker'
   gem 'simplecov', '~> 0.22.0', require: false
   gem 'simplecov-cobertura'
   gem 'simplecov_json_formatter'


### PR DESCRIPTION
## 🛠 Summary of changes

We moved `faker` outside of the test group in #7698, and removed the non-test usage in #9154. This PR moves it back to the test group so we aren't unnecessarily installing it in non-test environments.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
