### PR TITLE
LG-15303: Improve layout of step indicator at high text zoom levels

### DIFF
--- a/app/assets/stylesheets/components/_step-indicator.scss
+++ b/app/assets/stylesheets/components/_step-indicator.scss
@@ -85,8 +85,18 @@ lg-step-indicator {
   position: relative;
   text-align: center;
 
+  // In cases when browser text zoom is very high (i.e. the root font-size has
+  // been drastically increased), the step indicator will overflow the viewport
+  // by _a lot_. In those cases, 33% of the viewport will not be wide enough to
+  // keep the individual steps from crowding each other.
+  //
+  // This min-width takes effect under those circumstances, keeping individual
+  // steps far enough apart to remain legible.
+  min-width: 4rem;
+
   @include at-media('tablet') {
     flex: 1 1 0%;
+    min-width: auto;
   }
 }
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15303](https://cm-jira.usa.gov/browse/LG-15303)

## 🛠 Summary of changes

When the browser's text zoom level is very high, the step indicator steps can become very crowded.

This commit adds a min-width to individual steps that is based on the root font size to prevent this issue.

## 👀 Screenshots

<details>
    <summary>Google Chrome (Android)</summary>

<table>
<tbody>
<tr>
<th colspan="2">100% text zoom</th>
</tr>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![before_100](https://github.com/user-attachments/assets/ca74e25d-35d1-4996-b5af-e26ae53812c5)

</td>
<td>

![after_100](https://github.com/user-attachments/assets/c691cbff-478a-40dd-a8e8-c5e78ad98748)

</td>
</tr>

<tr>
<th colspan="2">200% text zoom</th>
</tr>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![before_200](https://github.com/user-attachments/assets/8e905107-007b-48d5-8277-2c01e71cf82e)

</td>
<td>

![after_200](https://github.com/user-attachments/assets/31e6d1d1-db07-4ae4-90cd-3196c936dd78)

</td>

</tr>

<tr>
<th colspan="2">250% text zoom</th>
</tr>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![before_250](https://github.com/user-attachments/assets/d60992e4-d60c-4941-b6e8-aad52f85aa75)


</td>
<td>

![after_250](https://github.com/user-attachments/assets/f5479329-8489-44c9-9643-bb10d5bb515b)

</td>
</tr>

<tr>
<th colspan="2">300% text zoom</th>
</tr>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![before_300](https://github.com/user-attachments/assets/ea8a3a28-6607-4c94-85b6-9533200c7cee)


</td>
<td>

![after_300](https://github.com/user-attachments/assets/7c3846d4-7485-4c56-8376-8fda12b103ec)

</td>
</tr>

</tbody>
</table>


</details>

<details>
    <summary>Safari (iPhone)</summary>

<table>
<tbody>
<tr>
<th colspan="2">100% text zoom</th>
</tr>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![before_100](https://github.com/user-attachments/assets/987c6d71-59bb-443b-8a7d-96d762d789ce)

</td>
<td>

![after_100](https://github.com/user-attachments/assets/7c03175a-3b4b-4574-ae82-12fcd3e7181a)


</td>
</tr>

<tr>
<th colspan="2">200% text zoom</th>
</tr>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![before_200](https://github.com/user-attachments/assets/f05d25a3-debf-4bb5-a3df-36ac6dd156da)


</td>
<td>

![after_200](https://github.com/user-attachments/assets/cbdf3959-c749-4ef4-8b67-b755cee3c886)


</td>

</tr>

<tr>
<th colspan="2">300% text zoom</th>
</tr>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>


![before_300](https://github.com/user-attachments/assets/b6cf60d9-b504-40f0-b6ad-baecfe68d314)


</td>
<td>

![after_300](https://github.com/user-attachments/assets/5e0cecd8-cc5c-4958-9da4-7663f2071a7d)


</td>
</tr>

</tbody>
</table>


</details>
