### PR TITLE
Do not report LexisNexis or AAMVA exceptions to NewRelic

### DIFF
--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -62,7 +62,6 @@ module DocAuth
       end
 
       def handle_connection_error(exception:, status_code: nil, status_message: nil)
-        NewRelic::Agent.notice_error(exception)
         DocAuth::Response.new(
           success: false,
           errors: { network: true },

--- a/app/services/proofing/aamva/proofer.rb
+++ b/app/services/proofing/aamva/proofer.rb
@@ -60,15 +60,13 @@ module Proofing
 
         build_result_from_response(response, applicant[:state_id_jurisdiction])
       rescue => exception
-        failed_result = Proofing::StateIdResult.new(
+        Proofing::StateIdResult.new(
           success: false, errors: {}, exception: exception, vendor_name: 'aamva:state_id',
           transaction_id: nil, verified_attributes: [],
           jurisdiction_in_maintenance_window: jurisdiction_in_maintenance_window?(
             applicant[:state_id_jurisdiction],
           )
         )
-        send_to_new_relic(failed_result)
-        failed_result
       end
 
       private
@@ -124,13 +122,6 @@ module Proofing
         (attribute_set - ADDRESS_ATTRIBUTES).tap do |result|
           result.add(:address) if all_present
         end
-      end
-
-      def send_to_new_relic(result)
-        if result.mva_timeout?
-          return # noop
-        end
-        NewRelic::Agent.notice_error(result.exception)
       end
 
       def successful?(verification_response)

--- a/spec/services/doc_auth/lexis_nexis/request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/request_spec.rb
@@ -87,17 +87,12 @@ RSpec.describe DocAuth::LexisNexis::Request do
           expect(response.class).to eq(DocAuth::Response)
         end
 
-        it 'includes information on the error and notifies NewRelic' do
+        it 'includes information on the error' do
           expected_message = [
             subject.class.name,
             'Unexpected HTTP response',
             status,
           ].join(' ')
-          expect(NewRelic::Agent).to receive(:notice_error) do |arg|
-            expect(arg).to be_an_instance_of(DocAuth::RequestError)
-            expect(arg.message).to eq(expected_message)
-            expect(arg.error_code).to eq(status)
-          end
           response = subject.fetch
 
           expect(response.exception.message).to eq(expected_message)

--- a/spec/services/proofing/aamva/proofer_spec.rb
+++ b/spec/services/proofing/aamva/proofer_spec.rb
@@ -649,9 +649,7 @@ RSpec.describe Proofing::Aamva::Proofer do
           .to receive(:send).and_raise(exception)
       end
 
-      it 'logs to NewRelic' do
-        expect(NewRelic::Agent).to receive(:notice_error)
-
+      it 'includes exception in result' do
         result = subject.proof(state_id_data)
 
         expect(result.success?).to eq(false)
@@ -662,9 +660,7 @@ RSpec.describe Proofing::Aamva::Proofer do
       context 'the exception is a timeout error' do
         let(:exception) { Proofing::TimeoutError.new }
 
-        it 'logs to NewRelic' do
-          expect(NewRelic::Agent).to receive(:notice_error)
-
+        it 'returns false for mva exception attributes in result' do
           result = subject.proof(state_id_data)
 
           expect(result.success?).to eq(false)
@@ -683,9 +679,7 @@ RSpec.describe Proofing::Aamva::Proofer do
           )
         end
 
-        it 'logs to NewRelic' do
-          expect(NewRelic::Agent).to receive(:notice_error)
-
+        it 'returns true for mva_unavailable?' do
           result = subject.proof(state_id_data)
 
           expect(result.success?).to eq(false)
@@ -704,9 +698,7 @@ RSpec.describe Proofing::Aamva::Proofer do
           )
         end
 
-        it 'logs to NewRelic' do
-          expect(NewRelic::Agent).to receive(:notice_error)
-
+        it 'returns true for mva_system_error?' do
           result = subject.proof(state_id_data)
 
           expect(result.success?).to eq(false)
@@ -725,9 +717,7 @@ RSpec.describe Proofing::Aamva::Proofer do
           )
         end
 
-        it 'does not log to NewRelic' do
-          expect(NewRelic::Agent).not_to receive(:notice_error)
-
+        it 'returns true for mva_timeout?' do
           result = subject.proof(state_id_data)
 
           expect(result.success?).to eq(false)


### PR DESCRIPTION
## 🛠 Summary of changes

Following yesterday's discussion on noisy NewRelic errors, this PR removes the NewRelic reporting from both AAMVA and LexisNexis exceptions. This should not be a significant change in visibility as we have existing alarms on the infrastructure side.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
