### PR TITLE
LG-15515: AB doc auth vendor bucketing default to configured default doc auth vendor

### DIFF
--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -40,7 +40,7 @@ module AbTests
   DOC_AUTH_VENDOR = AbTest.new(
     experiment_name: 'Doc Auth Vendor',
     should_log: /^idv/i,
-    default_bucket: :lexis_nexis,
+    default_bucket: IdentityConfig.store.doc_auth_vendor_default.to_sym,
     buckets: {
       socure: IdentityConfig.store.doc_auth_vendor_switching_enabled ?
         IdentityConfig.store.doc_auth_vendor_socure_percent : 0,

--- a/spec/controllers/idv/hybrid_mobile/entry_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/entry_controller_spec.rb
@@ -146,6 +146,36 @@ RSpec.describe Idv::HybridMobile::EntryController do
         end
       end
 
+      context 'AB vendor percentages are 0' do
+        context 'when default bucket it mock' do
+          let(:lexis_nexis_percent) { 0 }
+          let(:idv_vendor) { Idp::Constants::Vendors::MOCK }
+
+          before do
+            allow(IdentityConfig.store).to receive(:doc_auth_vendor_socure_percent)
+              .and_return(0)
+          end
+
+          it 'redirects to the default vendor' do
+            expect(response).to redirect_to idv_hybrid_mobile_document_capture_url
+          end
+        end
+
+        context 'when default bucket it socure' do
+          let(:lexis_nexis_percent) { 0 }
+          let(:idv_vendor) { Idp::Constants::Vendors::SOCURE }
+
+          before do
+            allow(IdentityConfig.store).to receive(:doc_auth_vendor_socure_percent)
+              .and_return(0)
+          end
+
+          it 'redirects to the default vendor' do
+            expect(response).to redirect_to idv_hybrid_mobile_socure_document_capture_url
+          end
+        end
+      end
+
       context 'but we already had a session' do
         let!(:different_document_capture_session) do
           DocumentCaptureSession.create!(


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15515](https://cm-jira.usa.gov/browse/LG-15515)

## 🛠 Summary of changes
Set the default bucket for AB routing to the default doc auth vendor.

## 📜 Testing Plan
1. Set doc_auth_vendor_switching_enabled to false in config
1. Set percentages for doc auth vendors to 0
1. Verify that the document capture controller for the default doc auth vendor is rendered

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
