### PR TITLE
Retry instance profile credentials when sending emails via SES

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -52,6 +52,7 @@ aws_kms_multi_region_key_id: alias/login-dot-gov-keymaker-multi-region
 aws_kms_session_key_id: alias/login-dot-gov-test-keymaker
 aws_logo_bucket: ''
 aws_region: 'us-west-2'
+aws_ses_client_pool_size: 5
 backup_code_cost: '2000$8$1$'
 backup_code_user_id_per_ip_attempt_window_exponential_factor: 1.1
 backup_code_user_id_per_ip_attempt_window_in_minutes: 720

--- a/lib/aws/ses.rb
+++ b/lib/aws/ses.rb
@@ -6,33 +6,31 @@
 module Aws
   module SES
     class Base
+      SES_CLIENT_POOL = ConnectionPool.new(size: IdentityConfig.store.aws_ses_client_pool_size) do
+        # https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/timeout-duration.html
+        Aws::SES::Client.new(
+          retry_limit: 3,
+          retry_backoff: ->(_context) { sleep(1) },
+          instance_profile_credentials_timeout: 1, # defaults to 1 second
+          instance_profile_credentials_retries: 5, # defaults to 0 retries
+        )
+      end.freeze
+
       def initialize(*); end
 
       def deliver(mail)
-        response = ses_client.send_raw_email(
-          raw_message: { data: mail.to_s },
-          configuration_set_name: IdentityConfig.store.ses_configuration_set_name,
-        )
+        response = SES_CLIENT_POOL.with do |client|
+          client.send_raw_email(
+            raw_message: { data: mail.to_s },
+            configuration_set_name: IdentityConfig.store.ses_configuration_set_name,
+          )
+        end
 
         mail.header[:ses_message_id] = response.message_id
         response
       end
 
       alias_method :deliver!, :deliver
-
-      private
-
-      def ses_client
-        @ses_client ||= Aws::SES::Client.new(ses_client_options)
-      end
-
-      def ses_client_options
-        {
-          # https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/timeout-duration.html
-          retry_limit: 3,
-          retry_backoff: ->(_context) { sleep(2) },
-        }
-      end
     end
   end
 end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -70,6 +70,7 @@ module IdentityConfig
     config.add(:aws_kms_session_key_id, type: :string)
     config.add(:aws_logo_bucket, type: :string)
     config.add(:aws_region, type: :string)
+    config.add(:aws_ses_client_pool_size, type: :integer)
     config.add(:backup_code_cost, type: :string)
     config.add(:backup_code_user_id_per_ip_attempt_window_exponential_factor, type: :float)
     config.add(:backup_code_user_id_per_ip_attempt_window_in_minutes, type: :integer)

--- a/lib/telephony/pinpoint/sms_sender.rb
+++ b/lib/telephony/pinpoint/sms_sender.rb
@@ -26,6 +26,8 @@ module Telephony
             region: sms_config.region,
             retry_limit: 0,
             credentials: credentials,
+            instance_profile_credentials_timeout: 1, # defaults to 1 second
+            instance_profile_credentials_retries: 5, # defaults to 0 retries
           )
         end
       end

--- a/lib/telephony/pinpoint/voice_sender.rb
+++ b/lib/telephony/pinpoint/voice_sender.rb
@@ -22,6 +22,8 @@ module Telephony
             region: voice_config.region,
             retry_limit: 0,
             credentials: credentials,
+            instance_profile_credentials_timeout: 1, # defaults to 1 second
+            instance_profile_credentials_retries: 5, # defaults to 0 retries
           )
         end
       end


### PR DESCRIPTION
## 🛠 Summary of changes

Similar to changes we've made elsewhere to put AWS clients in connection pools with a retry on instance profile credential requests (#1887, #7292), this PR does similar for SES since we've seen similar issues with instance profile credential requests failing.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
