### PR TITLE
Return error when SAML year is invalid

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -7,6 +7,7 @@ module SamlIdpAuthConcern
 
   included do
     # rubocop:disable Rails/LexicallyScopedActionFilter
+    before_action :validate_year
     before_action :validate_and_create_saml_request_object, only: :auth
     before_action :validate_service_provider_and_authn_context, only: :auth
     before_action :check_sp_active, only: :auth
@@ -20,6 +21,12 @@ module SamlIdpAuthConcern
   end
 
   private
+
+  def validate_year
+    if !SamlEndpoint.valid_year?(params[:path_year])
+      render plain: 'Invalid Year', status: :bad_request
+    end
+  end
 
   def sign_out_if_forceauthn_is_true_and_user_is_signed_in
     if !saml_request.force_authn?

--- a/app/services/saml_endpoint.rb
+++ b/app/services/saml_endpoint.rb
@@ -1,10 +1,20 @@
 # frozen_string_literal: true
 
 class SamlEndpoint
+  SAML_YEARS = AppArtifacts.store.members.map(&:to_s).map do |key|
+    regex = /saml_(?<year>\d{4})_(?<key_cert>key|cert)/
+    matches = regex.match(key)
+    matches && matches[:year]
+  end.compact.uniq.freeze
+
   attr_reader :year
 
   def initialize(year)
     @year = year
+  end
+
+  def self.valid_year?(year)
+    SAML_YEARS.include?(year)
   end
 
   def self.suffixes

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -8,6 +8,36 @@ RSpec.describe SamlIdpController do
   let(:path_year) { SamlAuthHelper::PATH_YEAR }
 
   describe '/api/saml/logout' do
+    let(:service_provider) do
+      create(
+        :service_provider,
+        certs: ['sp_sinatra_demo', 'saml_test_sp'],
+        active: true,
+        assertion_consumer_logout_service_url: 'https://example.com',
+      )
+    end
+
+    let(:right_cert_settings) do
+      saml_settings(
+        overrides: {
+          issuer: service_provider.issuer,
+          assertion_consumer_logout_service_url: 'https://example.com',
+        },
+      )
+    end
+
+    let(:wrong_cert_settings) do
+      saml_settings(
+        overrides: {
+          issuer: service_provider.issuer,
+          certificate: File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt')),
+          private_key: OpenSSL::PKey::RSA.new(
+            File.read(Rails.root + 'keys/saml_test_sp2.key'),
+          ).to_pem,
+        },
+      )
+    end
+
     it 'assigns devise session limited failure redirect url' do
       delete :logout, params: { path_year: path_year }
 
@@ -23,6 +53,17 @@ RSpec.describe SamlIdpController do
         'Logout Initiated',
         hash_including(sp_initiated: false, oidc: false, saml_request_valid: true),
       )
+    end
+
+    context 'with invalid year' do
+      let(:path_year) { 1999 }
+
+      it 'returns bad request error' do
+        delete :logout, params: { SAMLRequest: 'foo', path_year: path_year }
+
+        expect(response).to be_bad_request
+        expect(response.body).to eq('Invalid Year')
+      end
     end
 
     it 'tracks the event when sp initiated' do
@@ -52,36 +93,6 @@ RSpec.describe SamlIdpController do
         error_types: { saml_request_errors: true },
         event: :saml_logout_request,
         integration_exists: false,
-      )
-    end
-
-    let(:service_provider) do
-      create(
-        :service_provider,
-        certs: ['sp_sinatra_demo', 'saml_test_sp'],
-        active: true,
-        assertion_consumer_logout_service_url: 'https://example.com',
-      )
-    end
-
-    let(:right_cert_settings) do
-      saml_settings(
-        overrides: {
-          issuer: service_provider.issuer,
-          assertion_consumer_logout_service_url: 'https://example.com',
-        },
-      )
-    end
-
-    let(:wrong_cert_settings) do
-      saml_settings(
-        overrides: {
-          issuer: service_provider.issuer,
-          certificate: File.read(Rails.root.join('certs', 'sp', 'saml_test_sp2.crt')),
-          private_key: OpenSSL::PKey::RSA.new(
-            File.read(Rails.root + 'keys/saml_test_sp2.key'),
-          ).to_pem,
-        },
       )
     end
 
@@ -207,21 +218,6 @@ RSpec.describe SamlIdpController do
   end
 
   describe '/api/saml/remotelogout' do
-    it 'tracks the event when the saml request is invalid' do
-      stub_analytics
-
-      post :remotelogout, params: { SAMLRequest: 'foo', path_year: path_year }
-
-      expect(@analytics).to have_logged_event('Remote Logout initiated', saml_request_valid: false)
-      expect(@analytics).to have_logged_event(
-        :sp_integration_errors_present,
-        error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
-        error_types: { saml_request_errors: true },
-        event: :saml_remote_logout_request,
-        integration_exists: false,
-      )
-    end
-
     let(:agency) { create(:agency) }
     let(:service_provider) do
       create(
@@ -315,6 +311,21 @@ RSpec.describe SamlIdpController do
             File.read(Rails.root + 'keys/saml_test_sp2.key'),
           ).to_pem,
         },
+      )
+    end
+
+    it 'tracks the event when the saml request is invalid' do
+      stub_analytics
+
+      post :remotelogout, params: { SAMLRequest: 'foo', path_year: path_year }
+
+      expect(@analytics).to have_logged_event('Remote Logout initiated', saml_request_valid: false)
+      expect(@analytics).to have_logged_event(
+        :sp_integration_errors_present,
+        error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
+        error_types: { saml_request_errors: true },
+        event: :saml_remote_logout_request,
+        integration_exists: false,
       )
     end
 
@@ -519,6 +530,15 @@ RSpec.describe SamlIdpController do
 
     it 'renders XML inline' do
       expect(response.media_type).to eq 'text/xml'
+    end
+
+    context 'with invalid year' do
+      let(:path_year) { 1999 }
+
+      it 'returns bad request error' do
+        expect(response).to be_bad_request
+        expect(response.body).to eq('Invalid Year')
+      end
     end
 
     it 'contains an EntityDescriptor nodeset' do
@@ -2139,7 +2159,7 @@ RSpec.describe SamlIdpController do
 
     context 'with missing SAMLRequest params' do
       it 'responds with "403 Forbidden"' do
-        get :auth
+        get :auth, params: { path_year: path_year }
 
         expect(response.status).to eq(403)
       end
@@ -2147,7 +2167,7 @@ RSpec.describe SamlIdpController do
 
     context 'with invalid SAMLRequest param' do
       it 'responds with "403 Forbidden"' do
-        get :auth
+        get :auth, params: { path_year: path_year }
 
         expect(response.status).to eq(403)
       end


### PR DESCRIPTION
## 🛠 Summary of changes

We currently raise an unhandled exception in some cases when receiving a request for a SAML year that is not currently configured. This PR stores the SAML years from `AppArtifacts` in a constant and adds a year check to the SAML controller that returns an error if the year is not available.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
