### PR TITLE
allow subdomains of identitysandbox.gov to work

### DIFF
--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -66,7 +66,7 @@ class FeatureManagement
 
   def self.current_env_allowed_to_see_gpo_code?
     (Identity::Hostdata.domain == ('identitysandbox.gov') ||
-      Identity::Hostdata.domain.end_with? ('.identitysandbox.gov'))
+      Identity::Hostdata.domain.end_with?('.identitysandbox.gov'))
   end
 
   def self.show_demo_banner?

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -65,8 +65,8 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_gpo_code?
-    (Identity::Hostdata.domain == 'identitysandbox.gov' ||
-      Identity::Hostdata.domain.end_with?('.identitysandbox.gov'))
+    Identity::Hostdata.domain == 'identitysandbox.gov' ||
+      Identity::Hostdata.domain.end_with?('.identitysandbox.gov')
   end
 
   def self.show_demo_banner?

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -34,8 +34,8 @@ class FeatureManagement
   end
 
   def self.prefill_otp_codes_allowed_in_sandbox?
-    ! Identity::Hostdata.domain.nil? &&
-    (Identity::Hostdata.domain == 'identitysandbox.gov' ||
+    !Identity::Hostdata.domain.nil? &&
+      (Identity::Hostdata.domain == 'identitysandbox.gov' ||
       Identity::Hostdata.domain.end_with?('.identitysandbox.gov')) &&
       telephony_test_adapter?
   end
@@ -66,8 +66,8 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_gpo_code?
-    ! Identity::Hostdata.domain.nil? &&
-    (Identity::Hostdata.domain == 'identitysandbox.gov' ||
+    !Identity::Hostdata.domain.nil? &&
+      (Identity::Hostdata.domain == 'identitysandbox.gov' ||
       Identity::Hostdata.domain.end_with?('.identitysandbox.gov'))
   end
 

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -34,7 +34,7 @@ class FeatureManagement
   end
 
   def self.prefill_otp_codes_allowed_in_sandbox?
-    Identity::Hostdata.domain.end_with?('identitysandbox.gov') && telephony_test_adapter? 
+    Identity::Hostdata.domain.end_with?('identitysandbox.gov') && telephony_test_adapter?
   end
 
   def self.enable_load_testing_mode?

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -65,7 +65,8 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_gpo_code?
-    Identity::Hostdata.domain.end_with?('identitysandbox.gov')
+    (Identity::Hostdata.domain == ('identitysandbox.gov')
+      || Identity::Hostdata.domain.end_with? ('.identitysandbox.gov'))
   end
 
   def self.show_demo_banner?

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -34,7 +34,7 @@ class FeatureManagement
   end
 
   def self.prefill_otp_codes_allowed_in_sandbox?
-    Identity::Hostdata.domain.end_with?('identitysandbox.gov') && telephony_test_adapter?
+    Identity::Hostdata.domain.end_with?('identitysandbox.gov') && telephony_test_adapter? 
   end
 
   def self.enable_load_testing_mode?

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -65,7 +65,7 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_gpo_code?
-    (Identity::Hostdata.domain == ('identitysandbox.gov') ||
+    (Identity::Hostdata.domain == 'identitysandbox.gov' ||
       Identity::Hostdata.domain.end_with?('.identitysandbox.gov'))
   end
 

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -34,7 +34,9 @@ class FeatureManagement
   end
 
   def self.prefill_otp_codes_allowed_in_sandbox?
-    Identity::Hostdata.domain.end_with?('identitysandbox.gov') && telephony_test_adapter?
+    (Identity::Hostdata.domain == ('identitysandbox.gov')
+      || Identity::Hostdata.domain.end_with? ('.identitysandbox.gov'))
+      && telephony_test_adapter?
   end
 
   def self.enable_load_testing_mode?

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -34,6 +34,7 @@ class FeatureManagement
   end
 
   def self.prefill_otp_codes_allowed_in_sandbox?
+    ! Identity::Hostdata.domain.nil? &&
     (Identity::Hostdata.domain == 'identitysandbox.gov' ||
       Identity::Hostdata.domain.end_with?('.identitysandbox.gov')) &&
       telephony_test_adapter?
@@ -65,8 +66,9 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_gpo_code?
-    Identity::Hostdata.domain == 'identitysandbox.gov' ||
-      Identity::Hostdata.domain.end_with?('.identitysandbox.gov')
+    ! Identity::Hostdata.domain.nil? &&
+    (Identity::Hostdata.domain == 'identitysandbox.gov' ||
+      Identity::Hostdata.domain.end_with?('.identitysandbox.gov'))
   end
 
   def self.show_demo_banner?

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -34,7 +34,7 @@ class FeatureManagement
   end
 
   def self.prefill_otp_codes_allowed_in_sandbox?
-    Identity::Hostdata.domain == 'identitysandbox.gov' && telephony_test_adapter?
+    Identity::Hostdata.domain.end_with?('identitysandbox.gov') && telephony_test_adapter?
   end
 
   def self.enable_load_testing_mode?
@@ -63,7 +63,7 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_gpo_code?
-    Identity::Hostdata.domain == 'identitysandbox.gov'
+    Identity::Hostdata.domain.end_with?('identitysandbox.gov')
   end
 
   def self.show_demo_banner?

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -34,9 +34,9 @@ class FeatureManagement
   end
 
   def self.prefill_otp_codes_allowed_in_sandbox?
-    (Identity::Hostdata.domain == ('identitysandbox.gov')
-      || Identity::Hostdata.domain.end_with? ('.identitysandbox.gov'))
-      && telephony_test_adapter?
+    (Identity::Hostdata.domain == 'identitysandbox.gov' ||
+      Identity::Hostdata.domain.end_with?('.identitysandbox.gov')) &&
+      telephony_test_adapter?
   end
 
   def self.enable_load_testing_mode?
@@ -65,8 +65,8 @@ class FeatureManagement
   end
 
   def self.current_env_allowed_to_see_gpo_code?
-    (Identity::Hostdata.domain == ('identitysandbox.gov')
-      || Identity::Hostdata.domain.end_with? ('.identitysandbox.gov'))
+    (Identity::Hostdata.domain == ('identitysandbox.gov') ||
+      Identity::Hostdata.domain.end_with? ('.identitysandbox.gov'))
   end
 
   def self.show_demo_banner?


### PR DESCRIPTION
## 🛠 Summary of changes

This makes it so that we are not required to have LOGIN_DOMAIN set to identitysandbox.gov for certain things to happen, so  we can use things like tooling.identitysandbox.gov and have newrelic/prefill_otp_codes_allowed_in_sandbox/current_env_allowed_to_see_gpo_code config work.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Create image with this PR
- [x] Test the image in the loadtest k8s environment, which uses tooling.identitysandbox.gov for it's LOGIN_DOMAIN
- [x] Test the image in one of the sandbox k8s environments.
- [x] Dance!
