### PR TITLE
Update alternative content for Face/Touch recommended test

### DIFF
--- a/app/views/users/webauthn_platform_recommended/new.html.erb
+++ b/app/views/users/webauthn_platform_recommended/new.html.erb
@@ -3,23 +3,7 @@
 <%= render StatusPageComponent.new(status: :info, icon: :question) do |c| %>
   <% c.with_header { t('webauthn_platform_recommended.heading') } %>
 
-  <p><%= t('webauthn_platform_recommended.description_secure_account') %></p>
-
-  <p>
-    <%= t(
-          'webauthn_platform_recommended.description_private_html',
-          phishing_resistant_link_html: new_tab_link_to(
-            t('webauthn_platform_recommended.phishing_resistant'),
-            help_center_redirect_path(
-              category: 'get-started',
-              article: 'authentication-methods',
-              anchor: 'face-or-touch-unlock',
-              flow: @sign_in_flow,
-              step: :webauthn_platform_recommended,
-            ),
-          ),
-        ) %>
-  </p>
+  <p><%= t('webauthn_platform_recommended.description_save_time') %></p>
 
   <div class="grid-row margin-top-5">
     <div class="tablet:grid-col-9">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2043,7 +2043,6 @@ vendor_outage.working: We are working to resolve an error
 webauthn_platform_recommended.cta: Set up face or touch unlock
 webauthn_platform_recommended.description_save_time: Save time by using your face, fingerprint, password, or another method to access your account. This method is faster than receiving a one-time code through text or voice message.
 webauthn_platform_recommended.heading: Set up face or touch unlock for a quick and easy sign in
-webauthn_platform_recommended.phishing_resistant: phishing-resistant
 webauthn_platform_recommended.skip: Skip
 zxcvbn.feedback.a_word_by_itself_is_easy_to_guess: A word by itself is easy to guess
 zxcvbn.feedback.add_another_word_or_two_uncommon_words_are_better: Add another word or two. Uncommon words are better

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2041,9 +2041,8 @@ vendor_outage.get_updates: Get updates
 vendor_outage.get_updates_on_status_page: Get updates on our status page
 vendor_outage.working: We are working to resolve an error
 webauthn_platform_recommended.cta: Set up face or touch unlock
-webauthn_platform_recommended.description_private_html: Face or touch unlock is %{phishing_resistant_link_html} and we don’t store any recordings of your face or fingerprint, so your information stays private.
-webauthn_platform_recommended.description_secure_account: Secure your sign in with face or touch unlock. Use your face, fingerprint, password, or another method to keep your account safer.
-webauthn_platform_recommended.heading: Set up face or touch unlock for a more secure sign in
+webauthn_platform_recommended.description_save_time: Save time by using your face, fingerprint, password, or another method to access your account. This method is faster than receiving a one-time code through text or voice message.
+webauthn_platform_recommended.heading: Set up face or touch unlock for a quick and easy sign in
 webauthn_platform_recommended.phishing_resistant: phishing-resistant
 webauthn_platform_recommended.skip: Skip
 zxcvbn.feedback.a_word_by_itself_is_easy_to_guess: A word by itself is easy to guess

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2055,7 +2055,6 @@ vendor_outage.working: Estamos trabajando para corregir un error
 webauthn_platform_recommended.cta: Set up face or touch unlock
 webauthn_platform_recommended.description_save_time: Save time by using your face, fingerprint, password, or another method to access your account. This method is faster than receiving a one-time code through text or voice message.
 webauthn_platform_recommended.heading: Set up face or touch unlock for a quick and easy sign in
-webauthn_platform_recommended.phishing_resistant: phishing-resistant
 webauthn_platform_recommended.skip: Skip
 zxcvbn.feedback.a_word_by_itself_is_easy_to_guess: Una sola palabra es fácil de adivinar.
 zxcvbn.feedback.add_another_word_or_two_uncommon_words_are_better: Añada otra palabra o dos. Es mejor usar palabras poco comunes.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2053,9 +2053,8 @@ vendor_outage.get_updates: Obtenga actualizaciones
 vendor_outage.get_updates_on_status_page: Obtenga las actualizaciones en nuestra página de estado
 vendor_outage.working: Estamos trabajando para corregir un error
 webauthn_platform_recommended.cta: Set up face or touch unlock
-webauthn_platform_recommended.description_private_html: Face or touch unlock is %{phishing_resistant_link_html} and we don’t store any recordings of your face or fingerprint, so your information stays private.
-webauthn_platform_recommended.description_secure_account: Secure your sign in with face or touch unlock. Use your face, fingerprint, password, or another method to keep your account safer.
-webauthn_platform_recommended.heading: Set up face or touch unlock for a more secure sign in
+webauthn_platform_recommended.description_save_time: Save time by using your face, fingerprint, password, or another method to access your account. This method is faster than receiving a one-time code through text or voice message.
+webauthn_platform_recommended.heading: Set up face or touch unlock for a quick and easy sign in
 webauthn_platform_recommended.phishing_resistant: phishing-resistant
 webauthn_platform_recommended.skip: Skip
 zxcvbn.feedback.a_word_by_itself_is_easy_to_guess: Una sola palabra es fácil de adivinar.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2041,9 +2041,8 @@ vendor_outage.get_updates: Obtenir les dernières informations
 vendor_outage.get_updates_on_status_page: Obtenir les dernières informations sur notre page d’état des systèmes.
 vendor_outage.working: Nous travaillons à la résolution d’une erreur
 webauthn_platform_recommended.cta: Set up face or touch unlock
-webauthn_platform_recommended.description_private_html: Face or touch unlock is %{phishing_resistant_link_html} and we don’t store any recordings of your face or fingerprint, so your information stays private.
-webauthn_platform_recommended.description_secure_account: Secure your sign in with face or touch unlock. Use your face, fingerprint, password, or another method to keep your account safer.
-webauthn_platform_recommended.heading: Set up face or touch unlock for a more secure sign in
+webauthn_platform_recommended.description_save_time: Save time by using your face, fingerprint, password, or another method to access your account. This method is faster than receiving a one-time code through text or voice message.
+webauthn_platform_recommended.heading: Set up face or touch unlock for a quick and easy sign in
 webauthn_platform_recommended.phishing_resistant: phishing-resistant
 webauthn_platform_recommended.skip: Skip
 zxcvbn.feedback.a_word_by_itself_is_easy_to_guess: Un mot seul est facile à deviner

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2043,7 +2043,6 @@ vendor_outage.working: Nous travaillons à la résolution d’une erreur
 webauthn_platform_recommended.cta: Set up face or touch unlock
 webauthn_platform_recommended.description_save_time: Save time by using your face, fingerprint, password, or another method to access your account. This method is faster than receiving a one-time code through text or voice message.
 webauthn_platform_recommended.heading: Set up face or touch unlock for a quick and easy sign in
-webauthn_platform_recommended.phishing_resistant: phishing-resistant
 webauthn_platform_recommended.skip: Skip
 zxcvbn.feedback.a_word_by_itself_is_easy_to_guess: Un mot seul est facile à deviner
 zxcvbn.feedback.add_another_word_or_two_uncommon_words_are_better: Ajoutez un ou deux autres mots. Il est préférable d’utiliser des mots peu communs.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -2054,9 +2054,8 @@ vendor_outage.get_updates: 获得最新信息
 vendor_outage.get_updates_on_status_page: 在我们的状态页面获得最新信息。
 vendor_outage.working: 我们正在争取解决错误。
 webauthn_platform_recommended.cta: Set up face or touch unlock
-webauthn_platform_recommended.description_private_html: Face or touch unlock is %{phishing_resistant_link_html} and we don’t store any recordings of your face or fingerprint, so your information stays private.
-webauthn_platform_recommended.description_secure_account: Secure your sign in with face or touch unlock. Use your face, fingerprint, password, or another method to keep your account safer.
-webauthn_platform_recommended.heading: Set up face or touch unlock for a more secure sign in
+webauthn_platform_recommended.description_save_time: Save time by using your face, fingerprint, password, or another method to access your account. This method is faster than receiving a one-time code through text or voice message.
+webauthn_platform_recommended.heading: Set up face or touch unlock for a quick and easy sign in
 webauthn_platform_recommended.phishing_resistant: phishing-resistant
 webauthn_platform_recommended.skip: Skip
 zxcvbn.feedback.a_word_by_itself_is_easy_to_guess: 单字容易被人猜出

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -2056,7 +2056,6 @@ vendor_outage.working: 我们正在争取解决错误。
 webauthn_platform_recommended.cta: Set up face or touch unlock
 webauthn_platform_recommended.description_save_time: Save time by using your face, fingerprint, password, or another method to access your account. This method is faster than receiving a one-time code through text or voice message.
 webauthn_platform_recommended.heading: Set up face or touch unlock for a quick and easy sign in
-webauthn_platform_recommended.phishing_resistant: phishing-resistant
 webauthn_platform_recommended.skip: Skip
 zxcvbn.feedback.a_word_by_itself_is_easy_to_guess: 单字容易被人猜出
 zxcvbn.feedback.add_another_word_or_two_uncommon_words_are_better: 再加一两个字不常见的字更好

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -77,7 +77,6 @@ module I18n
         { key: 'webauthn_platform_recommended.cta' }, # English-only A/B test
         { key: 'webauthn_platform_recommended.description_save_time' }, # English-only A/B test
         { key: 'webauthn_platform_recommended.heading' }, # English-only A/B test
-        { key: 'webauthn_platform_recommended.phishing_resistant' }, # English-only A/B test
         { key: 'webauthn_platform_recommended.skip' }, # English-only A/B test
       ].freeze
       # rubocop:enable Layout/LineLength

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -75,8 +75,7 @@ module I18n
         { key: 'time.formats.full_date', locales: %i[es] }, # format is the same in Spanish and English
         { key: 'time.formats.sms_date' }, # for us date format
         { key: 'webauthn_platform_recommended.cta' }, # English-only A/B test
-        { key: 'webauthn_platform_recommended.description_private_html' }, # English-only A/B test
-        { key: 'webauthn_platform_recommended.description_secure_account' }, # English-only A/B test
+        { key: 'webauthn_platform_recommended.description_save_time' }, # English-only A/B test
         { key: 'webauthn_platform_recommended.heading' }, # English-only A/B test
         { key: 'webauthn_platform_recommended.phishing_resistant' }, # English-only A/B test
         { key: 'webauthn_platform_recommended.skip' }, # English-only A/B test

--- a/spec/views/users/webauthn_platform_recommended/new.html.erb_spec.rb
+++ b/spec/views/users/webauthn_platform_recommended/new.html.erb_spec.rb
@@ -7,19 +7,4 @@ RSpec.describe 'users/webauthn_platform_recommended/new.html.erb' do
     expect(rendered).to have_css('form:has(input[name=add_method]):has([type=submit])')
     expect(rendered).to have_css('form:not(:has(input[name=add_method])):has([type=submit])')
   end
-
-  it 'renders a help link for phishing-resistant including flow path' do
-    @sign_in_flow = :example
-
-    expect(rendered).to have_link(
-      t('webauthn_platform_recommended.phishing_resistant'),
-      href: help_center_redirect_path(
-        category: 'get-started',
-        article: 'authentication-methods',
-        anchor: 'face-or-touch-unlock',
-        flow: :example,
-        step: :webauthn_platform_recommended,
-      ),
-    )
-  end
 end


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-14655](https://cm-jira.usa.gov/browse/LG-14655)

## 🛠 Summary of changes

Updates content for an alternative design to recommend Face or Touch Unlock to users authenticating or creating an account with SMS.

This was originally intended to be included in [LG-14655](https://cm-jira.usa.gov/browse/LG-14655).

## 📜 Testing Plan

Repeat testing plan in #11402.

## 👀 Screenshots

<img alt="face touch recommended" src="https://github.com/user-attachments/assets/2483a38c-225a-46c1-9124-af1a56595ef0" width="300">

