### PR TITLE
Fix syntax error in Pinpoint scheduled job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -706,7 +706,7 @@ pinpoint_check_scheduled:
           --channel "#login-appdev" \
           --webhook "${SLACK_WEBHOOK}" \
           --raise \
-          --text "$(printf "Pinpoint supported countries check in GitLab failed.\nBuild Results: ${CI_JOB_URL}.\nCheck results locally with 'make lint_country_dialing_codes'")""
+          --text "$(printf "Pinpoint supported countries check in GitLab failed.\nBuild Results: ${CI_JOB_URL}.\nCheck results locally with 'make lint_country_dialing_codes'")"
       fi
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"


### PR DESCRIPTION
Turns out there was a syntax error in this scheduled job, so this has been failing and CI hasn't alerted us

[Example failed run](https://gitlab.login.gov/lg/identity-idp/-/jobs/1624861)