### PR TITLE
Fix string extraction for Webpack function renaming

### DIFF
--- a/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.js
@@ -18,7 +18,7 @@ const PLUGIN = 'ExtractKeysWebpackPlugin';
  *
  * @type {RegExp}
  */
-const TRANSLATE_CALL = /(?:^|[^\w'-])t\)?\(\[?(['"][a-z\d\s_.,'"]+['"])]?[,\s)]/g;
+const TRANSLATE_CALL = /(?:^|[^\w'-]|i18n_)t\)?\(\[?(['"][a-z\d\s_.,'"]+['"])]?[,\s)]/g;
 
 /**
  * Given an original file name and locale, returns a modified file name with the locale injected

--- a/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.spec.js
+++ b/app/javascript/packages/rails-i18n-webpack-plugin/extract-keys-webpack-plugin.spec.js
@@ -50,6 +50,9 @@ describe('getTranslationKeys', () => {
     // 2. https://babeljs.io/repl#?browsers=ie%2011&code_lz=C4CgBgZg9gTgtgZwHQBIDeBrApgTwL5JQB2WYAlEA
     t("forms.".concat(key, ".one"));
     t(["forms.".concat(key, ".one")]);
+
+    // Emulate Webpack function renaming
+    i18n_t('item.4')
   `;
 
   it('returns keys', () => {
@@ -61,6 +64,7 @@ describe('getTranslationKeys', () => {
       'item.1',
       'item.2',
       'item.3',
+      'item.4',
     ]);
   });
 });


### PR DESCRIPTION
## 🛠 Summary of changes

Updates Webpack i18n string extraction to match on a pattern of Webpack renamed source code for references to `t` in `@18f/identity-i18n`.

Example source:

```
 children: i18n_t('in_person_proofing.headings.cta')
```

This isn't an especially resilient solution, but since we don't currently operate on the raw source of the files, we have to try to extract with some transformations from Webpack and Babel applied (see related #6359).

## 📜 Testing Plan

Verify that production-optimized build includes previously-missing strings in output.

```
NODE_ENV=production yarn build
find ./public/packs -type f -name 'document-capture-*.en.js' -exec grep "in_person_proofing.headings.cta" {} +
```

The result of the `find` command should be non-empty. (On `main`, the result is empty)