### PR TITLE
Fail louder on missing translation data

### DIFF
--- a/app/javascript/packages/i18n/CHANGELOG.md
+++ b/app/javascript/packages/i18n/CHANGELOG.md
@@ -1,4 +1,6 @@
-# `Change Log`
+## Unreleased
+
+- Output console message when translation data missing for requested key.
 
 ## 1.0.1
 

--- a/app/javascript/packages/i18n/CHANGELOG.md
+++ b/app/javascript/packages/i18n/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Output console message when translation data missing for requested key.
+- Output console error message when translation data missing for requested key.
 
 ## 1.0.1
 

--- a/app/javascript/packages/i18n/index.spec.ts
+++ b/app/javascript/packages/i18n/index.spec.ts
@@ -1,3 +1,4 @@
+import { useDefineProperty } from '@18f/identity-test-helpers';
 import { I18n, replaceVariables } from './index';
 
 describe('replaceVariables', () => {
@@ -33,9 +34,25 @@ describe('I18n', () => {
       expect(t(['known', 'known'])).to.deep.equal(['translation', 'translation']);
     });
 
-    it('falls back to key value and logs to console', () => {
+    it('falls back to key value', () => {
       expect(t('unknown')).to.equal('unknown');
-      expect(console).to.have.loggedError('Missing translation for key `unknown`.');
+    });
+
+    context('in non-test environment', () => {
+      const defineProperty = useDefineProperty();
+      beforeEach(() => {
+        defineProperty(process.env, 'NODE_ENV', {
+          value: 'production',
+          configurable: true,
+          writable: true,
+          enumerable: true,
+        });
+      });
+
+      it('falls back to key value and logs to console', () => {
+        expect(t('unknown')).to.equal('unknown');
+        expect(console).to.have.loggedError('Missing translation for key `unknown`.');
+      });
     });
 
     describe('pluralization', () => {

--- a/app/javascript/packages/i18n/index.spec.ts
+++ b/app/javascript/packages/i18n/index.spec.ts
@@ -33,8 +33,9 @@ describe('I18n', () => {
       expect(t(['known', 'known'])).to.deep.equal(['translation', 'translation']);
     });
 
-    it('falls back to key value', () => {
+    it('falls back to key value and logs to console', () => {
       expect(t('unknown')).to.equal('unknown');
+      expect(console).to.have.loggedError('Missing translation for key `unknown`.');
     });
 
     describe('pluralization', () => {

--- a/app/javascript/packages/i18n/index.ts
+++ b/app/javascript/packages/i18n/index.ts
@@ -34,8 +34,13 @@ function getEntry(strings: Entries, key: string): Entry {
     return strings[key];
   }
 
-  // eslint-disable-next-line no-console
-  console.error(`Missing translation for key \`${key}\`.`);
+  if (process.env.NODE_ENV !== 'test') {
+    // String data is not populated in JavaScript tests, so falling back to the key is the expected
+    // behavior. In all other environments this is an unexpected behavior, so log accordingly.
+
+    // eslint-disable-next-line no-console
+    console.error(`Missing translation for key \`${key}\`.`);
+  }
 
   return key;
 }

--- a/app/javascript/packages/i18n/index.ts
+++ b/app/javascript/packages/i18n/index.ts
@@ -29,8 +29,16 @@ const getPluralizationKey = (count: number): keyof PluralizedEntry =>
  *
  * @return Entry string or object.
  */
-const getEntry = (strings: Entries, key: string): Entry =>
-  Object.hasOwn(strings, key) ? strings[key] : key;
+function getEntry(strings: Entries, key: string): Entry {
+  if (Object.hasOwn(strings, key)) {
+    return strings[key];
+  }
+
+  // eslint-disable-next-line no-console
+  console.error(`Missing translation for key \`${key}\`.`);
+
+  return key;
+}
 
 /**
  * Returns true if the given entry is a pluralization entry, or false otherwise.

--- a/scripts/enforce-typescript-files.mjs
+++ b/scripts/enforce-typescript-files.mjs
@@ -26,7 +26,6 @@ const LEGACY_FILE_EXCEPTIONS = [
   'spec/javascript/packs/form-steps-wait-spec.js',
   'spec/javascript/packs/state-guidance-spec.js',
   'spec/javascript/packs/webauthn-setup-spec.js',
-  'spec/javascript/support/console.js',
   'spec/javascript/support/document-capture.jsx',
   'spec/javascript/support/dom.js',
   'spec/javascript/support/file.js',

--- a/spec/javascript/support/console.ts
+++ b/spec/javascript/support/console.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 
+import { format } from 'node:util';
 import sinon from 'sinon';
-import { format } from 'util';
+import type Chai from 'chai';
 
 declare global {
   namespace Chai {
@@ -20,10 +21,10 @@ let unverifiedCalls: string[] = [];
  * @see https://www.chaijs.com/guide/plugins/
  * @see https://www.chaijs.com/api/plugins/
  *
- * @param {import('chai')}                chai  Chai object.
- * @param {import('chai/lib/chai/utils')} utils Chai plugin utilities.
+ * @param chai Chai object.
+ * @param utils Chai plugin utilities.
  */
-export function chaiConsoleSpy(chai, utils) {
+export const chaiConsoleSpy: Chai.ChaiPlugin = (chai, utils) => {
   utils.addChainableMethod(
     chai.Assertion.prototype,
     'loggedError',
@@ -46,7 +47,7 @@ export function chaiConsoleSpy(chai, utils) {
     },
     undefined,
   );
-}
+};
 
 /**
  * Test lifecycle helper which stubs `console.error` and verifies that any logging which occurs to
@@ -54,7 +55,7 @@ export function chaiConsoleSpy(chai, utils) {
  * `chaiConsoleSpy` Chai plugin.
  */
 export function useConsoleLogSpy() {
-  let originalConsoleError;
+  let originalConsoleError: Console['error'];
   before(() => {
     originalConsoleError = console.error;
     console.error = sinon.stub().callsFake((message, ...args) => {

--- a/spec/javascript/support/console.ts
+++ b/spec/javascript/support/console.ts
@@ -28,7 +28,7 @@ export const chaiConsoleSpy: Chai.ChaiPlugin = (chai, utils) => {
   utils.addChainableMethod(
     chai.Assertion.prototype,
     'loggedError',
-    (message) => {
+    (message: string | RegExp) => {
       if (message) {
         const index = unverifiedCalls.findIndex((calledMessage) =>
           message instanceof RegExp ? message.test(calledMessage) : message === calledMessage,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,7 +77,7 @@ RSpec.configure do |config|
       # rubocop:enable Style/GlobalVars
       # rubocop:disable Rails/Output
       print '                       Bundling JavaScript and stylesheets... '
-      system 'yarn concurrently "yarn:build:*" > /dev/null 2>&1'
+      system 'NODE_ENV=production yarn concurrently "yarn:build:*" > /dev/null 2>&1'
       puts '✨ Done!'
       # rubocop:enable Rails/Output
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,6 @@ const env = process.env.NODE_ENV || process.env.RAILS_ENV || 'development';
 const host = process.env.HOST || 'localhost';
 const isLocalhost = host === 'localhost';
 const isProductionEnv = env === 'production';
-const isTestEnv = env === 'test';
 const mode = isProductionEnv ? 'production' : 'development';
 const hashSuffix = isProductionEnv ? '-[chunkhash:8].digested' : '';
 const devServerPort = process.env.WEBPACK_PORT;
@@ -88,9 +87,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
     }),
     new RailsI18nWebpackPlugin({
       onMissingString(key, locale) {
-        if (isTestEnv) {
-          throw new Error(`Unexpected missing string for locale '${locale}': '${key}'`);
-        }
+        throw new Error(`Unexpected missing string for locale '${locale}': '${key}'`);
       },
     }),
     new RailsAssetsWebpackPlugin(),


### PR DESCRIPTION
## 🛠 Summary of changes

Builds upon #11775 to increase visibility of missing translation strings at build-time and in JavaScript-enabled feature tests:

- At build-time, fails build if attempting to compile locale data where string data is missing. Previously, this only failed in test environments.
- At runtime, logs output to console if attempting to reference missing translation string. Previously, this would silently fail and return the original key, resulting in scenarios like what led to #11775.
 
The latter works well in combination with feature test behavior to fail tests where any console logging occurs. Unfortunately most tests which involve document capture disable this behavior (`allow_browser_log: true`), but there's at least one which would have caught the original issue ([source](https://github.com/18F/identity-idp/blob/fabd0f7805f153a90d4aa2f46cb9c80072f83151/spec/features/idv/steps/in_person/verify_info_spec.rb#L118-L132)).

## 📜 Testing Plan

Verify that build passes.

Verify that build fails on a commit between 41f8d4119bd44640d57a17da2a94ec4a53118119 and 73795c9eeada8b109269001de807fd397185a22d:

```
git checkout 73795c9
rspec spec/features/idv/steps/in_person/verify_info_spec.rb:122
```