### PR TITLE
Skip S3 upload for daily sensitive column job if bucket name is blank

### DIFF
--- a/app/jobs/data_warehouse/daily_sensitive_column_job.rb
+++ b/app/jobs/data_warehouse/daily_sensitive_column_job.rb
@@ -6,7 +6,10 @@ module DataWarehouse
 
     def perform(timestamp)
       data = fetch_columns
-      upload_to_s3(data, timestamp)
+
+      if IdentityConfig.store.s3_idp_dw_tasks.present?
+        upload_to_s3(data, timestamp)
+      end
     end
 
     def fetch_columns
@@ -53,14 +56,12 @@ module DataWarehouse
     def upload_to_s3(body, timestamp)
       _latest, path = generate_s3_paths(REPORT_NAME, 'json', now: timestamp)
 
-      if bucket_name.present?
-        upload_file_to_s3_bucket(
-          path: path,
-          body: body,
-          content_type: 'application/json',
-          bucket: bucket_name,
-        )
-      end
+      upload_file_to_s3_bucket(
+        path: path,
+        body: body,
+        content_type: 'application/json',
+        bucket: bucket_name,
+      )
     end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

This job currently fails when there is no S3 bucket configured, though it looks like it intends to skip. This PR makes a small change to where the check happens and skips upload to S3 if the configured bucket name is blank.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
