### PR TITLE
LG-15392 Remove the locale param from the post-IdV follow-up URL

### DIFF
--- a/app/services/sp_return_url_resolver.rb
+++ b/app/services/sp_return_url_resolver.rb
@@ -25,9 +25,7 @@ class SpReturnUrlResolver
   end
 
   def post_idv_follow_up_url
-    url = service_provider.post_idv_follow_up_url || homepage_url
-    return if url.blank?
-    format(url.to_s, locale: I18n.locale.to_s)
+    service_provider.post_idv_follow_up_url || homepage_url
   end
 
   private

--- a/spec/services/sp_return_url_resolver_spec.rb
+++ b/spec/services/sp_return_url_resolver_spec.rb
@@ -170,13 +170,5 @@ RSpec.describe SpReturnUrlResolver do
 
       it { expect(post_idv_follow_up_url).to eq(sp_post_idv_follow_up_url) }
     end
-
-    context 'with a template param in the URL' do
-      let(:sp_post_idv_follow_up_url) { 'https://sp.gov/follow_up?locale=%{locale}' }
-
-      it 'interpolates the appropriate value' do
-        expect(post_idv_follow_up_url).to eq('https://sp.gov/follow_up?locale=en')
-      end
-    end
   end
 end


### PR DESCRIPTION
We added the locale param to the post-IdV follow-up URL as a short term solution for a partner who needed to get the user's locale when they clicked that link. In #11756 we made a change that allows SPs to request the locale via the OIDC claims or SAML attributes. This should resolve the issue for that partner.

This commit removes support for including the locale as a param on the post-IdV follow-up URL. It should not be merged until:

- [x] Our partner has configured their application to request the locale in the OIDC params
- [ ] We have removed the templated locale value from their configured post-IdV follow-up URL