### PR TITLE
Lg 15159 A user who has reached the capture complete page in hybrid flow should not be able to recapture

### DIFF
--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -18,6 +18,11 @@ module Idv
         before_action :fetch_test_verification_data, only: [:update]
 
         def show
+          if stored_result&.success?
+            redirect_to idv_hybrid_mobile_capture_complete_url
+            return
+          end
+
           Funnel::DocAuth::RegisterStep.new(document_capture_user.id, sp_session[:issuer])
             .call('hybrid_mobile_socure_document_capture', :view, true)
 

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -101,10 +101,11 @@ RSpec.describe 'Hybrid Flow' do
         expect(page).to have_text(t('doc_auth.instructions.switch_back'))
         expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
 
-        # To be fixed in app:
         # Confirm app disallows jumping back to DocumentCapture page
-        # visit idv_hybrid_mobile_socure_document_capture_url
-        # expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+        visit idv_hybrid_mobile_socure_document_capture_url
+        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+        visit idv_hybrid_mobile_socure_document_capture_update_url
+        expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
       end
 
       perform_in_browser(:desktop) do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15159](https://cm-jira.usa.gov/browse/LG-15159)

## 🛠 Summary of changes

Added check to see if user already made it to capture_complete on show, if so user is now redirected back to capture complete. Uncommented rspec tests meant for testing as well as adding more to it to test full AC of ticket.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - Ensure rspec test passes and adequately tests acceptance criteria listed in ticket.

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
