### PR TITLE
LG-15538: Add warning when returning local data

### DIFF
--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -4,12 +4,13 @@ require_relative './script_base'
 
 # rubocop:disable Metrics/BlockLength
 class ActionAccount
-  attr_reader :argv, :stdout, :stderr
+  attr_reader :argv, :stdout, :stderr, :rails_env
 
-  def initialize(argv:, stdout:, stderr:)
+  def initialize(argv:, stdout:, stderr:, rails_env: Rails.env)
     @argv = argv
     @stdout = stdout
     @stderr = stderr
+    @rails_env = rails_env
   end
 
   def script_base
@@ -20,6 +21,7 @@ class ActionAccount
       subtask_class: subtask(argv.shift),
       banner: banner,
       reason_arg: true,
+      rails_env:,
     )
   end
 

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -3,15 +3,24 @@
 require 'optparse'
 
 class ScriptBase
-  attr_reader :argv, :stdout, :stderr, :subtask_class, :banner
+  attr_reader :argv, :stdout, :stderr, :subtask_class, :banner, :rails_env
 
-  def initialize(argv:, stdout:, stderr:, subtask_class:, banner:, reason_arg:)
+  def initialize(
+    argv:,
+    stdout:,
+    stderr:,
+    subtask_class:,
+    banner:,
+    reason_arg:,
+    rails_env: Rails.env
+  )
     @argv = argv
     @stdout = stdout
     @stderr = stderr
     @subtask_class = subtask_class
     @banner = banner
     @reason_arg = reason_arg
+    @rails_env = rails_env
   end
 
   def reason_arg?
@@ -55,6 +64,10 @@ class ScriptBase
 
   def run
     option_parser.parse!(argv)
+
+    if rails_env.local?
+      stderr.puts "⚠️ WARNING: returning local data for #{File.basename($PROGRAM_NAME)}"
+    end
 
     if config.show_help? || !subtask_class
       stderr.puts '*Task*: `help`'

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe ActionAccount do
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
   let(:argv) { [] }
+  let(:rails_env) { ActiveSupport::EnvironmentInquirer.new('production') }
 
-  subject(:action_account) { ActionAccount.new(argv:, stdout:, stderr:) }
+  subject(:action_account) { ActionAccount.new(argv:, stdout:, stderr:, rails_env:) }
 
   describe 'command line run' do
     let(:argv) { ['review-pass', user.uuid, '--reason', 'INV1234'] }

--- a/spec/lib/script_base_spec.rb
+++ b/spec/lib/script_base_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ScriptBase do
     end
 
     context 'running in production vs locally' do
-      subject(:run) { subtask_class.new.run(args: nil, config: nil) }
+      subject(:run) { base.run }
 
       context 'in production' do
         let(:env) { 'production' }
@@ -45,7 +45,7 @@ RSpec.describe ScriptBase do
         it 'does not warn' do
           run
 
-          expect(stderr.string).to be_blank
+          expect(stderr.string).to_not include('WARNING')
         end
       end
 

--- a/spec/lib/script_base_spec.rb
+++ b/spec/lib/script_base_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ScriptBase do
 
   describe '#run' do
     let(:argv) { [] }
+    let(:env) { 'production' }
 
     subject(:base) do
       ScriptBase.new(
@@ -31,7 +32,32 @@ RSpec.describe ScriptBase do
         subtask_class:,
         banner: '',
         reason_arg: false,
+        rails_env: ActiveSupport::EnvironmentInquirer.new(env),
       )
+    end
+
+    context 'running in production vs locally' do
+      subject(:run) { subtask_class.new.run(args: nil, config: nil) }
+
+      context 'in production' do
+        let(:env) { 'production' }
+
+        it 'does not warn' do
+          run
+
+          expect(stderr.string).to be_blank
+        end
+      end
+
+      context 'in development' do
+        let(:env) { 'development' }
+
+        it 'warns that it is in development' do
+          run
+
+          expect(stderr.string).to include('WARNING: returning local data')
+        end
+      end
     end
 
     context 'with --deflate' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15538](https://cm-jira.usa.gov/browse/LG-15538)

## 🛠 Summary of changes

Adds a warning line with emoji when this script is running locally (it is expected to be run remotely via SSM in the devops repo instead of directly)

Example locally:
```bash
> ./bin/data-pull uuid-convert abc def
⚠️ WARNING: returning local data for data-pull
*Task*: `uuid-convert`
*UUIDs*: 
+--------------+-------------+---------------+---------+
| partner_uuid | source      | internal_uuid | deleted |
+--------------+-------------+---------------+---------+
| abc          | [NOT FOUND] | [NOT FOUND]   |         |
| def          | [NOT FOUND] | [NOT FOUND]   |         |
+--------------+-------------+---------------+---------+
```


