### PR TITLE
Restore faker for development environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :development, :test do
   gem 'bullet', '~> 7.0'
   gem 'capybara-webmock', git: 'https://github.com/hashrocket/capybara-webmock.git', ref: 'd3f3b7c'
   gem 'erb_lint', '~> 0.7.0', require: false
+  gem 'faker'
   gem 'i18n-tasks', '~> 1.0'
   gem 'knapsack'
   gem 'listen'
@@ -123,7 +124,6 @@ group :development, :test do
   gem 'rubocop-rspec', '~> 3.2.0', require: false
   gem 'rubocop-capybara', require: false
   gem 'sqlite3', require: false
-  gem 'faker'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -123,12 +123,12 @@ group :development, :test do
   gem 'rubocop-rspec', '~> 3.2.0', require: false
   gem 'rubocop-capybara', require: false
   gem 'sqlite3', require: false
+  gem 'faker'
 end
 
 group :test do
   gem 'axe-core-rspec', '~> 4.2'
   gem 'bundler-audit', require: false
-  gem 'faker'
   gem 'simplecov', '~> 0.22.0', require: false
   gem 'simplecov-cobertura'
   gem 'simplecov_json_formatter'

--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :development, :test do
   gem 'bullet', '~> 7.0'
   gem 'capybara-webmock', git: 'https://github.com/hashrocket/capybara-webmock.git', ref: 'd3f3b7c'
   gem 'erb_lint', '~> 0.7.0', require: false
-  gem 'faker'
+  gem 'faker', require: false # used in mailer previews
   gem 'i18n-tasks', '~> 1.0'
   gem 'knapsack'
   gem 'listen'

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,3 +1,5 @@
+require 'faker'
+
 class UserMailerPreview < ActionMailer::Preview
   def email_confirmation_instructions
     UserMailer.with(user: user, email_address: email_address_record)


### PR DESCRIPTION
## 🛠 Summary of changes
Shane and I worked on this during our 1:1.  The user mailer was broken because faker was missing.  I included a screenshot of the error.  We restored faker and the user mailer looks a-okay now.



## 📜 Testing Plan
- [ ] Confirm you can view an email at http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify_reminder



## 👀 Screenshots
<details>
<summary>Error:</summary>

![UserMailerBrokeDueToFaker](https://github.com/user-attachments/assets/f8ff0ea8-3b27-4ae9-9feb-f3c563756a7a)

</details>
