### PR TITLE
LG-15394 Add tooling for an SP proofing events by UUID report

### DIFF
--- a/app/jobs/reports/sp_proofing_events_by_uuid.rb
+++ b/app/jobs/reports/sp_proofing_events_by_uuid.rb
@@ -28,7 +28,7 @@ module Reports
       report_maker = build_report_maker(
         issuers:,
         agency_abbreviation:,
-        time_range: report_date.to_date.all_week(:sunday),
+        time_range: report_date.to_date.weeks_ago(1).all_week(:sunday),
       )
 
       csv = report_maker.to_csv

--- a/app/jobs/reports/sp_proofing_events_by_uuid.rb
+++ b/app/jobs/reports/sp_proofing_events_by_uuid.rb
@@ -4,57 +4,59 @@ require 'reporting/sp_proofing_events_by_uuid'
 
 module Reports
   class SpProofingEventsByUuid < BaseReport
-    attr_accessor :report_date, :issuers, :agency_abbreviation
+    attr_accessor :report_date
 
-    def perform(report_date, issuers, agency_abbreviation)
+    def perform(report_date)
       return unless IdentityConfig.store.s3_reports_enabled
+
       self.report_date = report_date
-      self.issuers = issuers
-      self.agency_abbreviation = agency_abbreviation
+
+      IdentityConfig.store.sp_proofing_events_by_uuid_report_configs.each do |report_config|
+        send_report(report_config)
+      end
+    end
+
+    def send_report(report_config)
+      return unless IdentityConfig.store.s3_reports_enabled
+      issuers = report_config['issuers']
+      agency_abbreviation = report_config['agency_abbreviation']
+      emails = report_config['emails']
+
+      agency_report_nane = "#{agency_abbreviation.downcase}_proofing_events_by_uuid"
+      agency_report_title = "#{agency_abbreviation} Proofing Events By UUID"
+
+      report_maker = build_report_maker(
+        issuers:,
+        agency_abbreviation:,
+        time_range: report_date.to_date.all_week(:sunday),
+      )
 
       csv = report_maker.to_csv
 
       save_report(agency_report_nane, csv, extension: 'csv')
 
-      email = IdentityConfig.store.team_ada_email
-      if email.blank?
+      if emails.blank?
         Rails.logger.warn "No email addresses received - #{agency_report_title} NOT SENT"
         return false
       end
 
-      ReportMailer.tables_report(
-        email: email,
-        subject: "#{agency_report_title} - #{report_date.to_date}",
-        reports: reports,
-        message: message,
-        attachment_format: :csv,
-      ).deliver_now
-    end
-
-    def agency_report_nane
-      "#{agency_abbreviation.downcase}_proofing_events_by_uuid"
-    end
-
-    def agency_report_title
-      "#{agency_abbreviation} Proofing Events By UUID"
-    end
-
-    def message
-      <<~HTML.html_safe # rubocop:disable Rails/OutputSafety
+      email_message = <<~HTML.html_safe # rubocop:disable Rails/OutputSafety
         <h2>#{agency_report_title}</h2>
       HTML
+
+      emails.each do |email|
+        ReportMailer.tables_report(
+          email: email,
+          subject: "#{agency_report_title} - #{report_date.to_date}",
+          reports: report_maker.as_emailable_reports,
+          message: email_message,
+          attachment_format: :csv,
+        ).deliver_now
+      end
     end
 
-    def reports
-      report_maker.as_emailable_reports
-    end
-
-    def report_maker
-      @report_maker ||= Reporting::SpProofingEventsByUuid.new(
-        issuers:,
-        agency_abbreviation:,
-        time_range: report_date.all_week(:sunday),
-      )
+    def build_report_maker(issuers:, agency_abbreviation:, time_range:)
+      Reporting::SpProofingEventsByUuid.new(issuers:, agency_abbreviation:, time_range:)
     end
   end
 end

--- a/app/jobs/reports/sp_proofing_events_by_uuid.rb
+++ b/app/jobs/reports/sp_proofing_events_by_uuid.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'reporting/sp_proofing_events_by_uuid'
+
+module Reports
+  class SpProofingEventsByUuid < BaseReport
+    attr_accessor :report_date, :issuers, :agency_abbreviation
+
+    def perform(report_date, issuers, agency_abbreviation)
+      return unless IdentityConfig.store.s3_reports_enabled
+      self.report_date = report_date
+      self.issuers = issuers
+      self.agency_abbreviation = agency_abbreviation
+
+      csv = report_maker.to_csv
+
+      save_report(agency_report_nane, csv, extension: 'csv')
+
+      email = IdentityConfig.store.team_ada_email
+      if email.blank?
+        Rails.logger.warn "No email addresses received - #{agency_report_title} NOT SENT"
+        return false
+      end
+
+      ReportMailer.tables_report(
+        email: email,
+        subject: "#{agency_report_title} - #{report_date.to_date}",
+        reports: reports,
+        message: message,
+        attachment_format: :csv,
+      ).deliver_now
+    end
+
+    def agency_report_nane
+      "#{agency_abbreviation.downcase}_proofing_events_by_uuid"
+    end
+
+    def agency_report_title
+      "#{agency_abbreviation} Proofing Events By UUID"
+    end
+
+    def message
+      <<~HTML.html_safe # rubocop:disable Rails/OutputSafety
+        <h2>#{agency_report_title}</h2>
+      HTML
+    end
+
+    def reports
+      report_maker.as_emailable_reports
+    end
+
+    def report_maker
+      @report_maker ||= Reporting::SpProofingEventsByUuid.new(
+        issuers:,
+        agency_abbreviation:,
+        time_range: report_date.all_week(:sunday),
+      )
+    end
+  end
+end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -403,6 +403,7 @@ socure_reason_code_base_url: ''
 socure_reason_code_timeout_in_seconds: 5
 sp_handoff_bounce_max_seconds: 2
 sp_issuer_user_counts_report_configs: '[]'
+sp_proofing_events_by_uuid_report_configs: '[]'
 state_tracking_enabled: true
 team_ada_email: ''
 team_all_login_emails: '[]'

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -119,6 +119,12 @@ else
         cron: cron_24h,
         args: -> { [Time.zone.yesterday] },
       },
+      # Send the SP IdV Weekly Dropoff Report
+      sp_idv_weekly_dropoff: {
+        class: 'Reports::SpProofingEventsByUuid',
+        cron: cron_every_monday_2am,
+        args: -> { [Time.zone.today] },
+      },
       # Sync opted out phone numbers from AWS
       phone_number_opt_out_sync_job: {
         class: 'PhoneNumberOptOutSyncJob',

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -439,6 +439,7 @@ module IdentityConfig
     config.add(:socure_reason_code_timeout_in_seconds, type: :integer)
     config.add(:sp_handoff_bounce_max_seconds, type: :integer)
     config.add(:sp_issuer_user_counts_report_configs, type: :json)
+    config.add(:sp_proofing_events_by_uuid_report_configs, type: :json)
     config.add(:state_tracking_enabled, type: :boolean)
     config.add(:team_ada_email, type: :string)
     config.add(:team_all_login_emails, type: :json)

--- a/lib/reporting/sp_proofing_events_by_uuid.rb
+++ b/lib/reporting/sp_proofing_events_by_uuid.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
-require 'csv'
-begin
-  require 'reporting/cloudwatch_client'
-  require 'reporting/cloudwatch_query_quoting'
-  require 'reporting/command_line_options'
-rescue LoadError => e
-  warn 'could not load paths, try running with "bundle exec rails runner"'
-  raise e
-end
+require 'reporting/cloudwatch_client'
+require 'reporting/cloudwatch_query_quoting'
 
 module Reporting
   class SpProofingEventsByUuid

--- a/lib/reporting/sp_proofing_events_by_uuid.rb
+++ b/lib/reporting/sp_proofing_events_by_uuid.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require 'csv'
+begin
+  require 'reporting/cloudwatch_client'
+  require 'reporting/cloudwatch_query_quoting'
+  require 'reporting/command_line_options'
+rescue LoadError => e
+  warn 'could not load paths, try running with "bundle exec rails runner"'
+  raise e
+end
+
+module Reporting
+  class SpProofingEventsByUuid
+    attr_reader :issuers, :agency_abbreviation, :time_range
+
+    def initialize(
+      issuers:,
+      agency_abbreviation:,
+      time_range:,
+      verbose: false,
+      progress: false,
+      cloudwatch_client: nil
+    )
+      @issuers = issuers
+      @agency_abbreviation = agency_abbreviation
+      @time_range = time_range
+      @verbose = verbose
+      @progress = progress
+      @cloudwatch_client = cloudwatch_client
+    end
+
+    def verbose?
+      @verbose
+    end
+
+    def progress?
+      @progress
+    end
+
+    def query
+      <<~QUERY
+        filter properties.service_provider in #{issuers.inspect} or
+              (name = "IdV: enter verify by mail code submitted" and properties.event_properties.initiating_service_provider in #{issuers.inspect})
+        | filter name in [
+          "IdV: doc auth welcome visited",
+          "IdV: doc auth document_capture visited",
+          "Frontend: IdV: front image added",
+          "Frontend: IdV: back image added",
+          "idv_selfie_image_added",
+          "IdV: doc auth image upload vendor submitted",
+          "IdV: doc auth ssn submitted",
+          "IdV: doc auth verify proofing results",
+          "IdV: phone confirmation form",
+          "IdV: phone confirmation vendor",
+          "IdV: final resolution",
+          "IdV: enter verify by mail code submitted",
+          "Fraud: Profile review passed",
+          "Fraud: Profile review rejected",
+          "User registration: agency handoff visited",
+          "SP redirect initiated"
+        ]
+
+        | fields coalesce(name = "Fraud: Profile review passed" and properties.event_properties.success, 0) * properties.event_properties.profile_age_in_seconds as fraud_review_profile_age_in_seconds,
+                coalesce(name = "IdV: enter verify by mail code submitted" and properties.event_properties.success and !properties.event_properties.pending_in_person_enrollment and !properties.event_properties.fraud_check_failed, 0) * properties.event_properties.profile_age_in_seconds  as gpo_profile_age_in_seconds,
+                fraud_review_profile_age_in_seconds + gpo_profile_age_in_seconds as profile_age_in_seconds
+
+        | stats sum(name = "IdV: doc auth welcome visited") > 0 as workflow_started,
+                sum(name = "IdV: doc auth document_capture visited") > 0 as doc_auth_started,
+                sum(name = "Frontend: IdV: front image added") > 0 and sum(name = "Frontend: IdV: back image added") > 0 as document_captured,
+                sum(name = "idv_selfie_image_added") > 0 as selfie_captured,
+                sum(name = "IdV: doc auth image upload vendor submitted" and properties.event_properties.success) > 0 as doc_auth_passed,
+                sum(name = "IdV: doc auth ssn submitted") > 0 as ssn_submitted,
+                sum(name = "IdV: doc auth verify proofing results") > 0 as personal_info_submitted,
+                sum(name = "IdV: doc auth verify proofing results" and properties.event_properties.success) > 0 as personal_info_verified,
+                sum(name = "IdV: phone confirmation form") > 0 as phone_submitted,
+                sum(name = "IdV: phone confirmation vendor" and properties.event_properties.success) > 0 as phone_verified,
+                sum(name = "IdV: final resolution") > 0 as online_workflow_completed,
+                sum(name = "IdV: final resolution" and !properties.event_properties.gpo_verification_pending and !properties.event_properties.in_person_verification_pending and !coalesce(properties.event_properties.fraud_pending_reason, 0)) > 0 as verified_in_band,
+                sum(name = "IdV: enter verify by mail code submitted" and properties.event_properties.success and !properties.event_properties.pending_in_person_enrollment and !properties.event_properties.fraud_check_failed) > 0 as verified_by_mail,
+                sum(name = "Fraud: Profile review passed" and properties.event_properties.success) > 0 as verified_fraud_review,
+                max(profile_age_in_seconds) as out_of_band_verification_pending_seconds,
+                sum(name = "User registration: agency handoff visited" and properties.event_properties.ial2) > 0 as agency_handoff,
+                sum(name = "SP redirect initiated" and properties.event_properties.ial == 2) > 0 as sp_redirect
+                by properties.user_id as login_uuid
+        | filter workflow_started > 0 or verified_by_mail > 0 or verified_fraud_review > 0
+        | limit 10000
+      QUERY
+    end
+
+    def as_csv
+      csv = []
+      csv << ['Date Range', "#{time_range.begin.to_date} - #{time_range.end.to_date}"]
+      csv << csv_header
+      data.each do |result_row|
+        csv << result_row
+      end
+      csv.compact
+    end
+
+    def to_csv
+      CSV.generate do |csv|
+        as_csv.each do |row|
+          csv << row
+        end
+      end
+    end
+
+    def as_emailable_reports
+      [
+        EmailableReport.new(
+          title: "#{agency_abbreviation} Proofing Events By UUID",
+          table: report_maker.as_csv,
+          filename: "#{agency_abbreviation.downcase}_proofing_events_by_uuid",
+        ),
+      ]
+    end
+
+    def csv_header
+      [
+        'UUID',
+        'Workflow Started',
+        'Documnet Capture Started',
+        'Document Captured',
+        'Selfie Captured',
+        'Document Authentication Passed',
+        'SSN Submitted',
+        'Personal Information Submitted',
+        'Personal Information Verified',
+        'Phone Submitted',
+        'Phone Verified',
+        'Verification Workflow Complete',
+        'Identity Verified for In-Band Users',
+        'Identity Verified for Verify-By-Mail Users',
+        'Identity Verified for Fraud Review Users',
+        'Out-of-Band Verification Pending Seconds',
+        'Agency Handoff Visited',
+        'Agency Handoff Submitted',
+      ]
+    end
+
+    def data
+      @data ||= fetch_results.map do |result_row|
+        process_result_row(result_row)
+      end
+    end
+
+    def process_result_row(result_row)
+      login_uuid = result_row['login_uuid']
+      agency_uuid = convert_uuid(login_uuid)
+      return unless agency_uuid.present?
+      [
+        agency_uuid,
+        result_row['workflow_started'] == '1',
+        result_row['doc_auth_started'] == '1',
+        result_row['document_captured'] == '1',
+        result_row['selfie_captured'] == '1',
+        result_row['doc_auth_passed'] == '1',
+        result_row['ssn_submitted'] == '1',
+        result_row['personal_info_submitted'] == '1',
+        result_row['personal_info_verified'] == '1',
+        result_row['phone_submitted'] == '1',
+        result_row['phone_verified'] == '1',
+        result_row['online_workflow_completed'] == '1',
+        result_row['verified_in_band'] == '1',
+        result_row['verified_by_mail'] == '1',
+        result_row['verified_fraud_review'] == '1',
+        result_row['out_of_band_verification_pending_seconds'].to_i,
+        result_row['agency_handoff'] == '1',
+        result_row['sp_redirect'] == '1',
+      ]
+    end
+
+    def convert_uuid(uuid)
+      user = User.find_by(uuid: uuid)
+      user&.agency_identities&.find_by(agency:)&.uuid
+    end
+
+    def agency
+      @agency ||= begin
+        record = Agency.find_by(abbreviation: agency_abbreviation)
+        raise "Unable to find agency with abbreviation: #{agency_abbreviation}" if record.nil?
+        record
+      end
+    end
+
+    def fetch_results
+      cloudwatch_client.fetch(
+        query:,
+        from: time_range.begin.beginning_of_day,
+        to: time_range.end.end_of_day,
+      )
+    end
+
+    def cloudwatch_client
+      @cloudwatch_client ||= Reporting::CloudwatchClient.new(
+        num_threads: 1,
+        ensure_complete_logs: false,
+        slice_interval: 100.years,
+        progress: progress?,
+        logger: verbose? ? Logger.new(STDERR) : nil,
+      )
+    end
+  end
+end

--- a/lib/reporting/sp_proofing_events_by_uuid.rb
+++ b/lib/reporting/sp_proofing_events_by_uuid.rb
@@ -74,7 +74,7 @@ module Reporting
                 sum(name = "Fraud: Profile review passed" and properties.event_properties.success) > 0 as verified_fraud_review,
                 max(profile_age_in_seconds) as out_of_band_verification_pending_seconds,
                 sum(name = "User registration: agency handoff visited" and properties.event_properties.ial2) > 0 as agency_handoff,
-                sum(name = "SP redirect initiated" and properties.event_properties.ial == 2) > 0 as sp_redirect
+                sum(name = "SP redirect initiated" and properties.event_properties.ial == 2) > 0 as sp_redirect,
                 toMillis(min(@timestamp)) as first_event
                 by properties.user_id as login_uuid
         | filter workflow_started > 0 or verified_by_mail > 0 or verified_fraud_review > 0

--- a/lib/reporting/sp_proofing_events_by_uuid.rb
+++ b/lib/reporting/sp_proofing_events_by_uuid.rb
@@ -110,7 +110,7 @@ module Reporting
       [
         EmailableReport.new(
           title: "#{agency_abbreviation} Proofing Events By UUID",
-          table: report_maker.as_csv,
+          table: as_csv,
           filename: "#{agency_abbreviation.downcase}_proofing_events_by_uuid",
         ),
       ]

--- a/spec/jobs/reports/sp_proofing_events_by_uuid_spec.rb
+++ b/spec/jobs/reports/sp_proofing_events_by_uuid_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::SpProofingEventsByUuid do
-  let(:report_date) { Date.new(2024, 12, 1).in_time_zone('UTC') }
+  let(:report_date) { Date.new(2024, 12, 9) }
   let(:agency_abbreviation) { 'ABC' }
   let(:report_emails) { ['test@example.com'] }
   let(:issuers) { ['super:cool:test:issuer'] }
@@ -61,7 +61,7 @@ RSpec.describe Reports::SpProofingEventsByUuid do
 
       expect(ReportMailer).to receive(:tables_report).once.with(
         email: 'test@example.com',
-        subject: 'ABC Proofing Events By UUID - 2024-12-01',
+        subject: 'ABC Proofing Events By UUID - 2024-12-09',
         reports: emailable_reports,
         message: anything,
         attachment_format: :csv,

--- a/spec/jobs/reports/sp_proofing_events_by_uuid_spec.rb
+++ b/spec/jobs/reports/sp_proofing_events_by_uuid_spec.rb
@@ -2,17 +2,30 @@ require 'rails_helper'
 
 RSpec.describe Reports::SpProofingEventsByUuid do
   let(:report_date) { Date.new(2024, 12, 1).in_time_zone('UTC') }
+  let(:agency_abbreviation) { 'ABC' }
+  let(:report_emails) { ['test@example.com'] }
   let(:issuers) { ['super:cool:test:issuer'] }
-  let(:agency_abbreviation) { 'DOL' }
+  let(:sp_proofing_events_by_uuid_report_configs) do
+    [
+      {
+        'issuers' => issuers,
+        'agency_abbreviation' => 'ABC',
+        'emails' => report_emails,
+      },
+    ]
+  end
 
   before do
     allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(
+      :sp_proofing_events_by_uuid_report_configs,
+    ).and_return(
+      sp_proofing_events_by_uuid_report_configs,
+    )
   end
 
   describe '#perform' do
     it 'gets a CSV from the report maker, saves it to S3, and sends email to team' do
-      allow(IdentityConfig.store).to receive(:team_ada_email).and_return('ada@example.com')
-
       report = [
         ['UUID', 'Welcome Visited', 'Welcome Submitted'],
         ['123abc', true, true],
@@ -35,54 +48,66 @@ RSpec.describe Reports::SpProofingEventsByUuid do
         as_emailable_reports: emailable_reports,
       )
 
-      allow(subject).to receive(:report_maker).and_return(report_maker)
+      allow(subject).to receive(:build_report_maker).with(
+        issuers: issuers,
+        agency_abbreviation: 'ABC',
+        time_range: Date.new(2024, 12, 1)..Date.new(2024, 12, 7),
+      ).and_return(report_maker)
       expect(subject).to receive(:save_report).with(
-        'dol_proofing_events_by_uuid',
+        'abc_proofing_events_by_uuid',
         csv_report,
         extension: 'csv',
       )
 
       expect(ReportMailer).to receive(:tables_report).once.with(
-        email: IdentityConfig.store.team_ada_email,
-        subject: 'DOL Proofing Events By UUID - 2024-12-01',
+        email: 'test@example.com',
+        subject: 'ABC Proofing Events By UUID - 2024-12-01',
         reports: emailable_reports,
         message: anything,
         attachment_format: :csv,
       ).and_call_original
 
-      subject.perform(report_date, issuers, agency_abbreviation)
+      subject.perform(report_date)
     end
 
-    it 'does not send report in email if the email field is empty' do
-      allow(IdentityConfig.store).to receive(:team_ada_email).and_return('')
+    context 'with no emails configured' do
+      let(:report_emails) { [] }
 
-      report_maker = double(
-        Reporting::SpProofingEventsByUuid,
-        to_csv: 'I am a CSV, see',
-        identity_verification_emailable_report: 'I am a report',
-      )
-      allow(subject).to receive(:report_maker).and_return(report_maker)
-      expect(subject).to receive(:save_report).with(
-        'dol_proofing_events_by_uuid',
-        'I am a CSV, see',
-        extension: 'csv',
-      )
+      it 'does not send the report in email' do
+        report_maker = double(
+          Reporting::SpProofingEventsByUuid,
+          to_csv: 'I am a CSV, see',
+          identity_verification_emailable_report: 'I am a report',
+        )
+        allow(subject).to receive(:build_report_maker).with(
+          issuers: issuers,
+          agency_abbreviation: 'ABC',
+          time_range: Date.new(2024, 12, 1)..Date.new(2024, 12, 7),
+        ).and_return(report_maker)
+        expect(subject).to receive(:save_report).with(
+          'abc_proofing_events_by_uuid',
+          'I am a CSV, see',
+          extension: 'csv',
+        )
 
-      expect(ReportMailer).to_not receive(:tables_report)
+        expect(ReportMailer).to_not receive(:tables_report)
 
-      subject.perform(report_date, issuers, agency_abbreviation)
+        subject.perform(report_date)
+      end
     end
   end
 
-  describe '#report_maker' do
+  describe '#build_report_maker' do
     it 'is a identity verification report maker with the correct attributes' do
-      subject.report_date = Date.new(2024, 12, 1)
-      subject.issuers = ['super:cool:test:issuer']
-      subject.agency_abbreviation = 'DOL'
+      report_maker = subject.build_report_maker(
+        issuers: ['super:cool:test:issuer'],
+        agency_abbreviation: 'ABC',
+        time_range: Date.new(2024, 12, 1)..Date.new(2024, 12, 7),
+      )
 
-      expect(subject.report_maker.time_range).to eq(Date.new(2024, 12, 1)..Date.new(2024, 12, 7))
-      expect(subject.report_maker.issuers).to eq(['super:cool:test:issuer'])
-      expect(subject.agency_abbreviation).to eq('DOL')
+      expect(report_maker.issuers).to eq(['super:cool:test:issuer'])
+      expect(report_maker.agency_abbreviation).to eq('ABC')
+      expect(report_maker.time_range).to eq(Date.new(2024, 12, 1)..Date.new(2024, 12, 7))
     end
   end
 end

--- a/spec/jobs/reports/sp_proofing_events_by_uuid_spec.rb
+++ b/spec/jobs/reports/sp_proofing_events_by_uuid_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe Reports::SpProofingEventsByUuid do
+  let(:report_date) { Date.new(2024, 12, 1).in_time_zone('UTC') }
+  let(:issuers) { ['super:cool:test:issuer'] }
+  let(:agency_abbreviation) { 'DOL' }
+
+  before do
+    allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
+  end
+
+  describe '#perform' do
+    it 'gets a CSV from the report maker, saves it to S3, and sends email to team' do
+      allow(IdentityConfig.store).to receive(:team_ada_email).and_return('ada@example.com')
+
+      report = [
+        ['UUID', 'Welcome Visited', 'Welcome Submitted'],
+        ['123abc', true, true],
+        ['456def', true, false],
+      ]
+      csv_report = CSV.generate do |csv|
+        report.each { |row| csv << row }
+      end
+      emailable_reports = [
+        Reporting::EmailableReport.new(
+          title: 'DOL Proofing Events By UUID - 2024-12-01',
+          table: report,
+          filename: 'dol_proofing_events_by_uuid',
+        ),
+      ]
+
+      report_maker = double(
+        Reporting::SpProofingEventsByUuid,
+        to_csv: csv_report,
+        as_emailable_reports: emailable_reports,
+      )
+
+      allow(subject).to receive(:report_maker).and_return(report_maker)
+      expect(subject).to receive(:save_report).with(
+        'dol_proofing_events_by_uuid',
+        csv_report,
+        extension: 'csv',
+      )
+
+      expect(ReportMailer).to receive(:tables_report).once.with(
+        email: IdentityConfig.store.team_ada_email,
+        subject: 'DOL Proofing Events By UUID - 2024-12-01',
+        reports: emailable_reports,
+        message: anything,
+        attachment_format: :csv,
+      ).and_call_original
+
+      subject.perform(report_date, issuers, agency_abbreviation)
+    end
+
+    it 'does not send report in email if the email field is empty' do
+      allow(IdentityConfig.store).to receive(:team_ada_email).and_return('')
+
+      report_maker = double(
+        Reporting::SpProofingEventsByUuid,
+        to_csv: 'I am a CSV, see',
+        identity_verification_emailable_report: 'I am a report',
+      )
+      allow(subject).to receive(:report_maker).and_return(report_maker)
+      expect(subject).to receive(:save_report).with(
+        'dol_proofing_events_by_uuid',
+        'I am a CSV, see',
+        extension: 'csv',
+      )
+
+      expect(ReportMailer).to_not receive(:tables_report)
+
+      subject.perform(report_date, issuers, agency_abbreviation)
+    end
+  end
+
+  describe '#report_maker' do
+    it 'is a identity verification report maker with the correct attributes' do
+      subject.report_date = Date.new(2024, 12, 1)
+      subject.issuers = ['super:cool:test:issuer']
+      subject.agency_abbreviation = 'DOL'
+
+      expect(subject.report_maker.time_range).to eq(Date.new(2024, 12, 1)..Date.new(2024, 12, 7))
+      expect(subject.report_maker.issuers).to eq(['super:cool:test:issuer'])
+      expect(subject.agency_abbreviation).to eq('DOL')
+    end
+  end
+end

--- a/spec/lib/reporting/sp_proofing_events_by_uuid_spec.rb
+++ b/spec/lib/reporting/sp_proofing_events_by_uuid_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+require 'reporting/sp_proofing_events_by_uuid'
+
+RSpec.describe Reporting::SpProofingEventsByUuid do
+  let(:issuer) { 'super_cool_test_issuer' }
+  let(:agency_abbreviation) { 'DOL' }
+  let(:agency) { Agency.find_by(abbreviation: agency_abbreviation) }
+
+  let(:time_range) { Date.new(2024, 12, 1).all_week(:sunday) }
+
+  let(:deleted_user_uuid) { 'deleted_user_test' }
+  let(:non_agency_user_uuid) { 'non_agency_user_test' }
+  let(:agency_user_login_uuid) { 'agency_user_login_uuid_test' }
+  let(:agency_user_agency_uuid) { 'agency_user_agency_uuid_test' }
+
+  let(:cloudwatch_logs) do
+    [
+      { 'login_uuid' => deleted_user_uuid, 'workflow_started' => '1' },
+      { 'login_uuid' => non_agency_user_uuid, 'workflow_started' => '1' },
+      { 'login_uuid' => agency_user_login_uuid, 'workflow_started' => '1' },
+    ]
+  end
+
+  before do
+    create(:user, uuid: non_agency_user_uuid)
+    agency_user = create(:user, uuid: agency_user_login_uuid)
+    create(:agency_identity, user: agency_user, uuid: agency_user_agency_uuid)
+
+    stub_cloudwatch_logs(cloudwatch_logs)
+  end
+
+  subject(:report) do
+    Reporting::SpProofingEventsByUuid.new(
+      issuers: Array(issuer), agency_abbreviation:, time_range:,
+    )
+  end
+
+  describe 'as_csv' do
+    it 'renders a CSV report with converted UUIDs' do
+      expected_csv = [
+        ['Date Range', '2024-12-01 - 2024-12-07'],
+        [
+          'UUID',
+          'Workflow Started',
+          'Documnet Capture Started',
+          'Document Captured',
+          'Selfie Captured',
+          'Document Authentication Passed',
+          'SSN Submitted',
+          'Personal Information Submitted',
+          'Personal Information Verified',
+          'Phone Submitted',
+          'Phone Verified',
+          'Verification Workflow Complete',
+          'Identity Verified for In-Band Users',
+          'Identity Verified for Verify-By-Mail Users',
+          'Identity Verified for Fraud Review Users',
+          'Out-of-Band Verification Pending Seconds',
+          'Agency Handoff Visited',
+          'Agency Handoff Submitted',
+        ],
+        [
+          agency_user_login_uuid,
+          true,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          false,
+          0,
+          false,
+          false,
+        ],
+      ]
+      aggregate_failures do
+        report.as_csv.zip(expected_csv).each do |actual, expected|
+          expect(actual).to eq(expected)
+        end
+      end
+    end
+  end
+
+  describe '#to_csv' do
+    it 'generates a csv' do
+      csv = CSV.parse(report.to_csv, headers: false)
+
+      expected_csv = [
+        ['Date Range', '2024-12-01 - 2024-12-07'],
+        [
+          'UUID',
+          'Workflow Started',
+          'Documnet Capture Started',
+          'Document Captured',
+          'Selfie Captured',
+          'Document Authentication Passed',
+          'SSN Submitted',
+          'Personal Information Submitted',
+          'Personal Information Verified',
+          'Phone Submitted',
+          'Phone Verified',
+          'Verification Workflow Complete',
+          'Identity Verified for In-Band Users',
+          'Identity Verified for Verify-By-Mail Users',
+          'Identity Verified for Fraud Review Users',
+          'Out-of-Band Verification Pending Seconds',
+          'Agency Handoff Visited',
+          'Agency Handoff Submitted',
+        ],
+        [
+          agency_user_login_uuid,
+          'true',
+          'false',
+          'false',
+          'false',
+          'false',
+          'false',
+          'false',
+          'false',
+          'false',
+          'false',
+          'false',
+          'false',
+          'false',
+          'false',
+          '0',
+          'false',
+          'false',
+        ],
+      ]
+
+      aggregate_failures do
+        csv.map(&:to_a).zip(expected_csv).each do |actual, expected|
+          expect(actual).to eq(expected)
+        end
+      end
+    end
+  end
+
+  describe '#as_emailable_reports' do
+    it 'returns an emailable report'
+  end
+end

--- a/spec/lib/reporting/sp_proofing_events_by_uuid_spec.rb
+++ b/spec/lib/reporting/sp_proofing_events_by_uuid_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Reporting::SpProofingEventsByUuid do
   end
 
   describe '#as_emailable_reports' do
-    it 'returns an emailable report' do
+    it 'returns an array with an emailable report' do
       expect(report.as_emailable_reports).to eq(
         [
           Reporting::EmailableReport.new(


### PR DESCRIPTION
We have an agency partner who requested a specialized report the involves a table with columns representing proofing events and rows representing users for the partner where the values in each cell correspond to whether that user encountered that event in the given time period. We have been manually servicing this request for a little while. This commit adds tooling to generate this report automatically so it does not require manual processing.

This commit does not add the report to the job schedule with the intention being to test it first before scheduling it to run automatically.
