### PR TITLE
LG-14052: Convert mismatched WebAuthn platform attachment

### DIFF
--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -12,7 +12,7 @@ class WebauthnSetupForm
   validate :name_is_unique
   validate :validate_attestation_response
 
-  attr_reader :attestation_response
+  attr_reader :attestation_response, :webauthn_configuration
 
   def initialize(user:, user_session:, device_name:)
     @user = user
@@ -46,6 +46,18 @@ class WebauthnSetupForm
 
   def platform_authenticator?
     !!@platform_authenticator
+  end
+
+  def setup_as_platform_authenticator?
+    if transports.present?
+      platform_authenticator_transports?
+    else
+      platform_authenticator?
+    end
+  end
+
+  def transports_mismatch?
+    transports.present? && platform_authenticator_transports? != platform_authenticator?
   end
 
   def generic_error_message
@@ -134,11 +146,11 @@ class WebauthnSetupForm
     credential = attestation_response.credential
     public_key = Base64.strict_encode64(credential.public_key)
     id = Base64.strict_encode64(credential.id)
-    user.webauthn_configurations.create(
+    @webauthn_configuration = user.webauthn_configurations.create(
       credential_public_key: public_key,
       credential_id: id,
       name: name,
-      platform_authenticator: platform_authenticator,
+      platform_authenticator: setup_as_platform_authenticator?,
       transports: transports.presence,
       authenticator_data_flags: authenticator_data_flags,
       aaguid: aaguid,
@@ -166,20 +178,29 @@ class WebauthnSetupForm
     nil
   end
 
+  def platform_authenticator_transports?
+    (transports & WebauthnConfiguration::PLATFORM_AUTHENTICATOR_TRANSPORTS.to_a).present?
+  end
+
+  def multi_factor_auth_method
+    if setup_as_platform_authenticator?
+      'webauthn_platform'
+    else
+      'webauthn'
+    end
+  end
+
   def extra_analytics_attributes
-    auth_method = if platform_authenticator?
-                    'webauthn_platform'
-                  else
-                    'webauthn'
-                  end
     {
       mfa_method_counts: mfa_user.enabled_two_factor_configuration_counts_hash,
       enabled_mfa_methods_count: mfa_user.enabled_mfa_methods_count,
-      multi_factor_auth_method: auth_method,
+      multi_factor_auth_method:,
       pii_like_keypaths: [[:mfa_method_counts, :phone]],
       authenticator_data_flags: authenticator_data_flags,
       unknown_transports: invalid_transports.presence,
       aaguid: aaguid,
+      transports: transports,
+      transports_mismatch: transports_mismatch?,
     }
   end
 end

--- a/app/models/webauthn_configuration.rb
+++ b/app/models/webauthn_configuration.rb
@@ -8,6 +8,12 @@ class WebauthnConfiguration < ApplicationRecord
   validate :valid_transports
 
   # https://w3c.github.io/webauthn/#enum-transport
+  PLATFORM_AUTHENTICATOR_TRANSPORTS = %w[
+    hybrid
+    internal
+  ].to_set.freeze
+
+  # https://w3c.github.io/webauthn/#enum-transport
   VALID_TRANSPORTS = %w[
     usb
     nfc

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5834,6 +5834,10 @@ module AnalyticsEvents
   # @param [String, nil] aaguid AAGUID value of WebAuthn device
   # @param [String[], nil] unknown_transports Array of unrecognized WebAuthn transports, intended to
   #   be used in case of future specification changes.
+  # @param [String[], nil] transports WebAuthn transports associated with registration.
+  # @param [Boolean, nil] transports_mismatch Whether the WebAuthn transports associated with
+  #   registration contradict the authenticator attachment for user setup. For example, a user can
+  #   set up a platform authenticator through the Security Key setup flow.
   # @param [:authentication, :account_creation, nil] webauthn_platform_recommended A/B test for
   # recommended Face or Touch Unlock setup, if applicable.
   def multi_factor_auth_setup(
@@ -5859,6 +5863,8 @@ module AnalyticsEvents
     attempts: nil,
     aaguid: nil,
     unknown_transports: nil,
+    transports: nil,
+    transports_mismatch: nil,
     webauthn_platform_recommended: nil,
     **extra
   )
@@ -5886,6 +5892,8 @@ module AnalyticsEvents
       attempts:,
       aaguid:,
       unknown_transports:,
+      transports:,
+      transports_mismatch:,
       webauthn_platform_recommended:,
       **extra,
     )
@@ -7753,9 +7761,12 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Boolean] platform_authenticator
-  # @param [Boolean] success
-  # @param [Hash, nil] errors
+  # @param [Boolean] platform_authenticator Whether submission is for setting up a platform
+  #   authenticator. This aligns to what the user experienced in setting up the authenticator.
+  #   However, if `transports_mismatch` is true, the authentication method is created as the
+  #   opposite of this value.
+  # @param [Boolean] success Whether the submission was successful
+  # @param [Hash, nil] errors Errors resulting from form validation, or nil if successful.
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation flow
   # Tracks whether or not Webauthn setup was successful
   def webauthn_setup_submitted(
@@ -7767,10 +7778,10 @@ module AnalyticsEvents
   )
     track_event(
       :webauthn_setup_submitted,
-      platform_authenticator: platform_authenticator,
-      success: success,
+      platform_authenticator:,
+      success:,
+      errors:,
       in_account_creation_flow:,
-      errors: errors,
       **extra,
     )
   end

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -19,13 +19,31 @@ RSpec.describe WebauthnSetupForm do
       protocol:,
     }
   end
-  let(:subject) { WebauthnSetupForm.new(user:, user_session:, device_name:) }
+  subject(:form) { WebauthnSetupForm.new(user:, user_session:, device_name:) }
 
   before do
     allow(IdentityConfig.store).to receive(:domain_name).and_return(domain_name)
   end
 
+  describe '#webauthn_configuration' do
+    subject(:webauthn_configuration) { form.webauthn_configuration }
+
+    it { is_expected.to be_nil }
+
+    context 'after successful submission' do
+      before do
+        form.submit(params)
+      end
+
+      it 'returns the created configuration' do
+        expect(webauthn_configuration).to eq(user.reload.webauthn_configurations.take)
+      end
+    end
+  end
+
   describe '#submit' do
+    subject(:result) { form.submit(params) }
+
     context 'when the input is valid' do
       context 'security key' do
         it 'returns FormResponse with success: true and creates a webauthn configuration' do
@@ -46,9 +64,11 @@ RSpec.describe WebauthnSetupForm do
             pii_like_keypaths: [[:mfa_method_counts, :phone]],
           }
 
-          expect(subject.submit(params).to_h).to eq(
+          expect(result.to_h).to eq(
             success: true,
             errors: nil,
+            transports: ['usb'],
+            transports_mismatch: false,
             **extra_attributes,
           )
 
@@ -63,11 +83,10 @@ RSpec.describe WebauthnSetupForm do
           expect(PushNotification::HttpPush).to receive(:deliver)
             .with(PushNotification::RecoveryInformationChangedEvent.new(user: user))
 
-          subject.submit(params)
+          result
         end
 
         it 'does not contains uuid' do
-          result = subject.submit(params)
           expect(result.extra[:aaguid]).to eq nil
         end
       end
@@ -79,7 +98,6 @@ RSpec.describe WebauthnSetupForm do
         end
 
         it 'creates a platform authenticator' do
-          result = subject.submit(params)
           expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn_platform'
 
           user.reload
@@ -94,8 +112,6 @@ RSpec.describe WebauthnSetupForm do
           let(:params) { super().merge(authenticator_data_value: '65') }
 
           it 'includes data flags with bs set as false ' do
-            result = subject.submit(params)
-
             expect(result.to_h[:authenticator_data_flags]).to eq(
               up: true,
               uv: false,
@@ -111,8 +127,6 @@ RSpec.describe WebauthnSetupForm do
           let(:params) { super().merge(authenticator_data_value: 'bad_error') }
 
           it 'should not include authenticator data flag' do
-            result = subject.submit(params)
-
             expect(result.to_h[:authenticator_data_flags]).to be_nil
           end
         end
@@ -121,14 +135,11 @@ RSpec.describe WebauthnSetupForm do
           let(:params) { super().merge(authenticator_data_value: nil) }
 
           it 'should not include authenticator data flag' do
-            result = subject.submit(params)
-
             expect(result.to_h[:authenticator_data_flags]).to be_nil
           end
         end
 
         it 'contains uuid' do
-          result = subject.submit(params)
           expect(result.extra[:aaguid]).to eq aaguid
         end
       end
@@ -137,7 +148,7 @@ RSpec.describe WebauthnSetupForm do
         let(:params) { super().merge(transports: 'wrong') }
 
         it 'creates a webauthn configuration without transports' do
-          subject.submit(params)
+          result
 
           user.reload
 
@@ -145,8 +156,6 @@ RSpec.describe WebauthnSetupForm do
         end
 
         it 'includes unknown transports in extra analytics' do
-          result = subject.submit(params)
-
           expect(result.to_h).to eq(
             success: true,
             errors: nil,
@@ -164,6 +173,8 @@ RSpec.describe WebauthnSetupForm do
             pii_like_keypaths: [[:mfa_method_counts, :phone]],
             unknown_transports: ['wrong'],
             aaguid: nil,
+            transports: [],
+            transports_mismatch: false,
           )
         end
       end
@@ -190,7 +201,7 @@ RSpec.describe WebauthnSetupForm do
           pii_like_keypaths: [[:mfa_method_counts, :phone]],
         }
 
-        expect(subject.submit(params).to_h).to eq(
+        expect(result.to_h).to eq(
           success: false,
           errors: {
             attestation_object: [
@@ -201,6 +212,8 @@ RSpec.describe WebauthnSetupForm do
             ],
           },
           error_details: { attestation_object: { invalid: true } },
+          transports: ['usb'],
+          transports_mismatch: false,
           **extra_attributes,
         )
       end
@@ -210,7 +223,7 @@ RSpec.describe WebauthnSetupForm do
       let(:params) { super().except(:transports) }
 
       it 'creates a webauthn configuration without transports' do
-        subject.submit(params)
+        result
 
         user.reload
 
@@ -242,7 +255,7 @@ RSpec.describe WebauthnSetupForm do
           pii_like_keypaths: [[:mfa_method_counts, :phone]],
         }
 
-        expect(subject.submit(params).to_h).to eq(
+        expect(result.to_h).to eq(
           success: false,
           errors: {
             attestation_object: [
@@ -253,11 +266,129 @@ RSpec.describe WebauthnSetupForm do
             ],
           },
           error_details: { attestation_object: { invalid: true } },
+          transports: ['usb'],
+          transports_mismatch: false,
           **extra_attributes,
         )
       end
     end
+
+    context 'with transports mismatch' do
+      let(:params) { super().merge(transports: 'internal') }
+
+      it 'returns setup as mismatched type' do
+        expect(result.to_h).to eq(
+          success: true,
+          errors: nil,
+          enabled_mfa_methods_count: 1,
+          mfa_method_counts: { webauthn_platform: 1 },
+          multi_factor_auth_method: 'webauthn_platform',
+          authenticator_data_flags: {
+            up: true,
+            uv: false,
+            be: true,
+            bs: true,
+            at: false,
+            ed: true,
+          },
+          unknown_transports: nil,
+          aaguid: nil,
+          transports: ['internal'],
+          transports_mismatch: true,
+          pii_like_keypaths: [[:mfa_method_counts, :phone]],
+        )
+      end
+    end
   end
+
+  describe '#setup_as_platform_authenticator?' do
+    subject(:setup_as_platform_authenticator?) { form.setup_as_platform_authenticator? }
+
+    it { is_expected.to eq(false) }
+
+    context 'after successful submission' do
+      before do
+        form.submit(params)
+      end
+
+      it { is_expected.to eq(false) }
+
+      context 'without transports' do
+        let(:params) { super().merge(transports: nil) }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'with platform authenticator transports' do
+        let(:params) { super().merge(transports: 'internal') }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when setup as platform authenticator' do
+        let(:params) { super().merge(platform_authenticator: true, transports: 'internal') }
+
+        it { is_expected.to eq(true) }
+
+        context 'without transports' do
+          let(:params) { super().merge(transports: nil) }
+
+          it { is_expected.to eq(true) }
+        end
+
+        context 'without platform authenticator transports' do
+          let(:params) { super().merge(transports: 'usb') }
+
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+  end
+
+  describe '#transports_mismatch?' do
+    subject(:transports_mismatch?) { form.transports_mismatch? }
+
+    it { is_expected.to eq(false) }
+
+    context 'after successful submission' do
+      before do
+        form.submit(params)
+      end
+
+      it { is_expected.to eq(false) }
+
+      context 'without transports' do
+        let(:params) { super().merge(transports: nil) }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'with platform authenticator transports' do
+        let(:params) { super().merge(transports: 'internal') }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when setup as platform authenticator' do
+        let(:params) { super().merge(platform_authenticator: true, transports: 'internal') }
+
+        it { is_expected.to eq(false) }
+
+        context 'without transports' do
+          let(:params) { super().merge(transports: nil) }
+
+          it { is_expected.to eq(false) }
+        end
+
+        context 'without platform authenticator transports' do
+          let(:params) { super().merge(transports: 'usb') }
+
+          it { is_expected.to eq(true) }
+        end
+      end
+    end
+  end
+
   describe '.name_is_unique' do
     context 'webauthn' do
       let(:user) do
@@ -266,7 +397,7 @@ RSpec.describe WebauthnSetupForm do
         user
       end
       it 'checks for unique device on a webauthn device' do
-        result = subject.submit(params)
+        result = form.submit(params)
         expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn'
         expect(result.errors[:name]).to eq(
           [I18n.t(
@@ -295,7 +426,7 @@ RSpec.describe WebauthnSetupForm do
         end
 
         it 'adds a new platform device with the same existing name and appends a (1)' do
-          result = subject.submit(params)
+          result = form.submit(params)
           expect(result.extra[:multi_factor_auth_method]).to eq 'webauthn_platform'
           expect(user.webauthn_configurations.platform_authenticators.count).to eq(2)
           expect(
@@ -321,7 +452,7 @@ RSpec.describe WebauthnSetupForm do
         end
 
         it 'adds a second new platform device with the same existing name and appends a (2)' do
-          result = subject.submit(params)
+          result = form.submit(params)
 
           expect(result.success?).to eq(true)
           expect(user.webauthn_configurations.platform_authenticators.count).to eq(3)

--- a/spec/models/webauthn_configuration_spec.rb
+++ b/spec/models/webauthn_configuration_spec.rb
@@ -10,6 +10,24 @@ RSpec.describe WebauthnConfiguration do
 
   let(:subject) { create(:webauthn_configuration) }
 
+  describe '.PLATFORM_AUTHENTICATOR_TRANSPORTS' do
+    subject(:transports) { WebauthnConfiguration::PLATFORM_AUTHENTICATOR_TRANSPORTS }
+
+    it 'is a frozen array of strings' do
+      expect(transports).to all be_a(String)
+      expect(transports.frozen?).to eq(true)
+    end
+  end
+
+  describe '.VALID_TRANSPORTS' do
+    subject(:transports) { WebauthnConfiguration::VALID_TRANSPORTS }
+
+    it 'is a frozen array of strings' do
+      expect(transports).to all be_a(String)
+      expect(transports.frozen?).to eq(true)
+    end
+  end
+
   describe '#selection_presenters' do
     context 'for a roaming authenticator' do
       it 'returns a WebauthnSelectionPresenter in an array' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-14052](https://cm-jira.usa.gov/browse/LG-14052)

## 🛠 Summary of changes

Updates Security Key and Face or Touch Unlock setup to automatically convert to the other if the reported [transports](https://w3c.github.io/webauthn/#enum-transport) are inconsistent with the expected platform attachment.

As outlined in the Testing Plan, despite hints that we provide to the browser to try to ensure that the user sets up a WebAuthn credential with the intended platform attachment, it is still often possible for a user to set up an authenticator of the other type (e.g. Chrome's "Save another way"). In these scenarios, converting the credential to the inferred type will ensure that the user has a better sign-in experience and that our usage tracking is more accurate to the actual type of authenticator used. [Previous investigation](https://gsa-tts.slack.com/archives/C01710KMYUB/p1722449034753999) found that a majority of "Security Key" enrollments are, in-fact, platform authenticators.

This is the second of two pull requests, using routes implemented in #11795. **Those changes must be fully deployed to production before this can be merged.**

## 📜 Testing Plan

Verify mismatched behavior displays confirmation prompt as expected:

**Setting up Security Key using a platform authenticator:**

1. Prerequisite: Have a mobile phone capable of setting up passkeys (iPhone with iCloud Keychain enabled, or Android)
2. On desktop, go to http://localhost:3000
3. Sign in or create a new account†
4. When presented the opportunity, add a Security Key
   - From the account dashboard for an existing account, click "Add security key" in the sidebar
   - From the MFA selection screen for a new account, choose "Security key" as one of your selected option(s) and "Continue"
5. Enter a nickname for the security key
6. Click "Set up security key"
7. As permitted by your browser, navigate the browser dialog to set up using a platform authenticator (e.g. phone)
   - In Chrome, click "Save another way", click "Use a different phone or tablet", and scan the displayed QR code using your phone
8. Observe that you're shown the screen "Face or touch unlock detected"
9. Click either "Continue" or "Undo"
10. Observe that...
   - ...if you click "Continue", you proceed to the next logical step (account page if set up from account page, or account page if set up as second MFA method, or 2nd MFA requirement if set up as sole MFA in account creation, or consent screen if set up as second MFA method while signing in to partner)
   - ...if you click "Undo", you're returned to the Security Key setup screen. You should be able to either set up again or cancel and return to the preceding step (MFA selection, account page)

**Setting up Security Key using a platform authenticator:**

_The steps below are currently hypothetical, but my own testing reveals that it is not possible to complete Step 5 in tested supported browsers_.

1. Go to http://localhost:3000
2. Sign in or create a new account†
3. When presented the opportunity, add Face or Touch unlock
   - From the account dashboard for an existing account, click "Add face or touch unlock" in the sidebar
   - From the MFA selection screen for a new account, choose "Face or touch unlock" as one of your selected option(s) and "Continue"
4. Click "Continue"
5. As permitted by your browser, navigate the browser dialog to set up using a security key
6. Observe that you're shown the screen "Security key detected"
7. Click either "Continue" or "Undo"
8. Observe that...
   - ...if you click "Continue", you proceed to the next logical step (account page if set up from account page, or account page if set up as second MFA method, or consent screen if set up as second MFA method while signing in to partner)
   - ...if you click "Undo", you're returned to the Face or Touch Unlock setup screen. You should be able to either set up again or cancel and return to the preceding step (MFA selection, account page)

† Creating a new account can be a useful test case, since the application currently has some assumptions about not permitting a user to delete their only MFA, but the process of "Undo"-ing a mismatched WebAuthn credential requires that we allow a user to delete their only MFA during account creation.

## 👀 Screenshots

Language|Face or Touch Unlock|Security Key
---|---|---
English|![ft-mismatch-en](https://github.com/user-attachments/assets/cc574939-e8e4-4bf8-a4e0-b804bc651ee9)|![sk-mismatch-en](https://github.com/user-attachments/assets/845ddf8e-7e2d-41a3-bcca-753b52a98501)
Spanish|![ft-mismatch-es](https://github.com/user-attachments/assets/cf8b0469-0639-4ec0-8bcf-849747171b9c)|![sk-mismatch-es](https://github.com/user-attachments/assets/e20b8798-48d4-4bf6-b29a-be7d8e35ce1b)
French|![ft-mismatch-fr](https://github.com/user-attachments/assets/c8e3fe17-542a-4f5c-b856-695793d8d051)|![sk-mismatch-fr](https://github.com/user-attachments/assets/c1302f02-d372-4cab-bd83-2359b1a4f6f2)
Chinese|![ft-mismatch-zh](https://github.com/user-attachments/assets/c354f911-4ede-493b-a4cc-aa33d29b3a18)|![sk-mismatch-zh](https://github.com/user-attachments/assets/f20764bd-a998-4baf-837f-b3b39cedc495)