### PR TITLE
Avoid printing preload_links_header attribute for scripts

### DIFF
--- a/app/helpers/script_helper.rb
+++ b/app/helpers/script_helper.rb
@@ -19,7 +19,7 @@ module ScriptHelper
         asset_sources.get_sources(name).each do |source|
           integrity = asset_sources.get_integrity(source)
 
-          if attributes[:preload_links_header] != false
+          if attributes.delete(:preload_links_header) != false
             AssetPreloadLinker.append(
               headers: response.headers,
               as: :script,

--- a/spec/helpers/script_helper_spec.rb
+++ b/spec/helpers/script_helper_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe ScriptHelper do
           javascript_packs_tag_once('application', preload_links_header: false)
         end
 
+        it 'prints tags with expected attributes' do
+          output = render_javascript_pack_once_tags
+
+          expect(output).to have_css(
+            "script:not([preload_links_header]):not([crossorigin])[src^='/application.js'] ~ \
+            script:not([preload_links_header]):not([crossorigin])[src^='/document-capture.js']",
+            count: 1,
+            visible: :all,
+          )
+        end
+
         it 'does not append preload header' do
           render_javascript_pack_once_tags
 


### PR DESCRIPTION
## 🛠 Summary of changes

Fixes an issue where scripts rendered using `preload_links_header: false` option unexpectedly output a `preload_links_header="false"` attribute on the rendered script tag.

This regressed in #11504, where we switched from using `javascript_include_tag` to `tag.script`. The `preload_links_header` behavior was intended to mimic that of `javascript_include_tag`, but did not recreate the behavior of deleting the option from attributes before rendering the script tag ([source](https://github.com/rails/rails/blob/33beb0a38db1c058123a8e3cc298cad918adfe32/actionview/lib/action_view/helpers/asset_tag_helper.rb#L117)).

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Right click and view source for page
3. Verify that `track-errors.js` script tag toward the bottom of page `<body>` content does not include a `preload_links_header` attribute