### PR TITLE
Remove Faker use in UserMailerPreview

### DIFF
--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -295,8 +295,8 @@ class UserMailerPreview < ActionMailer::Preview
         devices: [
           unsaveable(
             Device.new(
-              user_agent: Faker::Internet.user_agent,
-              last_ip: Faker::Internet.ip_v4_address,
+              user_agent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36', # rubocop:disable Layout/LineLength
+              last_ip: '8.8.8.8',
             ),
           ),
         ],


### PR DESCRIPTION
Alternative to https://github.com/18F/identity-idp/pull/11786

- Mailer previews occasionally load in production environments (sandbox) but in #11757, we moved the Faker gem to the test group (which breaks these previews in sandbox)
- Removing the usage of Faker in the previews helps keep the previews working, and keeps the production dependencies smaller
