### PR TITLE
LG-15179 Timed out hybrid user should be able to retry docv

### DIFF
--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -18,6 +18,8 @@ module Idv
         before_action :fetch_test_verification_data, only: [:update]
 
         def show
+          session[:socure_docv_wait_polling_started_at] = nil
+
           Funnel::DocAuth::RegisterStep.new(document_capture_user.id, sp_session[:issuer])
             .call('hybrid_mobile_socure_document_capture', :view, true)
 

--- a/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
@@ -143,6 +143,10 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
           )
       end
 
+      it 'sets any docv timeouts to nil' do
+        expect(session[:socure_docv_wait_polling_started_at]).to eq nil
+      end
+
       it 'logs correct info' do
         expect(@analytics).to have_logged_event(
           :idv_socure_document_request_submitted,

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
           )
       end
 
+      it 'sets any docv timeouts to nil' do
+        expect(subject.idv_session.socure_docv_wait_polling_started_at).to eq nil
+      end
+
       it 'logs correct info' do
         expect(@analytics).to have_logged_event(
           :idv_socure_document_request_submitted,


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-15179](https://cm-jira.usa.gov/browse/LG-15179)



## 🛠 Summary of changes

This fix makes sure a user is allowed to complete DocV after they timeout and the timeout is over.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Make sure specs pass.
- [ ] For in-depth testing we will need to follow the same plan as outlined in https://github.com/18F/identity-idp/pull/11734



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
