### PR TITLE
Reduce RiscDeliveryJob exception noise in NewRelic

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -29,6 +29,7 @@ production:
       ActionDispatch::Http::MimeNegotiation::InvalidType
       ActionDispatch::Http::Parameters::ParseError
       GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError
+      RiscDeliveryJob::DeliveryError
     ].join(',') %>"
   license_key: <%= IdentityConfig.store.newrelic_license_key %>
   log_level: info

--- a/lib/identity_job_log_subscriber.rb
+++ b/lib/identity_job_log_subscriber.rb
@@ -106,6 +106,7 @@ class IdentityJobLogSubscriber < ActiveSupport::LogSubscriber
     error_or_warn(
       event: event,
       extra_attributes: { attempts: job.executions },
+      include_exception_message: true,
     )
   end
 

--- a/spec/jobs/risc_delivery_job_spec.rb
+++ b/spec/jobs/risc_delivery_job_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe RiscDeliveryJob do
 
       context 'when the job fails for the 1st time' do
         it 'raises and retries via ActiveJob' do
-          expect { perform }.to raise_error(Faraday::SSLError)
+          expect { perform }.to raise_error(RiscDeliveryJob::DeliveryError)
 
           expect(job_analytics).not_to have_logged_event(
             :risc_security_event_pushed,
@@ -111,7 +111,7 @@ RSpec.describe RiscDeliveryJob do
 
       context 'when the job fails for the 1st time' do
         it 'raises and retries via ActiveJob' do
-          expect { perform }.to raise_error(Faraday::ConnectionFailed)
+          expect { perform }.to raise_error(RiscDeliveryJob::DeliveryError)
 
           expect(job_analytics).not_to have_logged_event(
             :risc_security_event_pushed,
@@ -156,7 +156,7 @@ RSpec.describe RiscDeliveryJob do
 
       context 'when the job fails for the 1st time' do
         it 'raises and retries via ActiveJob' do
-          expect { perform }.to raise_error(Errno::ECONNREFUSED)
+          expect { perform }.to raise_error(RiscDeliveryJob::DeliveryError)
 
           expect(job_analytics).not_to have_logged_event(
             :risc_security_event_pushed,
@@ -300,7 +300,7 @@ RSpec.describe RiscDeliveryJob do
   describe '.warning_error_classes' do
     it 'is all the network errors and rate limiting errors' do
       expect(described_class.warning_error_classes).to match_array(
-        [*described_class::NETWORK_ERRORS, RedisRateLimiter::LimitError],
+        [RiscDeliveryJob::DeliveryError, RedisRateLimiter::LimitError],
       )
     end
   end

--- a/spec/lib/identity_job_log_subscriber_spec.rb
+++ b/spec/lib/identity_job_log_subscriber_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
         now,
         event_uuid,
         job: job,
-        exception_object: Errno::ECONNREFUSED.new,
+        exception_object: RedisRateLimiter::LimitError.new('message'),
       )
 
       expect(subscriber).to_not receive(:error)
@@ -166,8 +166,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           duration_ms: kind_of(Float),
           cpu_time_ms: kind_of(Numeric),
           idle_time_ms: kind_of(Numeric),
-          exception_class_warn: 'Errno::ECONNREFUSED',
-          exception_message_warn: 'Connection refused',
+          exception_class_warn: 'RedisRateLimiter::LimitError',
+          exception_message_warn: 'message',
           job_class: 'RiscDeliveryJob',
           job_id: job.job_id,
           name: 'enqueue.active_job',
@@ -294,7 +294,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
         now,
         event_uuid,
         job: job,
-        exception_object: Errno::ECONNREFUSED.new,
+        exception_object: RedisRateLimiter::LimitError.new('message'),
       )
 
       expect(subscriber).to_not receive(:error)
@@ -308,8 +308,8 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           duration_ms: kind_of(Float),
           cpu_time_ms: kind_of(Numeric),
           idle_time_ms: kind_of(Numeric),
-          exception_class_warn: 'Errno::ECONNREFUSED',
-          exception_message_warn: 'Connection refused',
+          exception_class_warn: 'RedisRateLimiter::LimitError',
+          exception_message_warn: 'message',
           job_class: 'RiscDeliveryJob',
           job_id: job.job_id,
           name: 'enqueue.active_job',
@@ -338,7 +338,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
         now,
         event_uuid,
         job: job,
-        exception_object: Errno::ECONNREFUSED.new,
+        exception_object: RedisRateLimiter::LimitError.new,
       )
 
       subscriber.enqueue_at(event)
@@ -436,7 +436,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
         now,
         event_uuid,
         job: job,
-        error: Errno::ECONNREFUSED.new,
+        error: RedisRateLimiter::LimitError.new,
       )
 
       expect(subscriber).to_not receive(:error)
@@ -456,7 +456,7 @@ RSpec.describe IdentityJobLogSubscriber, type: :job do
           trace_id: nil,
           queue_name: kind_of(String),
           job_id: job.job_id,
-          exception_class_warn: 'Errno::ECONNREFUSED',
+          exception_class_warn: 'RedisRateLimiter::LimitError',
           log_filename: Idp::Constants::WORKER_LOG_FILENAME,
         )
       end


### PR DESCRIPTION
## 🛠 Summary of changes

A follow-up to an older change in #10806, this PR makes some bigger changes to exception handling in the `RiscDeliveryJob` to reduce the volume of noisy exceptions sent to NewRelic. Primarily, it wraps any of the `NETWORK_ERRORS` in a new `DeliveryError`. The original exception is still kept in [Exception#cause](https://ruby-doc.org/3.4.1/Exception.html#method-i-cause). The new error class is then added to the ignored list in NewRelic so that we still get any of the exceptions in `NETWORK_ERRORS` in other contexts if they're outside of this job.

I've added the flag to include the error message in the `retry_stopped` callback for job logging as that's primarily the event that will be useful when we give up on retrying due to network failures.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
