### PR TITLE
Extract mixin for common MFA deletion behaviors

### DIFF
--- a/app/controllers/concerns/mfa_deletion_concern.rb
+++ b/app/controllers/concerns/mfa_deletion_concern.rb
@@ -4,7 +4,7 @@ module MfaDeletionConcern
   include RememberDeviceConcern
 
   def handle_successful_mfa_deletion(event_type:)
-    create_user_event(event_type)
+    create_user_event(event_type) if event_type
     revoke_remember_device(current_user)
     event = PushNotification::RecoveryInformationChangedEvent.new(user: current_user)
     PushNotification::HttpPush.deliver(event)

--- a/spec/controllers/concerns/mfa_deletion_concern_spec.rb
+++ b/spec/controllers/concerns/mfa_deletion_concern_spec.rb
@@ -38,5 +38,15 @@ RSpec.describe MfaDeletionConcern do
 
       result
     end
+
+    context 'with nil event_type argument' do
+      let(:event_type) { nil }
+
+      it 'does not create user event' do
+        expect(controller).not_to receive(:create_user_event)
+
+        result
+      end
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-14052](https://cm-jira.usa.gov/browse/LG-14052)

## 🛠 Summary of changes

Refactors to create a new `MfaDeletionConcern#handle_successful_mfa_deletion` method. This builds upon #11795, where the method was initially introduced to handle "Undo" behaviors associated with a mismatched WebAuthn configuration.

Deleting a multi-factor authentication method always incurs the following:

- Creating a user history event
- Revoking remembered device
- Dispatching a RISC security event

Previously, these were duplicated across controllers for each method, which creates risk of human error for failing to account for one or more of these actions.

As an example, refactoring this behavior reveals that we don't have a user event associated with deleting backup codes, which became obvious when abstracting this method with a required `event_type` keyword argument. This will be addressed in a follow-up ticket.

## 📜 Testing Plan

Verify no regressions of impacted behavior, and that existing test coverage passes.