### PR TITLE
LG-14947 - stale data trigger update idp job

### DIFF
--- a/app/jobs/data_warehouse/table_summary_stats_export_job.rb
+++ b/app/jobs/data_warehouse/table_summary_stats_export_job.rb
@@ -9,7 +9,7 @@ module DataWarehouse
     ].freeze
 
     TIMESTAMP_OVERRIDE = {
-      'sp_return_logs' => 'requested_at',
+      'sp_return_logs' => 'returned_at',
       'registration_logs' => 'registered_at',
     }.freeze
 
@@ -53,9 +53,12 @@ module DataWarehouse
       SELECT COALESCE(MAX(id), 0) AS max_id, COUNT(*) AS row_count
       FROM #{quoted_table}
       SQL
-      if table_has_column?(table, 'created_at')
+      timestamp_column = 'created_at'
+      timestamp_column = TIMESTAMP_OVERRIDE[table] if TIMESTAMP_OVERRIDE.key?(table)
+
+      if table_has_column?(table, timestamp_column)
         quoted_timestamp = ActiveRecord::Base.connection.quote(timestamp)
-        query += " WHERE created_at <= #{quoted_timestamp}"
+        query += " WHERE #{timestamp_column} <= #{quoted_timestamp}"
       end
 
       result = ActiveRecord::Base.connection.execute(query).first

--- a/app/jobs/data_warehouse/table_summary_stats_export_job.rb
+++ b/app/jobs/data_warehouse/table_summary_stats_export_job.rb
@@ -8,6 +8,11 @@ module DataWarehouse
       agency_identities
     ].freeze
 
+    TIMESTAMP_OVERRIDE = {
+      'sp_return_logs' => 'requested_at',
+      'registration_logs' => 'registered_at',
+    }.freeze
+
     def perform(timestamp)
       return if data_warehouse_disabled?
 
@@ -54,11 +59,9 @@ module DataWarehouse
       end
 
       result = ActiveRecord::Base.connection.execute(query).first
-      if table_has_column?(table, 'created_at')
-        result['timestamp_column'] = 'created_at'
-      else
-        result['timestamp_column'] = nil
-      end
+      result['timestamp_column'] = nil
+      result['timestamp_column'] = 'created_at' if table_has_column?(table, 'created_at')
+      result['timestamp_column'] = TIMESTAMP_OVERRIDE[table] if TIMESTAMP_OVERRIDE.key?(table)
 
       result
     end

--- a/spec/jobs/data_warehouse/table_summary_stats_export_job_spec.rb
+++ b/spec/jobs/data_warehouse/table_summary_stats_export_job_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe DataWarehouse::TableSummaryStatsExportJob, type: :job do
           'sp_return_logs' => {
             'max_id' => 1,
             'row_count' => 1,
-            'timestamp_column' => 'requested_at',
+            'timestamp_column' => 'returned_at',
           },
           'agencies' => {
             'max_id' => 19,
@@ -183,7 +183,10 @@ RSpec.describe DataWarehouse::TableSummaryStatsExportJob, type: :job do
     User.create!(id: 1, created_at: (timestamp - 1.hour))
     User.create!(id: 2, created_at: (timestamp - 1.day))
     SpReturnLog.create!(
-      id: 1, requested_at: (timestamp - 1.day), request_id: 1, ial: 1, issuer: 'foo',
+      id: 1,
+      requested_at: (timestamp - 1.day),
+      returned_at: (timestamp - 1.day),
+      request_id: 1, ial: 1, issuer: 'foo'
     )
   end
 end

--- a/spec/jobs/data_warehouse/table_summary_stats_export_job_spec.rb
+++ b/spec/jobs/data_warehouse/table_summary_stats_export_job_spec.rb
@@ -108,13 +108,18 @@ RSpec.describe DataWarehouse::TableSummaryStatsExportJob, type: :job do
       end
     end
 
-    context 'when tables are missing the timestamp column' do
+    context 'pulls correct timestamp column value' do
       let(:expected_json) do
         {
           'users' => {
             'max_id' => 2,
             'row_count' => 2,
             'timestamp_column' => 'created_at',
+          },
+          'sp_return_logs' => {
+            'max_id' => 1,
+            'row_count' => 1,
+            'timestamp_column' => 'requested_at',
           },
           'agencies' => {
             'max_id' => 19,
@@ -125,7 +130,10 @@ RSpec.describe DataWarehouse::TableSummaryStatsExportJob, type: :job do
       end
 
       before do
-        allow(ActiveRecord::Base.connection).to receive(:tables).and_return(['users', 'agencies'])
+        allow(ActiveRecord::Base.connection).to receive(:tables).and_return(
+          ['users',
+           'sp_return_logs', 'agencies'],
+        )
       end
 
       it 'generates correct values without timestamp column' do
@@ -174,5 +182,8 @@ RSpec.describe DataWarehouse::TableSummaryStatsExportJob, type: :job do
   def add_data_to_tables
     User.create!(id: 1, created_at: (timestamp - 1.hour))
     User.create!(id: 2, created_at: (timestamp - 1.day))
+    SpReturnLog.create!(
+      id: 1, requested_at: (timestamp - 1.day), request_id: 1, ial: 1, issuer: 'foo',
+    )
   end
 end

--- a/spec/jobs/data_warehouse/table_summary_stats_export_job_spec.rb
+++ b/spec/jobs/data_warehouse/table_summary_stats_export_job_spec.rb
@@ -4,15 +4,21 @@ RSpec.describe DataWarehouse::TableSummaryStatsExportJob, type: :job do
   let(:timestamp) { Date.new(2024, 10, 10).in_time_zone('UTC').end_of_day }
   let(:job) { described_class.new }
   let(:expected_bucket) { 'login-gov-analytics-export-test-1234-us-west-2' }
-  let(:test_on_tables) { ['users'] }
+  let(:test_on_tables) { ['agencies', 'users'] }
   let(:s3_data_warehouse_bucket_prefix) { 'login-gov-analytics-export' }
   let(:data_warehouse_enabled) { true }
 
   let(:expected_json) do
     {
+      'agencies' => {
+        'max_id' => 19,
+        'row_count' => 19,
+        'timestamp_column' => nil,
+      },
       'users' => {
         'max_id' => 2,
         'row_count' => 2,
+        'timestamp_column' => 'created_at',
       },
     }.to_json
   end
@@ -66,7 +72,12 @@ RSpec.describe DataWarehouse::TableSummaryStatsExportJob, type: :job do
     end
 
     context 'when tables are empty' do
-      let(:expected_empty_json) { { 'users' => { 'max_id' => 0, 'row_count' => 0 } }.to_json }
+      let(:test_on_tables) { ['users'] }
+      let(:expected_empty_json) do
+        { 'users' => { 'max_id' => 0,
+                       'row_count' => 0,
+                       'timestamp_column' => 'created_at' } }.to_json
+      end
 
       before do
         User.delete_all # Clear the User table to simulate emptiness
@@ -94,6 +105,57 @@ RSpec.describe DataWarehouse::TableSummaryStatsExportJob, type: :job do
 
         expect { job.perform(timestamp) }.not_to raise_error
         expect(json_data.to_json).to eq(expected_empty_json)
+      end
+    end
+
+    context 'when tables are missing the timestamp column' do
+      let(:expected_json) do
+        {
+          'users' => {
+            'max_id' => 2,
+            'row_count' => 2,
+            'timestamp_column' => 'created_at',
+          },
+          'agencies' => {
+            'max_id' => 19,
+            'row_count' => 19,
+            'timestamp_column' => nil,
+          },
+        }.to_json
+      end
+
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:tables).and_return(['users', 'agencies'])
+      end
+
+      it 'generates correct values without timestamp column' do
+        json_data = job.fetch_table_max_ids_and_counts(timestamp)
+
+        expect(json_data.to_json).to eq(expected_json)
+      end
+    end
+
+    context 'when tables should be excluded' do
+      let(:test_on_tables) { ['agency_identities', 'users'] }
+      let(:expected_json) do
+        {
+          'users' => {
+            'max_id' => 2,
+            'row_count' => 2,
+            'timestamp_column' => 'created_at',
+          },
+        }.to_json
+      end
+
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:tables).and_return(test_on_tables)
+      end
+
+      it 'excludes tables in the exclusion list' do
+        json_data = job.fetch_table_max_ids_and_counts(timestamp)
+
+        expect(json_data.to_json).to eq(expected_json)
+        expect(json_data.keys).not_to include('agency_identities')
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket
Link to the relevant ticket:
[[LG-14947](https://gitlab.login.gov/lg-teams/agnes/data-warehouse-ag/-/issues/545)]

## 🛠 Summary of changes
The stale data check was showing in agnes/int environments that if we started created alarms team agnes would suffer daily alerts.
- Added timestamp columns so that we could use them downstream when querying redshift
- Added tests to reflect timestamp functionality
- Added a table exclusion list to remove certain tables like join tables that contain event data but dont contain a relevant timestamp column