### PR TITLE
Avoid queries for ServiceProvider with blank issuer

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -237,7 +237,12 @@ module SamlIdpAuthConcern
 
   def saml_request_service_provider
     return @saml_request_service_provider if defined?(@saml_request_service_provider)
-    @saml_request_service_provider = ServiceProvider.find_by(issuer: current_issuer)
+    @saml_request_service_provider =
+      if current_issuer.blank?
+        nil
+      else
+        ServiceProvider.find_by(issuer: current_issuer)
+      end
   end
 
   def current_issuer

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -101,7 +101,12 @@ class OpenidConnectAuthorizeForm
 
   def service_provider
     return @service_provider if defined?(@service_provider)
-    @service_provider = ServiceProvider.find_by(issuer: client_id)
+    @service_provider =
+      if client_id.blank?
+        nil
+      else
+        ServiceProvider.find_by(issuer: client_id)
+      end
   end
 
   def link_identity_to_service_provider(

--- a/app/services/saml_request_parser.rb
+++ b/app/services/saml_request_parser.rb
@@ -2,6 +2,7 @@
 
 class SamlRequestParser
   URI_PATTERN = Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF
+  ESCAPED_URI_PATTERN = /#{Regexp.escape(URI_PATTERN)}/
 
   def initialize(request)
     @request = request
@@ -24,7 +25,7 @@ class SamlRequestParser
         samlp: Saml::XML::Namespaces::PROTOCOL,
         saml: Saml::XML::Namespaces::ASSERTION,
       ).select do |node|
-        node.content =~ /#{Regexp.escape(URI_PATTERN)}/
+        node.content =~ ESCAPED_URI_PATTERN
       end
     end
   end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -784,4 +784,16 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
   end
+
+  describe '#service_provider' do
+    context 'empty client_id' do
+      let(:client_id) { '' }
+
+      it 'does not query the database' do
+        expect(ServiceProvider).to_not receive(:find_by)
+
+        expect(form.service_provider).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Small performance improvement to avoid queries for ServiceProvider where issuer is not present. We see this sometimes around SP requests based on looking into NewRelic metrics and local testing to confirm. Also moves a frequently used Regexp into a constant to avoid having to re-create it every time.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
