### PR TITLE
Avoid empty hash default values in analytics methods

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2077,7 +2077,7 @@ module AnalyticsEvents
     front_image_fingerprint: nil,
     back_image_fingerprint: nil,
     selfie_image_fingerprint: nil,
-    classification_info: {},
+    classification_info: nil,
     **extra
   )
     track_event(
@@ -6282,7 +6282,7 @@ module AnalyticsEvents
     errors:,
     confirmed:,
     active_profile:,
-    error_details: {},
+    error_details: nil,
     **extra
   )
     track_event(
@@ -6312,7 +6312,7 @@ module AnalyticsEvents
     profile_deactivated:,
     pending_profile_invalidated:,
     pending_profile_pending_reasons:,
-    error_details: {},
+    error_details: nil,
     **extra
   )
     track_event(

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -344,7 +344,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           expect(@analytics).to have_logged_event(
             'Password Reset: Password Submitted',
             success: true,
-            error_details: {},
             user_id: user.uuid,
             profile_deactivated: false,
             pending_profile_invalidated: false,
@@ -391,7 +390,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to have_logged_event(
           'Password Reset: Password Submitted',
           success: true,
-          error_details: {},
           user_id: user.uuid,
           profile_deactivated: true,
           pending_profile_invalidated: false,
@@ -435,7 +433,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to have_logged_event(
           'Password Reset: Password Submitted',
           success: true,
-          error_details: {},
           user_id: user.uuid,
           profile_deactivated: false,
           pending_profile_invalidated: false,
@@ -465,7 +462,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to have_logged_event(
           'Password Reset: Email Submitted',
           success: true,
-          error_details: {},
           user_id: 'nonexistent-uuid',
           confirmed: false,
           active_profile: false,
@@ -491,7 +487,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to have_logged_event(
           'Password Reset: Email Submitted',
           success: true,
-          error_details: {},
           user_id: user.uuid,
           confirmed: true,
           active_profile: false,
@@ -521,7 +516,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to have_logged_event(
           'Password Reset: Email Submitted',
           success: true,
-          error_details: {},
           user_id: user.uuid,
           confirmed: false,
           active_profile: false,
@@ -545,7 +539,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         expect(@analytics).to have_logged_event(
           'Password Reset: Email Submitted',
           success: true,
-          error_details: {},
           user_id: user.uuid,
           confirmed: true,
           active_profile: true,


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `AnalyticsEvents` method signatures to avoid assigning a default empty hash value `{}`, preferring `nil` instead to ensure values are omitted from logs.

As with #11799, this serves to reduce the size (and cost) of our logging payloads by removing values which aren't relevant for querying. It is not possible to query for an empty hash value in CloudWatch Insights.

This is also an iterative step in the migration away from `errors` to `error_details` which will involve making `error_details` a guaranteed return value from `FormResponse#to_h`.

## 📜 Testing Plan

Verify build passes.