### PR TITLE
Annotate sign-in reCAPTCHA from 2-factor attempts

### DIFF
--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -8,7 +8,10 @@ module TwoFactorAuthentication
     prepend_before_action :authenticate_user
 
     def show
-      analytics.multi_factor_auth_enter_backup_code_visit(context: context)
+      recaptcha_annotation = annotate_recaptcha(
+        RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+      )
+      analytics.multi_factor_auth_enter_backup_code_visit(context: context, recaptcha_annotation:)
       @presenter = TwoFactorAuthCode::BackupCodePresenter.new(
         view: view_context,
         data: { current_user: current_user },

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -13,7 +13,10 @@ module TwoFactorAuthentication
     helper_method :in_multi_mfa_selection_flow?
 
     def show
-      analytics.multi_factor_auth_enter_otp_visit(**analytics_properties)
+      recaptcha_annotation = annotate_recaptcha(
+        RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+      )
+      analytics.multi_factor_auth_enter_otp_visit(recaptcha_annotation:, **analytics_properties)
 
       @landline_alert = landline_warning?
       @presenter = presenter_for_two_factor_authentication_method

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -9,7 +9,10 @@ module TwoFactorAuthentication
     before_action :check_personal_key_enabled
 
     def show
-      analytics.multi_factor_auth_enter_personal_key_visit(context: context)
+      recaptcha_annotation = annotate_recaptcha(
+        RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+      )
+      analytics.multi_factor_auth_enter_personal_key_visit(context: context, recaptcha_annotation:)
       @presenter = TwoFactorAuthCode::PersonalKeyPresenter.new
       @personal_key_form = PersonalKeyForm.new(current_user)
     end

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -13,7 +13,10 @@ module TwoFactorAuthentication
       if params[:token]
         process_token
       else
-        analytics.multi_factor_auth_enter_piv_cac(**analytics_properties)
+        recaptcha_annotation = annotate_recaptcha(
+          RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+        )
+        analytics.multi_factor_auth_enter_piv_cac(**analytics_properties, recaptcha_annotation:)
         @presenter = presenter_for_two_factor_authentication_method
       end
     end

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -8,7 +8,10 @@ module TwoFactorAuthentication
     before_action :confirm_totp_enabled
 
     def show
-      analytics.multi_factor_auth_enter_totp_visit(context: context)
+      recaptcha_annotation = annotate_recaptcha(
+        RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+      )
+      analytics.multi_factor_auth_enter_totp_visit(context: context, recaptcha_annotation:)
 
       @presenter = presenter_for_two_factor_authentication_method
       return unless FeatureManagement.prefill_otp_codes?

--- a/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/webauthn_verification_controller.rb
@@ -10,7 +10,13 @@ module TwoFactorAuthentication
 
     def show
       save_challenge_in_session
-      analytics.multi_factor_auth_enter_webauthn_visit(**analytics_properties)
+      recaptcha_annotation = annotate_recaptcha(
+        RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+      )
+      analytics.multi_factor_auth_enter_webauthn_visit(
+        **analytics_properties,
+        recaptcha_annotation:,
+      )
       @presenter = presenter_for_two_factor_authentication_method
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -113,6 +113,10 @@ module Users
       )
     end
 
+    def recaptcha_assessment_id
+      recaptcha_form.assessment_id
+    end
+
     def recaptcha_form
       @recaptcha_form ||= SignInRecaptchaForm.new(
         email: auth_params[:email],
@@ -217,6 +221,7 @@ module Users
       success = current_user.present? &&
                 !user_locked_out?(user) &&
                 (recaptcha_response.success? || log_captcha_failures_only?)
+      session[:sign_in_recaptcha_assessment_id] = recaptcha_assessment_id if recaptcha_assessment_id
 
       analytics.email_and_password_auth(
         **recaptcha_response,

--- a/app/forms/sign_in_recaptcha_form.rb
+++ b/app/forms/sign_in_recaptcha_form.rb
@@ -5,7 +5,8 @@ class SignInRecaptchaForm
 
   RECAPTCHA_ACTION = 'sign_in'
 
-  attr_reader :form_class, :form_args, :email, :recaptcha_token, :device_cookie, :ab_test_bucket
+  attr_reader :form_class, :form_args, :email, :recaptcha_token, :device_cookie, :ab_test_bucket,
+              :assessment_id
 
   validate :validate_recaptcha_result
 
@@ -39,7 +40,7 @@ class SignInRecaptchaForm
   private
 
   def validate_recaptcha_result
-    recaptcha_response, _assessment_id = recaptcha_form.submit(recaptcha_token)
+    recaptcha_response, @assessment_id = recaptcha_form.submit(recaptcha_token)
     errors.merge!(recaptcha_form) if !recaptcha_response.success?
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5559,6 +5559,7 @@ module AnalyticsEvents
   # @param [String] frontend_error Name of error that occurred in frontend during submission
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation flow
   # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
+  # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # Multi-Factor Authentication
   def multi_factor_auth(
     success:,
@@ -5583,6 +5584,7 @@ module AnalyticsEvents
     phone_fingerprint: nil,
     frontend_error: nil,
     in_account_creation_flow: nil,
+    recaptcha_annotation: nil,
     **extra
   )
     track_event(
@@ -5609,6 +5611,7 @@ module AnalyticsEvents
       frontend_error:,
       in_account_creation_flow:,
       enabled_mfa_methods_count:,
+      recaptcha_annotation:,
       **extra,
     )
   end
@@ -5683,11 +5686,13 @@ module AnalyticsEvents
   end
 
   # @param ["authentication", "reauthentication", "confirmation"] context User session context
+  # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # User visited the page to enter a backup code as their MFA
-  def multi_factor_auth_enter_backup_code_visit(context:, **extra)
+  def multi_factor_auth_enter_backup_code_visit(context:, recaptcha_annotation: nil, **extra)
     track_event(
       'Multi-Factor Authentication: enter backup code visited',
       context: context,
+      recaptcha_annotation:,
       **extra,
     )
   end
@@ -5702,6 +5707,7 @@ module AnalyticsEvents
   # @param [String] phone_fingerprint HMAC fingerprint of the phone number formatted as E.164
   # @param [Boolean] in_account_creation_flow Whether user is going through account creation flow
   # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
+  # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # Multi-Factor Authentication enter OTP visited
   def multi_factor_auth_enter_otp_visit(
     context:,
@@ -5714,6 +5720,7 @@ module AnalyticsEvents
     in_account_creation_flow:,
     enabled_mfa_methods_count:,
     attempts: nil,
+    recaptcha_annotation: nil,
     **extra
   )
     track_event(
@@ -5728,16 +5735,19 @@ module AnalyticsEvents
       phone_fingerprint:,
       in_account_creation_flow:,
       enabled_mfa_methods_count:,
+      recaptcha_annotation:,
       **extra,
     )
   end
 
   # @param ["authentication", "reauthentication", "confirmation"] context User session context
+  # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # User visited the page to enter a personal key as their mfa (legacy flow)
-  def multi_factor_auth_enter_personal_key_visit(context:, **extra)
+  def multi_factor_auth_enter_personal_key_visit(context:, recaptcha_annotation:, **extra)
     track_event(
       'Multi-Factor Authentication: enter personal key visited',
       context: context,
+      recaptcha_annotation:,
       **extra,
     )
   end
@@ -5747,12 +5757,14 @@ module AnalyticsEvents
   # @param ["piv_cac"] multi_factor_auth_method
   # @param [Integer, nil] piv_cac_configuration_id PIV/CAC configuration database ID
   # @param [Boolean] new_device Whether the user is authenticating from a new device
+  # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # User used a PIV/CAC as their mfa
   def multi_factor_auth_enter_piv_cac(
     context:,
     multi_factor_auth_method:,
     piv_cac_configuration_id:,
     new_device:,
+    recaptcha_annotation: nil,
     **extra
   )
     track_event(
@@ -5761,14 +5773,21 @@ module AnalyticsEvents
       multi_factor_auth_method: multi_factor_auth_method,
       piv_cac_configuration_id: piv_cac_configuration_id,
       new_device:,
+      recaptcha_annotation:,
       **extra,
     )
   end
 
   # @param ["authentication", "reauthentication", "confirmation"] context User session context
+  # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # User visited the page to enter a TOTP as their mfa
-  def multi_factor_auth_enter_totp_visit(context:, **extra)
-    track_event('Multi-Factor Authentication: enter TOTP visited', context: context, **extra)
+  def multi_factor_auth_enter_totp_visit(context:, recaptcha_annotation: nil, **extra)
+    track_event(
+      'Multi-Factor Authentication: enter TOTP visited',
+      context: context,
+      recaptcha_annotation:,
+      **extra,
+    )
   end
 
   # @param ["authentication", "reauthentication", "confirmation"] context User session context
@@ -5777,12 +5796,14 @@ module AnalyticsEvents
   #   authenticator like face or touch ID
   # @param [Integer, nil] webauthn_configuration_id webauthn database ID
   # @param [String] multi_factor_auth_method_created_at When the authentication method was created
+  # @param [Hash] recaptcha_annotation Details of reCAPTCHA annotation, if submitted
   # User visited the page to authenticate with webauthn (yubikey, face ID or touch ID)
   def multi_factor_auth_enter_webauthn_visit(
     context:,
     multi_factor_auth_method:,
     webauthn_configuration_id:,
     multi_factor_auth_method_created_at:,
+    recaptcha_annotation: nil,
     **extra
   )
     track_event(
@@ -5791,6 +5812,7 @@ module AnalyticsEvents
       multi_factor_auth_method:,
       webauthn_configuration_id:,
       multi_factor_auth_method_created_at:,
+      recaptcha_annotation:,
       **extra,
     )
   end

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -7,6 +7,7 @@ class RecaptchaAnnotator
   module AnnotationReasons
     INITIATED_TWO_FACTOR = :INITIATED_TWO_FACTOR
     PASSED_TWO_FACTOR = :PASSED_TWO_FACTOR
+    FAILED_TWO_FACTOR = :FAILED_TWO_FACTOR
   end
 
   # See: https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1/projects.assessments/annotate#annotation

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -380,6 +380,7 @@ short_term_phone_otp_max_attempt_window_in_seconds: 10
 short_term_phone_otp_max_attempts: 2
 show_unsupported_passkey_platform_authentication_setup: false
 show_user_attribute_deprecation_warnings: false
+sign_in_recaptcha_annotation_enabled: false
 sign_in_recaptcha_log_failures_only: false
 sign_in_recaptcha_percent_tested: 0
 sign_in_recaptcha_score_threshold: 0.0
@@ -498,6 +499,7 @@ development:
   secret_key_base: development_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   show_unsupported_passkey_platform_authentication_setup: true
+  sign_in_recaptcha_annotation_enabled: true
   sign_in_recaptcha_percent_tested: 100
   sign_in_recaptcha_score_threshold: 0.3
   skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost"]'
@@ -599,6 +601,7 @@ test:
   secret_key_base: test_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   short_term_phone_otp_max_attempts: 100
+  sign_in_recaptcha_annotation_enabled: true
   skip_encryption_allowed_list: '[]'
   socure_docv_document_request_endpoint: 'https://sandbox.socure.test/documnt-request'
   socure_docv_webhook_secret_key: 'secret-key'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -418,6 +418,7 @@ module IdentityConfig
     config.add(:sign_in_user_id_per_ip_attempt_window_in_minutes, type: :integer)
     config.add(:sign_in_user_id_per_ip_attempt_window_max_minutes, type: :integer)
     config.add(:sign_in_user_id_per_ip_max_attempts, type: :integer)
+    config.add(:sign_in_recaptcha_annotation_enabled, type: :boolean)
     config.add(:sign_in_recaptcha_log_failures_only, type: :boolean)
     config.add(:sign_in_recaptcha_percent_tested, type: :integer)
     config.add(:sign_in_recaptcha_score_threshold, type: :float)

--- a/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
+++ b/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
@@ -164,6 +164,59 @@ RSpec.describe TwoFactorAuthenticatableMethods, type: :controller do
           end
         end
       end
+
+      context 'when there is a sign_in_recaptcha_assessment_id in the session' do
+        let(:assessment_id) { 'projects/project-id/assessments/assessment-id' }
+
+        context 'when sign_in_recaptcha_annotation_enabled is true' do
+          before do
+            allow(IdentityConfig.store).to receive(:sign_in_recaptcha_annotation_enabled)
+              .and_return(true)
+          end
+
+          it 'annotates assessment with PASSED_TWO_FACTOR and clears assessment id from session' do
+            recaptcha_annotation = {
+              assessment_id:,
+              reason: RecaptchaAnnotator::AnnotationReasons::PASSED_TWO_FACTOR,
+            }
+
+            controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+            expect(RecaptchaAnnotator).to receive(:annotate)
+              .with(**recaptcha_annotation)
+              .and_return(recaptcha_annotation)
+
+            stub_analytics
+
+            expect { result }
+              .to change { controller.session[:sign_in_recaptcha_assessment_id] }
+              .from(assessment_id).to(nil)
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication',
+              hash_including(recaptcha_annotation:),
+            )
+          end
+        end
+
+        context 'when sign_in_recaptcha_annotation_enabled is false' do
+          before do
+            allow(IdentityConfig.store).to receive(:sign_in_recaptcha_annotation_enabled)
+              .and_return(false)
+          end
+
+          it 'does not annotate the assessment' do
+            controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+            expect(RecaptchaAnnotator).not_to receive(:annotate)
+
+            stub_analytics
+
+            expect { result }
+              .not_to change { controller.session[:sign_in_recaptcha_assessment_id] }
+          end
+        end
+      end
     end
 
     context 'failed verification' do
@@ -195,6 +248,58 @@ RSpec.describe TwoFactorAuthenticatableMethods, type: :controller do
       it 'records unsuccessful 2fa event' do
         expect { result }.to change { user.events.count }.by(1)
         expect(user.events.last.event_type).to eq('sign_in_unsuccessful_2fa')
+      end
+
+      context 'when there is a sign_in_recaptcha_assessment_id in the session' do
+        let(:assessment_id) { 'projects/project-id/assessments/assessment-id' }
+
+        context 'when sign_in_recaptcha_annotation_enabled is true' do
+          before do
+            allow(IdentityConfig.store).to receive(:sign_in_recaptcha_annotation_enabled)
+              .and_return(true)
+          end
+
+          it 'annotates assessment with FAILED_TWO_FACTOR and clears assessment id from session' do
+            recaptcha_annotation = {
+              assessment_id:,
+              reason: RecaptchaAnnotator::AnnotationReasons::FAILED_TWO_FACTOR,
+            }
+
+            controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+            expect(RecaptchaAnnotator).to receive(:annotate)
+              .with(**recaptcha_annotation)
+              .and_return(recaptcha_annotation)
+
+            stub_analytics
+
+            expect { result }
+              .not_to change { controller.session[:sign_in_recaptcha_assessment_id] }
+              .from(assessment_id)
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication',
+              hash_including(recaptcha_annotation:),
+            )
+          end
+        end
+        context 'when sign_in_recaptcha_annotation_enabled is false' do
+          before do
+            allow(IdentityConfig.store).to receive(:sign_in_recaptcha_annotation_enabled)
+              .and_return(false)
+          end
+
+          it 'does not annotate the assessment' do
+            controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+            expect(RecaptchaAnnotator).not_to receive(:annotate)
+
+            stub_analytics
+
+            expect { result }
+              .not_to change { controller.session[:sign_in_recaptcha_assessment_id] }
+          end
+        end
       end
     end
 

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -19,6 +19,33 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
         context: 'authentication',
       )
     end
+
+    context 'when there is a sign_in_recaptcha_assessment_id in the session' do
+      let(:assessment_id) { 'projects/project-id/assessments/assessment-id' }
+
+      it 'annotates the assessment with INITIATED_TWO_FACTOR and logs the annotation' do
+        recaptcha_annotation = {
+          assessment_id:,
+          reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+        }
+
+        controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+        expect(RecaptchaAnnotator).to receive(:annotate)
+          .with(**recaptcha_annotation)
+          .and_return(recaptcha_annotation)
+
+        stub_sign_in_before_2fa(user)
+        stub_analytics
+
+        get :show
+
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication: enter backup code visited',
+          hash_including(recaptcha_annotation:),
+        )
+      end
+    end
   end
 
   describe '#create' do

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -28,6 +28,34 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
       )
     end
 
+    context 'when there is a sign_in_recaptcha_assessment_id in the session' do
+      let(:assessment_id) { 'projects/project-id/assessments/assessment-id' }
+
+      it 'annotates the assessment with INITIATED_TWO_FACTOR and logs the annotation' do
+        user = build(:user, :with_personal_key, password: ControllerHelper::VALID_PASSWORD)
+        recaptcha_annotation = {
+          assessment_id:,
+          reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+        }
+
+        controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+        expect(RecaptchaAnnotator).to receive(:annotate)
+          .with(**recaptcha_annotation)
+          .and_return(recaptcha_annotation)
+
+        stub_sign_in_before_2fa(user)
+        stub_analytics
+
+        get :show
+
+        expect(@analytics).to have_logged_event(
+          'Multi-Factor Authentication: enter personal key visited',
+          hash_including(recaptcha_annotation:),
+        )
+      end
+    end
+
     it 'redirects to the two_factor_options page if user is IAL2' do
       profile = create(:profile, :active, :verified, pii: { ssn: '1234' })
       user = profile.user

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -69,6 +69,32 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
           new_device: true,
         )
       end
+
+      context 'when there is a sign_in_recaptcha_assessment_id in the session' do
+        let(:assessment_id) { 'projects/project-id/assessments/assessment-id' }
+
+        it 'annotates the assessment with INITIATED_TWO_FACTOR and logs the annotation' do
+          recaptcha_annotation = {
+            assessment_id:,
+            reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+          }
+
+          controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+          expect(RecaptchaAnnotator).to receive(:annotate)
+            .with(**recaptcha_annotation)
+            .and_return(recaptcha_annotation)
+
+          stub_analytics
+
+          get :show
+
+          expect(@analytics).to have_logged_event(
+            :multi_factor_auth_enter_piv_cac,
+            hash_including(recaptcha_annotation:),
+          )
+        end
+      end
     end
 
     context 'when the user presents a valid PIV/CAC' do

--- a/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/webauthn_verification_controller_spec.rb
@@ -66,6 +66,30 @@ RSpec.describe TwoFactorAuthentication::WebauthnVerificationController do
           )
         end
 
+        context 'when there is a sign_in_recaptcha_assessment_id in the session' do
+          let(:assessment_id) { 'projects/project-id/assessments/assessment-id' }
+
+          it 'annotates the assessment with INITIATED_TWO_FACTOR and logs the annotation' do
+            recaptcha_annotation = {
+              assessment_id:,
+              reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+            }
+
+            controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+            expect(RecaptchaAnnotator).to receive(:annotate)
+              .with(**recaptcha_annotation)
+              .and_return(recaptcha_annotation)
+
+            get :show
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication: enter webAuthn authentication visited',
+              hash_including(recaptcha_annotation:),
+            )
+          end
+        end
+
         context 'with multiple webauthn configured' do
           let!(:first_webauthn_platform_configuration) do
             create(:webauthn_configuration, :platform_authenticator, user:, created_at: 2.days.ago)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -333,6 +333,17 @@ RSpec.describe Users::SessionsController, devise: true do
           .and_return(:sign_in_recaptcha)
       end
 
+      it 'stores the reCAPTCHA assessment id in the session' do
+        user = create(:user, :fully_registered)
+
+        post :create, params: { user: { email: user.email,
+                                        password: user.password,
+                                        score: 0.1,
+                                        recaptcha_token: 'token' } }
+
+        expect(controller.session[:sign_in_recaptcha_assessment_id]).to be_kind_of(String)
+      end
+
       context 'when configured to log failures only' do
         before do
           allow(IdentityConfig.store).to receive(:sign_in_recaptcha_log_failures_only)
@@ -342,7 +353,10 @@ RSpec.describe Users::SessionsController, devise: true do
         it 'redirects unsuccessful authentication for failed reCAPTCHA to failed page' do
           user = create(:user, :fully_registered)
 
-          post :create, params: { user: { email: user.email, password: user.password, score: 0.1 } }
+          post :create, params: { user: { email: user.email,
+                                          password: user.password,
+                                          score: 0.1,
+                                          recaptcha_token: 'token' } }
 
           expect(response).to redirect_to user_two_factor_authentication_url
         end


### PR DESCRIPTION
changelog: Upcoming Features, Recaptcha, Annotate sign-in reCAPTCHA from 2-factor attempts

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[Annotate sign-in reCAPTCHA after fully authenticated](https://cm-jira.usa.gov/browse/LG-15254)

## 🛠 Summary of changes

1. Store the `recaptcha_assessment_id` in session.
2. Annotate with INITIATED_TWO_FACTOR when attempting any MFA method if there is a `recaptcha_assessment_id` in session.
3. Annotate with PASSED_TWO_FACTOR or FAILED_TWO_FACTOR depending on success when completing any MFA method if there is a `recaptcha_assessment_id` in session.
4. Recording the `recaptcha_annotation` along with the pre-existing event whenever an annotation is made.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Enable reCAPTCHA in local environment using credentials from https://docs.google.com/document/d/1mXa1KtVdXvJ1QPF8T0vvhWxsabr-OzuPqcgNre_3wqU/edit?pli=1&tab=t.0
- [ ] Bump `sign_in_recaptcha_percent_tested` to 100
- [ ] Authenticate to your local environment using an incognito window and go through various MFA options. Fail intentionally so that you also test the FAILED_TWO_FACTOR annotations.
- [ ] Observe the events with `recaptcha_annotation` in log/events.log

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
