### PR TITLE
Raise error when analytics test hash_including is exactly equal

### DIFF
--- a/spec/controllers/event_disavowal_controller_spec.rb
+++ b/spec/controllers/event_disavowal_controller_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe EventDisavowalController do
         expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
+            user_id: event.user.uuid,
             success: false,
             errors: { event: [t('event_disavowals.errors.event_already_disavowed')] },
+            error_details: { event: { event_already_disavowed: true } },
           ),
         )
       end
@@ -60,8 +62,10 @@ RSpec.describe EventDisavowalController do
         expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
+            user_id: event.user.uuid,
             success: false,
             errors: { event: [t('event_disavowals.errors.event_already_disavowed')] },
+            error_details: { event: { event_already_disavowed: true } },
           ),
         )
         expect(assigns(:forbidden_passwords)).to be_nil
@@ -96,6 +100,7 @@ RSpec.describe EventDisavowalController do
         expect(@analytics).to have_logged_event(
           'Event disavowal password reset',
           build_analytics_hash(
+            user_id: event.user.uuid,
             success: false,
             errors: {
               password: [
@@ -104,6 +109,7 @@ RSpec.describe EventDisavowalController do
                 ),
               ],
             },
+            error_details: { password: { too_short: true } },
           ),
         )
       end
@@ -119,8 +125,10 @@ RSpec.describe EventDisavowalController do
         expect(@analytics).to have_logged_event(
           'Event disavowal password reset',
           build_analytics_hash(
+            user_id: event.user.uuid,
             success: false,
             errors: { password: ['Password must be at least 12 characters long'] },
+            error_details: { password: { too_short: true } },
           ),
         )
         expect(assigns(:forbidden_passwords)).to all(be_a(String))
@@ -141,8 +149,10 @@ RSpec.describe EventDisavowalController do
         expect(@analytics).to have_logged_event(
           'Event disavowal token invalid',
           build_analytics_hash(
+            user_id: event.user.uuid,
             success: false,
             errors: { event: [t('event_disavowals.errors.event_already_disavowed')] },
+            error_details: { event: { event_already_disavowed: true } },
           ),
         )
       end
@@ -166,26 +176,28 @@ RSpec.describe EventDisavowalController do
             errors: {
               user: [t('event_disavowals.errors.no_account')],
             },
+            error_details: {
+              user: { blank: true },
+            },
           ),
         )
       end
     end
   end
 
-  def build_analytics_hash(success: true, errors: nil, user_id: nil)
-    hash_including(
-      {
-        event_created_at: event.created_at,
-        disavowed_device_last_used_at: event.device&.last_used_at,
-        success: success,
-        errors: errors,
-        event_id: event.id,
-        event_type: event.event_type,
-        event_ip: event.ip,
-        disavowed_device_user_agent: event.device.user_agent,
-        disavowed_device_last_ip: event.device.last_ip,
-        user_id: user_id,
-      }.compact,
-    )
+  def build_analytics_hash(success: true, errors: nil, error_details: nil, user_id: nil)
+    {
+      event_created_at: event.created_at,
+      disavowed_device_last_used_at: event.device&.last_used_at,
+      success:,
+      errors:,
+      error_details:,
+      event_id: event.id,
+      event_type: event.event_type,
+      event_ip: event.ip,
+      disavowed_device_user_agent: event.device.user_agent,
+      disavowed_device_last_ip: event.device.last_ip,
+      user_id:,
+    }.compact
   end
 end

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -94,11 +94,9 @@ RSpec.describe Idv::ByMail::RequestLetterController do
 
       expect(@analytics).to have_logged_event(
         'IdV: USPS address letter requested',
-        hash_including(
-          resend: false,
-          phone_step_attempts: 1,
-          hours_since_first_letter: 0,
-        ),
+        resend: false,
+        phone_step_attempts: 1,
+        hours_since_first_letter: 0,
       )
     end
 

--- a/spec/controllers/idv/by_mail/resend_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/resend_letter_controller_spec.rb
@@ -66,11 +66,10 @@ RSpec.describe Idv::ByMail::ResendLetterController do
 
       expect(@analytics).to have_logged_event(
         'IdV: USPS address letter requested',
-        hash_including(
-          resend: true,
-          first_letter_requested_at: user.pending_profile.gpo_verification_pending_at,
-          hours_since_first_letter: 24,
-        ),
+        resend: true,
+        first_letter_requested_at: user.pending_profile.gpo_verification_pending_at,
+        hours_since_first_letter: 24,
+        phone_step_attempts: 0,
       )
 
       expect(@analytics).to have_logged_event(
@@ -90,11 +89,10 @@ RSpec.describe Idv::ByMail::ResendLetterController do
 
         expect(@analytics).to have_logged_event(
           'IdV: USPS address letter requested',
-          hash_including(
-            resend: true,
-            first_letter_requested_at: user.pending_profile.gpo_verification_pending_at,
-            hours_since_first_letter: 24,
-          ),
+          resend: true,
+          first_letter_requested_at: user.pending_profile.gpo_verification_pending_at,
+          hours_since_first_letter: 24,
+          phone_step_attempts: 0,
         )
 
         expect(@analytics).to have_logged_event(

--- a/spec/controllers/idv/cancellations_controller_spec.rb
+++ b/spec/controllers/idv/cancellations_controller_spec.rb
@@ -22,9 +22,7 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation visited',
-        hash_including(
-          request_came_from: 'no referer',
-        ),
+        request_came_from: 'no referer',
       )
     end
 
@@ -37,9 +35,7 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation visited',
-        hash_including(
-          request_came_from: 'users/sessions#new',
-        ),
+        request_came_from: 'users/sessions#new',
       )
     end
 
@@ -51,10 +47,8 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation visited',
-        hash_including(
-          request_came_from: 'no referer',
-          step: 'first',
-        ),
+        request_came_from: 'no referer',
+        step: 'first',
       )
     end
 
@@ -116,9 +110,7 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation go back',
-        hash_including(
-          step: 'first',
-        ),
+        step: 'first',
       )
     end
 
@@ -136,12 +128,10 @@ RSpec.describe Idv::CancellationsController do
 
         expect(@analytics).to have_logged_event(
           'IdV: cancellation go back',
-          hash_including(
-            step: 'barcode',
-            cancelled_enrollment: false,
-            enrollment_code: enrollment.enrollment_code,
-            enrollment_id: enrollment.id,
-          ),
+          step: 'barcode',
+          cancelled_enrollment: false,
+          enrollment_code: enrollment.enrollment_code,
+          enrollment_id: enrollment.id,
         )
       end
     end
@@ -172,7 +162,7 @@ RSpec.describe Idv::CancellationsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: cancellation confirmed',
-        hash_including(step: 'first'),
+        step: 'first',
       )
     end
 

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -274,13 +274,11 @@ RSpec.describe Idv::EnterPasswordController do
 
         expect(@analytics).to have_logged_event(
           :idv_enter_password_submitted,
-          hash_including(
-            success: false,
-            fraud_review_pending: false,
-            fraud_rejection: false,
-            gpo_verification_pending: false,
-            in_person_verification_pending: false,
-          ),
+          success: false,
+          fraud_review_pending: false,
+          fraud_rejection: false,
+          gpo_verification_pending: false,
+          in_person_verification_pending: false,
         )
       end
     end
@@ -290,14 +288,12 @@ RSpec.describe Idv::EnterPasswordController do
 
       expect(@analytics).to have_logged_event(
         :idv_enter_password_submitted,
-        hash_including(
-          success: true,
-          fraud_review_pending: false,
-          fraud_rejection: false,
-          gpo_verification_pending: false,
-          in_person_verification_pending: false,
-          proofing_workflow_time_in_seconds: 5.minutes.to_i,
-        ),
+        success: true,
+        fraud_review_pending: false,
+        fraud_rejection: false,
+        gpo_verification_pending: false,
+        in_person_verification_pending: false,
+        proofing_workflow_time_in_seconds: 5.minutes.to_i,
       )
       expect(@analytics).to have_logged_event(
         'IdV: final resolution',
@@ -891,16 +887,15 @@ RSpec.describe Idv::EnterPasswordController do
                   put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
                   expect(@analytics).to have_logged_event(
                     :idv_enter_password_submitted,
-                    hash_including(
-                      {
-                        success: true,
-                        fraud_review_pending: fraud_review_pending?,
-                        fraud_pending_reason: fraud_pending_reason,
-                        fraud_rejection: false,
-                        gpo_verification_pending: false,
-                        in_person_verification_pending: false,
-                      }.compact,
-                    ),
+                    {
+                      success: true,
+                      fraud_review_pending: fraud_review_pending?,
+                      fraud_pending_reason: fraud_pending_reason,
+                      fraud_rejection: false,
+                      gpo_verification_pending: false,
+                      in_person_verification_pending: false,
+                      proofing_workflow_time_in_seconds: kind_of(Numeric),
+                    }.compact,
                   )
                   expect(@analytics).to have_logged_event(
                     'IdV: final resolution',
@@ -963,13 +958,11 @@ RSpec.describe Idv::EnterPasswordController do
 
         expect(@analytics).to have_logged_event(
           'IdV: USPS address letter enqueued',
-          hash_including(
-            resend: false,
-            enqueued_at: Time.zone.now,
-            phone_step_attempts: 1,
-            first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
-            hours_since_first_letter: 0,
-          ),
+          resend: false,
+          enqueued_at: Time.zone.now,
+          phone_step_attempts: 1,
+          first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
+          hours_since_first_letter: 0,
         )
       end
 
@@ -982,13 +975,11 @@ RSpec.describe Idv::EnterPasswordController do
 
           expect(@analytics).to have_logged_event(
             'IdV: USPS address letter enqueued',
-            hash_including(
-              resend: false,
-              enqueued_at: Time.zone.now,
-              phone_step_attempts: RateLimiter.max_attempts(rate_limit_type),
-              first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
-              hours_since_first_letter: 0,
-            ),
+            resend: false,
+            enqueued_at: Time.zone.now,
+            phone_step_attempts: RateLimiter.max_attempts(rate_limit_type),
+            first_letter_requested_at: subject.idv_session.profile.gpo_verification_pending_at,
+            hours_since_first_letter: 0,
           )
         end
       end

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -158,13 +158,11 @@ RSpec.describe Idv::OtpVerificationController do
 
       expect(@analytics).to have_logged_event(
         'IdV: phone confirmation otp submitted',
-        hash_including(
-          success: true,
-          code_expired: false,
-          code_matches: true,
-          otp_delivery_preference: :sms,
-          second_factor_attempts_count: 0,
-        ),
+        success: true,
+        code_expired: false,
+        code_matches: true,
+        otp_delivery_preference: :sms,
+        second_factor_attempts_count: 0,
       )
     end
   end

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -468,12 +468,10 @@ RSpec.describe Idv::PersonalKeyController do
 
         expect(@analytics).to have_logged_event(
           'IdV: personal key submitted',
-          hash_including(
-            address_verification_method: 'phone',
-            fraud_review_pending: false,
-            fraud_rejection: false,
-            in_person_verification_pending: false,
-          ),
+          address_verification_method: 'phone',
+          fraud_review_pending: false,
+          fraud_rejection: false,
+          in_person_verification_pending: false,
         )
       end
     end
@@ -510,12 +508,10 @@ RSpec.describe Idv::PersonalKeyController do
 
           expect(@analytics).to have_logged_event(
             'IdV: personal key submitted',
-            hash_including(
-              address_verification_method: 'gpo',
-              fraud_review_pending: false,
-              fraud_rejection: false,
-              in_person_verification_pending: false,
-            ),
+            address_verification_method: 'gpo',
+            fraud_review_pending: false,
+            fraud_rejection: false,
+            in_person_verification_pending: false,
           )
         end
       end
@@ -540,12 +536,10 @@ RSpec.describe Idv::PersonalKeyController do
 
         expect(@analytics).to have_logged_event(
           'IdV: personal key submitted',
-          hash_including(
-            address_verification_method: 'phone',
-            fraud_review_pending: false,
-            fraud_rejection: false,
-            in_person_verification_pending: false,
-          ),
+          address_verification_method: 'phone',
+          fraud_review_pending: false,
+          fraud_rejection: false,
+          in_person_verification_pending: false,
         )
       end
     end
@@ -568,12 +562,10 @@ RSpec.describe Idv::PersonalKeyController do
 
           expect(@analytics).to have_logged_event(
             'IdV: personal key submitted',
-            hash_including(
-              address_verification_method: 'phone',
-              fraud_review_pending: false,
-              fraud_rejection: false,
-              in_person_verification_pending: false,
-            ),
+            address_verification_method: 'phone',
+            fraud_review_pending: false,
+            fraud_rejection: false,
+            in_person_verification_pending: false,
           )
         end
       end
@@ -595,12 +587,10 @@ RSpec.describe Idv::PersonalKeyController do
 
           expect(@analytics).to have_logged_event(
             'IdV: personal key submitted',
-            hash_including(
-              fraud_review_pending: true,
-              fraud_rejection: false,
-              address_verification_method: 'phone',
-              in_person_verification_pending: false,
-            ),
+            fraud_review_pending: true,
+            fraud_rejection: false,
+            address_verification_method: 'phone',
+            in_person_verification_pending: false,
           )
         end
       end

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -289,21 +289,19 @@ RSpec.describe Idv::PhoneController do
 
         expect(@analytics).to have_logged_event(
           'IdV: phone confirmation form',
-          hash_including(
-            success: false,
-            errors: {
-              phone: [improbable_phone_message],
-              otp_delivery_preference: [improbable_otp_message],
-            },
-            error_details: {
-              phone: { improbable_phone: true },
-              otp_delivery_preference: { inclusion: true },
-            },
-            carrier: 'Test Mobile Carrier',
-            phone_type: :mobile,
-            otp_delivery_preference: '🎷',
-            types: [],
-          ),
+          success: false,
+          errors: {
+            phone: [improbable_phone_message],
+            otp_delivery_preference: [improbable_otp_message],
+          },
+          error_details: {
+            phone: { improbable_phone: true },
+            otp_delivery_preference: { inclusion: true },
+          },
+          carrier: 'Test Mobile Carrier',
+          phone_type: :mobile,
+          otp_delivery_preference: '🎷',
+          types: [],
         )
 
         expect(subject.idv_session.vendor_phone_confirmation).to be_falsy
@@ -335,15 +333,13 @@ RSpec.describe Idv::PhoneController do
 
         expect(@analytics).to have_logged_event(
           'IdV: phone confirmation form',
-          hash_including(
-            success: true,
-            area_code: '703',
-            country_code: 'US',
-            carrier: 'Test Mobile Carrier',
-            phone_type: :mobile,
-            otp_delivery_preference: 'sms',
-            types: [:fixed_or_mobile],
-          ),
+          success: true,
+          area_code: '703',
+          country_code: 'US',
+          carrier: 'Test Mobile Carrier',
+          phone_type: :mobile,
+          otp_delivery_preference: 'sms',
+          types: [:fixed_or_mobile],
         )
       end
 
@@ -436,21 +432,19 @@ RSpec.describe Idv::PhoneController do
 
         expect(@analytics).to have_logged_event(
           'IdV: phone confirmation vendor',
-          hash_including(
-            success: true,
-            new_phone_added: true,
-            hybrid_handoff_phone_used: false,
-            phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
-            country_code: proofing_phone.country,
-            area_code: proofing_phone.area_code,
-            vendor: {
-              vendor_name: 'AddressMock',
-              exception: nil,
-              timed_out: false,
-              transaction_id: 'address-mock-transaction-id-123',
-              reference: '',
-            },
-          ),
+          success: true,
+          new_phone_added: true,
+          hybrid_handoff_phone_used: false,
+          phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
+          country_code: proofing_phone.country,
+          area_code: proofing_phone.area_code,
+          vendor: {
+            vendor_name: 'AddressMock',
+            exception: nil,
+            timed_out: false,
+            transaction_id: 'address-mock-transaction-id-123',
+            reference: '',
+          },
         )
       end
     end
@@ -515,24 +509,22 @@ RSpec.describe Idv::PhoneController do
 
         expect(@analytics).to have_logged_event(
           'IdV: phone confirmation vendor',
-          hash_including(
-            success: false,
-            new_phone_added: true,
-            hybrid_handoff_phone_used: false,
-            phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
-            country_code: proofing_phone.country,
-            area_code: proofing_phone.area_code,
-            errors: {
-              phone: ['The phone number could not be verified.'],
-            },
-            vendor: {
-              vendor_name: 'AddressMock',
-              exception: nil,
-              timed_out: false,
-              transaction_id: 'address-mock-transaction-id-123',
-              reference: '',
-            },
-          ),
+          success: false,
+          new_phone_added: true,
+          hybrid_handoff_phone_used: false,
+          phone_fingerprint: Pii::Fingerprinter.fingerprint(proofing_phone.e164),
+          country_code: proofing_phone.country,
+          area_code: proofing_phone.area_code,
+          errors: {
+            phone: ['The phone number could not be verified.'],
+          },
+          vendor: {
+            vendor_name: 'AddressMock',
+            exception: nil,
+            timed_out: false,
+            transaction_id: 'address-mock-transaction-id-123',
+            reference: '',
+          },
         )
       end
 

--- a/spec/controllers/idv/session_errors_controller_spec.rb
+++ b/spec/controllers/idv/session_errors_controller_spec.rb
@@ -188,10 +188,8 @@ RSpec.describe Idv::SessionErrorsController do
 
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
-          hash_including(
-            type: action.to_s,
-            remaining_submit_attempts: IdentityConfig.store.idv_max_attempts - 1,
-          ),
+          type: action.to_s,
+          remaining_submit_attempts: IdentityConfig.store.idv_max_attempts - 1,
         )
       end
 
@@ -269,10 +267,8 @@ RSpec.describe Idv::SessionErrorsController do
 
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
-          hash_including(
-            type: action.to_s,
-            remaining_submit_attempts: 0,
-          ),
+          type: action.to_s,
+          remaining_submit_attempts: 0,
         )
       end
     end
@@ -311,10 +307,8 @@ RSpec.describe Idv::SessionErrorsController do
 
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
-          hash_including(
-            type: 'ssn_failure',
-            remaining_submit_attempts: 0,
-          ),
+          type: 'ssn_failure',
+          remaining_submit_attempts: 0,
         )
       end
     end
@@ -345,10 +339,8 @@ RSpec.describe Idv::SessionErrorsController do
 
         expect(@analytics).to have_logged_event(
           'IdV: session error visited',
-          hash_including(
-            type: action.to_s,
-            remaining_submit_attempts: 0,
-          ),
+          type: action.to_s,
+          remaining_submit_attempts: 0,
         )
       end
     end

--- a/spec/controllers/idv/sessions_controller_spec.rb
+++ b/spec/controllers/idv/sessions_controller_spec.rb
@@ -44,10 +44,8 @@ RSpec.describe Idv::SessionsController do
 
       expect(@analytics).to have_logged_event(
         'IdV: start over',
-        hash_including(
-          location: 'get_help',
-          step: 'first',
-        ),
+        location: 'get_help',
+        step: 'first',
       )
     end
 
@@ -58,13 +56,11 @@ RSpec.describe Idv::SessionsController do
         delete :destroy, params: { step: 'barcode', location: '' }
         expect(@analytics).to have_logged_event(
           'IdV: start over',
-          hash_including(
-            location: '',
-            step: 'barcode',
-            cancelled_enrollment: true,
-            enrollment_code: user.pending_in_person_enrollment.enrollment_code,
-            enrollment_id: user.pending_in_person_enrollment.id,
-          ),
+          location: '',
+          step: 'barcode',
+          cancelled_enrollment: true,
+          enrollment_code: user.pending_in_person_enrollment.enrollment_code,
+          enrollment_id: user.pending_in_person_enrollment.id,
         )
       end
     end
@@ -92,10 +88,8 @@ RSpec.describe Idv::SessionsController do
 
         expect(@analytics).to have_logged_event(
           'IdV: start over',
-          hash_including(
-            location: 'clear_and_start_over',
-            step: 'gpo_verify',
-          ),
+          location: 'clear_and_start_over',
+          step: 'gpo_verify',
         )
       end
     end

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -165,14 +165,12 @@ RSpec.describe OpenidConnect::LogoutController do
             )
             expect(@analytics).to have_logged_event(
               'Logout Initiated',
-              hash_including(
-                success: true,
-                client_id: service_provider.issuer,
-                client_id_parameter_present: false,
-                id_token_hint_parameter_present: true,
-                sp_initiated: true,
-                oidc: true,
-              ),
+              success: true,
+              client_id: service_provider.issuer,
+              client_id_parameter_present: false,
+              id_token_hint_parameter_present: true,
+              sp_initiated: true,
+              oidc: true,
             )
 
             expect(@analytics).to_not have_logged_event(
@@ -329,14 +327,12 @@ RSpec.describe OpenidConnect::LogoutController do
             )
             expect(@analytics).to have_logged_event(
               'OIDC Logout Page Visited',
-              hash_including(
-                success: true,
-                client_id: service_provider.issuer,
-                client_id_parameter_present: true,
-                id_token_hint_parameter_present: false,
-                sp_initiated: true,
-                oidc: true,
-              ),
+              success: true,
+              client_id: service_provider.issuer,
+              client_id_parameter_present: true,
+              id_token_hint_parameter_present: false,
+              sp_initiated: true,
+              oidc: true,
             )
             expect(@analytics).to_not have_logged_event(
               :sp_integration_errors_present,
@@ -468,14 +464,12 @@ RSpec.describe OpenidConnect::LogoutController do
           )
           expect(@analytics).to have_logged_event(
             'OIDC Logout Page Visited',
-            hash_including(
-              success: true,
-              client_id: service_provider.issuer,
-              client_id_parameter_present: true,
-              id_token_hint_parameter_present: false,
-              sp_initiated: true,
-              oidc: true,
-            ),
+            success: true,
+            client_id: service_provider.issuer,
+            client_id_parameter_present: true,
+            id_token_hint_parameter_present: false,
+            sp_initiated: true,
+            oidc: true,
           )
 
           expect(@analytics).to_not have_logged_event(

--- a/spec/controllers/redirect/help_center_controller_spec.rb
+++ b/spec/controllers/redirect/help_center_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Redirect::HelpCenterController do
       expect(response).to redirect_to redirect_url
       expect(@analytics).to have_logged_event(
         'External Redirect',
-        hash_including(redirect_url: redirect_url_base),
+        redirect_url: redirect_url_base,
       )
     end
   end
@@ -45,10 +45,7 @@ RSpec.describe Redirect::HelpCenterController do
       it 'redirects to the help center article and logs' do
         redirect_url = MarketingSite.help_center_article_url(category:, article:)
         expect(response).to redirect_to redirect_url
-        expect(@analytics).to have_logged_event(
-          'External Redirect',
-          hash_including(redirect_url: redirect_url),
-        )
+        expect(@analytics).to have_logged_event('External Redirect', redirect_url:)
       end
 
       context 'with optional anchor' do

--- a/spec/controllers/redirect/marketing_site_controller_spec.rb
+++ b/spec/controllers/redirect/marketing_site_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Redirect::MarketingSiteController do
       response
       expect(@analytics).to have_logged_event(
         'External Redirect',
-        hash_including(redirect_url: MarketingSite.base_url),
+        redirect_url: MarketingSite.base_url,
       )
     end
   end

--- a/spec/controllers/redirect/return_to_sp_controller_spec.rb
+++ b/spec/controllers/redirect/return_to_sp_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Redirect::ReturnToSpController do
         expect(response).to redirect_to(expected_redirect_uri)
         expect(@analytics).to have_logged_event(
           'Return to SP: Cancelled',
-          hash_including(redirect_url: expected_redirect_uri),
+          redirect_url: expected_redirect_uri,
         )
       end
     end
@@ -59,7 +59,7 @@ RSpec.describe Redirect::ReturnToSpController do
         expect(response).to redirect_to(expected_redirect_uri)
         expect(@analytics).to have_logged_event(
           'Return to SP: Cancelled',
-          hash_including(redirect_url: expected_redirect_uri),
+          redirect_url: expected_redirect_uri,
         )
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe Redirect::ReturnToSpController do
         expect(response).to redirect_to('https://sp.gov/return_to_sp')
         expect(@analytics).to have_logged_event(
           'Return to SP: Cancelled',
-          hash_including(redirect_url: 'https://sp.gov/return_to_sp'),
+          redirect_url: 'https://sp.gov/return_to_sp',
         )
       end
     end
@@ -99,7 +99,7 @@ RSpec.describe Redirect::ReturnToSpController do
         expect(response).to redirect_to('https://sp.gov/failure_to_proof')
         expect(@analytics).to have_logged_event(
           'Return to SP: Failed to proof',
-          hash_including(redirect_url: 'https://sp.gov/failure_to_proof'),
+          redirect_url: 'https://sp.gov/failure_to_proof',
         )
       end
     end
@@ -110,11 +110,9 @@ RSpec.describe Redirect::ReturnToSpController do
 
         expect(@analytics).to have_logged_event(
           'Return to SP: Failed to proof',
-          hash_including(
-            redirect_url: a_kind_of(String),
-            step: 'first',
-            location: 'bottom',
-          ),
+          redirect_url: a_kind_of(String),
+          step: 'first',
+          location: 'bottom',
         )
       end
     end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe SamlIdpController do
 
       expect(@analytics).to have_logged_event(
         'Logout Initiated',
-        hash_including(sp_initiated: false, oidc: false, saml_request_valid: true),
+        sp_initiated: false,
+        oidc: false,
+        saml_request_valid: true,
       )
     end
 
@@ -74,7 +76,9 @@ RSpec.describe SamlIdpController do
 
       expect(@analytics).to have_logged_event(
         'Logout Initiated',
-        hash_including(sp_initiated: true, oidc: false, saml_request_valid: true),
+        sp_initiated: true,
+        oidc: false,
+        saml_request_valid: true,
       )
     end
 
@@ -85,7 +89,9 @@ RSpec.describe SamlIdpController do
 
       expect(@analytics).to have_logged_event(
         'Logout Initiated',
-        hash_including(sp_initiated: true, oidc: false, saml_request_valid: false),
+        sp_initiated: true,
+        oidc: false,
+        saml_request_valid: false,
       )
       expect(@analytics).to have_logged_event(
         :sp_integration_errors_present,
@@ -148,7 +154,9 @@ RSpec.describe SamlIdpController do
 
         expect(@analytics).to have_logged_event(
           'Logout Initiated',
-          hash_including(sp_initiated: true, oidc: false, saml_request_valid: false),
+          sp_initiated: true,
+          oidc: false,
+          saml_request_valid: false,
         )
         expect(@analytics).to have_logged_event(
           :sp_integration_errors_present,

--- a/spec/controllers/sign_out_controller_spec.rb
+++ b/spec/controllers/sign_out_controller_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe SignOutController do
 
       get :destroy
 
-      expect(@analytics)
-        .to have_logged_event('Logout Initiated', hash_including(method: 'cancel link'))
+      expect(@analytics).to have_logged_event('Logout Initiated', method: 'cancel link')
     end
   end
 end

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Users::BackupCodeSetupController do
       get :edit
       expect(@analytics).to have_logged_event(
         'Backup Code Regenerate Visited',
-        hash_including(in_account_creation_flow: false),
+        in_account_creation_flow: false,
       )
     end
   end

--- a/spec/controllers/users/email_language_controller_spec.rb
+++ b/spec/controllers/users/email_language_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Users::EmailLanguageController do
 
         expect(@analytics).to have_logged_event(
           'Email Language: Updated',
-          hash_including(success: true),
+          success: true,
         )
       end
     end

--- a/spec/controllers/users/rules_of_use_controller_spec.rb
+++ b/spec/controllers/users/rules_of_use_controller_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Users::RulesOfUseController do
 
         expect(@analytics).to have_logged_event(
           'Rules of Use Submitted',
-          hash_including(success: true),
+          success: true,
         )
       end
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -67,10 +67,8 @@ RSpec.describe Users::SessionsController, devise: true do
 
       expect(@analytics).to have_logged_event(
         'Logout Initiated',
-        hash_including(
-          sp_initiated: false,
-          oidc: false,
-        ),
+        sp_initiated: false,
+        oidc: false,
       )
       expect(controller.current_user).to be nil
     end

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'cancel IdV' do
     expect(page).to have_current_path(idv_welcome_path)
     expect(fake_analytics).to have_logged_event(
       'IdV: start over',
-      hash_including(step: 'agreement'),
+      step: 'agreement',
     )
   end
 
@@ -148,10 +148,8 @@ RSpec.describe 'cancel IdV' do
 
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation confirmed',
-        hash_including(
-          step: 'ssn',
-          proofing_components: { document_check: 'mock', document_type: 'state_id' },
-        ),
+        step: 'ssn',
+        proofing_components: { document_check: 'mock', document_type: 'state_id' },
       )
     end
   end

--- a/spec/features/idv/cancel_spec.rb
+++ b/spec/features/idv/cancel_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'cancel IdV' do
     expect(page).to have_current_path(original_path)
     expect(fake_analytics).to have_logged_event(
       'IdV: cancellation go back',
-      hash_including(step: 'agreement'),
+      step: 'agreement',
     )
   end
 
@@ -93,7 +93,7 @@ RSpec.describe 'cancel IdV' do
     expect(page).to have_current_path(account_path)
     expect(fake_analytics).to have_logged_event(
       'IdV: cancellation confirmed',
-      hash_including(step: 'agreement'),
+      step: 'agreement',
     )
 
     # After visiting /verify, expect to redirect to the first step in the IdV flow.
@@ -113,11 +113,9 @@ RSpec.describe 'cancel IdV' do
 
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation visited',
-        hash_including(
-          proofing_components: { document_check: 'mock', document_type: 'state_id' },
-          request_came_from: 'idv/ssn#show',
-          step: 'ssn',
-        ),
+        proofing_components: { document_check: 'mock', document_type: 'state_id' },
+        request_came_from: 'idv/ssn#show',
+        step: 'ssn',
       )
 
       expect(page).to have_unique_form_landmark_labels
@@ -130,10 +128,8 @@ RSpec.describe 'cancel IdV' do
 
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation go back',
-        hash_including(
-          proofing_components: { document_check: 'mock', document_type: 'state_id' },
-          step: 'ssn',
-        ),
+        proofing_components: { document_check: 'mock', document_type: 'state_id' },
+        step: 'ssn',
       )
 
       click_link t('links.cancel')
@@ -141,10 +137,8 @@ RSpec.describe 'cancel IdV' do
 
       expect(fake_analytics).to have_logged_event(
         'IdV: start over',
-        hash_including(
-          proofing_components: { document_check: 'mock', document_type: 'state_id' },
-          step: 'ssn',
-        ),
+        proofing_components: { document_check: 'mock', document_type: 'state_id' },
+        step: 'ssn',
       )
 
       complete_doc_auth_steps_before_ssn_step
@@ -195,7 +189,7 @@ RSpec.describe 'cancel IdV' do
       expect(current_url).to start_with('http://localhost:7654/auth/result?error=access_denied')
       expect(fake_analytics).to have_logged_event(
         'IdV: cancellation confirmed',
-        hash_including(step: 'agreement'),
+        step: 'agreement',
       )
 
       start_idv_from_sp(sp)

--- a/spec/support/fake_analytics_spec.rb
+++ b/spec/support/fake_analytics_spec.rb
@@ -467,6 +467,19 @@ RSpec.describe FakeAnalytics do
           end
       end
 
+      shared_examples 'a track event call within shared examples' do
+        it 'does not raise if hash_including match has exact properties in shared examples' do
+          track_event.call
+
+          expect(&code_under_test)
+            .not_to raise_error(RSpec::Expectations::ExpectationNotMetError) do |err|
+              expect(err.message).to match(/Unexpected use of hash_including/)
+            end
+        end
+      end
+
+      it_behaves_like 'a track event call within shared examples'
+
       it 'does not raise if matching + non-matching event logged' do
         track_matching_event_with_more_args.call
         track_event_with_different_args.call

--- a/spec/support/fake_analytics_spec.rb
+++ b/spec/support/fake_analytics_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe FakeAnalytics do
     context 'event name + hash' do
       let(:track_event) { -> { analytics.track_event :my_event, arg1: 42 } }
       let(:track_event_with_different_args) { -> { analytics.track_event :my_event, arg1: 43 } }
-      let(:track_event_with_extra_args) do
+      let(:track_matching_event_with_more_args) do
         -> {
           analytics.track_event :my_event, arg1: 42, arg2: 43
         }
@@ -175,7 +175,7 @@ RSpec.describe FakeAnalytics do
       end
 
       it 'raises if an event that matches but has additional args has been logged' do
-        track_event_with_extra_args.call
+        track_matching_event_with_more_args.call
 
         expect(&code_under_test)
           .to raise_error(RSpec::Expectations::ExpectationNotMetError) do |err|
@@ -326,28 +326,28 @@ RSpec.describe FakeAnalytics do
       end
 
       it 'does not raise if matching + non-matching event logged' do
-        track_event.call
-        track_event_with_different_args.call
+        track_matching_event_with_more_args.call
+        track_other_event.call
 
         expect(&code_under_test)
           .not_to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
 
       it 'does not raise if event was logged 1x' do
-        track_event.call
+        track_matching_event_with_more_args.call
         expect(&code_under_test)
           .not_to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
 
       it 'does not raise if event was logged 1x' do
-        track_event.call
+        track_matching_event_with_more_args.call
         expect(&code_under_test)
           .not_to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
 
       it 'does not raise if event was logged 2x' do
-        track_event.call
-        track_event.call
+        track_matching_event_with_more_args.call
+        track_matching_event_with_more_args.call
 
         expect(&code_under_test)
           .not_to raise_error(RSpec::Expectations::ExpectationNotMetError)
@@ -458,8 +458,17 @@ RSpec.describe FakeAnalytics do
           end
       end
 
-      it 'does not raise if matching + non-matching event logged' do
+      it 'raises if hash_including match has exact properties' do
         track_event.call
+
+        expect(&code_under_test)
+          .to raise_error(RSpec::Expectations::ExpectationNotMetError) do |err|
+            expect(err.message).to match(/Unexpected use of hash_including/)
+          end
+      end
+
+      it 'does not raise if matching + non-matching event logged' do
+        track_matching_event_with_more_args.call
         track_event_with_different_args.call
 
         expect(&code_under_test)
@@ -467,20 +476,20 @@ RSpec.describe FakeAnalytics do
       end
 
       it 'does not raise if event was logged 1x' do
-        track_event.call
+        track_matching_event_with_more_args.call
         expect(&code_under_test)
           .not_to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
 
       it 'does not raise if event was logged 1x' do
-        track_event.call
+        track_matching_event_with_more_args.call
         expect(&code_under_test)
           .not_to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
 
       it 'does not raise if event was logged 2x' do
-        track_event.call
-        track_event.call
+        track_matching_event_with_more_args.call
+        track_matching_event_with_more_args.call
 
         expect(&code_under_test)
           .not_to raise_error(RSpec::Expectations::ExpectationNotMetError)
@@ -507,14 +516,14 @@ RSpec.describe FakeAnalytics do
         end
 
         it 'does not raise if event was logged 1x' do
-          track_event.call
+          track_matching_event_with_more_args.call
           expect(&code_under_test)
             .not_to raise_error(RSpec::Expectations::ExpectationNotMetError)
         end
 
         it 'raises if event was logged 2x' do
-          track_event.call
-          track_event.call
+          track_matching_event_with_more_args.call
+          track_matching_event_with_more_args.call
 
           expect(&code_under_test)
             .to raise_error(RSpec::Expectations::ExpectationNotMetError) do |err|
@@ -523,7 +532,7 @@ RSpec.describe FakeAnalytics do
               with hash_including(arg1: 42)
 
               Events received:
-              {:my_event=>[{:arg1=>42}, {:arg1=>42}]}
+              {:my_event=>[{:arg1=>42, :arg2=>43}, {:arg1=>42, :arg2=>43}]}
             MESSAGE
           end
         end

--- a/spec/support/have_logged_event_matcher.rb
+++ b/spec/support/have_logged_event_matcher.rb
@@ -89,11 +89,7 @@ class HaveLoggedEventMatcher
   end
 
   def in_shared_example?
-    example_group = RSpec.current_example.metadata.dig(:example_group)
-    while (example_group = example_group.dig(:parent_example_group))
-      return true if example_group[:shared_group_name]
-    end
-    false
+    RSpec.current_example.metadata[:shared_group_inclusion_backtrace].present?
   end
 
   def fake_analytics_missing_failure_message

--- a/spec/support/have_logged_event_matcher.rb
+++ b/spec/support/have_logged_event_matcher.rb
@@ -4,6 +4,8 @@ class HaveLoggedEventMatcher
   include RSpec::Matchers::Composable
   include RSpec::Matchers::BuiltIn::CountExpectation
 
+  attr_reader :hash_including_equals_failure_message
+
   def initialize(
     expected_event_name: nil,
     expected_attributes: nil
@@ -13,6 +15,7 @@ class HaveLoggedEventMatcher
   end
 
   def failure_message
+    return hash_including_equals_failure_message if hash_including_equals_failure_message.present?
     return fake_analytics_missing_failure_message if fake_analytics_missing?
 
     matching_events = events[expected_event_name]
@@ -47,7 +50,8 @@ class HaveLoggedEventMatcher
         events[expected_event_name] || []
       else
         (events[expected_event_name] || []).filter do |actual_attributes|
-          values_match?(expected_attributes, actual_attributes)
+          values_match?(expected_attributes, actual_attributes) &&
+            !hash_including_equals(expected_attributes, actual_attributes)
         end
       end
 
@@ -64,6 +68,23 @@ class HaveLoggedEventMatcher
 
   def fake_analytics_missing?
     !@actual.is_a?(FakeAnalytics)
+  end
+
+  def hash_including_equals(expected_attributes, actual_attributes)
+    if expected_attributes.instance_of?(RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher) &&
+       expected_attributes.instance_variable_get(:@expected) == actual_attributes
+      @hash_including_equals_failure_message = <<~STR
+        Unexpected use of hash_including when included attributes are exactly equal to actual attributes
+
+        Strict equality is preferred over hash_including except when intentionally testing a hash including more than properties than what's asserted
+
+        Expected: #{expected_attributes.instance_variable_get(:@expected)}
+        Actual:   #{actual_attributes}
+      STR
+      true
+    else
+      false
+    end
   end
 
   def fake_analytics_missing_failure_message

--- a/spec/support/have_logged_event_matcher.rb
+++ b/spec/support/have_logged_event_matcher.rb
@@ -72,7 +72,8 @@ class HaveLoggedEventMatcher
 
   def hash_including_equals(expected_attributes, actual_attributes)
     if expected_attributes.instance_of?(RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher) &&
-       expected_attributes.instance_variable_get(:@expected) == actual_attributes
+       expected_attributes.instance_variable_get(:@expected) == actual_attributes &&
+       !in_shared_example?
       @hash_including_equals_failure_message = <<~STR
         Unexpected use of hash_including when included attributes are exactly equal to actual attributes
 
@@ -85,6 +86,14 @@ class HaveLoggedEventMatcher
     else
       false
     end
+  end
+
+  def in_shared_example?
+    example_group = RSpec.current_example.metadata.dig(:example_group)
+    while (example_group = example_group.dig(:parent_example_group))
+      return true if example_group[:shared_group_name]
+    end
+    false
   end
 
   def fake_analytics_missing_failure_message


### PR DESCRIPTION
## 🛠 Summary of changes

Changes `have_logged_event` analytics matcher to fail when using a `hash_including` matcher value which includes a hash exactly equal to the one that is logged.

Asserting against logs is intended to provide confidence in the expected shape of our analytics logging payload. `hash_including` allows for undesirable drift between the expected and actual logging payload, which may result in false positives or a general lack of test coverage. `hash_including` can be useful in cases where asserting specific differences in logged payload values in `context` blocks, in which case it is generally expected that the hash logged would include more properties than those specified in the `hash_including` argument.

It is easier to [review these changes with whitespace changes hidden](https://github.com/18F/identity-idp/pull/11802/files?w=1).

## 📜 Testing Plan

Verify build passes.