### PR TITLE
LG-15375: Ensure Socure user can opt in to IPP

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -76,8 +76,9 @@ module Idv
         when Idp::Constants::Vendors::LEXIS_NEXIS, Idp::Constants::Vendors::MOCK
           in_hybrid_mobile ? idv_hybrid_mobile_document_capture_path
                            : idv_document_capture_path
+        else
+          return
         end
-
       redirect_to correct_path
     end
 

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -41,7 +41,7 @@ module Idv
           idv_session.opted_in_to_in_person_proofing = true
           idv_session.flow_path = 'standard'
           idv_session.skip_doc_auth_from_how_to_verify = true
-          redirect_to idv_document_capture_url
+          redirect_to idv_document_capture_url(step: :how_to_verify)
         end
       else
         render :show, locals: { error: result.first_error_message }

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Idv::HowToVerifyController do
         put :update, params: params
 
         expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be true
-        expect(response).to redirect_to(idv_document_capture_url)
+        expect(response).to redirect_to(idv_document_capture_url(step: :how_to_verify))
       end
 
       it 'sends analytics_submitted event when remote proofing is selected' do

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -532,6 +532,8 @@ RSpec.feature 'direct access to IPP on desktop', :js do
     end
 
     context 'when selfie is enabled' do
+      let(:facial_match_required) { true }
+
       it 'redirects back to agreement page' do
         expect(page).to have_current_path(idv_agreement_path)
       end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15375](https://cm-jira.usa.gov/browse/LG-15375)

## 🛠 Summary of changes

We found a bug where if a user was bucketed into Socure for doc auth, when they tried to opt-in to IPP from the How To Verify page, they would be redirected to Socure. This fixes it.

## 📜 Testing Plan

- Both requiring a selfie and not, run through IdV in an environment configured for Socure only. 
- From the How To Verify page, attempt to opt in to IPP and verify that you are able.
- Go back and choose to continue online
- From the Hybrid Handoff page, attempt to opt in to IPP and verify that you are able.

