### PR TITLE
LG-15173: Adding email in select flow links back to select page

### DIFF
--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -26,7 +26,7 @@
         link_html: link_to(
           t('notices.use_diff_email.link'),
           add_email_path(in_select_email_flow: @in_select_email_flow),
-        )
+        ),
       ) %>
 </p>
 

--- a/app/views/users/emails/verify.html.erb
+++ b/app/views/users/emails/verify.html.erb
@@ -1,17 +1,9 @@
 <% self.title = t('titles.verify_email') %>
 
-<% if @resend_confirmation %>
-  <%= render AlertComponent.new(
-        type: :success,
-        class: 'margin-bottom-4',
-        message: t('notices.resend_confirmation_email.success'),
-      ) %>
-<% end %>
-
 <%= render PageHeadingComponent.new.with_content(t('headings.verify_email')) %>
 
 <p><%= t('notices.signed_up_and_confirmed.first_paragraph_start') %>
-   <strong><%= email %></strong>
+   <strong><%= @email %></strong>
    <%= t('notices.signed_up_and_confirmed.first_paragraph_end') %>
 </p>
 
@@ -20,17 +12,40 @@
 </div>
 
 <%= t('notices.signed_up_and_confirmed.no_email_sent_explanation_start') %>
-<%= button_to(add_email_resend_path, method: :post, class: 'usa-button usa-button--unstyled', form_class: 'display-inline-block padding-left-1') { t('links.resend') } %>
 
-<p><%= t('notices.use_diff_email.text_html', link_html: link_to(t('notices.use_diff_email.link'), add_email_path(in_select_email_flow: in_select_email_flow))) %></p>
+<%= render ButtonComponent.new(
+      url: add_email_resend_path(in_select_email_flow: @in_select_email_flow),
+      method: :post,
+      unstyled: true,
+      form_class: 'display-inline-block padding-left-1',
+    ).with_content(t('links.resend')) %>
+
+<p>
+  <%= t(
+        'notices.use_diff_email.text_html',
+        link_html: link_to(
+          t('notices.use_diff_email.link'),
+          add_email_path(in_select_email_flow: @in_select_email_flow),
+        )
+      ) %>
+</p>
+
 <p><%= t('devise.registrations.close_window') %></p>
 
-<% if FeatureManagement.enable_load_testing_mode? && EmailAddress.find_with_email(email) %>
+<% if FeatureManagement.enable_load_testing_mode? && EmailAddress.find_with_email(@email) %>
   <%= link_to(
         'CONFIRM NOW',
-        sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email).confirmation_token),
-        id: 'confirm-now',
+        sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(@email).confirmation_token),
       ) %>
+  <br />
 <% end %>
 
-<%= link_to t('idv.messages.return_to_profile', app_name: APP_NAME), account_path %>
+<% if @in_select_email_flow %>
+  <% if @pending_completions_consent %>
+    <%= link_to t('forms.buttons.back'), sign_up_select_email_path %>
+  <% else %>
+    <%= link_to t('forms.buttons.back'), account_connected_accounts_path %>
+  <% end %>
+<% else %>
+  <%= link_to t('idv.messages.return_to_profile', app_name: APP_NAME), account_path %>
+<% end %>

--- a/spec/views/users/emails/verify.html.erb_spec.rb
+++ b/spec/views/users/emails/verify.html.erb_spec.rb
@@ -1,11 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'users/emails/verify.html.erb' do
+  subject(:rendered) { render }
   let(:email) { 'foo@bar.com' }
+  let(:in_select_email_flow) { nil }
+  let(:pending_completions_consent) { false }
   before do
-    allow(view).to receive(:email).and_return(email)
-    allow(view).to receive(:in_select_email_flow).and_return(nil)
-    @resend_email_confirmation_form = ResendEmailConfirmationForm.new
+    assign(:email, email)
+    assign(:in_select_email_flow, in_select_email_flow)
+    assign(:pending_completions_consent, pending_completions_consent)
   end
 
   it 'has a localized title' do
@@ -15,15 +18,21 @@ RSpec.describe 'users/emails/verify.html.erb' do
   end
 
   it 'has a localized header' do
-    render
-
     expect(rendered).to have_selector('h1', text: t('headings.verify_email'))
   end
 
   it 'contains link to resend confirmation page' do
-    render
+    expect(rendered).to have_css(
+      "form[action='#{add_email_resend_path}'] button",
+      text: t('links.resend'),
+    )
+  end
 
-    expect(rendered).to have_button(t('links.resend'))
+  it 'contains link to return to account page' do
+    expect(rendered).to have_link(
+      t('idv.messages.return_to_profile', app_name: APP_NAME),
+      href: account_path,
+    )
   end
 
   context 'when enable_load_testing_mode? is true and email address found' do
@@ -38,7 +47,6 @@ RSpec.describe 'users/emails/verify.html.erb' do
       expect(rendered).to have_link(
         'CONFIRM NOW',
         href: sign_up_create_email_confirmation_url(confirmation_token: 'some_token'),
-        id: 'confirm-now',
       )
     end
   end
@@ -64,6 +72,39 @@ RSpec.describe 'users/emails/verify.html.erb' do
 
     it 'does not generate the link' do
       expect(rendered).not_to have_link('CONFIRM NOW', href: sign_up_create_email_confirmation_url)
+    end
+  end
+
+  context 'when in email select flow' do
+    let(:in_select_email_flow) { true }
+
+    it 'maintains email select flow parameter for resend' do
+      expect(rendered).to have_css(
+        "form[action='#{add_email_resend_path(in_select_email_flow: true)}'] button",
+        text: t('links.resend'),
+      )
+    end
+
+    context 'in sign up completions flow' do
+      let(:pending_completions_consent) { true }
+
+      it 'contains a link to return back to sign up select email selection screen' do
+        expect(rendered).to have_link(
+          t('forms.buttons.back'),
+          href: sign_up_select_email_path,
+        )
+      end
+    end
+
+    context 'in connected accounts flow' do
+      let(:pending_completions_consent) { false }
+
+      it 'contains a link to return back to connected accounts screen' do
+        expect(rendered).to have_link(
+          t('forms.buttons.back'),
+          href: account_connected_accounts_path,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-15173](https://cm-jira.usa.gov/browse/LG-15173)

## 🛠 Summary of changes

Updates the add email confirmation screen to link "Back" when adding during partner email selection flow, to ensure that the user can seamlessly continue to the partner application.

## 📜 Testing Plan

Verify that the "Check your email" confirmation screen links to:

- "Return to your profile" account page if added from the account dashboard
- "Back" to the email selection screen if added from the consent screen
- "Back" to the connected accounts page if added from the connected accounts page

1. Run [sample partner application](https://github.com/18F/identity-oidc-sinatra) in a separate terminal process
2. Go to http://localhost:9292
3. Click "Sign in"
4. Create an account or sign in with a user who has not already granted consent to the sample partner application
5. When reaching the consent screen, click "Change" under "Email address"
6. Click "Add new email"
7. Enter an email and click "Submit"
8. Observe that the "Check your email" page has a "Back" link
9. Click "Back"
10. Observe that you're returned to "Select your preferred email"

## 👀 Screenshots

Before|After
---|---
![Screenshot 2025-01-27 at 8 16 59 AM](https://github.com/user-attachments/assets/4a4f8971-9e42-4ae3-9476-ed8c1db78724)|![Screenshot 2025-01-27 at 8 16 48 AM](https://github.com/user-attachments/assets/0245b77c-3ab2-49cb-8c2c-25b1a79be889)

