### PR TITLE
bypass ID expiration by configuration in test mode

### DIFF
--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -111,7 +111,7 @@ module Idv
     def state_id_expired?
       # temporary fix
       return if IdentityConfig.store.socure_docv_verification_data_test_mode &&
-        state_id_expiration == Date.parse('2020-01-01')
+                state_id_expiration == Date.parse('2020-01-01')
 
       if state_id_expiration && DateParser.parse_legacy(state_id_expiration).past?
         errors.add(:state_id_expiration, generic_error, type: :state_id_expiration)

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -111,7 +111,7 @@ module Idv
     def state_id_expired?
       # temporary fix
       return if IdentityConfig.store.socure_docv_verification_data_test_mode &&
-                state_id_expiration == Date.parse('2020-01-01')
+                state_id_expiration == '2020-01-01'
 
       if state_id_expiration && DateParser.parse_legacy(state_id_expiration).past?
         errors.add(:state_id_expiration, generic_error, type: :state_id_expiration)

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -109,7 +109,7 @@ module Idv
     end
 
     def state_id_expired?
-      # temporary fix
+      # temporary fix, tracked for removal in LG-15600
       return if IdentityConfig.store.socure_docv_verification_data_test_mode &&
                 DateParser.parse_legacy(state_id_expiration) == Date.parse('2020-01-01')
 

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -109,6 +109,10 @@ module Idv
     end
 
     def state_id_expired?
+      # temporary fix
+      return if IdentityConfig.store.socure_docv_verification_data_test_mode &&
+        state_id_expiration == Date.parse('2020-01-01')
+
       if state_id_expiration && DateParser.parse_legacy(state_id_expiration).past?
         errors.add(:state_id_expiration, generic_error, type: :state_id_expiration)
       end

--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -111,7 +111,7 @@ module Idv
     def state_id_expired?
       # temporary fix
       return if IdentityConfig.store.socure_docv_verification_data_test_mode &&
-                state_id_expiration == '2020-01-01'
+                DateParser.parse_legacy(state_id_expiration) == Date.parse('2020-01-01')
 
       if state_id_expiration && DateParser.parse_legacy(state_id_expiration).past?
         errors.add(:state_id_expiration, generic_error, type: :state_id_expiration)

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -285,7 +285,8 @@ RSpec.describe Idv::DocPiiForm do
 
       context 'when in socure_test_mode' do
         before do
-          allow(IdentityConfig.store).to receive(:socure_docv_verification_data_test_mode).and_return(true)
+          allow(IdentityConfig.store).to receive(:socure_docv_verification_data_test_mode)
+            .and_return(true)
         end
 
         it 'returns a single state ID expiration error' do

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -283,6 +283,25 @@ RSpec.describe Idv::DocPiiForm do
         )
       end
 
+      context 'expiration date is 2020-01-01' do # test 2020-01-01 fails outside socure test mode
+        let(:pii) { state_id_expired_error_pii.merge(state_id_expiration: '2020-01-01') }
+        it 'returns a single state ID expiration error' do
+          result = subject.submit
+
+          expect(result).to be_kind_of(FormResponse)
+          expect(result.success?).to eq(false)
+          expect(result.errors[:state_id_expiration]).to eq [
+            t('doc_auth.errors.general.no_liveness'),
+          ]
+          expect(result.extra).to eq(
+            attention_with_barcode: false,
+            pii_like_keypaths: pii_like_keypaths,
+            id_issued_status: 'present',
+            id_expiration_status: 'present',
+          )
+        end
+      end
+
       context 'when in socure_test_mode' do
         before do
           allow(IdentityConfig.store).to receive(:socure_docv_verification_data_test_mode)

--- a/spec/forms/idv/doc_pii_form_spec.rb
+++ b/spec/forms/idv/doc_pii_form_spec.rb
@@ -282,6 +282,45 @@ RSpec.describe Idv::DocPiiForm do
           id_expiration_status: 'present',
         )
       end
+
+      context 'when in socure_test_mode' do
+        before do
+          allow(IdentityConfig.store).to receive(:socure_docv_verification_data_test_mode).and_return(true)
+        end
+
+        it 'returns a single state ID expiration error' do
+          result = subject.submit
+
+          expect(result).to be_kind_of(FormResponse)
+          expect(result.success?).to eq(false)
+          expect(result.errors[:state_id_expiration]).to eq [
+            t('doc_auth.errors.general.no_liveness'),
+          ]
+          expect(result.extra).to eq(
+            attention_with_barcode: false,
+            pii_like_keypaths: pii_like_keypaths,
+            id_issued_status: 'present',
+            id_expiration_status: 'present',
+          )
+        end
+
+        context 'expiration date is 2020-01-01' do
+          let(:pii) { state_id_expired_error_pii.merge(state_id_expiration: '2020-01-01') }
+          it 'returns a successful form response' do
+            result = subject.submit
+
+            expect(result).to be_kind_of(FormResponse)
+            expect(result.success?).to eq(true)
+            expect(result.errors).to be_empty
+            expect(result.extra).to eq(
+              attention_with_barcode: false,
+              pii_like_keypaths: pii_like_keypaths,
+              id_issued_status: 'present',
+              id_expiration_status: 'present',
+            )
+          end
+        end
+      end
     end
 
     context 'when there is a non-string zipcode' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15277](https://cm-jira.usa.gov/browse/LG-15277)

## 🛠 Summary of changes
The Socure  API in Sandbox environment returns test PII with an ID expiration date in the past.  This is a temporary solution, until the Socure Sandbox API is fixed, to be able to test DocV scenarios in dev.


## 📜 Testing Plan

1. Update application.yml as follows:
```
socure_docv_verification_data_test_mode: true
socure_docv_verification_data_test_mode_tokens: '["1111-1111"]'
``` 
2. Complete IdV until Socure document capture is rendered (ie: /verify/socure/document_capture)
3. visit path /verify/socure/document_capture_update?docv_token=1111-1111
4. verify ssn page is displayed
5. Verify ticket exists to undo this temporary solution - [LG-15600](https://cm-jira.usa.gov/browse/LG-15600)

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
