### PR TITLE
LG-15294: Integrate Flow Policy with IPP steps - State ID and Address

### DIFF
--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -60,7 +60,7 @@ module Idv
       Idv::StepInfo.new(
         key: :document_capture,
         controller: self,
-        next_steps: [:ssn, :ipp_ssn], # :ipp_state_id
+        next_steps: [:ssn, :ipp_state_id],
         preconditions: ->(idv_session:, user:) {
           idv_session.flow_path == 'standard' && (
             # mobile

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -59,10 +59,6 @@ module Idv
 
       private
 
-      def pii_from_user
-        user_session.dig('idv/in_person', :pii_from_user)
-      end
-
       def updating_address?
         pii_from_user.has_key?(:address1) && user_session[:idv].has_key?(:ssn)
       end

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -6,7 +6,7 @@ module Idv
       include Idv::AvailabilityConcern
       include IdvStepConcern
 
-      before_action :confirm_in_person_state_id_step_complete
+      before_action :confirm_step_allowed
       before_action :confirm_in_person_address_step_needed, only: :show
       before_action :set_usps_form_presenter
 
@@ -54,27 +54,23 @@ module Idv
           next_steps: [:ipp_ssn],
           preconditions: ->(idv_session:, user:) { idv_session.ipp_state_id_complete? },
           undo_step: ->(idv_session:, user:) do
-            flow_session[:pii_from_user][:address1] = nil
-            flow_session[:pii_from_user][:address2] = nil
-            flow_session[:pii_from_user][:city] = nil
-            flow_session[:pii_from_user][:zipcode] = nil
-            flow_session[:pii_from_user][:state] = nil
+            idv_session.invalidate_in_person_address_step!
           end,
         )
       end
 
       private
 
-      def flow_session
-        user_session.fetch('idv/in_person', {})
+      def pii_from_user
+        user_session.dig('idv/in_person', :pii_from_user)
       end
 
       def updating_address?
-        flow_session[:pii_from_user].has_key?(:address1) && user_session[:idv].has_key?(:ssn)
+        pii_from_user.has_key?(:address1) && user_session[:idv].has_key?(:ssn)
       end
 
       def pii
-        data = flow_session[:pii_from_user]
+        data = pii_from_user
         data = data.merge(flow_params) if params.has_key?(:in_person_address)
         data.deep_symbolize_keys
       end
@@ -104,11 +100,6 @@ module Idv
         else
           redirect_to idv_in_person_ssn_url
         end
-      end
-
-      def confirm_in_person_state_id_step_complete
-        return if pii_from_user&.has_key?(:identity_doc_address1)
-        redirect_to idv_in_person_state_id_url
       end
 
       def confirm_in_person_address_step_needed

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -45,8 +45,6 @@ module Idv
         }
       end
 
-      # update Idv::DocumentCaptureController.step_info.next_steps to include
-      # :ipp_address instead of :ipp_ssn in delete PR
       def self.step_info
         Idv::StepInfo.new(
           key: :ipp_address,

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -8,10 +8,9 @@ module Idv
 
       before_action :set_usps_form_presenter
       before_action :confirm_step_allowed
-      before_action :initialize_pii_from_user
+      before_action :initialize_pii_from_user, only: [:show]
 
       def show
-        pii_from_user
         analytics.idv_in_person_proofing_state_id_visited(**analytics_arguments)
 
         render :show, locals: extra_view_variables

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -168,7 +168,7 @@ module Idv
 
       def initialize_pii_from_user
         user_session['idv/in_person'] ||= {}
-        user_session['idv/in_person']['pii_from_user'] ||= {}
+        user_session['idv/in_person']['pii_from_user'] ||= { uuid: current_user.uuid }
       end
     end
   end

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -6,11 +6,11 @@ module Idv
       include Idv::AvailabilityConcern
       include IdvStepConcern
 
-      before_action :redirect_unless_enrollment # confirm previous step is complete
       before_action :set_usps_form_presenter
+      before_action :confirm_step_allowed
 
       def show
-        flow_session[:pii_from_user] ||= {}
+        pii_from_user
         analytics.idv_in_person_proofing_state_id_visited(**analytics_arguments)
 
         render :show, locals: extra_view_variables
@@ -20,7 +20,6 @@ module Idv
         # don't clear the ssn when updating address, clear after SsnController
         clear_future_steps_from!(controller: Idv::InPerson::SsnController)
 
-        pii_from_user = flow_session[:pii_from_user]
         initial_state_of_same_address_as_id = pii_from_user[:same_address_as_id]
 
         form_result = form.submit(flow_params)
@@ -83,24 +82,17 @@ module Idv
           next_steps: [:ipp_address, :ipp_ssn],
           preconditions: ->(idv_session:, user:) { user.establishing_in_person_enrollment },
           undo_step: ->(idv_session:, user:) do
-            pii_from_user[:identity_doc_address1] = nil
-            pii_from_user[:identity_doc_address2] = nil
-            pii_from_user[:identity_doc_city] = nil
-            pii_from_user[:identity_doc_zipcode] = nil
-            pii_from_user[:identity_doc_state] = nil
-            idv_session.doc_auth_vendor = nil
+            idv_session.invalidate_in_person_pii_from_user!
           end,
         )
       end
 
       private
 
-      def redirect_unless_enrollment
-        redirect_to idv_document_capture_url unless current_user.establishing_in_person_enrollment
-      end
-
-      def flow_session
-        user_session.fetch('idv/in_person', {})
+      def pii_from_user
+        user_session['idv/in_person'] ||= {}
+        user_session['idv/in_person'][:pii_from_user] ||= {}
+        user_session.dig('idv/in_person', :pii_from_user)
       end
 
       def analytics_arguments
@@ -183,4 +175,4 @@ module Idv
       end
     end
   end
-  end
+end

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -78,7 +78,7 @@ module Idv
           key: :ipp_state_id,
           controller: self,
           next_steps: [:ipp_address, :ipp_ssn],
-          preconditions: ->(idv_session:, user:) { user.establishing_in_person_enrollment },
+          preconditions: ->(idv_session:, user:) { user.has_establishing_in_person_enrollment? },
           undo_step: ->(idv_session:, user:) do
             idv_session.invalidate_in_person_pii_from_user!
           end,

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -8,6 +8,7 @@ module Idv
 
       before_action :set_usps_form_presenter
       before_action :confirm_step_allowed
+      before_action :initialize_pii_from_user
 
       def show
         pii_from_user
@@ -87,12 +88,6 @@ module Idv
 
       private
 
-      def pii_from_user
-        user_session['idv/in_person'] ||= {}
-        user_session['idv/in_person'][:pii_from_user] ||= {}
-        user_session.dig('idv/in_person', :pii_from_user)
-      end
-
       def analytics_arguments
         {
           flow_path: idv_session.flow_path,
@@ -170,6 +165,11 @@ module Idv
 
       def set_usps_form_presenter
         @presenter = Idv::InPerson::UspsFormPresenter.new
+      end
+
+      def initialize_pii_from_user
+        user_session['idv/in_person'] ||= {}
+        user_session['idv/in_person']['pii_from_user'] ||= {}
       end
     end
   end

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -73,8 +73,6 @@ module Idv
         }
       end
 
-      # update Idv::DocumentCaptureController.step_info.next_steps to include
-      # :ipp_state_id instead of :ipp_ssn (or :ipp_address) in delete PR
       def self.step_info
         Idv::StepInfo.new(
           key: :ipp_state_id,

--- a/app/policies/idv/flow_policy.rb
+++ b/app/policies/idv/flow_policy.rb
@@ -22,6 +22,7 @@ module Idv
         document_capture: Idv::DocumentCaptureController.step_info,
         socure_document_capture: Idv::Socure::DocumentCaptureController.step_info,
         socure_errors: Idv::Socure::ErrorsController.step_info,
+        ipp_state_id: Idv::InPerson::StateIdController.step_info,
         ipp_address: Idv::InPerson::AddressController.step_info,
         ssn: Idv::SsnController.step_info,
         ipp_ssn: Idv::InPerson::SsnController.step_info,

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -265,17 +265,27 @@ module Idv
       Time.zone.now - Time.zone.parse(proofing_started_at) if proofing_started_at.present?
     end
 
-    def pii_from_user_in_flow_session
+    def pii_from_user_in_session
       user_session.dig('idv/in_person', :pii_from_user)
     end
 
-    def has_pii_from_user_in_flow_session?
-      !!pii_from_user_in_flow_session
+    def has_pii_from_user_in_session?
+      !!pii_from_user_in_session
     end
 
     def invalidate_in_person_pii_from_user!
-      if has_pii_from_user_in_flow_session?
+      if has_pii_from_user_in_session?
         user_session['idv/in_person'][:pii_from_user] = nil
+      end
+    end
+
+    def invalidate_in_person_address_step!
+      if has_pii_from_user_in_session?
+        user_session['idv/in_person'][:pii_from_user][:address1] = nil
+        user_session['idv/in_person'][:pii_from_user][:address2] = nil
+        user_session['idv/in_person'][:pii_from_user][:city] = nil
+        user_session['idv/in_person'][:pii_from_user][:zipcode] = nil
+        user_session['idv/in_person'][:pii_from_user][:state] = nil
       end
     end
 
@@ -284,12 +294,12 @@ module Idv
     end
 
     def ipp_document_capture_complete?
-      has_pii_from_user_in_flow_session? &&
+      has_pii_from_user_in_session? &&
         user_session['idv/in_person'][:pii_from_user].has_key?(:address1)
     end
 
     def ipp_state_id_complete?
-      has_pii_from_user_in_flow_session? &&
+      has_pii_from_user_in_session? &&
         user_session['idv/in_person'][:pii_from_user].has_key?(:identity_doc_address1)
     end
 

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -390,13 +390,22 @@ RSpec.describe Idv::DocumentCaptureController do
       }
     end
 
-    it 'invalidates future steps' do
-      subject.idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT
-      expect(subject).to receive(:clear_future_steps!).and_call_original
+    context 'invalidates future steps' do
+      it 'invalidates in person pii data' do
+        stub_up_to(:ipp_state_id, idv_session: subject.idv_session)
+        expect(subject).to receive(:clear_future_steps!).and_call_original
+        put :update
+        expect(subject.idv_session.has_pii_from_user_in_session?).to eq(false)
+      end
 
-      put :update
-      expect(subject.idv_session.applicant).to be_nil
-      expect(subject.idv_session.doc_auth_vendor).to match(idv_vendor)
+      it 'invalidates applicant' do
+        subject.idv_session.applicant = Idp::Constants::MOCK_IDV_APPLICANT
+        expect(subject).to receive(:clear_future_steps!).and_call_original
+
+        put :update
+        expect(subject.idv_session.applicant).to be_nil
+        expect(subject.idv_session.doc_auth_vendor).to match(idv_vendor)
+      end
     end
 
     it 'sends analytics_submitted event' do

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Idv::InPerson::AddressController do
       .and_return(true)
     stub_sign_in(user)
     stub_up_to(:hybrid_handoff, idv_session: subject.idv_session)
+    allow(user).to receive(:establishing_in_person_enrollment).and_return(enrollment)
     subject.user_session['idv/in_person'] = {
       pii_from_user: pii_from_user,
     }

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Idv::InPerson::AddressController do
   include InPersonHelper
 
   let(:user) { build(:user) }
+  let(:enrollment) do
+    create(:in_person_enrollment, :establishing, user: user)
+  end
   let(:pii_from_user) { Idp::Constants::MOCK_IPP_APPLICANT_SAME_ADDRESS_AS_ID_FALSE }
 
   before do
@@ -20,6 +23,20 @@ RSpec.describe Idv::InPerson::AddressController do
   end
 
   describe '#step_info' do
+    let(:address1) { Idp::Constants::MOCK_IDV_APPLICANT[:address1] }
+    let(:address2) { 'APT 1B' }
+    let(:city) { Idp::Constants::MOCK_IDV_APPLICANT[:city] }
+    let(:zipcode) { Idp::Constants::MOCK_IDV_APPLICANT[:zipcode] }
+    let(:state) { 'Montana' }
+    let(:params) do
+      { in_person_address: {
+        address1: address1,
+        address2: address2,
+        city: city,
+        zipcode: zipcode,
+        state: state,
+      } }
+    end
     it 'returns a valid StepInfo object' do
       expect(Idv::InPerson::AddressController.step_info).to be_valid
     end
@@ -33,17 +50,17 @@ RSpec.describe Idv::InPerson::AddressController do
       )
       expect(subject).to have_actions(
         :before,
-        :confirm_in_person_state_id_step_complete,
-      )
-      expect(subject).to have_actions(
-        :before,
         :confirm_in_person_address_step_needed,
       )
     end
 
-    context '#confirm_in_person_state_id_step_complete' do
+    context '#step_info preconditions check if state id is complete' do
       before do
         subject.user_session['idv/in_person'][:pii_from_user].delete(:identity_doc_address1)
+        subject.user_session['idv/in_person'][:pii_from_user].delete(:identity_doc_address2)
+        subject.user_session['idv/in_person'][:pii_from_user].delete(:identity_doc_city)
+        subject.user_session['idv/in_person'][:pii_from_user].delete(:identity_doc_zipcode)
+        subject.user_session['idv/in_person'][:pii_from_user].delete(:identity_doc_state)
       end
 
       it 'redirects to state id page if not complete' do

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -48,10 +48,7 @@ RSpec.describe Idv::InPerson::AddressController do
       expect(subject).to have_actions(
         :before,
         :set_usps_form_presenter,
-      )
-      expect(subject).to have_actions(
-        :before,
-        :confirm_in_person_address_step_needed,
+        :confirm_step_allowed,
       )
     end
 

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Idv::InPerson::StateIdController do
       )
     end
 
-    context '#confirm_establishing_enrollment' do
+    context '#step_info preconditions check if enrollment exists' do
       let(:enrollment) { nil }
 
       it 'redirects to document capture if not complete' do
@@ -371,6 +371,53 @@ RSpec.describe Idv::InPerson::StateIdController do
           expect(pii_from_user[:zipcode]).to_not eq identity_doc_zipcode
         end
       end
+    end
+  end
+
+  describe '#step_info' do
+    let(:first_name) { 'Natalya' }
+    let(:last_name) { 'Rostova' }
+    let(:formatted_dob) { InPersonHelper::GOOD_DOB }
+
+    let(:dob) do
+      parsed_dob = Date.parse(formatted_dob)
+      { month: parsed_dob.month.to_s,
+        day: parsed_dob.day.to_s,
+        year: parsed_dob.year.to_s }
+    end
+
+    # residential
+    let(:address1) { InPersonHelper::GOOD_ADDRESS1 }
+    let(:address2) { InPersonHelper::GOOD_ADDRESS2 }
+    let(:city) { InPersonHelper::GOOD_CITY }
+    let(:state) { InPersonHelper::GOOD_STATE }
+    let(:zipcode) { InPersonHelper::GOOD_ZIPCODE }
+    let(:id_number) { 'ABC123234' }
+    let(:state_id_jurisdiction) { 'AL' }
+    let(:identity_doc_address1) { InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1 }
+    let(:identity_doc_address2) { InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2 }
+    let(:identity_doc_city) { InPersonHelper::GOOD_IDENTITY_DOC_CITY }
+    let(:identity_doc_address_state) { InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS_STATE }
+    let(:identity_doc_zipcode) { InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE }
+
+    let(:params) do
+      { identity_doc: {
+        first_name:,
+        last_name:,
+        same_address_as_id: 'true', # value on submission
+        identity_doc_address1:,
+        identity_doc_address2:,
+        identity_doc_city:,
+        state_id_jurisdiction:,
+        id_number:,
+        identity_doc_address_state:,
+        identity_doc_zipcode:,
+        dob:,
+      } }
+    end
+
+    it 'returns a valid StepInfo object' do
+      expect(Idv::InPerson::StateIdController.step_info).to be_valid
     end
   end
 end

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Idv::InPerson::StateIdController do
       expect(subject).to have_actions(
         :before,
         :set_usps_form_presenter,
+        :initialize_pii_from_user,
       )
     end
 
@@ -33,6 +34,26 @@ RSpec.describe Idv::InPerson::StateIdController do
         get :show
 
         expect(response).to redirect_to idv_document_capture_url
+      end
+    end
+
+    context 'initializes idv/in_person if it is not present' do
+      it 'initializes idv/in_person' do
+        subject.user_session.delete('idv/in_person')
+        get :show
+
+        expect(subject.user_session['idv/in_person']).to eq(
+          { 'pii_from_user' => { 'uuid' => user.uuid } },
+        )
+      end
+    end
+
+    context 'initializes pii_from_user if it is not present' do
+      it 'initializes pii_from_user' do
+        subject.user_session['idv/in_person'].delete(:pii_from_user)
+        get :show
+
+        expect(subject.user_session['idv/in_person'][:pii_from_user]).to eq({ 'uuid' => user.uuid })
       end
     end
   end
@@ -68,6 +89,17 @@ RSpec.describe Idv::InPerson::StateIdController do
       end
     end
 
+    context 'user_session does not have idv/in_person' do
+      before do
+        subject.user_session.delete('idv/in_person')
+      end
+
+      it 'renders the show template' do
+        get :show
+        expect(response).to render_template :show
+      end
+    end
+
     it 'logs idv_in_person_proofing_state_id_visited' do
       get :show
 
@@ -84,6 +116,7 @@ RSpec.describe Idv::InPerson::StateIdController do
         :address1,
       )
     end
+
   end
 
   describe '#update' do

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Idv::InPerson::StateIdController do
         :before,
         :set_usps_form_presenter,
         :initialize_pii_from_user,
+        :confirm_step_allowed,
       )
     end
 

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -116,7 +116,6 @@ RSpec.describe Idv::InPerson::StateIdController do
         :address1,
       )
     end
-
   end
 
   describe '#update' do

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -223,7 +223,8 @@ RSpec.describe 'Idv::FlowPolicy' do
 
     context 'preconditions for in_person ssn are present' do
       before do
-        stub_up_to(:hybrid_handoff, idv_session: idv_session)
+        stub_up_to(:ipp_address, idv_session: idv_session)
+        allow(user).to receive(:has_establishing_in_person_enrollment?).and_return(true)
         idv_session.send(:user_session)['idv/in_person'] = {
           pii_from_user: Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup,
         }
@@ -249,7 +250,7 @@ RSpec.describe 'Idv::FlowPolicy' do
     context 'preconditions for in_person verify_info are present' do
       it 'returns ipp_verify_info' do
         stub_up_to(:ipp_ssn, idv_session: idv_session)
-
+        allow(user).to receive(:has_establishing_in_person_enrollment?).and_return(true)
         expect(subject.info_for_latest_step.key).to eq(:ipp_verify_info)
         expect(subject.controller_allowed?(controller: Idv::InPerson::VerifyInfoController)).to be
         expect(subject.controller_allowed?(controller: Idv::PhoneController)).not_to be

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -22,6 +22,14 @@ module FlowPolicyHelper
       idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
     when :document_capture
       idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
+    when :ipp_state_id
+      idv_session.send(:user_session)['idv/in_person'] = {
+        pii_from_user: Idp::Constants::MOCK_IPP_APPLICANT.dup,
+      }
+    when :ipp_address
+      idv_session.send(:user_session)['idv/in_person'] = {
+        pii_from_user: Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup,
+      }
     when :ssn
       idv_session.ssn = Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn]
       idv_session.threatmetrix_session_id = 'a-random-session-id'
@@ -64,14 +72,19 @@ module FlowPolicyHelper
       %i[welcome agreement how_to_verify hybrid_handoff link_sent]
     when :document_capture
       %i[welcome agreement how_to_verify hybrid_handoff document_capture]
+    when :ipp_state_id
+      %i[welcome agreement how_to_verify hybrid_handoff ipp_state_id]
+    when :ipp_address
+      %i[welcome agreement how_to_verify hybrid_handoff ipp_state_id ipp_address]
     when :ssn
       %i[welcome agreement how_to_verify hybrid_handoff document_capture ssn]
     when :ipp_ssn
-      %i[welcome agreement how_to_verify hybrid_handoff ipp_ssn]
+      %i[welcome agreement how_to_verify hybrid_handoff ipp_state_id ipp_address ipp_ssn]
     when :verify_info
       %i[welcome agreement how_to_verify hybrid_handoff document_capture ssn verify_info]
     when :ipp_verify_info
-      %i[welcome agreement how_to_verify hybrid_handoff ipp_ssn ipp_verify_info]
+      %i[welcome agreement how_to_verify hybrid_handoff ipp_state_id ipp_address ipp_ssn
+         ipp_verify_info]
     when :phone
       %i[welcome agreement how_to_verify hybrid_handoff document_capture ssn
          verify_info phone]


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15294](https://cm-jira.usa.gov/browse/LG-15294)

## 🛠 Summary of changes

During FSM clean-up we discovered that the [flow policy](https://handbook.login.gov/articles/identity-verification-flow-policy.html) was not yet being fully used within the in_person/state_id_controller and in_person/address_controller. The step_info was included but it wasn't yet being called. These changes address that by adding the confirm_step_allowed before_action and refactoring the undo_step lambdas in both the state_id_controller and address_controller, so they could be properly called in the clear_future_steps! Flow Policy step.


## 📜 Testing Plan

There is no new or changed functionality for manual testing - you will want to test the IPP flow to make sure everything is working as usual. 

- [x] Enter through sinatra, choosing identity-verified for level of service
- [x] Begin through the in-person flow, stopping at document_capture
- [x] Try to change the url to /verify/in_person/state_id - there is no establishing enrollment yet so the precondition should fail and you should be redirected to document_capture.
- [x] Continue through /document_capture and arrive at /in_person/state_id. Do not submit state id yet.
- [x] Try to change the url to /verify/in_person/address. Because the state id step is not completed yet, the precondition should fail and you should be redirected to state_id.
- [x] Continue through the in-person flow and successfully create an enrollment.

