### PR TITLE
LG-15274 add socure user to redis set

### DIFF
--- a/app/controllers/concerns/idv/doc_auth_vendor_concern.rb
+++ b/app/controllers/concerns/idv/doc_auth_vendor_concern.rb
@@ -20,16 +20,6 @@ module Idv
       DocAuthRouter.doc_auth_vendor_for_bucket(bucket)
     end
 
-    def choose_non_socure_bucket
-      if doc_auth_vendor_enabled?(Idp::Constants::Vendors::LEXIS_NEXIS)
-        return :lexis_nexis
-      elsif doc_auth_vendor_enabled?(Idp::Constants::Vendors::MOCK)
-        return :mock
-      else
-        return nil
-      end
-    end
-
     def doc_auth_vendor_enabled?(vendor)
       return true if IdentityConfig.store.doc_auth_vendor_default == vendor
       return false unless IdentityConfig.store.doc_auth_vendor_switching_enabled
@@ -45,6 +35,14 @@ module Idv
     end
 
     private
+
+    def choose_non_socure_bucket
+      if doc_auth_vendor_enabled?(Idp::Constants::Vendors::LEXIS_NEXIS)
+        return :lexis_nexis
+      elsif doc_auth_vendor_enabled?(Idp::Constants::Vendors::MOCK)
+        return :mock
+      end
+    end
 
     def socure_user_set
       @socure_user_set ||= SocureUserSet.new

--- a/app/controllers/concerns/idv/doc_auth_vendor_concern.rb
+++ b/app/controllers/concerns/idv/doc_auth_vendor_concern.rb
@@ -17,6 +17,8 @@ module Idv
       else
         bucket = ab_test_bucket(:DOC_AUTH_VENDOR)
       end
+
+      add_user_to_socure_set if bucket == :socure
       DocAuthRouter.doc_auth_vendor_for_bucket(bucket)
     end
 
@@ -34,8 +36,14 @@ module Idv
       end
     end
 
+    private
+
     def socure_user_set
       @socure_user_set ||= SocureUserSet.new
+    end
+
+    def add_user_to_socure_set
+      socure_user_set.add_user!(user_uuid: current_user.uuid)
     end
   end
 end

--- a/app/controllers/concerns/idv/doc_auth_vendor_concern.rb
+++ b/app/controllers/concerns/idv/doc_auth_vendor_concern.rb
@@ -7,19 +7,27 @@ module Idv
     # @returns[String] String identifying the vendor to use for doc auth.
     def doc_auth_vendor
       if resolved_authn_context_result.facial_match? || socure_user_set.maxed_users?
-        if doc_auth_vendor_enabled?(Idp::Constants::Vendors::LEXIS_NEXIS)
-          bucket = :lexis_nexis
-        elsif doc_auth_vendor_enabled?(Idp::Constants::Vendors::MOCK)
-          bucket = :mock
-        else
-          return nil
-        end
+        bucket = choose_non_socure_bucket
       else
         bucket = ab_test_bucket(:DOC_AUTH_VENDOR)
       end
 
-      add_user_to_socure_set if bucket == :socure
+      if bucket == :socure
+        if !add_user_to_socure_set
+          bucket = choose_non_socure_bucket # force to lexis_nexis if max user reached
+        end
+      end
       DocAuthRouter.doc_auth_vendor_for_bucket(bucket)
+    end
+
+    def choose_non_socure_bucket
+      if doc_auth_vendor_enabled?(Idp::Constants::Vendors::LEXIS_NEXIS)
+        return :lexis_nexis
+      elsif doc_auth_vendor_enabled?(Idp::Constants::Vendors::MOCK)
+        return :mock
+      else
+        return nil
+      end
     end
 
     def doc_auth_vendor_enabled?(vendor)

--- a/app/controllers/concerns/idv/doc_auth_vendor_concern.rb
+++ b/app/controllers/concerns/idv/doc_auth_vendor_concern.rb
@@ -38,9 +38,9 @@ module Idv
 
     def choose_non_socure_bucket
       if doc_auth_vendor_enabled?(Idp::Constants::Vendors::LEXIS_NEXIS)
-        return :lexis_nexis
+        :lexis_nexis
       elsif doc_auth_vendor_enabled?(Idp::Constants::Vendors::MOCK)
-        return :mock
+        :mock
       end
     end
 

--- a/app/services/idv/socure_user_set.rb
+++ b/app/services/idv/socure_user_set.rb
@@ -9,11 +9,12 @@ module Idv
     end
 
     def add_user!(user_uuid:)
-      return if maxed_users?
+      return false if maxed_users?
 
       redis_pool.with do |client|
         client.sadd(key, user_uuid)
       end
+      true
     end
 
     def count

--- a/app/services/idv/socure_user_set.rb
+++ b/app/services/idv/socure_user_set.rb
@@ -4,17 +4,35 @@ module Idv
   class SocureUserSet
     attr_reader :redis_pool
 
+    ADD_USER_SCRIPT = <<~LUA_EOF
+      local key = KEYS[1]
+      local user_uuid = ARGV[1]
+      local max_allowed_users = tonumber(ARGV[2])
+
+      local number_of_socure_users = redis.call('SCARD', key)
+      if number_of_socure_users >= max_allowed_users then
+        return false
+      end
+      redis.call('SADD', key, user_uuid)
+      return true
+    LUA_EOF
+
+    ADD_USER_SCRIPT_SHA1 = Digest::SHA1.hexdigest(ADD_USER_SCRIPT).freeze
+
     def initialize(redis_pool: REDIS_POOL)
       @redis_pool = redis_pool
     end
 
     def add_user!(user_uuid:)
-      return false if maxed_users?
-
+      script_args = [user_uuid.to_s, IdentityConfig.store.doc_auth_socure_max_allowed_users.to_i]
       redis_pool.with do |client|
-        client.sadd(key, user_uuid)
+        begin
+          return client.evalsha(ADD_USER_SCRIPT_SHA1, [key], script_args)
+        rescue Redis::CommandError => error
+          raise error unless error.message.start_with?('NOSCRIPT')
+          return client.eval(ADD_USER_SCRIPT, [key], script_args)
+        end
       end
-      true
     end
 
     def count

--- a/app/services/idv/socure_user_set.rb
+++ b/app/services/idv/socure_user_set.rb
@@ -27,10 +27,10 @@ module Idv
       script_args = [user_uuid.to_s, IdentityConfig.store.doc_auth_socure_max_allowed_users.to_i]
       redis_pool.with do |client|
         begin
-          return client.evalsha(ADD_USER_SCRIPT_SHA1, [key], script_args)
+          client.evalsha(ADD_USER_SCRIPT_SHA1, [key], script_args)
         rescue Redis::CommandError => error
           raise error unless error.message.start_with?('NOSCRIPT')
-          return client.eval(ADD_USER_SCRIPT, [key], script_args)
+          client.eval(ADD_USER_SCRIPT, [key], script_args)
         end
       end
     end

--- a/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
+++ b/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
@@ -79,6 +79,17 @@ RSpec.describe Idv::DocAuthVendorConcern, :controller do
       it 'returns Lexis Nexis as the vendor' do
         expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::LEXIS_NEXIS)
       end
+
+      context 'Lexis Nexis is disabled' do
+        before do
+          allow(IdentityConfig.store)
+            .to receive(:doc_auth_vendor_lexis_nexis_percent).and_return(0)
+        end
+
+        it 'returns mock vendor' do
+          expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::MOCK)
+        end
+      end
     end
   end
 

--- a/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
+++ b/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
@@ -90,6 +90,17 @@ RSpec.describe Idv::DocAuthVendorConcern, :controller do
           expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::MOCK)
         end
       end
+      
+      context 'Lexis Nexis is disabled' do
+        before do
+          allow(IdentityConfig.store)
+            .to receive(:doc_auth_vendor_lexis_nexis_percent).and_return(0)
+        end
+
+        it 'returns mock vendor' do
+          expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::MOCK)
+        end
+      end
     end
   end
 

--- a/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
+++ b/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Idv::DocAuthVendorConcern, :controller do
           expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::MOCK)
         end
       end
-      
+
       context 'Lexis Nexis is disabled' do
         before do
           allow(IdentityConfig.store)

--- a/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
+++ b/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Idv::DocAuthVendorConcern, :controller do
+  let(:user) { create(:user) }
+
+  controller ApplicationController do
+    include DocAuthVendorConcern
+  end
+
+  describe '#doc_auth_vendor' do
+    before do
+      allow(ab_test).to receive(:bucket).and__return(ab_test_bucket)
+    end
+
+    context 'bucket is lexis nexis' do
+    end
+
+    context 'bucket is socure' do
+    end
+  end
+end

--- a/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
+++ b/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
@@ -23,15 +23,89 @@ RSpec.describe Idv::DocAuthVendorConcern, :controller do
         .and_return(bucket)
     end
 
-    context 'bucket is socure' do
+    context 'bucket is LexisNexis' do
+      let(:bucket) { :lexis_nexis }
+
+      it 'returns lexis nexis as the vendor' do
+        expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::LEXIS_NEXIS)
+      end
+    end
+
+    context 'bucket is Mock' do
+      let(:bucket) { :mock }
+
+      it 'returns mock as the vendor' do
+        expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::MOCK)
+      end
+    end
+
+    context 'bucket is Socure' do
       let(:bucket) { :socure }
 
-      it 'should return socure as the vendor' do
+      it 'returns socure as the vendor' do
         expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::SOCURE)
       end
 
       it 'adds a user to the socure redis set' do
         expect { controller.doc_auth_vendor }.to change { socure_user_set.count }.by(1)
+      end
+    end
+
+    context 'facial match is required' do
+      let(:bucket) { :socure }
+      let(:acr_values) do
+        [
+          Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF,
+          Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+        ].join(' ')
+      end
+
+      before do
+        allow(IdentityConfig.store)
+          .to receive(:doc_auth_vendor_switching_enabled).and_return(true)
+        allow(IdentityConfig.store)
+          .to receive(:doc_auth_vendor_lexis_nexis_percent).and_return(50)
+        allow(controller).to receive(:resolved_authn_context_result).and_return(true)
+        resolved_authn_context = AuthnContextResolver.new(
+          user: user,
+          service_provider: nil,
+          vtr: nil,
+          acr_values: acr_values,
+        ).result
+        allow(controller).to receive(:resolved_authn_context_result)
+          .and_return(resolved_authn_context)
+      end
+
+      it 'returns Lexis Nexis as the vendor' do
+        expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::LEXIS_NEXIS)
+      end
+    end
+  end
+
+  describe '#doc_auth_vendor_enabled?' do
+    let(:vendor) { Idp::Constants::Vendors::LEXIS_NEXIS }
+
+    context 'doc_auth_vendor_switching is false' do
+      before do
+        allow(IdentityConfig.store)
+          .to receive(:doc_auth_vendor_switching_enabled).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(controller.doc_auth_vendor_enabled?(vendor)).to eq false
+      end
+    end
+
+    context 'Lexis Nexis is disabled' do
+      before do
+        allow(IdentityConfig.store)
+          .to receive(:doc_auth_vendor_switching_enabled).and_return(true)
+        allow(IdentityConfig.store)
+          .to receive(:doc_auth_vendor_lexis_nexis_percent).and_return(0)
+      end
+
+      it 'returns false' do
+        expect(controller.doc_auth_vendor_enabled?(vendor)).to eq false
       end
     end
   end

--- a/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
+++ b/spec/controllers/concerns/idv/doc_auth_vendor_concern_spec.rb
@@ -2,20 +2,37 @@ require 'rails_helper'
 
 RSpec.describe Idv::DocAuthVendorConcern, :controller do
   let(:user) { create(:user) }
+  let(:socure_user_set) { Idv::SocureUserSet.new }
+  let(:bucket) { :mock }
 
   controller ApplicationController do
-    include DocAuthVendorConcern
+    include Idv::DocAuthVendorConcern
+  end
+
+  around do |ex|
+    REDIS_POOL.with { |client| client.flushdb }
+    ex.run
+    REDIS_POOL.with { |client| client.flushdb }
   end
 
   describe '#doc_auth_vendor' do
     before do
-      allow(ab_test).to receive(:bucket).and__return(ab_test_bucket)
-    end
-
-    context 'bucket is lexis nexis' do
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(controller).to receive(:ab_test_bucket)
+        .with(:DOC_AUTH_VENDOR)
+        .and_return(bucket)
     end
 
     context 'bucket is socure' do
+      let(:bucket) { :socure }
+
+      it 'should return socure as the vendor' do
+        expect(controller.doc_auth_vendor).to eq(Idp::Constants::Vendors::SOCURE)
+      end
+
+      it 'adds a user to the socure redis set' do
+        expect { controller.doc_auth_vendor }.to change { socure_user_set.count }.by(1)
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-15274](https://cm-jira.usa.gov/browse/LG-15274)



## 🛠 Summary of changes

Once a user is bucketed into using socure, this adds their UUID to the socure users redis set to keep track of how many socure users we have.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Ensure Specs pass



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
