### PR TITLE
Tracking AAL attribute value differences

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -305,6 +305,27 @@ module AnalyticsEvents
     )
   end
 
+  # Temporary event:
+  # Tracks when the AAL value that we are returning to the integration
+  # is different from the actual asserted value
+  # @param [String] asserted_aal_value The actual AAL value the IdP asserts
+  # @param [String] client_id
+  # @param [String] response_aal_value The AAL value the IdP returns via attributes
+  def asserted_aal_different_from_response_aal(
+    asserted_aal_value:,
+    client_id:,
+    response_aal_value:,
+    **extra
+  )
+    track_event(
+      :asserted_aal_different_from_response_aal,
+      asserted_aal_value:,
+      client_id:,
+      response_aal_value:,
+      **extra,
+    )
+  end
+
   # @identity.idp.previous_event_name TOTP: User Disabled
   # Tracks when a user deletes their auth app from account
   # @param [Boolean] success

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -32,6 +32,18 @@ class AuthnContextResolver
     end
   end
 
+  def asserted_aal_acr
+    if result.hspd12?
+      Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF
+    elsif result.phishing_resistant?
+      Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF
+    elsif result.aal2?
+      Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
+    else
+      Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
+    end
+  end
+
   private
 
   def selected_vtr_parser_result_from_vtr_list

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -35,8 +35,9 @@ RSpec.describe OpenidConnect::TokenController do
 
     let!(:identity) do
       IdentityLinker.new(user, service_provider).link_identity(
-        rails_session_id: SecureRandom.hex,
+        acr_values: Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
         ial: 1,
+        rails_session_id: SecureRandom.hex,
       )
     end
 

--- a/spec/factories/service_provider_identities.rb
+++ b/spec/factories/service_provider_identities.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :service_provider_identity do
+    acr_values { Saml::Idp::Constants::IAL_AUTH_ONLY_ACR }
     uuid { SecureRandom.uuid }
     service_provider { 'https://serviceprovider.com' }
   end

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe OpenidConnectTokenForm do
   let!(:identity) do
     IdentityLinker.new(user, service_provider)
       .link_identity(
+        acr_values: Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
         nonce: nonce,
         rails_session_id: SecureRandom.hex,
         ial: 1,

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe AttributeAsserter do
       attribute_bundle:,
     )
   end
+  let(:fake_analytics) { FakeAnalytics.new(user: user) }
 
   let(:authn_context) do
     [
@@ -38,7 +39,7 @@ RSpec.describe AttributeAsserter do
   let(:raw_authn_request) do
     raw = saml_authn_request_url(
       overrides: {
-        issuer: sp1_issuer,
+        issuer: service_provider.issuer,
       }.merge(options),
     )
 
@@ -67,6 +68,11 @@ RSpec.describe AttributeAsserter do
       decrypted_pii:,
       user_session:,
     )
+  end
+
+  before do
+    allow(Analytics).to receive(:new).and_return(fake_analytics)
+    stub_analytics
   end
 
   describe '#build' do
@@ -232,7 +238,7 @@ RSpec.describe AttributeAsserter do
         context 'when the user has been proofed with facial match' do
           let(:user) { create(:profile, :active, :verified, idv_level: :in_person).user }
 
-          it 'asserts IAL2' do
+          it 'sets aal attribute to IAL2' do
             expected_ial = Saml::Idp::Constants::IAL_VERIFIED_ACR
             expect(get_asserted_attribute(user, :ial)).to eq expected_ial
           end
@@ -399,7 +405,7 @@ RSpec.describe AttributeAsserter do
       context 'when the user has been proofed with facial match comparison' do
         let(:user) { create(:profile, :active, :verified, idv_level: :in_person).user }
 
-        it 'asserts IAL1' do
+        it 'sets aal attribute to IAL1' do
           expected_ial = Saml::Idp::Constants::IAL_AUTH_ONLY_ACR
           expect(get_asserted_attribute(user, :ial)).to eq expected_ial
         end
@@ -423,13 +429,26 @@ RSpec.describe AttributeAsserter do
           ]
         end
 
-        it 'asserts AAL3' do
-          expected_aal = Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
-          expect(get_asserted_attribute(user, :aal)).to eq expected_aal
+        it 'sets aal attribute to AAL2 with phishing resistance' do
+          expect(
+            get_asserted_attribute(
+              user,
+              :aal,
+            ),
+          ).to eq Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
+        end
+
+        it 'tracks the mismatch' do
+          expect(fake_analytics).to have_logged_event(
+            :asserted_aal_different_from_response_aal,
+            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            client_id: service_provider.issuer,
+            response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+          )
         end
       end
 
-      context 'service provider requests AAL3' do
+      context 'when service provider requests AAL3' do
         let(:authn_context) do
           [
             Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
@@ -437,9 +456,19 @@ RSpec.describe AttributeAsserter do
           ]
         end
 
-        it 'asserts AAL3' do
-          expected_aal = Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF
-          expect(get_asserted_attribute(user, :aal)).to eq expected_aal
+        it 'sets aal attribute to AAL3' do
+          expect(get_asserted_attribute(user, :aal)).to eq(
+            Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+          )
+        end
+
+        it 'tracks the mismatch' do
+          expect(@analytics).to have_logged_event(
+            :asserted_aal_different_from_response_aal,
+            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            client_id: service_provider.issuer,
+            response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+          )
         end
       end
     end
@@ -461,7 +490,7 @@ RSpec.describe AttributeAsserter do
           subject.build
         end
 
-        it 'asserts IAL1' do
+        it 'sets aal attribute to IAL1' do
           expected_ial = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
           expect(get_asserted_attribute(user, :ial)).to eq expected_ial
         end
@@ -490,7 +519,7 @@ RSpec.describe AttributeAsserter do
           subject.build
         end
 
-        it 'asserts IAL2' do
+        it 'sets aal attribute to IAL2' do
           expected_ial = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
           expect(get_asserted_attribute(user, :ial)).to eq expected_ial
         end
@@ -520,7 +549,7 @@ RSpec.describe AttributeAsserter do
         subject.build
       end
 
-      it 'asserts IAL1' do
+      it 'sets aal attribute to IAL1' do
         expected_ial = Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
         expect(get_asserted_attribute(user, :ial)).to eq expected_ial
       end
@@ -548,14 +577,14 @@ RSpec.describe AttributeAsserter do
       context 'when the user has been proofed with facial match' do
         let(:user) { facial_match_verified_user }
 
-        it 'asserts IAL2 with facial match comparison' do
+        it 'sets aal attribute to IAL2 with facial match comparison' do
           expected_ial = Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF
           expect(get_asserted_attribute(user, :ial)).to eq expected_ial
         end
       end
 
       context 'when the user has been proofed without facial match' do
-        it 'asserts IAL2 (without facial match comparison)' do
+        it 'sets aal attribute to IAL2 (without facial match comparison)' do
           expected_ial = Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF
           expect(get_asserted_attribute(user, :ial)).to eq expected_ial
         end
@@ -579,7 +608,7 @@ RSpec.describe AttributeAsserter do
           subject.build
         end
 
-        it 'asserts IAL2 with facial match comparison' do
+        it 'sets aal attribute to IAL2 with facial match comparison' do
           expected_ial = Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF
           expect(get_asserted_attribute(user, :ial)).to eq expected_ial
         end
@@ -805,7 +834,7 @@ RSpec.describe AttributeAsserter do
       context 'default_aal is nil' do
         let(:authn_context) { [] }
 
-        it 'asserts default aal' do
+        it 'sets aal attribute to default aal' do
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
           )
@@ -816,10 +845,19 @@ RSpec.describe AttributeAsserter do
         let(:service_provider_aal) { 1 }
         let(:authn_context) { [] }
 
-        it 'asserts aal1' do
+        it 'sets aal attribute to aal1' do
           # we do not enforce aal1, we enforce default aal, so this should be updated
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
+          )
+        end
+
+        it 'tracks the mismatch' do
+          expect(@analytics).to have_logged_event(
+            :asserted_aal_different_from_response_aal,
+            asserted_aal_value: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            client_id: service_provider.issuer,
+            response_aal_value: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
           )
         end
       end
@@ -828,7 +866,7 @@ RSpec.describe AttributeAsserter do
         let(:service_provider_aal) { 2 }
         let(:authn_context) { [] }
 
-        it 'asserts aal2' do
+        it 'sets aal attribute to aal2' do
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
           )
@@ -839,11 +877,20 @@ RSpec.describe AttributeAsserter do
         let(:service_provider_aal) { 3 }
         let(:authn_context) { [] }
 
-        it 'asserts aa33' do
+        it 'sets aal attribute to aal3' do
           # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
           # so should be updated
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+          )
+        end
+
+        it 'tracks the mismatch' do
+          expect(@analytics).to have_logged_event(
+            :asserted_aal_different_from_response_aal,
+            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            client_id: service_provider.issuer,
+            response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
         end
       end
@@ -855,9 +902,18 @@ RSpec.describe AttributeAsserter do
 
         # We do not support AAL1. when passed in, we enforce our default AAL value.
         # However, we are returning the AAL1 value, which is misleading.
-        it 'asserts default aal' do
+        it 'sets aal attribute to aal1' do
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
+          )
+        end
+
+        it 'tracks the mismatch' do
+          expect(@analytics).to have_logged_event(
+            :asserted_aal_different_from_response_aal,
+            asserted_aal_value: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            client_id: service_provider.issuer,
+            response_aal_value: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
           )
         end
       end
@@ -865,9 +921,15 @@ RSpec.describe AttributeAsserter do
       context 'aal2 is requested' do
         let(:authn_context) { Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF }
 
-        it 'asserts plain aal2' do
+        it 'sets aal attribute to plain aal2' do
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+          )
+        end
+
+        it 'does not track a mismatch' do
+          expect(@analytics).to_not have_logged_event(
+            :asserted_aal_different_from_response_aal,
           )
         end
       end
@@ -876,9 +938,18 @@ RSpec.describe AttributeAsserter do
         let(:authn_context) { Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF }
 
         # we should assert the more specific aal2 value
-        it 'asserts plain aal2' do
+        it 'sets aal attribute to plain aal2' do
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+          )
+        end
+
+        it 'tracks the mismatch' do
+          expect(@analytics).to have_logged_event(
+            :asserted_aal_different_from_response_aal,
+            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            client_id: service_provider.issuer,
+            response_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
           )
         end
       end
@@ -887,9 +958,18 @@ RSpec.describe AttributeAsserter do
         let(:authn_context) { Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF }
 
         # we should assert the more specific aal2 value
-        it 'asserts plain aal2' do
+        it 'sets aal attribute to plain aal2' do
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+          )
+        end
+
+        it 'tracks the mismatch' do
+          expect(@analytics).to have_logged_event(
+            :asserted_aal_different_from_response_aal,
+            asserted_aal_value: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+            client_id: service_provider.issuer,
+            response_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
           )
         end
       end
@@ -900,9 +980,18 @@ RSpec.describe AttributeAsserter do
 
         # when aal3 is requested, we are enforcing aal2 with phishing-resistant mfa.
         # we should update to assert that
-        it 'asserts plain aal3' do
+        it 'sets aal attribute to plain aal3' do
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+          )
+        end
+
+        it 'tracks the mismatch' do
+          expect(@analytics).to have_logged_event(
+            :asserted_aal_different_from_response_aal,
+            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            client_id: service_provider.issuer,
+            response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
         end
       end
@@ -912,9 +1001,18 @@ RSpec.describe AttributeAsserter do
 
         # when aal3 is requested, we are enforcing aal2 with HSPD12 mfa.
         # we should update to assert that
-        it 'asserts plain aal2' do
+        it 'sets aal attribute to plain aal3' do
           expect(get_asserted_attribute(user, :aal)).to eq(
             Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+          )
+        end
+
+        it 'tracks the mismatch' do
+          expect(@analytics).to have_logged_event(
+            :asserted_aal_different_from_response_aal,
+            asserted_aal_value: Saml::Idp::Constants::AAL2_HSPD12_AUTHN_CONTEXT_CLASSREF,
+            client_id: service_provider.issuer,
+            response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
         end
       end
@@ -930,9 +1028,15 @@ RSpec.describe AttributeAsserter do
             ]
           end
 
-          it 'asserts the default value' do
+          it 'sets aal attribute to the default value' do
             expect(get_asserted_attribute(user, :aal)).to eq(
               Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            )
+          end
+
+          it 'does not track a mismatch' do
+            expect(@analytics).to_not have_logged_event(
+              :asserted_aal_different_from_response_aal,
             )
           end
         end
@@ -945,9 +1049,40 @@ RSpec.describe AttributeAsserter do
             ]
           end
 
-          it 'asserts the aal1 value' do
+          it 'sets aal attribute to the default aal value' do
+            # we don't assert aal1, so this should be the default aal value
             expect(get_asserted_attribute(user, :aal)).to eq(
               Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
+            )
+          end
+
+          it 'tracks the mismatch' do
+            expect(@analytics).to have_logged_event(
+              :asserted_aal_different_from_response_aal,
+              asserted_aal_value: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+              client_id: service_provider.issuer,
+              response_aal_value: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
+            )
+          end
+        end
+
+        context 'aal2 is first' do
+          let(:authn_context) do
+            [
+              Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+              Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            ]
+          end
+
+          it 'sets aal attribute to the aal2 value' do
+            expect(get_asserted_attribute(user, :aal)).to eq(
+              Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+            )
+          end
+
+          it 'does not track a mismatch' do
+            expect(@analytics).to_not have_logged_event(
+              :asserted_aal_different_from_response_aal,
             )
           end
         end
@@ -960,9 +1095,15 @@ RSpec.describe AttributeAsserter do
 
         describe 'no aal is requested via authn_context' do
           context 'default_aal is nil' do
-            it 'asserts default aal' do
+            it 'sets aal attribute to default aal' do
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+
+            it 'does not track a mismatch' do
+              expect(@analytics).to_not have_logged_event(
+                :asserted_aal_different_from_response_aal,
               )
             end
           end
@@ -970,10 +1111,19 @@ RSpec.describe AttributeAsserter do
           context 'default_aal is 1' do
             let(:service_provider_aal) { 1 }
 
-            it 'asserts aal1' do
+            it 'sets aal attribute to aal1' do
               # we don't really have an aal1 level to enforce, so this should be updated
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+
+            it 'tracks the mismatch' do
+              expect(@analytics).to have_logged_event(
+                :asserted_aal_different_from_response_aal,
+                asserted_aal_value: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+                client_id: service_provider.issuer,
+                response_aal_value: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
               )
             end
           end
@@ -981,9 +1131,15 @@ RSpec.describe AttributeAsserter do
           context 'default_aal is 2' do
             let(:service_provider_aal) { 2 }
 
-            it 'asserts aal2' do
+            it 'sets aal attribute to aal2' do
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+
+            it 'does not track a mismatch' do
+              expect(@analytics).to_not have_logged_event(
+                :asserted_aal_different_from_response_aal,
               )
             end
           end
@@ -991,10 +1147,19 @@ RSpec.describe AttributeAsserter do
           context 'default_aal is 3' do
             let(:service_provider_aal) { 3 }
 
-            it 'asserts aal3' do
+            it 'sets aal attribute to aal3' do
               # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+
+            it 'tracks the mismatch' do
+              expect(@analytics).to have_logged_event(
+                :asserted_aal_different_from_response_aal,
+                asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+                client_id: service_provider.issuer,
+                response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
               )
             end
           end
@@ -1006,10 +1171,19 @@ RSpec.describe AttributeAsserter do
 
         describe 'no aal is requested via authn_context' do
           context 'default_aal is nil' do
-            it 'asserts default aal' do
+            it 'sets aal attribute to default aal' do
               # this should be upgraded to AAL2, as we enforce that on an identity-proofing request
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+
+            it 'tracks the mismatch' do
+              expect(@analytics).to have_logged_event(
+                :asserted_aal_different_from_response_aal,
+                asserted_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                client_id: service_provider.issuer,
+                response_aal_value: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
               )
             end
           end
@@ -1017,10 +1191,19 @@ RSpec.describe AttributeAsserter do
           context 'default_aal is 1' do
             let(:service_provider_aal) { 1 }
 
-            it 'asserts aal1' do
+            it 'sets aal attribute to aal1' do
               # this should be upgraded to AAL2, as we enforce that on an identity-proofing request
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+
+            it 'tracks the mismatch' do
+              expect(@analytics).to have_logged_event(
+                :asserted_aal_different_from_response_aal,
+                asserted_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                client_id: service_provider.issuer,
+                response_aal_value: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
               )
             end
           end
@@ -1028,9 +1211,15 @@ RSpec.describe AttributeAsserter do
           context 'default_aal is 2' do
             let(:service_provider_aal) { 2 }
 
-            it 'asserts base aal2' do
+            it 'sets aal attribute to base aal2' do
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+
+            it 'does not tracks a mismatch' do
+              expect(@analytics).to_not have_logged_event(
+                :asserted_aal_different_from_response_aal,
               )
             end
           end
@@ -1038,10 +1227,19 @@ RSpec.describe AttributeAsserter do
           context 'default_aal is 3' do
             let(:service_provider_aal) { 3 }
 
-            it 'asserts aal3' do
+            it 'sets aal attribute to aal3' do
               # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+
+            it 'tracks the mismatch' do
+              expect(@analytics).to have_logged_event(
+                :asserted_aal_different_from_response_aal,
+                asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+                client_id: service_provider.issuer,
+                response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
               )
             end
           end
@@ -1051,22 +1249,32 @@ RSpec.describe AttributeAsserter do
           context 'default is first' do
             let(:authn_context) do
               [
+                Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
                 Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
                 Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
               ]
             end
 
-            it 'asserts the default value' do
+            it 'sets aal attribute to the default value' do
               # identity proofing enforces aal2, so that is what should be asserted
               expect(get_asserted_attribute(user, :aal)).to eq(
                 Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+              )
+            end
+
+            it 'tracks the mismatch' do
+              expect(@analytics).to have_logged_event(
+                :asserted_aal_different_from_response_aal,
+                asserted_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                client_id: service_provider.issuer,
+                response_aal_value: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
               )
             end
           end
         end
       end
 
-      context 'ialmax is requested' do
+      context 'when ialmax is requested' do
         let(:options) do
           {
             authn_context: [
@@ -1076,7 +1284,7 @@ RSpec.describe AttributeAsserter do
           }
         end
 
-        context 'a non-verified user' do
+        context 'with a non-verified user' do
           # remove any profiles
           before do
             user.profiles.delete_all
@@ -1084,43 +1292,76 @@ RSpec.describe AttributeAsserter do
           end
 
           describe 'no aal is requested via authn_context' do
-            context 'default_aal is nil' do
-              it 'asserts default aal' do
-                # this is fine, as we have enforced auth-only
+            context 'when default_aal is nil' do
+              it 'sets aal attribute to default AAL' do
+                # ialmax should assert aal2
                 expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
                 )
               end
+
+              it 'tracks the mismatch' do
+                expect(@analytics).to have_logged_event(
+                  :asserted_aal_different_from_response_aal,
+                  asserted_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                  client_id: service_provider.issuer,
+                  response_aal_value: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+                )
+              end
             end
 
-            context 'default_aal is 1' do
+            context 'when default_aal is 1' do
               let(:service_provider_aal) { 1 }
 
-              it 'asserts aal1' do
-                # this is fine, as we have enforced auth-only
+              it 'sets aal attribute to aal2 value' do
+                # ialmax should assert aal2
                 expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
                 )
               end
-            end
 
-            context 'default_aal is 2' do
-              let(:service_provider_aal) { 2 }
-
-              it 'asserts base aal2' do
-                expect(get_asserted_attribute(user, :aal)).to eq(
-                  Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+              it 'tracks the mismatch' do
+                expect(@analytics).to have_logged_event(
+                  :asserted_aal_different_from_response_aal,
+                  asserted_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                  client_id: service_provider.issuer,
+                  response_aal_value: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
                 )
               end
             end
 
-            context 'default_aal is 3' do
+            context 'when default_aal is 2' do
+              let(:service_provider_aal) { 2 }
+
+              it 'sets aal attribute to base aal2' do
+                expect(get_asserted_attribute(user, :aal)).to eq(
+                  Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                )
+              end
+
+              it 'does not track a mismatch' do
+                expect(@analytics).to_not have_logged_event(
+                  :asserted_aal_different_from_response_aal,
+                )
+              end
+            end
+
+            context 'when default_aal is 3' do
               let(:service_provider_aal) { 3 }
 
-              it 'asserts aal3' do
+              it 'sets aal attribute to aal3' do
                 # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
                 expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+                )
+              end
+
+              it 'tracks the mismatch' do
+                expect(@analytics).to have_logged_event(
+                  :asserted_aal_different_from_response_aal,
+                  asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+                  client_id: service_provider.issuer,
+                  response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
                 )
               end
             end
@@ -1128,13 +1369,22 @@ RSpec.describe AttributeAsserter do
         end
 
         context 'a verified user' do
-          describe 'no aal is requested via authn_context' do
-            context 'default_aal is nil' do
-              it 'asserts default aal' do
+          describe 'no AAL is requested via authn_context' do
+            context 'when default_aal is nil' do
+              it 'sets aal attribute to default AAL' do
                 # this should be upgraded to AAL2, as we enforce that
                 # on an identity-proofing request
                 expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+                )
+              end
+
+              it 'tracks the mismatch' do
+                expect(@analytics).to have_logged_event(
+                  :asserted_aal_different_from_response_aal,
+                  asserted_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                  client_id: service_provider.issuer,
+                  response_aal_value: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
                 )
               end
             end
@@ -1142,11 +1392,20 @@ RSpec.describe AttributeAsserter do
             context 'default_aal is 1' do
               let(:service_provider_aal) { 1 }
 
-              it 'asserts aal1' do
+              it 'sets aal attribute to aal1' do
                 # this should be upgraded to AAL2, as we enforce that
                 # on an identity-proofing request
                 expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
+                )
+              end
+
+              it 'tracks the mismatch' do
+                expect(@analytics).to have_logged_event(
+                  :asserted_aal_different_from_response_aal,
+                  asserted_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
+                  client_id: service_provider.issuer,
+                  response_aal_value: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF,
                 )
               end
             end
@@ -1154,7 +1413,7 @@ RSpec.describe AttributeAsserter do
             context 'default_aal is 2' do
               let(:service_provider_aal) { 2 }
 
-              it 'asserts base aal2' do
+              it 'sets aal attribute to base aal2' do
                 expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
                 )
@@ -1164,10 +1423,19 @@ RSpec.describe AttributeAsserter do
             context 'default_aal is 3' do
               let(:service_provider_aal) { 3 }
 
-              it 'asserts aal3' do
+              it 'sets aal attribute to aal3' do
                 # we do not enforce aal3, we enforce aal2 with phishing-resistant mfa
                 expect(get_asserted_attribute(user, :aal)).to eq(
                   Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
+                )
+              end
+
+              it 'tracks the mismatch' do
+                expect(@analytics).to have_logged_event(
+                  :asserted_aal_different_from_response_aal,
+                  asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+                  client_id: service_provider.issuer,
+                  response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
                 )
               end
             end

--- a/spec/services/attribute_asserter_spec.rb
+++ b/spec/services/attribute_asserter_spec.rb
@@ -441,7 +441,8 @@ RSpec.describe AttributeAsserter do
         it 'tracks the mismatch' do
           expect(fake_analytics).to have_logged_event(
             :asserted_aal_different_from_response_aal,
-            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            asserted_aal_value:
+              Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
             client_id: service_provider.issuer,
             response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
@@ -465,7 +466,8 @@ RSpec.describe AttributeAsserter do
         it 'tracks the mismatch' do
           expect(@analytics).to have_logged_event(
             :asserted_aal_different_from_response_aal,
-            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            asserted_aal_value:
+              Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
             client_id: service_provider.issuer,
             response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
@@ -888,7 +890,8 @@ RSpec.describe AttributeAsserter do
         it 'tracks the mismatch' do
           expect(@analytics).to have_logged_event(
             :asserted_aal_different_from_response_aal,
-            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            asserted_aal_value:
+              Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
             client_id: service_provider.issuer,
             response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
@@ -947,7 +950,8 @@ RSpec.describe AttributeAsserter do
         it 'tracks the mismatch' do
           expect(@analytics).to have_logged_event(
             :asserted_aal_different_from_response_aal,
-            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            asserted_aal_value:
+              Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
             client_id: service_provider.issuer,
             response_aal_value: Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF,
           )
@@ -989,7 +993,8 @@ RSpec.describe AttributeAsserter do
         it 'tracks the mismatch' do
           expect(@analytics).to have_logged_event(
             :asserted_aal_different_from_response_aal,
-            asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+            asserted_aal_value:
+              Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
             client_id: service_provider.issuer,
             response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
           )
@@ -1157,7 +1162,8 @@ RSpec.describe AttributeAsserter do
             it 'tracks the mismatch' do
               expect(@analytics).to have_logged_event(
                 :asserted_aal_different_from_response_aal,
-                asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+                asserted_aal_value:
+                  Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
                 client_id: service_provider.issuer,
                 response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
               )
@@ -1237,7 +1243,8 @@ RSpec.describe AttributeAsserter do
             it 'tracks the mismatch' do
               expect(@analytics).to have_logged_event(
                 :asserted_aal_different_from_response_aal,
-                asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+                asserted_aal_value:
+                  Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
                 client_id: service_provider.issuer,
                 response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
               )
@@ -1359,7 +1366,8 @@ RSpec.describe AttributeAsserter do
               it 'tracks the mismatch' do
                 expect(@analytics).to have_logged_event(
                   :asserted_aal_different_from_response_aal,
-                  asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+                  asserted_aal_value:
+                    Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
                   client_id: service_provider.issuer,
                   response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
                 )
@@ -1433,7 +1441,8 @@ RSpec.describe AttributeAsserter do
               it 'tracks the mismatch' do
                 expect(@analytics).to have_logged_event(
                   :asserted_aal_different_from_response_aal,
-                  asserted_aal_value: Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
+                  asserted_aal_value:
+                    Saml::Idp::Constants::AAL2_PHISHING_RESISTANT_AUTHN_CONTEXT_CLASSREF,
                   client_id: service_provider.issuer,
                   response_aal_value: Saml::Idp::Constants::AAL3_AUTHN_CONTEXT_CLASSREF,
                 )

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -302,7 +302,9 @@ RSpec.describe AuthnContextResolver do
         end
 
         it 'returns the asserted default AAL value' do
-          expect(subject.asserted_aal_acr).to eq Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
+          expect(subject.asserted_aal_acr).to eq(
+            Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+          )
         end
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Add tracking for AAL resolution](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/146)

## 🛠 Summary of changes
This change:

- Adds a method to determine the asserted AAL level via the AuthnContextResolver
- Adds tracking in the OIDC and SAML attributes presenters in order to indicate when there is a mismatch

Note: In the OIDC code flow, this attribute is set in the [authorization_form class](https://github.com/18F/identity-idp/blob/main/app/forms/openid_connect_authorize_form.rb#L125). My hope is that once this bug is fixed, we will be able to remove that value and associated code.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
