### PR TITLE
Add feature-flagged Attempts API routes

### DIFF
--- a/app/controllers/api/attempts/configuration_controller.rb
+++ b/app/controllers/api/attempts/configuration_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module Attempts
+    class ConfigurationController < ApplicationController
+      include RenderConditionConcern
+      prepend_before_action :skip_session_load
+      prepend_before_action :skip_session_expiration
+
+      check_or_render_not_found -> { IdentityConfig.store.attempts_api_enabled }
+
+      def index
+        render json: AttemptsConfigurationPresenter.new.configuration
+      end
+    end
+  end
+end

--- a/app/controllers/api/attempts/configuration_controller.rb
+++ b/app/controllers/api/attempts/configuration_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module Attempts
     class ConfigurationController < ApplicationController

--- a/app/controllers/api/attempts/events_controller.rb
+++ b/app/controllers/api/attempts/events_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module Attempts
     class EventsController < ApplicationController

--- a/app/controllers/api/attempts/events_controller.rb
+++ b/app/controllers/api/attempts/events_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module Attempts
+    class EventsController < ApplicationController
+      include RenderConditionConcern
+      check_or_render_not_found -> { IdentityConfig.store.attempts_api_enabled }
+
+      prepend_before_action :skip_session_load
+      prepend_before_action :skip_session_expiration
+
+      def poll
+        head :method_not_allowed
+      end
+
+      def status
+        render json: {
+          status: :disabled,
+          reason: :not_yet_implemented,
+        }
+      end
+    end
+  end
+end

--- a/app/presenters/attempts_configuration_presenter.rb
+++ b/app/presenters/attempts_configuration_presenter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# https://openid.net/specs/openid-sharedsignals-framework-1_0-ID3.html#name-transmitter-configuration-m
+class AttemptsConfigurationPresenter
+  include Rails.application.routes.url_helpers
+
+  DELIVERY_METHOD_POLL = 'https://schemas.openid.net/secevent/risc/delivery-method/poll'
+
+  def configuration
+    {
+      issuer: root_url,
+      jwks_uri: api_openid_connect_certs_url,
+      delivery_methods_supported: [
+        DELIVERY_METHOD_POLL,
+      ],
+      delivery: [
+        {
+          delivery_method: DELIVERY_METHOD_POLL,
+          url: api_attempts_poll_url,
+        },
+      ],
+      status_endpoint: api_attempts_status_url,
+    }
+  end
+
+  def url_options
+    {}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,11 @@ Rails.application.routes.draw do
   post '/api/webhooks/socure/event' => 'socure_webhook#create'
 
   namespace :api do
+    namespace :attempts do
+      post '/poll' => 'events#poll', as: :poll
+      get '/status' => 'events#status', as: :status
+    end
+
     namespace :internal do
       get '/sessions' => 'sessions#show'
       put '/sessions' => 'sessions#update'
@@ -33,6 +38,9 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  # Attempts API
+  get '/.well-known/ssf-configuration' => 'api/attempts/configuration#index'
 
   # SAML secret rotation paths
   constraints(path_year: SamlEndpoint.suffixes) do

--- a/spec/controllers/api/attempts/events_controller_spec.rb
+++ b/spec/controllers/api/attempts/events_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Api::Attempts::EventsController do
+  include Rails.application.routes.url_helpers
+  let(:enabled) { false }
+
+  before do
+    allow(IdentityConfig.store).to receive(:attempts_api_enabled).and_return(enabled)
+  end
+
+  describe '#poll' do
+    let(:action) { post :poll }
+
+    context 'when the Attempts API is not enabled' do
+      it 'returns 404 not found' do
+        expect(action.status).to eq(404)
+      end
+    end
+
+    context 'when the Attempts API is enabled' do
+      let(:enabled) { true }
+      it 'returns 405 method not allowed' do
+        expect(action.status).to eq(405)
+      end
+    end
+  end
+
+  describe 'status' do
+    let(:action) { get :status }
+
+    context 'when the Attempts API is not enabled' do
+      it 'returns 404 not found' do
+        expect(action.status).to eq(404)
+      end
+    end
+
+    context 'when the Attempts API is enabled' do
+      let(:enabled) { true }
+      it 'returns a 200' do
+        expect(action.status).to eq(200)
+      end
+
+      it 'returns the disabled status and reason' do
+        body = JSON.parse(action.body, symbolize_names: true)
+        expect(body[:status]).to eq('disabled')
+        expect(body[:reason]).to eq('not_yet_implemented')
+      end
+    end
+  end
+end

--- a/spec/presenters/attempts_configuration_presenter_spec.rb
+++ b/spec/presenters/attempts_configuration_presenter_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe AttemptsConfigurationPresenter do
+  include Rails.application.routes.url_helpers
+
+  subject { AttemptsConfigurationPresenter.new }
+
+  describe '#configuration' do
+    let(:configuration) { subject.configuration }
+
+    it 'includes information about the RISC integration' do
+      aggregate_failures do
+        expect(configuration[:issuer]).to eq(root_url)
+        expect(configuration[:jwks_uri]).to eq(api_openid_connect_certs_url)
+        expect(configuration[:delivery_methods_supported])
+          .to eq([AttemptsConfigurationPresenter::DELIVERY_METHOD_POLL])
+
+        expect(configuration[:delivery]).to eq(
+          [
+            delivery_method: AttemptsConfigurationPresenter::DELIVERY_METHOD_POLL,
+            url: api_attempts_poll_url,
+          ],
+        )
+
+        expect(configuration[:status_endpoint]).to eq(api_attempts_status_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Note: this PR is dependent on https://github.com/18F/identity-idp/pull/11716 which adds the `attempts_api_enabled` feature flag

## 🎫 Ticket

Link to the relevant ticket:
[Create initial Attempts API endpoints](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/145)

## 🛠 Summary of changes
This change adds the three endpoints that will be utilized in the Attempts API. 
- A configuration endpoint for discovery (/.well-known/ssf-configuration)
- A status endpoint for API status information (/api/attempts/status)
- A polling endpoint for the eventual data stream (/api/attempts/poll)

Detailed descriptions of the end-state of the endpoints can be found [in our technical documentation draft](https://docs.google.com/document/d/1hXrpBPPm4WMusGkX_Q-D8AI0hYFQZNZ-pOy7zKeu0So/edit?tab=t.0#heading=h.z3sevm9fnyoo) and in the [shared signals framework spec](https://openid.net/specs/openid-sharedsignals-framework-1_0-ID3.html#name-stream-status).

In this initial change
When the feature flag `attempts_api_enabled` is set to `false`:
- All new endpoints 404
When the feature flag `attempts_api_enabled` is set to `true`
- The configuration endpoint returns basic configuration information as detailed [here](https://docs.google.com/document/d/1hXrpBPPm4WMusGkX_Q-D8AI0hYFQZNZ-pOy7zKeu0So/edit?tab=t.0#heading=h.z3sevm9fnyoo)
- The status endpoint returns a 200, with the body disabled and the reason not_yet_implemented
- The polling endpoint returns a 405 method_not_allowed error

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
