### PR TITLE
LG-15457 Read the sex attribute from the TrueID authentication result

### DIFF
--- a/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb
+++ b/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb
@@ -22,6 +22,7 @@ module DocAuth
       # @return [Pii::StateId, nil]
       def read_pii(true_id_product)
         id_auth_field_data = true_id_product&.dig(:IDAUTH_FIELD_DATA)
+        authentication_result_field_data = true_id_product&.dig(:AUTHENTICATION_RESULT)
         return nil unless id_auth_field_data.present?
 
         state_id_type_slug = id_auth_field_data['Fields_DocumentClassName']
@@ -42,7 +43,7 @@ module DocAuth
             month: id_auth_field_data['Fields_DOB_Month'],
             day: id_auth_field_data['Fields_DOB_Day'],
           ),
-          sex: parse_sex_value(id_auth_field_data['Fields_Sex']),
+          sex: parse_sex_value(authentication_result_field_data&.[]('Sex')),
           height: parse_height_value(id_auth_field_data['Fields_Height']),
           weight: nil,
           eye_color: nil,
@@ -87,10 +88,10 @@ module DocAuth
         # This code will return `nil` for those cases with the intent that they will not be verified
         # against the DLDV where they will not be recognized
         #
-        case sex_attribute&.upcase
-        when 'M'
+        case sex_attribute
+        when 'Male'
           'male'
-        when 'F'
+        when 'Female'
           'female'
         end
       end

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_attention_barcode.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_attention_barcode.json
@@ -696,11 +696,6 @@
       },
       {
         "Group": "IDAUTH_FIELD_DATA",
-        "Name": "Fields_Sex",
-        "Values": [{"Value": "M"}]
-      },
-      {
-        "Group": "IDAUTH_FIELD_DATA",
         "Name": "Fields_Height",
         "Values": [{"Value": "5' 10\""}]
       },

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_attention_barcode_with_face_match_fail.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_attention_barcode_with_face_match_fail.json
@@ -716,11 +716,6 @@
       },
       {
         "Group": "IDAUTH_FIELD_DATA",
-        "Name": "Fields_Sex",
-        "Values": [{"Value": "M"}]
-      },
-      {
-        "Group": "IDAUTH_FIELD_DATA",
         "Name": "Fields_Height",
         "Values": [{"Value": "5' 10\""}]
       },

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failed_to_ocr_dob.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failed_to_ocr_dob.json
@@ -409,12 +409,7 @@
            "Name": "Fields_PostalCode",
            "Values": [{"Value": "12345"}]
         },
-                 {
-           "Group": "IDAUTH_FIELD_DATA",
-           "Name": "Fields_Sex",
-           "Values": [{"Value": "M"}]
-        },
-                 {
+        {
            "Group": "IDAUTH_FIELD_DATA",
            "Name": "Fields_ControlNumber",
            "Values": [{"Value": "6820051160"}]

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_no_liveness.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_no_liveness.json
@@ -676,11 +676,6 @@
         },
         {
           "Group": "IDAUTH_FIELD_DATA",
-          "Name": "Fields_Sex",
-          "Values": [{"Value": "M"}]
-        },
-        {
-          "Group": "IDAUTH_FIELD_DATA",
           "Name": "Fields_ControlNumber",
           "Values": [{"Value": "demo a11230009"}]
         },

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_no_liveness_low_dpi.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_no_liveness_low_dpi.json
@@ -671,11 +671,6 @@
         },
         {
           "Group": "IDAUTH_FIELD_DATA",
-          "Name": "Fields_Sex",
-          "Values": [{"Value": "M"}]
-        },
-        {
-          "Group": "IDAUTH_FIELD_DATA",
           "Name": "Fields_ControlNumber",
           "Values": [{"Value": "demo a11230009"}]
         },

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_with_all_failures.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_with_all_failures.json
@@ -671,11 +671,6 @@
         },
         {
           "Group": "IDAUTH_FIELD_DATA",
-          "Name": "Fields_Sex",
-          "Values": [{"Value": "M"}]
-        },
-        {
-          "Group": "IDAUTH_FIELD_DATA",
           "Name": "Fields_ControlNumber",
           "Values": [{"Value": "demo a11230009"}]
         },

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_with_face_match_fail.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_with_face_match_fail.json
@@ -671,11 +671,6 @@
         },
         {
           "Group": "IDAUTH_FIELD_DATA",
-          "Name": "Fields_Sex",
-          "Values": [{"Value": "M"}]
-        },
-        {
-          "Group": "IDAUTH_FIELD_DATA",
           "Name": "Fields_ControlNumber",
           "Values": [{"Value": "demo a11230009"}]
         },

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_with_face_match_pass.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_with_face_match_pass.json
@@ -671,11 +671,6 @@
         },
         {
           "Group": "IDAUTH_FIELD_DATA",
-          "Name": "Fields_Sex",
-          "Values": [{"Value": "M"}]
-        },
-        {
-          "Group": "IDAUTH_FIELD_DATA",
           "Name": "Fields_ControlNumber",
           "Values": [{"Value": "demo a11230009"}]
         },

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_with_liveness.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_failure_with_liveness.json
@@ -671,11 +671,6 @@
         },
         {
           "Group": "IDAUTH_FIELD_DATA",
-          "Name": "Fields_Sex",
-          "Values": [{"Value": "M"}]
-        },
-        {
-          "Group": "IDAUTH_FIELD_DATA",
           "Name": "Fields_ControlNumber",
           "Values": [{"Value": "demo a11230009"}]
         },

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success.json
@@ -699,15 +699,6 @@
         },
         {
           "Group": "IDAUTH_FIELD_DATA",
-          "Name": "Fields_Sex",
-          "Values": [
-            {
-              "Value": "M"
-            }
-          ]
-        },
-        {
-          "Group": "IDAUTH_FIELD_DATA",
           "Name": "Fields_ControlNumber",
           "Values": [
             {

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         city: 'ANYTOWN',
         state: 'MD',
         dob: '1986-07-01',
-        sex: nil,
+        sex: 'male',
         height: 69,
         weight: nil,
         eye_color: nil,


### PR DESCRIPTION
We have received clarification on the following from our vendor:

1. The `Fields_Sex` attribute is no longer available in the `ID_AUTH_FIELDS` group
2. The `Sex` attribute available in the `AUTHENTICATION_RESULT` group can be used to reliably determine the sex displayed on the document
3. The `Sex` attribute in the `AUTHENTICATION_RESULT` group takes on the values of `Male` or `Female`.

This commit updates the `DocPiiReader` and the TrueID response fixtures to reflect this.
