### PR TITLE
LG-15479: Fix nil zipcode error during identity resolution

### DIFF
--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -24,6 +24,16 @@ module Idv
       analytics.idv_doc_auth_link_sent_submitted(**analytics_arguments)
 
       return render_document_capture_cancelled if document_capture_session&.cancelled_at
+
+      # If the user opted into in-person proofing in the hybrid session,
+      # we should be able to find an establishing IPP enrollment
+      if current_user.has_establishing_in_person_enrollment?
+        redirect_to idv_in_person_url
+        return
+      end
+
+      # Otherwise, we assume the user is still in the remote doc auth flow.
+
       return render_step_incomplete_error unless take_photo_with_phone_successful?
 
       # The doc capture flow will have fetched the results already. We need


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15479](https://cm-jira.usa.gov/browse/LG-15479)

## 🛠 Summary of changes

We have a rare but persistent issue where users get stuck on the "Verify your information" screen because the `zipcode` stored with their PII is `nil`.

One way the user can end up in this situation is:

1. Use hybrid handoff to upload identity documents that are valid, but have a barcode-related "attention" warning
2. Opt then to enroll in in-person proofing (from their mobile device) instead
3. Select a USPS location on their mobile device
4. When prompted, return to their desktop and click the "Continue" button

In this case, the user would end up in a state where they have _both_ an IPP enrollment _and_ `pii_from_doc` set in their session. This would cause the system to get confused, and attempt to use `pii_from_user` data for identity resolution. That structure would be empty, thus the nil zipcode error.

The cause here was that we had two different paths the user could take _off_ the "Link sent" page:

1. In the remote doc auth flow, we would have the polling javascript _click_ the "Continue" button when it detected that the hybrid document capture was complete
2. In the IPP flow, we would instead redirect the user (in Javascript, via `window.location`) directly into the IPP flow, bypassing form submission on the "Link sent" page.

This PR:

* Updates `LinkSentController::update` to redirect the user into in-person proofing if it detects they should be there

For users who complete IPP location selection and return to their desktop _before_ polling times out and the "Continue" button is shown, they will still be redirected into the IPP flow (via `window.location`) as before. A subsequent PR will stop `LinkSentPollController` from returning a `redirect_url` for IPP and instead route all traffic through the "Continue" path, but this PR must be in place in prod first.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

1. Begin IdV. Opt for the hybrid flow
2. On your mobile device, upload a document with a Barcode attention error
3. When asked if you want to proceed, choose In person proofing
4. **Wait** for the _Continue_ button to appear on the desktop side
5. Select an in-person proofing location.
6. When prompted to return to your desktop device, click the "Continue" button
7. Observe that you are redirected into the In-person proofing flow
8. Verify you can complete IPP enrollment, SSN entry, and the "Verify your information" step