### PR TITLE
LG-15734: Stop returning redirect_url from LinkSentPollController for IPP

### DIFF
--- a/app/controllers/idv/link_sent_poll_controller.rb
+++ b/app/controllers/idv/link_sent_poll_controller.rb
@@ -48,8 +48,6 @@ module Idv
 
       if rate_limiter.limited? && !session_result_passed?
         idv_session_errors_rate_limited_url
-      elsif user_has_establishing_in_person_enrollment?
-        idv_in_person_url
       end
     end
 

--- a/app/controllers/idv/link_sent_poll_controller.rb
+++ b/app/controllers/idv/link_sent_poll_controller.rb
@@ -30,8 +30,6 @@ module Idv
           :gone
         elsif rate_limiter.limited? && !session_result_passed?
           :too_many_requests
-        elsif confirmed_barcode_attention_result? || user_has_establishing_in_person_enrollment?
-          :ok
         elsif session_result.blank? || pending_barcode_attention_confirmation? ||
               redo_document_capture_pending?
           :accepted
@@ -79,16 +77,6 @@ module Idv
         user: document_capture_session.user,
         rate_limit_type: :idv_doc_auth,
       )
-    end
-
-    def user_has_establishing_in_person_enrollment?
-      return false unless IdentityConfig.store.in_person_proofing_enabled
-      current_user.establishing_in_person_enrollment.present?
-    end
-
-    def confirmed_barcode_attention_result?
-      !redo_document_capture_pending? && had_barcode_attention_result? &&
-        !document_capture_session.ocr_confirmation_pending?
     end
 
     def pending_barcode_attention_confirmation?

--- a/spec/controllers/idv/link_sent_poll_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_poll_controller_spec.rb
@@ -214,11 +214,10 @@ RSpec.describe Idv::LinkSentPollController do
         create(:in_person_enrollment, :establishing, user: user, profile: nil)
       end
 
-      it 'returns success with redirect' do
+      it 'returns success' do
         get :show
 
         expect(response.status).to eq(200)
-        expect(JSON.parse(response.body)).not_to include('redirect' => idv_in_person_url)
       end
     end
   end

--- a/spec/controllers/idv/link_sent_poll_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_poll_controller_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Idv::LinkSentPollController do
         get :show
 
         expect(response.status).to eq(200)
-        expect(JSON.parse(response.body)).to include('redirect' => idv_in_person_url)
+        expect(JSON.parse(response.body)).not_to include('redirect' => idv_in_person_url)
       end
     end
   end


### PR DESCRIPTION
**This PR cannot land until #11820 is in production**

## 🛠 Summary of changes

#11820 removed the need for an IPP-related `redirect_url` to come back from `LinkSentPollController`. This PR stops sending `redirect_url` back to the client entirely, ensuring that _all_ IPP enrollments in the hybrid flow are routed throught the `update` method of `LinkSentController`.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
