### PR TITLE
Log errors for profile reactivate password submitted

### DIFF
--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -13,12 +13,13 @@ module Users
     end
 
     def update
-      result = verify_password_form.submit
+      form = verify_password_form
+      result = form.submit
 
-      analytics.reactivate_account_verify_password_submitted(success: result.success?)
+      analytics.reactivate_account_verify_password_submitted(**result.to_h)
 
       if result.success?
-        handle_success(result)
+        handle_success(personal_key: form.personal_key)
       else
         flash[:error] = t('errors.messages.password_incorrect')
         render :new
@@ -32,8 +33,8 @@ module Users
       redirect_to root_url
     end
 
-    def handle_success(result)
-      user_session[:personal_key] = result.extra[:personal_key]
+    def handle_success(personal_key:)
+      user_session[:personal_key] = personal_key
       reactivate_account_session.clear
       redirect_to manage_personal_key_url
     end

--- a/app/forms/verify_password_form.rb
+++ b/app/forms/verify_password_form.rb
@@ -6,7 +6,7 @@ class VerifyPasswordForm
   validates :password, presence: true
   validate :validate_password
 
-  attr_reader :user, :password, :decrypted_pii
+  attr_reader :user, :password, :decrypted_pii, :personal_key
 
   def initialize(user:, password:, decrypted_pii:)
     @user = user
@@ -16,11 +16,10 @@ class VerifyPasswordForm
 
   def submit
     success = valid?
-    extra = {}
 
-    extra[:personal_key] = reencrypt_pii if success
+    @personal_key = reencrypt_pii if success
 
-    FormResponse.new(success: success, errors: errors, extra: extra)
+    FormResponse.new(success:, errors:, serialize_error_details_only: true)
   end
 
   private

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6689,8 +6689,9 @@ module AnalyticsEvents
 
   # Submission event for the "verify password" page the user sees after entering their personal key.
   # @param [Boolean] success Whether the form was submitted successfully.
-  def reactivate_account_verify_password_submitted(success:, **extra)
-    track_event(:reactivate_account_verify_password_submitted, success: success, **extra)
+  # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
+  def reactivate_account_verify_password_submitted(success:, error_details: nil, **extra)
+    track_event(:reactivate_account_verify_password_submitted, success:, error_details:, **extra)
   end
 
   # Visit event for the "verify password" page the user sees after entering their personal key.

--- a/spec/forms/verify_password_form_spec.rb
+++ b/spec/forms/verify_password_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe VerifyPasswordForm, type: :model do
         result = form.submit
 
         expect(profile.reload.active?).to eq true
-        expect(result.success?).to eq true
+        expect(result.to_h).to eq(success: true)
       end
     end
 
@@ -40,8 +40,10 @@ RSpec.describe VerifyPasswordForm, type: :model do
         result = form.submit
 
         expect(profile.reload.active?).to eq false
-        expect(result.success?).to eq false
-        expect(result.errors[:password]).to eq [t('errors.messages.password_incorrect')]
+        expect(result.to_h).to eq(
+          success: false,
+          error_details: { password: { password_incorrect: true } },
+        )
       end
     end
   end


### PR DESCRIPTION
## 🛠 Summary of changes

This pull request changes `VerifyPasswordForm` to avoid assigning `personal_key` on `FormResponse#extra` and instead assign as an instance variable accessible through a new attribute reader.

**Why?**

- `extra` is intended to be used for analytics logging and should exclude sensitive information ([docs](https://github.com/18F/identity-idp/blob/main/docs/backend.md#formresponse)). Personal key is a very sensitive value, and while we've taken steps to ensure that it isn't logged, the previous implementation creates a lot of unnecessary risk that it could accidentally be logged in future changes.
- The aforementioned "taken steps to ensure that it isn't logged" meant that we were only logging `success` values for this analytics event. By removing personal key from `extra`, we can log the entire response using `FormResponse#to_h`, including errors.

## 📜 Testing Plan

Verify that the build passes.

Verify using `make watch_events` that submitting password after reactivating a profile disabled due to password reset logs the `reactivate_account_verify_password_submitted` event (a) without `personal_key` and (b) with `error_details` if the submission is unsuccessful.