### PR TITLE
LG-11867: Create separate user events for platform authenticators

### DIFF
--- a/app/controllers/api/internal/two_factor_authentication/webauthn_controller.rb
+++ b/app/controllers/api/internal/two_factor_authentication/webauthn_controller.rb
@@ -30,15 +30,16 @@ module Api
         end
 
         def destroy
-          result = ::TwoFactorAuthentication::WebauthnDeleteForm.new(
+          form = ::TwoFactorAuthentication::WebauthnDeleteForm.new(
             user: current_user,
             configuration_id: params[:id],
-          ).submit
+          )
+          result = form.submit
 
           analytics.webauthn_delete_submitted(**result)
 
           if result.success?
-            handle_successful_mfa_deletion(event_type: :webauthn_key_removed)
+            handle_successful_mfa_deletion(event_type: form.event_type)
             render json: { success: true }
           else
             render json: { success: false, error: result.first_error_message }, status: :bad_request

--- a/app/controllers/users/webauthn_controller.rb
+++ b/app/controllers/users/webauthn_controller.rb
@@ -34,7 +34,7 @@ module Users
 
       if result.success?
         flash[:success] = presenter.delete_success_alert_text
-        handle_successful_mfa_deletion(event_type: :webauthn_key_removed)
+        handle_successful_mfa_deletion(event_type: form.event_type)
         redirect_to account_path
       else
         flash[:error] = result.first_error_message

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -127,7 +127,7 @@ module Users
     end
 
     def process_valid_webauthn(form)
-      create_user_event(:webauthn_key_added)
+      create_user_event(form.event_type)
       analytics.webauthn_setup_submitted(
         platform_authenticator: form.platform_authenticator?,
         in_account_creation_flow: user_session[:in_account_creation_flow] || false,

--- a/app/controllers/users/webauthn_setup_mismatch_controller.rb
+++ b/app/controllers/users/webauthn_setup_mismatch_controller.rb
@@ -32,16 +32,17 @@ module Users
     end
 
     def destroy
-      result = ::TwoFactorAuthentication::WebauthnDeleteForm.new(
+      form = ::TwoFactorAuthentication::WebauthnDeleteForm.new(
         user: current_user,
         configuration_id: webauthn_mismatch_id,
         skip_multiple_mfa_validation: in_multi_mfa_selection_flow?,
-      ).submit
+      )
+      result = form.submit
 
       analytics.webauthn_setup_mismatch_submitted(**result.to_h, confirmed_mismatch: false)
 
       if result.success?
-        handle_successful_mfa_deletion(event_type: :webauthn_key_removed)
+        handle_successful_mfa_deletion(event_type: form.event_type)
         redirect_to retry_setup_url
       else
         flash.now[:error] = result.first_error_message

--- a/app/forms/two_factor_authentication/webauthn_delete_form.rb
+++ b/app/forms/two_factor_authentication/webauthn_delete_form.rb
@@ -7,6 +7,8 @@ module TwoFactorAuthentication
 
     attr_reader :user, :configuration_id
 
+    delegate :platform_authenticator?, to: :configuration, allow_nil: true
+
     validate :validate_configuration_exists
     validate :validate_has_multiple_mfa
 
@@ -31,6 +33,14 @@ module TwoFactorAuthentication
 
     def configuration
       @configuration ||= user.webauthn_configurations.find_by(id: configuration_id)
+    end
+
+    def event_type
+      if platform_authenticator?
+        :webauthn_platform_removed
+      else
+        :webauthn_key_removed
+      end
     end
 
     private
@@ -63,7 +73,7 @@ module TwoFactorAuthentication
     def extra_analytics_attributes
       {
         configuration_id:,
-        platform_authenticator: configuration&.platform_authenticator?,
+        platform_authenticator: platform_authenticator?,
       }
     end
   end

--- a/app/forms/webauthn_setup_form.rb
+++ b/app/forms/webauthn_setup_form.rb
@@ -71,6 +71,14 @@ class WebauthnSetupForm
     end
   end
 
+  def event_type
+    if setup_as_platform_authenticator?
+      :webauthn_platform_added
+    else
+      :webauthn_key_added
+    end
+  end
+
   private
 
   attr_reader :success, :transports, :invalid_transports, :protocol

--- a/spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb
+++ b/spec/controllers/api/internal/two_factor_authentication/webauthn_controller_spec.rb
@@ -215,5 +215,13 @@ RSpec.describe Api::Internal::TwoFactorAuthentication::WebauthnController do
         expect(response.status).to eq(400)
       end
     end
+
+    context 'with a platform authenticator' do
+      let(:configuration) { create(:webauthn_configuration, :platform_authenticator, user:) }
+
+      it 'logs a user event for the removed credential' do
+        expect { response }.to change { user.events.webauthn_platform_removed.size }.by 1
+      end
+    end
   end
 end

--- a/spec/controllers/users/webauthn_controller_spec.rb
+++ b/spec/controllers/users/webauthn_controller_spec.rb
@@ -252,5 +252,13 @@ RSpec.describe Users::WebauthnController do
         expect(response).to be_not_found
       end
     end
+
+    context 'with a platform authenticator' do
+      let(:configuration) { create(:webauthn_configuration, :platform_authenticator, user:) }
+
+      it 'logs a user event for the removed credential' do
+        expect { response }.to change { user.events.webauthn_platform_removed.size }.by 1
+      end
+    end
   end
 end

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -153,6 +153,12 @@ RSpec.describe Users::WebauthnSetupController do
         )
       end
 
+      it 'creates user event' do
+        expect(controller).to receive(:create_user_event).with(:webauthn_key_added)
+
+        response
+      end
+
       context 'with transports mismatch' do
         let(:params) { super().merge(transports: 'internal') }
 
@@ -189,6 +195,12 @@ RSpec.describe Users::WebauthnSetupController do
           response
 
           expect(flash[:success]).to eq(t('notices.webauthn_platform_configured'))
+        end
+
+        it 'creates user event' do
+          expect(controller).to receive(:create_user_event).with(:webauthn_platform_added)
+
+          response
         end
 
         context 'with transports mismatch' do

--- a/spec/controllers/users/webauthn_setup_mismatch_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_mismatch_controller_spec.rb
@@ -226,6 +226,13 @@ RSpec.describe Users::WebauthnSetupMismatchController do
           confirmed_mismatch: false,
         )
       end
+
+      it 'invalidates deleted authenticator' do
+        expect(controller).to receive(:handle_successful_mfa_deletion)
+          .with(event_type: :webauthn_platform_removed)
+
+        response
+      end
     end
   end
 end

--- a/spec/forms/two_factor_authentication/webauthn_delete_form_spec.rb
+++ b/spec/forms/two_factor_authentication/webauthn_delete_form_spec.rb
@@ -130,4 +130,38 @@ RSpec.describe TwoFactorAuthentication::WebauthnDeleteForm do
       expect(form_configuration).to eq(configuration)
     end
   end
+
+  describe '#platform_authenticator?' do
+    subject(:platform_authenticator?) { form.platform_authenticator? }
+
+    context 'without configuration' do
+      let(:configuration) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'with configuration' do
+      let(:configuration) { create(:webauthn_configuration, user:) }
+
+      it 'delegates to configuration' do
+        expect(platform_authenticator?).to eq(configuration.platform_authenticator?)
+      end
+    end
+  end
+
+  describe '#event_type' do
+    subject(:event_type) { form.event_type }
+
+    context 'with security key' do
+      let(:configuration) { create(:webauthn_configuration, user:) }
+
+      it { is_expected.to eq(:webauthn_key_removed) }
+    end
+
+    context 'with platform authenticator' do
+      let(:configuration) { create(:webauthn_configuration, :platform_authenticator, user:) }
+
+      it { is_expected.to eq(:webauthn_platform_removed) }
+    end
+  end
 end

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -375,6 +375,25 @@ RSpec.describe WebauthnSetupForm do
     end
   end
 
+  describe '#event_type' do
+    subject(:event_type) { form.event_type }
+
+    before do
+      form.submit(params)
+    end
+
+    it { is_expected.to eq(:webauthn_key_added) }
+
+    context 'with platform authenticator' do
+      let(:attestation) { platform_auth_attestation_object }
+      let(:params) do
+        super().merge(platform_authenticator: true, transports: 'internal,hybrid')
+      end
+
+      it { is_expected.to eq(:webauthn_platform_added) }
+    end
+  end
+
   describe '.name_is_unique' do
     context 'webauthn' do
       let(:user) do


### PR DESCRIPTION
## 🎫 Ticket

[LG-11867](https://cm-jira.usa.gov/browse/LG-11867)

## 🛠 Summary of changes

Adds new user event types for Face or Touch Unlock platform authenticators.

The implementation of Face or Touch Unlock built upon support for WebAuthn-based security keys. In the implementation of Face or Touch Unlock, the user experience was segmented based on whether or not the authenticator is a [platform authenticator](https://www.w3.org/TR/webauthn-3/#sctn-authenticator-attachment-modality). However, prior to these changes, that did not extend to the user events created for adding an removing the authentication method. As a result, adding or removing Face or Touch Unlock would be reflected on a user's Activity page as "Hardware security key added" and "Hardware security key removed". The intent of these changes is to add new event types so that a more appropriate / familiar "Face or touch unlock added" and "Face or touch unlock removed" label can be shown instead.

## 📜 Testing Plan

1. Go to http://localhost:3000
2. Sign in
3. From your account dashboard, add and/or remove a Security Key and/or a Face or Touch Unlock credential
4. After changing your MFA methods, visit the "History" page on the account dashboard
5. Verify that the label shown under "Activity" matches the expectation of the action you performed:
   - Adding security key = "Hardware security key added"
   - Removing security key = "Hardware security key removed"
   - Adding face or touch unlock = "Face or touch unlock added"
   - Removing face or touch unlock = "Face or touch unlock removed"

## 👀 Screenshots

Language|Screenshot
---|---
English|<img alt="history screen" width="450" src="https://github.com/user-attachments/assets/862ab383-94f5-4bbe-9edc-8bab7f1841df">
Spanish|<img alt="history screen" width="450" src="https://github.com/user-attachments/assets/ef5dba9f-b774-46ce-b518-715d2985dd8b">
French|<img alt="history screen" width="450" src="https://github.com/user-attachments/assets/290f09b1-2785-4a6e-b5b3-bc1071c245ef">
Chinese|<img alt="history screen" width="450" src="https://github.com/user-attachments/assets/bc9d8673-9456-4936-8f71-7df5de055b40">
