### PR TITLE
LG-11867: Create separate user events for platform authenticators (event type, strings)

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -29,6 +29,8 @@ class Event < ApplicationRecord
     password_invalidated: 22,
     sign_in_unsuccessful_2fa: 23,
     sign_in_notification_timeframe_expired: 24,
+    webauthn_platform_added: 25,
+    webauthn_platform_removed: 26,
   }
 
   validates :event_type, presence: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -845,6 +845,8 @@ event_types.sign_in_notification_timeframe_expired: Expired notification timefra
 event_types.sign_in_unsuccessful_2fa: Failed to authenticate
 event_types.webauthn_key_added: Hardware security key added
 event_types.webauthn_key_removed: Hardware security key removed
+event_types.webauthn_platform_added: Face or touch unlock added
+event_types.webauthn_platform_removed: Face or touch unlock removed
 forms.backup_code_regenerate.caution: If you regenerate your backup codes you will receive a new set of backup codes. Your original backup codes will no longer be valid.
 forms.backup_code_regenerate.confirm: Are you sure you want to regenerate your backup codes?
 forms.backup_code_reminder.body_info: If you ever lose access to your primary authentication method, you can use backup codes to regain access to your account.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -856,6 +856,8 @@ event_types.sign_in_notification_timeframe_expired: Venció el tiempo del mensaj
 event_types.sign_in_unsuccessful_2fa: No se pudo autenticar
 event_types.webauthn_key_added: Clave de seguridad de hardware añadida
 event_types.webauthn_key_removed: Clave de seguridad de hardware eliminada
+event_types.webauthn_platform_added: Desbloqueo facial o táctil añadido
+event_types.webauthn_platform_removed: Desbloqueo facial o táctil eliminado
 forms.backup_code_regenerate.caution: Si vuelve a generar sus códigos de recuperación, recibirá un conjunto nuevo de códigos. Sus códigos de recuperación originales ya no serán válidos.
 forms.backup_code_regenerate.confirm: '¿Está seguro de que desea volver a generar sus códigos de recuperación?'
 forms.backup_code_reminder.body_info: Si no puede acceder a su método de autenticación principal, puede usar códigos de recuperación para acceder a su cuenta.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -845,6 +845,8 @@ event_types.sign_in_notification_timeframe_expired: Expiration du délai de noti
 event_types.sign_in_unsuccessful_2fa: Échec de l’authentification
 event_types.webauthn_key_added: Clé de sécurité physique ajoutée
 event_types.webauthn_key_removed: Clé de sécurité physique supprimée
+event_types.webauthn_platform_added: Déverrouillage facial ou tactile ajouté
+event_types.webauthn_platform_removed: Déverrouillage facial ou tactile supprimé
 forms.backup_code_regenerate.caution: Si vous régénérez vos codes de sauvegarde, vous recevrez un nouvel ensemble de codes de sauvegarde. Vos codes de sauvegarde d’origine ne seront plus valides.
 forms.backup_code_regenerate.confirm: Êtes-vous sûr de vouloir régénérer vos codes de sauvegarde ?
 forms.backup_code_reminder.body_info: Si vous perdez l’accès à votre méthode d’authentification principale, vous pouvez utiliser des codes de sauvegarde pour accéder à nouveau à votre compte.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -856,6 +856,8 @@ event_types.sign_in_notification_timeframe_expired: 从新设备登录的通知�
 event_types.sign_in_unsuccessful_2fa: 身份证实失败
 event_types.webauthn_key_added: 硬件安全密钥已添加
 event_types.webauthn_key_removed: 硬件安全密钥已去掉
+event_types.webauthn_platform_added: 人脸或触摸解锁已添加。
+event_types.webauthn_platform_removed: 人脸或触摸解锁已去掉。
 forms.backup_code_regenerate.caution: 如果你重新生成备用代码，会收到新的一套备用代码。你原来的备用代码就会失效。
 forms.backup_code_regenerate.confirm: 你确定要重新生成备用代码吗？
 forms.backup_code_reminder.body_info: 如果你无法使用自己的主要身份证实方法，可以使用备用代码重新获得对账户的访问权。


### PR DESCRIPTION
## 🎫 Ticket

[LG-11867](https://cm-jira.usa.gov/browse/LG-11867)

## 🛠 Summary of changes

Updates `Event` model to add support for `webauthn_platform_added` and `webauthn_platform_removed` event types, including corresponding label texts.

This is split from #11823 to avoid issues during deployment where an old server may not be aware of these event types when displaying user activity history.

## 📜 Testing Plan

Repeat Testing Plan from #11823 and then switch to this branch. The History page should continue to show expected labels. On `main`, this would show invalid label strings.

## 👀 Screenshots

See #11823 (there are no expected user-facing impact of these changes alone)