### PR TITLE
Avoid showing label for unknown event type

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -2,6 +2,7 @@
 
 EventDecorator = Struct.new(:event) do
   def event_type
+    return if event.event_type.blank?
     I18n.t("event_types.#{event.event_type}", app_name: APP_NAME)
   end
 

--- a/spec/decorators/event_decorator_spec.rb
+++ b/spec/decorators/event_decorator_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe EventDecorator do
   subject(:decorator) { EventDecorator.new(event) }
 
   describe '#event_type' do
+    subject(:event_type) { decorator.event_type }
+
     it 'returns the localized event_type' do
       expect(decorator.event_type).to eq t('event_types.email_changed')
     end
@@ -16,6 +18,18 @@ RSpec.describe EventDecorator do
         expect(decorator.event_type).to eq t('event_types.password_invalidated', app_name: APP_NAME)
         expect(decorator.event_type).to include(APP_NAME)
       end
+    end
+
+    context 'for a blank event type' do
+      # If the database has an event type value which isn't known to the application, it will be
+      # parsed as nil, which can result in unexpected behavior for retrieving a string label. This
+      # can happen during deployment of a new event type, where old servers aren't yet aware of the
+      # new event type, or it can happen if values are erroneously removed from the model enum while
+      # existing database records still use the value.
+
+      let(:event) { build_stubbed(:event, event_type: nil) }
+
+      it { is_expected.to be_nil }
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Related to [LG-11867](https://cm-jira.usa.gov/browse/LG-11867)

## 🛠 Summary of changes

Updates logic of `EventDecorator#event_type` to avoid trying to return a human-readable label for an event type that is not known to the application.

This isn't a typical behavior, but the included inline code comment explains the circumstances where it can occur:

```
# If the database has an event type value which isn't known to the application, it will be
# parsed as nil, which can result in unexpected behavior for retrieving a string label. This
# can happen during deployment of a new event type, where old servers aren't yet aware of the
# new event type, or it can happen if values are erroneously removed from the model enum while
# existing database records still use the value.
```

As an aside, tracking existing references to `EventDecorator#event_type` can be tricky since the name is the same as `Event#event_type`, where only the decorator returns a human-readable label. This label is used on the History and Devices pages. In the future, it could be worth renaming this method to more clearly differentiate (e.g. `readable_event_type`, or `event_type_label`)

## 📜 Testing Plan

Repeat Testing Planf rom #11823 and then switch to this branch. The History page should not show any text for the events associated with adding or removing Face or Touch Unlock. Previously, this would show all of the `event_types.*` labels as a stringified hash.

## 👀 Screenshots

Before|After
---|---
![image](https://github.com/user-attachments/assets/2e8fa7e1-854c-4ee8-81ae-776b8faaf921)|![image](https://github.com/user-attachments/assets/06f86e18-2ac9-4e52-9227-96de4ad21492)
