### PR TITLE
LG-15559: Add support for A/B tests daily reporting

### DIFF
--- a/app/jobs/reports/ab_tests_report.rb
+++ b/app/jobs/reports/ab_tests_report.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'reporting/ab_tests_report'
+
+module Reports
+  class AbTestsReport < BaseReport
+    attr_reader :report_date
+
+    def initialize(report_date = nil, *args, **kwargs)
+      @report_date = report_date
+      super(*args, **kwargs)
+    end
+
+    # @param [DateTime]
+    def perform(report_date)
+      @report_date = report_date
+
+      report_configs.each do |config|
+        tables_report(config).deliver_now
+      end
+    end
+
+    def tables_report(config)
+      experiment_name = config[:experiment_name]
+      subject = "A/B Tests Report - #{experiment_name} - #{report_date}"
+      reports = ab_tests_report(config).as_emailable_reports
+
+      ReportMailer.tables_report(
+        email: config[:email],
+        subject:,
+        message: subject,
+        reports:,
+        attachment_format: :csv,
+      )
+    end
+
+    def ab_tests_report(config)
+      Reporting::AbTestsReport.new(
+        queries: config[:queries],
+        time_range: report_date.yesterday..report_date,
+      )
+    end
+
+    private
+
+    def report_configs
+      AbTests
+        .all
+        .values
+        .select { |ab_test| ab_test.report&.[](:email)&.present? && ab_test.active? }
+        .map { |ab_test| ab_test.report.merge(experiment_name: ab_test.experiment_name) }
+    end
+  end
+end

--- a/app/jobs/reports/ab_tests_report.rb
+++ b/app/jobs/reports/ab_tests_report.rb
@@ -21,12 +21,12 @@ module Reports
     end
 
     def tables_report(config)
-      experiment_name = config[:experiment_name]
+      experiment_name = config.experiment_name
       subject = "A/B Tests Report - #{experiment_name} - #{report_date}"
       reports = ab_tests_report(config).as_emailable_reports
 
       ReportMailer.tables_report(
-        email: config[:email],
+        email: config.email,
         subject:,
         message: subject,
         reports:,
@@ -36,7 +36,7 @@ module Reports
 
     def ab_tests_report(config)
       Reporting::AbTestsReport.new(
-        queries: config[:queries],
+        queries: config.queries,
         time_range: report_date.yesterday..report_date,
       )
     end
@@ -47,8 +47,8 @@ module Reports
       AbTests
         .all
         .values
-        .select { |ab_test| ab_test.report&.[](:email)&.present? && ab_test.active? }
-        .map { |ab_test| ab_test.report.merge(experiment_name: ab_test.experiment_name) }
+        .select { |ab_test| ab_test.report&.email&.present? && ab_test.active? }
+        .map(&:report)
     end
   end
 end

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -35,7 +35,7 @@
         <tr>
           <% row.each do |cell| %>
             <td <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
-              <% if cell.is_a?(Float) && report.float_as_percent? %>
+              <% if cell.is_a?(Float) && report.float_as_percent? && cell.between?(0.0, 1.0) %>
                 <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
               <% else %>
                 <%= number_with_delimiter(cell) %>

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -35,7 +35,7 @@
         <tr>
           <% row.each do |cell| %>
             <td <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
-              <% if cell.is_a?(Float) && report.float_as_percent? && cell.between?(0.0, 1.0) %>
+              <% if cell.is_a?(Float) && report.float_as_percent? && cell.finite? && cell.between?(0.0, 1.0) %>
                 <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
               <% else %>
                 <%= number_with_delimiter(cell) %>

--- a/app/views/report_mailer/tables_report.html.erb
+++ b/app/views/report_mailer/tables_report.html.erb
@@ -35,7 +35,7 @@
         <tr>
           <% row.each do |cell| %>
             <td <%= cell.is_a?(Numeric) ? 'class=table-number' : nil %> >
-              <% if cell.is_a?(Float) && report.float_as_percent? && cell.finite? && cell.between?(0.0, 1.0) %>
+              <% if cell.is_a?(Float) && report.float_as_percent? && cell.finite? %>
                 <%= number_to_percentage(cell * 100, precision: report.precision || 2) %>
               <% else %>
                 <%= number_with_delimiter(cell) %>

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -236,6 +236,12 @@ else
         cron: cron_every_monday,
         args: -> { [Time.zone.yesterday.end_of_day] },
       },
+      # Send A/B test reports
+      ab_tests_report: {
+        class: 'Reports::AbTestsReport',
+        cron: cron_24h,
+        args: -> { [Time.zone.yesterday.end_of_day] },
+      },
       # Send fraud metrics to Team Judy
       fraud_metrics_report: {
         class: 'Reports::FraudMetricsReport',

--- a/lib/ab_test.rb
+++ b/lib/ab_test.rb
@@ -41,6 +41,7 @@ class AbTest
     raise 'invalid bucket data structure' unless valid_bucket_data_structure?
     ensure_numeric_percentages
     raise 'bucket percentages exceed 100' unless within_100_percent?
+    @active = buckets.present? && buckets.values.any?(&:positive?)
   end
 
   # @param [ActionDispatch::Request] request
@@ -83,8 +84,7 @@ class AbTest
   end
 
   def active?
-    return @active if defined?(@active)
-    @active = buckets.present? && buckets.values.any?(&:positive?)
+    @active
   end
 
   private

--- a/lib/ab_test.rb
+++ b/lib/ab_test.rb
@@ -7,6 +7,15 @@ class AbTest
 
   MAX_SHA = (16 ** 64) - 1
 
+  ReportQueryConfig = Struct.new(:title, :query, :row_labels, keyword_init: true).freeze
+
+  ReportConfig = Struct.new(:experiment_name, :email, :queries, keyword_init: true) do
+    def initialize(queries: [], **)
+      super
+      self.queries.map!(&ReportQueryConfig.method(:new))
+    end
+  end.freeze
+
   # @param [Proc<String>,Regexp,string,Boolean,nil] should_log Controls whether bucket data for this
   #                                                            A/B test is logged with specific
   #                                                            events.
@@ -28,7 +37,7 @@ class AbTest
     @experiment_name = experiment_name
     @default_bucket = default_bucket
     @should_log = should_log
-    @report = report
+    @report = ReportConfig.new(experiment_name:, **report.to_h)
     raise 'invalid bucket data structure' unless valid_bucket_data_structure?
     ensure_numeric_percentages
     raise 'bucket percentages exceed 100' unless within_100_percent?

--- a/lib/ab_test.rb
+++ b/lib/ab_test.rb
@@ -37,7 +37,7 @@ class AbTest
     @experiment_name = experiment_name
     @default_bucket = default_bucket
     @should_log = should_log
-    @report = ReportConfig.new(experiment_name:, **report.to_h)
+    @report = ReportConfig.new(experiment_name:, **report.to_h) if report
     raise 'invalid bucket data structure' unless valid_bucket_data_structure?
     ensure_numeric_percentages
     raise 'bucket percentages exceed 100' unless within_100_percent?

--- a/lib/reporting/ab_tests_report.rb
+++ b/lib/reporting/ab_tests_report.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-begin
-  require 'reporting/cloudwatch_client'
-  require 'reporting/cloudwatch_query_quoting'
-  require 'reporting/command_line_options'
-rescue LoadError => e
-  warn 'could not load paths, try running with "bundle exec rails runner"'
-  raise e
-end
+require 'reporting/cloudwatch_client'
+require 'reporting/cloudwatch_query_quoting'
 
 module Reporting
   class AbTestsReport

--- a/lib/reporting/ab_tests_report.rb
+++ b/lib/reporting/ab_tests_report.rb
@@ -30,6 +30,8 @@ module Reporting
       end
     end
 
+    private
+
     def table_for_query(query)
       query_data = fetch_results(query: query.query)
       headers = column_labels(query_data.first)

--- a/lib/reporting/ab_tests_report.rb
+++ b/lib/reporting/ab_tests_report.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+begin
+  require 'reporting/cloudwatch_client'
+  require 'reporting/cloudwatch_query_quoting'
+  require 'reporting/command_line_options'
+rescue LoadError => e
+  warn 'could not load paths, try running with "bundle exec rails runner"'
+  raise e
+end
+
+module Reporting
+  class AbTestsReport
+    attr_reader :queries, :time_range
+
+    # @param [Array<String>] queries
+    # @param [Range<Time>] time_range
+    def initialize(
+      queries:,
+      time_range:,
+      verbose: false
+    )
+      @queries = queries
+      @time_range = time_range
+      @verbose = verbose
+    end
+
+    def verbose?
+      @verbose
+    end
+
+    def as_tables
+      queries.map(&method(:table_for_query))
+    end
+
+    def as_emailable_reports
+      queries.map do |query|
+        Reporting::EmailableReport.new(
+          title: query[:title],
+          table: table_for_query(query),
+        )
+      end
+    end
+
+    def table_for_query(query)
+      query_data = fetch_results(query: query[:query])
+      headers = column_labels(query_data.first)
+      rows = query_data.map(&:values)
+
+      [
+        headers,
+        *format_rows(rows, headers, query[:row_labels]),
+      ]
+    end
+
+    def format_rows(rows, headers, row_labels)
+      if row_labels
+        rows = rows.each_with_index.map do |value, index|
+          [row_labels[index], *value.slice(1)]
+        end
+      end
+
+      headers.each_index.select { |i| headers[i] =~ /percent/i }.each do |percent_index|
+        rows.each { |row| row[percent_index] = format_as_percent(row[percent_index]) }
+      end
+
+      rows
+    end
+
+    def fetch_results(query:)
+      cloudwatch_client.fetch(query:, from: time_range.begin, to: time_range.end)
+    end
+
+    def column_labels(row)
+      row.keys
+    end
+
+    def cloudwatch_client
+      @cloudwatch_client ||= Reporting::CloudwatchClient.new(
+        progress: false,
+        ensure_complete_logs: false,
+        logger:,
+      )
+    end
+
+    def logger
+      Logger.new(STDERR) if verbose?
+    end
+
+    # @return [String]
+    def format_as_percent(number)
+      '%.2f%%' % number
+    end
+  end
+end

--- a/lib/reporting/ab_tests_report.rb
+++ b/lib/reporting/ab_tests_report.rb
@@ -89,7 +89,7 @@ module Reporting
 
     # @return [String]
     def format_as_percent(number)
-      '%.2f%%' % number
+      format('%.2f%%', number)
     end
   end
 end

--- a/lib/reporting/ab_tests_report.rb
+++ b/lib/reporting/ab_tests_report.rb
@@ -7,7 +7,7 @@ module Reporting
   class AbTestsReport
     attr_reader :queries, :time_range
 
-    # @param [Array<String>] queries
+    # @param [Array<AbTest::ReportQueryConfig>] queries
     # @param [Range<Time>] time_range
     def initialize(
       queries:,

--- a/lib/reporting/ab_tests_report.rb
+++ b/lib/reporting/ab_tests_report.rb
@@ -11,16 +11,10 @@ module Reporting
     # @param [Range<Time>] time_range
     def initialize(
       queries:,
-      time_range:,
-      verbose: false
+      time_range:
     )
       @queries = queries
       @time_range = time_range
-      @verbose = verbose
-    end
-
-    def verbose?
-      @verbose
     end
 
     def as_tables
@@ -73,12 +67,7 @@ module Reporting
       @cloudwatch_client ||= Reporting::CloudwatchClient.new(
         progress: false,
         ensure_complete_logs: false,
-        logger:,
       )
-    end
-
-    def logger
-      Logger.new(STDERR) if verbose?
     end
 
     # @return [String]

--- a/lib/reporting/ab_tests_report.rb
+++ b/lib/reporting/ab_tests_report.rb
@@ -36,20 +36,20 @@ module Reporting
     def as_emailable_reports
       queries.map do |query|
         Reporting::EmailableReport.new(
-          title: query[:title],
+          title: query.title,
           table: table_for_query(query),
         )
       end
     end
 
     def table_for_query(query)
-      query_data = fetch_results(query: query[:query])
+      query_data = fetch_results(query: query.query)
       headers = column_labels(query_data.first)
       rows = query_data.map(&:values)
 
       [
         headers,
-        *format_rows(rows, headers, query[:row_labels]),
+        *format_rows(rows, headers, query.row_labels),
       ]
     end
 

--- a/spec/jobs/reports/ab_tests_report_spec.rb
+++ b/spec/jobs/reports/ab_tests_report_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Reports::AbTestsReport do
+  let(:report_date) { Date.new(2023, 12, 25) }
+  let(:email) { 'email@example.com' }
+  let(:tested_percent) { 1 }
+  let(:queries) do
+    [
+      {
+        title: 'Sign in success rate by CAPTCHA validation performed',
+        query: <<~QUERY,
+          fields properties.event_properties.captcha_validation_performed as `Captcha Validation Performed`
+          | filter name = 'Email and Password Authentication'
+          | stats avg(properties.event_properties.success)*100 as `Success Percent` by `Captcha Validation Performed`
+          | sort `Captcha Validation Performed` asc
+        QUERY
+        row_labels: ['Validation Not Performed', 'Validation Performed'],
+      },
+    ]
+  end
+  let(:ab_tests) do
+    {
+      RECAPTCHA_SIGN_IN: AbTest.new(
+        experiment_name: 'reCAPTCHA at Sign-In',
+        buckets: { sign_in_recaptcha: tested_percent },
+        report: { email:, queries: },
+      ),
+    }
+  end
+
+  before do
+    allow(AbTests).to receive(:all).and_return(ab_tests)
+  end
+
+  describe '#perform' do
+    let(:emailable_reports) do
+      [
+        Reporting::EmailableReport.new(
+          title: 'Sign in success rate by CAPTCHA validation performed',
+          table: [
+            ['Captcha Validation Performed', 'Success Percent'],
+            ['Validation Not Performed', '90.19%'],
+            ['Validation Performed', '85.68%'],
+          ],
+        ),
+      ]
+    end
+
+    let(:report) do
+      double(Reporting::AbTestsReport, as_emailable_reports: emailable_reports)
+    end
+
+    before do
+      allow(Reporting::AbTestsReport).to receive(:new).with(
+        queries:,
+        time_range: report_date.yesterday..report_date,
+      ).and_return(report)
+
+      allow(ReportMailer).to receive(:tables_report).and_call_original
+    end
+
+    it 'emails the table report with csv' do
+      expect(ReportMailer).to receive(:tables_report).with(
+        email:,
+        subject: "A/B Tests Report - reCAPTCHA at Sign-In - #{report_date}",
+        message: "A/B Tests Report - reCAPTCHA at Sign-In - #{report_date}",
+        reports: emailable_reports,
+        attachment_format: :csv,
+      )
+
+      subject.perform(report_date)
+    end
+
+    context 'when associated report email is nil' do
+      let(:email) { nil }
+
+      it 'does not email the table report' do
+        expect(ReportMailer).not_to receive(:tables_report)
+
+        subject.perform(report_date)
+      end
+    end
+
+    context 'when a/b test buckets are zero (test is inactive)' do
+      let(:tested_percent) { 0 }
+
+      it 'does not email the table report' do
+        expect(ReportMailer).not_to receive(:tables_report)
+
+        subject.perform(report_date)
+      end
+    end
+  end
+end

--- a/spec/lib/ab_test_spec.rb
+++ b/spec/lib/ab_test_spec.rb
@@ -2,12 +2,15 @@ require 'rails_helper'
 
 RSpec.describe AbTest do
   subject(:ab_test) do
-    AbTest.new(
+    AbTest.new(**options, &discriminator)
+  end
+
+  let(:options) do
+    {
       experiment_name: 'test',
       buckets:,
       should_log:,
-      &discriminator
-    )
+    }
   end
 
   let(:discriminator) do
@@ -226,6 +229,38 @@ RSpec.describe AbTest do
       it 'raises' do
         expect { return_value }.to raise_error
       end
+    end
+  end
+
+  describe '#report' do
+    subject(:report) { ab_test.report }
+    let(:options) { super().merge(report: report_option) }
+    let(:report_option) { {} }
+
+    it 'reflects value provided from initializer' do
+      expect(report).to eq(report_option)
+    end
+  end
+
+  describe '#active?' do
+    subject(:active) { ab_test.active? }
+
+    context 'with non-zero buckets' do
+      let(:buckets) { { foo: 0, bar: 30, baz: 0 } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with all zero buckets' do
+      let(:buckets) { { foo: 0, bar: 0, baz: 0 } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'with empty buckets' do
+      let(:buckets) { {} }
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/lib/ab_test_spec.rb
+++ b/spec/lib/ab_test_spec.rb
@@ -248,6 +248,12 @@ RSpec.describe AbTest do
       expect(report.queries.first.query).to eq('limit 1')
     end
 
+    context 'with nil report option' do
+      let(:report_option) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
     context 'with blank options' do
       let(:report_option) { {} }
 

--- a/spec/lib/ab_test_spec.rb
+++ b/spec/lib/ab_test_spec.rb
@@ -235,10 +235,28 @@ RSpec.describe AbTest do
   describe '#report' do
     subject(:report) { ab_test.report }
     let(:options) { super().merge(report: report_option) }
-    let(:report_option) { {} }
+    let(:report_option) do
+      { email: 'email@example.com', queries: [{ title: 'Example Query', query: 'limit 1' }] }
+    end
 
-    it 'reflects value provided from initializer' do
-      expect(report).to eq(report_option)
+    it 'builds struct value from given hash option' do
+      expect(report).to be_a(AbTest::ReportConfig)
+      expect(report.experiment_name).to eq('test')
+      expect(report.email).to eq('email@example.com')
+      expect(report.queries).to all be_a(AbTest::ReportQueryConfig)
+      expect(report.queries.first.title).to eq('Example Query')
+      expect(report.queries.first.query).to eq('limit 1')
+    end
+
+    context 'with blank options' do
+      let(:report_option) { {} }
+
+      it 'gracefully builds an empty struct value' do
+        expect(report).to be_a(AbTest::ReportConfig)
+        expect(report.experiment_name).to eq('test')
+        expect(report.email).to be_nil
+        expect(report.queries).to eq([])
+      end
     end
   end
 

--- a/spec/lib/reporting/ab_tests_report_spec.rb
+++ b/spec/lib/reporting/ab_tests_report_spec.rb
@@ -60,35 +60,4 @@ RSpec.describe Reporting::AbTestsReport do
       end
     end
   end
-
-  describe '#cloudwatch_client' do
-    subject(:cloudwatch_client) { report.cloudwatch_client }
-    let(:default_args) do
-      {
-        ensure_complete_logs: false,
-        logger: nil,
-        progress: false,
-      }
-    end
-
-    describe 'when all args are default' do
-      it 'creates a client with the default options' do
-        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
-
-        cloudwatch_client
-      end
-    end
-
-    describe 'when verbose is passed in' do
-      let(:options) { { verbose: true } }
-      let(:logger) { double(Logger) }
-
-      it 'creates a client with the expected logger' do
-        expect(Logger).to receive(:new).with(STDERR).and_return(logger)
-        expect(Reporting::CloudwatchClient).to receive(:new).with({ **default_args, logger: })
-
-        cloudwatch_client
-      end
-    end
-  end
 end

--- a/spec/lib/reporting/ab_tests_report_spec.rb
+++ b/spec/lib/reporting/ab_tests_report_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Reporting::AbTestsReport do
       {
         ensure_complete_logs: false,
         logger: nil,
+        progress: false,
       }
     end
 

--- a/spec/lib/reporting/ab_tests_report_spec.rb
+++ b/spec/lib/reporting/ab_tests_report_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reporting::AbTestsReport do
   subject(:report) do
     Reporting::AbTestsReport.new(
       queries: [
-        {
+        AbTest::ReportQueryConfig.new(
           title: 'Sign in success rate by CAPTCHA validation performed',
           query: <<~QUERY,
             fields properties.event_properties.captcha_validation_performed as `Captcha Validation Performed`
@@ -17,7 +17,7 @@ RSpec.describe Reporting::AbTestsReport do
             | sort `Captcha Validation Performed` asc
           QUERY
           row_labels: ['Validation Not Performed', 'Validation Performed'],
-        },
+        ),
       ],
       time_range:,
       **options,

--- a/spec/lib/reporting/ab_tests_report_spec.rb
+++ b/spec/lib/reporting/ab_tests_report_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+require 'reporting/ab_tests_report'
+
+RSpec.describe Reporting::AbTestsReport do
+  let(:time_range) { Date.new(2025, 1, 1).all_day }
+  let(:options) { {} }
+
+  subject(:report) do
+    Reporting::AbTestsReport.new(
+      queries: [
+        {
+          title: 'Sign in success rate by CAPTCHA validation performed',
+          query: <<~QUERY,
+            fields properties.event_properties.captcha_validation_performed as `Captcha Validation Performed`
+            | filter name = 'Email and Password Authentication'
+            | stats avg(properties.event_properties.success)*100 as `Success Percent` by `Captcha Validation Performed`
+            | sort `Captcha Validation Performed` asc
+          QUERY
+          row_labels: ['Validation Not Performed', 'Validation Performed'],
+        },
+      ],
+      time_range:,
+      **options,
+    )
+  end
+
+  before do
+    stub_cloudwatch_logs(
+      [
+        { 'Captcha Validation Performed' => '0', 'Success Percent' => '90.18501' },
+        { 'Captcha Validation Performed' => '1', 'Success Percent' => '85.68103' },
+      ],
+    )
+  end
+
+  describe '#as_tables' do
+    subject(:tables) { report.as_tables }
+
+    it 'generates the tabular data' do
+      expect(tables).to eq(
+        [
+          [
+            ['Captcha Validation Performed', 'Success Percent'],
+            ['Validation Not Performed', '90.19%'],
+            ['Validation Performed', '85.68%'],
+          ],
+        ],
+      )
+    end
+  end
+
+  describe '#as_emailable_reports' do
+    subject(:emailable_reports) { report.as_emailable_reports }
+
+    it 'adds a "first row" hash with a title for tables_report mailer' do
+      aggregate_failures do
+        emailable_reports.each do |emailable_report|
+          expect(emailable_report.title).to be_present
+        end
+      end
+    end
+  end
+
+  describe '#cloudwatch_client' do
+    subject(:cloudwatch_client) { report.cloudwatch_client }
+    let(:default_args) do
+      {
+        ensure_complete_logs: false,
+        logger: nil,
+      }
+    end
+
+    describe 'when all args are default' do
+      it 'creates a client with the default options' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        cloudwatch_client
+      end
+    end
+
+    describe 'when verbose is passed in' do
+      let(:options) { { verbose: true } }
+      let(:logger) { double(Logger) }
+
+      it 'creates a client with the expected logger' do
+        expect(Logger).to receive(:new).with(STDERR).and_return(logger)
+        expect(Reporting::CloudwatchClient).to receive(:new).with({ **default_args, logger: })
+
+        cloudwatch_client
+      end
+    end
+  end
+end

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -148,13 +148,13 @@ class ReportMailerPreview < ActionMailer::Preview
 
   def stub_cloudwatch_client(report, data: [])
     class << report
-      attr_accessor :data
+      attr_accessor :_stubbed_cloudwatch_data
 
       def cloudwatch_client
-        FakeCloudwatchClient.new(data: @data)
+        FakeCloudwatchClient.new(data: @_stubbed_cloudwatch_data)
       end
     end
-    report.data = data
+    report._stubbed_cloudwatch_data = data
     report
   end
 end

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -23,18 +23,20 @@ class ReportMailerPreview < ActionMailer::Preview
 
   def ab_tests_report
     report = Reports::AbTestsReport.new(Time.zone.now).ab_tests_report(
-      queries: [
-        {
-          title: 'Sign in success rate by CAPTCHA validation performed',
-          query: <<~QUERY,
-            fields properties.event_properties.captcha_validation_performed as `Captcha Validation Performed`
-            | filter name = 'Email and Password Authentication'
-            | stats avg(properties.event_properties.success)*100 as `Success Percent` by `Captcha Validation Performed`
-            | sort `Captcha Validation Performed` asc
-          QUERY
-          row_labels: ['Validation Not Performed', 'Validation Performed'],
-        },
-      ],
+      AbTest::ReportConfig.new(
+        queries: [
+          {
+            title: 'Sign in success rate by CAPTCHA validation performed',
+            query: <<~QUERY,
+              fields properties.event_properties.captcha_validation_performed as `Captcha Validation Performed`
+              | filter name = 'Email and Password Authentication'
+              | stats avg(properties.event_properties.success)*100 as `Success Percent` by `Captcha Validation Performed`
+              | sort `Captcha Validation Performed` asc
+            QUERY
+            row_labels: ['Validation Not Performed', 'Validation Performed'],
+          },
+        ],
+      ),
     )
 
     stub_cloudwatch_client(

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe ReportMailer, type: :mailer do
         ['Float', 'Int', 'Float'],
         ['Row 1', 1, 0.5],
         ['Row 2', 1, 1.5],
+        ['Row 2', 1, Float::NAN],
       ]
     end
 
@@ -124,6 +125,10 @@ RSpec.describe ReportMailer, type: :mailer do
       percent_float_outside_range_cell = percent_table.at_css('tbody tr:nth-child(2) td:last-child')
       expect(percent_float_outside_range_cell.text.strip).to eq('1.5')
       expect(percent_float_outside_range_cell['class']).to eq('table-number')
+
+      percent_float_nan_cell = percent_table.at_css('tbody tr:nth-child(3) td:last-child')
+      expect(percent_float_nan_cell.text.strip).to eq('NaN')
+      expect(percent_float_nan_cell['class']).to eq('table-number')
 
       float_cell = float_table.at_css('tbody tr:nth-child(1) td:last-child')
       expect(float_cell.text.strip).to eq('1.0')

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ReportMailer, type: :mailer do
         ['Float', 'Int', 'Float'],
         ['Row 1', 1, 0.5],
         ['Row 2', 1, 1.5],
-        ['Row 2', 1, Float::NAN],
+        ['Row 3', 1, Float::NAN],
       ]
     end
 

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -122,9 +122,9 @@ RSpec.describe ReportMailer, type: :mailer do
       expect(percent_cell.text.strip).to eq('50.00%')
       expect(percent_cell['class']).to eq('table-number')
 
-      percent_float_outside_range_cell = percent_table.at_css('tbody tr:nth-child(2) td:last-child')
-      expect(percent_float_outside_range_cell.text.strip).to eq('1.5')
-      expect(percent_float_outside_range_cell['class']).to eq('table-number')
+      percent_exceeding_100_cell = percent_table.at_css('tbody tr:nth-child(2) td:last-child')
+      expect(percent_exceeding_100_cell.text.strip).to eq('150.00%')
+      expect(percent_exceeding_100_cell['class']).to eq('table-number')
 
       percent_float_nan_cell = percent_table.at_css('tbody tr:nth-child(3) td:last-child')
       expect(percent_float_nan_cell.text.strip).to eq('NaN')

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -121,6 +121,10 @@ RSpec.describe ReportMailer, type: :mailer do
       expect(percent_cell.text.strip).to eq('50.00%')
       expect(percent_cell['class']).to eq('table-number')
 
+      percent_float_outside_range_cell = percent_table.at_css('tbody tr:nth-child(2) td:last-child')
+      expect(percent_float_outside_range_cell.text.strip).to eq('1.5')
+      expect(percent_float_outside_range_cell['class']).to eq('table-number')
+
       float_cell = float_table.at_css('tbody tr:nth-child(1) td:last-child')
       expect(float_cell.text.strip).to eq('1.0')
       expect(percent_cell['class']).to eq('table-number')


### PR DESCRIPTION
## 🎫 Ticket

[LG-15559](https://cm-jira.usa.gov/browse/LG-15559)

## 🛠 Summary of changes

Adds the ability to generate email reports for A/B test results to be sent to a team contact email on a regular basis.

This is intended to help:

- Ensure accountability to create queries ahead of an A/B test being active in production, to guarantee that we're able to produce usable analytics for the test
- Reduce manual engineer effort to actively monitor an A/B test after a few hours and on subsequent days of a test being active to make sure that the data being reported is in line with expected values
- Be able to report data directly to relevant stakeholders automatically without additional involvement from an engineer
- Improve visibility of ongoing A/B test progress to an entire team and other stakeholders

## 📜 Testing Plan

End-to-end testing is difficult, but you can verify that the report generates with expected tabular data with AWS-authenticated manual script execution.

Example:

```
$ aws-vault exec sandbox-readonly -- rails c
```

```rb
require 'reporting/ab_tests_report'
query = AbTest::ReportQueryConfig.new(
  title: 'Sign in success rate by mobile',
  query: "fields properties.browser_mobile as `Device` " \
         "| filter name = 'Email and Password Authentication' " \
         "| stats avg(properties.event_properties.success) as `Success Percent` by `Device` " \
         "| sort `Device`",
  row_labels: ['Mobile', 'Desktop'],
)
report = Reporting::AbTestsReport.new(
  queries: [query],
  time_range: Time.zone.now.yesterday..Time.zone.now,
)
report.send(:cloudwatch_client).instance_variable_set(:@log_group_name, 'int_/srv/idp/shared/log/events.log')
report.as_tables
# Example:
# [[["Device", "Success Percent"], ["Mobile", "0.80%"], ["Desktop", "0.60%"]]]
```

Observe:

- Returned fields as table columns
- Customizable row labels (first cell)
- Table columns including "percent" are formatted as percentages

Verify that running the job class's `perform` method does not produce any errors. There are currently on A/B tests configured to use this feature, so no queries should be expected to be run.

```
$ rails c
Reports::AbTestsReport.new.perform(Time.zone.now)
# []
```