### PR TITLE
LG-15665: Move ThreatMetrix to email registration page

### DIFF
--- a/app/controllers/concerns/mfa_setup_concern.rb
+++ b/app/controllers/concerns/mfa_setup_concern.rb
@@ -95,7 +95,7 @@ module MfaSetupConcern
     {
       user_id: current_user.id,
       request_ip: request&.remote_ip,
-      threatmetrix_session_id: user_session[:sign_up_threatmetrix_session_id],
+      threatmetrix_session_id: session[:sign_up_threatmetrix_session_id],
       email: current_user.last_sign_in_email_address.email,
       uuid_prefix: current_sp&.app_id,
     }

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -3,16 +3,21 @@
 module SignUp
   class RegistrationsController < ApplicationController
     include ApplicationHelper # for ial2_requested?
+    include ThreatMetrixHelper
+    include ThreatMetrixConcern
 
     before_action :confirm_two_factor_authenticated, only: [:destroy_confirm]
     before_action :require_no_authentication
     before_action :redirect_if_ial2_and_idv_unavailable
+    before_action :override_csp_for_threat_metrix,
+                  if: -> { FeatureManagement.account_creation_device_profiling_collecting_enabled? }
 
     CREATE_ACCOUNT = 'create_account'
 
     def new
       @register_user_email_form = RegisterUserEmailForm.new(analytics:)
       analytics.user_registration_enter_email_visit
+      render :new, locals: threatmetrix_variables
     end
 
     def create
@@ -25,7 +30,7 @@ module SignUp
       if result.success?
         process_successful_creation
       else
-        render :new
+        render :new, locals: threatmetrix_variables
       end
     end
 
@@ -61,6 +66,21 @@ module SignUp
       if ial2_requested? && !FeatureManagement.idv_available?
         redirect_to idv_unavailable_path(from: CREATE_ACCOUNT)
       end
+    end
+
+    def threatmetrix_variables
+      return {} unless FeatureManagement.account_creation_device_profiling_collecting_enabled?
+      session_id = generate_threatmetrix_session_id
+
+      {
+        threatmetrix_session_id: session_id,
+        threatmetrix_javascript_urls: threatmetrix_javascript_urls(session_id),
+        threatmetrix_iframe_url: threatmetrix_iframe_url(session_id),
+      }
+    end
+
+    def generate_threatmetrix_session_id
+      session[:sign_up_threatmetrix_session_id] ||= SecureRandom.uuid
     end
   end
 end

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -6,14 +6,10 @@ module Users
     include MfaSetupConcern
     include AbTestingConcern
     include ApplicationHelper
-    include ThreatMetrixHelper
-    include ThreatMetrixConcern
 
     before_action :authenticate_user
     before_action :confirm_user_authenticated_for_2fa_setup
     before_action :check_if_possible_piv_user
-    before_action :override_csp_for_threat_metrix,
-                  if: -> { FeatureManagement.account_creation_device_profiling_collecting_enabled? }
 
     delegate :enabled_mfa_methods_count, to: :mfa_context
 
@@ -24,7 +20,6 @@ module Users
         enabled_mfa_methods_count:,
         gov_or_mil_email: fed_or_mil_email?,
       )
-      render :index, locals: threatmetrix_variables
     end
 
     def create
@@ -38,7 +33,7 @@ module Users
       else
         flash.now[:error] = result.first_error_message
         @presenter = two_factor_options_presenter
-        render :index, locals: threatmetrix_variables
+        render :index
       end
     end
 
@@ -91,21 +86,6 @@ module Users
 
     def in_ab_test_bucket?
       ab_test_bucket(:DESKTOP_FT_UNLOCK_SETUP) == (:desktop_ft_unlock_option_shown)
-    end
-
-    def threatmetrix_variables
-      return {} unless FeatureManagement.account_creation_device_profiling_collecting_enabled?
-      session_id = generate_threatmetrix_session_id
-
-      {
-        threatmetrix_session_id: session_id,
-        threatmetrix_javascript_urls: threatmetrix_javascript_urls(session_id),
-        threatmetrix_iframe_url: threatmetrix_iframe_url(session_id),
-      }
-    end
-
-    def generate_threatmetrix_session_id
-      user_session[:sign_up_threatmetrix_session_id] ||= SecureRandom.uuid
     end
   end
 end

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -42,6 +42,15 @@
         required: true,
       ) %>
 
+  <% if FeatureManagement.account_creation_device_profiling_collecting_enabled? %>
+    <%= render partial: 'shared/threat_metrix_profiling',
+               locals: {
+                 threatmetrix_session_id:,
+                 threatmetrix_javascript_urls:,
+                 threatmetrix_iframe_url:,
+               } %>
+  <% end %>
+
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
 <% end %>
 

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -51,16 +51,6 @@
 
   <%= hidden_field_tag :platform_authenticator_available, id: 'platform_authenticator_available' %>
   <% javascript_packs_tag_once('platform-authenticator-available') %>
-  <% if FeatureManagement.account_creation_device_profiling_collecting_enabled? %>
-    <div class="margin-bottom-2">
-      <%= render partial: 'shared/threat_metrix_profiling',
-                 locals: {
-                   threatmetrix_session_id:,
-                   threatmetrix_javascript_urls:,
-                   threatmetrix_iframe_url:,
-                 } %>
-    </div>
-  <% end %>
 
   <%= f.submit t('forms.buttons.continue'), class: 'margin-bottom-1' %>
 <% end %>

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -27,52 +27,6 @@ RSpec.describe Users::TwoFactorAuthenticationSetupController do
       expect(assigns(:presenter).desktop_ft_ab_test).to be false
     end
 
-    context 'with threatmetrix disabled' do
-      before do
-        allow(FeatureManagement).to receive(:proofing_device_profiling_collecting_enabled?)
-          .and_return(false)
-      end
-
-      it 'does not override CSPs for ThreatMetrix' do
-        expect(controller).not_to receive(:override_csp_for_threat_metrix)
-
-        response
-      end
-    end
-
-    context 'with threatmetrix enabled' do
-      let(:tmx_session_id) { '1234' }
-
-      before do
-        allow(FeatureManagement).to receive(:account_creation_device_profiling_collecting_enabled?)
-          .and_return(true)
-        allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_org_id).and_return('org1')
-        allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_mock_enabled)
-          .and_return(false)
-        controller.user_session[:sign_up_threatmetrix_session_id] = tmx_session_id
-      end
-
-      it 'renders new valid request' do
-        tmx_url = 'https://h.online-metrix.net/fp'
-        expect(controller).to receive(:render).with(
-          :index,
-          locals: { threatmetrix_session_id: tmx_session_id,
-                    threatmetrix_javascript_urls:
-                      ["#{tmx_url}/tags.js?org_id=org1&session_id=#{tmx_session_id}"],
-                    threatmetrix_iframe_url:
-                      "#{tmx_url}/tags?org_id=org1&session_id=#{tmx_session_id}" },
-        ).and_call_original
-
-        expect(response).to render_template(:index)
-      end
-
-      it 'overrides CSPs for ThreatMetrix' do
-        expect(controller).to receive(:override_csp_for_threat_metrix)
-
-        response
-      end
-    end
-
     context 'with user having gov or mil email' do
       let!(:federal_domain) { create(:federal_email_domain, name: 'gsa.gov') }
       let(:user) do
@@ -242,34 +196,6 @@ RSpec.describe Users::TwoFactorAuthenticationSetupController do
       it 'renders setup page with error message' do
         expect(response).to render_template(:index)
         expect(flash[:error]).to eq(t('errors.messages.inclusion'))
-      end
-
-      context 'with threatmetrix enabled' do
-        let(:tmx_session_id) { '1234' }
-
-        before do
-          allow(FeatureManagement)
-            .to receive(:account_creation_device_profiling_collecting_enabled?)
-            .and_return(true)
-          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_org_id).and_return('org1')
-          allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_mock_enabled)
-            .and_return(false)
-          controller.user_session[:sign_up_threatmetrix_session_id] = tmx_session_id
-        end
-
-        it 'renders new with invalid request' do
-          tmx_url = 'https://h.online-metrix.net/fp'
-          expect(controller).to receive(:render).with(
-            :index,
-            locals: { threatmetrix_session_id: tmx_session_id,
-                      threatmetrix_javascript_urls:
-                        ["#{tmx_url}/tags.js?org_id=org1&session_id=#{tmx_session_id}"],
-                      threatmetrix_iframe_url:
-                        "#{tmx_url}/tags?org_id=org1&session_id=#{tmx_session_id}" },
-          ).and_call_original
-
-          expect(response).to render_template(:index)
-        end
       end
     end
 

--- a/spec/features/account_creation/threat_metrix_spec.rb
+++ b/spec/features/account_creation/threat_metrix_spec.rb
@@ -11,13 +11,13 @@ RSpec.feature 'ThreatMetrix in account creation', :js do
     click_on t('links.create_account')
     fill_in t('forms.registration.labels.email'), with: Faker::Internet.email
     check t('sign_up.terms', app_name: APP_NAME)
+    select 'Reject', from: :mock_profiling_result
     click_button t('forms.buttons.submit.default')
     user = confirm_last_user
     set_password(user)
     fake_analytics = FakeAnalytics.new
     expect_any_instance_of(AccountCreationThreatMetrixJob).to receive(:analytics).with(user)
       .and_return(fake_analytics)
-    select 'Reject', from: :mock_profiling_result
     select_2fa_option('backup_code')
     click_continue
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-15665](https://cm-jira.usa.gov/browse/LG-15665)

## 🛠 Summary of changes

Moves ThreatMetrix script from MFA selection screen to email registration screen.

This effectively reverts #11654, restoring original behavior from #11340

## 📜 Testing Plan

Repeat Testing Plan from #11340.

## 👀 Screenshots

With mock profiler enabled:

![image](https://github.com/user-attachments/assets/3fac7124-584c-463e-853d-be11c2c714e0)
