### PR TITLE
Reduce object allocations in identity verification

### DIFF
--- a/app/policies/idv/flow_policy.rb
+++ b/app/policies/idv/flow_policy.rb
@@ -5,6 +5,36 @@ module Idv
     attr_reader :idv_session, :user
 
     FINAL = :final
+    STEPS =
+      {
+        root: Idv::StepInfo.new(
+          key: :root,
+          controller: AccountsController,
+          next_steps: [:welcome, :request_letter],
+          preconditions: ->(idv_session:, user:) { true },
+          undo_step: ->(idv_session:, user:) { true },
+        ),
+        welcome: Idv::WelcomeController.step_info,
+        agreement: Idv::AgreementController.step_info,
+        how_to_verify: Idv::HowToVerifyController.step_info,
+        hybrid_handoff: Idv::HybridHandoffController.step_info,
+        link_sent: Idv::LinkSentController.step_info,
+        document_capture: Idv::DocumentCaptureController.step_info,
+        socure_document_capture: Idv::Socure::DocumentCaptureController.step_info,
+        socure_errors: Idv::Socure::ErrorsController.step_info,
+        ipp_address: Idv::InPerson::AddressController.step_info,
+        ssn: Idv::SsnController.step_info,
+        ipp_ssn: Idv::InPerson::SsnController.step_info,
+        verify_info: Idv::VerifyInfoController.step_info,
+        ipp_verify_info: Idv::InPerson::VerifyInfoController.step_info,
+        address: Idv::AddressController.step_info,
+        phone: Idv::PhoneController.step_info,
+        phone_errors: Idv::PhoneErrorsController.step_info,
+        otp_verification: Idv::OtpVerificationController.step_info,
+        request_letter: Idv::ByMail::RequestLetterController.step_info,
+        enter_password: Idv::EnterPasswordController.step_info,
+        personal_key: Idv::PersonalKeyController.step_info,
+      }.freeze
 
     def initialize(idv_session:, user:)
       @idv_session = idv_session
@@ -44,35 +74,7 @@ module Idv
     end
 
     def steps
-      {
-        root: Idv::StepInfo.new(
-          key: :root,
-          controller: AccountsController,
-          next_steps: [:welcome, :request_letter],
-          preconditions: ->(idv_session:, user:) { true },
-          undo_step: ->(idv_session:, user:) { true },
-        ),
-        welcome: Idv::WelcomeController.step_info,
-        agreement: Idv::AgreementController.step_info,
-        how_to_verify: Idv::HowToVerifyController.step_info,
-        hybrid_handoff: Idv::HybridHandoffController.step_info,
-        link_sent: Idv::LinkSentController.step_info,
-        document_capture: Idv::DocumentCaptureController.step_info,
-        socure_document_capture: Idv::Socure::DocumentCaptureController.step_info,
-        socure_errors: Idv::Socure::ErrorsController.step_info,
-        ipp_address: Idv::InPerson::AddressController.step_info,
-        ssn: Idv::SsnController.step_info,
-        ipp_ssn: Idv::InPerson::SsnController.step_info,
-        verify_info: Idv::VerifyInfoController.step_info,
-        ipp_verify_info: Idv::InPerson::VerifyInfoController.step_info,
-        address: Idv::AddressController.step_info,
-        phone: Idv::PhoneController.step_info,
-        phone_errors: Idv::PhoneErrorsController.step_info,
-        otp_verification: Idv::OtpVerificationController.step_info,
-        request_letter: Idv::ByMail::RequestLetterController.step_info,
-        enter_password: Idv::EnterPasswordController.step_info,
-        personal_key: Idv::PersonalKeyController.step_info,
-      }
+      STEPS
     end
 
     def step_allowed?(key:)

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -185,6 +185,7 @@ module DocAuth
       end
 
       def parse_uri
+        return nil if !uploaded_file || !uploaded_file.ascii_only?
         uri = URI.parse(uploaded_file.chomp)
         if uri.scheme == 'data'
           {}


### PR DESCRIPTION
## 🛠 Summary of changes

During load testing, these two spaces currently generate a lot of object allocations, particularly the `STEPS` element. It seemed safe to move this into a constant in that looks like it shouldn't change, but I am less familiar with this area of things. In an IdV-only load-test, the allocations saved here might be up to as much of 33% of the memory allocated.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
