### PR TITLE
LG-14933 Remove extra space from document capture form.

### DIFF
--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -313,12 +313,13 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
         {shownErrorMessage}
       </StatusMessage>
 
-      <span className={
-        successMessage === fileLoadingText || successMessage === fileLoadedText
-          ? 'usa-sr-only'
-          : undefined
-      }>
-
+      <span
+        className={
+          successMessage === fileLoadingText || successMessage === fileLoadedText
+            ? 'usa-sr-only'
+            : undefined
+        }
+      >
         <StatusMessage
           id={successId}
           status={Status.SUCCESS}
@@ -330,7 +331,7 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
         >
           {!shownErrorMessage && successMessage}
         </StatusMessage>
-      </span>        
+      </span>
 
       <div
         className={[

--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -315,7 +315,7 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
         status={Status.SUCCESS}
         className={
           successMessage === fileLoadingText || successMessage === fileLoadedText
-            ? 'usa-sr-only'
+            ? 'usa-sr-only display-none'
             : undefined
         }
       >
@@ -375,6 +375,7 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
           <div className="usa-file-input__box">
             {isValuePending && <SpinnerDots isCentered className="text-base" />}
           </div>
+
           <input
             ref={inputRef}
             id={inputId}

--- a/app/javascript/packages/document-capture/components/file-input.tsx
+++ b/app/javascript/packages/document-capture/components/file-input.tsx
@@ -224,6 +224,7 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
   );
   const isPendingValueReceived = useMemo(
     () => previousIsValuePending && !isValuePending && !!value,
+
     [value, isValuePending, previousIsValuePending],
   );
   const [ownErrorMessage, setOwnErrorMessage] = useState<string | null>(null);
@@ -307,20 +308,30 @@ function FileInput(props: FileInputProps, ref: ForwardedRef<any>) {
           {hint}
         </span>
       )}
+
       <StatusMessage status={Status.ERROR} id={errorId}>
         {shownErrorMessage}
       </StatusMessage>
-      <StatusMessage
-        id={successId}
-        status={Status.SUCCESS}
-        className={
-          successMessage === fileLoadingText || successMessage === fileLoadedText
-            ? 'usa-sr-only display-none'
-            : undefined
-        }
-      >
-        {!shownErrorMessage && successMessage}
-      </StatusMessage>
+
+      <span className={
+        successMessage === fileLoadingText || successMessage === fileLoadedText
+          ? 'usa-sr-only'
+          : undefined
+      }>
+
+        <StatusMessage
+          id={successId}
+          status={Status.SUCCESS}
+          className={
+            successMessage === fileLoadingText || successMessage === fileLoadedText
+              ? 'usa-sr-only'
+              : undefined
+          }
+        >
+          {!shownErrorMessage && successMessage}
+        </StatusMessage>
+      </span>        
+
       <div
         className={[
           'usa-file-input usa-file-input--single-value',


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-14933](https://cm-jira.usa.gov/browse/LG-14933)

## 🛠 Summary of changes

The document capture success message was not displayed, but was taking up space on the screen, which was not intended as part of the design.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Running locally, create an account and enter IdV
- [ ] When you reach document capture, capture or upload images for the front and back of your ID.
- [ ] Verify that the the extra space above the preview images is gone (see screenshots below for reference).

## 👀 Screenshots

<details>
<summary>Before:</summary>

![Screenshot 2025-02-05 at 10 51 31 AM](https://github.com/user-attachments/assets/cd5a0d5a-2a42-4023-8218-3818d3dc9b7c)

</details>

<details>
<summary>After:</summary>

![Screenshot 2025-02-05 at 2 33 09 PM](https://github.com/user-attachments/assets/f489e1f6-e6ba-4aa0-8b17-57e60b15bf01)

</details>
