### PR TITLE
Reduce allocations in AesEncryptor

### DIFF
--- a/spec/services/encryption/encryptors/aes_encryptor_spec.rb
+++ b/spec/services/encryption/encryptors/aes_encryptor_spec.rb
@@ -25,5 +25,22 @@ RSpec.describe Encryption::Encryptors::AesEncryptor do
 
       expect { subject.decrypt(encrypted, diff_cek) }.to raise_error Encryption::EncryptionError
     end
+
+    it 'raises EncryptionError if ciphertext is not Base64 encoded' do
+      expect { subject.decrypt('!', aes_cek) }.to raise_error(
+        Encryption::EncryptionError,
+        'ciphertext is invalid',
+      )
+    end
+
+    it 'raises EncryptionError if decrypted text is not Base64 encoded' do
+      cipher = Encryption::AesCipher.new
+      encrypted = cipher.encrypt("\x00", aes_cek)
+      encoded_encrypted = Base64.strict_encode64(encrypted)
+      expect { subject.decrypt(encoded_encrypted, aes_cek) }.to raise_error(
+        Encryption::EncryptionError,
+        'payload is invalid',
+      )
+    end
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Similar to #11841, though with a different approach to reducing memory usage. We currently check whether the layers of encoded/encrypted content can be Base64 decoded before attempting to Base64 decode it. This is mostly redundant, and we can use the exceptions for control flow as they are used currently.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
