### PR TITLE
LG-15672: Only redirect to select email screen if feature enabled

### DIFF
--- a/app/controllers/users/email_confirmations_controller.rb
+++ b/app/controllers/users/email_confirmations_controller.rb
@@ -41,7 +41,7 @@ module Users
       confirm_and_notify(email_address)
       if current_user
         flash[:success] = t('devise.confirmations.confirmed')
-        if params[:request_id]
+        if params[:request_id] && IdentityConfig.store.feature_select_email_to_share_enabled
           redirect_to sign_up_select_email_url
         else
           redirect_to account_url


### PR DESCRIPTION
## 🎫 Ticket

[LG-15672](https://cm-jira.usa.gov/browse/LG-15672)

## 🛠 Summary of changes

Fixes an issue where users may be redirected to the email selection experience even if the feature is disabled, resulting in a 404.

Related Slack thread: https://gsa-tts.slack.com/archives/C01710KMYUB/p1738779905418149

## 📜 Testing Plan

Test with and without `feature_select_email_to_share_enabled` enabled:

1. Have [sample application](https://github.com/18F/identity-oidc-sinatra) running in separate process
2. Go to http://localhost:9292
3. Click "Sign in"
4. Sign in or create an account
5. After returned to sample application, go to http://localhost:3000
6. Add email address from account dashboard
7. Confirm email address
8. Observe that:
   - If feature is disabled, you're redirected to account dashboard with email selected
   - If feature is enabled, you're redirected to email selection screen

Previously, this would always redirect to email selection screen regardless if feature is enabled.

Follow-up work should explore whether email selection screen is the correct place to redirect in this workflow. 