### PR TITLE
Omit errors from serialized form response if details present

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -78,8 +78,8 @@ module AnalyticsEvents
   # An account reset was cancelled
   def account_reset_cancel(
     success:,
-    errors:,
     user_id:,
+    errors: nil,
     error_details: nil,
     message_id: nil,
     request_id: nil,
@@ -100,13 +100,11 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name Account Reset
   # @param [String] user_id
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # Validates the token used for cancelling an account reset
   def account_reset_cancel_token_validation(
     user_id:,
     success:,
-    errors:,
     error_details: nil,
     **extra
   )
@@ -114,7 +112,6 @@ module AnalyticsEvents
       'Account Reset: cancel token validation',
       user_id:,
       success:,
-      errors:,
       error_details:,
       **extra,
     )
@@ -128,7 +125,6 @@ module AnalyticsEvents
   #   (rounded) or nil if the account was not confirmed
   # @param [Hash] mfa_method_counts Hash of MFA method with the number of that method on the account
   # @param [Boolean] identity_verified if the deletion occurs on a verified account
-  # @param [Hash] errors Errors resulting from form validation
   # @param [String, nil] profile_idv_level shows how verified the user is
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # An account has been deleted through the account reset flow
@@ -139,7 +135,6 @@ module AnalyticsEvents
     account_confirmed_at:,
     mfa_method_counts:,
     identity_verified:,
-    errors:,
     profile_idv_level: nil,
     error_details: nil,
     **extra
@@ -153,7 +148,6 @@ module AnalyticsEvents
       mfa_method_counts:,
       profile_idv_level:,
       identity_verified:,
-      errors:,
       error_details:,
       **extra,
     )
@@ -162,12 +156,10 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name Account Reset
   # @param [String] user_id
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # Validates the granted token for account reset
   def account_reset_granted_token_validation(
     success:,
-    errors:,
     error_details: nil,
     user_id: nil,
     **extra
@@ -175,7 +167,6 @@ module AnalyticsEvents
     track_event(
       'Account Reset: granted token validation',
       success:,
-      errors:,
       error_details:,
       user_id:,
       **extra,
@@ -240,7 +231,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] user_id User the email is linked to
   # @param [Boolean] from_select_email_flow Whether email was added as part of partner email
@@ -249,7 +239,6 @@ module AnalyticsEvents
   def add_email_confirmation(
     user_id:,
     success:,
-    errors:,
     from_select_email_flow:,
     error_details: nil,
     **extra
@@ -258,7 +247,6 @@ module AnalyticsEvents
       'Add Email: Email Confirmation',
       user_id:,
       success:,
-      errors:,
       error_details:,
       from_select_email_flow:,
       **extra,
@@ -266,7 +254,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] domain_name Domain name of email address submitted
   # @param [Boolean] in_select_email_flow Whether email is being added as part of partner email
@@ -274,7 +261,6 @@ module AnalyticsEvents
   # Tracks request for adding new emails to an account
   def add_email_request(
     success:,
-    errors:,
     domain_name:,
     in_select_email_flow:,
     error_details: nil,
@@ -283,7 +269,6 @@ module AnalyticsEvents
     track_event(
       'Add Email Requested',
       success:,
-      errors:,
       error_details:,
       domain_name:,
       in_select_email_flow:,
@@ -429,21 +414,18 @@ module AnalyticsEvents
   # @param [Hash] mfa_method_counts Hash of MFA method with the number of that method on the account
   # @param [Integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Boolean] in_account_creation_flow Whether page is visited as part of account creation
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   def backup_code_setup_visit(
     success:,
     mfa_method_counts:,
     enabled_mfa_methods_count:,
     in_account_creation_flow:,
-    errors:,
     error_details: nil,
     **extra
   )
     track_event(
       'Backup Code Setup Visited',
       success:,
-      errors:,
       error_details:,
       mfa_method_counts:,
       enabled_mfa_methods_count:,
@@ -579,28 +561,24 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # Tracks request for deletion of email address
-  def email_deletion_request(success:, errors:, error_details: nil, **extra)
+  def email_deletion_request(success:, error_details: nil, **extra)
     track_event(
       'Email Deletion Requested',
       success:,
-      errors:,
       error_details:,
       **extra,
     )
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # Tracks if Email Language is updated
-  def email_language_updated(success:, errors:, error_details: nil, **extra)
+  def email_language_updated(success:, error_details: nil, **extra)
     track_event(
       'Email Language: Updated',
       success:,
-      errors:,
       error_details:,
       **extra,
     )
@@ -669,7 +647,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Time, nil] event_created_at timestamp for the event
   # @param [Time, nil] disavowed_device_last_used_at
@@ -682,7 +659,6 @@ module AnalyticsEvents
   # Event disavowal password reset was performed
   def event_disavowal_password_reset(
     success:,
-    errors:,
     user_id:,
     error_details: nil,
     event_created_at: nil,
@@ -697,7 +673,6 @@ module AnalyticsEvents
     track_event(
       'Event disavowal password reset',
       success:,
-      errors:,
       error_details:,
       event_created_at:,
       disavowed_device_last_used_at:,
@@ -712,7 +687,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Time, nil] event_created_at timestamp for the event
   # @param [Time, nil] disavowed_device_last_used_at
@@ -724,7 +698,6 @@ module AnalyticsEvents
   # An invalid disavowal token was clicked
   def event_disavowal_token_invalid(
     success:,
-    errors:,
     error_details: nil,
     event_created_at: nil,
     disavowed_device_last_used_at: nil,
@@ -738,7 +711,6 @@ module AnalyticsEvents
     track_event(
       'Event disavowal token invalid',
       success:,
-      errors:,
       error_details:,
       event_created_at:,
       disavowed_device_last_used_at:,
@@ -919,12 +891,10 @@ module AnalyticsEvents
 
   # @param [Boolean] success Whether form validation was successful
   # @param [Boolean] address_edited
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # User submitted an idv address
   def idv_address_submitted(
     success:,
-    errors:,
     address_edited: nil,
     error_details: nil,
     **extra
@@ -932,7 +902,6 @@ module AnalyticsEvents
     track_event(
       'IdV: address submitted',
       success: success,
-      errors: errors,
       address_edited: address_edited,
       error_details: error_details,
       **extra,
@@ -1268,7 +1237,6 @@ module AnalyticsEvents
   # User has consented to share information with document upload and may
   # view the "hybrid handoff" step next unless "skip_hybrid_handoff" param is true
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
@@ -1278,7 +1246,6 @@ module AnalyticsEvents
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_agreement_submitted(
     success:,
-    errors:,
     step:,
     analytics_id:,
     opted_in_to_in_person_proofing: nil,
@@ -1290,7 +1257,6 @@ module AnalyticsEvents
     track_event(
       'IdV: doc auth agreement submitted',
       success:,
-      errors:,
       error_details:,
       step:,
       analytics_id:,
@@ -1521,7 +1487,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
@@ -1530,7 +1495,6 @@ module AnalyticsEvents
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_how_to_verify_submitted(
     success:,
-    errors:,
     step:,
     analytics_id:,
     skip_hybrid_handoff:,
@@ -1542,7 +1506,6 @@ module AnalyticsEvents
     track_event(
       :idv_doc_auth_how_to_verify_submitted,
       success:,
-      errors:,
       error_details:,
       step:,
       analytics_id:,
@@ -1787,7 +1750,6 @@ module AnalyticsEvents
   # User submits IdV Social Security number step
   # @identity.idp.previous_event_name IdV: in person proofing ssn submitted
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
@@ -1798,7 +1760,6 @@ module AnalyticsEvents
   # @param [Number] previous_ssn_edit_distance The edit distance to the previous submitted SSN
   def idv_doc_auth_ssn_submitted(
     success:,
-    errors:,
     step:,
     analytics_id:,
     flow_path:,
@@ -1812,7 +1773,6 @@ module AnalyticsEvents
     track_event(
       'IdV: doc auth ssn submitted',
       success:,
-      errors:,
       error_details:,
       step:,
       analytics_id:,
@@ -1858,7 +1818,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Integer] submit_attempts Times that user has tried submitting (previously called
   #   "attempts")
@@ -1874,7 +1833,6 @@ module AnalyticsEvents
   # The document capture image uploaded was locally validated during the IDV process
   def idv_doc_auth_submitted_image_upload_form(
     success:,
-    errors:,
     remaining_submit_attempts:,
     flow_path:,
     liveness_checking_required:,
@@ -1890,7 +1848,6 @@ module AnalyticsEvents
     track_event(
       'IdV: doc auth image upload form submitted',
       success:,
-      errors:,
       error_details:,
       submit_attempts:,
       remaining_submit_attempts:,
@@ -2085,7 +2042,6 @@ module AnalyticsEvents
   # The PII that came back from the document capture vendor was validated
   def idv_doc_auth_submitted_pii_validation(
     success:,
-    errors:,
     remaining_submit_attempts:,
     flow_path:,
     liveness_checking_required:,
@@ -2093,6 +2049,7 @@ module AnalyticsEvents
     id_issued_status:,
     id_expiration_status:,
     submit_attempts:,
+    errors: nil,
     error_details: nil,
     user_id: nil,
     front_image_fingerprint: nil,
@@ -3111,7 +3068,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] step Current IdV step
@@ -3121,7 +3077,6 @@ module AnalyticsEvents
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_in_person_proofing_residential_address_submitted(
     success:,
-    errors:,
     flow_path:,
     step:,
     analytics_id:,
@@ -3134,7 +3089,6 @@ module AnalyticsEvents
     track_event(
       'IdV: in person proofing residential address submitted',
       success:,
-      errors:,
       flow_path:,
       step:,
       analytics_id:,
@@ -3150,7 +3104,6 @@ module AnalyticsEvents
   # @param [String] step
   # @param [String] analytics_id
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # @param [String] birth_year Birth year from document
@@ -3159,7 +3112,6 @@ module AnalyticsEvents
   # User submitted state id
   def idv_in_person_proofing_state_id_submitted(
     success:,
-    errors:,
     flow_path:,
     step:,
     analytics_id:,
@@ -3176,7 +3128,6 @@ module AnalyticsEvents
       step:,
       analytics_id:,
       success:,
-      errors:,
       error_details:,
       birth_year:,
       document_zip_code:,
@@ -4168,7 +4119,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param ["sms", "voice"] otp_delivery_preference Channel used to send the message
   # @param [String] phone_type Pinpoint phone classification type
@@ -4193,7 +4143,6 @@ module AnalyticsEvents
   def idv_phone_confirmation_form_submitted(
     success:,
     otp_delivery_preference:,
-    errors:,
     phone_type:,
     types:,
     carrier:,
@@ -4211,7 +4160,6 @@ module AnalyticsEvents
     track_event(
       'IdV: phone confirmation form',
       success:,
-      errors:,
       error_details:,
       phone_type:,
       types:,
@@ -5328,7 +5276,6 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name Account verification submitted
   # @identity.idp.previous_event_name IdV: GPO verification submitted
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [DateTime] enqueued_at When was this letter enqueued
   # @param [Integer] which_letter Sorted by enqueue time, which letter had this code
@@ -5344,7 +5291,6 @@ module AnalyticsEvents
   # GPO verification submitted
   def idv_verify_by_mail_enter_code_submitted(
     success:,
-    errors:,
     enqueued_at:,
     which_letter:,
     letter_count:,
@@ -5359,7 +5305,6 @@ module AnalyticsEvents
     track_event(
       'IdV: enter verify by mail code submitted',
       success:,
-      errors:,
       error_details:,
       enqueued_at:,
       which_letter:,
@@ -5504,7 +5449,6 @@ module AnalyticsEvents
   # @param [Boolean] sp_initiated
   # @param [Boolean] oidc
   # @param [Boolean] saml_request_valid
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] method
   # Logout Initiated
@@ -5516,7 +5460,6 @@ module AnalyticsEvents
     client_id_parameter_present: nil,
     id_token_hint_parameter_present: nil,
     saml_request_valid: nil,
-    errors: nil,
     error_details: nil,
     method: nil,
     **extra
@@ -5527,7 +5470,6 @@ module AnalyticsEvents
       client_id: client_id,
       client_id_parameter_present: client_id_parameter_present,
       id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
       error_details: error_details,
       sp_initiated: sp_initiated,
       oidc: oidc,
@@ -5829,14 +5771,12 @@ module AnalyticsEvents
 
   # Multi factor selected from auth options list
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] selection
   # @param [integer] enabled_mfa_methods_count Number of enabled MFA methods on the account
   # @param [Hash] mfa_method_counts Hash of MFA method with the number of that method on the account
   def multi_factor_auth_option_list(
     success:,
-    errors:,
     selection:,
     enabled_mfa_methods_count:,
     mfa_method_counts:,
@@ -5846,7 +5786,6 @@ module AnalyticsEvents
     track_event(
       'Multi-Factor Authentication: option list',
       success:,
-      errors:,
       error_details:,
       selection:,
       enabled_mfa_methods_count:,
@@ -5862,7 +5801,6 @@ module AnalyticsEvents
 
   # Multi factor auth phone setup
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param ["sms", "voice"] otp_delivery_preference Channel used to send the message
   # @param [String] area_code
@@ -5872,7 +5810,6 @@ module AnalyticsEvents
   # @param [Array<String>] types Phonelib parsed phone types
   def multi_factor_auth_phone_setup(
       success:,
-      errors:,
       otp_delivery_preference:,
       area_code:,
       carrier:,
@@ -5885,7 +5822,6 @@ module AnalyticsEvents
     track_event(
       'Multi-Factor Authentication: phone setup',
       success:,
-      errors:,
       error_details:,
       otp_delivery_preference:,
       area_code:,
@@ -5999,14 +5935,12 @@ module AnalyticsEvents
   # @param [Boolean] sp_initiated
   # @param [Boolean] oidc
   # @param [Boolean] saml_request_valid
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] method
   # @param [String] original_method Method of referring request
   # OIDC Logout Requested
   def oidc_logout_requested(
     success:,
-    errors:,
     error_details: nil,
     client_id: nil,
     sp_initiated: nil,
@@ -6024,7 +5958,6 @@ module AnalyticsEvents
       client_id: client_id,
       client_id_parameter_present: client_id_parameter_present,
       id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
       error_details: error_details,
       sp_initiated: sp_initiated,
       oidc: oidc,
@@ -6042,7 +5975,6 @@ module AnalyticsEvents
   # @param [Boolean] sp_initiated
   # @param [Boolean] oidc
   # @param [Boolean] saml_request_valid
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] method
   # OIDC Logout Submitted
@@ -6054,7 +5986,6 @@ module AnalyticsEvents
     client_id_parameter_present: nil,
     id_token_hint_parameter_present: nil,
     saml_request_valid: nil,
-    errors: nil,
     error_details: nil,
     method: nil,
     **extra
@@ -6065,7 +5996,6 @@ module AnalyticsEvents
       client_id: client_id,
       client_id_parameter_present: client_id_parameter_present,
       id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
       error_details: error_details,
       sp_initiated: sp_initiated,
       oidc: oidc,
@@ -6082,13 +6012,11 @@ module AnalyticsEvents
   # @param [Boolean] sp_initiated
   # @param [Boolean] oidc
   # @param [Boolean] saml_request_valid
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] method
   # OIDC Logout Visited
   def oidc_logout_visited(
     success:,
-    errors:,
     client_id: nil,
     sp_initiated: nil,
     oidc: nil,
@@ -6105,7 +6033,6 @@ module AnalyticsEvents
       client_id: client_id,
       client_id_parameter_present: client_id_parameter_present,
       id_token_hint_parameter_present: id_token_hint_parameter_present,
-      errors: errors,
       error_details: error_details,
       sp_initiated: sp_initiated,
       oidc: oidc,
@@ -6141,15 +6068,13 @@ module AnalyticsEvents
   # @param [Boolean] success Whether form validation was successful
   # @param [Integer] ial
   # @param [String] client_id Service Provider issuer
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  def openid_connect_bearer_token(success:, ial:, client_id:, errors:, error_details: nil, **extra)
+  def openid_connect_bearer_token(success:, ial:, client_id:, error_details: nil, **extra)
     track_event(
       'OpenID Connect: bearer token authentication',
       success:,
       ial:,
       client_id:,
-      errors:,
       error_details:,
       **extra,
     )
@@ -6157,7 +6082,6 @@ module AnalyticsEvents
 
   # Tracks when openid authorization request is made
   # @param [Boolean] success Whether form validations were succcessful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] prompt OIDC prompt parameter
   # @param [Boolean] allow_prompt_login Whether service provider is configured to allow prompt=login
@@ -6174,7 +6098,6 @@ module AnalyticsEvents
   # @param [String] unknown_authn_contexts space separated list of unknown contexts
   def openid_connect_request_authorization(
     success:,
-    errors:,
     prompt:,
     allow_prompt_login:,
     code_challenge_present:,
@@ -6194,7 +6117,6 @@ module AnalyticsEvents
     track_event(
       'OpenID Connect: authorization request',
       success:,
-      errors:,
       error_details:,
       prompt:,
       allow_prompt_login:,
@@ -6215,7 +6137,6 @@ module AnalyticsEvents
 
   # Tracks when an openid connect token request is made
   # @param [Boolean] success Whether the form was submitted successfully.
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] client_id Service provider issuer
   # @param [String] user_id User ID associated with code
@@ -6228,7 +6149,6 @@ module AnalyticsEvents
   def openid_connect_token(
     client_id:,
     success:,
-    errors:,
     user_id:,
     code_digest:,
     expires_in:,
@@ -6241,7 +6161,6 @@ module AnalyticsEvents
     track_event(
       'OpenID Connect: token',
       success:,
-      errors:,
       error_details:,
       client_id:,
       user_id:,
@@ -6256,7 +6175,6 @@ module AnalyticsEvents
 
   # Tracks when user makes an otp delivery selection
   # @param [Boolean] success Whether the form was submitted successfully.
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param ["authentication","reauthentication","confirmation"] context User session context
   # @param ["sms", "voice"] otp_delivery_preference Channel used to send the message
@@ -6265,7 +6183,6 @@ module AnalyticsEvents
   # @param [String] area_code Area code of phone number
   def otp_delivery_selection(
     success:,
-    errors:,
     context:,
     otp_delivery_preference:,
     resend:,
@@ -6277,7 +6194,6 @@ module AnalyticsEvents
     track_event(
       'OTP: Delivery Selection',
       success:,
-      errors:,
       error_details:,
       context:,
       otp_delivery_preference:,
@@ -6306,7 +6222,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Boolean] active_profile_present Whether active profile existed at time of change
   # @param [Boolean] pending_profile_present Whether pending profile existed at time of change
@@ -6315,7 +6230,6 @@ module AnalyticsEvents
   # The user updated their password
   def password_changed(
     success:,
-    errors:,
     active_profile_present:,
     pending_profile_present:,
     required_password_change:,
@@ -6325,7 +6239,6 @@ module AnalyticsEvents
     track_event(
       'Password Changed',
       success:,
-      errors:,
       error_details:,
       active_profile_present:,
       pending_profile_present:,
@@ -6335,14 +6248,12 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] user_id UUID of the user
   # @param [Boolean] request_id_present Whether request_id URL parameter is present
   # The user added a password after verifying their email for account creation
   def password_creation(
     success:,
-    errors:,
     user_id:,
     request_id_present:,
     error_details: nil,
@@ -6351,7 +6262,6 @@ module AnalyticsEvents
     track_event(
       'Password Creation',
       success:,
-      errors:,
       error_details:,
       user_id:,
       request_id_present:,
@@ -6365,7 +6275,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Boolean, nil] confirmed if the account the reset is being requested for has a
   #   confirmed email
   # @param [Boolean, nil] active_profile if the account the reset is being requested for has an
@@ -6374,7 +6283,6 @@ module AnalyticsEvents
   # The user entered an email address to request a password reset
   def password_reset_email(
     success:,
-    errors:,
     confirmed:,
     active_profile:,
     error_details: nil,
@@ -6383,7 +6291,6 @@ module AnalyticsEvents
     track_event(
       'Password Reset: Email Submitted',
       success:,
-      errors:,
       error_details:,
       confirmed:,
       active_profile:,
@@ -6392,7 +6299,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Boolean] profile_deactivated if the active profile for the account was deactivated
   #   (the user will need to use their personal key to reactivate their profile)
   # @param [Boolean] pending_profile_invalidated Whether a pending profile was invalidated as a
@@ -6403,7 +6309,6 @@ module AnalyticsEvents
   # The user changed the password for their account via the password reset flow
   def password_reset_password(
     success:,
-    errors:,
     profile_deactivated:,
     pending_profile_invalidated:,
     pending_profile_pending_reasons:,
@@ -6413,7 +6318,6 @@ module AnalyticsEvents
     track_event(
       'Password Reset: Password Submitted',
       success:,
-      errors:,
       error_details:,
       profile_deactivated:,
       pending_profile_invalidated:,
@@ -6423,15 +6327,13 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] user_id UUID of the user to receive password token
   # A password token has been sent for user
-  def password_reset_token(success:, errors:, user_id:, error_details: nil, **extra)
+  def password_reset_token(success:, user_id:, error_details: nil, **extra)
     track_event(
       'Password Reset: Token Submitted',
       success:,
-      errors:,
       error_details:,
       user_id:,
       **extra,
@@ -6485,19 +6387,16 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # Personal key form submitted
   def personal_key_reactivation_submitted(
     success:,
-    errors:,
     error_details: nil,
     **extra
   )
     track_event(
       'Personal key reactivation: Personal key form submitted',
       success:,
-      errors:,
       error_details:,
       **extra,
     )
@@ -6519,7 +6418,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] delivery_preference
   # @param [Integer] phone_configuration_id
@@ -6527,7 +6425,6 @@ module AnalyticsEvents
   # User has submitted a change in phone number
   def phone_change_submitted(
     success:,
-    errors:,
     delivery_preference:,
     phone_configuration_id:,
     make_default_number:,
@@ -6537,7 +6434,6 @@ module AnalyticsEvents
     track_event(
       'Phone Number Change: Form submitted',
       success:,
-      errors:,
       error_details:,
       delivery_preference:,
       phone_configuration_id:,
@@ -6981,13 +6877,11 @@ module AnalyticsEvents
 
   # Tracks when rules of use is submitted with a success or failure
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  def rules_of_use_submitted(success:, errors:, error_details: nil, **extra)
+  def rules_of_use_submitted(success:, error_details: nil, **extra)
     track_event(
       'Rules of Use Submitted',
       success:,
-      errors:,
       error_details:,
       **extra,
     )
@@ -7000,7 +6894,6 @@ module AnalyticsEvents
 
   # Record SAML authentication payload Hash
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] nameid_format The NameID format sent in the response
   # @param [String] requested_nameid_format The NameID format requested
@@ -7019,7 +6912,6 @@ module AnalyticsEvents
   # @param [String] unknown_authn_contexts space separated list of unknown contexts
   def saml_auth(
     success:,
-    errors:,
     nameid_format:,
     requested_nameid_format:,
     authn_context:,
@@ -7039,7 +6931,6 @@ module AnalyticsEvents
     track_event(
       'SAML Auth',
       success:,
-      errors:,
       error_details:,
       nameid_format:,
       requested_nameid_format:,
@@ -7115,7 +7006,6 @@ module AnalyticsEvents
   # Tracks when security event is received
   # @param [Boolean] success Whether form validation was successful
   # @param [String] error_code
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] jti
   # @param [String] user_id
@@ -7123,7 +7013,6 @@ module AnalyticsEvents
   # @param [String] event_type
   def security_event_received(
     success:,
-    errors:,
     event_type:,
     error_code: nil,
     error_details: nil,
@@ -7135,7 +7024,6 @@ module AnalyticsEvents
     track_event(
       'RISC: Security event received',
       success:,
-      errors:,
       error_details:,
       event_type:,
       error_code:,
@@ -7449,7 +7337,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Integer] enabled_mfa_methods_count
   # @param [Integer] selected_mfa_count
@@ -7457,7 +7344,6 @@ module AnalyticsEvents
   # Tracks when the the user has selected and submitted MFA auth methods on user registration
   def user_registration_2fa_setup(
     success:,
-    errors:,
     error_details: nil,
     selected_mfa_count: nil,
     enabled_mfa_methods_count: nil,
@@ -7467,7 +7353,6 @@ module AnalyticsEvents
     track_event(
       'User Registration: 2FA Setup',
       success:,
-      errors:,
       error_details:,
       selected_mfa_count:,
       enabled_mfa_methods_count:,
@@ -7584,7 +7469,6 @@ module AnalyticsEvents
   # Tracks when user submits registration email
   # @param [Boolean] success Whether form validation was successful
   # @param [Boolean] rate_limited Whether form submission was prevented by rate-limiting
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String] user_id ID of user associated with existing user, or current user
   # @param [Boolean] email_already_exists Whether an account with the email address already exists
@@ -7593,7 +7477,6 @@ module AnalyticsEvents
   def user_registration_email(
     success:,
     rate_limited:,
-    errors:,
     user_id:,
     email_already_exists:,
     domain_name:,
@@ -7605,7 +7488,6 @@ module AnalyticsEvents
       'User Registration: Email Submitted',
       success:,
       rate_limited:,
-      errors:,
       error_details:,
       user_id:,
       email_already_exists:,
@@ -7622,7 +7504,7 @@ module AnalyticsEvents
   # @param [String] user_id
   def user_registration_email_confirmation(
     success:,
-    errors:,
+    errors: nil,
     error_details: nil,
     user_id: nil,
     **extra

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -19,7 +19,7 @@ class FormResponse
 
   def to_h
     hash = { success: success }
-    hash[:errors] = (!defined?(@error_details) && errors).presence if !serialize_error_details_only?
+    hash[:errors] = errors.presence if !defined?(@error_details) && !serialize_error_details_only?
     hash[:error_details] = flatten_details(error_details) if error_details.present?
     hash.merge!(extra)
     hash

--- a/spec/forms/add_user_email_form_spec.rb
+++ b/spec/forms/add_user_email_form_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe AddUserEmailForm do
     it 'returns a successful result' do
       expect(submit.to_h).to eq(
         success: true,
-        errors: nil,
         domain_name: 'example.com',
         in_select_email_flow: false,
         user_id: user.uuid,
@@ -109,7 +108,6 @@ RSpec.describe AddUserEmailForm do
       it 'includes extra analytics in result for flow value' do
         expect(submit.to_h).to eq(
           success: true,
-          errors: nil,
           domain_name: 'example.com',
           in_select_email_flow: true,
           user_id: user.uuid,

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
       it 'is successful' do
         expect(result.to_h).to eq(
           success: true,
-          errors: nil,
           client_id: client_id,
           prompt: 'select_account',
           allow_prompt_login: true,
@@ -66,7 +65,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
         it 'is unsuccessful and has error messages' do
           expect(result.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: { response_type: { inclusion: true } },
             client_id: client_id,
             prompt: 'select_account',

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -376,7 +376,6 @@ RSpec.describe OpenidConnectTokenForm do
 
         expect(submission.to_h).to eq(
           success: true,
-          errors: nil,
           client_id: client_id,
           user_id: user.uuid,
           code_digest: Digest::SHA256.hexdigest(code),
@@ -396,7 +395,6 @@ RSpec.describe OpenidConnectTokenForm do
 
         expect(submission.to_h).to include(
           success: false,
-          errors: nil,
           error_details: hash_including(*form.errors.attribute_names),
           client_id: nil,
           user_id: nil,
@@ -413,7 +411,6 @@ RSpec.describe OpenidConnectTokenForm do
 
         expect(submission.to_h).to include(
           success: false,
-          errors: nil,
           error_details: hash_including(:grant_type),
           client_id: client_id,
           user_id: user.uuid,

--- a/spec/forms/otp_delivery_selection_form_spec.rb
+++ b/spec/forms/otp_delivery_selection_form_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe OtpDeliverySelectionForm do
 
         expect(subject.submit(otp_delivery_preference: 'sms', resend: 'true').to_h).to eq(
           success: true,
-          errors: nil,
           **extra,
         )
       end
@@ -57,7 +56,6 @@ RSpec.describe OtpDeliverySelectionForm do
 
         expect(subject.submit(otp_delivery_preference: 'foo').to_h).to include(
           success: false,
-          errors: nil,
           error_details: {
             otp_delivery_preference: { inclusion: true },
             phone: { blank: true },

--- a/spec/forms/password_form_spec.rb
+++ b/spec/forms/password_form_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe PasswordForm, type: :model do
       let(:expected_response) do
         {
           success: true,
-          errors: nil,
           user_id: user.uuid,
           request_id_present: true,
         }
@@ -134,7 +133,6 @@ RSpec.describe PasswordForm, type: :model do
         let(:expected_response) do
           {
             success: true,
-            errors: nil,
             user_id: user.uuid,
             request_id_present: true,
           }

--- a/spec/forms/password_reset_email_form_spec.rb
+++ b/spec/forms/password_reset_email_form_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe PasswordResetEmailForm do
 
         expect(subject.submit.to_h).to eq(
           success: true,
-          errors: nil,
           user_id: user.uuid,
           confirmed: true,
           active_profile: false,
@@ -27,7 +26,6 @@ RSpec.describe PasswordResetEmailForm do
       it 'returns hash with properties about the event and the nonexistent user' do
         expect(subject.submit.to_h).to eq(
           success: true,
-          errors: nil,
           user_id: 'nonexistent-uuid',
           confirmed: false,
           active_profile: false,
@@ -41,7 +39,6 @@ RSpec.describe PasswordResetEmailForm do
 
         expect(subject.submit.to_h).to include(
           success: false,
-          errors: nil,
           error_details: { email: { invalid: true } },
           user_id: 'nonexistent-uuid',
           confirmed: false,
@@ -54,7 +51,6 @@ RSpec.describe PasswordResetEmailForm do
 
         expect(subject.submit.to_h).to include(
           success: false,
-          errors: nil,
           error_details: { email: { domain: true } },
           user_id: 'nonexistent-uuid',
           confirmed: false,

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe PersonalKeyForm do
 
         expect(form.submit.to_h).to eq(
           success: true,
-          errors: nil,
         )
         expect(user.reload.encrypted_recovery_code_digest).to eq old_code
       end
@@ -26,7 +25,6 @@ RSpec.describe PersonalKeyForm do
 
         expect(form.submit.to_h).to include(
           success: false,
-          errors: nil,
           error_details: { personal_key: { personal_key_incorrect: true } },
         )
         expect(user.encrypted_recovery_code_digest).to_not be_nil

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe RegisterUserEmailForm do
       end
 
       it 'sets success to true to prevent revealing account existence' do
-        expect(subject.submit(params).to_h).to eq(success: true, errors: nil, **extra_params)
+        expect(subject.submit(params).to_h).to eq(success: true, **extra_params)
         expect(subject.email).to eq registered_email_address
         expect_delivered_email_count(1)
         expect_delivered_email(
@@ -168,7 +168,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(result).to eq(
           success: true,
-          errors: nil,
           **extra_params,
         )
       end
@@ -246,7 +245,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(submit_form.to_h).to eq(
           success: true,
-          errors: nil,
           **extra,
         )
       end
@@ -290,7 +288,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(subject.submit(email: invalid_email, terms_accepted: '1').to_h).to include(
           success: false,
-          errors: nil,
           error_details: { email: { invalid: true } },
           **extra,
         )
@@ -307,7 +304,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(subject.submit(email: 'test@çà.com', terms_accepted: '1').to_h).to include(
           success: false,
-          errors: nil,
           error_details: { email: { domain: true } },
           **extra,
         )
@@ -329,7 +325,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(subject.submit(email: blocked_email, terms_accepted: '1').to_h).to include(
           success: false,
-          errors: nil,
           error_details: { email: { t('valid_email.validations.email.invalid') => true } },
           **extra,
         )
@@ -344,7 +339,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(subject.submit(email: blocked_email, terms_accepted: '1').to_h).to include(
           success: false,
-          errors: nil,
           error_details: { email: { t('valid_email.validations.email.invalid') => true } },
           email_already_exists: false,
           rate_limited: false,
@@ -365,7 +359,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(result.to_h).to eq(
           success: true,
-          errors: nil,
           email_already_exists: false,
           rate_limited: false,
           user_id: User.find_with_email(email).uuid,
@@ -384,7 +377,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(result.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { terms_accepted: { terms: true } },
           email_already_exists: false,
           rate_limited: false,
@@ -437,7 +429,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(submit_form.to_h).to eq(
           success: true,
-          errors: nil,
           **extra,
         )
 
@@ -465,7 +456,6 @@ RSpec.describe RegisterUserEmailForm do
 
         expect(submit_form.to_h).to eq(
           success: true,
-          errors: nil,
           **extra,
         )
       end

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe ResetPasswordForm, type: :model do
         it 'returns a hash with errors' do
           expect(result.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: { reset_password_token: { token_expired: true } },
             user_id: '123',
             profile_deactivated: false,
@@ -53,7 +52,6 @@ RSpec.describe ResetPasswordForm, type: :model do
         it 'returns a hash with errors' do
           expect(result.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: {
               password: { too_short: true },
               password_confirmation: { too_short: true },
@@ -76,7 +74,6 @@ RSpec.describe ResetPasswordForm, type: :model do
 
           expect(result.to_h).to eq(
             success: true,
-            errors: nil,
             user_id: '123',
             profile_deactivated: false,
             pending_profile_invalidated: false,
@@ -95,7 +92,6 @@ RSpec.describe ResetPasswordForm, type: :model do
         it 'returns a hash with errors' do
           expect(result.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: {
               password: { too_short: true },
               password_confirmation: { too_short: true },
@@ -115,7 +111,6 @@ RSpec.describe ResetPasswordForm, type: :model do
         it 'returns a hash with errors' do
           expect(result.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: { reset_password_token: { invalid_token: true } },
             user_id: nil,
             profile_deactivated: false,
@@ -270,7 +265,6 @@ RSpec.describe ResetPasswordForm, type: :model do
         it 'returns a hash with errors' do
           expect(result.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: { reset_password_token: { token_expired: true } },
             user_id: '123',
             profile_deactivated: false,
@@ -290,7 +284,6 @@ RSpec.describe ResetPasswordForm, type: :model do
         it 'returns a hash with errors' do
           expect(result.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: {
               password: { too_short: true },
               password_confirmation: { too_short: true },
@@ -313,7 +306,6 @@ RSpec.describe ResetPasswordForm, type: :model do
 
           expect(result.to_h).to eq(
             success: true,
-            errors: nil,
             user_id: '123',
             profile_deactivated: false,
             pending_profile_invalidated: false,
@@ -332,7 +324,6 @@ RSpec.describe ResetPasswordForm, type: :model do
         it 'returns a hash with errors' do
           expect(result.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: {
               password: { too_short: true },
               password_confirmation: { too_short: true },
@@ -352,7 +343,6 @@ RSpec.describe ResetPasswordForm, type: :model do
         it 'returns a hash with errors' do
           expect(result.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: { reset_password_token: { invalid_token: true } },
             user_id: nil,
             profile_deactivated: false,

--- a/spec/forms/totp_setup_form_spec.rb
+++ b/spec/forms/totp_setup_form_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe TotpSetupForm do
 
         expect(form.submit.to_h).to eq(
           success: true,
-          errors: nil,
           **extra,
         )
         expect(user.auth_app_configurations.any?).to eq true
@@ -45,7 +44,6 @@ RSpec.describe TotpSetupForm do
 
         expect(form.submit.to_h).to include(
           success: false,
-          errors: nil,
           **extra,
         )
         expect(user.auth_app_configurations.any?).to eq false
@@ -65,7 +63,6 @@ RSpec.describe TotpSetupForm do
 
         expect(form.submit.to_h).to include(
           success: false,
-          errors: nil,
           **extra,
         )
         expect(user.auth_app_configurations.any?).to eq false
@@ -80,7 +77,6 @@ RSpec.describe TotpSetupForm do
 
         expect(form.submit.to_h).to include(
           success: false,
-          errors: nil,
           error_details: { name: { blank: true } },
         )
         expect(user.auth_app_configurations.any?).to eq false
@@ -95,7 +91,6 @@ RSpec.describe TotpSetupForm do
 
         expect(form2.submit.to_h).to include(
           success: false,
-          errors: nil,
           error_details: { name: { unique_name: true } },
         )
       end

--- a/spec/forms/two_factor_login_options_form_spec.rb
+++ b/spec/forms/two_factor_login_options_form_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe TwoFactorLoginOptionsForm do
 
         expect(subject.submit(selection: 'sms').to_h).to eq(
           success: true,
-          errors: nil,
           **extra,
         )
       end
@@ -36,7 +35,6 @@ RSpec.describe TwoFactorLoginOptionsForm do
 
         expect(subject.submit(selection: 'foo').to_h).to include(
           success: false,
-          errors: nil,
           error_details: { selection: { inclusion: true } },
           **extra,
         )

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
 
         expect(result).to include(
           success: false,
-          errors: nil,
           error_details: hash_including(:password, :password_confirmation),
         )
       end
@@ -42,7 +41,6 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
       it 'returns FormResponse with success: true' do
         expect(subject.submit(params).to_h).to eq(
           success: true,
-          errors: nil,
           active_profile_present: false,
           pending_profile_present: false,
           user_id: user.uuid,

--- a/spec/forms/webauthn_setup_form_spec.rb
+++ b/spec/forms/webauthn_setup_form_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe WebauthnSetupForm do
 
           expect(result.to_h).to eq(
             success: true,
-            errors: nil,
             transports: ['usb'],
             transports_mismatch: false,
             **extra_attributes,
@@ -158,7 +157,6 @@ RSpec.describe WebauthnSetupForm do
         it 'includes unknown transports in extra analytics' do
           expect(result.to_h).to eq(
             success: true,
-            errors: nil,
             enabled_mfa_methods_count: 1,
             mfa_method_counts: { webauthn: 1 },
             multi_factor_auth_method: 'webauthn',
@@ -203,7 +201,6 @@ RSpec.describe WebauthnSetupForm do
 
         expect(result.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { attestation_object: { invalid: true } },
           transports: ['usb'],
           transports_mismatch: false,
@@ -250,7 +247,6 @@ RSpec.describe WebauthnSetupForm do
 
         expect(result.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { attestation_object: { invalid: true } },
           transports: ['usb'],
           transports_mismatch: false,
@@ -265,7 +261,6 @@ RSpec.describe WebauthnSetupForm do
       it 'returns setup as mismatched type' do
         expect(result.to_h).to eq(
           success: true,
-          errors: nil,
           enabled_mfa_methods_count: 1,
           mfa_method_counts: { webauthn_platform: 1 },
           multi_factor_auth_method: 'webauthn_platform',

--- a/spec/forms/webauthn_visit_form_spec.rb
+++ b/spec/forms/webauthn_visit_form_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe WebauthnVisitForm do
 
       expect(subject.submit(params).to_h).to eq(
         success: true,
-        errors: nil,
         platform_authenticator: false,
         enabled_mfa_methods_count: 0,
       )
@@ -34,7 +33,6 @@ RSpec.describe WebauthnVisitForm do
 
         expect(subject.submit(params).to_h).to eq(
           success: true,
-          errors: nil,
           platform_authenticator: true,
           enabled_mfa_methods_count: 0,
         )
@@ -47,7 +45,6 @@ RSpec.describe WebauthnVisitForm do
 
         expect(subject.submit(params).to_h).to include(
           success: false,
-          errors: nil,
           error_details: { InvalidStateError: { invalid: true } },
         )
       end
@@ -57,7 +54,6 @@ RSpec.describe WebauthnVisitForm do
 
         expect(subject.submit(params).to_h).to include(
           success: false,
-          errors: nil,
           error_details: { NotSupportedError: { invalid: true } },
         )
       end
@@ -77,7 +73,6 @@ RSpec.describe WebauthnVisitForm do
 
           expect(subject.submit(params).to_h).to include(
             success: false,
-            errors: nil,
             error_details: { InvalidStateError: { invalid: true } },
           )
         end
@@ -87,7 +82,6 @@ RSpec.describe WebauthnVisitForm do
 
           expect(subject.submit(params).to_h).to include(
             success: false,
-            errors: nil,
             error_details: { NotSupportedError: { invalid: true } },
           )
         end
@@ -97,7 +91,6 @@ RSpec.describe WebauthnVisitForm do
 
           expect(subject.submit(params).to_h).to include(
             success: false,
-            errors: nil,
             error_details: { foo: { invalid: true } },
           )
         end
@@ -111,7 +104,6 @@ RSpec.describe WebauthnVisitForm do
 
             expect(subject.submit(params).to_h).to include(
               success: false,
-              errors: nil,
               error_details: { foo: { invalid: true } },
             )
           end

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe FormResponse do
     end
 
     context 'when errors is an ActiveModel::Errors' do
-      it 'returns a hash with success, errors, and error_details keys' do
+      it 'returns a hash with success and error_details keys' do
         errors = ActiveModel::Errors.new(build_stubbed(:user))
         errors.add(:email_language, :blank, message: 'Language cannot be blank')
         response = FormResponse.new(success: false, errors: errors)
@@ -220,7 +220,7 @@ RSpec.describe FormResponse do
       end
 
       context 'with error detail symbol defined as type option on error' do
-        it 'returns a hash with success, errors, and error_details keys' do
+        it 'returns a hash with success and error_details keys' do
           errors = ActiveModel::Errors.new(build_stubbed(:user))
           errors.add(:email_language, 'Language cannot be blank', type: :blank)
           response = FormResponse.new(success: false, errors: errors)

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -179,7 +179,6 @@ RSpec.describe FormResponse do
         response = FormResponse.new(success: false, errors: errors)
         response_hash = {
           success: false,
-          errors: nil,
           error_details: {
             email_language: { blank: true },
           },
@@ -195,7 +194,6 @@ RSpec.describe FormResponse do
           response = FormResponse.new(success: false, errors: errors)
           response_hash = {
             success: false,
-            errors: nil,
             error_details: {
               email_language: { blank: true },
             },
@@ -236,7 +234,6 @@ RSpec.describe FormResponse do
           response = FormResponse.new(success: false, errors: errors)
           response_hash = {
             success: false,
-            errors: nil,
             error_details: {
               email_language: { blank: true },
             },

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -206,12 +206,8 @@ RSpec.describe FormResponse do
       it 'omits details if errors are empty' do
         errors = ActiveModel::Errors.new(build_stubbed(:user))
         response = FormResponse.new(success: true, errors: errors)
-        response_hash = {
-          success: true,
-          errors: nil,
-        }
 
-        expect(response.to_h).to eq response_hash
+        expect(response.to_h).to eq(success: true)
       end
 
       it 'omits details if merged errors are empty' do
@@ -219,12 +215,8 @@ RSpec.describe FormResponse do
         response1 = FormResponse.new(success: true, errors: errors)
         response2 = FormResponse.new(success: true, errors: errors)
         combined_response = response1.merge(response2)
-        response_hash = {
-          success: true,
-          errors: nil,
-        }
 
-        expect(combined_response.to_h).to eq response_hash
+        expect(combined_response.to_h).to eq(success: true)
       end
 
       context 'with error detail symbol defined as type option on error' do

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -41,11 +41,7 @@ RSpec.describe SamlRequestValidator do
       ].each do |ial_value|
         let(:authn_context) { [ial_value] }
         it 'returns FormResponse with success: true' do
-          expect(response.to_h).to include(
-            success: true,
-            errors: nil,
-            **extra,
-          )
+          expect(response.to_h).to eq(success: true, **extra)
         end
       end
 
@@ -58,7 +54,6 @@ RSpec.describe SamlRequestValidator do
           it 'returns an error' do
             expect(response.to_h).to include(
               success: false,
-              errors: nil,
               error_details: { service_provider: { no_cert_registered: true } },
             )
           end
@@ -66,11 +61,7 @@ RSpec.describe SamlRequestValidator do
 
         context 'when block encryption is not turned on' do
           it 'is valid' do
-            expect(response.to_h).to include(
-              success: true,
-              errors: nil,
-              **extra,
-            )
+            expect(response.to_h).to eq(success: true, **extra)
           end
         end
       end
@@ -83,11 +74,7 @@ RSpec.describe SamlRequestValidator do
         end
 
         it 'returns FormResponse with success: true' do
-          expect(response.to_h).to include(
-            success: true,
-            errors: nil,
-            **extra,
-          )
+          expect(response.to_h).to eq(success: true, **extra)
         end
       end
     end
@@ -95,11 +82,7 @@ RSpec.describe SamlRequestValidator do
     context 'no authn context and valid sp and authorized nameID format' do
       let(:authn_context) { [] }
       it 'returns FormResponse with success: true' do
-        expect(response.to_h).to include(
-          success: true,
-          errors: nil,
-          **extra,
-        )
+        expect(response.to_h).to eq(success: true, **extra)
       end
     end
 
@@ -107,9 +90,8 @@ RSpec.describe SamlRequestValidator do
       let(:sp) { ServiceProvider.find_by(issuer: 'foo') }
 
       it 'returns FormResponse with success: false' do
-        expect(response.to_h).to include(
+        expect(response.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { service_provider: { unauthorized_service_provider: true } },
           **extra,
         )
@@ -120,9 +102,8 @@ RSpec.describe SamlRequestValidator do
       let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL }
 
       it 'returns FormResponse with success: false' do
-        expect(response.to_h).to include(
+        expect(response.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { nameid_format: { unauthorized_nameid_format: true } },
           **extra,
         )
@@ -136,11 +117,7 @@ RSpec.describe SamlRequestValidator do
       before { sp.update!(email_nameid_format_allowed: true) }
 
       it 'returns FormResponse with success: true' do
-        expect(response.to_h).to include(
-          success: true,
-          errors: nil,
-          **extra,
-        )
+        expect(response.to_h).to eq(success: true, **extra)
       end
 
       context 'ial2 authn context and ial2 sp' do
@@ -149,11 +126,7 @@ RSpec.describe SamlRequestValidator do
         before { sp.update!(ial: 2) }
 
         it 'returns FormResponse with success: true for ial2 on ial:2 sp' do
-          expect(response.to_h).to include(
-            success: true,
-            errors: nil,
-            **extra,
-          )
+          expect(response.to_h).to eq(success: true, **extra)
         end
       end
     end
@@ -170,11 +143,7 @@ RSpec.describe SamlRequestValidator do
             nameid_format: name_id_format,
           )
 
-          expect(response.to_h).to include(
-            success: true,
-            errors: nil,
-            **extra,
-          )
+          expect(response.to_h).to eq(success: true, **extra)
         end
       end
 
@@ -189,11 +158,7 @@ RSpec.describe SamlRequestValidator do
             nameid_format: name_id_format,
           )
 
-          expect(response.to_h).to include(
-            success: true,
-            errors: nil,
-            **extra,
-          )
+          expect(response.to_h).to eq(success: true, **extra)
         end
       end
     end
@@ -202,9 +167,8 @@ RSpec.describe SamlRequestValidator do
       Saml::Idp::Constants::PASSWORD_AUTHN_CONTEXT_CLASSREFS.each do |password_context|
         let(:authn_context) { [password_context] }
         it 'returns FormResponse with success: false for unknown authn context' do
-          expect(response.to_h).to include(
+          expect(response.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: { authn_context: { unauthorized_authn_context: true } },
             **extra,
           )
@@ -217,9 +181,8 @@ RSpec.describe SamlRequestValidator do
         let(:authn_context) { ['IAL1'] }
 
         it 'returns FormResponse with success: false' do
-          expect(response.to_h).to include(
+          expect(response.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: { authn_context: { unauthorized_authn_context: true } },
             **extra,
           )
@@ -229,11 +192,7 @@ RSpec.describe SamlRequestValidator do
           let(:authn_context) { ['IAL1', Saml::Idp::Constants::IAL_AUTH_ONLY_ACR] }
 
           it 'returns FormResponse with success: true' do
-            expect(response.to_h).to include(
-              success: true,
-              errors: nil,
-              **extra,
-            )
+            expect(response.to_h).to eq(success: true, **extra)
           end
         end
       end
@@ -246,9 +205,8 @@ RSpec.describe SamlRequestValidator do
           let(:authn_context) { [ial_value] }
 
           it 'returns FormResponse with success: false' do
-            expect(response.to_h).to include(
+            expect(response.to_h).to eq(
               success: false,
-              errors: nil,
               error_details: { authn_context: { unauthorized_authn_context: true } },
               **extra,
             )
@@ -260,9 +218,8 @@ RSpec.describe SamlRequestValidator do
         let(:authn_context) { [Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF] }
 
         it 'returns FormResponse with success: false' do
-          expect(response.to_h).to include(
+          expect(response.to_h).to eq(
             success: false,
-            errors: nil,
             error_details: { authn_context: { unauthorized_authn_context: true } },
             **extra,
           )
@@ -281,11 +238,7 @@ RSpec.describe SamlRequestValidator do
             end
 
             it 'returns a successful response' do
-              expect(response.to_h).to include(
-                success: true,
-                errors: nil,
-                **extra,
-              )
+              expect(response.to_h).to eq(success: true, **extra)
             end
           end
 
@@ -296,9 +249,8 @@ RSpec.describe SamlRequestValidator do
             end
 
             it 'fails with an unauthorized error' do
-              expect(response.to_h).to include(
+              expect(response.to_h).to eq(
                 success: false,
-                errors: nil,
                 error_details: { authn_context: { unauthorized_authn_context: true } },
                 **extra,
               )
@@ -329,11 +281,7 @@ RSpec.describe SamlRequestValidator do
             end
 
             it 'returns a successful response' do
-              expect(response.to_h).to include(
-                success: true,
-                errors: nil,
-                **extra,
-              )
+              expect(response.to_h).to eq(success: true, **extra)
             end
           end
         end
@@ -351,9 +299,8 @@ RSpec.describe SamlRequestValidator do
       let(:authn_context) { ['IAL1'] }
 
       it 'returns FormResponse with success: false' do
-        expect(response.to_h).to include(
+        expect(response.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: {
             authn_context: { unauthorized_authn_context: true },
             service_provider: { unauthorized_service_provider: true },
@@ -367,9 +314,8 @@ RSpec.describe SamlRequestValidator do
       let(:name_id_format) { Saml::Idp::Constants::NAME_ID_FORMAT_EMAIL }
 
       it 'returns FormResponse with success: false with unauthorized nameid format' do
-        expect(response.to_h).to include(
+        expect(response.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { nameid_format: { unauthorized_nameid_format: true } },
           **extra,
         )
@@ -380,11 +326,7 @@ RSpec.describe SamlRequestValidator do
       let(:authn_context) { ['C1'] }
 
       it 'returns FormResponse with success true' do
-        expect(response.to_h).to include(
-          success: true,
-          errors: nil,
-          **extra,
-        )
+        expect(response.to_h).to eq(success: true, **extra)
       end
     end
 
@@ -394,11 +336,7 @@ RSpec.describe SamlRequestValidator do
       before { sp.update!(ial: 2) }
 
       it 'returns FormResponse with success true' do
-        expect(response.to_h).to include(
-          success: true,
-          errors: nil,
-          **extra,
-        )
+        expect(response.to_h).to eq(success: true, **extra)
       end
     end
 
@@ -408,9 +346,8 @@ RSpec.describe SamlRequestValidator do
       before { sp.update!(ial: 1) }
 
       it 'returns FormResponse with success false' do
-        expect(response.to_h).to include(
+        expect(response.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { authn_context: { unauthorized_authn_context: true } },
           **extra,
         )
@@ -423,9 +360,8 @@ RSpec.describe SamlRequestValidator do
       before { sp.update!(ial: 1) }
 
       it 'returns FormResponse with success false' do
-        expect(response.to_h).to include(
+        expect(response.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { authn_context: { unauthorized_authn_context: true } },
           **extra,
         )
@@ -437,9 +373,8 @@ RSpec.describe SamlRequestValidator do
       let(:authn_context) { ['C1'] }
 
       it 'returns FormResponse with success false' do
-        expect(response.to_h).to include(
+        expect(response.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { authn_context: { unauthorized_authn_context: true } },
           **extra,
         )
@@ -450,9 +385,8 @@ RSpec.describe SamlRequestValidator do
       let(:authn_context) { ['Fa.Ke.Va.Lu.E0'] }
 
       it 'returns FormResponse with success false' do
-        expect(response.to_h).to include(
+        expect(response.to_h).to eq(
           success: false,
-          errors: nil,
           error_details: { authn_context: { unauthorized_authn_context: true } },
           **extra,
         )


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `FormResponse#to_h` to avoid including `errors` in the serialized hash if `error_details` is present.

This is a continuation (cleanup) of #11810, which effectively omitted `errors` from analytics logging, but continued to assign the value as `nil`. The changes here avoid assigning the value altogether.

Related: https://github.com/18F/identity-idp/pull/11810#discussion_r1932673815

## 📜 Testing Plan

Verify build passes.