### PR TITLE
Update FormResponse error detail serialization as default behavior

### DIFF
--- a/app/forms/backup_code_verification_form.rb
+++ b/app/forms/backup_code_verification_form.rb
@@ -24,7 +24,6 @@ class BackupCodeVerificationForm
       success: valid?,
       errors:,
       extra: extra_analytics_attributes,
-      serialize_error_details_only: true,
     )
   end
 

--- a/app/forms/frontend_error_form.rb
+++ b/app/forms/frontend_error_form.rb
@@ -13,7 +13,7 @@ class FrontendErrorForm
     @filename = filename
     @error_id = error_id
 
-    FormResponse.new(success: valid?, errors:, serialize_error_details_only: true)
+    FormResponse.new(success: valid?, errors:)
   end
 
   private

--- a/app/forms/otp_verification_form.rb
+++ b/app/forms/otp_verification_form.rb
@@ -25,7 +25,6 @@ class OtpVerificationForm
       success: success,
       errors: errors,
       extra: extra_analytics_attributes,
-      serialize_error_details_only: true,
     )
   end
 

--- a/app/forms/recaptcha_form.rb
+++ b/app/forms/recaptcha_form.rb
@@ -54,11 +54,11 @@ class RecaptchaForm
     @recaptcha_result = recaptcha_result if recaptcha_token.present? && !exempt?
 
     log_analytics(result: @recaptcha_result) if @recaptcha_result
-    response = FormResponse.new(success: valid?, errors:, serialize_error_details_only: true)
+    response = FormResponse.new(success: valid?, errors:)
     [response, @recaptcha_result&.assessment_id]
   rescue Faraday::Error => error
     log_analytics(error:)
-    response = FormResponse.new(success: true, serialize_error_details_only: true)
+    response = FormResponse.new(success: true)
     [response, nil]
   end
 

--- a/app/forms/select_email_form.rb
+++ b/app/forms/select_email_form.rb
@@ -26,7 +26,6 @@ class SelectEmailForm
       success:,
       errors:,
       extra: extra_analytics_attributes,
-      serialize_error_details_only: true,
     )
   end
 

--- a/app/forms/sign_in_recaptcha_form.rb
+++ b/app/forms/sign_in_recaptcha_form.rb
@@ -28,7 +28,7 @@ class SignInRecaptchaForm
     @recaptcha_token = recaptcha_token
 
     success = valid?
-    FormResponse.new(success:, errors:, serialize_error_details_only: true)
+    FormResponse.new(success:, errors:)
   end
 
   def exempt?

--- a/app/forms/two_factor_authentication/auth_app_delete_form.rb
+++ b/app/forms/two_factor_authentication/auth_app_delete_form.rb
@@ -24,7 +24,6 @@ module TwoFactorAuthentication
         success:,
         errors:,
         extra: extra_analytics_attributes,
-        serialize_error_details_only: true,
       )
     end
 

--- a/app/forms/two_factor_authentication/auth_app_update_form.rb
+++ b/app/forms/two_factor_authentication/auth_app_update_form.rb
@@ -30,7 +30,6 @@ module TwoFactorAuthentication
         success:,
         errors:,
         extra: extra_analytics_attributes,
-        serialize_error_details_only: true,
       )
     end
 

--- a/app/forms/two_factor_authentication/piv_cac_delete_form.rb
+++ b/app/forms/two_factor_authentication/piv_cac_delete_form.rb
@@ -24,7 +24,6 @@ module TwoFactorAuthentication
         success:,
         errors:,
         extra: extra_analytics_attributes,
-        serialize_error_details_only: true,
       )
     end
 

--- a/app/forms/two_factor_authentication/piv_cac_update_form.rb
+++ b/app/forms/two_factor_authentication/piv_cac_update_form.rb
@@ -30,7 +30,6 @@ module TwoFactorAuthentication
         success:,
         errors:,
         extra: extra_analytics_attributes,
-        serialize_error_details_only: true,
       )
     end
 

--- a/app/forms/two_factor_authentication/webauthn_delete_form.rb
+++ b/app/forms/two_factor_authentication/webauthn_delete_form.rb
@@ -27,7 +27,6 @@ module TwoFactorAuthentication
         success:,
         errors:,
         extra: extra_analytics_attributes,
-        serialize_error_details_only: true,
       )
     end
 

--- a/app/forms/two_factor_authentication/webauthn_update_form.rb
+++ b/app/forms/two_factor_authentication/webauthn_update_form.rb
@@ -30,7 +30,6 @@ module TwoFactorAuthentication
         success:,
         errors:,
         extra: extra_analytics_attributes,
-        serialize_error_details_only: true,
       )
     end
 

--- a/app/forms/webauthn_verification_form.rb
+++ b/app/forms/webauthn_verification_form.rb
@@ -56,7 +56,6 @@ class WebauthnVerificationForm
       success: success,
       errors: errors,
       extra: extra_analytics_attributes,
-      serialize_error_details_only: true,
     )
   end
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -187,7 +187,6 @@ module AnalyticsEvents
 
   # @identity.idp.previous_event_name Account Reset
   # @param [Boolean] success
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Boolean] sms_phone does the user have a phone factor configured?
   # @param [Boolean] totp does the user have an authentication app as a 2FA option?
   # @param [Boolean] piv_cac does the user have PIV/CAC as a 2FA option?
@@ -197,7 +196,6 @@ module AnalyticsEvents
   # An account reset has been requested
   def account_reset_request(
     success:,
-    errors:,
     sms_phone:,
     totp:,
     piv_cac:,
@@ -209,7 +207,6 @@ module AnalyticsEvents
     track_event(
       'Account Reset: request',
       success:,
-      errors:,
       sms_phone:,
       totp:,
       piv_cac:,
@@ -604,7 +601,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Time, nil] event_created_at timestamp for the event
   # @param [Time, nil] disavowed_device_last_used_at
@@ -617,7 +613,6 @@ module AnalyticsEvents
   # Tracks disavowed event
   def event_disavowal(
     success:,
-    errors:,
     user_id:,
     error_details: nil,
     event_created_at: nil,
@@ -632,7 +627,6 @@ module AnalyticsEvents
     track_event(
       'Event disavowal visited',
       success:,
-      errors:,
       error_details:,
       event_created_at:,
       disavowed_device_last_used_at:,
@@ -1369,12 +1363,12 @@ module AnalyticsEvents
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_document_capture_submitted(
     success:,
-    errors:,
     step:,
     analytics_id:,
     liveness_checking_required:,
     selfie_check_required:,
     flow_path:,
+    errors: nil,
     opted_in_to_in_person_proofing: nil,
     acuant_sdk_upgrade_ab_test_bucket: nil,
     redo_document_capture: nil,
@@ -4256,7 +4250,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param ["sms", "voice"] otp_delivery_preference Channel used to send the message
   # @param [String] country_code Abbreviated 2-letter country code associated with phone number
@@ -4278,7 +4271,6 @@ module AnalyticsEvents
   # The user resent an OTP during the IDV phone step
   def idv_phone_confirmation_otp_resent(
     success:,
-    errors:,
     otp_delivery_preference:,
     country_code:,
     area_code:,
@@ -4295,7 +4287,6 @@ module AnalyticsEvents
     track_event(
       'IdV: phone confirmation otp resent',
       success:,
-      errors:,
       error_details:,
       otp_delivery_preference:,
       country_code:,
@@ -4312,7 +4303,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param ["sms", "voice"] otp_delivery_preference Channel used to send the message
   # @param [String] country_code Abbreviated 2-letter country code associated with phone number
@@ -4334,7 +4324,6 @@ module AnalyticsEvents
   # The user requested an OTP to confirm their phone during the IDV phone step
   def idv_phone_confirmation_otp_sent(
     success:,
-    errors:,
     otp_delivery_preference:,
     country_code:,
     area_code:,
@@ -4351,7 +4340,6 @@ module AnalyticsEvents
     track_event(
       'IdV: phone confirmation otp sent',
       success:,
-      errors:,
       error_details:,
       otp_delivery_preference:,
       country_code:,
@@ -4368,7 +4356,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Boolean] code_expired if the one-time code expired
   # @param [Boolean] code_matches
@@ -4391,7 +4378,6 @@ module AnalyticsEvents
   # When a user attempts to confirm possession of a new phone number during the IDV process
   def idv_phone_confirmation_otp_submitted(
     success:,
-    errors:,
     code_expired:,
     code_matches:,
     otp_delivery_preference:,
@@ -4409,7 +4395,6 @@ module AnalyticsEvents
     track_event(
       'IdV: phone confirmation otp submitted',
       success:,
-      errors:,
       error_details:,
       code_expired:,
       code_matches:,
@@ -6356,7 +6341,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Integer] emails Number of email addresses the notification was sent to
   # @param [Array<String>] sms_message_ids AWS Pinpoint SMS message IDs for each phone number that
@@ -6364,7 +6348,6 @@ module AnalyticsEvents
   # Alert user if a personal key was used to sign in
   def personal_key_alert_about_sign_in(
     success:,
-    errors:,
     emails:,
     sms_message_ids:,
     error_details: nil,
@@ -6373,7 +6356,6 @@ module AnalyticsEvents
     track_event(
       'Personal key: Alert user about sign in',
       success:,
-      errors:,
       error_details:,
       emails:,
       sms_message_ids:,
@@ -6610,7 +6592,6 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [Integer] emails Number of email addresses the notification was sent to
   # @param [Array<String>] sms_message_ids AWS Pinpoint SMS message IDs for each phone number that
@@ -6619,7 +6600,6 @@ module AnalyticsEvents
   # were sent to phone numbers and email addresses for the user
   def profile_personal_key_create_notifications(
     success:,
-    errors:,
     emails:,
     sms_message_ids:,
     error_details: nil,
@@ -6628,7 +6608,6 @@ module AnalyticsEvents
     track_event(
       'Profile: Created new personal key notifications',
       success:,
-      errors:,
       error_details:,
       emails:,
       sms_message_ids:,

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
 class FormResponse
-  attr_reader :errors, :extra, :serialize_error_details_only
+  attr_reader :errors, :extra
 
-  alias_method :serialize_error_details_only?, :serialize_error_details_only
-
-  def initialize(success:, errors: {}, extra: {}, serialize_error_details_only: false)
+  def initialize(success:, errors: nil, extra: {})
     @success = success
-    @errors = errors.is_a?(ActiveModel::Errors) ? errors.messages.to_hash : errors
-    @error_details = errors.details if errors.is_a?(ActiveModel::Errors)
+    @errors = errors.is_a?(ActiveModel::Errors) ? errors.messages.to_hash : errors.to_h
+    @error_details = errors&.details if !errors.is_a?(Hash)
     @extra = extra
-    @serialize_error_details_only = serialize_error_details_only
   end
 
   def success?
@@ -19,7 +16,7 @@ class FormResponse
 
   def to_h
     hash = { success: success }
-    hash[:errors] = errors.presence if !defined?(@error_details) && !serialize_error_details_only?
+    hash[:errors] = errors.presence if !defined?(@error_details)
     hash[:error_details] = flatten_details(error_details) if error_details.present?
     hash.merge!(extra)
     hash

--- a/spec/forms/totp_verification_form_spec.rb
+++ b/spec/forms/totp_verification_form_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe TotpVerificationForm do
 
         expect(form.submit.to_h).to eq(
           success: true,
-          errors: nil,
           auth_app_configuration_id: cfg.id,
           multi_factor_auth_method_created_at: cfg.created_at.strftime('%s%L'),
         )
@@ -30,7 +29,6 @@ RSpec.describe TotpVerificationForm do
 
         expect(form.submit.to_h).to eq(
           success: false,
-          errors: nil,
           auth_app_configuration_id: nil,
           multi_factor_auth_method_created_at: nil,
         )
@@ -48,7 +46,6 @@ RSpec.describe TotpVerificationForm do
 
           expect(form.submit.to_h).to eq(
             success: false,
-            errors: nil,
             auth_app_configuration_id: nil,
             multi_factor_auth_method_created_at: nil,
           )

--- a/spec/services/form_response_spec.rb
+++ b/spec/services/form_response_spec.rb
@@ -143,6 +143,14 @@ RSpec.describe FormResponse do
   end
 
   describe '#to_h' do
+    context 'when errors is default value' do
+      it 'returns a hash with success key' do
+        response = FormResponse.new(success: true)
+
+        expect(response.to_h).to eq(success: true)
+      end
+    end
+
     context 'when the extra argument is nil' do
       it 'returns a hash with success and errors keys' do
         errors = { foo: 'bar' }
@@ -234,25 +242,6 @@ RSpec.describe FormResponse do
           expect(response.to_h).to eq response_hash
         end
       end
-
-      context 'with serialize_error_details_only' do
-        it 'excludes errors from the hash' do
-          errors = ActiveModel::Errors.new(build_stubbed(:user))
-          errors.add(:email_language, :blank, message: 'Language cannot be blank')
-          response = FormResponse.new(
-            success: false,
-            errors: errors,
-            serialize_error_details_only: true,
-          )
-
-          expect(response.to_h).to eq(
-            success: false,
-            error_details: {
-              email_language: { blank: true },
-            },
-          )
-        end
-      end
     end
   end
 
@@ -260,7 +249,7 @@ RSpec.describe FormResponse do
     it 'allows for splatting response as alias of #to_h' do
       errors = ActiveModel::Errors.new(build_stubbed(:user))
       errors.add(:email_language, :blank, message: 'Language cannot be blank')
-      response = FormResponse.new(success: false, errors:, serialize_error_details_only: true)
+      response = FormResponse.new(success: false, errors:)
 
       expect(**response).to eq(
         success: false,


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `FormResponse` to remove the `serialize_error_details_only`, which is now already treated as the baseline behavior. Additionally, it inverts the assumed default usage of `FormResponse` from hash-based `errors` to `ActiveModel::Errors`-based errors when creating an instance without any errors, resulting in a few more instances where `errors` is omitted from the resulting serialized hash.

This continues from #11846, and should be the last piece of work in the primary migration away from `errors` to `error_details` for typical `FormResponse` usage with `ActiveModel::Errors` (not hash) form validation.

## 📜 Testing Plan

Verify build passes.