### PR TITLE
Remove frequently unnecessary hash allocation

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -380,7 +380,7 @@ module Idv
     end
 
     def session
-      user_session.fetch(:idv, {})
+      user_session[:idv] || {}
     end
 
     def build_profile_maker(user_password)


### PR DESCRIPTION
## 🛠 Summary of changes

Sort of a continuation of #11841 and #11844, this PR removes a frequently unnecessary hash allocation. `#fetch(key, default)` will always instantiate the default even if the key exists. The behavior is not identical in that a `nil` value in the hash will be returned if it is there and this will fall through and return the empty hash. We should never be storing `nil` here as we use [delete](https://github.com/18F/identity-idp/blob/e2452fb9f1f210ff3e197fa66eb4d50846e18f2f/app/services/idv/session.rb#L188) when clearing the session value.

We could alternatively use the block form `#fetch(key) { |key| ... }` as a "lazy" instantiation of the hash, but it didn't feel necessary in this case.

The pattern of a default empty hash value appears in other places in the codebase, but `session` is called quite frequently and seems to contribute much more significantly.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
