### PR TITLE
LG-15216 Handle password reset for in-person enrollments waiting for fraud review

### DIFF
--- a/app/controllers/concerns/fraud_review_concern.rb
+++ b/app/controllers/concerns/fraud_review_concern.rb
@@ -32,7 +32,7 @@ module FraudReviewConcern
   # bypassing the typical flow of showing the Please Call or Fraud Rejection screens.
   def in_person_prevent_fraud_redirection?
     IdentityConfig.store.in_person_proofing_enforce_tmx &&
-      current_user.ipp_enrollment_status_not_passed? &&
+      current_user.ipp_enrollment_status_not_passed_or_in_fraud_review? &&
       (fraud_review_pending? || fraud_rejection?)
   end
 

--- a/app/controllers/concerns/verify_profile_concern.rb
+++ b/app/controllers/concerns/verify_profile_concern.rb
@@ -27,7 +27,7 @@ module VerifyProfileConcern
   # bypassing the typical flow of showing the Please Call or Fraud Rejection screens.
   def user_failed_ipp_with_fraud_review_pending?
     IdentityConfig.store.in_person_proofing_enforce_tmx &&
-      current_user.ipp_enrollment_status_not_passed? &&
+      current_user.ipp_enrollment_status_not_passed_or_in_fraud_review? &&
       current_user.fraud_review_pending?
   end
 end

--- a/app/controllers/idv/please_call_controller.rb
+++ b/app/controllers/idv/please_call_controller.rb
@@ -15,12 +15,12 @@ module Idv
       analytics.idv_please_call_visited
       pending_at = current_user.fraud_review_pending_profile.fraud_review_pending_at
       @call_by_date = pending_at + FRAUD_REVIEW_CONTACT_WITHIN_DAYS
-      @in_person = ipp_enabled_and_enrollment_passed?
+      @in_person = ipp_enabled_and_enrollment_passed_or_in_fraud_review?
     end
 
-    def ipp_enabled_and_enrollment_passed?
+    def ipp_enabled_and_enrollment_passed_or_in_fraud_review?
       return unless in_person_tmx_enabled?
-      in_person_proofing_enabled? && ipp_enrollment_passed?
+      in_person_proofing_enabled? && (ipp_enrollment_passed? || ipp_enrollment_in_fraud_review?)
     end
 
     private
@@ -42,6 +42,10 @@ module Idv
     # we only want to handle enrollments that have passed
     def ipp_enrollment_passed?
       current_user&.in_person_enrollment_status == 'passed'
+    end
+
+    def ipp_enrollment_in_fraud_review?
+      current_user&.in_person_enrollment_status == 'in_fraud_review'
     end
   end
 end

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -62,8 +62,9 @@ module Idv
 
     def cancel_previous_in_person_enrollments
       return unless IdentityConfig.store.in_person_proofing_enabled
-      UspsInPersonProofing::EnrollmentHelper
-        .cancel_establishing_and_pending_enrollments(current_user)
+      UspsInPersonProofing::EnrollmentHelper.cancel_establishing_and_in_progress_enrollments(
+        current_user,
+      )
     end
   end
 end

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -70,12 +70,12 @@ class ResetPasswordForm
 
   def password_reset_profile
     FeatureManagement.pending_in_person_password_reset_enabled? ?
-      find_pending_in_person_or_active_profile :
+      find_in_progress_in_person_or_active_profile :
       active_profile
   end
 
-  def find_pending_in_person_or_active_profile
-    user.pending_in_person_enrollment&.profile || active_profile
+  def find_in_progress_in_person_or_active_profile
+    user.current_in_progress_in_person_enrollment_profile || active_profile
   end
 
   # It is possible for an account that is resetting their password to be "invalid".
@@ -104,7 +104,9 @@ class ResetPasswordForm
 
   def pending_profile_invalidated?
     if FeatureManagement.pending_in_person_password_reset_enabled?
-      pending_profile.present? && !pending_profile.in_person_verification_pending?
+      pending_profile.present? &&
+        !pending_profile.in_person_verification_pending? &&
+        !pending_profile.fraud_deactivation_reason?
     else
       pending_profile.present?
     end

--- a/app/jobs/fraud_rejection_daily_job.rb
+++ b/app/jobs/fraud_rejection_daily_job.rb
@@ -5,6 +5,7 @@ class FraudRejectionDailyJob < ApplicationJob
 
   def perform(_date)
     profiles_eligible_for_fraud_rejection.find_each do |profile|
+      profile.in_person_enrollment&.failed!
       profile.reject_for_fraud(notify_user: false)
       analytics(user: profile.user).automatic_fraud_rejection(
         fraud_rejection_at: profile.fraud_rejection_at,

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -13,12 +13,15 @@ class InPersonEnrollment < ApplicationRecord
 
   has_one :notification_phone_configuration, dependent: :destroy, inverse_of: :in_person_enrollment
 
+  IN_PROGRESS_ENROLLMENT_STATUSES = %w[pending in_fraud_review].to_set.freeze
+
   STATUS_ESTABLISHING = 'establishing'
   STATUS_PENDING = 'pending'
   STATUS_PASSED = 'passed'
   STATUS_FAILED = 'failed'
   STATUS_EXPIRED = 'expired'
   STATUS_CANCELLED = 'cancelled'
+  STATUS_IN_FRAUD_REVIEW = 'in_fraud_review'
 
   enum :status, {
     STATUS_ESTABLISHING.to_sym => 0,
@@ -27,6 +30,7 @@ class InPersonEnrollment < ApplicationRecord
     STATUS_FAILED.to_sym => 3,
     STATUS_EXPIRED.to_sym => 4,
     STATUS_CANCELLED.to_sym => 5,
+    STATUS_IN_FRAUD_REVIEW.to_sym => 6,
   }
 
   validate :profile_belongs_to_user

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3334,6 +3334,7 @@ module AnalyticsEvents
   # @param [Integer] enrollments_failed number of enrollments which failed identity proofing
   # @param [Integer] enrollments_in_progress number of enrollments which did not have any change
   # @param [Integer] enrollments_passed number of enrollments which passed identity proofing
+  # @param [Integer] enrollments_in_fraud_review number of enrollments in fraud review
   # @param [Integer] enrollments_skipped number of enrollments skipped
   # @param [Integer] enrollments_network_error
   # @param [Integer] enrollments_cancelled
@@ -3348,6 +3349,7 @@ module AnalyticsEvents
     enrollments_failed:,
     enrollments_in_progress:,
     enrollments_passed:,
+    enrollments_in_fraud_review:,
     enrollments_skipped:,
     enrollments_network_error:,
     enrollments_cancelled:,
@@ -3365,6 +3367,7 @@ module AnalyticsEvents
       enrollments_failed:,
       enrollments_in_progress:,
       enrollments_passed:,
+      enrollments_in_fraud_review:,
       enrollments_skipped:,
       enrollments_network_error:,
       enrollments_cancelled:,

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -91,13 +91,15 @@ module UspsInPersonProofing
           .find_each(&:cancelled!)
       end
 
-      # Cancel a user's associated establishing and pending in-person enrollments.
+      # Cancel a user's associated establishing, pending, and in_fraud_review in-person enrollments.
       #
       # @param user [User] The user model
-      def cancel_establishing_and_pending_enrollments(user)
+      def cancel_establishing_and_in_progress_enrollments(user)
         user
           .in_person_enrollments
-          .where(status: [:establishing, :pending])
+          .where(status:
+            [InPersonEnrollment::STATUS_ESTABLISHING] +
+            InPersonEnrollment::IN_PROGRESS_ENROLLMENT_STATUSES.to_a)
           .find_each(&:cancel)
       end
 

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -190,6 +190,7 @@ class ActionAccount
         elsif FraudReviewChecker.new(user).fraud_review_eligible?
           profile = user.fraud_review_pending_profile
           profile_fraud_review_pending_at = profile.fraud_review_pending_at
+          profile.in_person_enrollment&.failed!
           profile.reject_for_fraud(notify_user: true)
           success = true
 
@@ -281,6 +282,7 @@ class ActionAccount
         elsif FraudReviewChecker.new(user).fraud_review_eligible?
           profile = user.fraud_review_pending_profile
           profile_fraud_review_pending_at = profile.fraud_review_pending_at
+          profile.in_person_enrollment&.passed!
           profile.activate_after_passing_review
           success = true
 

--- a/spec/controllers/concerns/idv_step_concern_spec.rb
+++ b/spec/controllers/concerns/idv_step_concern_spec.rb
@@ -259,5 +259,28 @@ RSpec.describe 'IdvStepConcern' do
         expect(response).to redirect_to idv_verify_by_mail_enter_code_url
       end
     end
+
+    context 'with a passed in-person enrollment and a fraudulent profile' do
+      let(:user) do
+        profile = create(:profile, :in_person_fraud_review_pending, in_person_enrollment: nil)
+        create(:in_person_enrollment, :passed, profile:, user: profile.user).user
+      end
+
+      it 'redirects to please call page' do
+        get :show
+
+        expect(response).to redirect_to idv_please_call_url
+      end
+    end
+
+    context 'with a in_fraud_review in-person enrollment and a fraudulent profile' do
+      let(:user) { create(:profile, :in_person_fraud_review_pending).user }
+
+      it 'redirects to please call page' do
+        get :show
+
+        expect(response).to redirect_to idv_please_call_url
+      end
+    end
   end
 end

--- a/spec/controllers/idv/please_call_controller_spec.rb
+++ b/spec/controllers/idv/please_call_controller_spec.rb
@@ -127,4 +127,66 @@ RSpec.describe Idv::PleaseCallController do
       end
     end
   end
+
+  describe '#ipp_enabled_and_enrollment_passed_or_in_fraud_review?' do
+    context 'when in person tmx is enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enforce_tmx).and_return(true)
+      end
+
+      context 'when ipp is enabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+        end
+
+        context 'when user has a passed enrollment' do
+          let!(:enrollment) { create(:in_person_enrollment, :passed, user: user, profile: profile) }
+
+          it 'returns true' do
+            expect(subject.ipp_enabled_and_enrollment_passed_or_in_fraud_review?).to be(true)
+          end
+        end
+
+        context 'when user has an in_fraud_review enrollment' do
+          let!(:enrollment) do
+            create(:in_person_enrollment, :in_fraud_review, user: user, profile: profile)
+          end
+
+          it 'returns true' do
+            expect(subject.ipp_enabled_and_enrollment_passed_or_in_fraud_review?).to be(true)
+          end
+        end
+
+        context 'when user has a non passed or in_fraud_review enrollment' do
+          let!(:enrollment) do
+            create(:in_person_enrollment, :pending, user: user, profile: profile)
+          end
+
+          it 'returns false' do
+            expect(subject.ipp_enabled_and_enrollment_passed_or_in_fraud_review?).to be(false)
+          end
+        end
+      end
+
+      context 'when ipp is disabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(false)
+        end
+
+        it 'returns false' do
+          expect(subject.ipp_enabled_and_enrollment_passed_or_in_fraud_review?).to be(false)
+        end
+      end
+    end
+
+    context 'when in person tmx is disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enforce_tmx).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(subject.ipp_enabled_and_enrollment_passed_or_in_fraud_review?).to be_nil
+      end
+    end
+  end
 end

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -140,16 +140,23 @@ RSpec.describe Idv::WelcomeController do
       let!(:pending_enrollment) do
         create(:in_person_enrollment, :pending, user: user, profile: password_reset_profile)
       end
+      let(:fraud_password_reset_profile) { create(:profile, :password_reset, user: user) }
+      let!(:fraud_review_enrollment) do
+        create(
+          :in_person_enrollment, :in_fraud_review, user: user, profile: fraud_password_reset_profile
+        )
+      end
 
       before do
         allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
       end
 
-      it 'cancels all previous establishing and pending enrollments' do
+      it 'cancels all previous establishing, pending, and in_fraud_review enrollments' do
         put :update
 
         expect(establishing_enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
         expect(pending_enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
+        expect(fraud_review_enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
         expect(user.establishing_in_person_enrollment).to be_blank
         expect(user.pending_in_person_enrollment).to be_blank
       end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1494,6 +1494,44 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 end
               end
 
+              context 'user has ipp enrollment with fraud review pending' do
+                context 'when the enrollment has a status of passed' do
+                  let(:user) do
+                    profile = create(:profile, :fraud_review_pending)
+                    create(:in_person_enrollment, :passed, profile:, user: profile.user).user
+                  end
+
+                  it 'redirects to fraud review page if fraud review is pending' do
+                    action
+                    expect(controller).to redirect_to(idv_please_call_url)
+                  end
+                end
+
+                context 'when the enrollment has a status of in_fraud_review' do
+                  let(:user) do
+                    profile = create(:profile, :fraud_review_pending)
+                    create(:in_person_enrollment, :in_fraud_review, profile:, user: profile.user).user
+                  end
+
+                  it 'redirects to fraud review page if fraud review is pending' do
+                    action
+                    expect(controller).to redirect_to(idv_please_call_url)
+                  end
+                end
+
+                context 'when the enrollment does not have a status of pending or in_fraud_review' do
+                  let(:user) do
+                    profile = create(:profile, :fraud_review_pending, deactivation_reason: :verification_cancelled)
+                    create(:in_person_enrollment, :failed, profile:, user: profile.user).user
+                  end
+
+                  it 'redirects the user to verify their account' do
+                    action
+                    expect(controller).to redirect_to(idv_url)
+                  end
+                end
+              end
+
               context 'user has two pending reasons' do
                 context 'user has gpo and fraud review pending' do
                   let(:user) do

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -43,6 +43,21 @@ FactoryBot.define do
       status_updated_at { Time.zone.now }
     end
 
+    trait :in_fraud_review do
+      enrollment_code { Faker::Number.number(digits: 16) }
+      enrollment_established_at { Time.zone.now }
+      status { :in_fraud_review }
+      status_updated_at { Time.zone.now }
+      profile do
+        association(
+          :profile,
+          :fraud_review_pending,
+          user: user,
+          in_person_enrollment: instance,
+        )
+      end
+    end
+
     trait :with_service_provider do
       service_provider { association :service_provider }
     end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -53,6 +53,16 @@ FactoryBot.define do
       end
     end
 
+    trait :in_person_fraud_review_pending do
+      idv_level { :in_person }
+      fraud_pending_reason { 'threatmetrix_review' }
+      fraud_review_pending_at { 15.days.ago }
+      proofing_components { { threatmetrix_review_status: 'review' } }
+      in_person_enrollment do
+        association(:in_person_enrollment, :in_fraud_review, profile: instance, user:)
+      end
+    end
+
     trait :fraud_pending_reason do
       fraud_pending_reason { 'threatmetrix_review' }
       proofing_components { { threatmetrix_review_status: 'review' } }

--- a/spec/features/idv/get_proofing_results_job_scenarios_spec.rb
+++ b/spec/features/idv/get_proofing_results_job_scenarios_spec.rb
@@ -708,7 +708,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
 
       # Then the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
-        status: 'passed',
+        status: 'in_fraud_review',
       )
 
       # And the user has a Profile that is deactivated with reason "encryption_error" and
@@ -728,7 +728,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
       expect(page).to have_current_path(idv_please_call_path)
       # And the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
-        status: 'passed',
+        status: 'in_fraud_review',
       )
       # And the user has a Profile that is pending fraud review
       expect(@user.in_person_enrollments.first.profile).to have_attributes(
@@ -829,7 +829,7 @@ RSpec.feature 'GetUspsProofingResultsJob Scenarios', js: true do
 
       # Then the user has an InPersonEnrollment with status "cancelled"
       expect(@user.in_person_enrollments.first).to have_attributes(
-        status: 'passed',
+        status: 'in_fraud_review',
       )
       # And the user has a Profile that is pending fraud review
       expect(@user.in_person_enrollments.first.profile).to have_attributes(

--- a/spec/jobs/fraud_rejection_daily_job_spec.rb
+++ b/spec/jobs/fraud_rejection_daily_job_spec.rb
@@ -20,5 +20,26 @@ RSpec.describe FraudRejectionDailyJob do
         fraud_rejection_at: rejected_profiles.first.fraud_rejection_at,
       )
     end
+
+    it 'rejects in-person profiles which have been review pending for more than 30 days' do
+      rejectedable_profile = create(:profile, fraud_review_pending_at: 31.days.ago)
+      enrollment = create(
+        :in_person_enrollment, :in_fraud_review, profile: rejectedable_profile,
+                                                 user: rejectedable_profile.user
+      )
+      create(:profile, fraud_review_pending_at: 20.days.ago)
+
+      rejected_profiles = Profile.where.not(fraud_rejection_at: nil)
+
+      allow(job).to receive(:analytics).with(user: rejectedable_profile.user)
+        .and_return(job_analytics)
+
+      expect { job.perform(Time.zone.today) }.to change { rejected_profiles.count }.by(1)
+      expect(job_analytics).to have_logged_event(
+        'Fraud: Automatic Fraud Rejection',
+        fraud_rejection_at: rejected_profiles.first.fraud_rejection_at,
+      )
+      expect(enrollment.reload.status).to eq('failed')
+    end
   end
 end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
       enrollments_cancelled: 0,
       enrollments_in_progress: 0,
       enrollments_passed: 0,
+      enrollments_in_fraud_review: 0,
       enrollments_skipped: 0,
       duration_seconds: 0.0,
       percent_enrollments_errored: 0.0,
@@ -1604,9 +1605,9 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                   )
                 end
 
-                it 'passes the enrollment' do
+                it 'updates the enrollment with "in_fraud_review" status' do
                   expect(enrollment.reload).to have_attributes(
-                    status: 'passed',
+                    status: 'in_fraud_review',
                     proofed_at: usps_enrollment_end_date.getlocal('UTC'),
                     status_check_attempted_at: current_time,
                     status_check_completed_at: current_time,
@@ -1645,7 +1646,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                   ).with(
                     **default_job_completion_analytics,
                     enrollments_checked: 1,
-                    enrollments_passed: 1,
+                    enrollments_in_fraud_review: 1,
                   )
                 end
               end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -383,28 +383,18 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
     end
   end
 
-  describe '#cancel_establishing_and_pending_enrollments' do
-    context 'when the user has an establishing in-person enrollment' do
-      let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user) }
+  describe '#cancel_establishing_and_in_progress_enrollments' do
+    [:establishing, :pending, :in_fraud_review].each do |status|
+      context "when the user has an '#{status}' in-person enrollment" do
+        let!(:enrollment) { create(:in_person_enrollment, status, user: user) }
 
-      before do
-        subject.cancel_establishing_and_pending_enrollments(user)
-      end
+        before do
+          subject.cancel_establishing_and_in_progress_enrollments(user)
+        end
 
-      it "cancels the user's establishing in-person enrollment" do
-        expect(enrollment.reload.status).to eq('cancelled')
-      end
-    end
-
-    context 'when the user has a pending in-person enrollment' do
-      let!(:enrollment) { create(:in_person_enrollment, :pending, user: user) }
-
-      before do
-        subject.cancel_establishing_and_pending_enrollments(user)
-      end
-
-      it "cancels the user's pending in-person enrollment" do
-        expect(enrollment.reload.status).to eq('cancelled')
+        it "cancels the user's in-person enrollment" do
+          expect(enrollment.reload.status).to eq('cancelled')
+        end
       end
     end
 
@@ -413,7 +403,7 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
       let!(:pending_enrollment) { create(:in_person_enrollment, :pending, user: user) }
 
       before do
-        subject.cancel_establishing_and_pending_enrollments(user)
+        subject.cancel_establishing_and_in_progress_enrollments(user)
       end
 
       it "cancels the user's establishing in-person enrollment" do
@@ -425,9 +415,9 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
       end
     end
 
-    context 'when the user has no establishing and pending in-person enrollments' do
+    context 'when the user has no establishing or in-progress in-person enrollments' do
       it 'does not throw an error' do
-        expect { subject.cancel_establishing_and_pending_enrollments(user) }.not_to raise_error
+        expect { subject.cancel_establishing_and_in_progress_enrollments(user) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15216](https://cm-jira.usa.gov/browse/LG-15216)

## 🛠 Summary of changes

Enable user's to not lose in-person enrollment progress after a password reset when the user in fraud review.

Changes Include:

- New InPersonEnrollment status `in_fraud_review`
- New metric for GetUspsProofingResultsJob `enrollments_in_fraud_review`
- Update to the action account scripts to update relevant in-person enrollments base on result 

## 📜 Testing Plan

### In-Person Password Reset enabled
- [x] Set `feature_pending_in_person_password_reset_enabled: true` in `application.yml.default`

Scenario: Fraud review in-person enrollment and user password resets with personal key
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the ready ssn page.
- [x] Mark the threat metrics as review on the ready ssn page.
- [x] Submit the ssn form.
- [x] Continue the ID-IPP flow reaching the ready to verify page.
- [x] Run the GetUspsProofingResultsJob
```ruby
# To manually run the job in the rails console run the following:
job = GetUspsProofingResultsJob.new
job.perform(Time.zone.now)
```
- [x] Ensure the enrollment is updated to have `in_fraud_review` status.
- [x] Ensure user is navigated to the LG-99 screen.
- [x] Logout
- [x] Reset the password of the user.
- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Ensure user is prompted for personal key entry
- [x] Enter in user's personal key
- [x] Ensure user is navigated to the LG-99 screen

Scenario: Fraud review in-person enrollment and user password resets without personal key
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the ready ssn page.
- [x] Mark the threat metrics as review on the ready ssn page.
- [x] Submit the ssn form.
- [x] Continue the ID-IPP flow reaching the ready to verify page.
- [x] Run the GetUspsProofingResultsJob
```ruby
# To manually run the job in the rails console run the following:
job = GetUspsProofingResultsJob.new
job.perform(Time.zone.now)
```
- [x] Ensure the enrollment is updated to have `in_fraud_review` status.
- [x] Ensure user is navigated to the LG-99 screen.
- [x] Logout
- [x] Reset the password of the user.
- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Ensure user is prompted for personal key entry
- [x] Continue without a personal key
- [x] Ensure user is navigated to the welcome page
- [x] Click Continue on welcome page
- [x] Ensure enrollment is `cancelled`

Scenario: Fraud review in-person enrollment and user password resets before deployment
- [x] Checkout main and start the idp application
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the ready ssn page.
- [x] Mark the threat metrics as review on the ready ssn page.
- [x] Submit the ssn form.
- [x] Continue the ID-IPP flow reaching the ready to verify page.
- [x] Run the GetUspsProofingResultsJob
```ruby
# To manually run the job in the rails console run the following:
job = GetUspsProofingResultsJob.new
job.perform(Time.zone.now)
```
- [x] Ensure the enrollment is updated to have `passed` status.
- [x] Ensure user is navigated to the LG-99 screen.
- [x] Logout
- [x] Checkout LG-15216 and restart the idp application
- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Ensure user is navigated to the LG-99 screen.
- [x] Logout
- [x] Reset the password of the user.
- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Ensure user is navigated to the welcome page

Scenario: Fraud review in-person enrollment and user has passed review
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the ready ssn page.
- [x] Mark the threat metrics as review on the ready ssn page.
- [x] Submit the ssn form.
- [x] Continue the ID-IPP flow reaching the ready to verify page.
- [x] Run the GetUspsProofingResultsJob
```ruby
# To manually run the job in the rails console run the following:
job = GetUspsProofingResultsJob.new
job.perform(Time.zone.now)
```
- [x] Ensure the enrollment is updated to have `in_fraud_review` status.
- [x] Ensure user is navigated to the LG-99 screen.
- [x] Run the review-passed script `bin/action-account review-passed <user_uuid>`
- [x] Ensure the enrollment is updated to have `passed` status.
- [x] Ensure the user is prompted to activate their account.

Scenario: Fraud review in-person enrollment and user has failed review
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the ready ssn page.
- [x] Mark the threat metrics as review on the ready ssn page.
- [x] Submit the ssn form.
- [x] Continue the ID-IPP flow reaching the ready to verify page.
- [x] Run the GetUspsProofingResultsJob
```ruby
# To manually run the job in the rails console run the following:
job = GetUspsProofingResultsJob.new
job.perform(Time.zone.now)
```
- [x] Ensure the enrollment is updated to have `in_fraud_review` status.
- [x] Ensure user is navigated to the LG-99 screen.
- [x] Run the review-reject script `bin/action-account review-reject <user_uuid>`
- [x] Ensure the enrollment is updated to have `failed` status.
- [x] Ensure the user is redirected to the unverified page.

### In-Person Password Reset disabled
- [x] Set `feature_pending_in_person_password_reset_enabled: false` in `application.yml.default`

Scenario: Fraud review in-person enrollment and user password resets
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the ready ssn page.
- [x] Mark the threat metrics as review on the ready ssn page.
- [x] Submit the ssn form.
- [x] Continue the ID-IPP flow reaching the ready to verify page.
- [x] Run the GetUspsProofingResultsJob
```ruby
# To manually run the job in the rails console run the following:
job = GetUspsProofingResultsJob.new
job.perform(Time.zone.now)
```
- [x] Ensure the enrollment is updated to have `in_fraud_review` status.
- [x] Ensure user is navigated to the LG-99 screen.
- [x] Logout
- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Ensure user is navigated to the LG-99 screen.
- [x] Logout
- [x] Reset the password of the user.
- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Ensure user is navigated to the welcome page

