### PR TITLE
Remove method_missing usage in Idv::Session

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -90,26 +90,21 @@ module Idv
 
     attr_reader :current_user, :gpo_otp, :service_provider
 
+    VALID_SESSION_ATTRIBUTES.each do |attr|
+      define_method(attr) do
+        session[attr]
+      end
+
+      define_method(:"#{attr}=") do |val|
+        session[attr] = val
+      end
+    end
+
     def initialize(user_session:, current_user:, service_provider:)
       @user_session = user_session
       @current_user = current_user
       @service_provider = service_provider
       set_idv_session
-    end
-
-    def method_missing(method_sym, *arguments, &block)
-      attr_name_sym = method_sym.to_s.delete_suffix('=').to_sym
-      if VALID_SESSION_ATTRIBUTES.include?(attr_name_sym)
-        return session[attr_name_sym] if arguments.empty?
-        session[attr_name_sym] = arguments.first
-      else
-        super
-      end
-    end
-
-    def respond_to_missing?(method_sym, include_private)
-      attr_name_sym = method_sym.to_s.delete_suffix('=').to_sym
-      VALID_SESSION_ATTRIBUTES.include?(attr_name_sym) || super
     end
 
     # @return [Profile]

--- a/spec/presenters/idv/by_mail/letter_enqueued_presenter_spec.rb
+++ b/spec/presenters/idv/by_mail/letter_enqueued_presenter_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Idv::ByMail::LetterEnqueuedPresenter do
     def add_to_idv_session_applicant(pii:)
       pii_hash = Pii::StateId.members.index_with(nil).merge(pii)
 
-      idv_session.applicant(pii_hash)
+      idv_session.applicant = pii_hash
     end
 
     def add_to_gpo_pending_profile(pii:)

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -47,27 +47,24 @@ RSpec.describe Idv::Session do
     end
   end
 
-  describe '#method_missing' do
-    it 'disallows un-supported attributes' do
+  describe 'attribute methods' do
+    it 'disallows un-supported setters' do
       expect { subject.foo = 'bar' }.to raise_error NoMethodError
     end
 
-    it 'allows supported attributes' do
+    it 'allows using supported setters and getters' do
       Idv::Session::VALID_SESSION_ATTRIBUTES.each do |attr|
-        subject.send attr, 'foo'
-        expect(subject.send(attr)).to eq 'foo'
+        expect(subject.send(attr)).to eq nil
         subject.send :"#{attr}=", 'foo'
         expect(subject.send(attr)).to eq 'foo'
       end
     end
-  end
 
-  describe '#respond_to_missing?' do
-    it 'disallows un-supported attributes' do
+    it 'allows checking for un-supported attributes' do
       expect(subject.respond_to?(:foo=, false)).to eq false
     end
 
-    it 'allows supported attributes' do
+    it 'allows checking for supported attributes' do
       Idv::Session::VALID_SESSION_ATTRIBUTES.each do |attr|
         expect(subject.respond_to?(attr, false)).to eq true
         expect(subject.respond_to?(:"#{attr}=", false)).to eq true

--- a/spec/views/idv/by_mail/letter_enqueued/show.html.erb_spec.rb
+++ b/spec/views/idv/by_mail/letter_enqueued/show.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'idv/by_mail/letter_enqueued/show.html.erb' do
       current_user: nil,
       service_provider: service_provider,
     )
-    idv_session.applicant(applicant_pii)
+    idv_session.applicant = applicant_pii
     idv_session
   end
 


### PR DESCRIPTION
- [Per comment on #11854](https://github.com/18F/identity-idp/pull/11854#discussion_r1947096203), the dynamic access and string manipulation makes these methods a hotspot

- Dynamically defining these methods one should hopefully let the JIT optimize this a little better, and lets us use the default implementations for #method_missing and #respond_to_missing?

NB, I have not performance tested this myself to confirm the hypothesis, I am open to checking that before merging. The unit test coverage is solid so this should still work