### PR TITLE
Update AnalyticsEventsDocumenter to require exact "**extra"

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1083,17 +1083,15 @@ module AnalyticsEvents
   end
 
   # @param [Hash] error
-  def idv_camera_info_error(error:, **_extra)
-    track_event(:idv_camera_info_error, error: error)
+  def idv_camera_info_error(error:, **extra)
+    track_event(:idv_camera_info_error, error:, **extra)
   end
 
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [Array] camera_info Information on the users cameras max resolution
   #   as captured by the browser
-  def idv_camera_info_logged(flow_path:, camera_info:, **_extra)
-    track_event(
-      :idv_camera_info_logged, flow_path: flow_path, camera_info: camera_info
-    )
+  def idv_camera_info_logged(flow_path:, camera_info:, **extra)
+    track_event(:idv_camera_info_logged, flow_path:, camera_info:, **extra)
   end
 
   # @param [String] step the step that the user was on when they clicked cancel
@@ -4937,21 +4935,22 @@ module AnalyticsEvents
     proofing_components: nil,
     active_profile_idv_level: nil,
     pending_profile_idv_level: nil,
-    **_extra
+    **extra
   )
     track_event(
       :idv_selfie_image_clicked,
-      acuant_sdk_upgrade_a_b_testing_enabled: acuant_sdk_upgrade_a_b_testing_enabled,
-      acuant_version: acuant_version,
-      flow_path: flow_path,
-      isDrop: isDrop,
-      click_source: click_source,
-      use_alternate_sdk: use_alternate_sdk,
-      captureAttempts: captureAttempts,
-      liveness_checking_required: liveness_checking_required,
-      proofing_components: proofing_components,
-      active_profile_idv_level: active_profile_idv_level,
-      pending_profile_idv_level: pending_profile_idv_level,
+      acuant_sdk_upgrade_a_b_testing_enabled:,
+      acuant_version:,
+      flow_path:,
+      isDrop:,
+      click_source:,
+      use_alternate_sdk:,
+      captureAttempts:,
+      liveness_checking_required:,
+      proofing_components:,
+      active_profile_idv_level:,
+      pending_profile_idv_level:,
+      **extra,
     )
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName

--- a/lib/analytics_events_documenter.rb
+++ b/lib/analytics_events_documenter.rb
@@ -117,7 +117,7 @@ class AnalyticsEventsDocumenter
         errors << "#{error_prefix} #{attribute} (undocumented)"
       end
 
-      if require_extra_params? && param_names.size > 0 && !param_names.last.start_with?('**')
+      if require_extra_params? && param_names.size > 0 && param_names.last != '**extra'
         errors << "#{error_prefix} missing **extra"
       end
 

--- a/spec/lib/analytics_events_documenter_spec.rb
+++ b/spec/lib/analytics_events_documenter_spec.rb
@@ -180,6 +180,21 @@ RSpec.describe AnalyticsEventsDocumenter do
         expect(documenter.missing_documentation.first).to include('some_event missing **extra')
       end
 
+      context 'when extra keyword arguments is incorrectly named' do
+        let(:source_code) { <<~RUBY }
+          class AnalyticsEvents
+            # @param [Boolean] success
+            def some_event(success:, **_extra)
+              track_event('Some Event')
+            end
+          end
+        RUBY
+
+        it 'requires **extra param' do
+          expect(documenter.missing_documentation.first).to include('some_event missing **extra')
+        end
+      end
+
       context 'when require_extra_params is false' do
         let(:require_extra_params) { false }
 


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `make lint_analytics_events` to check for consistent use of `**extra` extra keyword arguments on analytics events methods when required. Previously, the check was flexible in allowing other names, or unused variables (prefixed with `_`).

**Why?** So that we're consistent with how we expect additional keyword arguments to be logged.

## 📜 Testing Plan

Verify build passes.

Optional: Check for `AnalyticsEvents` method keyword arguments not named `**extra`.