### PR TITLE
LG-15693 undefined method profiles for nil

### DIFF
--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -7,7 +7,10 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
 
-    before_action :confirm_not_rate_limited
+    before_action -> do
+      confirm_not_rate_limited(check_last_submission: true)
+    end
+
     before_action :confirm_step_allowed
 
     def show

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -9,20 +9,17 @@ module Idv
       include RenderConditionConcern
 
       check_or_render_not_found -> { IdentityConfig.store.socure_docv_enabled }
-      before_action :confirm_not_rate_limited
+
+      before_action :confirm_not_rate_limited, except: :update
+      before_action -> do
+        confirm_not_rate_limited(check_last_submission: true)
+      end, only: :update
+
       before_action :confirm_step_allowed
       before_action -> do
         redirect_to_correct_vendor(Idp::Constants::Vendors::SOCURE, in_hybrid_mobile: false)
       end, only: :show
       before_action :fetch_test_verification_data, only: [:update]
-
-      # reconsider and maybe remove these when implementing the real
-      # update handler
-      skip_before_action :redirect_unless_idv_session_user, only: [:update]
-      skip_before_action :confirm_two_factor_authenticated, only: [:update]
-      skip_before_action :confirm_idv_needed, only: [:update]
-      skip_before_action :confirm_not_rate_limited, only: [:update]
-      skip_before_action :confirm_step_allowed, only: [:update]
 
       def show
         idv_session.socure_docv_wait_polling_started_at = nil

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -390,6 +390,8 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
 
   describe '#update' do
     before do
+      stub_sign_in(user)
+      subject.idv_session.flow_path = 'standard'
       get :update
     end
 

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -114,25 +114,29 @@ RSpec.feature 'document capture step', :js do
           end
         end
 
-        it 'redirects to the rate limited error page' do
-          # recovers when fails to repeat webhook to an endpoint
-          allow_any_instance_of(DocAuth::Socure::WebhookRepeater)
-            .to receive(:send_http_post_request).and_raise('doh')
-          expect(page).to have_current_path(fake_socure_document_capture_app_url)
-          visit idv_socure_document_capture_path
-          expect(page).to have_current_path(idv_socure_document_capture_path)
-          socure_docv_upload_documents(
-            docv_transaction_token: @docv_transaction_token,
-          )
-          visit idv_socure_document_capture_path
-          expect(page).to have_current_path(idv_session_errors_rate_limited_path)
-          expect(fake_analytics).to have_logged_event(
-            'Rate Limit Reached',
-            limiter_type: :idv_doc_auth,
-          )
-          expect(fake_analytics).to have_logged_event(
-            :idv_socure_document_request_submitted,
-          )
+        context 'when we fail on the last attempt' do
+          before do
+            allow_any_instance_of(DocAuth::Socure::WebhookRepeater)
+              .to receive(:send_http_post_request).and_raise('doh')
+          end
+
+          it 'redirects to the rate limited error page' do
+            expect(page).to have_current_path(fake_socure_document_capture_app_url)
+            visit idv_socure_document_capture_path
+            expect(page).to have_current_path(idv_socure_document_capture_path)
+            socure_docv_upload_documents(
+              docv_transaction_token: @docv_transaction_token,
+            )
+            visit idv_socure_document_capture_path
+            expect(page).to have_current_path(idv_session_errors_rate_limited_path)
+            expect(fake_analytics).to have_logged_event(
+              'Rate Limit Reached',
+              limiter_type: :idv_doc_auth,
+            )
+            expect(fake_analytics).to have_logged_event(
+              :idv_socure_document_request_submitted,
+            )
+          end
         end
 
         context 'successfully processes image on last attempt' do
@@ -146,6 +150,9 @@ RSpec.feature 'document capture step', :js do
             expect(page).to have_current_path(idv_socure_document_capture_path)
             socure_docv_upload_documents(
               docv_transaction_token: @docv_transaction_token,
+            )
+            DocumentCaptureSession.find_by(user_id: @user.id).update(
+              last_doc_auth_result: 'Passed',
             )
 
             visit idv_socure_document_capture_update_path


### PR DESCRIPTION
## 🎫 Ticket [LG-15693](https://cm-jira.usa.gov/browse/LG-15963)

## 🛠 Summary of changes

We strongly suspect that the `before:` filters should've caught this condition, but they were largely bypassed for the update event. It turns out that we don't need the bypasses if we change the rate-limiting logic slightly. Instead of making our before filter "smart", we simply pass in whether or not we should check for successful document capture.

Removed the filter bypasses from `socure/document_capture_controller.rb`

## 📜 Testing Plan

- Configure your environment to use Socure.
- Proceed through IdV using the hybrid handoff flow, and verify that you are able to complete document capture.
- Cancel after document capture, and re-try IdV. Repeat until you have one attempt remaining.
- Verify that on your final attempt, you are able to complete document capture and proceed through IdV