### PR TITLE
Invert default logging behavior for A/B test

### DIFF
--- a/lib/ab_test.rb
+++ b/lib/ab_test.rb
@@ -16,9 +16,9 @@ class AbTest
     end
   end.freeze
 
-  # @param [Proc<String>,Regexp,string,Boolean,nil] should_log Controls whether bucket data for this
-  #                                                            A/B test is logged with specific
-  #                                                            events.
+  # @param [Regexp,#include?,nil] should_log A list of analytics event names for which the A/B test
+  #   bucket assignment should be logged, or a regular expression pattern which is tested against an
+  #   analytics event name when an event is being logged.
   # @yieldparam [ActionDispatch::Request] request
   # @yieldparam [String,nil] service_provider Issuer string for the service provider associated with
   #                                           the current session.
@@ -79,7 +79,7 @@ class AbTest
     elsif !should_log.nil?
       raise 'Unexpected value used for should_log'
     else
-      true
+      false
     end
   end
 

--- a/spec/lib/ab_test_spec.rb
+++ b/spec/lib/ab_test_spec.rb
@@ -171,23 +171,20 @@ RSpec.describe AbTest do
     subject(:return_value) { ab_test.include_in_analytics_event?(event_name) }
 
     context 'when should_log is nil' do
-      it 'returns true' do
-        expect(return_value).to eql(true)
-      end
+      it { is_expected.to eql(false) }
     end
 
     context 'when Regexp is used' do
       context 'and it matches' do
         let(:should_log) { /cool/ }
-        it 'returns true' do
-          expect(return_value).to eql(true)
-        end
+
+        it { is_expected.to eql(true) }
       end
+
       context 'and it does not match' do
         let(:should_log) { /not cool/ }
-        it 'returns false' do
-          expect(return_value).to eql(false)
-        end
+
+        it { is_expected.to eql(false) }
       end
     end
 

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -154,9 +154,7 @@ RSpec.describe Analytics do
               bucket_b: 50,
             },
             should_log:,
-          ) do |user:, **|
-            user.id
-          end,
+          ),
         }
       end
 
@@ -181,7 +179,7 @@ RSpec.describe Analytics do
             analytics_attributes.merge(
               ab_tests: {
                 foo_test: {
-                  bucket: kind_of(Symbol),
+                  bucket: be_in([:bucket_a, :bucket_b]),
                 },
               },
             ),

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -166,28 +166,25 @@ RSpec.describe Analytics do
         allow(AbTests).to receive(:all).and_return(ab_tests)
       end
 
-      it 'includes ab_tests in logged event' do
-        expect(ahoy).to receive(:track).with(
-          'Trackable Event',
-          analytics_attributes.merge(
-            ab_tests: {
-              foo_test: {
-                bucket: anything,
-              },
-            },
-          ),
-        )
+      it 'does not include ab_tests in logged event' do
+        expect(ahoy).to receive(:track).with('Trackable Event', analytics_attributes)
 
         analytics.track_event('Trackable Event')
       end
 
-      context 'when should_log says not to' do
-        let(:should_log) { /some other event/ }
+      context 'for an included test' do
+        let(:should_log) { /Trackable/ }
 
-        it 'does not include ab_test in logged event' do
+        it 'includes ab_test bucket detail in logged event' do
           expect(ahoy).to receive(:track).with(
             'Trackable Event',
-            analytics_attributes,
+            analytics_attributes.merge(
+              ab_tests: {
+                foo_test: {
+                  bucket: kind_of(Symbol),
+                },
+              },
+            ),
           )
 
           analytics.track_event('Trackable Event')


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the behavior of `AbTest` to not include bucket assignments in logs if `should_log` is not defined.

Previously, if a test did not define `should_log`, the A/B test assignment for that test would be included in every application event. To avoid unnecessary noise in unrelated analytics events, this pull request proposes to change the default from an opt-out to an opt-in.

Existing tests already assign `should_log` and should be unimpacted by these changes.

## 📜 Testing Plan

Verify build passes.

Optionally, delete the `should_log` option for one of the existing test configuration and verify with `make watch_events` that unrelated analytics events do not include the A/B test assignment.