### PR TITLE
Add openid scope analytics

### DIFF
--- a/spec/lib/reporting/protocols_report_spec.rb
+++ b/spec/lib/reporting/protocols_report_spec.rb
@@ -99,12 +99,22 @@ RSpec.describe Reporting::ProtocolsReport do
       },
     ]
 
+    no_openid_scope_query_response = [
+      {
+        'issuer' => 'Issuer1',
+      },
+      {
+        'issuer' => 'Issuer2',
+      },
+    ]
+
     stub_multiple_cloudwatch_logs(
       protocol_query_response,
       saml_signature_query_response,
       loa_issuers_query_response,
       aal3_issuers_query_response,
       id_token_hint_query_response,
+      no_openid_scope_query_response,
       facial_match_issuers_query_response,
     )
   end
@@ -137,6 +147,7 @@ RSpec.describe Reporting::ProtocolsReport do
           loa_issuers_query
           protocol_query
           saml_signature_query
+          no_openid_scope_query
         ].each do |query|
           expect(client).to have_received(:fetch).with(
             query: report.public_send(query),
@@ -282,6 +293,11 @@ RSpec.describe Reporting::ProtocolsReport do
           'id_token_hint',
           string_or_num(strings, 2),
           'Issuer3, Issuer4',
+        ],
+        [
+          'No openid in scope',
+          string_or_num(strings, 2),
+          'Issuer1, Issuer2',
         ],
       ],
       [


### PR DESCRIPTION
## 🎫 Ticket

[Add analytics to track integrations not passing `openid` in the scope parameter](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/148)

## 🛠 Summary of changes
OIDC requests are supposed to have an `openid` scope value in order to conform to the spec. We currently do not have a validation for that value, so many integrations not passing it through. This ticket is to add tracking to the weekly protocols report to get a list of integrations that are not conforming, so we can do targeted outreach to get them to update their requests.

I have tested that the cloudwatch query is valid via:

`aws-vault exec prod-power -- bundle exec rails runner lib/reporting/protocols_report.rb --date 2025-02-09`

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
