### PR TITLE
Update net-imap gem to 0.5.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ GEM
       uri
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.5.1)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `net-imap` gem to resolve a security advisory:

GHSA-7fc5-f82f-cx69

Changelog: https://github.com/ruby/net-imap/releases

## 📜 Testing Plan

This does not appear to be flagged (yet) by `bundle-audit`, but ensure build passes and `make audit` produces no advisories.