### PR TITLE
Limit Webpack dev server allowed CORS origins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 CONFIG = config/application.yml
 HOST ?= localhost
 PORT ?= 3000
+ORIGIN_PORT ?= $(PORT)
 GZIP_COMMAND ?= gzip
 ARTIFACT_DESTINATION_FILE ?= ./tmp/idp.tar.gz
 

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: WEBPACK_PORT=${WEBPACK_PORT:-3035} bundle exec rackup config.ru --port ${PORT:-3000} --host ${FOREMAN_HOST:-${HOST:-localhost}}
 worker: bundle exec good_job start
-js: WEBPACK_PORT=${WEBPACK_PORT:-3035} yarn webpack --watch
+js: WEBPACK_PORT=${WEBPACK_PORT:-3035} ORIGIN_PORT=${ORIGIN_PORT:-3000} yarn webpack --watch
 css: yarn build:css --watch

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const isLocalhost = host === 'localhost';
 const isProductionEnv = env === 'production';
 const mode = isProductionEnv ? 'production' : 'development';
 const hashSuffix = isProductionEnv ? '-[chunkhash:8].digested' : '';
+const originPort = process.env.ORIGIN_PORT || 3000;
 const devServerPort = process.env.WEBPACK_PORT;
 const devtool = process.env.WEBPACK_DEVTOOL || (isProductionEnv ? 'source-map' : 'eval-source-map');
 
@@ -97,6 +98,7 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
         publicPath: './public',
         port: Number(devServerPort),
         headers: {
+          'Access-Control-Allow-Origin': `http://${host}:${originPort}`,
           'Cache-Control': 'no-store',
           Vary: '*',
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,6 @@ module.exports = /** @type {import('webpack').Configuration} */ ({
         publicPath: './public',
         port: Number(devServerPort),
         headers: {
-          'Access-Control-Allow-Origin': '*',
           'Cache-Control': 'no-store',
           Vary: '*',
         },


### PR DESCRIPTION
## 🛠 Summary of changes

Updates local Webpack development server to limit allowed origins for CORS to the expected local web server origin (usually http://localhost:3000).

This is motivated by a security advisory GHSA-67mh-4wv8-2f99 which addresses a similar issue in a package that we don't use in the IdP.

The risk here is fairly minimal, since the dev server only serves files out of the `public/` directory.

An original approach considered disabling CORS altogether. CORS is enabled because we [specify](https://github.com/18F/identity-idp/blob/fa802ad600f8ca5191468a249cf2a1ec212d244a/app/helpers/script_helper.rb#L35) [the `crossorigin` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) on script assets in local development, and we specify this attribute because it allows for better error messages in pages using React.js (see #6126).

## 📜 Testing Plan

Verify in local development that there are no issues loading JavaScript. It should be pretty evident if JavaScript is not working, because the "Here's how you know" USA banner will display as expanded by default.