### PR TITLE
LG-15107 selfie capture fix

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -132,6 +132,10 @@ interface AcuantCaptureProps {
    * Prefix to prepend to user action analytics labels.
    */
   name: string;
+  /**
+   * Determine whether the selfie help text shoule be shown.
+   */
+  showSelfieHelp: () => void;
 }
 
 /**
@@ -308,6 +312,7 @@ function AcuantCapture(
     allowUpload = true,
     errorMessage,
     name,
+    showSelfieHelp,
   }: AcuantCaptureProps,
   ref: Ref<HTMLInputElement | null>,
 ) {
@@ -545,6 +550,7 @@ function AcuantCapture(
     });
 
     setImageCaptureText('');
+    showSelfieHelp();
     setIsCapturingEnvironment(false);
   }
 

--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -83,6 +83,7 @@ function DocumentCaptureReviewIssues({
           selfieValue={value.selfie}
           isReviewStep
           showHelp={false}
+          showSelfieHelp={() => undefined}
         />
       )}
       <FormStepsButton.Submit />

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -23,6 +23,7 @@ interface DocumentSideAcuantCaptureProps {
   onError: OnErrorCallback;
   className?: string;
   isReviewStep: boolean;
+  showSelfieHelp: () => void;
 }
 
 /**
@@ -54,6 +55,7 @@ function DocumentSideAcuantCapture({
   onError,
   className,
   isReviewStep,
+  showSelfieHelp,
 }: DocumentSideAcuantCaptureProps) {
   const error = errors.find(({ field }) => field === side)?.error;
   const { changeStepCanComplete } = useContext(FormStepsContext);
@@ -97,6 +99,7 @@ function DocumentSideAcuantCapture({
       name={side}
       className={className}
       allowUpload={isUploadAllowed}
+      showSelfieHelp={showSelfieHelp}
     />
   );
 }

--- a/app/javascript/packages/document-capture/components/documents-step.tsx
+++ b/app/javascript/packages/document-capture/components/documents-step.tsx
@@ -36,6 +36,7 @@ export function DocumentsCaptureStep({
           side={side}
           value={value[side]}
           isReviewStep={isReviewStep}
+          showSelfieHelp={() => undefined}
         />
       ))}
     </>

--- a/app/javascript/packages/document-capture/components/selfie-step.tsx
+++ b/app/javascript/packages/document-capture/components/selfie-step.tsx
@@ -24,11 +24,13 @@ export function SelfieCaptureStep({
   selfieValue,
   isReviewStep,
   showHelp,
+  showSelfieHelp,
 }: {
   defaultSideProps: DefaultSideProps;
   selfieValue: ImageValue;
   isReviewStep: boolean;
   showHelp: boolean;
+  showSelfieHelp: () => void;
 }) {
   const { t } = useI18n();
 
@@ -55,6 +57,7 @@ export function SelfieCaptureStep({
           side="selfie"
           value={selfieValue}
           isReviewStep={isReviewStep}
+          showSelfieHelp={showSelfieHelp}
         />
       )}
     </>
@@ -73,6 +76,10 @@ export default function SelfieStep({
   const { flowPath } = useContext(UploadContext);
   const { showHelpInitially } = useContext(SelfieCaptureContext);
   const [showHelp, setShowHelp] = useState(showHelpInitially);
+
+  const showSelfieHelp = () => {
+    setShowHelp(true);
+  };
 
   function TakeSelfieButton() {
     return (
@@ -106,6 +113,7 @@ export default function SelfieStep({
         selfieValue={value.selfie}
         isReviewStep={false}
         showHelp={showHelp}
+        showSelfieHelp={showSelfieHelp}
       />
       {showHelp && <TakeSelfieButton />}
       {!showHelp && isLastStep && <FormStepsButton.Submit />}

--- a/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/acuant-capture-spec.jsx
@@ -1068,6 +1068,7 @@ describe('document-capture/components/acuant-capture', () => {
 
   context('mobile selfie', () => {
     const trackEvent = sinon.stub();
+    const showSelfieHelp = sinon.stub();
 
     beforeEach(async () => {
       // Set up the components so that everything is as it would actually be -except- the AcuantSDK
@@ -1076,7 +1077,7 @@ describe('document-capture/components/acuant-capture', () => {
         <DeviceContext.Provider value={{ isMobile: true }}>
           <AnalyticsContext.Provider value={{ trackEvent }}>
             <AcuantContextProvider sdkSrc="about:blank" cameraSrc="about:blank">
-              <AcuantCapture label="Image" name="selfie" isReady />
+              <AcuantCapture label="Image" name="selfie" showSelfieHelp={showSelfieHelp} isReady />
             </AcuantContextProvider>
           </AnalyticsContext.Provider>
         </DeviceContext.Provider>,
@@ -1130,6 +1131,16 @@ describe('document-capture/components/acuant-capture', () => {
       expect(trackEvent).to.have.been.calledWith(
         'idv_sdk_selfie_image_capture_closed_without_photo',
       );
+    });
+
+    it('calls showSelfieHelp from onSelfieCaptureClosed', () => {
+      initialize({
+        selfieStart: sinon.stub().callsFake((callbacks) => {
+          callbacks.onClosed();
+        }),
+      });
+
+      expect(showSelfieHelp).to.have.been.called();
     });
 
     it('calls trackEvent from onSelfieCaptureSuccess', () => {

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
@@ -11,6 +11,7 @@ describe('DocumentSideAcuantCapture', () => {
     onChange: () => undefined,
     onError: () => undefined,
     isReviewStep: false,
+    showSelfieHelp: () => undefined,
   };
 
   context('when selfie is _not_ enabled', () => {


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15107](https://cm-jira.usa.gov/browse/LG-15107)


## 🛠 Summary of changes

Fixed an issue where if a user closes the selfie camera without selecting the green checkmark, it does not show  "How to capture" guidance. 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through doc auth with selfie.
- [ ] Upon reaching the selfie capture screen, close out rather than selecting the green checkmark.
- [ ] Confirm that the selfie help screen is still there


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
