### PR TITLE
Fix DOL report issues

### DIFF
--- a/app/jobs/reports/sp_idv_weekly_dropoff_report.rb
+++ b/app/jobs/reports/sp_idv_weekly_dropoff_report.rb
@@ -55,7 +55,7 @@ module Reports
     end
 
     def build_report_maker(issuers:, agency_abbreviation:, time_range:)
-      Reporting::SpProofingEventsByUuid.new(issuers:, agency_abbreviation:, time_range:)
+      Reporting::SpIdvWeeklyDropoffReport.new(issuers:, agency_abbreviation:, time_range:)
     end
   end
 end

--- a/lib/reporting/sp_proofing_events_by_uuid.rb
+++ b/lib/reporting/sp_proofing_events_by_uuid.rb
@@ -183,11 +183,13 @@ module Reporting
       uuid_map = Hash.new
 
       uuids.each_slice(1000) do |uuid_slice|
-        AgencyIdentity.joins(:user).where(
-          agency:,
-          users: { uuid: uuid_slice },
-        ).each do |agency_identity|
-          uuid_map[agency_identity.user.uuid] = agency_identity.uuid
+        Reports::BaseReport.transaction_with_timeout do
+          AgencyIdentity.joins(:user).where(
+            agency:,
+            users: { uuid: uuid_slice },
+          ).each do |agency_identity|
+            uuid_map[agency_identity.user.uuid] = agency_identity.uuid
+          end
         end
       end
 


### PR DESCRIPTION
This commit fixes 2 issues I found when test-driving the new DOL reports:

1. The IdV weekly dropoff report invoked the wrong report maker class. This commit fixes that.
2. The UUID matrix report timed out trying to batch fetch agency UUIDs. This commit modifies it to use the report timeout.
