### PR TITLE
LG-15484: Update design of Sign In/Create Account tabs

### DIFF
--- a/app/components/tab_navigation_component.html.erb
+++ b/app/components/tab_navigation_component.html.erb
@@ -1,29 +1,14 @@
 <%= content_tag(:nav, aria: { label: }, **tag_options, class: [*tag_options[:class], 'tab-navigation']) do %>
-  <ul class="usa-button-group usa-button-group--segmented">
+  <ul class="usa-button-group">
     <% routes.each do |route| %>
-      <% if current_path?(route[:path]) %>
-        <%= render ClickObserverComponent.new(
-              event_name: 'tab_navigation_current_page_clicked',
-              payload: { path: route[:path] },
-              role: 'listitem',
-              class: 'usa-button-group__item display-list-item',
-            ) do %>
-          <%= render ButtonComponent.new(
-                url: route[:path],
-                big: true,
-                outline: !current_path?(route[:path]),
-                aria: { current: current_path?(route[:path]) ? 'page' : nil },
-              ).with_content(route[:text]) %>
-        <% end %>
-      <% else %>
-        <li class="usa-button-group__item">
-          <%= render ButtonComponent.new(
-                url: route[:path],
-                big: true,
-                outline: !current_path?(route[:path]),
-                aria: { current: current_path?(route[:path]) ? 'page' : nil },
-              ).with_content(route[:text]) %>
-        </li>
+      <%= nav_list_item(route) do %>
+        <%= render ButtonComponent.new(
+              url: route[:path],
+              big: true,
+              outline: current_path?(route[:path]),
+              unstyled: !current_path?(route[:path]),
+              aria: { current: current_path?(route[:path]) ? 'page' : nil },
+            ).with_content(route[:text]) %>
       <% end %>
     <% end %>
   </ul>

--- a/app/components/tab_navigation_component.rb
+++ b/app/components/tab_navigation_component.rb
@@ -10,10 +10,35 @@ class TabNavigationComponent < BaseComponent
   end
 
   def current_path?(path)
-    recognized_path = Rails.application.routes.recognize_path(path, method: request.method)
-    request.params[:controller] == recognized_path[:controller] &&
-      request.params[:action] == recognized_path[:action]
-  rescue ActionController::RoutingError
-    false
+    @current_path ||= {}
+    if !@current_path.key?(path)
+      @current_path[path] = begin
+        recognized_path = Rails.application.routes.recognize_path(path, method: request.method)
+        request.params[:controller] == recognized_path[:controller] &&
+          request.params[:action] == recognized_path[:action]
+      rescue ActionController::RoutingError
+        false
+      end
+    end
+
+    @current_path[path]
+  end
+
+  private
+
+  def nav_list_item(route, &block)
+    if current_path?(route[:path])
+      render(
+        ClickObserverComponent.new(
+          event_name: 'tab_navigation_current_page_clicked',
+          payload: { path: route[:path] },
+          role: 'listitem',
+          class: 'usa-button-group__item display-list-item',
+        ),
+        &block
+      )
+    else
+      tag.li(class: 'usa-button-group__item', &block)
+    end
   end
 end

--- a/app/components/tab_navigation_component.scss
+++ b/app/components/tab_navigation_component.scss
@@ -2,14 +2,25 @@
 
 @forward 'usa-button-group/src/styles';
 
-.tab-navigation .usa-button-group--segmented {
+.tab-navigation .usa-button-group {
+  @include u-bg('base-lightest');
+  border-radius: 1.625rem;
+  flex-flow: nowrap;
+
   .usa-button-group__item {
     flex-basis: 50%;
   }
 
-  .usa-button-group__item:last-child > .usa-button,
   .usa-button {
+    @include u-flex('align-center', 'justify-center');
+    @include u-padding(1.5);
+    border-radius: 1.375rem;
     width: 100%;
+  }
+
+  .usa-button--unstyled {
+    @include u-text('bold');
+    text-decoration: none;
   }
 
   .usa-button--big {

--- a/app/javascript/packages/analytics/README.md
+++ b/app/javascript/packages/analytics/README.md
@@ -40,3 +40,8 @@ The custom element will implement the analytics logging behavior, but all markup
   <button type="button">Click me!</button>
 </lg-click-observer>
 ```
+
+The element supports the following attributes to customize its behavior:
+
+- `event-name`: The name of the analytics event that should be logged when clicked
+- `payload`: (Optional) JSON payload of additional data that should be included in the logged event

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -48,9 +48,9 @@
           form: f,
           action: SignInRecaptchaForm::RECAPTCHA_ACTION,
           button_options: { full_width: true },
-        ).with_content(t('links.sign_in')) %>
+        ).with_content(t('forms.buttons.submit.default')) %>
   <% else %>
-    <%= f.submit t('links.sign_in'), full_width: true, wide: false %>
+    <%= f.submit t('forms.buttons.submit.default'), full_width: true, wide: false %>
   <% end %>
 <% end %>
 <% if desktop_device? %>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -42,7 +42,12 @@
         required: true,
       ) %>
 
-  <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
+  <%= f.submit(
+        t('forms.buttons.submit.default'),
+        full_width: true,
+        wide: false,
+        class: 'display-block margin-y-5',
+      ) %>
 <% end %>
 
 <%= render 'shared/cancel', link: decorated_sp_session.cancel_link_url %>

--- a/spec/components/tab_navigation_component_spec.rb
+++ b/spec/components/tab_navigation_component_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe TabNavigationComponent, type: :component do
 
   it 'renders labelled navigation' do
     expect(rendered).to have_css('.tab-navigation[aria-label="Navigation"]')
+    expect(rendered).to have_css('li', count: 2)
     expect(rendered).to have_link('First') { |link| !is_current_link?(link) }
     expect(rendered).to have_link('Second') { |link| !is_current_link?(link) }
   end
@@ -41,8 +42,18 @@ RSpec.describe TabNavigationComponent, type: :component do
     end
 
     it 'renders current link as highlighted' do
+      expect(rendered).to have_css('li,[role=listitem]', count: 2)
       expect(rendered).to have_link('First') { |link| is_current_link?(link) }
       expect(rendered).to have_link('Second') { |link| !is_current_link?(link) }
+    end
+
+    it 'wraps link in click observer' do
+      expect(rendered).to have_link('First') do |link|
+        expect(link).to have_ancestor('lg-click-observer')
+      end
+      expect(rendered).to have_link('Second') do |link|
+        expect(link).not_to have_ancestor('lg-click-observer')
+      end
     end
 
     context 'with routes defining full URL' do
@@ -112,6 +123,6 @@ RSpec.describe TabNavigationComponent, type: :component do
   end
 
   def is_current_link?(link)
-    link.matches_css?('[aria-current="page"]:not(.usa-button--outline)')
+    link.matches_css?('[aria-current="page"].usa-button--outline')
   end
 end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -284,7 +284,7 @@ RSpec.feature 'saml api' do
           expect(page).to have_content(
             t('headings.create_account_with_sp.sp_text', app_name: APP_NAME),
           )
-          expect(page).to have_button('Sign in')
+          expect(page).to have_button(t('forms.buttons.submit.default'))
           # visit from SP with force_authn: true
           expect(page).to have_content(
             strip_tags(
@@ -334,7 +334,7 @@ RSpec.feature 'saml api' do
               ),
             ),
           )
-          expect(page).to have_button('Sign in')
+          expect(page).to have_button(t('forms.buttons.submit.default'))
           # Log in with Test SP as the SP session
           fill_in_credentials_and_submit(user.email, user.password)
           fill_in_code_with_last_phone_otp
@@ -363,7 +363,7 @@ RSpec.feature 'saml api' do
               ),
             ),
           )
-          expect(page).to have_button('Sign in')
+          expect(page).to have_button(t('forms.buttons.submit.default'))
 
           # log in for second time
           fill_in_credentials_and_submit(user.email, user.password)
@@ -404,7 +404,7 @@ RSpec.feature 'saml api' do
         expect(page).to have_content(
           t('headings.create_account_with_sp.sp_text', app_name: APP_NAME),
         )
-        expect(page).to have_button('Sign in')
+        expect(page).to have_button(t('forms.buttons.submit.default'))
         expect(page).to have_content(
           strip_tags(
             t(
@@ -439,7 +439,7 @@ RSpec.feature 'saml api' do
         expect(page).to have_content(
           t('headings.create_account_with_sp.sp_text', app_name: APP_NAME),
         )
-        expect(page).to have_button('Sign in')
+        expect(page).to have_button(t('forms.buttons.submit.default'))
         expect(page).to have_content(
           strip_tags(
             t(
@@ -454,7 +454,7 @@ RSpec.feature 'saml api' do
         expect(page).to have_content(
           t('headings.create_account_with_sp.sp_text', app_name: APP_NAME),
         )
-        expect(page).to have_button('Sign in')
+        expect(page).to have_button(t('forms.buttons.submit.default'))
         expect(page).to_not have_content(
           strip_tags(
             t(

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -192,7 +192,7 @@ RSpec.feature 'Password Recovery' do
 
         fill_in t('account.index.email'), with: @user.email
         fill_in t('components.password_toggle.label'), with: 'NewVal!dPassw0rd'
-        click_button t('links.sign_in')
+        click_button t('forms.buttons.submit.default')
         fill_in_code_with_last_phone_otp
         click_submit_default
         click_agree_and_continue

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -98,7 +98,7 @@ module Features
     def fill_in_credentials_and_submit(email, password)
       fill_in t('account.index.email'), with: email
       fill_in t('account.index.password'), with: password
-      click_button t('links.sign_in')
+      click_button t('forms.buttons.submit.default')
     end
 
     def fill_in_totp_name(nickname = 'App')

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
       let(:sign_in_recaptcha_enabled) { false }
 
       it 'renders default sign-in submit button' do
-        expect(rendered).to have_button(t('links.sign_in'))
+        expect(rendered).to have_button(t('forms.buttons.submit.default'))
         expect(rendered).not_to have_css('lg-captcha-submit-button')
       end
 
@@ -243,7 +243,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
         let(:recaptcha_mock_validator) { true }
 
         it 'renders captcha sign-in submit button' do
-          expect(rendered).to have_button(t('links.sign_in'))
+          expect(rendered).to have_button(t('forms.buttons.submit.default'))
           expect(rendered).to have_css('lg-captcha-submit-button')
         end
       end
@@ -253,7 +253,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
       let(:sign_in_recaptcha_enabled) { true }
 
       it 'renders captcha sign-in submit button' do
-        expect(rendered).to have_button(t('links.sign_in'))
+        expect(rendered).to have_button(t('forms.buttons.submit.default'))
         expect(rendered).to have_css('lg-captcha-submit-button')
       end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-15484](https://cm-jira.usa.gov/browse/LG-15484)

## 🛠 Summary of changes

Updates the visual appearance of the "Sign in" and "Create an Account" tabs on the sign-in page.

The intention of these changes is to improve the design clarity of the buttons being a tab control, since we have observed with the current (previous) designs that many users will click on the active button (e.g. "Sign in") while already on that page, with the expectation of it being a call-to-action button to continue signing in.

Changes also include some standardization of button appearance between the "Sign in" and "Create an account" pages:

- Always display the button at full-width (previously the button was full-width on the Sign In page, but wide width on the Create an Account page)
- Always display the button with a "Submit" label (previously the button was "Submit" on the Create an Account page, but "Sign in" on the Sign In page)

## 📜 Testing Plan

Verify there are no regressions in toggling between "Sign in" and "Create an Account", including expected states of links (hover, focus, active).

Verify there are no regressions with submitting "Sign in" or "Create an Account" page forms.

## 👀 Screenshots

Screen|Before|After
---|---|---
Sign In|![Screenshot 2025-02-12 at 8 57 07 AM](https://github.com/user-attachments/assets/f790781f-10a3-4330-89f6-b995ce5d2468)|![Screenshot 2025-02-12 at 8 56 49 AM](https://github.com/user-attachments/assets/3e92d43d-5ebe-4195-82dd-e052948d6942)
Create an Account|![Screenshot 2025-02-12 at 8 57 10 AM](https://github.com/user-attachments/assets/79c7d82f-9866-4f80-8b1b-ec7c26898d37)|![Screenshot 2025-02-12 at 8 56 53 AM](https://github.com/user-attachments/assets/4f4ef310-5eb4-417e-8e8d-eb6ff97a7939)