### PR TITLE
LG-15753: Update translations for Face/Touch user events

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -856,8 +856,8 @@ event_types.sign_in_notification_timeframe_expired: Venció el tiempo del mensaj
 event_types.sign_in_unsuccessful_2fa: No se pudo autenticar
 event_types.webauthn_key_added: Clave de seguridad de hardware añadida
 event_types.webauthn_key_removed: Clave de seguridad de hardware eliminada
-event_types.webauthn_platform_added: Desbloqueo facial o táctil añadido
-event_types.webauthn_platform_removed: Desbloqueo facial o táctil eliminado
+event_types.webauthn_platform_added: Se agregó el desbloqueo facial o táctil
+event_types.webauthn_platform_removed: Se eliminó el desbloqueo facial o táctil
 forms.backup_code_regenerate.caution: Si vuelve a generar sus códigos de recuperación, recibirá un conjunto nuevo de códigos. Sus códigos de recuperación originales ya no serán válidos.
 forms.backup_code_regenerate.confirm: '¿Está seguro de que desea volver a generar sus códigos de recuperación?'
 forms.backup_code_reminder.body_info: Si no puede acceder a su método de autenticación principal, puede usar códigos de recuperación para acceder a su cuenta.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -856,8 +856,8 @@ event_types.sign_in_notification_timeframe_expired: 从新设备登录的通知�
 event_types.sign_in_unsuccessful_2fa: 身份证实失败
 event_types.webauthn_key_added: 硬件安全密钥已添加
 event_types.webauthn_key_removed: 硬件安全密钥已去掉
-event_types.webauthn_platform_added: 人脸或触摸解锁已添加。
-event_types.webauthn_platform_removed: 人脸或触摸解锁已去掉。
+event_types.webauthn_platform_added: 添加了人脸或触摸解锁
+event_types.webauthn_platform_removed: 取消了人脸或触摸解锁
 forms.backup_code_regenerate.caution: 如果你重新生成备用代码，会收到新的一套备用代码。你原来的备用代码就会失效。
 forms.backup_code_regenerate.confirm: 你确定要重新生成备用代码吗？
 forms.backup_code_reminder.body_info: 如果你无法使用自己的主要身份证实方法，可以使用备用代码重新获得对账户的访问权。


### PR DESCRIPTION
## 🎫 Ticket

[LG-15753](https://cm-jira.usa.gov/browse/LG-15753)

## 🛠 Summary of changes

Updates translations for Face or Touch Unlock user events added in LG-11867 (#11833, #11823), for the following labels:

- "Face or touch unlock added"
- "Face or touch unlock removed"

The translations implemented in those pull requests were temporary texts while we worked to obtain translations from our translation partner.

Only Spanish and Chinese updates were required, since the French translation provided to us was identical to what was already implemented.

## 📜 Testing Plan

Repeat Testing Plan from #11823, specifically observing updated labels for when viewing the page in Spanish or Chinese.

## 👀 Screenshots

Note that "English" and "French" in the screenshots below are identical between "Before" and "After".

Language|Before|After
---|---|---
English|![image](https://github.com/user-attachments/assets/54b7ffbd-d185-4779-8067-23f30db47363)|![image](https://github.com/user-attachments/assets/54b7ffbd-d185-4779-8067-23f30db47363)
French|![image](https://github.com/user-attachments/assets/491c6a29-bd26-4cac-9436-f8418d7c5581)|![image](https://github.com/user-attachments/assets/491c6a29-bd26-4cac-9436-f8418d7c5581)
Spanish|![image](https://github.com/user-attachments/assets/e3ab9e9d-4b8c-470a-8d6f-c084323afe09)|![image](https://github.com/user-attachments/assets/70243e2d-cf04-4317-a50e-05a0c404b4c1)
Chinese|![image](https://github.com/user-attachments/assets/f9eca50b-1661-4105-8808-6b3dca2bc59a)|![image](https://github.com/user-attachments/assets/01618768-dc00-43ea-8cf3-2cf98510725a)