### PR TITLE
Include MJS and CJS files in ESLint lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "postinstall": "yarn workspace @18f/identity-analytics run postinstall",
     "typecheck": "tsc",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.cjs,.mjs",
     "lint:css": "stylelint 'app/assets/stylesheets/**/*.scss' 'app/javascript/**/*.scss' 'app/components/*.scss'",
     "lint:openapi": "./scripts/lint-openapi-spec.mjs",
     "test": "mocha 'spec/javascript/**/**spec.+(j|t)s?(x)' 'app/javascript/packages/**/*.spec.+(j|t)s?(x)'",

--- a/scripts/lint-openapi-spec.mjs
+++ b/scripts/lint-openapi-spec.mjs
@@ -12,4 +12,5 @@ assert(
   `The OpenAPI spec is not valid.
 
   Found ${JSON.stringify(lintResults, null, 2)}
-  `)
+  `,
+);


### PR DESCRIPTION
## 🛠 Summary of changes

Updates `lint` NPM script to include `.cjs` and `.mjs` files in lint checks.

These file extensions are used when using either [CommonJS](https://nodejs.org/docs/latest/api/modules.html#modules-commonjs-modules) or [ES Modules](https://nodejs.org/docs/latest/api/esm.html#modules-ecmascript-modules) in a package with an opposing [`type`](https://nodejs.org/api/packages.html#type).

## 📜 Testing Plan

Verify `yarn lint` passes.