### PR TITLE
Update Rack gem to latest 3.1.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,7 +512,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.0.11)
+    rack (3.1.10)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-headers_filter (0.0.1)


### PR DESCRIPTION
## 🛠 Summary of changes

Updates the Rack gem to the latest version.

Changelog: https://github.com/rack/rack/blob/main/CHANGELOG.md

Note that the [3.1.0 release](https://github.com/rack/rack/blob/main/CHANGELOG.md#310---2024-06-11) includes a number of breaking changes, though upon review, there does not appear to be any changes impacting our current usage.

## 📜 Testing Plan

Verify build passes.

Verify `make audit` produces no security advisories output after running `bundle install`.