### PR TITLE
LG-15655: Offload reCAPTCHA annotations to worker job (Part 1 of 2)

### DIFF
--- a/app/jobs/recaptcha_annotate_job.rb
+++ b/app/jobs/recaptcha_annotate_job.rb
@@ -8,7 +8,7 @@ class RecaptchaAnnotateJob < ApplicationJob
   queue_as :low
 
   good_job_control_concurrency_with(
-    enqueue_limit: 1,
+    perform_limit: 1,
     key: -> { "#{self.class.name}-#{queue_name}-#{arguments.last[:assessment_id]}" },
   )
 

--- a/app/jobs/recaptcha_annotate_job.rb
+++ b/app/jobs/recaptcha_annotate_job.rb
@@ -10,7 +10,7 @@ class RecaptchaAnnotateJob < ApplicationJob
     key: -> { "#{self.class.name}-#{queue_name}-#{arguments.last[:assessment_id]}" },
   )
 
-  def perform(assessment_id:, reason: nil, annotation: nil)
+  def perform(assessment_id:, reason:, annotation: nil)
     RecaptchaAnnotator.annotate(assessment_id:, reason:, annotation:)
   end
 end

--- a/app/jobs/recaptcha_annotate_job.rb
+++ b/app/jobs/recaptcha_annotate_job.rb
@@ -3,8 +3,6 @@
 class RecaptchaAnnotateJob < ApplicationJob
   include GoodJob::ActiveJobExtensions::Concurrency
 
-  BASE_ENDPOINT = 'https://recaptchaenterprise.googleapis.com/v1'
-
   queue_as :low
 
   good_job_control_concurrency_with(
@@ -13,39 +11,6 @@ class RecaptchaAnnotateJob < ApplicationJob
   )
 
   def perform(assessment_id:, reason: nil, annotation: nil)
-    submit_annotation(assessment_id:, reason:, annotation:)
-  end
-
-  private
-
-  def submit_annotation(assessment_id:, reason:, annotation:)
-    request_body = { annotation:, reasons: reason && [reason] }.compact
-    faraday.post(annotation_url(assessment_id:), request_body) do |request|
-      request.options.context = { service_name: 'recaptcha_annotate' }
-    end
-  rescue Faraday::Error => error
-    NewRelic::Agent.notice_error(error)
-  end
-
-  def faraday
-    Faraday.new do |conn|
-      conn.options.timeout = IdentityConfig.store.recaptcha_request_timeout_in_seconds
-
-      conn.request :instrumentation, name: 'request_log.faraday'
-      conn.request :json
-      conn.response :json
-    end
-  end
-
-  def annotation_url(assessment_id:)
-    UriService.add_params(
-      format(
-        '%{base_endpoint}/%{assessment_id}:annotate',
-        base_endpoint: BASE_ENDPOINT,
-        project_id: IdentityConfig.store.recaptcha_enterprise_project_id,
-        assessment_id:,
-      ),
-      key: IdentityConfig.store.recaptcha_enterprise_api_key,
-    )
+    RecaptchaAnnotator.annotate(assessment_id:, reason:, annotation:)
   end
 end

--- a/app/jobs/recaptcha_annotate_job.rb
+++ b/app/jobs/recaptcha_annotate_job.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class RecaptchaAnnotateJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  BASE_ENDPOINT = 'https://recaptchaenterprise.googleapis.com/v1'
+
+  queue_as :low
+
+  good_job_control_concurrency_with(
+    enqueue_limit: 1,
+    key: -> { "#{self.class.name}-#{queue_name}-#{arguments.last[:assessment_id]}" },
+  )
+
+  def perform(assessment_id:, reason: nil, annotation: nil)
+    submit_annotation(assessment_id:, reason:, annotation:)
+  end
+
+  private
+
+  def submit_annotation(assessment_id:, reason:, annotation:)
+    request_body = { annotation:, reasons: reason && [reason] }.compact
+    faraday.post(annotation_url(assessment_id:), request_body) do |request|
+      request.options.context = { service_name: 'recaptcha_annotate' }
+    end
+  rescue Faraday::Error => error
+    NewRelic::Agent.notice_error(error)
+  end
+
+  def faraday
+    Faraday.new do |conn|
+      conn.options.timeout = IdentityConfig.store.recaptcha_request_timeout_in_seconds
+
+      conn.request :instrumentation, name: 'request_log.faraday'
+      conn.request :json
+      conn.response :json
+    end
+  end
+
+  def annotation_url(assessment_id:)
+    UriService.add_params(
+      format(
+        '%{base_endpoint}/%{assessment_id}:annotate',
+        base_endpoint: BASE_ENDPOINT,
+        project_id: IdentityConfig.store.recaptcha_enterprise_project_id,
+        assessment_id:,
+      ),
+      key: IdentityConfig.store.recaptcha_enterprise_api_key,
+    )
+  end
+end

--- a/app/jobs/recaptcha_annotate_job.rb
+++ b/app/jobs/recaptcha_annotate_job.rb
@@ -1,16 +1,7 @@
 # frozen_string_literal: true
 
 class RecaptchaAnnotateJob < ApplicationJob
-  include GoodJob::ActiveJobExtensions::Concurrency
-
-  queue_as :low
-
-  good_job_control_concurrency_with(
-    perform_limit: 1,
-    key: -> { "#{self.class.name}-#{queue_name}-#{arguments.last[:assessment_id]}" },
-  )
-
-  def perform(assessment_id:, reason:, annotation: nil)
-    RecaptchaAnnotator.annotate(assessment_id:, reason:, annotation:)
+  def perform(assessment:)
+    RecaptchaAnnotator.submit_assessment(assessment)
   end
 end

--- a/app/models/recaptcha_assessment.rb
+++ b/app/models/recaptcha_assessment.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RecaptchaAssessment < ApplicationRecord
+  enum :annotation, {
+    legitimate: 'LEGITIMATE',
+    fraudulent: 'FRAUDULENT',
+  }
+
+  enum :annotation_reason, {
+    initiated_two_factor: 'INITIATED_TWO_FACTOR',
+    passed_two_factor: 'PASSED_TWO_FACTOR',
+    failed_two_factor: 'FAILED_TWO_FACTOR',
+  }
+end

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -5,15 +5,15 @@ class RecaptchaAnnotator
 
   # See: https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1/projects.assessments/annotate#reason
   module AnnotationReasons
-    INITIATED_TWO_FACTOR = :INITIATED_TWO_FACTOR
-    PASSED_TWO_FACTOR = :PASSED_TWO_FACTOR
-    FAILED_TWO_FACTOR = :FAILED_TWO_FACTOR
+    INITIATED_TWO_FACTOR = 'INITIATED_TWO_FACTOR'
+    PASSED_TWO_FACTOR = 'PASSED_TWO_FACTOR'
+    FAILED_TWO_FACTOR = 'FAILED_TWO_FACTOR'
   end
 
   # See: https://cloud.google.com/recaptcha-enterprise/docs/reference/rest/v1/projects.assessments/annotate#annotation
   module Annotations
-    LEGITIMATE = :LEGITIMATE
-    FRAUDULENT = :FRAUDULENT
+    LEGITIMATE = 'LEGITIMATE'
+    FRAUDULENT = 'FRAUDULENT'
   end
 
   class << self
@@ -42,7 +42,7 @@ class RecaptchaAnnotator
 
     def create_or_update_assessment!(assessment_id:, reason:, annotation:)
       assessment = RecaptchaAssessment.find_or_initialize_by(id: assessment_id)
-      assessment.update(annotation_reason: reason&.to_s, annotation: annotation&.to_s)
+      assessment.update(annotation_reason: reason, annotation:)
       assessment
     end
 

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -22,12 +22,29 @@ class RecaptchaAnnotator
 
       if FeatureManagement.recaptcha_enterprise?
         submit_annotation(assessment_id:, reason:, annotation:)
+        # Future:
+        # assessment = create_or_update_assessment!(assessment_id:, reason:, annotation:)
+        # RecaptchaAnnotateJob.perform_later(assessment:)
       end
 
       { assessment_id:, reason:, annotation: }
     end
 
+    def submit_assessment(assessment)
+      submit_annotation(
+        assessment_id: assessment.id,
+        annotation: assessment.annotation_before_type_cast,
+        reason: assessment.annotation_reason_before_type_cast,
+      )
+    end
+
     private
+
+    def create_or_update_assessment!(assessment_id:, reason:, annotation:)
+      assessment = RecaptchaAssessment.find_or_initialize_by(id: assessment_id)
+      assessment.update(annotation_reason: reason&.to_s, annotation: annotation&.to_s)
+      assessment
+    end
 
     def submit_annotation(assessment_id:, reason:, annotation:)
       request_body = { annotation:, reasons: reason && [reason] }.compact

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
 
   config.action_controller.asset_host = ENV['RAILS_ASSET_HOST'] if ENV.key?('RAILS_ASSET_HOST')
 
+  config.good_job.inline_execution_respects_schedule = true
+
   config.middleware.use RackSessionAccess::Middleware
 
   config.after_initialize do

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,8 +31,6 @@ Rails.application.configure do
 
   config.action_controller.asset_host = ENV['RAILS_ASSET_HOST'] if ENV.key?('RAILS_ASSET_HOST')
 
-  config.good_job.inline_execution_respects_schedule = true
-
   config.middleware.use RackSessionAccess::Middleware
 
   config.after_initialize do

--- a/db/primary_migrate/20250224134110_create_recaptcha_assessments.rb
+++ b/db/primary_migrate/20250224134110_create_recaptcha_assessments.rb
@@ -1,0 +1,8 @@
+class CreateRecaptchaAssessments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :recaptcha_assessments, id: :string do |t|
+      t.string :annotation, comment: 'sensitive=false'
+      t.string :annotation_reason, comment: 'sensitive=false'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_19_164618) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_24_134110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -477,6 +477,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_164618) do
     t.index ["ssn_signature"], name: "index_profiles_on_ssn_signature"
     t.index ["user_id", "active"], name: "index_profiles_on_user_id_and_active", unique: true, where: "(active = true)"
     t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
+
+  create_table "recaptcha_assessments", id: :string, force: :cascade do |t|
+    t.string "annotation", comment: "sensitive=false"
+    t.string "annotation_reason", comment: "sensitive=false"
   end
 
   create_table "registration_logs", force: :cascade do |t|

--- a/spec/factories/recaptcha_assessments.rb
+++ b/spec/factories/recaptcha_assessments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :recaptcha_assessment do
+    id { "projects/0000000000/assessments/#{Random.hex(8)}" }
+    annotation_reason { 'INITIATED_TWO_FACTOR' }
+  end
+end

--- a/spec/jobs/recaptcha_annotate_job_spec.rb
+++ b/spec/jobs/recaptcha_annotate_job_spec.rb
@@ -1,65 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe RecaptchaAnnotateJob do
-  include ActiveJob::TestHelper
-
-  subject(:instance) { described_class.new(assessment_id:, reason:, annotation:) }
-  let(:recaptcha_enterprise_api_key) { 'recaptcha_enterprise_api_key' }
-  let(:recaptcha_enterprise_project_id) { 'project_id' }
-  let(:assessment_id) { "projects/#{recaptcha_enterprise_project_id}/assessments/assessment-id" }
-  let(:reason) { RecaptchaAnnotator::AnnotationReasons::PASSED_TWO_FACTOR }
-  let(:annotation) { RecaptchaAnnotator::Annotations::LEGITIMATE }
-  let(:annotation_url) do
-    format(
-      '%{base_endpoint}/%{assessment_id}:annotate?key=%{api_key}',
-      base_endpoint: RecaptchaAnnotator::BASE_ENDPOINT,
-      assessment_id:,
-      api_key: recaptcha_enterprise_api_key,
-    )
-  end
-
-  before do
-    allow(FeatureManagement).to receive(:recaptcha_enterprise?).and_return(true)
-    allow(IdentityConfig.store).to receive(:recaptcha_enterprise_project_id)
-      .and_return(recaptcha_enterprise_project_id)
-    allow(IdentityConfig.store).to receive(:recaptcha_enterprise_api_key)
-      .and_return(recaptcha_enterprise_api_key)
-    stub_request(:post, annotation_url)
-      .to_return(headers: { 'Content-Type': 'application/json' }, body: '{}')
-  end
+  subject(:instance) { described_class.new }
+  let(:assessment) { create(:recaptcha_assessment) }
 
   describe '#perform' do
-    subject(:result) { instance.perform(assessment_id:, reason:, annotation:) }
+    subject(:result) { instance.perform(assessment:) }
 
-    it 'processes in order' do
-      ActiveJob::Base.queue_adapter = :good_job
+    it 'submits annotation for assessment' do
+      expect(RecaptchaAnnotator).to receive(:submit_assessment).with(assessment)
 
-      initiate_instance = described_class.new(
-        assessment_id:,
-        reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
-        annotation:,
-      )
-      initiate_instance.enqueue
-      instance.enqueue
-      GoodJob.perform_inline
-
-      requests_enum = WebMock::RequestRegistry.instance.requested_signatures.to_enum.each
-      expect(requests_enum.next).to satisfy do |request, _order|
-        expected_body = {
-          annotation:,
-          reasons: [RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR],
-        }.to_json
-        request.uri == Addressable::URI.parse(annotation_url) &&
-          request.method == :post &&
-          request.body == expected_body
-      end
-      expect(requests_enum.next).to satisfy do |request, _order|
-        expected_body = { annotation:, reasons: [reason] }.to_json
-        request.uri == Addressable::URI.parse(annotation_url) &&
-          request.method == :post &&
-          request.body == expected_body
-      end
-      expect { requests_enum.peek }.to raise_error(StopIteration)
+      result
     end
   end
 end

--- a/spec/jobs/recaptcha_annotate_job_spec.rb
+++ b/spec/jobs/recaptcha_annotate_job_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe RecaptchaAnnotateJob do
+  include ActiveJob::TestHelper
+
+  subject(:instance) { described_class.new }
+  let(:recaptcha_enterprise_api_key) { 'recaptcha_enterprise_api_key' }
+  let(:recaptcha_enterprise_project_id) { 'project_id' }
+  let(:assessment_id) { "projects/#{recaptcha_enterprise_project_id}/assessments/assessment-id" }
+  let(:reason) { RecaptchaAnnotator::AnnotationReasons::PASSED_TWO_FACTOR }
+  let(:annotation) { RecaptchaAnnotator::Annotations::LEGITIMATE }
+  let(:annotation_url) do
+    format(
+      '%{base_endpoint}/%{assessment_id}:annotate?key=%{api_key}',
+      base_endpoint: RecaptchaAnnotateJob::BASE_ENDPOINT,
+      assessment_id:,
+      api_key: recaptcha_enterprise_api_key,
+    )
+  end
+
+  before do
+    allow(FeatureManagement).to receive(:recaptcha_enterprise?).and_return(true)
+    allow(IdentityConfig.store).to receive(:recaptcha_enterprise_project_id)
+      .and_return(recaptcha_enterprise_project_id)
+    allow(IdentityConfig.store).to receive(:recaptcha_enterprise_api_key)
+      .and_return(recaptcha_enterprise_api_key)
+    stub_request(:post, annotation_url)
+      .to_return(headers: { 'Content-Type': 'application/json' }, body: '{}')
+  end
+
+  describe '#perform' do
+    subject(:result) { instance.perform(assessment_id:, reason:, annotation:) }
+
+    it 'processes in order' do
+      ActiveJob::Base.queue_adapter = :good_job
+
+      RecaptchaAnnotateJob.set(wait: 10.minutes).perform_later(assessment_id:, reason:, annotation:)
+      RecaptchaAnnotateJob.set(wait: 5.minutes).perform_later(
+        assessment_id:,
+        reason: RecaptchaAnnotator::AnnotationReasons::FAILED_TWO_FACTOR,
+        annotation:,
+      )
+      RecaptchaAnnotateJob.perform_later(
+        assessment_id:,
+        reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
+        annotation:,
+      )
+
+      expect(WebMock).not_to have_requested(:post, annotation_url)
+
+      travel_to 11.minutes.from_now do
+        GoodJob.perform_inline
+        expect(WebMock).to have_requested(:post, annotation_url).once
+        expect(WebMock).to have_requested(:post, annotation_url)
+          .with(body: { annotation:, reasons: [reason] }.to_json)
+      end
+    end
+
+    context 'with an optional argument omitted' do
+      let(:annotation) { nil }
+
+      it 'submits only what is provided' do
+        result
+
+        expect(WebMock).to have_requested(:post, annotation_url)
+          .with(body: { reasons: [reason] }.to_json)
+      end
+    end
+
+    context 'with connection error' do
+      before do
+        stub_request(:post, annotation_url).to_timeout
+      end
+
+      it 'fails gracefully' do
+        result
+      end
+
+      it 'notices the error to NewRelic' do
+        expect(NewRelic::Agent).to receive(:notice_error).with(Faraday::Error)
+
+        result
+      end
+    end
+  end
+end

--- a/spec/jobs/recaptcha_annotate_job_spec.rb
+++ b/spec/jobs/recaptcha_annotate_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RecaptchaAnnotateJob do
   let(:annotation_url) do
     format(
       '%{base_endpoint}/%{assessment_id}:annotate?key=%{api_key}',
-      base_endpoint: RecaptchaAnnotateJob::BASE_ENDPOINT,
+      base_endpoint: RecaptchaAnnotator::BASE_ENDPOINT,
       assessment_id:,
       api_key: recaptcha_enterprise_api_key,
     )
@@ -60,33 +60,6 @@ RSpec.describe RecaptchaAnnotateJob do
           request.body == expected_body
       end
       expect { requests_enum.peek }.to raise_error(StopIteration)
-    end
-
-    context 'with an optional argument omitted' do
-      let(:annotation) { nil }
-
-      it 'submits only what is provided' do
-        result
-
-        expect(WebMock).to have_requested(:post, annotation_url)
-          .with(body: { reasons: [reason] }.to_json)
-      end
-    end
-
-    context 'with connection error' do
-      before do
-        stub_request(:post, annotation_url).to_timeout
-      end
-
-      it 'fails gracefully' do
-        result
-      end
-
-      it 'notices the error to NewRelic' do
-        expect(NewRelic::Agent).to receive(:notice_error).with(Faraday::Error)
-
-        result
-      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[LG-15655](https://cm-jira.usa.gov/browse/LG-15655)

## 🛠 Summary of changes

Implements a new worker job to send [annotations for Google reCAPTCHA Enterprise](https://cloud.google.com/recaptcha/docs/annotate-assessment).

The intent is to avoid these external API requests slowing user response times in the main application. Since these annotations are already treated as "fire and forget", they're a prime candidate to worker-ize, particularly since we don't rely on any result of the job.

The primary challenge with this is ensuring that annotations for a particular assessment are handled in order in a "last wins" approach. We don't necessarily need all annotations to be sent, as long as the last annotation enqueued is the one to be sent. ~This is achieved using GoodJob's concurrency helpers with a maximum `enqueue_limit` of `1` ([see docs](https://github.com/bensheldon/good_job?tab=readme-ov-file#concurrency-controls)).~ **Edit:** After additional challenges noted in comments below, the implementation was changed to save the latest annotation in a new database table, with the worker job being responsible for sending the latest annotated value.

The changes here only include the implementation of the job, [to avoid deployment issues](https://handbook.login.gov/articles/manage-50-50-state.html#add-a-new-job). A follow-up pull request will update the `RecaptchaAnnotator` class to enqueue jobs.

## 📜 Testing Plan

Verify that build passes.

You can also verify how this will be expected to behave by replacing [the current `submit_annotation` behavior with the commented future code](https://github.com/18F/identity-idp/pull/11883/files#diff-106b346b4850d8e073894d521d78b0be1276bbbd0827a727fc0ed98fc942c0e0R24-R27).

Then, ensure you have reCAPTCHA configured to run, using local development credentials in `config/application.yml`:

```yml
development:
  sign_in_recaptcha_score_threshold: 0.3
  sign_in_recaptcha_percent_tested: 100
  recaptcha_site_key: '<insert site key>'
  recaptcha_enterprise_api_key: '<insert api key>'
  recaptcha_enterprise_project_id: '<insert project id>'
  recaptcha_mock_validator: false
```

The best way to verify that the annotation is submitted is by placing a `binding.pry` breakpoint in `RecaptchaAnnotator#submit_annotation`, which should include expected parameters when MFA is initiated, submitted unsuccessfully, and submitted successfully.