### PR TITLE
LG-15624: Hide the warning banner on the password reset page

### DIFF
--- a/app/views/user_mailer/reset_password_instructions.html.erb
+++ b/app/views/user_mailer/reset_password_instructions.html.erb
@@ -17,7 +17,7 @@
   </h1>
 <% end %>
 
-<% if @in_person_verification_pending_profile %>
+<% if @in_person_verification_pending_profile && !IdentityConfig.store.feature_pending_in_person_password_reset_enabled %>
   <%= render 'user_mailer/shared/in_person_warning_banner' %>
   <h1>
     <%= @header || message.subject %>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -185,8 +185,8 @@ RSpec.describe UserMailer, type: :mailer do
         expect(mail.subject).to eq t('user_mailer.reset_password_instructions.subject')
       end
 
-      it 'renders the in person warning banner' do
-        expect(mail.html_part.body).to have_content(
+      it 'does not render the in person warning banner' do
+        expect(mail.html_part.body).not_to have_content(
           strip_tags(
             t('user_mailer.reset_password_instructions.in_person_warning_description_html'),
           ),

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -185,12 +185,34 @@ RSpec.describe UserMailer, type: :mailer do
         expect(mail.subject).to eq t('user_mailer.reset_password_instructions.subject')
       end
 
-      it 'does not render the in person warning banner' do
-        expect(mail.html_part.body).not_to have_content(
-          strip_tags(
-            t('user_mailer.reset_password_instructions.in_person_warning_description_html'),
-          ),
-        )
+      context 'when feature_pending_in_person_password_reset_enabled flag is true' do
+        before do
+          allow(IdentityConfig.store).to receive(:feature_pending_in_person_password_reset_enabled)
+            .and_return(true)
+        end
+
+        it 'does not render the in person warning banner' do
+          expect(mail.html_part.body).not_to have_content(
+            strip_tags(
+              t('user_mailer.reset_password_instructions.in_person_warning_description_html'),
+            ),
+          )
+        end
+      end
+
+      context 'when feature_pending_in_person_password_reset_enabled flag is false' do
+        before do
+          allow(IdentityConfig.store).to receive(:feature_pending_in_person_password_reset_enabled)
+            .and_return(false)
+        end
+
+        it 'renders the in person warning banner' do
+          expect(mail.html_part.body).to have_content(
+            strip_tags(
+              t('user_mailer.reset_password_instructions.in_person_warning_description_html'),
+            ),
+          )
+        end
       end
 
       it 'does not render the gpo warning alert' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15624](https://cm-jira.usa.gov/browse/LG-15624)

## 🛠 Summary of changes

- Update "in person verification" pending test to check banner is hidden
- If person proofing verification must be pending AND feature flag `feature_pending_in_person_password_reset_enabled` is enabled, hide the banner

## 📜 Testing Plan

- [x] Login through the identity-oidc-sinatra application selecting Identity Verified
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the barcode email (pending review)
- [x] Go to [your account](http://localhost:3000/account)
- [x] Sign out
- [x] Click "Forgot your password?"
- [x] Enter email

## 👀 Screenshots
*Before*
<img width="577" alt="Screenshot 2025-02-14 at 9 39 52 AM" src="https://github.com/user-attachments/assets/9763e4a8-3625-4a65-97b3-a586251dee19" />

*After*
<img width="579" alt="Screenshot 2025-02-14 at 9 35 26 AM" src="https://github.com/user-attachments/assets/ada04926-bbce-4661-b1b3-1e35cd0c761b" />
