### PR TITLE
LG-15602 Track user event for deleted backup codes

### DIFF
--- a/app/controllers/concerns/mfa_deletion_concern.rb
+++ b/app/controllers/concerns/mfa_deletion_concern.rb
@@ -4,7 +4,7 @@ module MfaDeletionConcern
   include RememberDeviceConcern
 
   def handle_successful_mfa_deletion(event_type:)
-    create_user_event(event_type) if event_type
+    create_user_event(event_type)
     revoke_remember_device(current_user)
     event = PushNotification::RecoveryInformationChangedEvent.new(user: current_user)
     PushNotification::HttpPush.deliver(event)

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -59,7 +59,7 @@ module Users
 
     def delete
       current_user.backup_code_configurations.destroy_all
-      handle_successful_mfa_deletion(event_type: nil)
+      handle_successful_mfa_deletion(event_type: :backup_codes_removed)
       flash[:success] = t('notices.backup_codes_deleted')
       if in_multi_mfa_selection_flow?
         redirect_to authentication_methods_setup_path

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,6 +31,7 @@ class Event < ApplicationRecord
     sign_in_notification_timeframe_expired: 24,
     webauthn_platform_added: 25,
     webauthn_platform_removed: 26,
+    backup_codes_removed: 27,
   }
 
   validates :event_type, presence: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -825,6 +825,7 @@ event_types.authenticated_at_html: Signed in at %{service_provider_link_html}
 event_types.authenticator_disabled: Authenticator app removed
 event_types.authenticator_enabled: Authenticator app added
 event_types.backup_codes_added: Backup codes added
+event_types.backup_codes_removed: Backup codes removed
 event_types.eastern_timestamp: '%{timestamp} (Eastern)'
 event_types.email_changed: Email address changed
 event_types.email_deleted: Email address deleted

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -836,6 +836,7 @@ event_types.authenticated_at_html: Sesión iniciada en %{service_provider_link_h
 event_types.authenticator_disabled: Aplicación de autenticación eliminada
 event_types.authenticator_enabled: Aplicación de autenticación agregada
 event_types.backup_codes_added: Códigos de recuperación añadidos
+event_types.backup_codes_removed: Se eliminó el códigos de recuperación
 event_types.eastern_timestamp: '%{timestamp} (hora del Este)'
 event_types.email_changed: Dirección de correo electrónico modificada
 event_types.email_deleted: Dirección de correo electrónico eliminada

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -836,7 +836,7 @@ event_types.authenticated_at_html: Sesión iniciada en %{service_provider_link_h
 event_types.authenticator_disabled: Aplicación de autenticación eliminada
 event_types.authenticator_enabled: Aplicación de autenticación agregada
 event_types.backup_codes_added: Códigos de recuperación añadidos
-event_types.backup_codes_removed: Se eliminó el códigos de recuperación
+event_types.backup_codes_removed: Códigos de recuperación eliminados
 event_types.eastern_timestamp: '%{timestamp} (hora del Este)'
 event_types.email_changed: Dirección de correo electrónico modificada
 event_types.email_deleted: Dirección de correo electrónico eliminada

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -825,6 +825,7 @@ event_types.authenticated_at_html: Connecté à %{service_provider_link_html}
 event_types.authenticator_disabled: Appli d’authentification supprimée
 event_types.authenticator_enabled: Appli d’authentification ajoutée
 event_types.backup_codes_added: Codes de sauvegarde ajoutés
+event_types.backup_codes_removed: Codes de sauvegarde supprimés
 event_types.eastern_timestamp: '%{timestamp} (heure de l’Est)'
 event_types.email_changed: Adresse e-mail modifiée
 event_types.email_deleted: Adresse e-mail supprimée

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -836,6 +836,7 @@ event_types.authenticated_at_html: 已在 %{service_provider_link_html}登录
 event_types.authenticator_disabled: 身份证实器应用程序已去掉
 event_types.authenticator_enabled: 身份证实器应用程序已添加
 event_types.backup_codes_added: 备用代码已添加
+event_types.backup_codes_removed: 备份代码已删除
 event_types.eastern_timestamp: '%{timestamp}（东部）'
 event_types.email_changed: 电邮地址已更改
 event_types.email_deleted: 电邮地址已删除

--- a/spec/controllers/concerns/mfa_deletion_concern_spec.rb
+++ b/spec/controllers/concerns/mfa_deletion_concern_spec.rb
@@ -38,15 +38,5 @@ RSpec.describe MfaDeletionConcern do
 
       result
     end
-
-    context 'with nil event_type argument' do
-      let(:event_type) { nil }
-
-      it 'does not create user event' do
-        expect(controller).not_to receive(:create_user_event)
-
-        result
-      end
-    end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-15602](https://cm-jira.usa.gov/browse/LG-15602)



## 🛠 Summary of changes

Updates the existing `handle_successful_mfa_deletion` method parameter to include a newly added event type for `backup_codes_removed`. Adds translation strings for 'Backup codes removed'


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create an account in local environment that has Backup Codes and 1 other MFA method
- [ ] From the Your account page click delete in the Backup Codes card
- [ ] Go to the History page and notice occurrence of Backup codes removed under the Activity


## 👀 Screenshots

English
![english-backup-codes-removed](https://github.com/user-attachments/assets/8f3fdf8a-ce3e-4f0c-9ecb-393dc112a2bf)

French
![french-backup-codes-removed](https://github.com/user-attachments/assets/9444244d-6378-493a-b2fd-9648e2008e0c)

Spanish
![spanish-backup-codes-removed](https://github.com/user-attachments/assets/f53874cf-de76-468f-a6fe-77d657bbf031)

Chinese
![chinese-backup-codes-removed](https://github.com/user-attachments/assets/efe1440a-05cd-468e-9ec1-e6a0cf53a039)

