### PR TITLE
LG-15484: Update design of Sign In/Create Account tabs (Redo)

### DIFF
--- a/app/components/tab_navigation_component.html.erb
+++ b/app/components/tab_navigation_component.html.erb
@@ -1,29 +1,14 @@
 <%= content_tag(:nav, aria: { label: }, **tag_options, class: [*tag_options[:class], 'tab-navigation']) do %>
-  <ul class="usa-button-group usa-button-group--segmented">
+  <ul class="usa-button-group">
     <% routes.each do |route| %>
-      <% if current_path?(route[:path]) %>
-        <%= render ClickObserverComponent.new(
-              event_name: 'tab_navigation_current_page_clicked',
-              payload: { path: route[:path] },
-              role: 'listitem',
-              class: 'usa-button-group__item display-list-item',
-            ) do %>
-          <%= render ButtonComponent.new(
-                url: route[:path],
-                big: true,
-                outline: !current_path?(route[:path]),
-                aria: { current: current_path?(route[:path]) ? 'page' : nil },
-              ).with_content(route[:text]) %>
-        <% end %>
-      <% else %>
-        <li class="usa-button-group__item">
-          <%= render ButtonComponent.new(
-                url: route[:path],
-                big: true,
-                outline: !current_path?(route[:path]),
-                aria: { current: current_path?(route[:path]) ? 'page' : nil },
-              ).with_content(route[:text]) %>
-        </li>
+      <%= nav_list_item(route) do %>
+        <%= render ButtonComponent.new(
+              url: route[:path],
+              big: true,
+              outline: current_path?(route[:path]),
+              unstyled: !current_path?(route[:path]),
+              aria: { current: current_path?(route[:path]) ? 'page' : nil },
+            ).with_content(route[:text]) %>
       <% end %>
     <% end %>
   </ul>

--- a/app/components/tab_navigation_component.rb
+++ b/app/components/tab_navigation_component.rb
@@ -10,10 +10,35 @@ class TabNavigationComponent < BaseComponent
   end
 
   def current_path?(path)
-    recognized_path = Rails.application.routes.recognize_path(path, method: request.method)
-    request.params[:controller] == recognized_path[:controller] &&
-      request.params[:action] == recognized_path[:action]
-  rescue ActionController::RoutingError
-    false
+    @current_path ||= {}
+    if !@current_path.key?(path)
+      @current_path[path] = begin
+        recognized_path = Rails.application.routes.recognize_path(path, method: request.method)
+        request.params[:controller] == recognized_path[:controller] &&
+          request.params[:action] == recognized_path[:action]
+      rescue ActionController::RoutingError
+        false
+      end
+    end
+
+    @current_path[path]
+  end
+
+  private
+
+  def nav_list_item(route, &block)
+    if current_path?(route[:path])
+      render(
+        ClickObserverComponent.new(
+          event_name: 'tab_navigation_current_page_clicked',
+          payload: { path: route[:path] },
+          role: 'listitem',
+          class: 'usa-button-group__item display-list-item',
+        ),
+        &block
+      )
+    else
+      tag.li(class: 'usa-button-group__item', &block)
+    end
   end
 end

--- a/app/components/tab_navigation_component.scss
+++ b/app/components/tab_navigation_component.scss
@@ -2,14 +2,25 @@
 
 @forward 'usa-button-group/src/styles';
 
-.tab-navigation .usa-button-group--segmented {
+.tab-navigation .usa-button-group {
+  @include u-bg('base-lightest');
+  border-radius: 1.625rem;
+  flex-flow: nowrap;
+
   .usa-button-group__item {
     flex-basis: 50%;
   }
 
-  .usa-button-group__item:last-child > .usa-button,
   .usa-button {
+    @include u-flex('align-center', 'justify-center');
+    @include u-padding(1.5);
+    border-radius: 1.375rem;
     width: 100%;
+  }
+
+  .usa-button--unstyled {
+    @include u-text('bold');
+    text-decoration: none;
   }
 
   .usa-button--big {

--- a/app/components/tab_navigation_component.scss
+++ b/app/components/tab_navigation_component.scss
@@ -16,6 +16,7 @@
     @include u-padding(1.5);
     border-radius: 1.375rem;
     width: 100%;
+    text-align: center;
   }
 
   .usa-button--unstyled {

--- a/app/javascript/packages/analytics/README.md
+++ b/app/javascript/packages/analytics/README.md
@@ -40,3 +40,8 @@ The custom element will implement the analytics logging behavior, but all markup
   <button type="button">Click me!</button>
 </lg-click-observer>
 ```
+
+The element supports the following attributes to customize its behavior:
+
+- `event-name`: The name of the analytics event that should be logged when clicked
+- `payload`: (Optional) JSON payload of additional data that should be included in the logged event

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -48,9 +48,9 @@
           form: f,
           action: SignInRecaptchaForm::RECAPTCHA_ACTION,
           button_options: { full_width: true },
-        ).with_content(t('links.sign_in')) %>
+        ).with_content(t('forms.buttons.submit.default')) %>
   <% else %>
-    <%= f.submit t('links.sign_in'), full_width: true, wide: false %>
+    <%= f.submit t('forms.buttons.submit.default'), full_width: true, wide: false %>
   <% end %>
 <% end %>
 <% if desktop_device? %>

--- a/app/views/sign_up/registrations/new.html.erb
+++ b/app/views/sign_up/registrations/new.html.erb
@@ -42,7 +42,12 @@
         required: true,
       ) %>
 
-  <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
+  <%= f.submit(
+        t('forms.buttons.submit.default'),
+        full_width: true,
+        wide: false,
+        class: 'display-block margin-y-5',
+      ) %>
 <% end %>
 
 <%= render 'shared/cancel', link: decorated_sp_session.cancel_link_url %>

--- a/spec/components/tab_navigation_component_spec.rb
+++ b/spec/components/tab_navigation_component_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe TabNavigationComponent, type: :component do
 
   it 'renders labelled navigation' do
     expect(rendered).to have_css('.tab-navigation[aria-label="Navigation"]')
+    expect(rendered).to have_css('li', count: 2)
     expect(rendered).to have_link('First') { |link| !is_current_link?(link) }
     expect(rendered).to have_link('Second') { |link| !is_current_link?(link) }
   end
@@ -41,8 +42,18 @@ RSpec.describe TabNavigationComponent, type: :component do
     end
 
     it 'renders current link as highlighted' do
+      expect(rendered).to have_css('li,[role=listitem]', count: 2)
       expect(rendered).to have_link('First') { |link| is_current_link?(link) }
       expect(rendered).to have_link('Second') { |link| !is_current_link?(link) }
+    end
+
+    it 'wraps link in click observer' do
+      expect(rendered).to have_link('First') do |link|
+        expect(link).to have_ancestor('lg-click-observer')
+      end
+      expect(rendered).to have_link('Second') do |link|
+        expect(link).not_to have_ancestor('lg-click-observer')
+      end
     end
 
     context 'with routes defining full URL' do
@@ -112,6 +123,6 @@ RSpec.describe TabNavigationComponent, type: :component do
   end
 
   def is_current_link?(link)
-    link.matches_css?('[aria-current="page"]:not(.usa-button--outline)')
+    link.matches_css?('[aria-current="page"].usa-button--outline')
   end
 end

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -284,7 +284,7 @@ RSpec.feature 'saml api' do
           expect(page).to have_content(
             t('headings.create_account_with_sp.sp_text', app_name: APP_NAME),
           )
-          expect(page).to have_button('Sign in')
+          expect(page).to have_button(t('forms.buttons.submit.default'))
           # visit from SP with force_authn: true
           expect(page).to have_content(
             strip_tags(
@@ -334,7 +334,7 @@ RSpec.feature 'saml api' do
               ),
             ),
           )
-          expect(page).to have_button('Sign in')
+          expect(page).to have_button(t('forms.buttons.submit.default'))
           # Log in with Test SP as the SP session
           fill_in_credentials_and_submit(user.email, user.password)
           fill_in_code_with_last_phone_otp
@@ -363,7 +363,7 @@ RSpec.feature 'saml api' do
               ),
             ),
           )
-          expect(page).to have_button('Sign in')
+          expect(page).to have_button(t('forms.buttons.submit.default'))
 
           # log in for second time
           fill_in_credentials_and_submit(user.email, user.password)
@@ -404,7 +404,7 @@ RSpec.feature 'saml api' do
         expect(page).to have_content(
           t('headings.create_account_with_sp.sp_text', app_name: APP_NAME),
         )
-        expect(page).to have_button('Sign in')
+        expect(page).to have_button(t('forms.buttons.submit.default'))
         expect(page).to have_content(
           strip_tags(
             t(
@@ -439,7 +439,7 @@ RSpec.feature 'saml api' do
         expect(page).to have_content(
           t('headings.create_account_with_sp.sp_text', app_name: APP_NAME),
         )
-        expect(page).to have_button('Sign in')
+        expect(page).to have_button(t('forms.buttons.submit.default'))
         expect(page).to have_content(
           strip_tags(
             t(
@@ -454,7 +454,7 @@ RSpec.feature 'saml api' do
         expect(page).to have_content(
           t('headings.create_account_with_sp.sp_text', app_name: APP_NAME),
         )
-        expect(page).to have_button('Sign in')
+        expect(page).to have_button(t('forms.buttons.submit.default'))
         expect(page).to_not have_content(
           strip_tags(
             t(

--- a/spec/features/visitors/password_recovery_spec.rb
+++ b/spec/features/visitors/password_recovery_spec.rb
@@ -192,7 +192,7 @@ RSpec.feature 'Password Recovery' do
 
         fill_in t('account.index.email'), with: @user.email
         fill_in t('components.password_toggle.label'), with: 'NewVal!dPassw0rd'
-        click_button t('links.sign_in')
+        click_button t('forms.buttons.submit.default')
         fill_in_code_with_last_phone_otp
         click_submit_default
         click_agree_and_continue

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -98,7 +98,7 @@ module Features
     def fill_in_credentials_and_submit(email, password)
       fill_in t('account.index.email'), with: email
       fill_in t('account.index.password'), with: password
-      click_button t('links.sign_in')
+      click_button t('forms.buttons.submit.default')
     end
 
     def fill_in_totp_name(nickname = 'App')

--- a/spec/views/devise/sessions/new.html.erb_spec.rb
+++ b/spec/views/devise/sessions/new.html.erb_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
       let(:sign_in_recaptcha_enabled) { false }
 
       it 'renders default sign-in submit button' do
-        expect(rendered).to have_button(t('links.sign_in'))
+        expect(rendered).to have_button(t('forms.buttons.submit.default'))
         expect(rendered).not_to have_css('lg-captcha-submit-button')
       end
 
@@ -243,7 +243,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
         let(:recaptcha_mock_validator) { true }
 
         it 'renders captcha sign-in submit button' do
-          expect(rendered).to have_button(t('links.sign_in'))
+          expect(rendered).to have_button(t('forms.buttons.submit.default'))
           expect(rendered).to have_css('lg-captcha-submit-button')
         end
       end
@@ -253,7 +253,7 @@ RSpec.describe 'devise/sessions/new.html.erb' do
       let(:sign_in_recaptcha_enabled) { true }
 
       it 'renders captcha sign-in submit button' do
-        expect(rendered).to have_button(t('links.sign_in'))
+        expect(rendered).to have_button(t('forms.buttons.submit.default'))
         expect(rendered).to have_css('lg-captcha-submit-button')
       end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-15484](https://cm-jira.usa.gov/browse/LG-15484)

## 🛠 Summary of changes

Updates the visual appearance of the "Sign in" and "Create an Account" tabs on the sign-in page.

This is a redo of #11872, which was reverted in #11893 due to a minor visual regression in narrow-width devices.

It is identical to the original pull request, with the added fix in bfa93663a0caca02d86d7a80cfb5ac20a5ff9813 (`text-align: center`).

## 📜 Testing Plan

Repeat Testing Plan from #11872.

Verify that at very narrow screen widths (360px and smaller), the text is center-aligned when it starts to wrap.

## 👀 Screenshots

See original screenshots in #11872.

The screenshots below show the difference at very narrow screen width (360px):

Before|After
---|---
![localhost_3000_ (1)](https://github.com/user-attachments/assets/46bfe279-76f4-4170-aea9-7dc1239c286a)|![localhost_3000_](https://github.com/user-attachments/assets/19c46e18-bfdf-4a38-999d-6485f284ecc3)
