### PR TITLE
LG-15716: Dont show link when user has already been directed

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -16,9 +16,11 @@ class AccountsController < ApplicationController
       sp_session_request_url: sp_session_request_url_with_updated_params,
       authn_context: resolved_authn_context_result,
       sp_name: decorated_sp_session.sp_name,
+      sp_handoff_already_occurred: session[:sp_successful_handoff],
       user: current_user,
       locked_for_session: pii_locked_for_session?(current_user),
     )
+    session.delete(:sp_successful_handoff)
     if session.delete(:from_select_email_flow)
       flash.now[:success] = t(
         'account.emails.confirmed_html',

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -16,11 +16,10 @@ class AccountsController < ApplicationController
       sp_session_request_url: sp_session_request_url_with_updated_params,
       authn_context: resolved_authn_context_result,
       sp_name: decorated_sp_session.sp_name,
-      sp_handoff_already_occurred: session[:sp_successful_handoff],
+      sp_handoff_already_occurred: decorated_sp_session.successful_handoff,
       user: current_user,
       locked_for_session: pii_locked_for_session?(current_user),
     )
-    session.delete(:sp_successful_handoff)
     if session.delete(:from_select_email_flow)
       flash.now[:success] = t(
         'account.emails.confirmed_html',

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -16,7 +16,7 @@ class AccountsController < ApplicationController
       sp_session_request_url: sp_session_request_url_with_updated_params,
       authn_context: resolved_authn_context_result,
       sp_name: decorated_sp_session.sp_name,
-      sp_handoff_already_occurred: decorated_sp_session.successful_handoff,
+      sp_handoff_already_occurred: decorated_sp_session.successful_handoff?,
       user: current_user,
       locked_for_session: pii_locked_for_session?(current_user),
     )

--- a/app/controllers/concerns/fully_authenticatable.rb
+++ b/app/controllers/concerns/fully_authenticatable.rb
@@ -3,10 +3,6 @@
 module FullyAuthenticatable
   def delete_branded_experience(logout: false)
     ServiceProviderRequestProxy.delete(request_id)
-    if session[:sp]
-      session[:sp][:successful_handoff] = true
-    end
-
     session[:sp] = {} if logout
     nil
   end

--- a/app/controllers/concerns/fully_authenticatable.rb
+++ b/app/controllers/concerns/fully_authenticatable.rb
@@ -5,7 +5,6 @@ module FullyAuthenticatable
     ServiceProviderRequestProxy.delete(request_id)
     if session[:sp]
       session[:sp][:successful_handoff] = true
-
     end
 
     session[:sp] = {} if logout

--- a/app/controllers/concerns/fully_authenticatable.rb
+++ b/app/controllers/concerns/fully_authenticatable.rb
@@ -3,7 +3,11 @@
 module FullyAuthenticatable
   def delete_branded_experience(logout: false)
     ServiceProviderRequestProxy.delete(request_id)
-    session[:sp][:successful_handoff] = true
+    if session[:sp]
+      session[:sp][:successful_handoff] = true
+
+    end
+
     session[:sp] = {} if logout
     nil
   end

--- a/app/controllers/concerns/fully_authenticatable.rb
+++ b/app/controllers/concerns/fully_authenticatable.rb
@@ -3,6 +3,7 @@
 module FullyAuthenticatable
   def delete_branded_experience(logout: false)
     ServiceProviderRequestProxy.delete(request_id)
+    session[:sp_successful_handoff] = true
     session[:sp] = {} if logout
     nil
   end

--- a/app/controllers/concerns/fully_authenticatable.rb
+++ b/app/controllers/concerns/fully_authenticatable.rb
@@ -3,7 +3,7 @@
 module FullyAuthenticatable
   def delete_branded_experience(logout: false)
     ServiceProviderRequestProxy.delete(request_id)
-    session[:sp_successful_handoff] = true
+    session[:sp][:successful_handoff] = true
     session[:sp] = {} if logout
     nil
   end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -126,6 +126,8 @@ module OpenidConnect
         current_user.uuid,
       )
 
+      sp_session[:successful_handoff] = true
+
       delete_branded_experience
     end
 

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -191,6 +191,7 @@ class SamlIdpController < ApplicationController
 
   def handle_successful_handoff
     track_events
+    sp_session[:successful_handoff] = true
     delete_branded_experience
     return redirect_to(account_url) if saml_request.response_url.blank?
     render_template_for(saml_response, saml_request.response_url, 'SAMLResponse')

--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -31,6 +31,10 @@ class NullServiceProviderSession
 
   def sp_alert(_section); end
 
+  def successful_handoff?
+    false
+  end
+
   def requested_more_recent_verification?
     false
   end

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -56,8 +56,8 @@ class ServiceProviderSession
     (sp_session[:requested_attributes] || service_provider_request.requested_attributes).sort
   end
 
-  def successful_handoff
-    sp_session[:successful_handoff]
+  def successful_handoff?
+    sp_session[:successful_handoff] || false
   end
 
   def sp_create_link

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -56,6 +56,10 @@ class ServiceProviderSession
     (sp_session[:requested_attributes] || service_provider_request.requested_attributes).sort
   end
 
+  def successful_handoff
+    sp_session[:successful_handoff]
+  end
+
   def sp_create_link
     view_context.sign_up_email_path(request_id: sp_session[:request_id])
   end

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -7,6 +7,7 @@ class AccountShowPresenter
               :pii,
               :sp_session_request_url,
               :authn_context,
+              :sp_handoff_already_occurred,
               :sp_name
 
   delegate :identity_verified_with_facial_match?, to: :user
@@ -17,7 +18,8 @@ class AccountShowPresenter
     authn_context:,
     sp_name:,
     user:,
-    locked_for_session:
+    locked_for_session:,
+    sp_handoff_already_occurred: false
   )
     @decrypted_pii = decrypted_pii
     @user = user
@@ -25,6 +27,7 @@ class AccountShowPresenter
     @sp_session_request_url = sp_session_request_url
     @authn_context = authn_context
     @locked_for_session = locked_for_session
+    @sp_handoff_already_occurred = sp_handoff_already_occurred
     @pii = determine_pii
   end
 
@@ -38,7 +41,7 @@ class AccountShowPresenter
   end
 
   def show_service_provider_continue_partial?
-    sp_name.present? && sp_session_request_url.present?
+    sp_name.present? && sp_session_request_url.present? && !sp_handoff_already_occurred
   end
 
   def showing_alerts?

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -96,6 +96,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
           expect(redirect_params[:state]).to eq(params[:state])
         end
 
+        it 'stores successful_handoff in sp_session' do
+        end
+
         it 'renders a JS client-side redirect back to the client app with a code if it is enabled' do
           allow(IdentityConfig.store).to receive(:openid_connect_redirect)
             .and_return('client_side_js')
@@ -993,6 +996,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
           expect(redirect_params[:code]).to be_present
           expect(redirect_params[:state]).to eq(params[:state])
+        end
+
+        it 'stores successful_handoff in sp_session' do
         end
 
         it 'renders a client-side redirect back to the client app with a code if it is enabled' do

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
 
         it 'stores successful_handoff in sp_session' do
+          allow(IdentityConfig.store).to receive(:openid_connect_redirect)
+            .and_return('server_side')
+          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
+          user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
+          action
+
+          expect(response).to redirect_to(/^#{params[:redirect_uri]}/)
+
+          expect(session[:sp][:successful_handoff]).to eq(true)
         end
 
         it 'renders a JS client-side redirect back to the client app with a code if it is enabled' do
@@ -996,9 +1005,6 @@ RSpec.describe OpenidConnect::AuthorizationController do
 
           expect(redirect_params[:code]).to be_present
           expect(redirect_params[:state]).to eq(params[:state])
-        end
-
-        it 'stores successful_handoff in sp_session' do
         end
 
         it 'renders a client-side redirect back to the client app with a code if it is enabled' do

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1005,6 +1005,11 @@ RSpec.describe SamlIdpController do
         expect(response).to_not be_redirect
       end
 
+      it 'marks session as a successful_handoff' do
+        saml_get_auth(ialmax_settings)
+        expect(session[:sp][:successful_handoff]).to eq(true)
+      end
+
       it 'contains verified attributes' do
         saml_get_auth(ialmax_settings)
 

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -177,21 +177,23 @@ RSpec.feature 'OIDC Authorization Confirmation' do
       )
     end
 
-    it 'shows "continue to SP" on account page if user has already been redirected to SP' do
-      sign_in_user(user1)
-      visit_idp_from_ial1_oidc_sp
+    context 'when a user has not yet been redirected to SP' do
+      it 'shows "continue to SP" on account page' do
+        sign_in_user(user1)
+        visit_idp_from_ial1_oidc_sp
 
-      expect(page).to have_current_path(user_authorization_confirmation_path)
-      visit account_path
+        expect(page).to have_current_path(user_authorization_confirmation_path)
+        visit account_path
 
-      identity = user1.identities.find_by(service_provider: OidcAuthHelper::OIDC_IAL1_ISSUER)
+        identity = user1.identities.find_by(service_provider: OidcAuthHelper::OIDC_IAL1_ISSUER)
 
-      expect(page).to have_content(
-        t(
-          'account.index.continue_to_service_provider',
-          service_provider: identity.display_name,
-        ),
-      )
+        expect(page).to have_content(
+          t(
+            'account.index.continue_to_service_provider',
+            service_provider: identity.display_name,
+          ),
+        )
+      end
     end
 
     it 'does not render the confirmation screen on a return visit to the SP by default' do

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -158,7 +158,40 @@ RSpec.feature 'OIDC Authorization Confirmation' do
       expect(oidc_redirect_url).to match('http://localhost:7654/auth/result')
     end
 
-    it 'does not show continue to SP on account page if user has already been redirected to SP' do
+    it 'does not show "continue to SP" on account page if user has already been redirected to SP' do
+      sign_in_user(user1)
+      visit_idp_from_ial1_oidc_sp
+
+      expect(page).to have_current_path(user_authorization_confirmation_path)
+
+      click_button t('user_authorization_confirmation.sign_in')
+      visit account_path
+
+      identity = user1.identities.find_by(service_provider: OidcAuthHelper::OIDC_IAL1_ISSUER)
+
+      expect(page).to_not have_content(
+        t(
+          'account.index.continue_to_service_provider',
+          service_provider: identity.display_name,
+        ),
+      )
+    end
+
+    it 'shows "continue to SP" on account page if user has already been redirected to SP' do
+      sign_in_user(user1)
+      visit_idp_from_ial1_oidc_sp
+
+      expect(page).to have_current_path(user_authorization_confirmation_path)
+      visit account_path
+
+      identity = user1.identities.find_by(service_provider: OidcAuthHelper::OIDC_IAL1_ISSUER)
+
+      expect(page).to have_content(
+        t(
+          'account.index.continue_to_service_provider',
+          service_provider: identity.display_name,
+        ),
+      )
     end
 
     it 'does not render the confirmation screen on a return visit to the SP by default' do

--- a/spec/features/openid_connect/authorization_confirmation_spec.rb
+++ b/spec/features/openid_connect/authorization_confirmation_spec.rb
@@ -158,6 +158,9 @@ RSpec.feature 'OIDC Authorization Confirmation' do
       expect(oidc_redirect_url).to match('http://localhost:7654/auth/result')
     end
 
+    it 'does not show continue to SP on account page if user has already been redirected to SP' do
+    end
+
     it 'does not render the confirmation screen on a return visit to the SP by default' do
       second_email = create(:email_address, user: user1)
       sign_in_user(user1, second_email.email)

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -141,6 +141,9 @@ RSpec.feature 'SAML Authorization Confirmation' do
       expect(page).to have_current_path(new_user_session_path)
     end
 
+    it 'does not show continue to SP on account page if user has already been redirected to SP' do
+    end
+
     it 'does not render the confirmation screen on a return visit to the SP by default' do
       second_email = create(:email_address, user: user1)
       sign_in_user(user1, second_email.email)

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -142,6 +142,39 @@ RSpec.feature 'SAML Authorization Confirmation' do
     end
 
     it 'does not show continue to SP on account page if user has already been redirected to SP' do
+      sign_in_user(user1)
+
+      visit request_url
+      expect(page).to have_current_path(user_authorization_confirmation_path)
+
+      click_button t('user_authorization_confirmation.sign_in')
+      visit account_path
+
+      identity = user1.identities.find_by(service_provider: SamlAuthHelper::SP_ISSUER)
+
+      expect(page).to_not have_content(
+        t(
+          'account.index.continue_to_service_provider',
+          service_provider: identity.display_name,
+        ),
+      )
+    end
+
+    it 'shows continue to SP on account page if user has not been yet redirected to SP' do
+      sign_in_user(user1)
+
+      visit request_url
+      expect(page).to have_current_path(user_authorization_confirmation_path)
+      visit account_path
+
+      identity = user1.identities.find_by(service_provider: SamlAuthHelper::SP_ISSUER)
+
+      expect(page).to have_content(
+        t(
+          'account.index.continue_to_service_provider',
+          service_provider: identity.display_name,
+        ),
+      )
     end
 
     it 'does not render the confirmation screen on a return visit to the SP by default' do

--- a/spec/features/saml/authorization_confirmation_spec.rb
+++ b/spec/features/saml/authorization_confirmation_spec.rb
@@ -160,21 +160,23 @@ RSpec.feature 'SAML Authorization Confirmation' do
       )
     end
 
-    it 'shows continue to SP on account page if user has not been yet redirected to SP' do
-      sign_in_user(user1)
+    context 'when a user has not yet been redirected to SP' do
+      it 'shows "continue to SP" on account page' do
+        sign_in_user(user1)
 
-      visit request_url
-      expect(page).to have_current_path(user_authorization_confirmation_path)
-      visit account_path
+        visit request_url
+        expect(page).to have_current_path(user_authorization_confirmation_path)
+        visit account_path
 
-      identity = user1.identities.find_by(service_provider: SamlAuthHelper::SP_ISSUER)
+        identity = user1.identities.find_by(service_provider: SamlAuthHelper::SP_ISSUER)
 
-      expect(page).to have_content(
-        t(
-          'account.index.continue_to_service_provider',
-          service_provider: identity.display_name,
-        ),
-      )
+        expect(page).to have_content(
+          t(
+            'account.index.continue_to_service_provider',
+            service_provider: identity.display_name,
+          ),
+        )
+      end
     end
 
     it 'does not render the confirmation screen on a return visit to the SP by default' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15716](https://cm-jira.usa.gov/browse/LG-15716)

## 🛠 Summary of changes

This adds a check on the session that is added when a user is handed off to SP. Which prevents the continue to SP link to appear in account page. 

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- Start from SP 
- Sign in and be redirected to SP
- From SP go straight back to login.gov and reach account page
- Verify that the "continue to SP" link does not appear.

## 👀 Screenshots

Before 
![Screenshot 2025-02-24 at 10 30 25 AM](https://github.com/user-attachments/assets/ed2ebe5e-8ba6-458c-af3e-89007be57bb7)

After

![Screenshot 2025-02-24 at 10 34 39 AM](https://github.com/user-attachments/assets/42998cc7-bed9-4c61-955d-85c0ddea06b9)
