### PR TITLE
LG-15783: add doc_auth_vendor as a column to document_capture_sessions

### DIFF
--- a/db/primary_migrate/20250219164618_add_doc_auth_vendor_to_document_capture_sessions_w_comment.rb
+++ b/db/primary_migrate/20250219164618_add_doc_auth_vendor_to_document_capture_sessions_w_comment.rb
@@ -1,0 +1,9 @@
+class AddDocAuthVendorToDocumentCaptureSessionsWComment < ActiveRecord::Migration[7.2]
+  def up
+    add_column :document_capture_sessions, :doc_auth_vendor, :string, comment: 'sensitive=false'
+  end
+
+  def down
+    remove_column :document_capture_sessions, :doc_auth_vendor
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_07_144037) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_19_164618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -200,6 +200,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_07_144037) do
     t.string "last_doc_auth_result", comment: "sensitive=false"
     t.string "socure_docv_transaction_token", comment: "sensitive=false"
     t.string "socure_docv_capture_app_url", comment: "sensitive=false"
+    t.string "doc_auth_vendor", comment: "sensitive=false"
     t.index ["result_id"], name: "index_document_capture_sessions_on_result_id"
     t.index ["socure_docv_transaction_token"], name: "index_socure_docv_transaction_token", unique: true
     t.index ["user_id"], name: "index_document_capture_sessions_on_user_id"


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-15783](https://cm-jira.usa.gov/browse/LG-15783)

## 🛠 Summary of changes
Add column _doc_auth_vendor_ to document_capture_sessions table in order to store the bucketed doc auth vendor.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
