### PR TITLE
LG-15120 Remove usps_ipp_transliteration_enabled flag

### DIFF
--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -170,8 +170,6 @@ module UspsInPersonProofing
       end
 
       def transliterate(value)
-        return value unless IdentityConfig.store.usps_ipp_transliteration_enabled
-
         result = transliterator.transliterate(value)
         if result.unsupported_chars.present?
           result.original

--- a/app/services/usps_in_person_proofing/transliterable_validator.rb
+++ b/app/services/usps_in_person_proofing/transliterable_validator.rb
@@ -33,7 +33,6 @@ module UspsInPersonProofing
     #
     # @param [ActiveModel::Validations] record
     def validate(record)
-      return unless IdentityConfig.store.usps_ipp_transliteration_enabled
       nontransliterable_chars = Set.new
       @fields.each do |field|
         next unless record.respond_to?(field)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -440,7 +440,6 @@ usps_ipp_password: ''
 usps_ipp_request_timeout: 10
 usps_ipp_root_url: ''
 usps_ipp_sponsor_id: ''
-usps_ipp_transliteration_enabled: false
 usps_ipp_username: ''
 usps_mock_fallback: true
 usps_upload_enabled: false
@@ -518,7 +517,6 @@ development:
   use_dashboard_service_providers: true
   usps_eipp_sponsor_id: '222222222222222'
   usps_ipp_sponsor_id: '111111111111111'
-  usps_ipp_transliteration_enabled: true
   usps_upload_sftp_directory: '/gsa_order'
   usps_upload_sftp_host: localhost
   usps_upload_sftp_password: test

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -475,7 +475,6 @@ module IdentityConfig
     config.add(:usps_ipp_request_timeout, type: :integer)
     config.add(:usps_ipp_root_url, type: :string)
     config.add(:usps_ipp_sponsor_id, type: :string)
-    config.add(:usps_ipp_transliteration_enabled, type: :boolean)
     config.add(:usps_ipp_username, type: :string)
     config.add(:usps_ipp_enrollment_status_update_email_address, type: :string)
     config.add(:usps_mock_fallback, type: :boolean)

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe Idv::InPerson::AddressController do
   let(:pii_from_user) { Idp::Constants::MOCK_IPP_APPLICANT_SAME_ADDRESS_AS_ID_FALSE }
 
   before do
-    allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled)
-      .and_return(true)
     stub_sign_in(user)
     stub_up_to(:ipp_state_id, idv_session: subject.idv_session)
     allow(user).to receive(:establishing_in_person_enrollment).and_return(enrollment)

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe Idv::InPerson::StateIdController do
   let(:enrollment) { InPersonEnrollment.new }
 
   before do
-    allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled)
-      .and_return(true)
     stub_sign_in(user)
     stub_up_to(:hybrid_handoff, idv_session: subject.idv_session)
     allow(user).to receive(:establishing_in_person_enrollment).and_return(enrollment)

--- a/spec/features/idv/steps/in_person/address_spec.rb
+++ b/spec/features/idv/steps/in_person/address_spec.rb
@@ -81,11 +81,6 @@ RSpec.describe 'doc auth In person proofing residential address step', :js do
   end
 
   context 'transliterable Validation' do
-    before do
-      allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled)
-        .and_return(true)
-    end
-
     it 'shows validation errors',
        allow_browser_log: true do
       complete_idv_steps_before_address

--- a/spec/features/idv/steps/in_person/state_id_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_spec.rb
@@ -318,11 +318,6 @@ RSpec.describe 'state id controller enabled', :js do
   end
 
   context 'transliterable validation' do
-    before do
-      allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled)
-        .and_return(true)
-    end
-
     it 'shows validation errors',
        allow_browser_log: true do
       complete_steps_before_state_id_controller

--- a/spec/forms/idv/in_person/address_form_spec.rb
+++ b/spec/forms/idv/in_person/address_form_spec.rb
@@ -22,63 +22,32 @@ RSpec.describe Idv::InPerson::AddressForm do
         city: invalid_char + Faker::Address.city,
       }
     end
-    context 'when usps_ipp_transliteration_enabled is false' do
-      let(:subject) { described_class.new }
-      before(:each) do
-        allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).and_return(false)
-      end
-      it 'submit success with good params' do
-        good_params[:same_address_as_id] = true
-        result = subject.submit(good_params)
-        expect(subject.errors.empty?).to be(true)
-        expect(result).to be_kind_of(FormResponse)
-        expect(result.success?).to be(true)
-      end
+    let(:subject) { described_class.new }
 
-      it 'submit success with good params' do
-        good_params[:same_address_as_id] = false
-        result = subject.submit(good_params)
-        expect(subject.errors.empty?).to be(true)
-        expect(result).to be_kind_of(FormResponse)
-        expect(result.success?).to be(true)
-      end
-
-      it 'submit success with bad params' do
-        bad_params[:same_address_as_id] = false
-        result = subject.submit(bad_params)
-        expect(subject.errors.empty?).to be(true)
-        expect(result).to be_kind_of(FormResponse)
-        expect(result.success?).to be(true)
-      end
+    it 'submit success with good params' do
+      good_params[:same_address_as_id] = true
+      result = subject.submit(good_params)
+      expect(subject.errors.empty?).to be(true)
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to be(true)
     end
-    context 'when usps_ipp_transliteration_enabled is enabled ' do
-      let(:subject) { described_class.new }
-      before(:each) do
-        allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).and_return(true)
-      end
-      it 'submit success with good params' do
-        good_params[:same_address_as_id] = true
-        result = subject.submit(good_params)
-        expect(subject.errors.empty?).to be(true)
-        expect(result).to be_kind_of(FormResponse)
-        expect(result.success?).to be(true)
-      end
-      it 'submit failure with bad params' do
-        bad_params[:same_address_as_id] = false
-        result = subject.submit(bad_params)
-        expect(subject.errors.empty?).to be(false)
-        expect(subject.errors.to_hash).to include(:address1, :address2, :city)
-        expect(result).to be_kind_of(FormResponse)
-        expect(result.success?).to be(false)
-        expect(result.errors.empty?).to be(true)
-      end
-      it 'submit with missing same_address_as_id should be successful' do
-        missing_required_params = good_params.except(:same_address_as_id)
-        result = subject.submit(missing_required_params)
-        expect(subject.errors.empty?).to be(true)
-        expect(result).to be_kind_of(FormResponse)
-        expect(result.success?).to be(true)
-      end
+
+    it 'submit failure with bad params' do
+      bad_params[:same_address_as_id] = false
+      result = subject.submit(bad_params)
+      expect(subject.errors.empty?).to be(false)
+      expect(subject.errors.to_hash).to include(:address1, :address2, :city)
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to be(false)
+      expect(result.errors.empty?).to be(true)
+    end
+
+    it 'submit with missing same_address_as_id should be successful' do
+      missing_required_params = good_params.except(:same_address_as_id)
+      result = subject.submit(missing_required_params)
+      expect(subject.errors).to be_empty
+      expect(result).to be_kind_of(FormResponse)
+      expect(result.success?).to be(true)
     end
   end
 end

--- a/spec/forms/idv/state_id_form_spec.rb
+++ b/spec/forms/idv/state_id_form_spec.rb
@@ -99,7 +99,6 @@ RSpec.describe Idv::StateIdForm do
 
     context 'when there is an error with name' do
       it 'returns a single name error when name is wrong' do
-        allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).and_return(true)
         result = subject.submit(name_error_params)
         expect(subject.errors.empty?).to be(false)
         expect(result).to be_kind_of(FormResponse)
@@ -113,7 +112,6 @@ RSpec.describe Idv::StateIdForm do
         expect(result.errors.empty?).to be(true)
       end
       it 'returns both name and dob error when both fields are invalid' do
-        allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled).and_return(true)
         result = subject.submit(dob_min_age_name_error_params)
         expect(subject.errors.empty?).to be(false)
         expect(result).to be_kind_of(FormResponse)

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
   let(:subject_analytics) { FakeAnalytics.new }
   let(:transliterator) { UspsInPersonProofing::Transliterator.new }
   let(:service_provider) { nil }
-  let(:usps_ipp_transliteration_enabled) { true }
   let(:usps_ipp_enrollment_status_update_email_address) do
     'registration@usps.local.identitysandbox.gov'
   end
@@ -38,8 +37,6 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
         transliterated_without_change(val)
       end
     allow(subject).to receive(:analytics).and_return(subject_analytics)
-    allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled)
-      .and_return(usps_ipp_transliteration_enabled)
     allow(IdentityConfig.store).to receive(:usps_ipp_sponsor_id).and_return(usps_ipp_sponsor_id)
   end
 
@@ -95,90 +92,35 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
           expect(enrollment.current_address_matches_id).to eq(current_address_matches_id)
         end
 
-        context 'transliteration disabled' do
-          let(:usps_ipp_transliteration_enabled) { false }
+        it 'creates usps enrollment while using transliteration' do
+          first_name = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
+          last_name = Idp::Constants::MOCK_IDV_APPLICANT[:last_name]
+          address = Idp::Constants::MOCK_IDV_APPLICANT[:address1]
+          city = Idp::Constants::MOCK_IDV_APPLICANT[:city]
 
-          it 'creates usps enrollment without using transliteration' do
-            expect(transliterator).not_to receive(:transliterate)
-            expect(proofer).to receive(:request_enroll) do |applicant|
-              expect(applicant.first_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
-              expect(applicant.last_name).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:last_name])
-              expect(applicant.address).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:address1])
-              expect(applicant.city).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:city])
-              expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
-              expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
-              expect(applicant.unique_id).to eq(enrollment.unique_id)
+          expect(transliterator).to receive(:transliterate)
+            .with(first_name).and_return(transliterated_without_change(first_name))
+          expect(transliterator).to receive(:transliterate)
+            .with(last_name).and_return(transliterated(last_name))
+          expect(transliterator).to receive(:transliterate)
+            .with(address).and_return(transliterated_with_failure(address))
+          expect(transliterator).to receive(:transliterate)
+            .with(city).and_return(transliterated(city))
 
-              UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
-            end
+          expect(proofer).to receive(:request_enroll) do |applicant|
+            expect(applicant.first_name).to eq(first_name)
+            expect(applicant.last_name).to eq("transliterated_#{last_name}")
+            expect(applicant.address).to eq(address)
+            expect(applicant.city).to eq("transliterated_#{city}")
+            expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
+            expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
+            expect(applicant.email).to eq(usps_ipp_enrollment_status_update_email_address)
+            expect(applicant.unique_id).to eq(enrollment.unique_id)
 
-            subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
+            UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
           end
 
-          context 'same address as id is false' do
-            let(:pii) do
-              Pii::Attributes.new_from_hash(
-                Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE
-                  .merge(same_address_as_id: current_address_matches_id ? 'true' : 'false')
-                  .merge(Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS)
-                  .transform_keys(&:to_s),
-              )
-            end
-
-            it 'maps enrollment address fields' do
-              expect(proofer).to receive(:request_enroll) do |applicant|
-                expect(applicant).to have_attributes(
-                  address: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
-                    :identity_doc_address1
-                  ],
-                  city: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_city],
-                  state: Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[
-                    :identity_doc_address_state
-                  ],
-                  zip_code:
-                    Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode],
-                )
-                UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
-              end
-
-              subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-            end
-          end
-        end
-
-        context 'transliteration enabled' do
-          let(:usps_ipp_transliteration_enabled) { true }
-
-          it 'creates usps enrollment while using transliteration' do
-            first_name = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
-            last_name = Idp::Constants::MOCK_IDV_APPLICANT[:last_name]
-            address = Idp::Constants::MOCK_IDV_APPLICANT[:address1]
-            city = Idp::Constants::MOCK_IDV_APPLICANT[:city]
-
-            expect(transliterator).to receive(:transliterate)
-              .with(first_name).and_return(transliterated_without_change(first_name))
-            expect(transliterator).to receive(:transliterate)
-              .with(last_name).and_return(transliterated(last_name))
-            expect(transliterator).to receive(:transliterate)
-              .with(address).and_return(transliterated_with_failure(address))
-            expect(transliterator).to receive(:transliterate)
-              .with(city).and_return(transliterated(city))
-
-            expect(proofer).to receive(:request_enroll) do |applicant|
-              expect(applicant.first_name).to eq(first_name)
-              expect(applicant.last_name).to eq("transliterated_#{last_name}")
-              expect(applicant.address).to eq(address)
-              expect(applicant.city).to eq("transliterated_#{city}")
-              expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
-              expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
-              expect(applicant.email).to eq(usps_ipp_enrollment_status_update_email_address)
-              expect(applicant.unique_id).to eq(enrollment.unique_id)
-
-              UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
-            end
-
-            subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-          end
+          subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
         end
 
         it <<~STR.squish do

--- a/spec/services/usps_in_person_proofing/transliterable_validator_spec.rb
+++ b/spec/services/usps_in_person_proofing/transliterable_validator_spec.rb
@@ -28,210 +28,99 @@ RSpec.describe UspsInPersonProofing::TransliterableValidator do
     }
   end
 
-  before do
-    allow(IdentityConfig.store).to receive(:usps_ipp_transliteration_enabled)
-      .and_return(usps_ipp_transliteration_enabled)
-  end
-
   subject(:validator) { described_class.new(options) }
 
   describe '#validate' do
-    context 'transliteration enabled' do
-      let(:usps_ipp_transliteration_enabled) { true }
+    let(:valid_field) { 'abc' }
+    let(:extra_field) { 'hello world' }
 
-      let(:valid_field) { 'abc' }
-      let(:extra_field) { 'hello world' }
+    before do
+      allow(validator.transliterator).to receive(:transliterate) do |param|
+        UspsInPersonProofing::Transliterator::TransliterationResult.new(
+          changed?: true,
+          original: param,
+          transliterated: "transliterated#{param}",
+          unsupported_chars: [],
+        )
+      end
+    end
 
-      before do
-        allow(validator.transliterator).to receive(:transliterate) do |param|
-          UspsInPersonProofing::Transliterator::TransliterationResult.new(
-            changed?: true,
-            original: param,
-            transliterated: "transliterated#{param}",
-            unsupported_chars: [],
-          )
+    context 'no invalid fields' do
+      context 'with missing field' do
+        let(:fields) { [:missing_field, :valid_field] }
+
+        it 'does not check the configured field that is missing' do
+          expect do
+            validator.validate(model)
+          end.not_to raise_error
         end
       end
 
-      context 'no invalid fields' do
-        context 'with missing field' do
-          let(:fields) { [:missing_field, :valid_field] }
+      context 'with non-stringable field' do
+        let(:valid_field) { non_str_double }
+        let(:non_str_double) { double }
 
-          it 'does not check the configured field that is missing' do
-            expect do
-              validator.validate(model)
-            end.not_to raise_error
-          end
-        end
+        it 'does not attempt to transliterate the field' do
+          allow(non_str_double).to receive(:respond_to?).with(:to_s).and_return(false)
 
-        context 'with non-stringable field' do
-          let(:valid_field) { non_str_double }
-          let(:non_str_double) { double }
-
-          it 'does not attempt to transliterate the field' do
-            allow(non_str_double).to receive(:respond_to?).with(:to_s).and_return(false)
-
-            validator.validate(model)
-            expect(validator.transliterator).not_to have_received(:transliterate)
-          end
-        end
-
-        it 'does not check the non-configured field that is present' do
           validator.validate(model)
-          expect(model).not_to have_received(:extra_field)
-        end
-
-        it 'checks the configured field that is present' do
-          validator.validate(model)
-          expect(model).to have_received(:valid_field)
-        end
-
-        it 'does not set validation message' do
-          validator.validate(model)
-          expect(errors).to be_empty
+          expect(validator.transliterator).not_to have_received(:transliterate)
         end
       end
 
-      context 'one invalid field' do
-        let(:fields) { [:valid_field, :invalid_field] }
-
-        context 'failing regex check' do
-          let(:invalid_field) { '123' }
-
-          it 'sets a validation message' do
-            validator.validate(model)
-
-            expect(model.errors).to include(:invalid_field)
-          end
-        end
-
-        context 'failing transliteration' do
-          let(:invalid_field) { 'def' }
-          let(:analytics) { FakeAnalytics.new }
-
-          before do
-            allow(validator).to receive(:analytics).and_return(analytics)
-            allow(validator.transliterator).to receive(:transliterate).with('def')
-              .and_return(
-                UspsInPersonProofing::Transliterator::TransliterationResult.new(
-                  changed?: true,
-                  original: 'def',
-                  transliterated: 'efg',
-                  unsupported_chars: ['*', '3', 'C'],
-                ),
-              )
-          end
-
-          it 'sets a validation message' do
-            validator.validate(model)
-
-            error = model.errors.group_by_attribute[:invalid_field].first
-
-            expect(error.type).to eq(:nontransliterable_field)
-            expect(error.options[:message]).to eq(message)
-          end
-
-          it 'logs nontransliterable characters' do
-            validator.validate(model)
-
-            expect(analytics).to have_logged_event(
-              'IdV: in person proofing characters submitted could not be transliterated',
-              nontransliterable_characters: ['*', '3', 'C'],
-            )
-          end
-        end
-
-        context 'with callable error message' do
-          let(:generated_message) { 'my_generated_message' }
-          let(:chars_passed) { [] }
-          let(:message) do
-            proc do |invalid_chars|
-              chars_passed.push(*invalid_chars)
-              generated_message
-            end
-          end
-
-          context 'combined transliteration and regex issues' do
-            let(:unsupported_chars_returned) { ['*', '3', 'C'] }
-            let(:transliterated_value_returned) { '1234' }
-            let(:invalid_field) { 'def' }
-            before do
-              allow(validator.transliterator).to receive(:transliterate).with('def')
-                .and_return(
-                  UspsInPersonProofing::Transliterator::TransliterationResult.new(
-                    changed?: true,
-                    original: 'def',
-                    transliterated: transliterated_value_returned,
-                    unsupported_chars: unsupported_chars_returned,
-                  ),
-                )
-            end
-
-            context 'with remaining question mark in transliterated string' do
-              let(:transliterated_value_returned) do
-                "#{UspsInPersonProofing::Transliterator::REPLACEMENT * 4}1234"
-              end
-
-              it 'passes unique sorted chars to message generator' do
-                # The replacement character needs special treatment in this test,
-                # hence this precondition check.
-                expect(
-                  transliterated_value_returned.count(
-                    UspsInPersonProofing::Transliterator::REPLACEMENT,
-                  ),
-                ).to be > unsupported_chars_returned.size
-
-                validator.validate(model)
-
-                expect(chars_passed).to eq(
-                  ['*', '1', '2', '3', '4',
-                   UspsInPersonProofing::Transliterator::REPLACEMENT, 'C'],
-                )
-              end
-            end
-
-            context 'without remaining question mark in transliterated string' do
-              it 'passes unique sorted chars to message generator' do
-                # The replacement character needs special treatment in this test,
-                # hence this precondition check.
-                expect(
-                  transliterated_value_returned.count(
-                    UspsInPersonProofing::Transliterator::REPLACEMENT,
-                  ),
-                ).to be <= unsupported_chars_returned.size
-
-                validator.validate(model)
-
-                expect(chars_passed).to eq(['*', '1', '2', '3', '4', 'C'])
-              end
-            end
-
-            it 'sets the error from the message returned by the message generator' do
-              validator.validate(model)
-
-              error = model.errors.group_by_attribute[:invalid_field].first
-              expect(error.type).to eq(:nontransliterable_field)
-              expect(error.options[:message]).to eq(generated_message)
-            end
-          end
-        end
+      it 'does not check the non-configured field that is present' do
+        validator.validate(model)
+        expect(model).not_to have_received(:extra_field)
       end
 
-      context 'multiple invalid fields' do
-        let(:fields) { [:other_invalid_field, :valid_field, :invalid_field] }
+      it 'checks the configured field that is present' do
+        validator.validate(model)
+        expect(model).to have_received(:valid_field)
+      end
+
+      it 'does not set validation message' do
+        validator.validate(model)
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'one invalid field' do
+      let(:fields) { [:valid_field, :invalid_field] }
+
+      context 'failing regex check' do
         let(:invalid_field) { '123' }
-        let(:other_invalid_field) { "\#@$%" }
+
+        it 'sets a validation message' do
+          validator.validate(model)
+
+          expect(model.errors).to include(:invalid_field)
+        end
+      end
+
+      context 'failing transliteration' do
+        let(:invalid_field) { 'def' }
         let(:analytics) { FakeAnalytics.new }
 
         before do
           allow(validator).to receive(:analytics).and_return(analytics)
+          allow(validator.transliterator).to receive(:transliterate).with('def')
+            .and_return(
+              UspsInPersonProofing::Transliterator::TransliterationResult.new(
+                changed?: true,
+                original: 'def',
+                transliterated: 'efg',
+                unsupported_chars: ['*', '3', 'C'],
+              ),
+            )
         end
 
-        it 'sets multiple validation messages' do
+        it 'sets a validation message' do
           validator.validate(model)
 
-          expect(errors).to include(:invalid_field)
-          expect(errors).to include(:other_invalid_field)
+          error = model.errors.group_by_attribute[:invalid_field].first
+
+          expect(error.type).to eq(:nontransliterable_field)
+          expect(error.options[:message]).to eq(message)
         end
 
         it 'logs nontransliterable characters' do
@@ -239,19 +128,111 @@ RSpec.describe UspsInPersonProofing::TransliterableValidator do
 
           expect(analytics).to have_logged_event(
             'IdV: in person proofing characters submitted could not be transliterated',
-            nontransliterable_characters: ['#', '$', '%', '1', '2', '3', '@'],
+            nontransliterable_characters: ['*', '3', 'C'],
           )
+        end
+      end
+
+      context 'with callable error message' do
+        let(:generated_message) { 'my_generated_message' }
+        let(:chars_passed) { [] }
+        let(:message) do
+          proc do |invalid_chars|
+            chars_passed.push(*invalid_chars)
+            generated_message
+          end
+        end
+
+        context 'combined transliteration and regex issues' do
+          let(:unsupported_chars_returned) { ['*', '3', 'C'] }
+          let(:transliterated_value_returned) { '1234' }
+          let(:invalid_field) { 'def' }
+          before do
+            allow(validator.transliterator).to receive(:transliterate).with('def')
+              .and_return(
+                UspsInPersonProofing::Transliterator::TransliterationResult.new(
+                  changed?: true,
+                  original: 'def',
+                  transliterated: transliterated_value_returned,
+                  unsupported_chars: unsupported_chars_returned,
+                ),
+              )
+          end
+
+          context 'with remaining question mark in transliterated string' do
+            let(:transliterated_value_returned) do
+              "#{UspsInPersonProofing::Transliterator::REPLACEMENT * 4}1234"
+            end
+
+            it 'passes unique sorted chars to message generator' do
+              # The replacement character needs special treatment in this test,
+              # hence this precondition check.
+              expect(
+                transliterated_value_returned.count(
+                  UspsInPersonProofing::Transliterator::REPLACEMENT,
+                ),
+              ).to be > unsupported_chars_returned.size
+
+              validator.validate(model)
+
+              expect(chars_passed).to eq(
+                ['*', '1', '2', '3', '4',
+                 UspsInPersonProofing::Transliterator::REPLACEMENT, 'C'],
+              )
+            end
+          end
+
+          context 'without remaining question mark in transliterated string' do
+            it 'passes unique sorted chars to message generator' do
+              # The replacement character needs special treatment in this test,
+              # hence this precondition check.
+              expect(
+                transliterated_value_returned.count(
+                  UspsInPersonProofing::Transliterator::REPLACEMENT,
+                ),
+              ).to be <= unsupported_chars_returned.size
+
+              validator.validate(model)
+
+              expect(chars_passed).to eq(['*', '1', '2', '3', '4', 'C'])
+            end
+          end
+
+          it 'sets the error from the message returned by the message generator' do
+            validator.validate(model)
+
+            error = model.errors.group_by_attribute[:invalid_field].first
+            expect(error.type).to eq(:nontransliterable_field)
+            expect(error.options[:message]).to eq(generated_message)
+          end
         end
       end
     end
 
-    context 'transliteration disabled' do
-      let(:usps_ipp_transliteration_enabled) { false }
+    context 'multiple invalid fields' do
+      let(:fields) { [:other_invalid_field, :valid_field, :invalid_field] }
+      let(:invalid_field) { '123' }
+      let(:other_invalid_field) { "\#@$%" }
+      let(:analytics) { FakeAnalytics.new }
 
-      it 'does not validate fields' do
+      before do
+        allow(validator).to receive(:analytics).and_return(analytics)
+      end
+
+      it 'sets multiple validation messages' do
         validator.validate(model)
 
-        expect(errors).to be_empty
+        expect(errors).to include(:invalid_field)
+        expect(errors).to include(:other_invalid_field)
+      end
+
+      it 'logs nontransliterable characters' do
+        validator.validate(model)
+
+        expect(analytics).to have_logged_event(
+          'IdV: in person proofing characters submitted could not be transliterated',
+          nontransliterable_characters: ['#', '$', '%', '1', '2', '3', '@'],
+        )
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15120](https://cm-jira.usa.gov/browse/LG-15120)

## 🛠 Summary of changes

Removed the usps_ipp_transliteration_enabled flag.

## 📜 Testing Plan

**Scenario: Fill out state-ID form with transliterate-able characters**
- [x] Add a breakpoint to `app/services/usps_in_person_proofing/enrollment_helper.rb` line 78
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the state-ID page.
- [x] Update the first and last name fields with `Simón Muñoz`
- [x] Submit the state-ID form.
- [x] Continue the ID-IPP flow reaching enter password page.
- [x] Submit the password form
- [x] After triggering your breakpoint check that the applicant has `Simon Munoz`
- [x] Ensure a pending enrollment is present for the user 

**Scenario: Fill out state-ID form with supported characters (A-Z, a-z)**
- [x] Add a breakpoint to `app/services/usps_in_person_proofing/enrollment_helper.rb` line 78
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the state-ID page.
- [x] Update the first and last name fields with `John Doe`
- [x] Submit the state-ID form.
- [x] Continue the ID-IPP flow reaching enter password page.
- [x] Submit the password form
- [x] After hitting your breakpoint check that the applicant has `John Doe`
- [x] Ensure a pending enrollment is present for the user

**Scenario: Fill out state-ID form with non-transliterate-able characters**
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the state-ID page.
- [x] Update the first and last name fields with `Ӑ𝒏𝒔lee Müller`
- [x] Submit the state-ID form.
- [x] Ensure the form errors with the following messages
```
Our system cannot read the following characters: Ӑ, 𝒏, 𝒔. Please try again using the characters on your ID.
```
