### PR TITLE
LG-15114 Add Option to Throw Timeout Error in USPS In-person Mock Proofer

### DIFF
--- a/app/services/usps_in_person_proofing/mock/proofer.rb
+++ b/app/services/usps_in_person_proofing/mock/proofer.rb
@@ -40,7 +40,7 @@ module UspsInPersonProofing
       def request_facilities(location, is_enhanced_ipp)
         if location['address'] == 'usps waiting'
           body = JSON.parse(Fixtures.internal_server_error_response)
-          response = { body: body, status: 422 }
+          response = { body: body, status: 500 }
           raise Faraday::TimeoutError.new('Timeout error', response)
         elsif is_enhanced_ipp
           parse_facilities(JSON.parse(Fixtures.request_enhanced_ipp_facilities_response))

--- a/app/services/usps_in_person_proofing/mock/proofer.rb
+++ b/app/services/usps_in_person_proofing/mock/proofer.rb
@@ -38,7 +38,11 @@ module UspsInPersonProofing
       end
 
       def request_facilities(_location, is_enhanced_ipp)
-        if is_enhanced_ipp
+        if _location['address'] == 'usps waiting'
+          body = JSON.parse(Fixtures.internal_server_error_response)
+          response = { body: body, status: 422 }
+          raise Faraday::TimeoutError.new('Timeout error', response)
+        elsif is_enhanced_ipp
           parse_facilities(JSON.parse(Fixtures.request_enhanced_ipp_facilities_response))
         else
           parse_facilities(JSON.parse(Fixtures.request_facilities_response))

--- a/app/services/usps_in_person_proofing/mock/proofer.rb
+++ b/app/services/usps_in_person_proofing/mock/proofer.rb
@@ -37,8 +37,8 @@ module UspsInPersonProofing
         Response::RequestEnrollResponse.new(res)
       end
 
-      def request_facilities(_location, is_enhanced_ipp)
-        if _location['address'] == 'usps waiting'
+      def request_facilities(location, is_enhanced_ipp)
+        if location['address'] == 'usps waiting'
           body = JSON.parse(Fixtures.internal_server_error_response)
           response = { body: body, status: 422 }
           raise Faraday::TimeoutError.new('Timeout error', response)


### PR DESCRIPTION
## 🎫 Ticket

- This pull request supports work for [LG-15114](https://cm-jira.usa.gov/browse/LG-15114)  Create an alarm for In Person Locations Request Failure.

- It is so I can test an alarm I created in [identity-devops- PR# 5546 ](https://gitlab.login.gov/lg/identity-devops/-/merge_requests/5546/diffs) in the Joy sandbox more easily. 

## 🛠 Summary of changes
* Add option to throw a Timeout Error to the UPSP In-person proofing mocks when address for USPS search = 'usps waiting'

## 📜 Testing Plan
- [ ] Step 1 Run app locally. Create an account and sign in. Move to the IPP flow. Stop when you arrive on "Find a participating Post Office" view (/verify/document_capture#location)
- [ ] Step 2 Search for a Post Office as you normally would to ensure the list of 10 mock locations are returned. Check event logs for 'IdV: in person proofing location search submitted'. It should have attributes success with true and result_total with 10. (Ensure there are no regressions.)
- [ ] Step 3 Search for a Post Office as you normally would but type **usps waiting** in the Address field. You should see an error on the screen when you search. Check event logs for `Request USPS IPP locations: request failed`. Ensure it has attributes api_status_code: 422 and exception_class of Faraday::TimeoutError. This is necessary so that I can test my alarm with no additional over head and can be used in the future to test USPS timeout errors. Please review [LG-15114](https://cm-jira.usa.gov/browse/LG-15114) to confirm that this is compatible.  (This mock will also be helpful when we want to skip USPS search because of outages.)
- [ ] Step 4 Come in through Sinatra for EIPP. Search for a Post Office as you normally would. Ensure only 3 mock locations are returned. (Ensure there are no regressions.)

## 👀 Screenshots

<details>
<summary>After:</summary>
This view already existed. It will now be able to mimick a timeout error for USPS get facilities. 

<img width="536" alt="Screenshot 2025-02-24 at 10 24 22 AM" src="https://github.com/user-attachments/assets/8e3a0bf1-43c9-42c6-8145-8b2b848fd2b2" />

</details>