### PR TITLE
LG-15803: Include all arguments in A/B report base job class initialization

### DIFF
--- a/app/jobs/reports/ab_tests_report.rb
+++ b/app/jobs/reports/ab_tests_report.rb
@@ -8,7 +8,7 @@ module Reports
 
     def initialize(report_date = nil, *args, **kwargs)
       @report_date = report_date
-      super(*args, **kwargs)
+      super(report_date, *args, **kwargs)
     end
 
     # @param [DateTime]

--- a/spec/jobs/reports/ab_tests_report_spec.rb
+++ b/spec/jobs/reports/ab_tests_report_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::AbTestsReport do
+  subject(:job) { described_class.new(report_date) }
   let(:report_date) { Date.new(2023, 12, 25) }
   let(:email) { 'email@example.com' }
   let(:tested_percent) { 1 }
@@ -81,7 +82,7 @@ RSpec.describe Reports::AbTestsReport do
         attachment_format: :csv,
       )
 
-      subject.perform(report_date)
+      job.perform(report_date)
     end
 
     context 'when associated report email is nil' do
@@ -90,7 +91,7 @@ RSpec.describe Reports::AbTestsReport do
       it 'does not email the table report' do
         expect(ReportMailer).not_to receive(:tables_report)
 
-        subject.perform(report_date)
+        job.perform(report_date)
       end
     end
 
@@ -100,7 +101,15 @@ RSpec.describe Reports::AbTestsReport do
       it 'does not email the table report' do
         expect(ReportMailer).not_to receive(:tables_report)
 
-        subject.perform(report_date)
+        job.perform(report_date)
+      end
+    end
+
+    context 'when called on class' do
+      it 'emails the table report' do
+        expect(ReportMailer).to receive(:tables_report)
+
+        described_class.perform_now(report_date)
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[LG-15803](https://cm-jira.usa.gov/browse/LG-15803)

## 🛠 Summary of changes

Fixes an error where the recurring job for A/B test reporting doesn't complete because the `perform` method doesn't receive all arguments.

The underlying issue is that the `super` call did not pass all of the original position arguments received by the call, so the job did not have the arguments to send to the enqueued `perform` ([ref](https://github.com/rails/rails/blob/04775277406fe6bb26e7c8052d2459c568a780d8/activejob/lib/active_job/core.rb#L104)).

## 📜 Testing Plan

```
rspec spec/jobs/reports/ab_tests_report_spec.rb
```

You could also locally modify the [job configuration](https://github.com/18F/identity-idp/blob/25c473a5acb6d0ef0d149281564039bd6ffa7dc2/config/initializers/job_configurations.rb#L239-L244) to either use a shorter `cron` value, or modify the `cron_24h` value to occur on a quicker cadence, and then ensure that the job does not error when run via `bundle exec good_job start`.