### PR TITLE
Restore line break for partner email selection

### DIFF
--- a/app/views/accounts/_connected_app.html.erb
+++ b/app/views/accounts/_connected_app.html.erb
@@ -17,6 +17,7 @@
               'account.connected_apps.associated_attributes_html',
               timestamp_html: render(TimeComponent.new(time: identity.created_at)),
             ) %>
+      <br>
       <strong>
         <%= identity.email_address&.email || t('account.connected_apps.email_not_selected') %>
       </strong>


### PR DESCRIPTION
## 🛠 Summary of changes

Updates layout of partner email selection screen to include a line break between "connected with:" line and the selected email, per the original design. This [regressed](https://github.com/18F/identity-idp/pull/11701/files#diff-24662f53f7421ce345236893cae4aaaeeeacf654f0a8f57c94229488bd946563L19) in recent changes. It particularly affects cases where the user has not yet selected an email to be shared with the partner application.

## 📜 Testing Plan

Disable partner email selection feature before starting, in `config/application.yml`:

```
development:
  feature_select_email_to_share_enabled: false
```

1. Have [sample application](https://github.com/18F/identity-oidc-sinatra) running in a separate process
2. Go to http://localhost:9292
3. Click "Sign in"
4. Create an account
5. Once returned to the partner, visit http://localhost:3000
6. Go to "Your connected accounts" page in account dashboard
7. Re-enable partner email selection feature by removing the `config/application.yml` added above, and restarting the local server
8. Refresh the "Your connected accounts" page
9. Verify "Email not yet selected" appears on its own line with "Change"

## 👀 Screenshots

Before|After
---|---
![Screenshot 2025-02-25 at 8 07 37 AM](https://github.com/user-attachments/assets/191112dc-e758-44e1-9760-2b38aa142075)|![Screenshot 2025-02-25 at 8 07 43 AM](https://github.com/user-attachments/assets/26192a59-143a-4340-b06d-d3e719d63a91)

