### PR TITLE
LG-15831: ApiImageUploader use default doc auth vendor when doc auth vendor is nil in document capture session

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -326,7 +326,8 @@ module Idv
 
     def doc_auth_client
       @doc_auth_client ||= DocAuthRouter.client(
-        vendor: document_capture_session.doc_auth_vendor,
+        vendor: document_capture_session.doc_auth_vendor ||
+          IdentityConfig.store.doc_auth_vendor_default,
         warn_notifier: proc do |attrs|
           analytics&.doc_auth_warning(
             **attrs,

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -236,6 +236,18 @@ RSpec.describe Idv::ApiImageUploadForm do
         expect(response.pii_from_doc).to eq(Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT))
       end
 
+      context 'when doc_auth_vendor is not set in the document_capture_session' do
+        let!(:document_capture_session) { create(:document_capture_session) }
+
+        it 'returns the expected response using default doc auth vendor' do
+          expect(document_capture_session.doc_auth_vendor).to be_nil
+          response = form.submit
+
+          expect(response).to be_a_kind_of DocAuth::Response
+          expect(response.success?).to eq(true)
+        end
+      end
+
       context 'when liveness check is required' do
         let(:liveness_checking_required) { true }
         let(:back_image) { DocAuthImageFixtures.portrait_match_success_yaml }


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-15831](https://cm-jira.usa.gov/browse/LG-15831)

## 🛠 Summary of changes
The API image uploader uses the configured doc_auth_vendor_default as the vendor when document_captuere_session.doc_auth_vendor is nil

After deployed, will remove this in cleanup issue [LG-15835](https://cm-jira.usa.gov/browse/LG-15835)
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
