### PR TITLE
LG-13405 Incorrect section heading for backup codes in account dashboard

### DIFF
--- a/app/views/accounts/_backup_codes.html.erb
+++ b/app/views/accounts/_backup_codes.html.erb
@@ -1,5 +1,5 @@
 <h2 class="margin-top-0 margin-bottom-1">
-  <%= t('forms.backup_code.title') %>
+  <%= t('two_factor_authentication.login_options.backup_code') %>
 </h2>
 <div class="grid-row padding-1 border border-primary-light">
   <% if TwoFactorAuthentication::BackupCodePolicy.new(current_user).configured? %>

--- a/app/views/accounts/_backup_codes.html.erb
+++ b/app/views/accounts/_backup_codes.html.erb
@@ -1,5 +1,5 @@
 <h2 class="margin-top-0 margin-bottom-1">
-  <%= t('two_factor_authentication.login_options.backup_code') %>
+  <%= t('account.index.backup_codes') %>
 </h2>
 <div class="grid-row padding-1 border border-primary-light">
   <% if TwoFactorAuthentication::BackupCodePolicy.new(current_user).configured? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,7 @@ account.index.auth_app_disabled: not enabled
 account.index.auth_app_enabled: enabled
 account.index.backup_code_confirm_delete: Yes, delete codes
 account.index.backup_code_confirm_regenerate: Yes, regenerate codes
+account.index.backup_codes: Backup codes
 account.index.backup_codes_exist: Generated
 account.index.backup_codes_no_exist: Not generated
 account.index.continue_to_service_provider: Continue to %{service_provider}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -58,6 +58,7 @@ account.index.auth_app_disabled: no habilitada
 account.index.auth_app_enabled: habilitada
 account.index.backup_code_confirm_delete: Sí, eliminar códigos
 account.index.backup_code_confirm_regenerate: Sí, regenerar códigos
+account.index.backup_codes: Códigos de recuperación
 account.index.backup_codes_exist: Generados
 account.index.backup_codes_no_exist: No generados
 account.index.continue_to_service_provider: Continuar con %{service_provider}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -58,6 +58,7 @@ account.index.auth_app_disabled: non activé
 account.index.auth_app_enabled: activé
 account.index.backup_code_confirm_delete: Oui, supprimer les codes
 account.index.backup_code_confirm_regenerate: Oui, régénérer les codes
+account.index.backup_codes: Codes de sauvegarde
 account.index.backup_codes_exist: Généré
 account.index.backup_codes_no_exist: Non généré
 account.index.continue_to_service_provider: Continuer sur %{service_provider}

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -58,6 +58,7 @@ account.index.auth_app_disabled: 未启用
 account.index.auth_app_enabled: 已启用
 account.index.backup_code_confirm_delete: 是的，删除代码
 account.index.backup_code_confirm_regenerate: 是的，重新生成代码
+account.index.backup_codes: 备用代码
 account.index.backup_codes_exist: 生成了
 account.index.backup_codes_no_exist: 未生成
 account.index.continue_to_service_provider: 继续到 %{service_provider}


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-13405](https://cm-jira.usa.gov/browse/LG-13405)



## 🛠 Summary of changes

Uses existing translation string for 'Backup codes' in place of currently applied 'Save these backup codes'


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go to http://localhost:3000 and log in
- [ ] If needed add Backup codes
- [ ] The heading for Backup codes should just say Backup codes on the Account page and Your authentication methods page.



## 👀 Screenshots

|    | Before | After |
|----|:------:|:-----:|
| En |    ![Screenshot 2025-02-26 at 8 22 54 AM (2)](https://github.com/user-attachments/assets/4906f0b6-8818-416f-afd7-fb4f4becbea6)   |   ![Screenshot 2025-02-26 at 8 17 48 AM (2)](https://github.com/user-attachments/assets/ad52c097-4ae9-490a-a287-2e2170ba7092)   |
| Es |    ![Screenshot 2025-02-26 at 8 23 00 AM (2)](https://github.com/user-attachments/assets/42c7f026-fede-4066-90a2-0f230d39a0e3)   |   ![Screenshot 2025-02-26 at 8 17 56 AM (2)](https://github.com/user-attachments/assets/296eb64a-a9f9-4dbe-8538-4948da485460)   |
| Fr |    ![Screenshot 2025-02-26 at 8 23 05 AM (2)](https://github.com/user-attachments/assets/917f4f3b-a385-4053-8526-74247f300f57)   |   ![Screenshot 2025-02-26 at 8 18 03 AM (2)](https://github.com/user-attachments/assets/26c7c6eb-ee14-498d-8bd6-c588aec44e2a)   |
| Zh |    ![Screenshot 2025-02-26 at 8 23 17 AM (2)](https://github.com/user-attachments/assets/21643066-4b61-4808-98d8-195ea5b68999)   |   ![Screenshot 2025-02-26 at 8 18 08 AM (2)](https://github.com/user-attachments/assets/e8475970-9e12-4907-9fd5-75e858d5e0f1)   |






