### PR TITLE
LG-14115: Remove dead code [skip changelog]

### DIFF
--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -9,12 +9,6 @@ module UspsInPersonProofing
 
         enrollment.current_address_matches_id = pii['same_address_as_id']
 
-        if enrollment.sponsor_id.nil?
-          enrollment.sponsor_id = is_enhanced_ipp ?
-            IdentityConfig.store.usps_eipp_sponsor_id :
-            IdentityConfig.store.usps_ipp_sponsor_id
-        end
-
         enrollment.save!
 
         # Send state ID address to USPS


### PR DESCRIPTION
## 🎫 Ticket
[LG-14115](https://cm-jira.usa.gov/browse/LG-14115)



## 🛠 Summary of changes
- Remove code that is no longer needed.
- Most of the extraneous code mentioned in [LG-14115](https://cm-jira.usa.gov/browse/LG-14115) has already been deleted.  However, we still needed to do a little bit of cleanup in the enrollment_helper.



## 📜 Testing Plan
- [x] Locally create an in_person_enrollment
- [x] Use rails console to confirm that the in_person_enrollment has a sponsor_id
- [x] Rejoice