### PR TITLE
fix: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,4 +143,5 @@ group :test do
   gem 'tableparser', require: false
   gem 'webmock'
   gem 'zonebie'
+  gem "argon2", "2.3.2"
 end

--- a/app/services/binary_search_sorted_hash_file.rb
+++ b/app/services/binary_search_sorted_hash_file.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'argon2'
 
 class BinarySearchSortedHashFile
   include ::NewRelic::Agent::MethodTracer
@@ -10,7 +11,7 @@ class BinarySearchSortedHashFile
   end
 
   def call(password)
-    key = Digest::SHA1.hexdigest(password).upcase
+    key = Argon2::Password.create(password).upcase
     min = 0
     max = File.size(@file_name) / RECORD_SIZE
     middle = 0
@@ -22,7 +23,7 @@ class BinarySearchSortedHashFile
         return false if middle == old_middle
         file.seek middle * RECORD_SIZE
         val = file.readline.chomp
-        return true if val == key
+        return true if Argon2::Password.verify_password(password, val)
         if file.eof? || val > key
           max = middle
         else


### PR DESCRIPTION
#11924 

Using a broken or weak cryptographic hash function can leave data vulnerable, and should not be used in security related code.

A strong cryptographic hash function should be resistant to:
  - pre-image attacks: if you know a hash value `h(x)`, you should not be able to easily find the input `x`.
  - collision attacks: if you know a hash value h(x), you should not be able to easily find a different input `y` with the same hash value `h(x) = h(y)`.
In cases with a limited input space, such as for passwords, the hash function also needs to be computationally expensive to be resistant to brute-force attacks. Passwords should also have an unique salt applied before hashing, but that is not considered by this query.

As an vulnerable, both MD5 and SHA-1 are known to be vulnerable to collision attacks. Since it's OK to use a weak cryptographic hash function in a non-security context, this query only alerts when these are used to hash sensitive data (such as passwords, certificates, usernames). Use of broken or weak cryptographic algorithms that are not hashing algorithms, is handled by the `rb/weak-cryptographic-algorithm` query.