### PR TITLE
Avoid orphaned punctuation using non-breaking whitespace

### DIFF
--- a/app/views/shared/_banner-lock-icon.html.erb
+++ b/app/views/shared/_banner-lock-icon.html.erb
@@ -1,7 +1,0 @@
-<%= image_tag(
-      asset_path('lock.svg'),
-      width: 9,
-      height: 12,
-      class: 'usa-banner__lock-image',
-      alt: t('shared.banner.lock_description'),
-    ) %>

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -49,7 +49,17 @@
             <div class="usa-media-block__body">
               <p>
                 <strong><%= t('shared.banner.secure_heading') %></strong>
-                <br> <%= t('shared.banner.secure_description_html', lock_icon: render('shared/banner-lock-icon')) %>
+                <br>
+                <%= t(
+                      'shared.banner.secure_description_html',
+                      lock_icon: image_tag(
+                        asset_path('lock.svg'),
+                        width: 9,
+                        height: 12,
+                        class: 'usa-banner__lock-image',
+                        alt: t('shared.banner.lock_description'),
+                      ),
+                    ) %>
               </p>
             </div>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1561,7 +1561,7 @@ shared.banner.how: Here’s how you know
 shared.banner.landmark_label: Official government website
 shared.banner.lock_description: A locked padlock
 shared.banner.official_site: An official website of the United States government
-shared.banner.secure_description_html: A <strong>lock</strong> ( %{lock_icon} ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
+shared.banner.secure_description_html: A <strong>lock</strong> ( %{lock_icon} ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
 shared.banner.secure_heading: Secure .gov websites use HTTPS
 shared.footer_lite.gsa: US General Services Administration
 shared.skip_link: Skip to main content

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1573,7 +1573,7 @@ shared.banner.how: Así es como usted puede saberlo
 shared.banner.landmark_label: Sitio web oficial del Gobierno
 shared.banner.lock_description: Un candado cerrado
 shared.banner.official_site: Un sitio web oficial del Gobierno de los Estados Unidos
-shared.banner.secure_description_html: Un <strong>candado</strong> ( %{lock_icon} ) o <strong>https://</strong> significa que se conectó de forma segura a un sitio web .gov. Comunique información confidencial solo en los sitios web oficiales protegidos.
+shared.banner.secure_description_html: Un <strong>candado</strong> ( %{lock_icon} ) o <strong>https://</strong> significa que se conectó de forma segura a un sitio web .gov. Comunique información confidencial solo en los sitios web oficiales protegidos.
 shared.banner.secure_heading: Los sitios web .gov protegidos usan HTTPS
 shared.footer_lite.gsa: Administración General de Servicios de los EE. UU.
 shared.skip_link: Saltar al contenido principal

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1477,11 +1477,11 @@ notices.signed_up_but_unconfirmed.first_paragraph_end: avec un lien pour confirm
 notices.signed_up_but_unconfirmed.first_paragraph_start: Nous avons envoyé un e-mail à
 notices.signed_up_but_unconfirmed.resend_confirmation_email: Renvoyer le courriel de confirmation
 notices.timeout_warning.partially_signed_in.continue: Continuer la connexion
-notices.timeout_warning.partially_signed_in.live_region_message_html: Vous serez déconnecté dans %{time_left_in_session_html}. Sélectionnez « Gardez ma connexion active » pour rester connecté. Sélectionnez « Déconnectez-moi » pour vous déconnecter.
+notices.timeout_warning.partially_signed_in.live_region_message_html: Vous serez déconnecté dans %{time_left_in_session_html}. Sélectionnez « Gardez ma connexion active » pour rester connecté. Sélectionnez « Déconnectez-moi » pour vous déconnecter.
 notices.timeout_warning.partially_signed_in.message_html: Pour votre sécurité, nous annulerons votre connexion dans %{time_left_in_session_html}.
 notices.timeout_warning.partially_signed_in.sign_out: Annuler la connexion
 notices.timeout_warning.signed_in.continue: Gardez ma connexion active
-notices.timeout_warning.signed_in.live_region_message_html: Vous serez déconnecté dans %{time_left_in_session_html}. Sélectionnez « Gardez ma connexion active » pour rester connecté. Sélectionnez « Déconnectez-moi » pour vous déconnecter.
+notices.timeout_warning.signed_in.live_region_message_html: Vous serez déconnecté dans %{time_left_in_session_html}. Sélectionnez « Gardez ma connexion active » pour rester connecté. Sélectionnez « Déconnectez-moi » pour vous déconnecter.
 notices.timeout_warning.signed_in.message_html: Pour votre sécurité, nous vous déconnecterons dans %{time_left_in_session_html}, sauf en cas d’avis contraire de votre part.
 notices.timeout_warning.signed_in.sign_out: Déconnectez-moi
 notices.totp_configured: Une appli d’authentification a été ajoutée à votre compte.
@@ -1561,7 +1561,7 @@ shared.banner.how: Voici comment le savoir
 shared.banner.landmark_label: Site Web officiel des autorités
 shared.banner.lock_description: Un cadenas fermé
 shared.banner.official_site: Un site Web officiel de l’administration des États-Unis
-shared.banner.secure_description_html: La présence d’un <strong>cadenas</strong> ( %{lock_icon} ) ou de <strong>https://</strong> signifie que vous êtes connecté en toute sécurité au site Web .gov. Ne partagez des informations sensibles que sur des sites Web officiels et sécurisés.
+shared.banner.secure_description_html: La présence d’un <strong>cadenas</strong> ( %{lock_icon} ) ou de <strong>https://</strong> signifie que vous êtes connecté en toute sécurité au site Web .gov. Ne partagez des informations sensibles que sur des sites Web officiels et sécurisés.
 shared.banner.secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
 shared.footer_lite.gsa: Administration des services généraux des États-Unis
 shared.skip_link: Passer au contenu principal

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1574,7 +1574,7 @@ shared.banner.how: 这里告诉你如何知道
 shared.banner.landmark_label: 官方政府网站
 shared.banner.lock_description: 锁上的锁头
 shared.banner.official_site: 美国政府的一个官方网站
-shared.banner.secure_description_html: 一把 <strong>锁</strong>（ %{lock_icon} ）或者 <strong>https://</strong> 意味着你已安全连接到 .gov 网站。只在官方、安全的网站上分享敏感信息。
+shared.banner.secure_description_html: 一把 <strong>锁</strong>（ %{lock_icon} ）或者 <strong>https://</strong> 意味着你已安全连接到 .gov 网站。只在官方、安全的网站上分享敏感信息。
 shared.banner.secure_heading: 安全的 .gov 网站使用 HTTPS
 shared.footer_lite.gsa: 美国联邦总务管理局
 shared.skip_link: 跳到主要内容


### PR DESCRIPTION
## 🛠 Summary of changes

Enforces consistency of using non-breaking spaces within paired punctuation to avoid orphaned punctuation when line breaks occur, and fixes existing issues. It also adds French quotation characters ("guillemets": « ») as expected punctuation pairs.

The intent is to avoid the sorts of issues observed in #11911, consistently requiring that non-breaking spaces be used whenever there is whitespace within paired punctuation (parentheses, quotes, etc.).

Example (fixed in #11911):

![Screenshot 2025-02-27 at 1 53 58 PM](https://github.com/user-attachments/assets/c4a60a4e-7d4a-4bfc-a3f6-eae680525784)

## 📜 Testing Plan

Verify there's no regressions in the affected text. For example, ensure that the expanded banner text shows the lock icon within parentheses with whitespace.

![image](https://github.com/user-attachments/assets/645163ac-2bc6-4464-a66d-2f2fbc110c11)
