### PR TITLE
LG-15833: Maintain partner link when session times out at sign-in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -149,7 +149,7 @@ class ApplicationController < ActionController::Base
                           else
                             {
                               value: current_sp.issuer,
-                              expires: IdentityConfig.store.session_timeout_in_minutes.minutes,
+                              expires: IdentityConfig.store.session_timeout_in_seconds.seconds,
                             }
                           end
   end
@@ -162,12 +162,12 @@ class ApplicationController < ActionController::Base
       flash[:info] = t(
         'notices.session_timedout',
         app_name: APP_NAME,
-        minutes: IdentityConfig.store.session_timeout_in_minutes,
+        minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes,
       )
     elsif current_user.blank?
       flash[:info] = t(
         'notices.session_cleared',
-        minutes: IdentityConfig.store.session_timeout_in_minutes,
+        minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes,
       )
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -162,12 +162,12 @@ class ApplicationController < ActionController::Base
       flash[:info] = t(
         'notices.session_timedout',
         app_name: APP_NAME,
-        minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes,
+        minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes.to_i,
       )
     elsif current_user.blank?
       flash[:info] = t(
         'notices.session_cleared',
-        minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes,
+        minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes.to_i,
       )
     end
 

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -34,7 +34,7 @@ class OpenidConnectTokenForm
     ATTRS.each do |key|
       instance_variable_set(:"@#{key}", params[key])
     end
-    @session_expiration = IdentityConfig.store.session_timeout_in_minutes.minutes.ago
+    @session_expiration = IdentityConfig.store.session_timeout_in_seconds.seconds.ago
     @identity = find_identity_with_code
   end
 

--- a/app/javascript/packs/session-expire-session.ts
+++ b/app/javascript/packs/session-expire-session.ts
@@ -8,9 +8,8 @@ const warning = Number(warningEl.dataset.warning!) * 1000;
 const sessionsURL = warningEl.dataset.sessionsUrl!;
 const sessionTimeout = Number(warningEl.dataset.sessionTimeoutIn!) * 1000;
 const modal = document.querySelector<ModalElement>('lg-modal.session-timeout-modal')!;
-const keepaliveEl = document.getElementById('session-keepalive-btn');
+const keepaliveButton = document.getElementById('session-keepalive-btn')!;
 const countdownEls: NodeListOf<CountdownElement> = modal.querySelectorAll('lg-countdown');
-const timeoutRefreshPath = warningEl.dataset.timeoutRefreshPath || '';
 
 let sessionExpiration = new Date(Date.now() + sessionTimeout);
 
@@ -22,19 +21,20 @@ function showModal() {
   });
 }
 
-function keepalive() {
+function keepalive(event: MouseEvent) {
   const isExpired = new Date() > sessionExpiration;
   if (isExpired) {
-    document.location.href = timeoutRefreshPath;
-  } else {
-    modal.hide();
-    sessionExpiration = new Date(Date.now() + sessionTimeout);
-
-    setTimeout(showModal, sessionTimeout - warning);
-    countdownEls.forEach((countdownEl) => countdownEl.stop());
-    extendSession(sessionsURL);
+    return;
   }
+
+  event.preventDefault();
+  modal.hide();
+  sessionExpiration = new Date(Date.now() + sessionTimeout);
+
+  setTimeout(showModal, sessionTimeout - warning);
+  countdownEls.forEach((countdownEl) => countdownEl.stop());
+  extendSession(sessionsURL);
 }
 
-keepaliveEl?.addEventListener('click', keepalive, false);
+keepaliveButton.addEventListener('click', keepalive);
 setTimeout(showModal, sessionTimeout - warning);

--- a/app/javascript/packs/session-timeout-ping.ts
+++ b/app/javascript/packs/session-timeout-ping.ts
@@ -15,7 +15,7 @@ const timeoutURL = warningEl?.dataset.timeoutUrl!;
 const sessionsURL = warningEl?.dataset.sessionsUrl!;
 
 const modal = document.querySelector<ModalElement>('lg-modal.session-timeout-modal')!;
-const keepaliveEl = document.getElementById('session-keepalive-btn');
+const keepaliveButton = document.getElementById('session-keepalive-btn')!;
 const countdownEls: NodeListOf<CountdownElement> = modal.querySelectorAll('lg-countdown');
 
 function success({ isLive, timeout }: SessionStatus) {
@@ -46,11 +46,12 @@ function success({ isLive, timeout }: SessionStatus) {
 
 const ping = () => requestSessionStatus(sessionsURL).then(success);
 
-function keepalive() {
+function keepalive(event: MouseEvent) {
+  event.preventDefault();
   modal.hide();
   countdownEls.forEach((countdownEl) => countdownEl.stop());
   extendSession(sessionsURL);
 }
 
-keepaliveEl?.addEventListener('click', keepalive, false);
+keepaliveButton.addEventListener('click', keepalive);
 setTimeout(ping, start);

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -38,7 +38,7 @@
     </p>
   </div>
   <%= render ButtonComponent.new(
-        url: url_for(request_id: sp_session[:request_id]),
+        url: new_user_session_url(timeout: :session, request_id: sp_session[:request_id]),
         id: 'session-keepalive-btn',
         big: true,
         full_width: true,

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -38,7 +38,7 @@
     </p>
   </div>
   <%= render ButtonComponent.new(
-        type: :button,
+        url: url_for(request_id: sp_session[:request_id]),
         id: 'session-keepalive-btn',
         big: true,
         full_width: true,

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -383,7 +383,7 @@ session_check_delay: 30
 session_check_frequency: 30
 session_encryption_key:
 session_encryptor_alert_enabled: false
-session_timeout_in_minutes: 15
+session_timeout_in_seconds: 900
 session_timeout_warning_seconds: 150
 session_total_duration_timeout_in_minutes: 720
 short_term_phone_otp_max_attempt_window_in_seconds: 10

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -15,7 +15,7 @@ end
 
 Ahoy.api = false
 # Period of inactivity before a new visit is created
-Ahoy.visit_duration = IdentityConfig.store.session_timeout_in_minutes.minutes
+Ahoy.visit_duration = IdentityConfig.store.session_timeout_in_seconds.seconds
 Ahoy.server_side_visits = false
 Ahoy.geocode = false
 Ahoy.user_agent_parser = :browser

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   config.skip_session_storage = [:http_auth]
   config.strip_whitespace_keys = []
   config.stretches = Rails.env.test? ? 1 : 12
-  config.timeout_in = IdentityConfig.store.session_timeout_in_minutes.minutes
+  config.timeout_in = IdentityConfig.store.session_timeout_in_seconds.seconds
 
   config.warden do |manager|
     manager.failure_app = CustomDeviseFailureApp

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -16,7 +16,7 @@ Rails.application.config.session_store(
     write_private_id: true,
 
     # Redis expires session after N minutes
-    ttl: IdentityConfig.store.session_timeout_in_minutes.minutes,
+    ttl: IdentityConfig.store.session_timeout_in_seconds.seconds,
 
     key_prefix: "#{IdentityConfig.store.domain_name}:session:",
     client_pool: REDIS_POOL,

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -417,7 +417,7 @@ module IdentityConfig
     config.add(:session_check_frequency, type: :integer)
     config.add(:session_encryption_key, type: :string)
     config.add(:session_encryptor_alert_enabled, type: :boolean)
-    config.add(:session_timeout_in_minutes, type: :integer)
+    config.add(:session_timeout_in_seconds, type: :integer)
     config.add(:session_timeout_warning_seconds, type: :integer)
     config.add(:session_total_duration_timeout_in_minutes, type: :integer)
     config.add(:show_unsupported_passkey_platform_authentication_setup, type: :boolean)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ApplicationController do
 
         expect(cookies[:sp_issuer]).to eq(sp.issuer)
         expect(cookie_expiration).to be_within(3.seconds).of(
-          IdentityConfig.store.session_timeout_in_minutes.minutes.from_now,
+          IdentityConfig.store.session_timeout_in_seconds.seconds.from_now,
         )
       end
     end
@@ -414,7 +414,7 @@ RSpec.describe ApplicationController do
         expect(flash[:info]).to eq t(
           'notices.session_timedout',
           app_name: APP_NAME,
-          minutes: IdentityConfig.store.session_timeout_in_minutes,
+          minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes,
         )
       end
     end
@@ -447,7 +447,7 @@ RSpec.describe ApplicationController do
 
         expect(flash[:info]).to eq t(
           'notices.session_cleared',
-          minutes: IdentityConfig.store.session_timeout_in_minutes,
+          minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes,
         )
       end
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe ApplicationController do
         expect(flash[:info]).to eq t(
           'notices.session_timedout',
           app_name: APP_NAME,
-          minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes,
+          minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes.to_i,
         )
       end
     end
@@ -447,7 +447,7 @@ RSpec.describe ApplicationController do
 
         expect(flash[:info]).to eq t(
           'notices.session_cleared',
-          minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes,
+          minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes.to_i,
         )
       end
     end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -322,7 +322,6 @@ RSpec.feature 'Sign in' do
 
         visit_idp_from_sp_with_ial1(:oidc)
 
-        expect(page).to have_css('.usa-js-modal--active', wait: 10)
         expect(page).to have_content(
           t(
             'notices.timeout_warning.partially_signed_in.message_html',

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -221,7 +221,7 @@ RSpec.feature 'Sign in' do
 
     scenario 'user can continue browsing with refreshed CSRF token' do
       token = first('[name=authenticity_token]', visible: false).value
-      click_button t('notices.timeout_warning.signed_in.continue')
+      click_on t('notices.timeout_warning.signed_in.continue')
       expect(page).not_to have_css('.usa-js-modal--active')
       expect(page).to have_css(
         "[name=authenticity_token]:not([value='#{token}'])",

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -199,7 +199,10 @@ RSpec.feature 'Sign in' do
 
     scenario 'user sees warning before session times out' do
       minutes_and = [
-        t('datetime.dotiw.minutes', count: IdentityConfig.store.session_timeout_in_minutes - 1),
+        t(
+          'datetime.dotiw.minutes',
+          count: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes - 1,
+        ),
         t('datetime.dotiw.two_words_connector'),
       ].join('')
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -319,6 +319,7 @@ RSpec.feature 'Sign in' do
       it 'maintains partner request if the user continues after the session expires', js: true do
         allow(IdentityConfig.store).to receive(:session_timeout_in_seconds).and_return(1)
         allow(IdentityConfig.store).to receive(:session_check_delay).and_return(0)
+        allow(Devise).to receive(:timeout_in).and_return(1)
 
         visit_idp_from_sp_with_ial1(:oidc)
 

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -201,7 +201,7 @@ RSpec.feature 'Sign in' do
       minutes_and = [
         t(
           'datetime.dotiw.minutes',
-          count: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes - 1,
+          count: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes.to_i - 1,
         ),
         t('datetime.dotiw.two_words_connector'),
       ].join('')

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -295,7 +295,7 @@ RSpec.feature 'Sign in' do
 
         expect(page).to have_css('.usa-js-modal--active', wait: 10)
 
-        click_button t('notices.timeout_warning.partially_signed_in.continue')
+        click_on t('notices.timeout_warning.partially_signed_in.continue')
 
         expect(page).not_to have_css('.usa-js-modal--active')
         expect(find_field(t('forms.registration.labels.email')).value).not_to be_blank
@@ -312,8 +312,27 @@ RSpec.feature 'Sign in' do
 
         expect(page).to have_css('.usa-js-modal--active', wait: 10)
 
-        click_button t('notices.timeout_warning.partially_signed_in.continue')
+        click_on t('notices.timeout_warning.partially_signed_in.continue')
         expect(find_field(t('account.index.email')).value).not_to be_blank
+      end
+
+      it 'maintains partner request if the user continues after the session expires', js: true do
+        allow(IdentityConfig.store).to receive(:session_timeout_in_seconds).and_return(1)
+        allow(IdentityConfig.store).to receive(:session_check_delay).and_return(0)
+
+        visit_idp_from_sp_with_ial1(:oidc)
+
+        expect(page).to have_css('.usa-js-modal--active', wait: 10)
+        expect(page).to have_content(
+          t(
+            'notices.timeout_warning.partially_signed_in.message_html',
+            time_left_in_session_html: t('datetime.dotiw.seconds', count: 0),
+          ),
+          wait: 10,
+        )
+
+        click_on t('notices.timeout_warning.partially_signed_in.continue')
+        expect_branded_experience
       end
 
       it 'reloads the sign in page when cancel is clicked', js: true do

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'layouts/application.html.erb' do
     )
     allow(view.request).to receive(:original_fullpath).and_return('/foobar')
     allow(view).to receive(:user_fully_authenticated?).and_return(false)
+    allow(view).to receive(:url_for).and_return('/')
     view.title = title_content if title_content
   end
 


### PR DESCRIPTION
## 🎫 Ticket

[LG-15833](https://cm-jira.usa.gov/browse/LG-15833)

## 🛠 Summary of changes

Fixes an issue where the partner request details are lost if the user clicks "Continue sign in" at sign-in after the session has already expired.

The approach here is to change "Continue sign in" to be a plain link element with the `request_id` as an added parameter of the current page, and limit the behavior of the JavaScript to only override this behavior while the session is still assumed to be active. When the session expires, the JavaScript won't do anything, and will allow it to behave as a normal link, refreshing the page with the `request_id`. The sign-in page controller is already set up to [interpret and save the `request_id` parameter](https://github.com/18F/identity-idp/blob/321ea52d8a04065d292b83fc1729cb4bba20a4ad/app/controllers/users/sessions_controller.rb#L258-L265).

Review is simplified by reviewing changes with whitespace hidden: https://github.com/18F/identity-idp/pull/11930/files?w=1

## 📜 Testing Plan

It's easiest to test by shortening your session timeout via configuration, so you don't have to wait a full 15 minutes:

```
session_timeout_in_minutes: 3
```

1. Have the [sample application](https://github.com/18F/identity-oidc-sinatra) running in a separate process
2. Go to http://localhost:9292
3. Click "Sign in"
4. Wait 30 seconds for the modal to appear
5. Wait until the session timeout counts all the way down to 0
6. Click "Continue sign in"
7. Observe that the "Example Sinatra App is using Login.gov to allow you to sign in to your account safely and securely." text is still shown

A few other scenarios to consider:

- There should be no regressions in the behavior of the session timeout while fully signed-in (both fully expired session redirect as well as clicking "Stay signed in")
- Partially-signed-in session expiration applies up 'til fully authenticated, so the behavior of continuing sign in should extend to other unauthenticated screens ("Create an account", or MFA entry screens). In these cases, it's expected that clicking "Continue sign in" should dismiss the modal and maintain page state if clicked prior to the session being expired. If the session is fully expired (it's counted down to 0), then clicking "Continue sign in" should return to the sign-in page with the partner link maintained.