### PR TITLE
Lg-15755 do not display previous empty design for selfie capture

### DIFF
--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -136,6 +136,10 @@ interface AcuantCaptureProps {
    * Determine whether the selfie help text shoule be shown.
    */
   showSelfieHelp: () => void;
+  /**
+   * Whether user is on the failed submission review step
+   */
+  isReviewStep?: boolean;
 }
 
 /**
@@ -313,6 +317,7 @@ function AcuantCapture(
     errorMessage,
     name,
     showSelfieHelp,
+    isReviewStep,
   }: AcuantCaptureProps,
   ref: Ref<HTMLInputElement | null>,
 ) {
@@ -327,7 +332,7 @@ function AcuantCapture(
   } = useContext(AcuantContext);
   const { isMockClient } = useContext(UploadContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const { isSelfieCaptureEnabled } = useContext(SelfieCaptureContext);
+  const { isSelfieCaptureEnabled, immediatelyBeginCapture } = useContext(SelfieCaptureContext);
   const fullScreenRef = useRef<FullScreenRefHandle>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const isForceUploading = useRef(false);
@@ -349,7 +354,9 @@ function AcuantCapture(
   // This hook does that.
   const isBackOfId = name === 'back';
   useLogCameraInfo({ isBackOfId, hasStartedCropping });
-  const [isCapturingEnvironment, setIsCapturingEnvironment] = useState(selfieCapture);
+  const [isCapturingEnvironment, setIsCapturingEnvironment] = useState(
+    selfieCapture && immediatelyBeginCapture && !isReviewStep,
+  );
 
   const {
     failedCaptureAttempts,

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -332,7 +332,7 @@ function AcuantCapture(
   } = useContext(AcuantContext);
   const { isMockClient } = useContext(UploadContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const { isSelfieCaptureEnabled, immediatelyBeginCapture } = useContext(SelfieCaptureContext);
+  const { isSelfieCaptureEnabled } = useContext(SelfieCaptureContext);
   const fullScreenRef = useRef<FullScreenRefHandle>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const isForceUploading = useRef(false);
@@ -355,7 +355,7 @@ function AcuantCapture(
   const isBackOfId = name === 'back';
   useLogCameraInfo({ isBackOfId, hasStartedCropping });
   const [isCapturingEnvironment, setIsCapturingEnvironment] = useState(
-    selfieCapture && immediatelyBeginCapture && !isReviewStep,
+    selfieCapture && !isReviewStep,
   );
 
   const {

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -327,7 +327,7 @@ function AcuantCapture(
   } = useContext(AcuantContext);
   const { isMockClient } = useContext(UploadContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const { isSelfieCaptureEnabled, immediatelyBeginCapture } = useContext(SelfieCaptureContext);
+  const { isSelfieCaptureEnabled } = useContext(SelfieCaptureContext);
   const fullScreenRef = useRef<FullScreenRefHandle>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const isForceUploading = useRef(false);
@@ -349,9 +349,7 @@ function AcuantCapture(
   // This hook does that.
   const isBackOfId = name === 'back';
   useLogCameraInfo({ isBackOfId, hasStartedCropping });
-  const [isCapturingEnvironment, setIsCapturingEnvironment] = useState(
-    selfieCapture && immediatelyBeginCapture,
-  );
+  const [isCapturingEnvironment, setIsCapturingEnvironment] = useState(selfieCapture);
 
   const {
     failedCaptureAttempts,

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -100,6 +100,7 @@ function DocumentSideAcuantCapture({
       className={className}
       allowUpload={isUploadAllowed}
       showSelfieHelp={showSelfieHelp}
+      isReviewStep={isReviewStep}
     />
   );
 }

--- a/app/javascript/packages/document-capture/context/selfie-capture.tsx
+++ b/app/javascript/packages/document-capture/context/selfie-capture.tsx
@@ -14,17 +14,12 @@ interface SelfieCaptureProps {
    * the capture component.
    */
   showHelpInitially: boolean;
-  /**
-   * Specify whether we should try to capture using Acuant immediately
-   */
-  immediatelyBeginCapture: boolean;
 }
 
 const SelfieCaptureContext = createContext<SelfieCaptureProps>({
   isSelfieCaptureEnabled: false,
   isSelfieDesktopTestMode: false,
   showHelpInitially: true,
-  immediatelyBeginCapture: true,
 });
 
 SelfieCaptureContext.displayName = 'SelfieCaptureContext';

--- a/app/javascript/packages/document-capture/context/selfie-capture.tsx
+++ b/app/javascript/packages/document-capture/context/selfie-capture.tsx
@@ -24,7 +24,7 @@ const SelfieCaptureContext = createContext<SelfieCaptureProps>({
   isSelfieCaptureEnabled: false,
   isSelfieDesktopTestMode: false,
   showHelpInitially: true,
-  immediatelyBeginCapture: false,
+  immediatelyBeginCapture: true,
 });
 
 SelfieCaptureContext.displayName = 'SelfieCaptureContext';

--- a/app/javascript/packages/document-capture/context/selfie-capture.tsx
+++ b/app/javascript/packages/document-capture/context/selfie-capture.tsx
@@ -14,12 +14,17 @@ interface SelfieCaptureProps {
    * the capture component.
    */
   showHelpInitially: boolean;
+  /**
+   * Specify whether we should try to capture using Acuant immediately
+   */
+  immediatelyBeginCapture: boolean;
 }
 
 const SelfieCaptureContext = createContext<SelfieCaptureProps>({
   isSelfieCaptureEnabled: false,
   isSelfieDesktopTestMode: false,
   showHelpInitially: true,
+  immediatelyBeginCapture: true,
 });
 
 SelfieCaptureContext.displayName = 'SelfieCaptureContext';

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -179,6 +179,7 @@ render(
                       isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
                       isSelfieDesktopTestMode: String(docAuthSelfieDesktopTestMode) === 'true',
                       showHelpInitially: true,
+                      immediatelyBeginCapture: true,
                     }}
                   >
                     <FailedCaptureAttemptsContextProvider

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -179,7 +179,7 @@ render(
                       isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
                       isSelfieDesktopTestMode: String(docAuthSelfieDesktopTestMode) === 'true',
                       showHelpInitially: true,
-                      immediatelyBeginCapture: false,
+                      immediatelyBeginCapture: true,
                     }}
                   >
                     <FailedCaptureAttemptsContextProvider

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -179,7 +179,6 @@ render(
                       isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
                       isSelfieDesktopTestMode: String(docAuthSelfieDesktopTestMode) === 'true',
                       showHelpInitially: true,
-                      immediatelyBeginCapture: true,
                     }}
                   >
                     <FailedCaptureAttemptsContextProvider

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
@@ -25,6 +25,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -49,6 +50,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -75,6 +77,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -97,6 +100,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -123,6 +127,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -151,6 +156,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -187,6 +193,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
@@ -25,7 +25,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -50,7 +49,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -77,7 +75,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -100,7 +97,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -127,7 +123,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -156,7 +151,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -193,7 +187,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
@@ -25,7 +25,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -50,7 +50,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -77,7 +77,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -100,7 +100,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -127,7 +127,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -156,7 +156,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -193,7 +193,7 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
+                  immediatelyBeginCapture: true,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
@@ -148,6 +148,7 @@ describe('document-capture/components/documents-step', () => {
           isSelfieCaptureEnabled: true,
           isSelfieDesktopTestMode: false,
           showHelpInitially: true,
+          immediatelyBeginCapture: true,
         }}
       >
         <DocumentsStep

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
@@ -148,7 +148,6 @@ describe('document-capture/components/documents-step', () => {
           isSelfieCaptureEnabled: true,
           isSelfieDesktopTestMode: false,
           showHelpInitially: true,
-          immediatelyBeginCapture: true,
         }}
       >
         <DocumentsStep

--- a/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
@@ -35,7 +35,7 @@ describe('document-capture/components/selfie-step', () => {
             isSelfieCaptureEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
-            immediatelyBeginCapture: false,
+            immediatelyBeginCapture: true,
           }}
         >
           <SelfieStep
@@ -76,7 +76,7 @@ describe('document-capture/components/selfie-step', () => {
             isSelfieCaptureEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
-            immediatelyBeginCapture: false,
+            immediatelyBeginCapture: true,
           }}
         >
           <SelfieStep

--- a/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
@@ -35,7 +35,6 @@ describe('document-capture/components/selfie-step', () => {
             isSelfieCaptureEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
-            immediatelyBeginCapture: true,
           }}
         >
           <SelfieStep
@@ -76,7 +75,6 @@ describe('document-capture/components/selfie-step', () => {
             isSelfieCaptureEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
-            immediatelyBeginCapture: true,
           }}
         >
           <SelfieStep

--- a/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
@@ -35,6 +35,7 @@ describe('document-capture/components/selfie-step', () => {
             isSelfieCaptureEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
+            immediatelyBeginCapture: true,
           }}
         >
           <SelfieStep

--- a/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
@@ -75,6 +75,7 @@ describe('document-capture/components/selfie-step', () => {
             isSelfieCaptureEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
+            immediatelyBeginCapture: true,
           }}
         >
           <SelfieStep

--- a/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
@@ -10,7 +10,6 @@ describe('document-capture/context/selfie-capture', () => {
       'isSelfieCaptureEnabled',
       'isSelfieDesktopTestMode',
       'showHelpInitially',
-      'immediatelyBeginCapture',
     ]);
     expect(result.current.isSelfieCaptureEnabled).to.be.a('boolean');
   });

--- a/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
@@ -10,6 +10,7 @@ describe('document-capture/context/selfie-capture', () => {
       'isSelfieCaptureEnabled',
       'isSelfieDesktopTestMode',
       'showHelpInitially',
+      'immediatelyBeginCapture',
     ]);
     expect(result.current.isSelfieCaptureEnabled).to.be.a('boolean');
   });


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15755](https://cm-jira.usa.gov/browse/LG-15755)


## 🛠 Summary of changes

Utilized immediatelyBeginCapture to remove step where user clicks take photo and sees empty selfie state design (and needs to click again) before sdk opens. 
Tested on local machine with phone using [Mobile Local Dev](https://github.com/18F/identity-idp/blob/main/docs/mobile.md)

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - Configure application.yml to use 'lexsis_nexis' w Prod credentials since we are going to be testing failed doc auth flow also. Retrieve credentials using aws-vault commands

> doc_auth_selfie_capture_enabled: true
  domain_name: <local IP>:3000
  mailer_domain_name: <local IP>:3000
  enable_load_testing_mode: true
  doc_auth_vendor: 'lexisnexis'
  doc_auth_vendor_default: 'lexis_nexis'
  lexisnexis_base_url:
  lexisnexis_hmac_auth_enabled: true
  lexisnexis_trueid_account_id:
  lexisnexis_trueid_username:
  lexisnexis_trueid_password:
  lexisnexis_trueid_liveness_cropping_workflow:
  lexisnexis_trueid_liveness_nocropping_workflow: 
  lexisnexis_trueid_noliveness_cropping_workflow: 
  lexisnexis_trueid_noliveness_nocropping_workflow:
  lexisnexis_trueid_timeout: '60'

- [ ] Step 2 - Setup local machine w branch [Mobile Local Dev](https://github.com/18F/identity-idp/blob/main/docs/mobile.md)
- [ ] Step 3 - Go through Doc Auth with selfie on phone (main thing is that doc capture is on your phone so you can start on your local machine and use telephony to get a link to put on your phone)
- [ ] Step 4 - Once on selfie capture, click the close button on the top right and ensure that empty state design is not show
- [ ] Step 5 - Fail doc auth (Take a empty selfie does it for me)
- [ ] Step 6 - Once at the fail rate limit page click try again
- [ ] Step 7 - Ensure you are brought to a review step page and not have the selfie capture open up immediately [as described in this ticket](https://cm-jira.usa.gov/browse/LG-14948) 



## 👀 Screenshots

[Video of Walkthrough](https://drive.google.com/file/d/10Yg48kdfuswbjCMIAS2zOGuiGPFHirJA/view?usp=sharing)
</details>
