### PR TITLE
Add idv_level to ProfileSummary report

### DIFF
--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -276,6 +276,7 @@ class DataPull
         uuid
         profile_id
         status
+        idv_level
         activated_timestamp
         disabled_reason
         gpo_verification_pending_timestamp
@@ -290,6 +291,7 @@ class DataPull
               user.uuid,
               profile.id,
               profile.active ? 'active' : 'inactive',
+              profile.idv_level,
               profile.activated_at,
               profile.deactivation_reason,
               profile.gpo_verification_pending_at,

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -384,12 +384,13 @@ RSpec.describe DataPull do
       it 'loads profile summary for the user', aggregate_failures: true do
         expect(result.table).to match_array(
           [
-            ['uuid', 'profile_id', 'status', 'activated_timestamp', 'disabled_reason',
+            ['uuid', 'profile_id', 'status', 'idv_level', 'activated_timestamp', 'disabled_reason',
              'gpo_verification_pending_timestamp', 'fraud_review_pending_timestamp',
              'fraud_rejection_timestamp'],
             *user.profiles.sort_by(&:id).map do |p|
               profile_status = p.active ? 'active' : 'inactive'
-              [user.uuid, p.id, profile_status, kind_of(Time), p.deactivation_reason, nil, nil, nil]
+              [user.uuid, p.id, profile_status, p.idv_level, kind_of(Time), p.deactivation_reason,
+               nil, nil, nil]
             end,
             [user_without_profile.uuid, '[HAS NO PROFILE]', nil, nil, nil, nil, nil, nil],
             ['uuid-does-not-exist', '[UUID NOT FOUND]', nil, nil, nil, nil, nil, nil],

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -389,8 +389,17 @@ RSpec.describe DataPull do
              'fraud_rejection_timestamp'],
             *user.profiles.sort_by(&:id).map do |p|
               profile_status = p.active ? 'active' : 'inactive'
-              [user.uuid, p.id, profile_status, p.idv_level, kind_of(Time), p.deactivation_reason,
-               nil, nil, nil]
+              [
+                user.uuid,
+                p.id,
+                profile_status,
+                p.idv_level,
+                kind_of(Time),
+                p.deactivation_reason,
+                nil,
+                nil,
+                nil,
+              ]
             end,
             [user_without_profile.uuid, '[HAS NO PROFILE]', nil, nil, nil, nil, nil, nil],
             ['uuid-does-not-exist', '[UUID NOT FOUND]', nil, nil, nil, nil, nil, nil],


### PR DESCRIPTION
Based on discussion [here](https://gsa-tts.slack.com/archives/C03KDV9S8T1/p1740766941059479). It would be useful when looking at the summary of profiles to know what level they were proofed at. This PR adds the `idv_level` column to the output of the report.

Sample output:

```
+--------------------------------------+------------+--------+---------------------+-------------------------+-----------------+------------------------------------+--------------------------------+---------------------------+
| uuid                                 | profile_id | status | idv_level           | activated_timestamp     | disabled_reason | gpo_verification_pending_timestamp | fraud_review_pending_timestamp | fraud_rejection_timestamp |
+--------------------------------------+------------+--------+---------------------+-------------------------+-----------------+------------------------------------+--------------------------------+---------------------------+
| 0fe5c163-d9db-49a3-a9cf-c2a9c1826b2e | 3          | active | legacy_unsupervised | 2025-02-04 20:00:38 UTC |                 |                                    |                                |                           |
+--------------------------------------+------------+--------+---------------------+-------------------------+-----------------+------------------------------------+--------------------------------+---------------------------+
```