### PR TITLE
changelog: Internal, Reporting, adding timestamp override

### DIFF
--- a/app/jobs/data_warehouse/table_summary_stats_export_job.rb
+++ b/app/jobs/data_warehouse/table_summary_stats_export_job.rb
@@ -11,7 +11,7 @@ module DataWarehouse
     TIMESTAMP_OVERRIDE = {
       'sp_return_logs' => 'returned_at',
       'registration_logs' => 'registered_at',
-      'letter_requests_to_usps_ftp_logs' => 'ftp_at'
+      'letter_requests_to_usps_ftp_logs' => 'ftp_at',
     }.freeze
 
     def perform(timestamp)

--- a/app/jobs/data_warehouse/table_summary_stats_export_job.rb
+++ b/app/jobs/data_warehouse/table_summary_stats_export_job.rb
@@ -11,6 +11,7 @@ module DataWarehouse
     TIMESTAMP_OVERRIDE = {
       'sp_return_logs' => 'returned_at',
       'registration_logs' => 'registered_at',
+      'letter_requests_to_usps_ftp_logs' => 'ftp_at'
     }.freeze
 
     def perform(timestamp)

--- a/app/jobs/data_warehouse/table_summary_stats_export_job.rb
+++ b/app/jobs/data_warehouse/table_summary_stats_export_job.rb
@@ -6,6 +6,7 @@ module DataWarehouse
 
     TABLE_EXCLUSION_LIST = %w[
       agency_identities
+      usps_confirmations
     ].freeze
 
     TIMESTAMP_OVERRIDE = {


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-930](https://gitlab.login.gov/lg-teams/agnes/data-warehouse-ag/-/issues/930)

## 🛠 Summary of changes

- Added a timestamp overwrite for a table to the idp job for the stale data check
- Added table exclusion for the usps_confirmations table which has been identified as a transient table
