### PR TITLE
Update uri gem to resolve security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -706,7 +706,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     uniform_notifier (1.16.0)
-    uri (1.0.2)
+    uri (1.0.3)
     useragent (0.16.11)
     view_component (3.21.0)
       activesupport (>= 5.2.0, < 8.1)


### PR DESCRIPTION
## 🛠 Summary of changes

Addresses [CVE-2025-27221](https://www.cve.org/CVERecord?id=CVE-2025-27221)

```
Name: uri
Version: 1.0.2
CVE: CVE-2025-27221
GHSA: GHSA-22h5-pq3x-2gf2
Criticality: Low
URL: https://www.cve.org/CVERecord?id=CVE-2025-27221
Title: CVE-2025-27221 - userinfo leakage in URI#join, URI#merge and URI#+.
Solution: update to '~> 0.11.3', '~> 0.12.4', '~> 0.13.2', '>= 1.0.3'
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
