### PR TITLE
Ensure validations work when there is no valid service provider

### DIFF
--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -59,6 +59,9 @@ class SamlRequestValidator
   end
 
   def authorized_authn_context
+    # if there is no service provider, an error has already been added
+    return unless service_provider.present?
+
     if !valid_authn_context? ||
        (identity_proofing_requested? && !service_provider.identity_proofing_allowed?) ||
        (ial_max_requested? && !service_provider.ialmax_allowed?) ||
@@ -74,7 +77,7 @@ class SamlRequestValidator
   end
 
   def registered_cert_exists
-    # if there is no service provider, this error has already been added
+    # if there is no service provider, an error has already been added
     return if service_provider.blank?
     return if service_provider.certs.present?
     return unless service_provider.encrypt_responses?

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1418,14 +1418,12 @@ RSpec.describe SamlIdpController do
 
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)
-        expect(response.body).to include(t('errors.messages.unauthorized_authn_context'))
         expect(response.body).to include(t('errors.messages.unauthorized_service_provider'))
         expect(@analytics).to have_logged_event(
           'SAML Auth',
           hash_including(
             success: false,
             error_details: {
-              authn_context: { unauthorized_authn_context: true },
               service_provider: { unauthorized_service_provider: true },
             },
             nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
@@ -1440,7 +1438,7 @@ RSpec.describe SamlIdpController do
         )
         expect(@analytics).to have_logged_event(
           :sp_integration_errors_present,
-          error_details: ['Unauthorized Service Provider', 'Unauthorized authentication context'],
+          error_details: ['Unauthorized Service Provider'],
           error_types: { saml_request_errors: true },
           event: :saml_auth_request,
           integration_exists: false,

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe SamlRequestValidator do
     end
 
     context 'valid authn context and invalid sp and authorized nameID format' do
-      let(:sp) { ServiceProvider.find_by(issuer: 'foo') }
+      let(:sp) { nil }
 
       it 'returns FormResponse with success: false' do
         expect(response.to_h).to eq(

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -338,7 +338,6 @@ RSpec.describe SamlRequestValidator do
         expect(response.to_h).to eq(
           success: false,
           error_details: {
-            authn_context: { unauthorized_authn_context: true },
             service_provider: { unauthorized_service_provider: true },
           },
           **extra,

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -96,6 +96,42 @@ RSpec.describe SamlRequestValidator do
           **extra,
         )
       end
+
+      context 'when identity proofing is requested' do
+        let(:authn_context) { [Saml::Idp::Constants::IAL_VERIFIED_ACR] }
+
+        it 'returns FormResponse with success: false' do
+          expect(response.to_h).to eq(
+            success: false,
+            error_details: { service_provider: { unauthorized_service_provider: true } },
+            **extra,
+          )
+        end
+      end
+
+      context 'when IALmax is requested' do
+        let(:authn_context) { [Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF] }
+
+        it 'returns FormResponse with success: false' do
+          expect(response.to_h).to eq(
+            success: false,
+            error_details: { service_provider: { unauthorized_service_provider: true } },
+            **extra,
+          )
+        end
+      end
+
+      context 'when facial matching is requested' do
+        let(:authn_context) { [Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR] }
+
+        it 'returns FormResponse with success: false' do
+          expect(response.to_h).to eq(
+            success: false,
+            error_details: { service_provider: { unauthorized_service_provider: true } },
+            **extra,
+          )
+        end
+      end
     end
 
     context 'valid authn context and unauthorized nameid format' do


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[Validation nil error](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/150)

## 🛠 Summary of changes

This change adds a guard for the `authorized_authn_context` validation. Before, if the service provider did not exist but the authn_context was requesting IdV, IALMax, or IAL2, the validation would throw a no method error.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
