### PR TITLE
LG-15739: Enable user to switch from in-person proofing to remote identity verification

### DIFF
--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -35,7 +35,7 @@ module Idv
         if how_to_verify_form_params['selection'] == Idv::HowToVerifyForm::REMOTE
           idv_session.opted_in_to_in_person_proofing = false
           idv_session.skip_doc_auth_from_how_to_verify = false
-          idv_session_user.establishing_in_person_enrollment&.cancel
+          abandon_any_ipp_progress
           redirect_to idv_hybrid_handoff_url
         else
           idv_session.opted_in_to_in_person_proofing = true
@@ -71,6 +71,10 @@ module Idv
     end
 
     private
+
+    def abandon_any_ipp_progress
+      idv_session_user.establishing_in_person_enrollment&.cancel
+    end
 
     def analytics_arguments
       {

--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -35,6 +35,7 @@ module Idv
         if how_to_verify_form_params['selection'] == Idv::HowToVerifyForm::REMOTE
           idv_session.opted_in_to_in_person_proofing = false
           idv_session.skip_doc_auth_from_how_to_verify = false
+          idv_session_user.establishing_in_person_enrollment&.cancel
           redirect_to idv_hybrid_handoff_url
         else
           idv_session.opted_in_to_in_person_proofing = true

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -12,6 +12,7 @@ module Idv
     before_action :confirm_hybrid_handoff_needed, only: :show
 
     def show
+      abandon_any_ipp_progress
       @upload_disabled = upload_disabled?
 
       @direct_ipp_with_selfie_enabled = IdentityConfig.store.in_person_doc_auth_button_enabled &&
@@ -72,6 +73,10 @@ module Idv
     end
 
     private
+
+    def abandon_any_ipp_progress
+      current_user&.establishing_in_person_enrollment&.cancel
+    end
 
     def handle_phone_submission
       return rate_limited_failure if rate_limiter.limited?

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -57,6 +57,7 @@ module Idv
 
       failed_fingerprints = store_failed_images(client_response, doc_pii_response)
       response.extra[:failed_image_fingerprints] = failed_fingerprints
+      abandon_any_ipp_progress
       response
     end
 
@@ -64,6 +65,10 @@ module Idv
 
     attr_reader :params, :analytics, :service_provider, :form_response, :uuid_prefix,
                 :liveness_checking_required, :acuant_sdk_upgrade_ab_test_bucket
+
+    def abandon_any_ipp_progress
+      User.find(user_id).establishing_in_person_enrollment&.cancel
+    end
 
     def increment_rate_limiter!
       return unless document_capture_session

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -67,7 +67,7 @@ module Idv
                 :liveness_checking_required, :acuant_sdk_upgrade_ab_test_bucket
 
     def abandon_any_ipp_progress
-      User.find(user_id).establishing_in_person_enrollment&.cancel
+      user_id && User.find(user_id).establishing_in_person_enrollment&.cancel
     end
 
     def increment_rate_limiter!

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -221,6 +221,17 @@ RSpec.describe Idv::HowToVerifyController do
 
         expect(@analytics).to have_logged_event(analytics_name, analytics_args)
       end
+
+      context 'the user has an establishing in-person enrollment' do
+        let(:user) { create(:user, :with_establishing_in_person_enrollment) }
+        it 'cancels the establishing in-person enrollment' do
+          expect(user.in_person_enrollments.first.status).to eq('establishing')
+
+          put :update, params: params
+
+          expect(user.in_person_enrollments.first.status).to eq('cancelled')
+        end
+      end
     end
 
     context 'ipp' do

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -226,11 +226,11 @@ RSpec.describe Idv::HowToVerifyController do
         let(:user) { create(:user, :with_establishing_in_person_enrollment) }
 
         it 'cancels the in-person enrollment' do
-          expect(user.in_person_enrollments.first.status).to eq('establishing')
-
-          put :update, params: params
-
-          expect(user.in_person_enrollments.first.status).to eq('cancelled')
+          expect { put :update, params: params }.to change {
+            user.in_person_enrollments.first.status
+          }
+            .from('establishing')
+            .to('cancelled')
         end
       end
     end

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Idv::HowToVerifyController do
       context 'the user has an establishing in-person enrollment' do
         let(:user) { create(:user, :with_establishing_in_person_enrollment) }
 
-        it 'cancels the establishing in-person enrollment' do
+        it 'cancels the in-person enrollment' do
           expect(user.in_person_enrollments.first.status).to eq('establishing')
 
           put :update, params: params

--- a/spec/controllers/idv/how_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/how_to_verify_controller_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe Idv::HowToVerifyController do
 
       context 'the user has an establishing in-person enrollment' do
         let(:user) { create(:user, :with_establishing_in_person_enrollment) }
+
         it 'cancels the establishing in-person enrollment' do
           expect(user.in_person_enrollments.first.status).to eq('establishing')
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -1058,6 +1058,30 @@ RSpec.describe Idv::ImageUploadsController do
         expect(document_capture_session.reload.load_result.success?).to eq(true)
       end
     end
+
+    context 'the user has an establishing in-person enrollment' do
+      let(:user) { create(:user, :with_establishing_in_person_enrollment) }
+
+      it 'cancels the in-person enrollment' do
+        expect(user.in_person_enrollments.first.status).to eq('establishing')
+
+        expect_any_instance_of(DocAuth::Mock::DocAuthMockClient)
+          .to receive(:post_images).with(
+            front_image: an_instance_of(String),
+            back_image: an_instance_of(String),
+            selfie_image: nil,
+            image_source: :unknown,
+            user_uuid: an_instance_of(String),
+            uuid_prefix: nil,
+            liveness_checking_required: false,
+            images_cropped: false,
+          ).and_call_original
+
+        action
+
+        expect(user.in_person_enrollments.first.status).to eq('cancelled')
+      end
+    end
   end
 
   def expect_funnel_update_counts(user, count)

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -222,6 +222,125 @@ RSpec.describe 'In Person Proofing', js: true do
     end
   end
 
+  context 'the user fails remote docauth, starts IPP, then resumes remote with successful images' do
+    let(:ipp_service_provider) { create(:service_provider, :active, :in_person_proofing_enabled) }
+    let(:user) { user_with_2fa }
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+
+      visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+      sign_in_via_branded_page(user)
+      complete_doc_auth_steps_before_document_capture_step(expect_accessible: true)
+      # Fail docauth
+      complete_document_capture_step_with_yml(
+        'spec/fixtures/ial2_test_credential_multiple_doc_auth_failures_both_sides.yml',
+        expected_path: idv_document_capture_url,
+      )
+      # begin in-person proofing
+      find(:button, t('in_person_proofing.body.cta.button'), wait: 10).click
+
+      complete_prepare_step
+      complete_location_step
+      complete_state_id_controller(user)
+
+      # Change mind and resume remote identity verification
+      visit idv_how_to_verify_url
+    end
+    it 'allows the user to successfully complete remote identity verification' do
+      # choose remote
+      click_on t('forms.buttons.continue_remote')
+      complete_hybrid_handoff_step
+      complete_document_capture_step(with_selfie: false)
+
+      # IT BREAKS HERE - IPP flow displays instead of Remote flow on SSN step
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      complete_ssn_step
+
+      # verify step
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      complete_verify_step
+
+      # verify phone
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_phone'))
+      complete_phone_step(user)
+
+      # re-enter password
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.re_enter_password'))
+      complete_enter_password_step(user: user)
+
+      # personal key page
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.re_enter_password'))
+      expect(page).to have_current_path(idv_personal_key_url)
+      acknowledge_and_confirm_personal_key
+
+      # sign up completed
+      expect(page).to have_current_path(sign_up_completed_url)
+    end
+  end
+
+  context 'the user starts in-person proofing then navigates back to how to verify' do
+    let(:ipp_service_provider) { create(:service_provider, :active, :in_person_proofing_enabled) }
+    let(:user) { user_with_2fa }
+
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+
+      # Begin identity verification via in-person proofing
+      visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+      sign_in_via_branded_page(user)
+      begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
+      complete_prepare_step
+      complete_location_step
+      complete_state_id_controller(user)
+      complete_ssn_step(user)
+      expect_in_person_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+
+      # Change mind and start remote identity verification
+      visit idv_how_to_verify_url
+    end
+
+    it 'allows the user to successfully complete remote identity verification' do
+      # choose remote
+      click_on t('forms.buttons.continue_remote')
+      complete_hybrid_handoff_step
+      complete_document_capture_step(with_selfie: false)
+
+      # IT BREAKS HERE - IPP flow displays instead of Remote flow on SSN step
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      complete_ssn_step
+
+      # verify step
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+      complete_verify_step
+
+      # verify phone
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_phone'))
+      complete_phone_step(user)
+
+      # re-enter password
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.re_enter_password'))
+      complete_enter_password_step(user: user)
+
+      # personal key page
+      expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+      expect_step_indicator_current_step(t('step_indicator.flows.idv.re_enter_password'))
+      expect(page).to have_current_path(idv_personal_key_url)
+      acknowledge_and_confirm_personal_key
+
+      # sign up completed
+      expect(page).to have_current_path(sign_up_completed_url)
+    end
+  end
+
   context 'with hybrid document capture' do
     before do
       allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
@@ -267,6 +386,81 @@ RSpec.describe 'In Person Proofing', js: true do
 
       perform_mobile_hybrid_steps
       perform_desktop_hybrid_steps(user, same_address_as_id: false)
+    end
+
+    context 'when the user changes from IPP to remote verification after returning to desktop' do
+      let(:ipp_service_provider) { create(:service_provider, :active, :in_person_proofing_enabled) }
+      let(:user) { user_with_2fa }
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+
+        perform_in_browser(:desktop) do
+          visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+          # user = sign_in_and_2fa_user
+          sign_in_via_branded_page(user)
+          complete_doc_auth_steps_before_hybrid_handoff_step
+          # choose remote
+          click_on t('forms.buttons.continue_remote')
+          clear_and_fill_in(:doc_auth_phone, '415-555-0199')
+          click_send_link
+
+          expect(page).to have_content(t('doc_auth.headings.text_message'))
+        end
+
+        perform_mobile_hybrid_steps
+      end
+      it 'allows the user to successfully complete remote identity verification' do
+        perform_in_browser(:desktop) do
+          # Change mind and resume remote identity verification
+          visit idv_how_to_verify_url
+
+          # choose remote
+          click_on t('forms.buttons.continue_remote')
+          complete_hybrid_handoff_step
+          successful_response = instance_double(
+            Faraday::Response,
+            status: 200,
+            body: LexisNexisFixtures.true_id_response_success,
+          )
+          DocAuth::Mock::DocAuthMockClient.mock_response!(
+            method: :get_results,
+            response: DocAuth::LexisNexis::Responses::TrueIdResponse.new(
+              successful_response,
+              DocAuth::LexisNexis::Config.new,
+            ),
+          )
+          complete_document_capture_step(with_selfie: false)
+
+          # IT BREAKS HERE - IPP flow displays instead of Remote flow on SSN step
+          expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+          expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+          complete_ssn_step
+
+          # verify step
+          expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+          expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+          complete_verify_step
+
+          # verify phone
+          expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+          expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_phone'))
+          complete_phone_step(user)
+
+          # re-enter password
+          expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+          expect_step_indicator_current_step(t('step_indicator.flows.idv.re_enter_password'))
+          complete_enter_password_step(user: user)
+
+          # personal key page
+          expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+          expect_step_indicator_current_step(t('step_indicator.flows.idv.re_enter_password'))
+          expect(page).to have_current_path(idv_personal_key_url)
+          acknowledge_and_confirm_personal_key
+
+          # sign up completed
+          expect(page).to have_current_path(sign_up_completed_url)
+        end
+      end
     end
 
     context 'when polling times out and the user has to click the "Continue" button' do

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -365,7 +365,8 @@ RSpec.describe 'In Person Proofing', js: true do
       perform_desktop_hybrid_steps(user, same_address_as_id: false)
     end
 
-    context 'when the user changes from IPP to remote verification after returning to desktop' do
+    context 'when the user navigates to the how to verify page and changes from IPP to remote
+    verification after returning to desktop' do
       before do
         allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
 
@@ -408,6 +409,44 @@ RSpec.describe 'In Person Proofing', js: true do
           complete_document_capture_step(with_selfie: false)
 
           complete_remote_idv_from_ssn(user)
+        end
+      end
+    end
+
+    context 'when the user fails docauth remote in the hybrid flow, begins IPP on the desktop,
+    navigates back to the hybrid handoff page, selects remote verification via the hybrid flow' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+
+        perform_in_browser(:desktop) do
+          visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+          sign_in_via_branded_page(user)
+          complete_doc_auth_steps_before_hybrid_handoff_step
+
+          # choose remote
+          click_on t('forms.buttons.continue_remote')
+          # clear_and_fill_in(:doc_auth_phone, '415-555-0199')
+          click_send_link
+
+          expect(page).to have_content(t('doc_auth.headings.text_message'))
+        end
+
+        perform_mobile_hybrid_steps
+      end
+
+      it 'allows the user to successfully complete remote identity verification',
+         allow_browser_log: true do
+        # click back link while on the state id page
+        perform_in_browser(:desktop) do
+          visit idv_hybrid_handoff_url
+          click_send_link
+
+          # Test that user stays on the link sent page
+          sleep(5)
+          expect(page).to(have_content(t('doc_auth.headings.text_message')))
+
+          # Test that user does not automatically get moved forward to the state id page on desktop
+          expect(page).not_to(have_content(t('in_person_proofing.headings.state_id_milestone_2')))
         end
       end
     end

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -353,6 +353,7 @@ RSpec.describe 'In Person Proofing', js: true do
 
         perform_mobile_hybrid_steps
       end
+
       it 'allows the user to successfully complete remote identity verification' do
         perform_in_browser(:desktop) do
           # Change mind and resume remote identity verification

--- a/spec/support/features/idv_step_helper.rb
+++ b/spec/support/features/idv_step_helper.rb
@@ -134,4 +134,35 @@ module IdvStepHelper
     fill_out_state_id_form_ok(same_address_as_id: true)
     click_idv_continue
   end
+
+  def complete_remote_idv_from_ssn(user = user_with_2fa)
+    # ssn step
+    expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+    complete_ssn_step
+
+    # verify step
+    expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+    complete_verify_step
+
+    # verify phone
+    expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_phone'))
+    complete_phone_step(user)
+
+    # re-enter password
+    expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.re_enter_password'))
+    complete_enter_password_step(user)
+
+    # personal key page
+    expect(page).not_to have_content(t('step_indicator.flows.idv.go_to_the_post_office'))
+    expect_step_indicator_current_step(t('step_indicator.flows.idv.re_enter_password'))
+    expect(page).to have_current_path(idv_personal_key_url)
+    acknowledge_and_confirm_personal_key
+
+    # sign up completed
+    expect(page).to have_current_path(sign_up_completed_url)
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket
[LG-15739: Enable user to switch from in-person proofing to remote identity verification](https://cm-jira.usa.gov/browse/LG-15739)

## 🛠 Summary of changes
- User now has the ability to start in-person proofing, change their mind, and successfully complete remote identity verification.  Before, this was not possible.
- Originally, when this jira ticket was written, the suggested tactic was to add FlowPolicy to the usps_locations_controller and cancel any lingering establishing enrollments when the user navigated backward from the usps_locations_controller.  Since the usps_locations_controller is only an API call, this approach did not work.  I met with the engineer who wrote the ticket, and we agreed on the approach that this PR takes.


## 📜 Testing Plan
Scenario 1: User fails remote idv, starts IPP, then resumes remote idv with successful images
- [x] Create an account and begin the identity verification process
- [x] On the how to verify page, choose remote idv
- [x] Submit yml files that fail idv
- [x] After failing idv, select IPP
- [x] Navigate to the post office search page, enter an address, and select a post office location
- [x] Fill out the state id page
- [x] Have a change of heart!
- [x] Navigate to the how to verify page and choose remote idv
- [x] Submit yml files that pass idv
- [x] Complete remote idv and bask in your success.

Scenario 2: User opts into IPP, gets partway though IPP, then changes their mind and completes remote idv with successful images
- [x] Create an account and begin the identity verification process
- [x] On the how to verify page, choose IPP
- [x] Navigate to the post office search page, enter an address, and select a post office location
- [x] Fill out the state id page
- [x] Have a change of heart!
- [x] Navigate to the how to verify page and choose remote idv
- [x] Submit yml files that pass idv
- [x] Complete remote idv and bask in your success.

Scenario 3: User starts remote idv via the hybrid flow, fails remote IDV on their phone, starts IPP on their phone, then resumes the desktop remote idv flow with successful images after returning to the desktop from their phone
- [x] Create an account and begin the identity verification process
- [x] Begin remote idv via the hybrid flow
- [x] On mobile, submit yml files that fail idv
- [x] After failing idv, select IPP on mobile
- [x] Navigate to the post office search page, enter an address, and select a post office location
- [x] Switch back to desktop
- [x] Fill out the state id page
- [x] Have a change of heart!
- [x] Navigate to the how to verify page and choose remote idv.
- [ ] Don't switch back to hybrid.  Remain on the desktop.
- [x] Submit yml files that pass idv
- [x] Complete remote idv and bask in your success.

Scenario 4: User starts remote idv via the hybrid flow, fails remote IDV on their phone, starts IPP on their phone, then resumes remote idv with successful images after returning to the desktop from their phone

- [x]  Create an account and begin the identity verification process
- [x]  Begin remote idv via the hybrid flow
- [x]  On mobile, submit yml files that fail idv
- [x]  After failing idv, select IPP on mobile
- [x]  Navigate to the post office search page, enter an address, and select a post office location
- [x]  Switch back to desktop
- [x]  Fill out the state id page
- [ ]  Have a change of heart!
- [ ]  Using the back arrow, navigate backward to the hybrid handoff page
- [ ] Choose the hybrid flow and begin remote identity verification
- [ ]  Submit yml files that pass idv
- [ ]  Complete remote idv and bask in your success.





