### PR TITLE
LG-15643 Pre-check phone number when the phone number is present in the applicant

### DIFF
--- a/app/jobs/resolution_proofing_job.rb
+++ b/app/jobs/resolution_proofing_job.rb
@@ -25,9 +25,7 @@ class ResolutionProofingJob < ApplicationJob
     service_provider_issuer: nil,
     threatmetrix_session_id: nil,
     request_ip: nil,
-    proofing_components: nil,
-    # DEPRECATED ARGUMENTS
-    should_proof_state_id: false # rubocop:disable Lint/UnusedMethodArgument
+    proofing_components: nil
   )
     timer = JobHelpers::Timer.new
 

--- a/app/services/proofing/resolution/plugins/phone_finder_plugin.rb
+++ b/app/services/proofing/resolution/plugins/phone_finder_plugin.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Proofing
+  module Resolution
+    module Plugins
+      class PhoneFinderPlugin
+        def call(
+          applicant_pii:,
+          current_sp:,
+          state_id_address_resolution_result:,
+          residential_address_resolution_result:,
+          state_id_result:,
+          ipp_enrollment_in_progress:,
+          timer:
+        )
+          if ipp_enrollment_in_progress
+            return ignore_phone_for_in_person_result
+          end
+
+          if !state_id_address_resolution_result.success? ||
+             !residential_address_resolution_result.success? ||
+             !state_id_result.success?
+            return resolution_cannot_pass_result
+          end
+
+          if applicant_pii[:phone].blank?
+            return no_phone_available_result
+          end
+
+          phone_finder_applicant = applicant_pii.slice(
+            :uuid, :uuid_prefix, :first_name, :last_name, :ssn, :dob, :phone
+          )
+
+          timer.time('phone') do
+            proofer.proof(phone_finder_applicant)
+          end.tap do |result|
+            if result.exception.blank?
+              Db::SpCost::AddSpCost.call(
+                current_sp,
+                :lexis_nexis_address,
+                transaction_id: result.transaction_id,
+              )
+            end
+          end
+        end
+
+        def proofer
+          @proofer ||=
+            if IdentityConfig.store.proofer_mock_fallback
+              Proofing::Mock::AddressMockClient.new
+            else
+              Proofing::LexisNexis::PhoneFinder::Proofer.new(
+                phone_finder_workflow: IdentityConfig.store.lexisnexis_phone_finder_workflow,
+                account_id: IdentityConfig.store.lexisnexis_account_id,
+                base_url: IdentityConfig.store.lexisnexis_base_url,
+                username: IdentityConfig.store.lexisnexis_username,
+                password: IdentityConfig.store.lexisnexis_password,
+                hmac_key_id: IdentityConfig.store.lexisnexis_hmac_key_id,
+                hmac_secret_key: IdentityConfig.store.lexisnexis_hmac_secret_key,
+                request_mode: IdentityConfig.store.lexisnexis_request_mode,
+              )
+            end
+        end
+
+        private
+
+        def resolution_cannot_pass_result
+          Proofing::Resolution::Result.new(
+            success: false, vendor_name: 'ResolutionCannotPass',
+          )
+        end
+
+        def ignore_phone_for_in_person_result
+          Proofing::Resolution::Result.new(
+            success: false, vendor_name: 'PhoneIgnoredForInPersonProofing',
+          )
+        end
+
+        def no_phone_available_result
+          Proofing::Resolution::Result.new(
+            success: false, vendor_name: 'NoPhoneNumberAvailable',
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -11,7 +11,8 @@ module Proofing
       class InvalidProofingVendorError; end
 
       attr_reader :aamva_plugin,
-                  :threatmetrix_plugin
+                  :threatmetrix_plugin,
+                  :phone_finder_plugin
 
       PROOFING_VENDOR_SP_COST_TOKENS = {
         mock: :mock_resolution,
@@ -22,6 +23,7 @@ module Proofing
       def initialize
         @aamva_plugin = Plugins::AamvaPlugin.new
         @threatmetrix_plugin = Plugins::ThreatMetrixPlugin.new
+        @phone_finder_plugin = Plugins::PhoneFinderPlugin.new
       end
 
       # @param [Hash] applicant_pii keys are symbols and values are strings, confidential user info
@@ -75,6 +77,16 @@ module Proofing
           timer:,
         )
 
+        phone_finder_result = phone_finder_plugin.call(
+          applicant_pii:,
+          current_sp:,
+          residential_address_resolution_result:,
+          state_id_address_resolution_result:,
+          state_id_result:,
+          ipp_enrollment_in_progress:,
+          timer:,
+        )
+
         ResultAdjudicator.new(
           device_profiling_result: device_profiling_result,
           ipp_enrollment_in_progress: ipp_enrollment_in_progress,
@@ -82,6 +94,7 @@ module Proofing
           should_proof_state_id: aamva_plugin.aamva_supports_state_id_jurisdiction?(applicant_pii),
           state_id_result: state_id_result,
           residential_resolution_result: residential_address_resolution_result,
+          phone_finder_result: phone_finder_result,
           same_address_as_id: applicant_pii[:same_address_as_id],
           applicant_pii: applicant_pii,
         )

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -3,17 +3,23 @@
 module Proofing
   module Resolution
     class ResultAdjudicator
-      attr_reader :resolution_result, :state_id_result, :device_profiling_result,
-                  :ipp_enrollment_in_progress, :residential_resolution_result, :same_address_as_id,
+      attr_reader :resolution_result,
+                  :state_id_result,
+                  :device_profiling_result,
+                  :ipp_enrollment_in_progress,
+                  :residential_resolution_result,
+                  :phone_finder_result,
+                  :same_address_as_id,
                   :applicant_pii
 
       def initialize(
         resolution_result:, # InstantVerify
         state_id_result:, # AAMVA
         residential_resolution_result:, # InstantVerify Residential
+        phone_finder_result:, # PhoneFinder
         should_proof_state_id:,
         ipp_enrollment_in_progress:,
-        device_profiling_result:,
+        device_profiling_result:, # ThreatMetrix
         same_address_as_id:,
         applicant_pii:
       )
@@ -23,6 +29,7 @@ module Proofing
         @ipp_enrollment_in_progress = ipp_enrollment_in_progress
         @device_profiling_result = device_profiling_result
         @residential_resolution_result = residential_resolution_result
+        @phone_finder_result = phone_finder_result
         @same_address_as_id = same_address_as_id # this is a string, "true" or "false"
         @applicant_pii = applicant_pii
       end
@@ -38,6 +45,7 @@ module Proofing
             exception: exception,
             timed_out: timed_out?,
             threatmetrix_review_status: device_profiling_result.review_status,
+            phone_finder_precheck_passed: phone_finder_result.success?,
             context: {
               device_profiling_adjudication_reason: device_profiling_reason,
               resolution_adjudication_reason: resolution_reason,
@@ -47,6 +55,7 @@ module Proofing
                 residential_address: residential_resolution_result.to_h,
                 state_id: state_id_result.to_h,
                 threatmetrix: device_profiling_result.to_h,
+                phone_precheck: phone_finder_result.to_h,
               },
             },
             biographical_info: biographical_info,

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -267,6 +267,12 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
             transaction_id: 'abc123',
             verified_attributes: [],
           ),
+          phone_finder_result: Proofing::AddressResult.new(
+            success: true,
+            errors: {},
+            exception: nil,
+            vendor_name: 'test-phone-vendor',
+          ),
           device_profiling_result: Proofing::DdpResult.new(success: true),
           ipp_enrollment_in_progress: true,
           residential_resolution_result: Proofing::Resolution::Result.new(

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -397,6 +397,12 @@ RSpec.describe Idv::VerifyInfoController do
         # Here we're trying to match the store to redis -> read from redis flow this data travels
         adjudicated_result = Proofing::Resolution::ResultAdjudicator.new(
           state_id_result: Proofing::StateIdResult.new(success: true),
+          phone_finder_result: Proofing::AddressResult.new(
+            success: true,
+            errors: {},
+            exception: nil,
+            vendor_name: 'test-phone-vendor',
+          ),
           device_profiling_result: Proofing::DdpResult.new(success: true),
           ipp_enrollment_in_progress: true,
           residential_resolution_result: Proofing::Resolution::Result.new(success: true),
@@ -449,6 +455,12 @@ RSpec.describe Idv::VerifyInfoController do
             vendor_name: vendor_name,
             transaction_id: 'abc123',
             verified_attributes: [],
+          ),
+          phone_finder_result: Proofing::AddressResult.new(
+            success: true,
+            errors: {},
+            exception: nil,
+            vendor_name: 'test-phone-vendor',
           ),
           device_profiling_result: Proofing::DdpResult.new(success: true),
           ipp_enrollment_in_progress: true,
@@ -551,6 +563,12 @@ RSpec.describe Idv::VerifyInfoController do
             transaction_id: 'abc123',
             verified_attributes: [],
           ),
+          phone_finder_result: Proofing::AddressResult.new(
+            success: true,
+            errors: {},
+            exception: nil,
+            vendor_name: 'test-phone-vendor',
+          ),
           device_profiling_result: Proofing::DdpResult.new(success: true),
           ipp_enrollment_in_progress: true,
           residential_resolution_result: Proofing::Resolution::Result.new(success: true),
@@ -644,6 +662,12 @@ RSpec.describe Idv::VerifyInfoController do
             vendor_name: :aamva,
             transaction_id: 'abc123',
             verified_attributes: [],
+          ),
+          phone_finder_result: Proofing::AddressResult.new(
+            success: true,
+            errors: {},
+            exception: nil,
+            vendor_name: 'test-phone-vendor',
           ),
           device_profiling_result: Proofing::DdpResult.new(success: true),
           ipp_enrollment_in_progress: true,

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -94,20 +94,6 @@ RSpec.feature 'Analytics Regression', :js do
       verified_attributes: nil }
   end
 
-  let(:phone_precheck_block) do
-    { attributes_requiring_additional_verification: [],
-      can_pass_with_additional_verification: false,
-      errors: {},
-      exception: nil,
-      reference: '',
-      success: false,
-      timed_out: false,
-      transaction_id: '',
-      vendor_name: 'NoPhoneNumberAvailable',
-      vendor_workflow: nil,
-      verified_attributes: nil }
-  end
-
   let(:base_proofing_results) do
     {
       exception: nil,
@@ -134,7 +120,17 @@ RSpec.feature 'Analytics Regression', :js do
                                  verified_attributes: nil },
           state_id: state_id_resolution,
           threatmetrix: threatmetrix_response,
-          phone_precheck: phone_precheck_block,
+          phone_precheck: { attributes_requiring_additional_verification: [],
+                            can_pass_with_additional_verification: false,
+                            errors: {},
+                            exception: nil,
+                            reference: '',
+                            success: false,
+                            timed_out: false,
+                            transaction_id: '',
+                            vendor_name: 'NoPhoneNumberAvailable',
+                            vendor_workflow: nil,
+                            verified_attributes: nil },
         },
       },
       biographical_info: {
@@ -179,7 +175,17 @@ RSpec.feature 'Analytics Regression', :js do
                                  verified_attributes: nil },
           state_id: state_id_resolution,
           threatmetrix: threatmetrix_response,
-          phone_precheck: phone_precheck_block,
+          phone_precheck: { attributes_requiring_additional_verification: [],
+                            can_pass_with_additional_verification: false,
+                            errors: {},
+                            exception: nil,
+                            reference: '',
+                            success: false,
+                            timed_out: false,
+                            transaction_id: '',
+                            vendor_name: 'PhoneIgnoredForInPersonProofing',
+                            vendor_workflow: nil,
+                            verified_attributes: nil },
         },
       },
       biographical_info: {

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -94,12 +94,27 @@ RSpec.feature 'Analytics Regression', :js do
       verified_attributes: nil }
   end
 
+  let(:phone_precheck_block) do
+    { attributes_requiring_additional_verification: [],
+      can_pass_with_additional_verification: false,
+      errors: {},
+      exception: nil,
+      reference: '',
+      success: false,
+      timed_out: false,
+      transaction_id: '',
+      vendor_name: 'NoPhoneNumberAvailable',
+      vendor_workflow: nil,
+      verified_attributes: nil }
+  end
+
   let(:base_proofing_results) do
     {
       exception: nil,
       ssn_is_unique: true,
       timed_out: false,
       threatmetrix_review_status: 'pass',
+      phone_finder_precheck_passed: false,
       context: {
         device_profiling_adjudication_reason: 'device_profiling_result_pass',
         resolution_adjudication_reason: 'pass_resolution_and_state_id',
@@ -119,6 +134,7 @@ RSpec.feature 'Analytics Regression', :js do
                                  verified_attributes: nil },
           state_id: state_id_resolution,
           threatmetrix: threatmetrix_response,
+          phone_precheck: phone_precheck_block,
         },
       },
       biographical_info: {
@@ -143,6 +159,7 @@ RSpec.feature 'Analytics Regression', :js do
       ssn_is_unique: true,
       timed_out: false,
       threatmetrix_review_status: 'pass',
+      phone_finder_precheck_passed: false,
       context: {
         device_profiling_adjudication_reason: 'device_profiling_result_pass',
         resolution_adjudication_reason: 'pass_resolution_and_state_id',
@@ -162,6 +179,7 @@ RSpec.feature 'Analytics Regression', :js do
                                  verified_attributes: nil },
           state_id: state_id_resolution,
           threatmetrix: threatmetrix_response,
+          phone_precheck: phone_precheck_block,
         },
       },
       biographical_info: {

--- a/spec/services/proofing/resolution/plugins/phone_finder_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/phone_finder_plugin_spec.rb
@@ -1,0 +1,151 @@
+require 'rails_helper'
+
+RSpec.describe Proofing::Resolution::Plugins::PhoneFinderPlugin do
+  let(:applicant_pii) do
+    Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE.merge(uuid_prefix: '123', uuid: 'abc')
+  end
+  let(:current_sp) { build(:service_provider) }
+  let(:ipp_enrollment_in_progress) { false }
+  let(:timer) { JobHelpers::Timer.new }
+
+  let(:state_id_address_resolution_result) do
+    Proofing::Resolution::Result.new(success: true, vendor_name: 'lexisnexis:instant_verify')
+  end
+  let(:residential_address_resolution_result) do
+    Proofing::Resolution::Result.new(success: true, vendor_name: 'lexisnexis:instant_verify')
+  end
+  let(:state_id_result) do
+    Proofing::Resolution::Result.new(success: true, vendor_name: 'aamva:state_id')
+  end
+
+  subject(:plugin) { described_class.new }
+
+  describe '#call' do
+    subject(:call) do
+      plugin.call(
+        applicant_pii:,
+        current_sp:,
+        state_id_address_resolution_result:,
+        residential_address_resolution_result:,
+        state_id_result:,
+        ipp_enrollment_in_progress:,
+        timer:,
+      )
+    end
+
+    def sp_cost_count_with_transaction_id
+      SpCost.where(
+        cost_type: :lexis_nexis_address,
+        issuer: current_sp.issuer,
+        transaction_id: 'address-mock-transaction-id-123',
+      ).count
+    end
+
+    context 'unsupervised remote proofing' do
+      it 'returns an unsuccessful result if any upstream results are unsuccessful' do
+        failed_upstream_vendor_result = Proofing::Resolution::Result.new(
+          success: false,
+          vendor_name: 'vendor:test',
+        )
+        default_plugin_arguments = {
+          applicant_pii:,
+          current_sp:,
+          state_id_address_resolution_result:,
+          residential_address_resolution_result:,
+          state_id_result:,
+          ipp_enrollment_in_progress:,
+          timer:,
+        }
+
+        state_id_address_failed_result = plugin.call(
+          **default_plugin_arguments,
+          state_id_address_resolution_result: failed_upstream_vendor_result,
+        )
+        expect(state_id_address_failed_result.success?).to eq(false)
+        expect(state_id_address_failed_result.vendor_name).to eq('ResolutionCannotPass')
+
+        residential_address_failed_result = plugin.call(
+          **default_plugin_arguments,
+          residential_address_resolution_result: failed_upstream_vendor_result,
+        )
+        expect(residential_address_failed_result.success?).to eq(false)
+        expect(residential_address_failed_result.vendor_name).to eq('ResolutionCannotPass')
+
+        state_id_failed_result = plugin.call(
+          **default_plugin_arguments,
+          state_id_result: failed_upstream_vendor_result,
+        )
+        expect(state_id_failed_result.success?).to eq(false)
+        expect(state_id_failed_result.vendor_name).to eq('ResolutionCannotPass')
+      end
+
+      context 'there is no phone number in the applicant' do
+        let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
+
+        it 'returns an unsuccessful result' do
+          result = call
+
+          expect(result.success?).to eq(false)
+          expect(result.vendor_name).to eq('NoPhoneNumberAvailable')
+        end
+      end
+
+      context 'the applicant has a phone number' do
+        it 'calls the proofer and returns the results' do
+          expect(plugin.proofer).to receive(:proof).with(
+            {
+              uuid: 'abc',
+              uuid_prefix: '123',
+              first_name: 'FAKEY',
+              last_name: 'MCFAKERSON',
+              ssn: '900-66-1234',
+              dob: '1938-10-06',
+              phone: '12025551212',
+            },
+          ).and_call_original
+
+          result = call
+
+          expect(result.success?).to eq(true)
+          expect(result.vendor_name).to eq('AddressMock')
+        end
+
+        it 'records an SP cost' do
+          expect do
+            call
+          end.to(change { sp_cost_count_with_transaction_id }.by(1))
+        end
+
+        context 'the transaction raises an error' do
+          let(:applicant_pii) do
+            super().merge(phone: Proofing::Mock::AddressMockClient::FAILED_TO_CONTACT_PHONE_NUMBER)
+          end
+
+          it 'returns an unsuccessful result' do
+            result = call
+
+            expect(result.success?).to eq(false)
+            expect(result.exception).to be_present
+          end
+
+          it 'does not record an SP cost' do
+            expect do
+              call
+            end.to_not(change { sp_cost_count_with_transaction_id })
+          end
+        end
+      end
+    end
+
+    context 'in-person proofing' do
+      let(:ipp_enrollment_in_progress) { true }
+
+      it 'returns an unsuccessful result' do
+        result = call
+
+        expect(result.success?).to eq(false)
+        expect(result.vendor_name).to eq('PhoneIgnoredForInPersonProofing')
+      end
+    end
+  end
+end

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
       verified_attributes: state_id_verified_attributes,
     )
   end
+  let(:phone_finder_result) do
+    Proofing::AddressResult.new(
+      success: true,
+      errors: {},
+      exception: nil,
+      vendor_name: 'test-phone-vendor',
+    )
+  end
 
   let(:should_proof_state_id) { true }
   let(:ipp_enrollment_in_progress) { true }
@@ -54,6 +62,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
       should_proof_state_id: should_proof_state_id,
       ipp_enrollment_in_progress: ipp_enrollment_in_progress,
       device_profiling_result: device_profiling_result,
+      phone_finder_result: phone_finder_result,
       same_address_as_id: same_address_as_id,
       applicant_pii: applicant_pii,
     )


### PR DESCRIPTION
We are working on a feature where the user's phone number can be verified in the verify-info check. This feature is called "Phone Finder Pre-check".

Phone-Finder Pre-check will make a best effort to find a phone number on the user's account (either from their MFA methods or hybrid flow) and validate that phone number when the user submits their info. If the number matches the user will be sent straight to OTP confirmation for that phone number.

As part of this feature we will need the resolution proofing job to send the phone number to phone finder if a phone number is found for the user at the verify info step. This commit implements that by have the resolution proofing job communicate with phone finder and store a result if a phone number is provided in the applicant hash.
