### PR TITLE
Deploy RC 458 to Production

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -706,7 +706,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     uniform_notifier (1.16.0)
-    uri (1.0.2)
+    uri (1.0.3)
     useragent (0.16.11)
     view_component (3.21.0)
       activesupport (>= 5.2.0, < 8.1)

--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -29,17 +29,23 @@ module TwoFactorAuthenticatableMethods
     if result.success?
       handle_valid_verification_for_authentication_context(auth_method:)
       user_session.delete(:mfa_attempts)
-      session.delete(:sign_in_recaptcha_assessment_id)
+      session.delete(:sign_in_recaptcha_assessment_id) if sign_in_recaptcha_annotation_enabled?
     else
       handle_invalid_verification_for_authentication_context
     end
   end
 
   def annotate_recaptcha(reason)
-    RecaptchaAnnotator.annotate(assessment_id: session[:sign_in_recaptcha_assessment_id], reason:)
+    if sign_in_recaptcha_annotation_enabled?
+      RecaptchaAnnotator.annotate(assessment_id: session[:sign_in_recaptcha_assessment_id], reason:)
+    end
   end
 
   private
+
+  def sign_in_recaptcha_annotation_enabled?
+    IdentityConfig.store.sign_in_recaptcha_annotation_enabled
+  end
 
   def handle_valid_verification_for_authentication_context(auth_method:)
     mark_user_session_authenticated(auth_method:, authentication_type: :valid_2fa)

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -7,6 +7,7 @@ module Idv
     include StepIndicatorConcern
 
     before_action :confirm_not_rate_limited
+    before_action :cancel_previous_in_person_enrollments, only: :show
 
     def show
       idv_session.proofing_started_at ||= Time.zone.now.iso8601
@@ -23,7 +24,6 @@ module Idv
       analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
 
       create_document_capture_session
-      cancel_previous_in_person_enrollments
 
       idv_session.welcome_visited = true
 
@@ -61,7 +61,6 @@ module Idv
     end
 
     def cancel_previous_in_person_enrollments
-      return unless IdentityConfig.store.in_person_proofing_enabled
       UspsInPersonProofing::EnrollmentHelper.cancel_establishing_and_in_progress_enrollments(
         current_user,
       )

--- a/app/javascript/packages/document-capture/components/acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/acuant-capture.tsx
@@ -136,6 +136,10 @@ interface AcuantCaptureProps {
    * Determine whether the selfie help text shoule be shown.
    */
   showSelfieHelp: () => void;
+  /**
+   * Whether user is on the failed submission review step
+   */
+  isReviewStep?: boolean;
 }
 
 /**
@@ -313,6 +317,7 @@ function AcuantCapture(
     errorMessage,
     name,
     showSelfieHelp,
+    isReviewStep,
   }: AcuantCaptureProps,
   ref: Ref<HTMLInputElement | null>,
 ) {
@@ -327,7 +332,7 @@ function AcuantCapture(
   } = useContext(AcuantContext);
   const { isMockClient } = useContext(UploadContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const { isSelfieCaptureEnabled, immediatelyBeginCapture } = useContext(SelfieCaptureContext);
+  const { isSelfieCaptureEnabled } = useContext(SelfieCaptureContext);
   const fullScreenRef = useRef<FullScreenRefHandle>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const isForceUploading = useRef(false);
@@ -350,7 +355,7 @@ function AcuantCapture(
   const isBackOfId = name === 'back';
   useLogCameraInfo({ isBackOfId, hasStartedCropping });
   const [isCapturingEnvironment, setIsCapturingEnvironment] = useState(
-    selfieCapture && immediatelyBeginCapture,
+    selfieCapture && !isReviewStep,
   );
 
   const {

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -100,6 +100,7 @@ function DocumentSideAcuantCapture({
       className={className}
       allowUpload={isUploadAllowed}
       showSelfieHelp={showSelfieHelp}
+      isReviewStep={isReviewStep}
     />
   );
 }

--- a/app/javascript/packages/document-capture/context/selfie-capture.tsx
+++ b/app/javascript/packages/document-capture/context/selfie-capture.tsx
@@ -14,17 +14,12 @@ interface SelfieCaptureProps {
    * the capture component.
    */
   showHelpInitially: boolean;
-  /**
-   * Specify whether we should try to capture using Acuant immediately
-   */
-  immediatelyBeginCapture: boolean;
 }
 
 const SelfieCaptureContext = createContext<SelfieCaptureProps>({
   isSelfieCaptureEnabled: false,
   isSelfieDesktopTestMode: false,
   showHelpInitially: true,
-  immediatelyBeginCapture: false,
 });
 
 SelfieCaptureContext.displayName = 'SelfieCaptureContext';

--- a/app/javascript/packages/phone-input/package.json
+++ b/app/javascript/packages/phone-input/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "dependencies": {
     "intl-tel-input": "^24.5.0",
-    "libphonenumber-js": "^1.12.4"
+    "libphonenumber-js": "^1.12.5"
   },
   "sideEffects": [
     "./index.ts"

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -179,7 +179,6 @@ render(
                       isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
                       isSelfieDesktopTestMode: String(docAuthSelfieDesktopTestMode) === 'true',
                       showHelpInitially: true,
-                      immediatelyBeginCapture: false,
                     }}
                   >
                     <FailedCaptureAttemptsContextProvider

--- a/app/jobs/data_warehouse/table_summary_stats_export_job.rb
+++ b/app/jobs/data_warehouse/table_summary_stats_export_job.rb
@@ -6,11 +6,13 @@ module DataWarehouse
 
     TABLE_EXCLUSION_LIST = %w[
       agency_identities
+      usps_confirmations
     ].freeze
 
     TIMESTAMP_OVERRIDE = {
       'sp_return_logs' => 'returned_at',
       'registration_logs' => 'registered_at',
+      'letter_requests_to_usps_ftp_logs' => 'ftp_at',
     }.freeze
 
     def perform(timestamp)

--- a/app/services/encryption/contextless_kms_client.rb
+++ b/app/services/encryption/contextless_kms_client.rb
@@ -19,13 +19,23 @@ module Encryption
     }.freeze
 
     def encrypt(plaintext, log_context: nil)
-      KmsLogger.log(:encrypt, key_id: IdentityConfig.store.aws_kms_key_id, log_context: log_context)
+      KmsLogger.log(
+        action: :encrypt,
+        timestamp: Time.zone.now,
+        key_id: IdentityConfig.store.aws_kms_key_id,
+        log_context: log_context,
+      )
       return encrypt_kms(plaintext) if FeatureManagement.use_kms?
       encrypt_local(plaintext)
     end
 
     def decrypt(ciphertext, log_context: nil)
-      KmsLogger.log(:decrypt, key_id: IdentityConfig.store.aws_kms_key_id, log_context: log_context)
+      KmsLogger.log(
+        action: :decrypt,
+        timestamp: Time.zone.now,
+        key_id: IdentityConfig.store.aws_kms_key_id,
+        log_context: log_context,
+      )
       return decrypt_kms(ciphertext) if use_kms?(ciphertext)
       decrypt_local(ciphertext)
     end

--- a/app/services/encryption/kms_client.rb
+++ b/app/services/encryption/kms_client.rb
@@ -32,7 +32,12 @@ module Encryption
     end
 
     def encrypt(plaintext, encryption_context)
-      KmsLogger.log(:encrypt, context: encryption_context, key_id: kms_key_id)
+      KmsLogger.log(
+        action: :encrypt,
+        timestamp: Time.zone.now,
+        context: encryption_context,
+        key_id: kms_key_id,
+      )
       return encrypt_kms(plaintext, encryption_context) if FeatureManagement.use_kms?
       encrypt_local(plaintext, encryption_context)
     end
@@ -41,7 +46,12 @@ module Encryption
       if self.class.looks_like_contextless?(ciphertext)
         return decrypt_contextless_kms(ciphertext, encryption_context)
       end
-      KmsLogger.log(:decrypt, context: encryption_context, key_id: kms_key_id)
+      KmsLogger.log(
+        action: :decrypt,
+        timestamp: Time.zone.now,
+        context: encryption_context,
+        key_id: kms_key_id,
+      )
       return decrypt_kms(ciphertext, encryption_context) if use_kms?(ciphertext)
       decrypt_local(ciphertext, encryption_context)
     end

--- a/app/services/encryption/kms_logger.rb
+++ b/app/services/encryption/kms_logger.rb
@@ -2,9 +2,10 @@
 
 module Encryption
   class KmsLogger
-    def self.log(action, key_id:, context: nil, log_context: nil)
+    def self.log(action:, timestamp:, key_id:, context: nil, log_context: nil)
       output = {
         kms: {
+          timestamp: timestamp,
           action: action,
           encryption_context: context,
           log_context: log_context,

--- a/app/services/recaptcha_annotator.rb
+++ b/app/services/recaptcha_annotator.rb
@@ -21,8 +21,10 @@ class RecaptchaAnnotator
       return if assessment_id.blank?
 
       if FeatureManagement.recaptcha_enterprise?
-        assessment = create_or_update_assessment!(assessment_id:, reason:, annotation:)
-        RecaptchaAnnotateJob.perform_later(assessment:)
+        submit_annotation(assessment_id:, reason:, annotation:)
+        # Future:
+        # assessment = create_or_update_assessment!(assessment_id:, reason:, annotation:)
+        # RecaptchaAnnotateJob.perform_later(assessment:)
       end
 
       { assessment_id:, reason:, annotation: }
@@ -34,7 +36,6 @@ class RecaptchaAnnotator
         annotation: assessment.annotation_before_type_cast,
         reason: assessment.annotation_reason_before_type_cast,
       )
-      assessment.destroy
     end
 
     private

--- a/app/services/saml_request_validator.rb
+++ b/app/services/saml_request_validator.rb
@@ -59,6 +59,9 @@ class SamlRequestValidator
   end
 
   def authorized_authn_context
+    # if there is no service provider, an error has already been added
+    return unless service_provider.present?
+
     if !valid_authn_context? ||
        (identity_proofing_requested? && !service_provider.identity_proofing_allowed?) ||
        (ial_max_requested? && !service_provider.ialmax_allowed?) ||
@@ -74,7 +77,7 @@ class SamlRequestValidator
   end
 
   def registered_cert_exists
-    # if there is no service provider, this error has already been added
+    # if there is no service provider, an error has already been added
     return if service_provider.blank?
     return if service_provider.certs.present?
     return unless service_provider.encrypt_responses?

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -390,6 +390,7 @@ short_term_phone_otp_max_attempt_window_in_seconds: 10
 short_term_phone_otp_max_attempts: 2
 show_unsupported_passkey_platform_authentication_setup: false
 show_user_attribute_deprecation_warnings: false
+sign_in_recaptcha_annotation_enabled: false
 sign_in_recaptcha_log_failures_only: false
 sign_in_recaptcha_percent_tested: 0
 sign_in_recaptcha_score_threshold: 0.0
@@ -507,6 +508,7 @@ development:
   secret_key_base: development_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   show_unsupported_passkey_platform_authentication_setup: true
+  sign_in_recaptcha_annotation_enabled: true
   sign_in_recaptcha_percent_tested: 100
   sign_in_recaptcha_score_threshold: 0.3
   skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost"]'
@@ -607,6 +609,7 @@ test:
   secret_key_base: test_secret_key_base
   session_encryption_key: 27bad3c25711099429c1afdfd1890910f3b59f5a4faec1c85e945cb8b02b02f261ba501d99cfbb4fab394e0102de6fecf8ffe260f322f610db3e96b2a775c120
   short_term_phone_otp_max_attempts: 100
+  sign_in_recaptcha_annotation_enabled: true
   skip_encryption_allowed_list: '[]'
   socure_docv_document_request_endpoint: 'https://sandbox.socure.test/documnt-request'
   socure_docv_webhook_secret_key: 'secret-key'

--- a/db/primary_migrate/20250228141538_add_timestamps_to_recaptcha_assessments.rb
+++ b/db/primary_migrate/20250228141538_add_timestamps_to_recaptcha_assessments.rb
@@ -1,7 +1,0 @@
-class AddTimestampsToRecaptchaAssessments < ActiveRecord::Migration[8.0]
-  def change
-    add_timestamps :recaptcha_assessments
-    change_column_comment :recaptcha_assessments, :created_at, from: nil, to: 'sensitive=false'
-    change_column_comment :recaptcha_assessments, :updated_at, from: nil, to: 'sensitive=false'
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_28_141538) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_24_134110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -482,8 +482,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_28_141538) do
   create_table "recaptcha_assessments", id: :string, force: :cascade do |t|
     t.string "annotation", comment: "sensitive=false"
     t.string "annotation_reason", comment: "sensitive=false"
-    t.datetime "created_at", null: false, comment: "sensitive=false"
-    t.datetime "updated_at", null: false, comment: "sensitive=false"
   end
 
   create_table "registration_logs", force: :cascade do |t|

--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -300,13 +300,13 @@ class DataPull
             ]
           end
         elsif config.include_missing?
-          table << [user.uuid, '[HAS NO PROFILE]', nil, nil, nil, nil, nil, nil]
+          table << [user.uuid, '[HAS NO PROFILE]', nil, nil, nil, nil, nil, nil, nil]
         end
       end
 
       if config.include_missing?
         (uuids - users.map(&:uuid)).each do |missing_uuid|
-          table << [missing_uuid, '[UUID NOT FOUND]', nil, nil, nil, nil, nil, nil]
+          table << [missing_uuid, '[UUID NOT FOUND]', nil, nil, nil, nil, nil, nil, nil]
         end
       end
 

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -428,6 +428,7 @@ module IdentityConfig
     config.add(:sign_in_user_id_per_ip_attempt_window_in_minutes, type: :integer)
     config.add(:sign_in_user_id_per_ip_attempt_window_max_minutes, type: :integer)
     config.add(:sign_in_user_id_per_ip_max_attempts, type: :integer)
+    config.add(:sign_in_recaptcha_annotation_enabled, type: :boolean)
     config.add(:sign_in_recaptcha_log_failures_only, type: :boolean)
     config.add(:sign_in_recaptcha_percent_tested, type: :integer)
     config.add(:sign_in_recaptcha_score_threshold, type: :float)

--- a/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
+++ b/spec/controllers/concerns/two_factor_authenticatable_methods_spec.rb
@@ -168,28 +168,53 @@ RSpec.describe TwoFactorAuthenticatableMethods, type: :controller do
       context 'when there is a sign_in_recaptcha_assessment_id in the session' do
         let(:assessment_id) { 'projects/project-id/assessments/assessment-id' }
 
-        it 'annotates assessment with PASSED_TWO_FACTOR and clears assessment id from session' do
-          recaptcha_annotation = {
-            assessment_id:,
-            reason: RecaptchaAnnotator::AnnotationReasons::PASSED_TWO_FACTOR,
-          }
+        context 'when sign_in_recaptcha_annotation_enabled is true' do
+          before do
+            allow(IdentityConfig.store).to receive(:sign_in_recaptcha_annotation_enabled)
+              .and_return(true)
+          end
 
-          controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+          it 'annotates assessment with PASSED_TWO_FACTOR and clears assessment id from session' do
+            recaptcha_annotation = {
+              assessment_id:,
+              reason: RecaptchaAnnotator::AnnotationReasons::PASSED_TWO_FACTOR,
+            }
 
-          expect(RecaptchaAnnotator).to receive(:annotate)
-            .with(**recaptcha_annotation)
-            .and_return(recaptcha_annotation)
+            controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
 
-          stub_analytics
+            expect(RecaptchaAnnotator).to receive(:annotate)
+              .with(**recaptcha_annotation)
+              .and_return(recaptcha_annotation)
 
-          expect { result }
-            .to change { controller.session[:sign_in_recaptcha_assessment_id] }
-            .from(assessment_id).to(nil)
+            stub_analytics
 
-          expect(@analytics).to have_logged_event(
-            'Multi-Factor Authentication',
-            hash_including(recaptcha_annotation:),
-          )
+            expect { result }
+              .to change { controller.session[:sign_in_recaptcha_assessment_id] }
+              .from(assessment_id).to(nil)
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication',
+              hash_including(recaptcha_annotation:),
+            )
+          end
+        end
+
+        context 'when sign_in_recaptcha_annotation_enabled is false' do
+          before do
+            allow(IdentityConfig.store).to receive(:sign_in_recaptcha_annotation_enabled)
+              .and_return(false)
+          end
+
+          it 'does not annotate the assessment' do
+            controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+            expect(RecaptchaAnnotator).not_to receive(:annotate)
+
+            stub_analytics
+
+            expect { result }
+              .not_to change { controller.session[:sign_in_recaptcha_assessment_id] }
+          end
         end
       end
     end
@@ -228,28 +253,52 @@ RSpec.describe TwoFactorAuthenticatableMethods, type: :controller do
       context 'when there is a sign_in_recaptcha_assessment_id in the session' do
         let(:assessment_id) { 'projects/project-id/assessments/assessment-id' }
 
-        it 'annotates assessment with FAILED_TWO_FACTOR and clears assessment id from session' do
-          recaptcha_annotation = {
-            assessment_id:,
-            reason: RecaptchaAnnotator::AnnotationReasons::FAILED_TWO_FACTOR,
-          }
+        context 'when sign_in_recaptcha_annotation_enabled is true' do
+          before do
+            allow(IdentityConfig.store).to receive(:sign_in_recaptcha_annotation_enabled)
+              .and_return(true)
+          end
 
-          controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+          it 'annotates assessment with FAILED_TWO_FACTOR and clears assessment id from session' do
+            recaptcha_annotation = {
+              assessment_id:,
+              reason: RecaptchaAnnotator::AnnotationReasons::FAILED_TWO_FACTOR,
+            }
 
-          expect(RecaptchaAnnotator).to receive(:annotate)
-            .with(**recaptcha_annotation)
-            .and_return(recaptcha_annotation)
+            controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
 
-          stub_analytics
+            expect(RecaptchaAnnotator).to receive(:annotate)
+              .with(**recaptcha_annotation)
+              .and_return(recaptcha_annotation)
 
-          expect { result }
-            .not_to change { controller.session[:sign_in_recaptcha_assessment_id] }
-            .from(assessment_id)
+            stub_analytics
 
-          expect(@analytics).to have_logged_event(
-            'Multi-Factor Authentication',
-            hash_including(recaptcha_annotation:),
-          )
+            expect { result }
+              .not_to change { controller.session[:sign_in_recaptcha_assessment_id] }
+              .from(assessment_id)
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication',
+              hash_including(recaptcha_annotation:),
+            )
+          end
+        end
+        context 'when sign_in_recaptcha_annotation_enabled is false' do
+          before do
+            allow(IdentityConfig.store).to receive(:sign_in_recaptcha_annotation_enabled)
+              .and_return(false)
+          end
+
+          it 'does not annotate the assessment' do
+            controller.session[:sign_in_recaptcha_assessment_id] = assessment_id
+
+            expect(RecaptchaAnnotator).not_to receive(:annotate)
+
+            stub_analytics
+
+            expect { result }
+              .not_to change { controller.session[:sign_in_recaptcha_assessment_id] }
+          end
         end
       end
     end

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -28,6 +28,41 @@ RSpec.describe Idv::WelcomeController do
         :check_for_mail_only_outage,
       )
     end
+
+    it 'includes cancelling previous in person enrollments' do
+      expect(subject).to have_actions(
+        :before,
+        :cancel_previous_in_person_enrollments,
+      )
+    end
+
+    context 'with previous establishing and pending in-person enrollments' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      end
+
+      let!(:establishing_enrollment) { create(:in_person_enrollment, :establishing, user: user) }
+      let(:password_reset_profile) { create(:profile, :password_reset, user: user) }
+      let!(:pending_enrollment) do
+        create(:in_person_enrollment, :pending, user: user, profile: password_reset_profile)
+      end
+      let(:fraud_password_reset_profile) { create(:profile, :password_reset, user: user) }
+      let!(:fraud_review_enrollment) do
+        create(
+          :in_person_enrollment, :in_fraud_review, user: user, profile: fraud_password_reset_profile
+        )
+      end
+
+      it 'cancels all previous establishing, pending, and in_fraud_review enrollments' do
+        put :show
+
+        expect(establishing_enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
+        expect(pending_enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
+        expect(fraud_review_enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
+        expect(user.establishing_in_person_enrollment).to be_blank
+        expect(user.pending_in_person_enrollment).to be_blank
+      end
+    end
   end
 
   describe '#show' do
@@ -105,6 +140,22 @@ RSpec.describe Idv::WelcomeController do
 
       expect(response).to redirect_to(idv_please_call_url)
     end
+
+    context 'has pending in-person enrollment' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      end
+
+      it 'redirects to ready to verify' do
+        profile = create(:profile, :in_person_verification_pending, user:)
+
+        stub_sign_in(profile.user)
+
+        get :show
+
+        expect(response).to redirect_to(idv_in_person_ready_to_verify_url)
+      end
+    end
   end
 
   describe '#update' do
@@ -132,34 +183,6 @@ RSpec.describe Idv::WelcomeController do
     it 'creates a document capture session' do
       expect { put :update }
         .to change { subject.idv_session.document_capture_session_uuid }.from(nil)
-    end
-
-    context 'with previous establishing and pending in-person enrollments' do
-      let!(:establishing_enrollment) { create(:in_person_enrollment, :establishing, user: user) }
-      let(:password_reset_profile) { create(:profile, :password_reset, user: user) }
-      let!(:pending_enrollment) do
-        create(:in_person_enrollment, :pending, user: user, profile: password_reset_profile)
-      end
-      let(:fraud_password_reset_profile) { create(:profile, :password_reset, user: user) }
-      let!(:fraud_review_enrollment) do
-        create(
-          :in_person_enrollment, :in_fraud_review, user: user, profile: fraud_password_reset_profile
-        )
-      end
-
-      before do
-        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-      end
-
-      it 'cancels all previous establishing, pending, and in_fraud_review enrollments' do
-        put :update
-
-        expect(establishing_enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
-        expect(pending_enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
-        expect(fraud_review_enrollment.reload.status).to eq(InPersonEnrollment::STATUS_CANCELLED)
-        expect(user.establishing_in_person_enrollment).to be_blank
-        expect(user.pending_in_person_enrollment).to be_blank
-      end
     end
   end
 end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -1418,14 +1418,12 @@ RSpec.describe SamlIdpController do
 
         expect(controller).to render_template('saml_idp/auth/error')
         expect(response.status).to eq(400)
-        expect(response.body).to include(t('errors.messages.unauthorized_authn_context'))
         expect(response.body).to include(t('errors.messages.unauthorized_service_provider'))
         expect(@analytics).to have_logged_event(
           'SAML Auth',
           hash_including(
             success: false,
             error_details: {
-              authn_context: { unauthorized_authn_context: true },
               service_provider: { unauthorized_service_provider: true },
             },
             nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
@@ -1440,7 +1438,7 @@ RSpec.describe SamlIdpController do
         )
         expect(@analytics).to have_logged_event(
           :sp_integration_errors_present,
-          error_details: ['Unauthorized Service Provider', 'Unauthorized authentication context'],
+          error_details: ['Unauthorized Service Provider'],
           error_types: { saml_request_errors: true },
           event: :saml_auth_request,
           integration_exists: false,

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
@@ -25,7 +25,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -50,7 +49,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -77,7 +75,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -100,7 +97,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -127,7 +123,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -156,7 +151,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
@@ -193,7 +187,6 @@ describe('DocumentSideAcuantCapture', () => {
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
-                  immediatelyBeginCapture: false,
                 }}
               >
                 <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
@@ -148,7 +148,6 @@ describe('document-capture/components/documents-step', () => {
           isSelfieCaptureEnabled: true,
           isSelfieDesktopTestMode: false,
           showHelpInitially: true,
-          immediatelyBeginCapture: true,
         }}
       >
         <DocumentsStep

--- a/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
@@ -35,7 +35,6 @@ describe('document-capture/components/selfie-step', () => {
             isSelfieCaptureEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
-            immediatelyBeginCapture: false,
           }}
         >
           <SelfieStep
@@ -76,7 +75,6 @@ describe('document-capture/components/selfie-step', () => {
             isSelfieCaptureEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
-            immediatelyBeginCapture: false,
           }}
         >
           <SelfieStep

--- a/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
@@ -10,7 +10,6 @@ describe('document-capture/context/selfie-capture', () => {
       'isSelfieCaptureEnabled',
       'isSelfieDesktopTestMode',
       'showHelpInitially',
-      'immediatelyBeginCapture',
     ]);
     expect(result.current.isSelfieCaptureEnabled).to.be.a('boolean');
   });

--- a/spec/services/encryption/contextless_kms_client_spec.rb
+++ b/spec/services/encryption/contextless_kms_client_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe Encryption::ContextlessKmsClient do
   let(:password_pepper) { '1' * 32 }
   let(:local_plaintext) { 'local plaintext' }
   let(:local_ciphertext) { 'local ciphertext' }
+  let(:log_timestamp) { Time.utc(2025, 2, 28, 15, 30, 1) }
+
+  around do |example|
+    freeze_time { example.run }
+  end
 
   before do
     stub_const(
@@ -149,7 +154,8 @@ RSpec.describe Encryption::ContextlessKmsClient do
 
       it 'logs the encryption' do
         expect(Encryption::KmsLogger).to receive(:log).with(
-          :encrypt,
+          action: :encrypt,
+          timestamp: Time.zone.now,
           log_context: { context: 'abc' },
           key_id: IdentityConfig.store.aws_kms_key_id,
         )
@@ -185,7 +191,8 @@ RSpec.describe Encryption::ContextlessKmsClient do
 
       it 'logs the decryption' do
         expect(Encryption::KmsLogger).to receive(:log).with(
-          :decrypt,
+          action: :decrypt,
+          timestamp: Time.zone.now,
           log_context: { context: 'abc' },
           key_id: IdentityConfig.store.aws_kms_key_id,
         )

--- a/spec/services/encryption/kms_logger_spec.rb
+++ b/spec/services/encryption/kms_logger_spec.rb
@@ -2,10 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Encryption::KmsLogger do
   describe '.log' do
+    let(:log_timestamp) { Time.utc(2025, 2, 28, 15, 30, 1) }
+
     context 'with a context' do
       it 'logs the context' do
         log = {
           kms: {
+            timestamp: log_timestamp,
             action: 'encrypt',
             encryption_context: { context: 'pii-encryption', user_uuid: '1234-abc' },
             log_context: 'log_context',
@@ -17,10 +20,11 @@ RSpec.describe Encryption::KmsLogger do
         expect(described_class.logger).to receive(:info).with(log)
 
         described_class.log(
-          :encrypt,
+          action: :encrypt,
           context: { context: 'pii-encryption', user_uuid: '1234-abc' },
           log_context: 'log_context',
           key_id: 'super-duper-aws-kms-key-id',
+          timestamp: log_timestamp,
         )
       end
     end
@@ -29,6 +33,7 @@ RSpec.describe Encryption::KmsLogger do
       it 'logs that an encryption happened without a context' do
         log = {
           kms: {
+            timestamp: log_timestamp,
             action: 'decrypt',
             encryption_context: nil,
             log_context: nil,
@@ -39,7 +44,11 @@ RSpec.describe Encryption::KmsLogger do
 
         expect(described_class.logger).to receive(:info).with(log)
 
-        described_class.log(:decrypt, key_id: 'super-duper-aws-kms-key-id')
+        described_class.log(
+          action: :decrypt,
+          timestamp: log_timestamp,
+          key_id: 'super-duper-aws-kms-key-id',
+        )
       end
     end
   end

--- a/spec/services/saml_request_validator_spec.rb
+++ b/spec/services/saml_request_validator_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe SamlRequestValidator do
     end
 
     context 'valid authn context and invalid sp and authorized nameID format' do
-      let(:sp) { ServiceProvider.find_by(issuer: 'foo') }
+      let(:sp) { nil }
 
       it 'returns FormResponse with success: false' do
         expect(response.to_h).to eq(
@@ -95,6 +95,42 @@ RSpec.describe SamlRequestValidator do
           error_details: { service_provider: { unauthorized_service_provider: true } },
           **extra,
         )
+      end
+
+      context 'when identity proofing is requested' do
+        let(:authn_context) { [Saml::Idp::Constants::IAL_VERIFIED_ACR] }
+
+        it 'returns FormResponse with success: false' do
+          expect(response.to_h).to eq(
+            success: false,
+            error_details: { service_provider: { unauthorized_service_provider: true } },
+            **extra,
+          )
+        end
+      end
+
+      context 'when IALmax is requested' do
+        let(:authn_context) { [Saml::Idp::Constants::IALMAX_AUTHN_CONTEXT_CLASSREF] }
+
+        it 'returns FormResponse with success: false' do
+          expect(response.to_h).to eq(
+            success: false,
+            error_details: { service_provider: { unauthorized_service_provider: true } },
+            **extra,
+          )
+        end
+      end
+
+      context 'when facial matching is requested' do
+        let(:authn_context) { [Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR] }
+
+        it 'returns FormResponse with success: false' do
+          expect(response.to_h).to eq(
+            success: false,
+            error_details: { service_provider: { unauthorized_service_provider: true } },
+            **extra,
+          )
+        end
       end
     end
 
@@ -302,7 +338,6 @@ RSpec.describe SamlRequestValidator do
         expect(response.to_h).to eq(
           success: false,
           error_details: {
-            authn_context: { unauthorized_authn_context: true },
             service_provider: { unauthorized_service_provider: true },
           },
           **extra,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4082,10 +4082,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-libphonenumber-js@^1.12.4:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.12.4.tgz#15062e61ac29d381305f0a37b0c2aad6ae432931"
-  integrity sha512-vLmhg7Gan7idyAKfc6pvCtNzvar4/eIzrVVk3hjNFH5+fGqyjD0gQRovdTrDl20wsmZhBtmZpcsR0tOfquwb8g==
+libphonenumber-js@^1.12.5:
+  version "1.12.5"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.12.5.tgz#8e6043a67112d4beedb8627b359a613f04d88fba"
+  integrity sha512-DOjiaVjjSmap12ztyb4QgoFmUe/GbgnEXHu+R7iowk0lzDIjScvPAm8cK9RYTEobbRb0OPlwlZUGTTJPJg13Kw==
 
 lightningcss-darwin-arm64@1.23.0:
   version "1.23.0"


### PR DESCRIPTION
## Bug Fixes
- Code Revert: Revert changes introduced in 621346b30ba5efc7065a3b394521e92914e8ff98 ([#11947](https://github.com/18F/identity-idp/pull/11947))
- Reporting: Fix missing field in profile-summary when data is missing ([#11952](https://github.com/18F/identity-idp/pull/11952))
- SAML: Ensure validations work when there is no valid service provider ([#11946](https://github.com/18F/identity-idp/pull/11946))
- selfie capture: Do not display previous empty state design ([#11931](https://github.com/18F/identity-idp/pull/11931))

## Internal
- Dependencies: Update dependencies to latest versions ([#11949](https://github.com/18F/identity-idp/pull/11949))
- In-person proofing: Move in person enrollment clean up in welcome controller from on update to a before action ([#11939](https://github.com/18F/identity-idp/pull/11939))
- KMS logging: Add a timestamp to the kms logger ([#11933](https://github.com/18F/identity-idp/pull/11933))
- Maintenance: Update uri gem to resolve security vulnerability ([#11945](https://github.com/18F/identity-idp/pull/11945))
- Reporting: Adding timestamp and table exclusion overrides ([#11937](https://github.com/18F/identity-idp/pull/11937))
