### PR TITLE
LG-15586 Remove the "Entered the wrong number" message from IdV OTP verification controller

### DIFF
--- a/app/views/idv/otp_verification/show.html.erb
+++ b/app/views/idv/otp_verification/show.html.erb
@@ -42,7 +42,6 @@
     ).with_content(t('links.two_factor_authentication.send_another_code')) %>
 
 <p>
-  <%= t('instructions.mfa.wrong_number') %><br>
   <%= link_to(t('forms.two_factor.try_again'), idv_phone_path(step: 'phone_otp_verification')) %>
 </p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1396,7 +1396,6 @@ instructions.mfa.voice.number_message_html: We made a call with a one-time code 
 instructions.mfa.webauthn_platform.learn_more_help: Learn more about face or touch unlock
 instructions.mfa.webauthn.confirm_webauthn: Present the security key that you associated with your account.
 instructions.mfa.webauthn.confirm_webauthn_platform_html: '<p>You can authenticate the same way you unlock your device, whether it’s with your face or fingerprint, a password or another method. </p> <p>If you used a password manager to set up face or touch unlock, you can authenticate from any device that uses that password manager. Otherwise, use the same device where you set up face or touch unlock.</p>'
-instructions.mfa.wrong_number: Entered the wrong phone number?
 instructions.password.forgot: Don’t know your password? Reset it after confirming your email address.
 instructions.password.help_text: Avoid reusing passwords from your other accounts, such as your banks, email and social media. Don’t include words from your email address.
 instructions.password.help_text_header: Password safety tips

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1407,7 +1407,6 @@ instructions.mfa.voice.number_message_html: Hicimos una llamada con un código d
 instructions.mfa.webauthn_platform.learn_more_help: Obtenga más información sobre el desbloqueo facial o táctil
 instructions.mfa.webauthn.confirm_webauthn: Presente la clave de seguridad que asoció con su cuenta.
 instructions.mfa.webauthn.confirm_webauthn_platform_html: '<p>Puede autenticarse de la misma forma que desbloquea el dispositivo, sea con su rostro o huella dactilar, contraseña u otro método. </p><p>Si usó un administrador de contraseñas para configurar el desbloqueo facial o táctil, puede autenticarse desde cualquier dispositivo que utilice ese administrador de contraseñas. De lo contrario, use el mismo dispositivo con el que configuró el desbloqueo facial o táctil.</p>'
-instructions.mfa.wrong_number: '¿Ingresó el número de teléfono equivocado?'
 instructions.password.forgot: '¿No sabe su contraseña? Restablézcala después de confirmar su dirección de correo electrónico.'
 instructions.password.help_text: Evite usar las mismas contraseñas de sus otras cuentas, como las de su banco, correo electrónico y redes sociales. No incluya palabras de su dirección de correo electrónico.
 instructions.password.help_text_header: Consejos para la seguridad de las contraseñas

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1396,7 +1396,6 @@ instructions.mfa.voice.number_message_html: Nous avons passé un appel avec un c
 instructions.mfa.webauthn_platform.learn_more_help: En savoir plus sur le déverrouillage facial ou tactile
 instructions.mfa.webauthn.confirm_webauthn: Présentez la clé de sécurité associée à votre compte.
 instructions.mfa.webauthn.confirm_webauthn_platform_html: '<p>Vous pouvez vous authentifier de la même manière que vous déverrouillez votre appareil, que ce soit avec votre visage ou votre empreinte digitale, un mot de passe ou une autre méthode. </p> <p>Si vous avez utilisé un gestionnaire de mots de passe pour configurer le déverrouillage facial ou tactile, vous pouvez vous authentifier à partir de n’importe quel appareil utilisant ce gestionnaire. Sinon, utilisez le même appareil que celui sur lequel vous avez configuré le déverrouillage facial ou tactile.</p>'
-instructions.mfa.wrong_number: Vous avez saisi un mauvais numéro de téléphone ?
 instructions.password.forgot: Vous ne connaissez pas votre mot de passe ? Réinitialisez-le après avoir confirmé votre adresse e-mail.
 instructions.password.help_text: Évitez de réutiliser les mots de passe de vos autres comptes, tels que ceux de vos banques, adresses e-mail et comptes de réseaux sociaux. N’incluez pas de mots figurant dans votre adresse e-mail.
 instructions.password.help_text_header: Conseils de sécurité pour votre mot de passe

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1409,7 +1409,6 @@ instructions.mfa.voice.number_message_html: 我们给 %{number_html}打了电话
 instructions.mfa.webauthn_platform.learn_more_help: 了解更多有关人脸或触摸解锁的信息
 instructions.mfa.webauthn.confirm_webauthn: 提供与你账户相关的安全密钥。
 instructions.mfa.webauthn.confirm_webauthn_platform_html: '<p>你可以像解锁你的设备一样来做身份证实，无论是用你的面孔还是指纹、密码或者其他方法。</p> <p>如果你用一个密码管理器设置了人脸或触摸解锁，则可以从使用那一密码管理器的任何设备进行身份证实。否则的话，使用你设置人脸或触摸解锁的同一设备。</p>'
-instructions.mfa.wrong_number: 输入的电话号码不对？
 instructions.password.forgot: 不知道你的密码？确认你的电邮地址后重设密码。
 instructions.password.help_text: 避免重复使用你其他网上账户（比如银行、电邮和社交媒体）的密码。请勿包括你电邮地址中的单词。
 instructions.password.help_text_header: 密码安全提示


### PR DESCRIPTION
As part of the phone-finder pre-check work the user can arrive on the OTP verification screen without entering a number. In this case the "Entered the wrong number" message on the screen does not make sense.

This commit removes the message and leaves the link that allows a user to try a different number.

English:
![image](https://github.com/user-attachments/assets/64987383-2f98-492b-adbd-4b8fe5b17516)

Spanish:
![image](https://github.com/user-attachments/assets/1eb7e46d-2c2b-457a-b6b7-6722ff98b4a7)

French:
![image](https://github.com/user-attachments/assets/f3a99384-e642-4859-91c8-7473d569ec50)

Chinese:
![image](https://github.com/user-attachments/assets/95351338-b3cb-4ddd-ba5e-0e7ca7bbf1fa)
