### PR TITLE
LG-12326 Update the phone warning screen message

### DIFF
--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -9,7 +9,7 @@
       <% if @phone %>
         <p>
           <%= t('idv.failure.phone.warning.you_entered') %>
-          <strong><%= PhoneFormatter.format(@phone, country_code: @country_code) %></strong>
+          <strong class='text-no-wrap'><%= PhoneFormatter.format(@phone, country_code: @country_code) %></strong>
         </p>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1089,7 +1089,7 @@ idv.failure.phone.warning.heading: We couldn’t match you to this number
 idv.failure.phone.warning.learn_more_link: Learn more about what phone number to use
 idv.failure.phone.warning.next_steps_html: Try <strong>another</strong> number that you use often and have used for a long time. This can be a work or home number.
 idv.failure.phone.warning.try_again_button: Try another number
-idv.failure.phone.warning.you_entered: "We couldn't find a record of you using this number:"
+idv.failure.phone.warning.you_entered: 'We couldn’t find a record of you using this number:'
 idv.failure.sessions.exception: There was an internal error processing your request.
 idv.failure.sessions.fail_html: For your security, we limit the number of times you can attempt to verify personal information online. <strong>Try again in %{timeout}.</strong>
 idv.failure.sessions.heading: We couldn’t find records matching your personal information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1089,7 +1089,7 @@ idv.failure.phone.warning.heading: We couldn’t match you to this number
 idv.failure.phone.warning.learn_more_link: Learn more about what phone number to use
 idv.failure.phone.warning.next_steps_html: Try <strong>another</strong> number that you use often and have used for a long time. This can be a work or home number.
 idv.failure.phone.warning.try_again_button: Try another number
-idv.failure.phone.warning.you_entered: 'You entered:'
+idv.failure.phone.warning.you_entered: "We couldn't find a record of you using this number:"
 idv.failure.sessions.exception: There was an internal error processing your request.
 idv.failure.sessions.fail_html: For your security, we limit the number of times you can attempt to verify personal information online. <strong>Try again in %{timeout}.</strong>
 idv.failure.sessions.heading: We couldn’t find records matching your personal information

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1100,7 +1100,7 @@ idv.failure.phone.warning.heading: No pudimos asociarlo a este número
 idv.failure.phone.warning.learn_more_link: Obtenga más información sobre el número de teléfono que debe usar
 idv.failure.phone.warning.next_steps_html: Intente con <strong>otro</strong> número que use a menudo y haya usado por mucho tiempo. Puede ser el número del trabajo o de casa.
 idv.failure.phone.warning.try_again_button: Intentar con otro número
-idv.failure.phone.warning.you_entered: 'Usted ingresó:'
+idv.failure.phone.warning.you_entered: 'No pudimos encontrar su registro con este número:'
 idv.failure.sessions.exception: Hubo un error interno al procesar su solicitud.
 idv.failure.sessions.fail_html: Por su seguridad, limitamos el número de veces que puede intentar verificar la información personal en línea. <strong>Vuelva a intentarlo en %{timeout}.</strong>
 idv.failure.sessions.heading: No encontramos registros que coincidan con sus datos personales

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1089,7 +1089,7 @@ idv.failure.phone.warning.heading: Nous n’avons pas pu vous associer à ce num
 idv.failure.phone.warning.learn_more_link: En savoir plus sur quel numéro de téléphone utiliser
 idv.failure.phone.warning.next_steps_html: Essayez <strong>un autre</strong> numéro que vous utilisez souvent et depuis longtemps. Il peut s’agir d’un numéro professionnel ou personnel.
 idv.failure.phone.warning.try_again_button: Essayez un autre numéro
-idv.failure.phone.warning.you_entered: 'Vous avez saisi :'
+idv.failure.phone.warning.you_entered: 'Nous n’avons pas trouvé de données vous associant au numéro suivant :'
 idv.failure.sessions.exception: Une erreur interne s’est produite lors du traitement de votre demande.
 idv.failure.sessions.fail_html: Pour votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier des renseignements personnels en ligne. <strong>Réessayez dans %{timeout}.</strong>
 idv.failure.sessions.heading: Nous n’avons pas trouvé de dossiers correspondant à vos informations personnelles

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1102,7 +1102,7 @@ idv.failure.phone.warning.heading: 我们无法将你与该号码匹配。
 idv.failure.phone.warning.learn_more_link: 了解有关使用什么号码的更多信息。
 idv.failure.phone.warning.next_steps_html: 尝试 <strong>另一个</strong> 你经常使用并用了很久的号码。 工作或住宅号码都行。
 idv.failure.phone.warning.try_again_button: 尝试另一个号码
-idv.failure.phone.warning.you_entered: 你输入了：
+idv.failure.phone.warning.you_entered: 我们找不到你使用此号码的记录：
 idv.failure.sessions.exception: 处理你的请求时内部出错。
 idv.failure.sessions.fail_html: 出于安全考虑，我们限制你在网上尝试验证个人信息的次数。<strong> %{timeout}后再试。</strong>
 idv.failure.sessions.heading: 我们找不到与你个人信息匹配的记录


### PR DESCRIPTION
As part of the phone-finder pre-check work the user can arrive on the phone warning screen without entering a number. In this case the "You entered (XXX) XXX-XXXX" message on the screen does not make sense.

This commit changes the message to say "We couldn't find a record of you using this number: (XXX) XXX-XXXX".

English:
![image](https://github.com/user-attachments/assets/8e06244d-c13a-4148-ab7f-1cdd7223f2b7)

Spanish:
![image](https://github.com/user-attachments/assets/dbf073ac-6a9e-4673-916b-f4053b71d0fe)

French:
![image](https://github.com/user-attachments/assets/6f3d5033-1318-4984-82b2-7a7dea058f22)

Chinese:
![image](https://github.com/user-attachments/assets/d3e7da0f-4fa4-41a6-84d2-b8b6e8c20a7d)
