### PR TITLE
LG-15573 Make the `--depth` argument required for IG data pull script

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -895,6 +895,10 @@ Rails/EnumSyntax:
 Rails/EnvLocal:
   Enabled: true
 
+# Disabling this can cause confusing errors and disabling it should be avoided
+Rails/Exit:
+  Enabled: true
+
 Rails/ExpandedDateRange:
   Enabled: true
 

--- a/bin/action-account
+++ b/bin/action-account
@@ -3,4 +3,10 @@
 ENV['LOGIN_TASK_LOG_LEVEL'] ||= 'warn'
 require_relative '../config/environment.rb'
 require 'action_account'
-ActionAccount.new(argv: ARGV.dup, stdout: STDOUT, stderr: STDERR).run
+begin
+  ActionAccount.new(argv: ARGV.dup, stdout: STDOUT, stderr: STDERR).run
+rescue => err
+  STDERR.puts "#{err.class.name}: #{err.message}"
+
+  exit 1
+end

--- a/bin/data-pull
+++ b/bin/data-pull
@@ -3,4 +3,10 @@
 ENV['LOGIN_TASK_LOG_LEVEL'] ||= 'warn'
 require_relative '../config/environment.rb'
 require 'data_pull'
-DataPull.new(argv: ARGV.dup, stdout: STDOUT, stderr: STDERR).run
+begin
+  DataPull.new(argv: ARGV.dup, stdout: STDOUT, stderr: STDERR).run
+rescue => err
+  STDERR.puts "#{err.class.name}: #{err.message}"
+
+  exit 1
+end

--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -203,6 +203,10 @@ class DataPull
       ActiveRecord::Base.connection.execute('SET statement_timeout = 0')
       uuids = args
 
+      if config.depth.nil?
+        raise 'Required argument --depth is missing'
+      end
+
       requesting_issuers =
         config.requesting_issuers.presence || compute_requesting_issuers(uuids)
 
@@ -211,7 +215,7 @@ class DataPull
       end.partition { |u| u.is_a?(User) }
 
       shared_device_users =
-        if config.depth && config.depth > 0
+        if config.depth > 0
           DataRequests::Deployed::LookupSharedDeviceUsers.new(users, config.depth).call
         else
           users

--- a/lib/script_base.rb
+++ b/lib/script_base.rb
@@ -108,10 +108,6 @@ class ScriptBase
       format: config.format,
       stdout: stdout,
     )
-
-    stderr.puts "#{err.class.name}: #{err.message}"
-
-    exit 1 # rubocop:disable Rails/Exit
   end
 
   # rubocop:disable Metrics/BlockLength

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -110,7 +110,8 @@ RSpec.describe DataPull do
       let(:identity) { IdentityLinker.new(user, service_provider).link_identity }
 
       let(:argv) do
-        ['ig-request', identity.uuid, '--requesting-issuer', service_provider.issuer]
+        ['ig-request', identity.uuid, '--requesting-issuer', service_provider.issuer,
+         '--depth', '1']
       end
 
       it 'runs the data requests report and prints it as JSON' do
@@ -130,7 +131,7 @@ RSpec.describe DataPull do
       context 'with a UUID that is not found' do
         let(:uuid) { 'abcdef' }
         let(:argv) do
-          ['ig-request', uuid, '--requesting-issuer', service_provider.issuer]
+          ['ig-request', uuid, '--requesting-issuer', service_provider.issuer, '--depth', '1']
         end
 
         it 'returns an empty hash for that user' do

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -327,7 +327,9 @@ RSpec.describe DataPull do
       let(:service_provider) { create(:service_provider) }
       let(:identity) { IdentityLinker.new(user, service_provider).link_identity }
       let(:args) { [user.uuid] }
-      let(:config) { ScriptBase::Config.new(requesting_issuers: [service_provider.issuer]) }
+      let(:config) do
+        ScriptBase::Config.new(requesting_issuers: [service_provider.issuer], depth: 0)
+      end
 
       subject(:result) { subtask.run(args:, config:) }
 
@@ -348,7 +350,7 @@ RSpec.describe DataPull do
 
       context 'with SP UUID argument and no requesting issuer' do
         let(:args) { [identity.uuid] }
-        let(:config) { ScriptBase::Config.new }
+        let(:config) { ScriptBase::Config.new(depth: 0) }
 
         it 'runs the report with computed requesting issuer', aggregate_failures: true do
           expect(result.table).to be_nil
@@ -363,6 +365,14 @@ RSpec.describe DataPull do
 
           expect(result.subtask).to eq('ig-request')
           expect(result.uuids).to eq([user.uuid])
+        end
+      end
+
+      context 'without a depth argument' do
+        let(:config) { ScriptBase::Config.new }
+
+        it 'raises an error about the argument being required' do
+          expect { result }.to raise_error('Required argument --depth is missing')
         end
       end
     end

--- a/spec/lib/script_base_spec.rb
+++ b/spec/lib/script_base_spec.rb
@@ -85,12 +85,9 @@ RSpec.describe ScriptBase do
         base.config.format = :csv
       end
 
-      it 'logs the error message to stderr but not the backtrace' do
-        expect(base).to receive(:exit).with(1)
-
+      it 'logs the error message in the output but not the backtrace' do
         expect { base.run }.to_not raise_error
 
-        expect(stderr.string.chomp).to eq('RuntimeError: some dangerous error')
         expect(CSV.parse(stdout.string)).to eq(
           [
             %w[Error Message],


### PR DESCRIPTION
We often get requests for data that involve searching for accounts that share devices. These kinds of requests occur more often than not. Currently we default to not searching for shared devices. This has led to mistakes where we did not provide shared account data.

This commit attempts to address the issue by making the `--depth` argument required. This will require investigators to explicitly opt-in or out of shared device searches.

From @mitchellhenke:

> The `exit 1` in `lib/script_base.rb` was causing some rather opaque failures in CI as it sets the status code to 1 and caused some tests to end early rather without reporting whether they failed. The unhelpful message at the end of a CI run was `Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected`.
> 
> This only became an issue because the PR added a case where we raise an exception and it resulted in a non-zero status code. 