### PR TITLE
Remove single-region key encryption for password and recovery key

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -23,8 +23,9 @@ module UserAccessKeyOverrides
   def password=(new_password)
     @password = new_password
     return if @password.blank?
-    self.encrypted_password_digest, self.encrypted_password_digest_multi_region =
-      Encryption::PasswordVerifier.new.create_digest_pair(
+    self.encrypted_password_digest = nil
+    self.encrypted_password_digest_multi_region =
+      Encryption::PasswordVerifier.new.create_digest(
         password: @password,
         user_uuid: uuid || generate_uuid,
       )
@@ -49,8 +50,9 @@ module UserAccessKeyOverrides
   def personal_key=(new_personal_key)
     @personal_key = new_personal_key
     return if new_personal_key.blank?
-    self.encrypted_recovery_code_digest, self.encrypted_recovery_code_digest_multi_region =
-      Encryption::PasswordVerifier.new.create_digest_pair(
+    self.encrypted_recovery_code_digest = nil
+    self.encrypted_recovery_code_digest_multi_region =
+      Encryption::PasswordVerifier.new.create_digest(
         password: new_personal_key,
         user_uuid: uuid || generate_uuid,
       )

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -163,16 +163,14 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
     it 'does generate a new personal key after the user signs in with their old one' do
       user = create(:user)
       raw_key = PersonalKeyGenerator.new(user).generate!
-      old_key = user.reload.encrypted_recovery_code_digest
-      old_multi_region_key = user.reload.encrypted_recovery_code_digest_multi_region
+      old_key = user.reload.encrypted_recovery_code_digest_multi_region
       stub_sign_in_before_2fa(user)
       post :create, params: { personal_key_form: { personal_key: raw_key } }
       user.reload
 
-      expect(user.encrypted_recovery_code_digest).to be_present
-      expect(user.encrypted_recovery_code_digest).to_not eq old_key
+      expect(user.encrypted_recovery_code_digest).to_not be_present
       expect(user.encrypted_recovery_code_digest_multi_region).to be_present
-      expect(user.encrypted_recovery_code_digest_multi_region).to_not eq old_multi_region_key
+      expect(user.encrypted_recovery_code_digest_multi_region).to_not eq old_key
     end
 
     it 'redirects to the two_factor_options page if user is IAL2' do

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -76,11 +76,7 @@ RSpec.describe Users::PasswordsController do
           patch :update, params: { update_user_password_form: params }
         end.to(
           change { user.reload.encrypted_password_digest_multi_region }.and(
-            change { user.reload.encrypted_recovery_code_digest_multi_region }.and(
-              change { user.reload.encrypted_password_digest }.and(
-                change { user.reload.encrypted_recovery_code_digest },
-              ),
-            ),
+            change { user.reload.encrypted_recovery_code_digest_multi_region },
           ),
         )
 

--- a/spec/features/legacy_passwords_spec.rb
+++ b/spec/features/legacy_passwords_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'legacy passwords' do
     )
   end
 
-  scenario 'signing in with a personal key digested by the uak verifier make a new digest' do
+  scenario 'signing in with a personal key digested by the uak verifier makes a new digest' do
     user = create(:user, :fully_registered)
     user.update!(
       encrypted_recovery_code_digest: Encryption::UakPasswordVerifier.digest('1111 2222 3333 4444'),
@@ -55,7 +55,7 @@ RSpec.feature 'legacy passwords' do
     click_submit_default
     user.reload
 
-    expect(user.encrypted_recovery_code_digest).to be_present
+    expect(user.encrypted_recovery_code_digest).to be_nil
     expect(user.encrypted_recovery_code_digest_multi_region).to be_present
   end
 

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -7,15 +7,16 @@ RSpec.feature 'Signing in via one-time use personal key' do
       with: { phone: '+1 (202) 345-6789' }
     )
     raw_key = PersonalKeyGenerator.new(user).generate!
-    old_key_multi_region = user.reload.encrypted_recovery_code_digest_multi_region
-    old_key = user.reload.encrypted_recovery_code_digest
+    old_key = user.reload.encrypted_recovery_code_digest_multi_region
 
     sign_in_before_2fa(user)
     choose_another_security_option('personal_key')
     enter_personal_key(personal_key: raw_key)
     click_submit_default
-    expect(user.reload.encrypted_recovery_code_digest).to_not eq old_key
-    expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq old_key_multi_region
+
+    user.reload
+    expect(user.encrypted_recovery_code_digest).to_not be_present
+    expect(user.encrypted_recovery_code_digest_multi_region).to_not eq old_key
     expect(page).to have_current_path account_path
 
     last_message = Telephony::Test::Message.messages.last

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -11,8 +11,7 @@ RSpec.feature 'View personal key' do
     context 'regenerating personal key' do
       scenario 'displays new code and notifies the user' do
         sign_in_and_2fa_user(user)
-        old_digest = user.encrypted_recovery_code_digest
-        old_digest_multi_region = user.encrypted_recovery_code_digest_multi_region
+        old_digest = user.encrypted_recovery_code_digest_multi_region
 
         expect(Telephony).to receive(:send_personal_key_regeneration_notice)
           .with(to: user.phone_configurations.first.phone, country_code: 'US')
@@ -21,10 +20,9 @@ RSpec.feature 'View personal key' do
         click_on(t('account.links.regenerate_personal_key'), match: :prefer_exact)
         click_continue
 
-        expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq(
-          old_digest_multi_region,
-        )
-        expect(user.reload.encrypted_recovery_code_digest).to_not eq(old_digest)
+        user.reload
+        expect(user.encrypted_recovery_code_digest).to_not be_present
+        expect(user.encrypted_recovery_code_digest_multi_region).to_not eq old_digest
 
         expect_delivered_email_count(1)
         expect_delivered_email(
@@ -37,8 +35,7 @@ RSpec.feature 'View personal key' do
     context 'regenerating new code after canceling edit password action' do
       scenario 'displays new code' do
         sign_in_and_2fa_user(user)
-        old_digest = user.encrypted_recovery_code_digest
-        old_digest_multi_region = user.encrypted_recovery_code_digest_multi_region
+        old_digest = user.encrypted_recovery_code_digest_multi_region
 
         first(:link, t('forms.buttons.edit')).click
         click_on(t('links.cancel'))
@@ -61,10 +58,8 @@ RSpec.feature 'View personal key' do
         expect(page).to have_content(t('forms.personal_key_partial.acknowledgement.header'))
         acknowledge_and_confirm_personal_key
 
-        expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq(
-          old_digest_multi_region,
-        )
-        expect(user.reload.encrypted_recovery_code_digest).to_not eq(old_digest)
+        expect(user.reload.encrypted_recovery_code_digest).to_not be_present
+        expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq old_digest
       end
     end
   end

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PersonalKeyForm do
           success: false,
           error_details: { personal_key: { personal_key_incorrect: true } },
         )
-        expect(user.encrypted_recovery_code_digest).to_not be_nil
+        expect(user.encrypted_recovery_code_digest).to be_nil
         expect(user.encrypted_recovery_code_digest_multi_region).to_not be_nil
         expect(form.personal_key).to be_nil
       end

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -64,9 +64,7 @@ RSpec.describe ResetPasswordForm, type: :model do
       end
 
       it 'sets the user password to the submitted password' do
-        expect { result }.to change { user.reload.encrypted_password_digest }.and(
-          change { user.reload.encrypted_password_digest_multi_region },
-        )
+        expect { result }.to change { user.reload.encrypted_password_digest_multi_region }
 
         expect(result.to_h).to eq(
           success: true,

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -79,11 +79,7 @@ RSpec.describe SecurityEventForm do
         end
 
         it 'resets the user password for authorization fraud detected events' do
-          expect { submit }.to(
-            change { user.reload.encrypted_password_digest_multi_region }.and(
-              change { user.reload.encrypted_password_digest },
-            ),
-          )
+          expect { submit }.to(change { user.reload.encrypted_password_digest_multi_region })
         end
       end
 

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -25,12 +25,10 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
         expect(UserProfilesEncryptor).not_to receive(:new)
         user.save!
 
-        old_digest = user.encrypted_password_digest
-        old_digest_multi_region = user.encrypted_password_digest_multi_region
+        old_digest = user.encrypted_password_digest_multi_region
 
         result = subject.submit(params).to_h
-        expect(old_digest_multi_region).to eq(user.reload.encrypted_password_digest_multi_region)
-        expect(old_digest).to eq(user.reload.encrypted_password_digest)
+        expect(old_digest).to eq(user.reload.encrypted_password_digest_multi_region)
 
         expect(result).to include(
           success: false,
@@ -55,11 +53,7 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
 
         expect do
           subject.submit(params)
-        end.to(
-          change { user.reload.encrypted_password_digest_multi_region }.and(
-            change { user.reload.encrypted_password_digest },
-          ),
-        )
+        end.to(change { user.reload.encrypted_password_digest_multi_region })
       end
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -100,18 +100,16 @@ RSpec.describe Profile do
       expect(profile.encrypted_pii_recovery).to be_nil
       expect(profile.encrypted_pii_recovery_multi_region).to be_nil
 
-      initial_personal_key = user.encrypted_recovery_code_digest
-      initial_personal_key_multi_region = user.encrypted_recovery_code_digest_multi_region
+      initial_personal_key = user.encrypted_recovery_code_digest_multi_region
 
       encrypt_pii
 
       expect(profile.encrypted_pii_recovery).to be_present
       expect(profile.encrypted_pii_recovery_multi_region).to be_present
 
-      expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq(
-        initial_personal_key_multi_region,
-      )
-      expect(user.reload.encrypted_recovery_code_digest).to_not eq initial_personal_key
+      user.reload
+      expect(user.encrypted_recovery_code_digest).to_not be_present
+      expect(user.encrypted_recovery_code_digest_multi_region).to_not eq initial_personal_key
     end
 
     it 'updates the personal key digest generation time' do
@@ -172,21 +170,16 @@ RSpec.describe Profile do
       expect(profile.encrypted_pii_recovery).to be_nil
       expect(profile.encrypted_pii_recovery_multi_region).to be_nil
 
-      initial_personal_key = user.encrypted_recovery_code_digest
-      initial_personal_key_multi_region = user.encrypted_recovery_code_digest_multi_region
+      initial_personal_key = user.encrypted_recovery_code_digest_multi_region
 
       profile.encrypt_recovery_pii(pii)
 
       expect(profile.encrypted_pii_recovery).to be_present
       expect(profile.encrypted_pii_recovery_multi_region).to be_present
 
-      expect(user.reload.encrypted_recovery_code_digest).to_not eq(
-        initial_personal_key,
-      )
-      expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq(
-        initial_personal_key_multi_region,
-      )
-      expect(profile.personal_key).to_not eq user.encrypted_recovery_code_digest
+      user.reload
+      expect(user.encrypted_recovery_code_digest).to_not be_present
+      expect(user.encrypted_recovery_code_digest_multi_region).to_not eq initial_personal_key
       expect(profile.personal_key).to_not eq user.encrypted_recovery_code_digest_multi_region
     end
 

--- a/spec/services/personal_key_generator_spec.rb
+++ b/spec/services/personal_key_generator_spec.rb
@@ -41,13 +41,13 @@ RSpec.describe PersonalKeyGenerator do
       expect(generator.generate!).to match(fourteen_letters_and_spaces_start_end_with_letter)
     end
 
-    it 'sets the encrypted recovery code digest' do
+    it 'sets only the multi-region encrypted recovery code digest' do
       user = create(:user)
       generator = PersonalKeyGenerator.new(user)
       key = generator.generate!
 
-      expect(user.encrypted_recovery_code_digest).to_not be_empty
-      expect(user.encrypted_recovery_code_digest_multi_region).to_not be_empty
+      expect(user.encrypted_recovery_code_digest).to be_blank
+      expect(user.encrypted_recovery_code_digest_multi_region).to_not be_blank
       expect(generator.verify(key)).to eq(true)
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[!51](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/151)

## 🛠 Summary of changes

Related PRs:
- https://github.com/18F/identity-idp/pull/8934
- https://github.com/18F/identity-idp/pull/8973
- https://github.com/18F/identity-idp/pull/9047
- https://github.com/18F/identity-idp/pull/9164

We have been using the multi-region key as our primary key, and can begin winding down the encryption usage of the old single-region key. We cannot yet remove it entirely due to passwords and recover keys encrypted via `UserAccessKey`.

This PR stops encrypting new passwords and personal keys with the single-region KMS key.

This should not be merged until #11966 has been deployed.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
