### PR TITLE
Ensure reading of multi-region encrypted passwords and personal keys

### DIFF
--- a/app/models/concerns/user_access_key_overrides.rb
+++ b/app/models/concerns/user_access_key_overrides.rb
@@ -70,6 +70,7 @@ module UserAccessKeyOverrides
   end
 
   def rotate_stale_password_digest
+    return if encrypted_password_digest.blank?
     return unless Encryption::PasswordVerifier.new.stale_digest?(
       encrypted_password_digest,
     )
@@ -80,9 +81,10 @@ module UserAccessKeyOverrides
   # as Devise depends on this for things like building the key to use when
   # storing the user in the session.
   def authenticatable_salt
-    return if encrypted_password_digest.blank?
+    digest = password_regional_digest_pair.multi_or_single_region_ciphertext
+    return if digest.blank?
     Encryption::PasswordVerifier::PasswordDigest.parse_from_string(
-      encrypted_password_digest,
+      digest,
     ).password_salt
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -543,6 +543,10 @@ class User < ApplicationRecord
       .first&.profile
   end
 
+  def has_recovery_code?
+    encrypted_recovery_code_digest_multi_region.present? || encrypted_recovery_code_digest.present?
+  end
+
   private
 
   def find_password_reset_profile

--- a/app/policies/two_factor_authentication/personal_key_policy.rb
+++ b/app/policies/two_factor_authentication/personal_key_policy.rb
@@ -9,8 +9,7 @@ module TwoFactorAuthentication
     end
 
     def configured?
-      user&.encrypted_recovery_code_digest_multi_region.present? ||
-        user&.encrypted_recovery_code_digest.present?
+      user&.has_recovery_code?
     end
 
     def enabled?

--- a/app/policies/two_factor_authentication/personal_key_policy.rb
+++ b/app/policies/two_factor_authentication/personal_key_policy.rb
@@ -9,7 +9,8 @@ module TwoFactorAuthentication
     end
 
     def configured?
-      user&.encrypted_recovery_code_digest.present?
+      user&.encrypted_recovery_code_digest_multi_region.present? ||
+        user&.encrypted_recovery_code_digest.present?
     end
 
     def enabled?

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -36,7 +36,8 @@ class AccountShowPresenter
   end
 
   def show_manage_personal_key_partial?
-    user.encrypted_recovery_code_digest.present? &&
+    (user.encrypted_recovery_code_digest_multi_region.present? ||
+     user.encrypted_recovery_code_digest.present?) &&
       user.password_reset_profile.blank?
   end
 

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -36,9 +36,7 @@ class AccountShowPresenter
   end
 
   def show_manage_personal_key_partial?
-    (user.encrypted_recovery_code_digest_multi_region.present? ||
-     user.encrypted_recovery_code_digest.present?) &&
-      user.password_reset_profile.blank?
+    user.has_recovery_code? && user.password_reset_profile.blank?
   end
 
   def show_service_provider_continue_partial?

--- a/app/presenters/navigation_presenter.rb
+++ b/app/presenters/navigation_presenter.rb
@@ -19,7 +19,7 @@ class NavigationPresenter
           NavItem.new(I18n.t('account.navigation.add_email'), add_email_path),
           NavItem.new(I18n.t('account.navigation.edit_password'), manage_password_path),
           NavItem.new(I18n.t('account.navigation.delete_account'), account_delete_path),
-          recovery_code_present? && user.active_profile ? NavItem.new(
+          user.has_recovery_code? && user.active_profile ? NavItem.new(
             I18n.t('account.navigation.reset_personal_key'), create_new_personal_key_path
           ) : nil,
         ].compact
@@ -58,11 +58,6 @@ class NavigationPresenter
       ),
       NavItem.new(I18n.t('account.navigation.customer_support'), help_center_redirect_url, []),
     ]
-  end
-
-  def recovery_code_present?
-    user.encrypted_recovery_code_digest_multi_region.present? ||
-      user.encrypted_recovery_code_digest.present?
   end
 
   def backup_codes_path

--- a/app/presenters/navigation_presenter.rb
+++ b/app/presenters/navigation_presenter.rb
@@ -19,7 +19,7 @@ class NavigationPresenter
           NavItem.new(I18n.t('account.navigation.add_email'), add_email_path),
           NavItem.new(I18n.t('account.navigation.edit_password'), manage_password_path),
           NavItem.new(I18n.t('account.navigation.delete_account'), account_delete_path),
-          user.encrypted_recovery_code_digest.present? && user.active_profile ? NavItem.new(
+          recovery_code_present? && user.active_profile ? NavItem.new(
             I18n.t('account.navigation.reset_personal_key'), create_new_personal_key_path
           ) : nil,
         ].compact
@@ -58,6 +58,11 @@ class NavigationPresenter
       ),
       NavItem.new(I18n.t('account.navigation.customer_support'), help_center_redirect_url, []),
     ]
+  end
+
+  def recovery_code_present?
+    user.encrypted_recovery_code_digest_multi_region.present? ||
+      user.encrypted_recovery_code_digest.present?
   end
 
   def backup_codes_path

--- a/app/services/encryption/password_verifier.rb
+++ b/app/services/encryption/password_verifier.rb
@@ -87,6 +87,7 @@ module Encryption
     end
 
     def stale_digest?(digest)
+      return false if digest.blank?
       PasswordDigest.parse_from_string(digest).uak_password_digest?
     end
 

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -164,12 +164,15 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
       user = create(:user)
       raw_key = PersonalKeyGenerator.new(user).generate!
       old_key = user.reload.encrypted_recovery_code_digest
+      old_multi_region_key = user.reload.encrypted_recovery_code_digest_multi_region
       stub_sign_in_before_2fa(user)
       post :create, params: { personal_key_form: { personal_key: raw_key } }
       user.reload
 
       expect(user.encrypted_recovery_code_digest).to be_present
       expect(user.encrypted_recovery_code_digest).to_not eq old_key
+      expect(user.encrypted_recovery_code_digest_multi_region).to be_present
+      expect(user.encrypted_recovery_code_digest_multi_region).to_not eq old_multi_region_key
     end
 
     it 'redirects to the two_factor_options page if user is IAL2' do

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -75,8 +75,12 @@ RSpec.describe Users::PasswordsController do
         expect do
           patch :update, params: { update_user_password_form: params }
         end.to(
-          change { user.reload.encrypted_password_digest }.and(
-            change { user.reload.encrypted_recovery_code_digest },
+          change { user.reload.encrypted_password_digest_multi_region }.and(
+            change { user.reload.encrypted_recovery_code_digest_multi_region }.and(
+              change { user.reload.encrypted_password_digest }.and(
+                change { user.reload.encrypted_recovery_code_digest },
+              ),
+            ),
           ),
         )
 

--- a/spec/features/legacy_passwords_spec.rb
+++ b/spec/features/legacy_passwords_spec.rb
@@ -56,6 +56,7 @@ RSpec.feature 'legacy passwords' do
     user.reload
 
     expect(user.encrypted_recovery_code_digest).to be_present
+    expect(user.encrypted_recovery_code_digest_multi_region).to be_present
   end
 
   scenario 'signing in with an incorrect uak personal key digest does not grant access' do

--- a/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
+++ b/spec/features/two_factor_authentication/sign_in_via_personal_key_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Signing in via one-time use personal key' do
       with: { phone: '+1 (202) 345-6789' }
     )
     raw_key = PersonalKeyGenerator.new(user).generate!
+    old_key_multi_region = user.reload.encrypted_recovery_code_digest_multi_region
     old_key = user.reload.encrypted_recovery_code_digest
 
     sign_in_before_2fa(user)
@@ -14,6 +15,7 @@ RSpec.feature 'Signing in via one-time use personal key' do
     enter_personal_key(personal_key: raw_key)
     click_submit_default
     expect(user.reload.encrypted_recovery_code_digest).to_not eq old_key
+    expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq old_key_multi_region
     expect(page).to have_current_path account_path
 
     last_message = Telephony::Test::Message.messages.last

--- a/spec/features/users/regenerate_personal_key_spec.rb
+++ b/spec/features/users/regenerate_personal_key_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'View personal key' do
       scenario 'displays new code and notifies the user' do
         sign_in_and_2fa_user(user)
         old_digest = user.encrypted_recovery_code_digest
+        old_digest_multi_region = user.encrypted_recovery_code_digest_multi_region
 
         expect(Telephony).to receive(:send_personal_key_regeneration_notice)
           .with(to: user.phone_configurations.first.phone, country_code: 'US')
@@ -20,7 +21,10 @@ RSpec.feature 'View personal key' do
         click_on(t('account.links.regenerate_personal_key'), match: :prefer_exact)
         click_continue
 
-        expect(user.reload.encrypted_recovery_code_digest).to_not eq old_digest
+        expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq(
+          old_digest_multi_region,
+        )
+        expect(user.reload.encrypted_recovery_code_digest).to_not eq(old_digest)
 
         expect_delivered_email_count(1)
         expect_delivered_email(
@@ -34,6 +38,7 @@ RSpec.feature 'View personal key' do
       scenario 'displays new code' do
         sign_in_and_2fa_user(user)
         old_digest = user.encrypted_recovery_code_digest
+        old_digest_multi_region = user.encrypted_recovery_code_digest_multi_region
 
         first(:link, t('forms.buttons.edit')).click
         click_on(t('links.cancel'))
@@ -56,7 +61,10 @@ RSpec.feature 'View personal key' do
         expect(page).to have_content(t('forms.personal_key_partial.acknowledgement.header'))
         acknowledge_and_confirm_personal_key
 
-        expect(user.reload.encrypted_recovery_code_digest).to_not eq old_digest
+        expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq(
+          old_digest_multi_region,
+        )
+        expect(user.reload.encrypted_recovery_code_digest).to_not eq(old_digest)
       end
     end
   end

--- a/spec/forms/personal_key_form_spec.rb
+++ b/spec/forms/personal_key_form_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe PersonalKeyForm do
           error_details: { personal_key: { personal_key_incorrect: true } },
         )
         expect(user.encrypted_recovery_code_digest).to_not be_nil
+        expect(user.encrypted_recovery_code_digest_multi_region).to_not be_nil
         expect(form.personal_key).to be_nil
       end
     end

--- a/spec/forms/reset_password_form_spec.rb
+++ b/spec/forms/reset_password_form_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe ResetPasswordForm, type: :model do
       end
 
       it 'sets the user password to the submitted password' do
-        expect { result }.to change { user.reload.encrypted_password_digest }
+        expect { result }.to change { user.reload.encrypted_password_digest }.and(
+          change { user.reload.encrypted_password_digest_multi_region },
+        )
 
         expect(result.to_h).to eq(
           success: true,

--- a/spec/forms/security_event_form_spec.rb
+++ b/spec/forms/security_event_form_spec.rb
@@ -79,7 +79,11 @@ RSpec.describe SecurityEventForm do
         end
 
         it 'resets the user password for authorization fraud detected events' do
-          expect { submit }.to(change { user.reload.encrypted_password_digest })
+          expect { submit }.to(
+            change { user.reload.encrypted_password_digest_multi_region }.and(
+              change { user.reload.encrypted_password_digest },
+            ),
+          )
         end
       end
 

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -25,10 +25,12 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
         expect(UserProfilesEncryptor).not_to receive(:new)
         user.save!
 
-        result = nil
-        expect do
-          result = subject.submit(params).to_h
-        end.to_not(change { user.reload.encrypted_password_digest })
+        old_digest = user.encrypted_password_digest
+        old_digest_multi_region = user.encrypted_password_digest_multi_region
+
+        result = subject.submit(params).to_h
+        expect(old_digest_multi_region).to eq(user.reload.encrypted_password_digest_multi_region)
+        expect(old_digest).to eq(user.reload.encrypted_password_digest)
 
         expect(result).to include(
           success: false,
@@ -53,7 +55,11 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
 
         expect do
           subject.submit(params)
-        end.to(change { user.reload.encrypted_password_digest })
+        end.to(
+          change { user.reload.encrypted_password_digest_multi_region }.and(
+            change { user.reload.encrypted_password_digest },
+          ),
+        )
       end
     end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -98,12 +98,19 @@ RSpec.describe Profile do
 
     it 'generates new personal key' do
       expect(profile.encrypted_pii_recovery).to be_nil
+      expect(profile.encrypted_pii_recovery_multi_region).to be_nil
 
       initial_personal_key = user.encrypted_recovery_code_digest
+      initial_personal_key_multi_region = user.encrypted_recovery_code_digest_multi_region
 
       encrypt_pii
 
       expect(profile.encrypted_pii_recovery).to be_present
+      expect(profile.encrypted_pii_recovery_multi_region).to be_present
+
+      expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq(
+        initial_personal_key_multi_region,
+      )
       expect(user.reload.encrypted_recovery_code_digest).to_not eq initial_personal_key
     end
 
@@ -163,18 +170,29 @@ RSpec.describe Profile do
   describe '#encrypt_recovery_pii' do
     it 'generates new personal key' do
       expect(profile.encrypted_pii_recovery).to be_nil
+      expect(profile.encrypted_pii_recovery_multi_region).to be_nil
 
       initial_personal_key = user.encrypted_recovery_code_digest
+      initial_personal_key_multi_region = user.encrypted_recovery_code_digest_multi_region
 
       profile.encrypt_recovery_pii(pii)
 
       expect(profile.encrypted_pii_recovery).to be_present
-      expect(user.reload.encrypted_recovery_code_digest).to_not eq initial_personal_key
+      expect(profile.encrypted_pii_recovery_multi_region).to be_present
+
+      expect(user.reload.encrypted_recovery_code_digest).to_not eq(
+        initial_personal_key,
+      )
+      expect(user.reload.encrypted_recovery_code_digest_multi_region).to_not eq(
+        initial_personal_key_multi_region,
+      )
       expect(profile.personal_key).to_not eq user.encrypted_recovery_code_digest
+      expect(profile.personal_key).to_not eq user.encrypted_recovery_code_digest_multi_region
     end
 
     it 'can be passed a personal key' do
       expect(profile.encrypted_pii_recovery).to be_nil
+      expect(profile.encrypted_pii_recovery_multi_region).to be_nil
 
       personal_key = 'ABCD-1234'
       returned_personal_key = profile.encrypt_recovery_pii(pii, personal_key: personal_key)
@@ -182,6 +200,7 @@ RSpec.describe Profile do
       expect(returned_personal_key).to eql(personal_key)
 
       expect(profile.encrypted_pii_recovery).to be_present
+      expect(profile.encrypted_pii_recovery_multi_region).to be_present
       expect(profile.personal_key).to eq personal_key
     end
   end

--- a/spec/services/encryption/password_verifier_spec.rb
+++ b/spec/services/encryption/password_verifier_spec.rb
@@ -176,11 +176,10 @@ RSpec.describe Encryption::PasswordVerifier do
     it 'returns false if the digest is fresh' do
       digest = subject.create_digest_pair(
         password: password, user_uuid: user_uuid,
-      ).single_region_ciphertext
+      )
 
-      result = subject.stale_digest?(digest)
-
-      expect(result).to eq(false)
+      expect(subject.stale_digest?(digest.multi_region_ciphertext)).to eq false
+      expect(subject.stale_digest?(digest.single_region_ciphertext)).to eq false
     end
   end
 end

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe Idv::ProfileMaker do
       expect(profile.id).to_not be_nil
       expect(profile.encrypted_pii).to_not be_nil
       expect(profile.encrypted_pii).to_not match('Some')
+      expect(profile.encrypted_pii_multi_region).to_not be_nil
+      expect(profile.encrypted_pii_multi_region).to_not match('Some')
       expect(profile.fraud_pending_reason).to be_nil
       expect(profile.proofing_components).to match(proofing_components.as_json)
       expect(profile.active).to eq(false)

--- a/spec/services/personal_key_generator_spec.rb
+++ b/spec/services/personal_key_generator_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe PersonalKeyGenerator do
       key = generator.generate!
 
       expect(user.encrypted_recovery_code_digest).to_not be_empty
+      expect(user.encrypted_recovery_code_digest_multi_region).to_not be_empty
       expect(generator.verify(key)).to eq(true)
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[!51](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/151)

## 🛠 Summary of changes

To address some of the issues in #11963, we need to ensure that we are reading both the multi-region and single-region encrypted values before we stop writing the single region key. This PR adds the missing multi-region reads with tests. It should not result in a change in behavior.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
