### PR TITLE
LG-15886: Fix bug in user model's latest_in_person_enrollment_status method

### DIFF
--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -52,7 +52,7 @@ module Idv
 
         @gpo_verify_form = build_gpo_verify_form
 
-        result = @gpo_verify_form.submit(resolved_authn_context_result.enhanced_ipp?)
+        result = @gpo_verify_form.submit
         analytics.idv_verify_by_mail_enter_code_submitted(**result)
 
         send_please_call_email_if_necessary(result:)

--- a/app/controllers/idv/please_call_controller.rb
+++ b/app/controllers/idv/please_call_controller.rb
@@ -41,11 +41,11 @@ module Idv
 
     # we only want to handle enrollments that have passed
     def ipp_enrollment_passed?
-      current_user&.in_person_enrollment_status == 'passed'
+      current_user&.latest_in_person_enrollment_status == 'passed'
     end
 
     def ipp_enrollment_in_fraud_review?
-      current_user&.in_person_enrollment_status == 'in_fraud_review'
+      current_user&.latest_in_person_enrollment_status == 'in_fraud_review'
     end
   end
 end

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -18,16 +18,14 @@ class GpoVerifyForm
     @otp = otp
   end
 
-  def submit(is_enhanced_ipp)
+  def submit
     result = valid?
     fraud_check_failed = pending_profile&.fraud_pending_reason.present?
 
     if result
       pending_profile&.remove_gpo_deactivation_reason
 
-      if user.has_establishing_in_person_enrollment_safe?
-        schedule_in_person_enrollment_and_deactivate_profile(is_enhanced_ipp)
-      elsif fraud_check_failed && threatmetrix_enabled?
+      if fraud_check_failed && threatmetrix_enabled?
         pending_profile&.deactivate_for_fraud_review
       elsif fraud_check_failed
         pending_profile&.activate_after_fraud_review_unnecessary

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,11 +241,6 @@ class User < ApplicationRecord
     establishing_in_person_enrollment.present?
   end
 
-  # Trust `pending_profile` rather than enrollment associations
-  def has_establishing_in_person_enrollment_safe?
-    !!pending_profile&.in_person_enrollment&.establishing?
-  end
-
   def personal_key_generated_at
     encrypted_recovery_code_digest_generated_at ||
       active_profile&.verified_at ||

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -216,19 +216,19 @@ class User < ApplicationRecord
   end
 
   ##
-  # Return the status of the current In Person Proofing Enrollment
+  # Return the status of the latest in person enrollment
   # @return [String] enrollment status
-  def in_person_enrollment_status
-    pending_profile&.in_person_enrollment&.status
+  def latest_in_person_enrollment_status
+    in_person_enrollments.order(created_at: :desc).first&.status
   end
 
   # Whether the user's in person enrollment status is not passed or in_fraud_review. Enrollments
   # used to go to passed status when profiles were marked as in fraud review. Since LG-15216, this
   # will no longer be the case.
   def ipp_enrollment_status_not_passed_or_in_fraud_review?
-    !in_person_enrollment_status.blank? &&
+    !latest_in_person_enrollment_status.blank? &&
       [InPersonEnrollment::STATUS_PASSED, InPersonEnrollment::STATUS_IN_FRAUD_REVIEW].exclude?(
-        in_person_enrollment_status,
+        latest_in_person_enrollment_status,
       )
   end
 

--- a/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
@@ -459,35 +459,5 @@ RSpec.describe Idv::ByMail::EnterCodeController do
         end
       end
     end
-
-    context 'when the user is going through enhanced ipp' do
-      subject(:action) do
-        post(:create, params: { gpo_verify_form: { otp: good_otp } })
-      end
-      let(:is_enhanced_ipp) { true }
-      let(:user) { create(:user, :with_pending_gpo_profile, created_at: 2.days.ago) }
-      let(:gpo_verify_form) do
-        GpoVerifyForm.new(
-          user: user,
-          pii: {},
-          resolved_authn_context_result: Vot::Parser::Result.no_sp_result,
-          otp: good_otp,
-        )
-      end
-      before do
-        authn_context_result = Vot::Parser.new(vector_of_trust: 'Pe').parse
-        allow(controller).to(
-          receive(:resolved_authn_context_result).and_return(authn_context_result),
-        )
-        allow(GpoVerifyForm).to receive(:new).and_return(gpo_verify_form)
-        allow(gpo_verify_form).to receive(:submit).and_call_original
-      end
-
-      it 'passes the correct param to the gpo verify form submit method' do
-        action
-
-        expect(gpo_verify_form).to have_received(:submit).with(is_enhanced_ipp)
-      end
-    end
   end
 end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe GpoVerifyForm do
     )
   end
   let(:proofing_components) { nil }
-  let(:is_enhanced_ipp) { false }
 
   before do
     next if pending_profile.blank?
@@ -42,7 +41,7 @@ RSpec.describe GpoVerifyForm do
       let(:entered_otp) { nil }
 
       it 'is invalid' do
-        result = subject.submit(is_enhanced_ipp)
+        result = subject.submit
         expect(result.success?).to eq(false)
         expect(result.errors[:otp]).to eq [t('errors.messages.blank')]
       end
@@ -53,7 +52,7 @@ RSpec.describe GpoVerifyForm do
       let(:user) { build_stubbed(:user) }
 
       it 'is invalid' do
-        result = subject.submit(is_enhanced_ipp)
+        result = subject.submit
         expect(result.success?).to eq(false)
         expect(result.errors[:base]).to eq [t('errors.messages.no_pending_profile')]
       end
@@ -65,7 +64,7 @@ RSpec.describe GpoVerifyForm do
         let(:otp) { 'ABCDEF12345' }
 
         it 'is valid' do
-          result = subject.submit(is_enhanced_ipp)
+          result = subject.submit
           expect(result.success?).to eq(true)
         end
       end
@@ -75,7 +74,7 @@ RSpec.describe GpoVerifyForm do
         let(:otp) { '0000000000' }
 
         it 'is valid' do
-          result = subject.submit(is_enhanced_ipp)
+          result = subject.submit
           expect(result.success?).to eq(true)
         end
       end
@@ -85,7 +84,7 @@ RSpec.describe GpoVerifyForm do
       let(:entered_otp) { 'wrong' }
 
       it 'is invalid' do
-        result = subject.submit(is_enhanced_ipp)
+        result = subject.submit
         expect(result.success?).to eq(false)
         expect(result.errors[:otp]).to eq [t('errors.messages.confirmation_code_incorrect')]
       end
@@ -104,7 +103,7 @@ RSpec.describe GpoVerifyForm do
       end
 
       it 'is invalid' do
-        result = subject.submit(is_enhanced_ipp)
+        result = subject.submit
         expect(result.success?).to eq(false)
         expect(subject.errors[:otp]).to eq [t('errors.messages.gpo_otp_expired')]
       end
@@ -114,7 +113,7 @@ RSpec.describe GpoVerifyForm do
           allow(subject).to receive(:user_can_request_another_letter?).and_return(false)
         end
         it 'is invalid and uses different messaging' do
-          result = subject.submit(is_enhanced_ipp)
+          result = subject.submit
           expect(result.success?).to eq(false)
           expect(subject.errors[:otp]).to eq [
             t('errors.messages.gpo_otp_expired_and_cannot_request_another'),
@@ -126,85 +125,6 @@ RSpec.describe GpoVerifyForm do
 
   describe '#submit' do
     context 'correct OTP' do
-      it 'returns true' do
-        result = subject.submit(is_enhanced_ipp)
-        expect(result.success?).to eq true
-      end
-
-      it 'activates the pending profile' do
-        expect(pending_profile).to_not be_active
-
-        subject.submit(is_enhanced_ipp)
-
-        expect(pending_profile.reload).to be_active
-      end
-
-      it 'logs the date the code was sent at' do
-        result = subject.submit(is_enhanced_ipp)
-
-        confirmation_code = pending_profile.gpo_confirmation_codes.last
-        expect(result.to_h[:enqueued_at]).to eq(confirmation_code.code_sent_at)
-      end
-
-      context 'establishing in person enrollment' do
-        let!(:establishing_enrollment) do
-          create(
-            :in_person_enrollment,
-            :establishing,
-            profile: pending_profile,
-            user: user,
-          )
-        end
-
-        before do
-          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-        end
-
-        it 'sets profile to pending in person verification' do
-          subject.submit(is_enhanced_ipp)
-          pending_profile.reload
-
-          expect(pending_profile).not_to be_active
-          expect(pending_profile.in_person_verification_pending?).to eq(true)
-          expect(pending_profile.gpo_verification_pending?).to eq(false)
-        end
-
-        it 'updates establishing in-person enrollment to pending' do
-          subject.submit(is_enhanced_ipp)
-
-          establishing_enrollment.reload
-
-          expect(establishing_enrollment.status).to eq(InPersonEnrollment::STATUS_PENDING)
-          expect(establishing_enrollment.user_id).to eq(user.id)
-          expect(establishing_enrollment.enrollment_code).to be_a(String)
-        end
-      end
-
-      context 'pending in person enrollment' do
-        let!(:pending_enrollment) do
-          create(
-            :in_person_enrollment,
-            :pending,
-            profile: pending_profile,
-            user: user,
-          )
-        end
-
-        before do
-          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-        end
-
-        it 'changes profile from pending to active' do
-          subject.submit(is_enhanced_ipp)
-          pending_profile.reload
-
-          expect(pending_profile).to be_active
-          expect(pending_profile.deactivation_reason).to be_nil
-          expect(pending_profile.in_person_verification_pending_at).to be_nil
-          expect(pending_profile.gpo_verification_pending?).to eq(false)
-        end
-      end
-
       context 'ThreatMetrix rejection' do
         let(:pending_profile) do
           create(:profile, :verify_by_mail_pending, :fraud_pending_reason, user: user)
@@ -215,19 +135,19 @@ RSpec.describe GpoVerifyForm do
         end
 
         it 'returns true' do
-          result = subject.submit(is_enhanced_ipp)
+          result = subject.submit
           expect(result.success?).to eq true
         end
 
         it 'does not activate the users profile' do
-          subject.submit(is_enhanced_ipp)
+          subject.submit
           profile = user.profiles.first
           expect(profile.active).to eq(false)
           expect(profile.fraud_review_pending?).to eq(true)
         end
 
         it 'notes that threatmetrix failed' do
-          result = subject.submit(is_enhanced_ipp)
+          result = subject.submit
           expect(result.extra).to include(fraud_check_failed: true)
         end
 
@@ -237,19 +157,19 @@ RSpec.describe GpoVerifyForm do
           end
 
           it 'returns true' do
-            result = subject.submit(is_enhanced_ipp)
+            result = subject.submit
             expect(result.success?).to eq true
           end
 
           it 'does activate the users profile' do
-            subject.submit(is_enhanced_ipp)
+            subject.submit
             profile = user.profiles.first
             expect(profile.active).to eq(true)
             expect(profile.deactivation_reason).to eq(nil)
           end
 
           it 'notes that threatmetrix failed' do
-            result = subject.submit(is_enhanced_ipp)
+            result = subject.submit
             expect(result.extra).to include(fraud_check_failed: true)
           end
         end
@@ -260,7 +180,7 @@ RSpec.describe GpoVerifyForm do
       let(:entered_otp) { 'wrong' }
 
       it 'clears form' do
-        subject.submit(is_enhanced_ipp)
+        subject.submit
 
         expect(subject.otp).to be_nil
       end
@@ -291,7 +211,7 @@ RSpec.describe GpoVerifyForm do
         let(:entered_otp) { first_otp }
 
         it 'logs which letter and letter count' do
-          result = subject.submit(is_enhanced_ipp)
+          result = subject.submit
 
           expect(result.to_h[:which_letter]).to eq(1)
           expect(result.to_h[:letter_count]).to eq(3)
@@ -302,7 +222,7 @@ RSpec.describe GpoVerifyForm do
         let(:entered_otp) { second_otp }
 
         it 'logs which letter and letter count' do
-          result = subject.submit(is_enhanced_ipp)
+          result = subject.submit
 
           expect(result.to_h[:which_letter]).to eq(2)
           expect(result.to_h[:letter_count]).to eq(3)
@@ -313,29 +233,11 @@ RSpec.describe GpoVerifyForm do
         let(:entered_code) { third_otp }
 
         it 'logs which letter and letter count' do
-          result = subject.submit(is_enhanced_ipp)
+          result = subject.submit
 
           expect(result.to_h[:which_letter]).to eq(3)
           expect(result.to_h[:letter_count]).to eq(3)
         end
-      end
-    end
-
-    context 'when the user is going through enhanced ipp' do
-      let(:is_enhanced_ipp) { true }
-      let!(:establishing_enrollment) do
-        create(
-          :in_person_enrollment,
-          :establishing,
-          profile: pending_profile,
-          user: user,
-        )
-      end
-      it 'sends the correct information for scheduling an in person enrollment' do
-        expect(UspsInPersonProofing::EnrollmentHelper).to receive(:schedule_in_person_enrollment)
-          .with(user: anything, pii: anything, is_enhanced_ipp: is_enhanced_ipp)
-
-        subject.submit(is_enhanced_ipp)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -364,28 +364,57 @@ RSpec.describe User do
       end
     end
 
-    describe '#in_person_enrollment_status' do
-      let(:new_user) { create(:user, :fully_registered) }
+    describe '#latest_in_person_enrollment_status' do
       let(:proofing_components) { nil }
-      let(:new_pending_profile) do
-        create(
-          :profile,
-          :verify_by_mail_pending,
-          user: new_user,
-          proofing_components: proofing_components,
-        )
-      end
-      let!(:establishing_enrollment) do
-        create(
-          :in_person_enrollment,
-          :passed,
-          profile: new_pending_profile,
-          user: new_user,
-        )
+
+      context 'when the enrollment is pending' do
+        let(:pending_user) { create(:user, :fully_registered) }
+        let!(:profile) do
+          create(
+            :profile,
+            :in_person_verification_pending,
+            user: pending_user,
+            proofing_components: proofing_components,
+          )
+        end
+
+        it 'returns pending' do
+          expect(pending_user.latest_in_person_enrollment_status).to eq('pending')
+        end
       end
 
-      it 'returns the status of the enrollment' do
-        expect(new_user.in_person_enrollment_status).to eq('passed')
+      context 'when the enrollment is establishing' do
+        let!(:establishing_user) do
+          create(:user, :fully_registered, :with_establishing_in_person_enrollment)
+        end
+
+        it 'returns establishing' do
+          expect(establishing_user.latest_in_person_enrollment_status).to eq('establishing')
+        end
+      end
+
+      context 'when the enrollment is cancelled' do
+        let(:cancelled_user) { create(:user, :fully_registered) }
+        let(:cancelled_profile) do
+          create(
+            :profile,
+            :verification_cancelled,
+            user: cancelled_user,
+            proofing_components: proofing_components,
+          )
+        end
+        let!(:cancelled_enrollment) do
+          create(
+            :in_person_enrollment,
+            :cancelled,
+            profile: cancelled_profile,
+            user: cancelled_user,
+          )
+        end
+
+        it 'returns cancelled' do
+          expect(cancelled_user.latest_in_person_enrollment_status).to eq('cancelled')
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -310,34 +310,6 @@ RSpec.describe User do
       end
     end
 
-    # We don't know yet if #establishing_in_person_enrollment is, in fact, `establishing`
-    # so we trust the pending profile in the meantime
-    describe '#has_establishing_in_person_enrollment_safe?' do
-      let(:new_user) { create(:user, :fully_registered) }
-      let(:proofing_components) { nil }
-      let(:new_pending_profile) do
-        create(
-          :profile,
-          :verify_by_mail_pending,
-          user: new_user,
-          proofing_components: proofing_components,
-        )
-      end
-      let!(:establishing_enrollment) do
-        create(
-          :in_person_enrollment,
-          :establishing,
-          profile: new_pending_profile,
-          user: new_user,
-        )
-      end
-
-      it 'returns the establishing IPP enrollment through the pending profile' do
-        # trust pending_profile
-        expect(new_user.has_establishing_in_person_enrollment_safe?).to eq(true)
-      end
-    end
-
     describe '#latest_in_person_enrollment_status' do
       let(:proofing_components) { nil }
 

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe GpoReminderSender do
               enhanced_ipp?: is_enhanced_ipp,
             ),
             otp: otp,
-          ).submit(is_enhanced_ipp)
+          ).submit
         end
 
         include_examples 'sends no emails'


### PR DESCRIPTION
## 🎫 Ticket
[LG-15886](https://cm-jira.usa.gov/browse/LG-15886)

## 🛠 Summary of changes
- Rename `in_person_enrollment_status` method to `latest_in_person_enrollment_status`

## 📜 Testing Plan
Since this faulty method didn't cause any user-facing bugs, there isn't a manual testing plan for the change.  Running the automated tests should be sufficient.