### PR TITLE
LG-15887: default doc auth vendor to LN when not defined

### DIFF
--- a/app/controllers/idv/hybrid_mobile/entry_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/entry_controller.rb
@@ -13,6 +13,13 @@ module Idv
 
         return handle_invalid_document_capture_session if !validate_document_capture_user_id
 
+        # to be removed 50/50 - start
+        unless document_capture_session.doc_auth_vendor
+          document_capture_session
+            .update!(doc_auth_vendor: IdentityConfig.store.doc_auth_vendor_default)
+        end
+        # to be removed 50/50 - end
+
         case document_capture_session.doc_auth_vendor
         when Idp::Constants::Vendors::SOCURE, Idp::Constants::Vendors::SOCURE_MOCK
           redirect_to idv_hybrid_mobile_socure_document_capture_url

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -330,6 +330,13 @@ module Idv
     end
 
     def doc_auth_client
+      # to be removed 50/50 - start
+      unless document_capture_session.doc_auth_vendor
+        document_capture_session
+          .update!(doc_auth_vendor: IdentityConfig.store.doc_auth_vendor_default)
+      end
+      # to be removed 50/50 - end
+
       @doc_auth_client ||= DocAuthRouter.client(
         vendor: document_capture_session.doc_auth_vendor,
         warn_notifier: proc do |attrs|


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-15887](https://cm-jira.usa.gov/browse/LG-15887)

## 🛠 Summary of changes
When nil, set document_capture_session.doc_auth_vendor to the default doc auth vendor. This is for 50/50 state for users who were setting document_capture_session later after the welcome page.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
