### PR TITLE
Remove single-region key encryption for Profile PII

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -268,12 +268,7 @@ class Profile < ApplicationRecord
   def decrypt_pii(password)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
 
-    encrypted_pii_ciphertext_pair = Encryption::RegionalCiphertextPair.new(
-      single_region_ciphertext: encrypted_pii,
-      multi_region_ciphertext: encrypted_pii_multi_region,
-    )
-
-    decrypted_json = encryptor.decrypt(encrypted_pii_ciphertext_pair, user_uuid: user.uuid)
+    decrypted_json = encryptor.decrypt(encrypted_pii_multi_region, user_uuid: user.uuid)
     Pii::Attributes.new_from_json(decrypted_json)
   end
 
@@ -281,13 +276,8 @@ class Profile < ApplicationRecord
   def recover_pii(personal_key)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(personal_key)
 
-    encrypted_pii_recovery_ciphertext_pair = Encryption::RegionalCiphertextPair.new(
-      single_region_ciphertext: encrypted_pii_recovery,
-      multi_region_ciphertext: encrypted_pii_recovery_multi_region,
-    )
-
     decrypted_recovery_json = encryptor.decrypt(
-      encrypted_pii_recovery_ciphertext_pair, user_uuid: user.uuid
+      encrypted_pii_recovery_multi_region, user_uuid: user.uuid
     )
     return nil if JSON.parse(decrypted_recovery_json).nil?
     Pii::Attributes.new_from_json(decrypted_recovery_json)
@@ -298,7 +288,8 @@ class Profile < ApplicationRecord
     encrypt_ssn_fingerprint(pii)
     encrypt_compound_pii_fingerprint(pii)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-    self.encrypted_pii, self.encrypted_pii_multi_region = encryptor.encrypt(
+    self.encrypted_pii = nil
+    self.encrypted_pii_multi_region = encryptor.encrypt(
       pii.to_json, user_uuid: user.uuid
     )
     encrypt_recovery_pii(pii)
@@ -310,7 +301,8 @@ class Profile < ApplicationRecord
     encryptor = Encryption::Encryptors::PiiEncryptor.new(
       personal_key_generator.normalize(personal_key),
     )
-    self.encrypted_pii_recovery, self.encrypted_pii_recovery_multi_region = encryptor.encrypt(
+    self.encrypted_pii_recovery = nil
+    self.encrypted_pii_recovery_multi_region = encryptor.encrypt(
       pii.to_json, user_uuid: user.uuid
     )
     @personal_key = personal_key

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -318,9 +318,14 @@ class User < ApplicationRecord
     last_personal_key_at = self.encrypted_recovery_code_digest_generated_at
 
     if active_profile.present?
+      # This should only apply to encrypted_pii_recovery since encrypted_pii_recovery_multi_region
+      # was created after this time window.
       encrypted_pii_too_short =
-        active_profile.encrypted_pii_recovery.present? &&
-        active_profile.encrypted_pii_recovery.length < MINIMUM_LIKELY_ENCRYPTED_DATA_LENGTH
+        (active_profile.encrypted_pii_recovery_multi_region.present? &&
+        active_profile.encrypted_pii_recovery_multi_region.length <
+          MINIMUM_LIKELY_ENCRYPTED_DATA_LENGTH) ||
+        (active_profile.encrypted_pii_recovery.present? &&
+        active_profile.encrypted_pii_recovery.length < MINIMUM_LIKELY_ENCRYPTED_DATA_LENGTH)
 
       inside_broken_key_window =
         (!last_personal_key_at || last_personal_key_at < window_finish) &&

--- a/app/services/encryption/encryptors/pii_encryptor.rb
+++ b/app/services/encryption/encryptors/pii_encryptor.rb
@@ -38,9 +38,6 @@ module Encryption
       def initialize(password)
         @password = password
         @aes_cipher = AesCipher.new
-        @single_region_kms_client = KmsClient.new(
-          kms_key_id: IdentityConfig.store.aws_kms_key_id,
-        )
         @multi_region_kms_client = KmsClient.new(
           kms_key_id: IdentityConfig.store.aws_kms_multi_region_key_id,
         )
@@ -51,28 +48,16 @@ module Encryption
         cost = IdentityConfig.store.scrypt_cost
         aes_encryption_key = scrypt_password_digest(salt: salt, cost: cost)
         aes_encrypted_ciphertext = aes_cipher.encrypt(plaintext, aes_encryption_key)
-        single_region_kms_encrypted_ciphertext = single_region_kms_client.encrypt(
-          aes_encrypted_ciphertext, kms_encryption_context(user_uuid: user_uuid)
-        )
-        single_region_ciphertext = Ciphertext.new(
-          single_region_kms_encrypted_ciphertext, salt, cost
-        ).to_s
 
         multi_region_kms_encrypted_ciphertext = multi_region_kms_client.encrypt(
           aes_encrypted_ciphertext, kms_encryption_context(user_uuid: user_uuid)
         )
-        multi_region_ciphertext = Ciphertext.new(
+        Ciphertext.new(
           multi_region_kms_encrypted_ciphertext, salt, cost
         ).to_s
-
-        RegionalCiphertextPair.new(
-          single_region_ciphertext: single_region_ciphertext,
-          multi_region_ciphertext: multi_region_ciphertext,
-        )
       end
 
-      def decrypt(ciphertext_pair, user_uuid: nil)
-        ciphertext_string = ciphertext_pair.multi_or_single_region_ciphertext
+      def decrypt(ciphertext_string, user_uuid: nil)
         ciphertext = Ciphertext.parse_from_string(ciphertext_string)
         aes_encrypted_ciphertext = multi_region_kms_client.decrypt(
           ciphertext.encrypted_data, kms_encryption_context(user_uuid: user_uuid)
@@ -83,7 +68,7 @@ module Encryption
 
       private
 
-      attr_reader :password, :aes_cipher, :single_region_kms_client, :multi_region_kms_client
+      attr_reader :password, :aes_cipher, :multi_region_kms_client
 
       def kms_encryption_context(user_uuid:)
         {

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Profile do
   describe '#encrypt_pii' do
     subject(:encrypt_pii) { profile.encrypt_pii(pii, user.password) }
 
-    it 'encrypts pii and stores the multi region ciphertext' do
+    it 'encrypts pii and stores only the multi region ciphertext' do
       expect(profile.encrypted_pii).to be_nil
       expect(profile.encrypted_pii_recovery).to be_nil
       expect(profile.encrypted_pii_multi_region).to be_nil
@@ -79,13 +79,9 @@ RSpec.describe Profile do
 
       profile.encrypt_pii(pii, user.password)
 
-      expect(profile.encrypted_pii).to be_present
-      expect(profile.encrypted_pii).to_not match 'Jane'
-      expect(profile.encrypted_pii).to_not match(ssn)
+      expect(profile.encrypted_pii).to be_nil
 
-      expect(profile.encrypted_pii_recovery).to be_present
-      expect(profile.encrypted_pii_recovery).to_not match 'Jane'
-      expect(profile.encrypted_pii_recovery).to_not match(ssn)
+      expect(profile.encrypted_pii_recovery).to be_nil
 
       expect(profile.encrypted_pii_multi_region).to be_present
       expect(profile.encrypted_pii_multi_region).to_not match 'Jane'
@@ -104,11 +100,11 @@ RSpec.describe Profile do
 
       encrypt_pii
 
-      expect(profile.encrypted_pii_recovery).to be_present
+      expect(profile.encrypted_pii_recovery).to be_nil
       expect(profile.encrypted_pii_recovery_multi_region).to be_present
 
       user.reload
-      expect(user.encrypted_recovery_code_digest).to_not be_present
+      expect(user.encrypted_recovery_code_digest).to be_nil
       expect(user.encrypted_recovery_code_digest_multi_region).to_not eq initial_personal_key
     end
 
@@ -174,11 +170,11 @@ RSpec.describe Profile do
 
       profile.encrypt_recovery_pii(pii)
 
-      expect(profile.encrypted_pii_recovery).to be_present
+      expect(profile.encrypted_pii_recovery).to be_nil
       expect(profile.encrypted_pii_recovery_multi_region).to be_present
 
       user.reload
-      expect(user.encrypted_recovery_code_digest).to_not be_present
+      expect(user.encrypted_recovery_code_digest).to be_nil
       expect(user.encrypted_recovery_code_digest_multi_region).to_not eq initial_personal_key
       expect(profile.personal_key).to_not eq user.encrypted_recovery_code_digest_multi_region
     end
@@ -192,7 +188,7 @@ RSpec.describe Profile do
 
       expect(returned_personal_key).to eql(personal_key)
 
-      expect(profile.encrypted_pii_recovery).to be_present
+      expect(profile.encrypted_pii_recovery).to be_nil
       expect(profile.encrypted_pii_recovery_multi_region).to be_present
       expect(profile.personal_key).to eq personal_key
     end
@@ -203,15 +199,6 @@ RSpec.describe Profile do
       profile.encrypt_pii(pii, user.password)
 
       expect(profile.encrypted_pii_multi_region).to_not be_nil
-
-      decrypted_pii = profile.decrypt_pii(user.password)
-
-      expect(decrypted_pii).to eq pii
-    end
-
-    it 'decrypts the PII for users with only a single region ciphertext' do
-      profile.encrypt_pii(pii, user.password)
-      profile.update!(encrypted_pii_multi_region: nil)
 
       decrypted_pii = profile.decrypt_pii(user.password)
 
@@ -235,18 +222,6 @@ RSpec.describe Profile do
       normalized_personal_key = PersonalKeyGenerator.new(user).normalize(personal_key)
 
       expect(profile.encrypted_pii_recovery_multi_region).to_not be_nil
-
-      decrypted_pii = profile.recover_pii(normalized_personal_key)
-
-      expect(decrypted_pii).to eq pii
-    end
-
-    it 'decrypts recovery PII with personal key for users with only a single region ciphertext' do
-      profile.encrypt_pii(pii, user.password)
-      profile.update!(encrypted_pii_recovery_multi_region: nil)
-      personal_key = profile.personal_key
-
-      normalized_personal_key = PersonalKeyGenerator.new(user).normalize(personal_key)
 
       decrypted_pii = profile.recover_pii(normalized_personal_key)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1347,23 +1347,31 @@ RSpec.describe User do
       let(:user) { create(:user) }
       let(:personal_key) { RandomPhrase.new(num_words: 4).to_s }
 
-      before do
-        encrypted_pii_recovery, encrypted_pii_recovery_multi_region =
-          Encryption::Encryptors::PiiEncryptor.new(
-            personal_key,
-          ).encrypt('null', user_uuid: user.uuid).single_region_ciphertext
-
+      it 'returns true if multi-region recovery PII is too short' do
         create(
           :profile,
           user: user,
           active: true,
           verified_at: Time.zone.now,
-          encrypted_pii_recovery: encrypted_pii_recovery,
-          encrypted_pii_recovery_multi_region: encrypted_pii_recovery_multi_region,
+          encrypted_pii_recovery: nil,
+          encrypted_pii_recovery_multi_region: 'abcdefgh',
         )
+
+        expect(user.broken_personal_key?).to eq(true)
       end
 
-      it { expect(user.broken_personal_key?).to eq(true) }
+      it 'returns true if single-region recovery PII is too short' do
+        create(
+          :profile,
+          user: user,
+          active: true,
+          verified_at: Time.zone.now,
+          encrypted_pii_recovery: 'abcdefgh',
+          encrypted_pii_recovery_multi_region: nil,
+        )
+
+        expect(user.broken_personal_key?).to eq(true)
+      end
     end
   end
 

--- a/spec/services/idv/profile_maker_spec.rb
+++ b/spec/services/idv/profile_maker_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe Idv::ProfileMaker do
 
       expect(profile).to be_a Profile
       expect(profile.id).to_not be_nil
-      expect(profile.encrypted_pii).to_not be_nil
-      expect(profile.encrypted_pii).to_not match('Some')
+      expect(profile.encrypted_pii).to be_nil
       expect(profile.encrypted_pii_multi_region).to_not be_nil
       expect(profile.encrypted_pii_multi_region).to_not match('Some')
       expect(profile.fraud_pending_reason).to be_nil


### PR DESCRIPTION
## 🛠 Summary of changes

Similar to #11963, but for Profile PII. We currently only attempt to [decrypt PII with the multi-region key](https://github.com/18F/identity-idp/blob/main/app/services/encryption/encryptors/pii_encryptor.rb#L77-L79), so it should now be safe to stop writing with the single-region key.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
