### PR TITLE
LG-15917 Add user uuid to enrollment skip events

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -147,7 +147,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   end
 
   def skip_enrollment(enrollment, profile_deactivation_reason)
-    analytics.idv_in_person_usps_proofing_results_job_enrollment_skipped(
+    analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_enrollment_skipped(
       **enrollment_analytics_attributes(enrollment, complete: false),
       reason: "Profile has a deactivation reason of #{profile_deactivation_reason}",
       job_name: self.class.name,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15917](https://cm-jira.usa.gov/browse/LG-15917)

## 🛠 Summary of changes

Add the user's uuid to the enrollment skipped event during the GetUspsProofingResultsJob

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

**Scenario: When the user resets their password and does not login to complete password reset**

- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the ready to verify page.
- [x] Logout
- [x] Reset the password of the user.
- [x] Run the GetUspsProofingResultsJob
- [ ] Ensure enrollment skipped event is logged with the user's uuid in the event properties
- [x] Ensure GetUspsProofingResultsJob: Job complete event contains enrollment_skipped count