### PR TITLE
Add delete_events to Attempts API RedisClient

### DIFF
--- a/app/services/attempts_api/redis_client.rb
+++ b/app/services/attempts_api/redis_client.rb
@@ -21,6 +21,18 @@ module AttemptsApi
       events
     end
 
+    def delete_events(issuer:, keys:)
+      hourly_keys = REDIS_ATTEMPTS_API_POOL.with do |client|
+        client.keys("attempts-api-events:#{issuer}:*")
+      end
+
+      hourly_keys.each do |hourly_key|
+        REDIS_ATTEMPTS_API_POOL.with do |client|
+          client.hdel(hourly_key, keys)
+        end
+      end
+    end
+
     def key(timestamp, issuer)
       formatted_time = timestamp.in_time_zone('UTC').change(min: 0, sec: 0).iso8601
       "attempts-api-events:#{issuer}:#{formatted_time}"


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[!142](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/142)
-->

## 🛠 Summary of changes

To assist with acknowledging received events, this PR implements a method to delete keys out of the hash. The hourly bucket makes this a little wonky, and may need to be re-evaluated in the future.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
