### PR TITLE
Add initial polling

### DIFF
--- a/app/controllers/api/attempts/events_controller.rb
+++ b/app/controllers/api/attempts/events_controller.rb
@@ -13,10 +13,12 @@ module Api
       before_action :authenticate_client, only: :poll
 
       def poll
-        redis_client.delete_events(
-          issuer: request_token.issuer,
-          keys: poll_params[:acks],
-        )
+        if poll_params[:acks].present?
+          redis_client.delete_events(
+            issuer: request_token.issuer,
+            keys: poll_params[:acks],
+          )
+        end
         render json: { sets: }
       end
 

--- a/spec/controllers/api/attempts/events_controller_spec.rb
+++ b/spec/controllers/api/attempts/events_controller_spec.rb
@@ -11,15 +11,23 @@ RSpec.describe Api::Attempts::EventsController do
   describe '#poll' do
     let(:sp) { create(:service_provider) }
     let(:issuer) { sp.issuer }
+    let(:acks) do
+      [
+        'acknowleded-jti-id-1',
+        'acknowleded-jti-id-2',
+      ]
+    end
+
     let(:payload) do
       {
         maxEvents: '1000',
-        acks: [
-          'acknowleded-jti-id-1',
-          'acknowleded-jti-id-2',
-        ],
+        acks:,
       }
     end
+
+    let(:private_key) { OpenSSL::PKey::RSA.new(2048) }
+    let(:public_key) { private_key.public_key }
+    let(:redis_client) { AttemptsApi::RedisClient.new }
 
     let(:token) { 'a-shared-secret' }
     let(:salt) { SecureRandom.hex(32) }
@@ -41,6 +49,7 @@ RSpec.describe Api::Attempts::EventsController do
           tokens: [{ value: hashed_token, salt: }],
         }],
       )
+      allow(AttemptsApi::RedisClient).to receive(:new).and_return redis_client
     end
 
     let(:action) { post :poll, params: payload }
@@ -55,8 +64,108 @@ RSpec.describe Api::Attempts::EventsController do
       let(:enabled) { true }
 
       context 'with a valid authorization header' do
-        it 'returns 405 method not allowed' do
-          expect(action.status).to eq(405)
+        it 'returns 200 status' do
+          expect(action.status).to eq(200)
+        end
+
+        context 'with events stored in redis' do
+          let(:timestamp) { Time.zone.now }
+          let(:event) do
+            AttemptsApi::AttemptEvent.new(
+              event_type: 'test_event',
+              session_id: 'test-session-id',
+              occurred_at: Time.zone.now,
+              event_metadata: {
+                first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
+              },
+            )
+          end
+          let(:event_key) { event.jti }
+          let(:jwe) { event.to_jwe(issuer:, public_key:) }
+
+          before do
+            redis_client.write_event(
+              event_key:,
+              jwe:,
+              timestamp:,
+              issuer:,
+            )
+          end
+
+          it 'returns a json blob including that set' do
+            expect(redis_client).to receive(:delete_events).with(
+              issuer:,
+              keys: [*acks],
+            ).and_call_original
+            expect(action.body).to eq({ sets: { "#{event_key}": jwe } }.to_json)
+          end
+
+          context 'when an event is acknowledged' do
+            let(:acks) { [event_key] }
+
+            it 'does not return any acknowledged events' do
+              expect(redis_client).to receive(:delete_events).with(
+                issuer:,
+                keys: [event_key],
+              ).and_call_original
+
+              expect(action.body).to eq({ sets: {} }.to_json)
+            end
+          end
+
+          context 'when there are multiple events' do
+            let(:events) { {} }
+            before do
+              3.times do
+                event = AttemptsApi::AttemptEvent.new(
+                  event_type: 'test_event',
+                  session_id: 'test-session-id',
+                  occurred_at: Time.zone.now,
+                  event_metadata: {
+                    first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
+                  },
+                )
+                event_key = event.jti
+                jwe = event.to_jwe(issuer:, public_key:)
+                events[event_key] = jwe
+              end
+              events.each do |event_key, jwe|
+                redis_client.write_event(
+                  event_key:, jwe:, timestamp: Time.zone.now - 2.hours,
+                  issuer:
+                )
+              end
+            end
+
+            it 'returns a json blob including all those events set' do
+              sets = events.merge({ event_key => jwe })
+              expect(JSON.parse(action.body)).to eq({ 'sets' => sets })
+            end
+
+            context 'when the payload includes a maxEvents parameter' do
+              let(:payload) do
+                {
+                  maxEvents: 3,
+                  acks:,
+                }
+              end
+
+              it 'only returns the number of events indicated' do
+                expect(JSON.parse(action.body)['sets'].length).to be 3
+              end
+
+              it 'returns the oldest events' do
+                expect(JSON.parse(action.body)['sets'].keys).to_not include event_key
+              end
+            end
+          end
+        end
+
+        context 'with no events in Redis' do
+          it 'returns an empty set' do
+            expect(redis_client).to receive(:delete_events).and_call_original
+            expect(action.body).to eq({ sets: {} }.to_json)
+          end
         end
       end
 

--- a/spec/services/attempts_api/redis_client_spec.rb
+++ b/spec/services/attempts_api/redis_client_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AttemptsApi::RedisClient do
 
         subject.write_event(event_key: event_key, jwe: jwe, timestamp: now, issuer: issuer)
 
-        result = subject.read_events(timestamp: now, issuer: issuer)
+        result = subject.read_events(issuer: issuer)
         expect(result[event_key]).to eq(jwe)
       end
     end
@@ -50,43 +50,43 @@ RSpec.describe AttemptsApi::RedisClient do
           subject.write_event(event_key: event_key, jwe: jwe, timestamp: now, issuer: issuer)
         end
 
-        result = subject.read_events(timestamp: now, issuer: issuer)
+        result = subject.read_events(issuer:)
 
         expect(result).to eq(events)
       end
     end
 
-    it 'stores events in hourly buckets' do
-      time1 = Time.new(2022, 1, 1, 1, 0, 0, 'Z')
-      time2 = Time.new(2022, 1, 1, 2, 0, 0, 'Z')
-      event1 = AttemptsApi::AttemptEvent.new(
-        event_type: 'test_event',
-        session_id: 'test-session-id',
-        occurred_at: time1,
-        event_metadata: {
-          first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
-        },
-      )
-      event2 = AttemptsApi::AttemptEvent.new(
-        event_type: 'test_event',
-        session_id: 'test-session-id',
-        occurred_at: time2,
-        event_metadata: {
-          first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
-        },
-      )
-      jwe1 = event1.to_jwe(issuer: issuer, public_key: attempts_api_public_key)
-      jwe2 = event2.to_jwe(issuer: issuer, public_key: attempts_api_public_key)
+    context 'when events are in different buckets' do
+      let(:events) { {} }
 
-      subject.write_event(
-        event_key: event1.jti, jwe: jwe1, timestamp: event1.occurred_at, issuer: issuer,
-      )
-      subject.write_event(
-        event_key: event2.jti, jwe: jwe2, timestamp: event2.occurred_at, issuer: issuer,
-      )
+      before do
+        now = Time.zone.now
+        3.times do |n|
+          event = AttemptsApi::AttemptEvent.new(
+            event_type: 'test_event',
+            session_id: 'test-session-id',
+            occurred_at: now - n.hours,
+            event_metadata: {
+              first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
+            },
+          )
+          jwe = event.to_jwe(issuer:, public_key: attempts_api_public_key)
+          subject.write_event(
+            event_key: event.jti, jwe:, timestamp: event.occurred_at, issuer:,
+          )
+          events[event.jti] = jwe
+        end
+      end
 
-      expect(subject.read_events(timestamp: time1, issuer: issuer)).to eq({ event1.jti => jwe1 })
-      expect(subject.read_events(timestamp: time2, issuer: issuer)).to eq({ event2.jti => jwe2 })
+      it 'returns all the events' do
+        expect(subject.read_events(issuer:)).to eq(events)
+      end
+
+      context 'when there is a batch_size limit' do
+        it 'returns the older events first' do
+          expect(subject.read_events(issuer:, batch_size: 2).keys).not_to include(events.keys.first)
+        end
+      end
     end
   end
 
@@ -120,9 +120,8 @@ RSpec.describe AttemptsApi::RedisClient do
         event_key: event2.jti, jwe: jwe2, timestamp: event2.occurred_at, issuer: issuer,
       )
 
-      subject.delete_events(issuer: issuer, keys: [event1.jti])
-      expect(subject.read_events(timestamp: time1, issuer: issuer)).to eq({})
-      expect(subject.read_events(timestamp: time2, issuer: issuer)).to eq({ event2.jti => jwe2 })
+      subject.delete_events(issuer:, keys: [event1.jti])
+      expect(subject.read_events(issuer:)).to eq({ event2.jti => jwe2 })
     end
   end
 end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe AttemptsApi::Tracker do
         subject.track_event(:test_event, foo: :bar)
 
         events = AttemptsApi::RedisClient.new.read_events(
-          timestamp: Time.zone.now,
           issuer: service_provider.issuer,
         )
 
@@ -78,7 +77,6 @@ RSpec.describe AttemptsApi::Tracker do
         subject.track_event(:event, first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name])
 
         events = AttemptsApi::RedisClient.new.read_events(
-          timestamp: Time.zone.now,
           issuer: service_provider.issuer,
         )
 
@@ -95,7 +93,6 @@ RSpec.describe AttemptsApi::Tracker do
           subject.track_event(:test_event, foo: :bar)
 
           events = AttemptsApi::RedisClient.new.read_events(
-            timestamp: Time.zone.now,
             issuer: service_provider.issuer,
           )
 
@@ -112,7 +109,6 @@ RSpec.describe AttemptsApi::Tracker do
           subject.track_event(:test_event, foo: :bar)
 
           events = AttemptsApi::RedisClient.new.read_events(
-            timestamp: Time.zone.now,
             issuer: service_provider.issuer,
           )
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[153](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/153)

## 🛠 Summary of changes
This change adds some functionality to the `poll` endpoint.

- Calls a delete method to remove all acknowledged sets
- Reads events, starting from the earliest redis bucket
- Returns the events as json 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
