### PR TITLE
Fix  Local File Inclusion in Rack::Static

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,7 +512,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.0.12)
+    rack (3.0.14)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-headers_filter (0.0.1)
@@ -831,7 +831,7 @@ DEPENDENCIES
   pry-rails
   psych
   puma (~> 6.0)
-  rack (~> 3.0.12)
+  rack (~> 3.0.14)
   rack-attack!
   rack-cors (> 2.0.1)
   rack-headers_filter


### PR DESCRIPTION
`Rack::Static` can serve files under the specified root: even if `urls:` are provided, which may expose other files under the specified `root:` unexpectedly. By exploiting this vulnerability, an attacker can gain access to all files under the specified `root:` directory, provided they are able to determine then path of the file.


## Mitigation
- Update to the latest version of Rack
- Remove usage of `Rack::Static`
- Ensure that root: points at a directory path which only contains files which should be accessed publicly.


CWE-23
[CVE-2025-27610](https://nvd.nist.gov/vuln/detail/CVE-2025-27610)