### PR TITLE
Improve test reliability by adding page assertions in feature test helpers

### DIFF
--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature 'how to verify step', js: true do
                  facial_match_required: facial_match_required }
     )
     sign_in_via_branded_page(user)
+    expect(page).to have_current_path(idv_welcome_path)
     complete_doc_auth_steps_before_agreement_step
     complete_agreement_step
   end

--- a/spec/support/features/session_helper.rb
+++ b/spec/support/features/session_helper.rb
@@ -537,7 +537,9 @@ module Features
     end
 
     def sign_in_via_branded_page(user)
+      expect(page).to have_current_path new_user_session_path
       fill_in_credentials_and_submit(user.last_sign_in_email_address.email, user.password)
+      expect(page).to have_current_path(login_two_factor_path(otp_delivery_preference: 'sms'))
       fill_in_code_with_last_phone_otp
       click_submit_default
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Based on reports [here](https://gsa-tts.slack.com/archives/C0NGESUN5/p1742421743002739) where a test attempts to go to the next page before completing authentication. Adding some additional assertions around page expectations addresses the issue for me locally. We don't see the issue in CI, so I suspect it's due to the speed of the system, and adding assertions makes sure requests can complete before moving on to the next step in the test.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
