### PR TITLE
changelog: Internal, In-person Proofing, Add comments to usps_control…

### DIFF
--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -98,6 +98,10 @@ module Idv
       end
 
       def handle_error(err)
+        # Due to app-wide level alarms triggering on 5XX error codes, we are
+        # only returning 5XX error codes in the case of an 'unhandled' scenario.
+        # When diving into error logs for this controller trust exception_class
+        # and exception_message over api_status_code as the codes are misleading.
         remapped_error = case err
                          when ActionController::InvalidAuthenticityToken,
                               Faraday::Error,
@@ -107,6 +111,9 @@ module Idv
                            :internal_server_error
                          end
 
+        # Below, the api_status_code is our internally remapped error code,
+        # while response_status_code is the status code returned from the USPS
+        # endpoint itself.
         analytics.idv_in_person_locations_request_failure(
           api_status_code: Rack::Utils.status_code(remapped_error),
           exception_class: err.class,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15823](https://cm-jira.usa.gov/browse/LG-15823)

## 🛠 Summary of changes

After [this conversation](https://gsa-tts.slack.com/archives/C0NGESUN5/p1742324579804419) in slack about why 5XX errors are treated as unhandled errors, it was decided to not change the error codes in this controller to follow RFC1910 as outlined in [this doc](https://docs.google.com/document/d/1vELpOE9nvq_yTElXS3k6iQtCPbYOkphNlwP7SkyCug0/edit?usp=sharing).

After the conversation I was going to update only the 4XX level error codes to be spec specific, but quickly realized that this would effectively only result in changing one error code and in the end adding clarifying comments to this remapping section of the code seemed like the best path forward for now.