### PR TITLE
LG-15873 delete log only recaptcha feature toggle

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -43,7 +43,7 @@ module Users
 
       rate_limit_password_failure = true
 
-      return process_failed_captcha unless recaptcha_response.success? || log_captcha_failures_only?
+      return process_failed_captcha unless recaptcha_response.success?
 
       self.resource = warden.authenticate!(auth_options)
       handle_valid_authentication
@@ -325,10 +325,6 @@ module Users
     def randomize_check_password?
       SecureRandom.random_number(IdentityConfig.store.compromised_password_randomizer_value) >=
         IdentityConfig.store.compromised_password_randomizer_threshold
-    end
-
-    def log_captcha_failures_only?
-      IdentityConfig.store.sign_in_recaptcha_log_failures_only
     end
   end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -388,7 +388,6 @@ short_term_phone_otp_max_attempts: 2
 show_unsupported_passkey_platform_authentication_setup: false
 show_user_attribute_deprecation_warnings: false
 sign_in_recaptcha_annotation_enabled: false
-sign_in_recaptcha_log_failures_only: false
 sign_in_recaptcha_percent_tested: 0
 sign_in_recaptcha_score_threshold: 0.0
 sign_in_user_id_per_ip_attempt_window_exponential_factor: 1.1

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -420,7 +420,6 @@ module IdentityConfig
     config.add(:sign_in_user_id_per_ip_attempt_window_max_minutes, type: :integer)
     config.add(:sign_in_user_id_per_ip_max_attempts, type: :integer)
     config.add(:sign_in_recaptcha_annotation_enabled, type: :boolean)
-    config.add(:sign_in_recaptcha_log_failures_only, type: :boolean)
     config.add(:sign_in_recaptcha_percent_tested, type: :integer)
     config.add(:sign_in_recaptcha_score_threshold, type: :float)
     config.add(:skip_encryption_allowed_list, type: :json)

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -923,8 +923,6 @@ RSpec.feature 'Sign in' do
     before do
       allow(FeatureManagement).to receive(:sign_in_recaptcha_enabled?).and_return(true)
       allow(IdentityConfig.store).to receive(:recaptcha_mock_validator).and_return(true)
-      allow(IdentityConfig.store).to receive(:sign_in_recaptcha_log_failures_only)
-        .and_return(sign_in_recaptcha_log_failures_only)
       allow(IdentityConfig.store).to receive(:sign_in_recaptcha_score_threshold).and_return(0.2)
       allow(IdentityConfig.store).to receive(:sign_in_recaptcha_percent_tested).and_return(100)
       reload_ab_tests
@@ -934,14 +932,7 @@ RSpec.feature 'Sign in' do
       reload_ab_tests
     end
 
-    context 'when configured to log failures only' do
-      let(:sign_in_recaptcha_log_failures_only) { true }
-      it_behaves_like 'logs reCAPTCHA event and redirects appropriately',
-                      successful_sign_in: true
-    end
-
     context 'when not configured to log failures only' do
-      let(:sign_in_recaptcha_log_failures_only) { false }
       it_behaves_like 'logs reCAPTCHA event and redirects appropriately',
                       successful_sign_in: false
     end


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-15873](https://cm-jira.usa.gov/browse/LG-15873)

## 🛠 Summary of changes
This removes log only mode for recaptcha sign in

## 📜 Testing Plan

- Signing in works as expected if valid recaptcha result
- if user gives invalid result, properly redirected to error page


