### PR TITLE
Use the session locale on OIDC requests with no locale param

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -407,6 +407,14 @@ class ApplicationController < ActionController::Base
     user_session[:web_locale] = I18n.locale.to_s
   end
 
+  def override_locale_with_web_locale
+    return unless user_signed_in?
+    return if user_session[:web_locale].nil?
+    return if params[:locale].present?
+
+    I18n.locale = LocaleChooser.new(user_session[:web_locale], request).locale
+  end
+
   def pii_requested_but_locked?
     if resolved_authn_context_result.identity_proofing? || resolved_authn_context_result.ialmax?
       current_user.identity_verified? &&

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -12,9 +12,9 @@ module OpenidConnect
     include OpenidConnectRedirectConcern
     include SignInDurationConcern
 
-    before_action :override_locale_with_web_locale
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :set_devise_failure_redirect_for_concurrent_session_logout
+    before_action :override_locale_with_web_locale
     before_action :pre_validate_authorize_form, only: [:index]
     before_action :sign_out_if_prompt_param_is_login_and_user_is_signed_in, only: [:index]
     before_action :store_request, only: [:index]

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -12,6 +12,7 @@ module OpenidConnect
     include OpenidConnectRedirectConcern
     include SignInDurationConcern
 
+    before_action :override_locale_with_web_locale
     before_action :build_authorize_form_from_params, only: [:index]
     before_action :set_devise_failure_redirect_for_concurrent_session_logout
     before_action :pre_validate_authorize_form, only: [:index]


### PR DESCRIPTION
When partners initiate an authentication they can include a locale in the request which we honor when we render the next page. However, many partners do not do this and we assume the default locale of English.

If the user was previously on Login.gov they may have a locale in the session. This commit changes the IdP to honor that locale if no locale is present in the OIDC authorization request. This fixes the following weird behaviors:

_The step up flow_:

1. The user authenticates for auth-only and selects a non-English locale for that
2. The user is redirected to the SP
3. The SP determines the user needs to identity proof and redirects back to Login.gov
4. The user's language choice is not longer respected

_The post-IdV follow up flow_:

1. The user enters a GPO code. They elect to do so with a non-English locale
2. They are presented the post-IdV follow up button on the next screen. They click the button to proceed to the service provider
3. The service provider recognizes it needs attributes from the user. It makes a redirect back to the IdP for the OIDC authorization endpoint
4. The user sees the screen to share proofed attributes. The language preference is no longer respected on this screen

This change causes the language preference to be respected in both of these cases.
