### PR TITLE
Wiring up first attempt event

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -235,6 +235,7 @@ module Users
         remember_device: remember_device_cookie.present?,
         new_device: success ? new_device? : nil,
       )
+      attempts_api_tracker.email_and_password_auth(success:)
     end
 
     def user_locked_out?(user)

--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -47,6 +47,8 @@ class NullServiceProviderSession
     view_context&.current_user
   end
 
+  def attempts_api_session_id; end
+
   private
 
   attr_reader :view_context

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -13,6 +13,10 @@ class ServiceProviderSession
     @service_provider_request = service_provider_request
   end
 
+  def attempts_api_session_id
+    request_url_params['attempts_api_session_id']
+  end
+
   def remember_device_default
     sp_aal < 2
   end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -99,7 +99,7 @@ class ServiceProvider < ApplicationRecord
   def attempts_config
     IdentityConfig.store.allowed_attempts_providers.find do |config|
       config['issuer'] == issuer
-    end
+    end || {}
   end
 
   # @return [String,nil]

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -87,6 +87,7 @@ class ServiceProvider < ApplicationRecord
   end
 
   def attempts_public_key
+    return if attempts_config.nil?
     if attempts_config['keys'].present?
       OpenSSL::PKey::RSA.new(attempts_config['keys'].first)
     else
@@ -99,7 +100,7 @@ class ServiceProvider < ApplicationRecord
   def attempts_config
     IdentityConfig.store.allowed_attempts_providers.find do |config|
       config['issuer'] == issuer
-    end || {}
+    end
   end
 
   # @return [String,nil]

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -87,8 +87,7 @@ class ServiceProvider < ApplicationRecord
   end
 
   def attempts_public_key
-    return if attempts_config.nil?
-    if attempts_config['keys'].present?
+    if attempts_config.present? && attempts_config['keys'].present?
       OpenSSL::PKey::RSA.new(attempts_config['keys'].first)
     else
       ssl_certs.first.public_key

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -82,7 +82,25 @@ class ServiceProvider < ApplicationRecord
     IdentityConfig.store.facial_match_general_availability_enabled
   end
 
+  def attempts_api_enabled?
+    IdentityConfig.store.attempts_api_enabled && attempts_config.present?
+  end
+
+  def attempts_public_key
+    if attempts_config['keys'].present?
+      OpenSSL::PKey::RSA.new(attempts_config['keys'].first)
+    else
+      ssl_certs.first.public_key
+    end
+  end
+
   private
+
+  def attempts_config
+    IdentityConfig.store.allowed_attempts_providers.find do |config|
+      config['issuer'] == issuer
+    end
+  end
 
   # @return [String,nil]
   def load_cert(cert)

--- a/app/services/attempts_api/request_token_validator.rb
+++ b/app/services/attempts_api/request_token_validator.rb
@@ -28,14 +28,6 @@ module AttemptsApi
       )
     end
 
-    def issuer_is_authorized
-      errors.add(
-        :issuer,
-        :not_authorized,
-        message: 'Issuer is not authorized to use Attempts API',
-      )
-    end
-
     def service_provider_exists
       return if service_provider.present?
 

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -3,10 +3,10 @@
 module AttemptsApi
   class Tracker
     attr_reader :session_id, :enabled_for_session, :request, :user, :sp, :cookie_device_uuid,
-                :sp_request_uri, :analytics
+                :sp_request_uri
 
     def initialize(session_id:, request:, user:, sp:, cookie_device_uuid:,
-                   sp_request_uri:, enabled_for_session:, analytics:)
+                   sp_request_uri:, enabled_for_session:)
       @session_id = session_id
       @request = request
       @user = user
@@ -14,7 +14,6 @@ module AttemptsApi
       @cookie_device_uuid = cookie_device_uuid
       @sp_request_uri = sp_request_uri
       @enabled_for_session = enabled_for_session
-      @analytics = analytics
     end
     include TrackerEvents
 
@@ -50,7 +49,7 @@ module AttemptsApi
 
       jwe = event.to_jwe(
         issuer: sp.issuer,
-        public_key: sp.ssl_certs.first.public_key,
+        public_key: sp.attempts_public_key,
       )
 
       redis_client.write_event(

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -2,13 +2,11 @@
 
 module AttemptsApi
   module TrackerEvents
-    # @param [String] email The submitted email address
     # @param [Boolean] success True if the email and password matched
     # A user has submitted an email address and password for authentication
-    def email_and_password_auth(email:, success:)
+    def email_and_password_auth(success:)
       track_event(
         'login-email-and-password-auth',
-        email: email,
         success: success,
       )
     end

--- a/spec/decorators/null_service_provider_session_spec.rb
+++ b/spec/decorators/null_service_provider_session_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe NullServiceProviderSession do
     end
   end
 
+  describe '#attempts_api_session_id' do
+    it 'returns nil' do
+      expect(subject.attempts_api_session_id).to be_nil
+    end
+  end
+
   describe '#cancel_link_url' do
     it 'returns view_context.root url' do
       view_context = ActionController::Base.new.view_context

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -290,4 +290,24 @@ RSpec.describe ServiceProviderSession do
       end
     end
   end
+
+  describe '#attempt_api_session_id' do
+    let(:service_provider_request) { ServiceProviderRequest.new(url:) }
+
+    context 'without an an attempts_api_session_id in the request_url_params' do
+      let(:url) { 'https://example.com/auth?param0=p0&param1=p1&param2=p2' }
+
+      it 'returns nil' do
+        expect(subject.attempts_api_session_id).to be nil
+      end
+    end
+
+    context 'with an attempts_api_session_id in the request_url_params' do
+      let(:url) { 'https://example.com/auth?attempts_api_session_id=abc123&param1=p1&param2=p2' }
+
+      it 'returns the value in the attempts_api_session_id param' do
+        expect(subject.attempts_api_session_id).to eq 'abc123'
+      end
+    end
+  end
 end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe AttemptsApi::Tracker do
   let(:cookie_device_uuid) { 'device_id' }
   let(:sp_request_uri) { 'https://example.com/auth_page' }
   let(:user) { create(:user) }
-  let(:analytics) { FakeAnalytics.new }
 
   subject do
     described_class.new(
@@ -30,7 +29,6 @@ RSpec.describe AttemptsApi::Tracker do
       cookie_device_uuid: cookie_device_uuid,
       sp_request_uri: sp_request_uri,
       enabled_for_session: enabled_for_session,
-      analytics: analytics,
     )
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[154](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/154)

## 🛠 Summary of changes
This change wires in the first attempt event to be stored in Redis. This code:

- Adds an attempts_api_tracker object in the applications controller
- Adds a way to access the `attempts_api_session_id` from the session object
- wires in a call to the `email_and_password_auth` event

I tested it locally using the OIDC sinatra sample app. I want to add a view there to make it easy to see events as they are generated/delete them


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
