### PR TITLE
LG-12304 Remove unused phone confirmation data (1a of 2)

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -124,6 +124,7 @@ module TwoFactorAuthentication
       return if params[:otp_delivery_preference] == 'sms'
 
       phone_is_confirmed = UserSessionContext.authentication_or_reauthentication_context?(context)
+
       capabilities = PhoneNumberCapabilities.new(phone, phone_confirmed: phone_is_confirmed)
 
       return if capabilities.supports_voice?
@@ -233,6 +234,7 @@ module TwoFactorAuthentication
         user: current_user,
         attributes: { phone_id: user_session[:phone_id],
                       phone: user_session[:unconfirmed_phone],
+                      phone_confirmed_at: Time.zone.now,
                       otp_make_default_number: selected_otp_make_default_number },
       )
     end

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -36,7 +36,7 @@ class PhoneConfiguration < ApplicationRecord
   end
 
   def capabilities
-    PhoneNumberCapabilities.new(phone, phone_confirmed: !!confirmed_at?)
+    PhoneNumberCapabilities.new(phone, phone_confirmed: false)
   end
 
   def friendly_name

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -2,7 +2,6 @@
 
 class PhoneConfiguration < ApplicationRecord
   self.ignored_columns += %w[confirmation_sent_at]
-  self.ignored_columns += %w[confirmed_at]
   include EncryptableAttribute
 
   belongs_to :user, inverse_of: :phone_configurations
@@ -37,7 +36,7 @@ class PhoneConfiguration < ApplicationRecord
   end
 
   def capabilities
-    PhoneNumberCapabilities.new(phone, phone_confirmed: false)
+    PhoneNumberCapabilities.new(phone, phone_confirmed: !!confirmed_at?)
   end
 
   def friendly_name

--- a/app/models/phone_configuration.rb
+++ b/app/models/phone_configuration.rb
@@ -2,6 +2,7 @@
 
 class PhoneConfiguration < ApplicationRecord
   self.ignored_columns += %w[confirmation_sent_at]
+  self.ignored_columns += %w[confirmed_at]
   include EncryptableAttribute
 
   belongs_to :user, inverse_of: :phone_configurations

--- a/app/services/update_user_phone_configuration.rb
+++ b/app/services/update_user_phone_configuration.rb
@@ -14,7 +14,10 @@ class UpdateUserPhoneConfiguration
 
   def call
     result = user.update!(
-      attributes.except(:phone_id, :phone, :otp_make_default_number),
+      attributes.except(
+        :phone_id, :phone, :phone_confirmed_at,
+        :otp_make_default_number
+      ),
     )
     manage_phone_configuration
     result
@@ -51,6 +54,7 @@ class UpdateUserPhoneConfiguration
   def phone_attributes
     @phone_attributes ||= {
       phone: attributes[:phone],
+      confirmed_at: attributes[:phone_confirmed_at],
       delivery_preference: attribute(:otp_delivery_preference),
       made_default_at: made_default_at_date,
     }.delete_if { |_, value| value.nil? }

--- a/lib/data_requests/deployed/create_mfa_configurations_report.rb
+++ b/lib/data_requests/deployed/create_mfa_configurations_report.rb
@@ -45,6 +45,7 @@ module DataRequests
             id: phone_configuration.id,
             phone: phone_configuration.phone,
             created_at: phone_configuration.created_at,
+            confirmed_at: phone_configuration.confirmed_at,
           }
         end
       end

--- a/lib/tasks/create_test_accounts.rb
+++ b/lib/tasks/create_test_accounts.rb
@@ -18,6 +18,7 @@ def create_account(email: 'joe.smith@email.com', password: 'salty pickles', mfa_
   user.save!
   MfaContext.new(user).phone_configurations.create(
     phone: mfa_phone || phone,
+    confirmed_at: Time.zone.now,
     delivery_preference: user.otp_delivery_preference
   )
   Event.create(user_id: user.id, event_type: :account_created)

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -237,6 +237,7 @@ namespace :dev do
     {
       delivery_preference: user.otp_delivery_preference,
       phone: format('+1 (415) 555-%04d', args[:num]),
+      confirmed_at: Time.zone.now,
     }
   end
 end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -514,7 +514,8 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
         controller.user_session[:unconfirmed_phone] = '+1 (703) 555-5555'
         controller.user_session[:context] = 'confirmation'
 
-        @previous_phone_confirmed_at = true
+        @previous_phone_confirmed_at =
+          MfaContext.new(controller.current_user).phone_configurations.first&.confirmed_at
 
         controller.current_user.create_direct_otp
 
@@ -606,9 +607,10 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
             expect(subject.user_session[:unconfirmed_phone]).to eq('+1 (703) 555-5555')
           end
 
-          it 'does not update user phone' do
+          it 'does not update user phone or phone_confirmed_at attributes' do
             first_configuration = MfaContext.new(subject.current_user).phone_configurations.first
             expect(first_configuration.phone).to eq('+1 202-555-1212')
+            expect(first_configuration.confirmed_at).to eq(@previous_phone_confirmed_at)
           end
 
           it 'renders :show' do

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -514,8 +514,7 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
         controller.user_session[:unconfirmed_phone] = '+1 (703) 555-5555'
         controller.user_session[:context] = 'confirmation'
 
-        @previous_phone_confirmed_at =
-          MfaContext.new(controller.current_user).phone_configurations.first&.confirmed_at
+        @previous_phone_confirmed_at = true
 
         controller.current_user.create_direct_otp
 

--- a/spec/factories/phone_configurations.rb
+++ b/spec/factories/phone_configurations.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   Faker::Config.locale = :en
 
   factory :phone_configuration do
+    confirmed_at { Time.zone.now }
     phone { '+1 202-555-1212' }
     mfa_enabled { true }
     user { association :user }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -121,7 +121,7 @@ FactoryBot.define do
             user_id: -1,
           }.merge(
             evaluator.with.slice(
-              :phone, :delivery_preference, :mfa_enabled
+              :phone, :confirmed_at, :delivery_preference, :mfa_enabled
             ),
           ),
         )
@@ -135,7 +135,7 @@ FactoryBot.define do
             delivery_preference: user.otp_delivery_preference,
           }.merge(
             evaluator.with.slice(
-              :phone, :delivery_preference, :mfa_enabled
+              :phone, :confirmed_at, :delivery_preference, :mfa_enabled
             ),
           ),
         )

--- a/spec/features/phone/add_phone_spec.rb
+++ b/spec/features/phone/add_phone_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'Add a new phone number' do
 
     expect(page).to have_current_path(account_path)
     expect(user.reload.phone_configurations.count).to eq(2)
+    expect(user.phone_configurations[0].confirmed_at).to be_present
+    expect(user.phone_configurations[1].confirmed_at).to be_present
   end
 
   scenario 'adding a new phone number sends the user an email with a disavowal link' do

--- a/spec/features/phone/confirmation_spec.rb
+++ b/spec/features/phone/confirmation_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'phone otp confirmation' do
       expect(page).to have_content(t('notices.phone_confirmed'))
 
       expect(page).to have_current_path(auth_method_confirmation_path)
+      expect(phone_configuration.confirmed_at).to_not be_nil
       expect(phone_configuration.delivery_preference).to eq(delivery_method.to_s)
     end
 
@@ -76,6 +77,7 @@ RSpec.describe 'phone otp confirmation' do
     def expect_successful_otp_confirmation(delivery_method)
       expect(page).to have_content(t('notices.phone_confirmed'))
       expect(page).to have_current_path(account_path)
+      expect(phone_configuration.confirmed_at).to_not be_nil
       expect(phone_configuration.delivery_preference).to eq(delivery_method.to_s)
     end
 

--- a/spec/fixtures/data_request.json
+++ b/spec/fixtures/data_request.json
@@ -15,7 +15,8 @@
         {
           "id": 123456,
           "phone": "+1 555-555-5555",
-          "created_at": "2021-10-21T14:53:08.803Z"
+          "created_at": "2021-10-21T14:53:08.803Z",
+          "confirmed_at": "2021-10-21T14:53:08.790Z"
         }
       ],
       "auth_app_configurations": [],

--- a/spec/lib/data_requests/deployed/create_mfa_configurations_report_spec.rb
+++ b/spec/lib/data_requests/deployed/create_mfa_configurations_report_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe DataRequests::Deployed::CreateMfaConfigurationsReport do
       expect(phone_data.first[:created_at]).to be_within(1.second).of(
         phone_configuration.created_at,
       )
+      expect(phone_data.first[:confirmed_at]).to be_within(1.second).of(
+        phone_configuration.confirmed_at,
+      )
     end
 
     it 'includes an array for authentication apps' do

--- a/spec/lib/data_requests/local/write_user_info_spec.rb
+++ b/spec/lib/data_requests/local/write_user_info_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe DataRequests::Local::WriteUserInfo do
       expect(email_row['uuid']).to eq(uuid)
       expect(email_row['value']).to eq('test@example.com')
       expect(email_row['created_at']).to be_present
+      expect(email_row['confirmed_at']).to be_present
       expect(email_row['internal_id']).to be_nil
 
       phone_row = parsed.find { |r| r['type'] == 'Phone configuration' }

--- a/spec/lib/data_requests/local/write_user_info_spec.rb
+++ b/spec/lib/data_requests/local/write_user_info_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe DataRequests::Local::WriteUserInfo do
       expect(phone_row['uuid']).to eq(uuid)
       expect(phone_row['value']).to eq('+1 555-555-5555')
       expect(phone_row['created_at']).to be_present
+      expect(phone_row['confirmed_at']).to be_present
       expect(phone_row['internal_id']).to be_present
     end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-12304](https://cm-jira.usa.gov/browse/LG-12304)

Restores phone_configurations.confirmed_at changes from prior PR and keeps in changes for the other 2 removed DB columns.

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
