### PR TITLE
Adds user registration events

### DIFF
--- a/app/controllers/sign_up/passwords_controller.rb
+++ b/app/controllers/sign_up/passwords_controller.rb
@@ -38,6 +38,12 @@ module SignUp
 
     def track_analytics(result)
       analytics.password_creation(**result)
+
+      failure_reason = attempts_api_tracker.parse_failure_reason(result)
+      attempts_api_tracker.user_registration_password_submitted(
+        success: result.success?,
+        failure_reason:,
+      )
     end
 
     def permitted_params

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -23,6 +23,7 @@ module Users
       result = BackupCodeSetupForm.new(current_user).submit
       visit_result = result.to_h.merge(analytics_properties_for_visit)
       analytics.backup_code_setup_visit(**visit_result)
+      attempts_api_tracker.mfa_enroll_backup_code(success: result.success?)
 
       generate_codes
       track_backup_codes_created
@@ -35,6 +36,7 @@ module Users
       result = BackupCodeSetupForm.new(current_user).submit
       visit_result = result.to_h.merge(analytics_properties_for_visit)
       analytics.backup_code_setup_visit(**visit_result)
+      attempts_api_tracker.mfa_enroll_backup_code(success: result.success?)
 
       generate_codes
       track_backup_codes_created

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -30,6 +30,8 @@ module Users
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)
 
+      attempts_api_tracker.mfa_enroll_totp(success: result.success?)
+
       if result.success?
         process_valid_code
         user_session.delete(:mfa_attempts)

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -7,7 +7,39 @@ module AttemptsApi
     def email_and_password_auth(success:)
       track_event(
         'login-email-and-password-auth',
-        success: success,
+        success:,
+      )
+    end
+
+    # @param [Boolean] success
+    # A user has attempted to enroll the Backup Codes MFA method to their account
+    def mfa_enroll_backup_code(success:)
+      track_event(
+        'mfa-enroll-backup-code',
+        success:,
+      )
+    end
+
+    # @param [Boolean] success
+    # A user has attempted to enroll the TOTP MFA method to their account
+    def mfa_enroll_totp(success:)
+      track_event(
+        'mfa-enroll-totp',
+        success:,
+      )
+    end
+
+    # Tracks when user submits registration password
+    # @param [Boolean] success
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    def user_registration_password_submitted(
+      success:,
+      failure_reason: nil
+    )
+      track_event(
+        'user-registration-password-submitted',
+        success:,
+        failure_reason:,
       )
     end
   end

--- a/docs/attempts-api/schemas/events/sign-in/MfaLoginBackupCodeSubmitted.yml
+++ b/docs/attempts-api/schemas/events/sign-in/MfaLoginBackupCodeSubmitted.yml
@@ -1,4 +1,4 @@
-description: During a login attempt, the user uses face or touch unlock for MFA.
+description: During a login attempt, the user has selected a set of backup codes for MFA..
 allOf:
   - $ref: '../shared/EventProperties.yml'
   - type: object

--- a/docs/attempts-api/schemas/events/sign-in/MfaLoginBackupCodeSubmitted.yml
+++ b/docs/attempts-api/schemas/events/sign-in/MfaLoginBackupCodeSubmitted.yml
@@ -1,4 +1,4 @@
-description: During a login attempt, the user has selected a set of backup codes for MFA..
+description:  During a login attempt, the user submits a code from their backup code list.
 allOf:
   - $ref: '../shared/EventProperties.yml'
   - type: object

--- a/docs/attempts-api/schemas/events/sign-in/MfaLoginWebauthnRoamingSubmitted.yml
+++ b/docs/attempts-api/schemas/events/sign-in/MfaLoginWebauthnRoamingSubmitted.yml
@@ -1,4 +1,4 @@
-description: During a login attempt, the user uses face or touch unlock for MFA.
+description: During a login attempt, the user uses a security key for MFA.
 allOf:
   - $ref: '../shared/EventProperties.yml'
   - type: object

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe Users::BackupCodeSetupController do
 
     it 'creates backup codes and logs expected events' do
       stub_analytics
+      stub_attempts_tracker
       allow(controller).to receive(:in_multi_mfa_selection_flow?).and_return(true)
+      expect(@attempts_api_tracker).to receive(:mfa_enroll_backup_code).with(success: true)
 
       Funnel::Registration::AddMfa.call(user.id, 'phone', @analytics, threatmetrix_attrs)
       expect(PushNotification::HttpPush).to receive(:deliver)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include AgreementsHelper
   config.include AnalyticsHelper
+  config.include AttemptsApiTrackingHelper
   config.include AwsCloudwatchHelper
   config.include AwsKmsClientHelper
   config.include DiffHelper

--- a/spec/support/attempts_api_tracking_helper.rb
+++ b/spec/support/attempts_api_tracking_helper.rb
@@ -1,0 +1,34 @@
+module AttemptsApiTrackingHelper
+  class AttemptsApiEventDecryptor
+    def self.public_key
+      private_key.public_key
+    end
+
+    def self.private_key
+      @private_key ||= OpenSSL::PKey::RSA.new(4096)
+    end
+
+    def decrypted_events_from_store(timestamp:)
+      jwes = AttemptsApi::RedisClient.new.read_events(timestamp: timestamp)
+      jwes.transform_values do |jwe|
+        AttemptsApi::AttemptEvent.from_jwe(jwe, self.class.private_key)
+      end
+    end
+  end
+
+  def attempts_api_tracked_events(timestamp:)
+    AttemptsApiEventDecryptor.new.decrypted_events_from_store(timestamp: timestamp).values
+  end
+
+  def stub_attempts_tracker
+    attempts_api_tracker = FakeAttemptsTracker.new
+
+    if respond_to?(:controller)
+      allow(controller).to receive(:attempts_api_tracker).and_return(attempts_api_tracker)
+    else
+      allow(self).to receive(:attempts_api_tracker).and_return(attempts_api_tracker)
+    end
+
+    @attempts_api_tracker = attempts_api_tracker
+  end
+end

--- a/spec/support/fake_attempts_tracker.rb
+++ b/spec/support/fake_attempts_tracker.rb
@@ -1,0 +1,29 @@
+module AttemptsApiTrackingHelper
+  class FakeAttemptsTracker
+    include AttemptsApi::TrackerEvents
+
+    attr_reader :events
+
+    def initialize
+      @events = Hash.new
+    end
+
+    def track_event(event, attributes = {})
+      events[event] ||= []
+      events[event] << attributes
+      nil
+    end
+
+    def parse_failure_reason(result)
+      return result.to_h[:error_details] || result.errors.presence
+    end
+
+    def track_mfa_submit_event(_attributes)
+      # no-op
+    end
+
+    def browser_attributes
+      {}
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[155](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/155)

## 🛠 Summary of changes
This change adds three user registration events. those events are:
- mfa-enroll-backup-code
- mfa-enroll-totp
-  user-registration-password-submitted

This change also adds some spec support to make it easier to test, as well as updating a couple of event descriptions in the openapi spec.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->


## 👀 Screenshots

![Sample app table view of different attempt events](https://github.com/user-attachments/assets/4801b787-c4b8-45ed-a3e7-dac7af26ac76)
