### PR TITLE
LG-15435: Conditionally show passport as option if available on Welcome and How to Verify

### DIFF
--- a/app/controllers/idv/how_to_verify_controller.rb
+++ b/app/controllers/idv/how_to_verify_controller.rb
@@ -5,6 +5,7 @@ module Idv
     include Idv::AvailabilityConcern
     include IdvStepConcern
     include RenderConditionConcern
+    include DocAuthVendorConcern
 
     before_action :confirm_step_allowed
     before_action :set_how_to_verify_presenter
@@ -64,9 +65,9 @@ module Idv
           idv_session.service_provider&.in_person_proofing_enabled
         end,
         undo_step: ->(idv_session:, user:) {
-                     idv_session.skip_doc_auth_from_how_to_verify = nil
-                     idv_session.opted_in_to_in_person_proofing = nil
-                   },
+          idv_session.skip_doc_auth_from_how_to_verify = nil
+          idv_session.opted_in_to_in_person_proofing = nil
+        },
       )
     end
 
@@ -96,19 +97,13 @@ module Idv
       @presenter = Idv::HowToVerifyPresenter.new(
         mobile_required: @mobile_required,
         selfie_check_required: @selfie_required,
+        passport_allowed: idv_session.passport_allowed,
       )
     end
 
     def mobile_required?
       idv_session.selfie_check_required ||
         document_capture_session.doc_auth_vendor == Idp::Constants::Vendors::SOCURE
-    end
-
-    def document_capture_session
-      return @document_capture_session if defined?(@document_capture_session)
-      @document_capture_session = DocumentCaptureSession.find_by(
-        uuid: idv_session.document_capture_session_uuid,
-      )
     end
   end
 end

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -30,10 +30,8 @@ module Idv
 
     def update
       clear_future_steps!
-      analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
-
       create_document_capture_session
-
+      analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
       idv_session.welcome_visited = true
 
       redirect_to idv_agreement_url

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -44,7 +44,7 @@ module Idv
         key: :welcome,
         controller: self,
         next_steps: [:agreement],
-        preconditions: ->(idv_session:, user:) { !user.gpo_verification_pending_profile? },
+        preconditions: ->(idv_session:, user:) { true },
         undo_step: ->(idv_session:, user:) do
           idv_session.welcome_visited = nil
           idv_session.document_capture_session_uuid = nil

--- a/app/presenters/idv/how_to_verify_presenter.rb
+++ b/app/presenters/idv/how_to_verify_presenter.rb
@@ -14,12 +14,6 @@ class Idv::HowToVerifyPresenter
 
   def how_to_verify_info
     t('doc_auth.headings.how_to_verify')
-
-    # if mobile_required
-    #   t('doc_auth.info.how_to_verify_mobile')
-    # else
-    #   t('doc_auth.info.how_to_verify')
-    # end
   end
 
   def header_text

--- a/app/presenters/idv/how_to_verify_presenter.rb
+++ b/app/presenters/idv/how_to_verify_presenter.rb
@@ -4,22 +4,29 @@ class Idv::HowToVerifyPresenter
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :mobile_required, :selfie_required
+  attr_reader :mobile_required, :selfie_required, :passport_allowed
 
-  def initialize(mobile_required:, selfie_check_required:)
+  def initialize(mobile_required:, selfie_check_required:, passport_allowed:)
     @mobile_required = mobile_required
     @selfie_required = selfie_check_required
+    @passport_allowed = passport_allowed
   end
 
   def how_to_verify_info
-    if mobile_required
-      t('doc_auth.info.how_to_verify_mobile')
-    else
-      t('doc_auth.info.how_to_verify')
-    end
+    t('doc_auth.headings.how_to_verify')
+
+    # if mobile_required
+    #   t('doc_auth.info.how_to_verify_mobile')
+    # else
+    #   t('doc_auth.info.how_to_verify')
+    # end
   end
 
-  def asset_url
+  def header_text
+    t('doc_auth.headings.how_to_verify')
+  end
+
+  def online_asset_url
     if mobile_required
       'idv/mobile-phone-icon.svg'
     else
@@ -27,7 +34,7 @@ class Idv::HowToVerifyPresenter
     end
   end
 
-  def alt_text
+  def online_asset_alt_text
     if mobile_required
       t('image_description.phone_icon')
     else
@@ -51,34 +58,46 @@ class Idv::HowToVerifyPresenter
   end
 
   def verify_online_description
-    if mobile_required
-      t('doc_auth.info.verify_online_description_mobile')
+    if passport_allowed
+      t('doc_auth.info.verify_online_description_passport')
     else
-      t('doc_auth.info.verify_online_description')
+      ''
     end
   end
 
-  def submit
+  def online_submit
     if mobile_required
-      t('forms.buttons.continue_remote_mobile')
+      t('forms.buttons.continue_online_mobile')
     else
-      t('forms.buttons.continue_remote')
+      t('forms.buttons.continue_online')
     end
+  end
+
+  def post_office_asset_url
+    'idv/in-person.svg'
+  end
+
+  def post_office_asset_alt_text
+    t('image_description.post_office')
+  end
+
+  def verify_at_post_office_text
+    t('doc_auth.headings.verify_at_post_office')
   end
 
   def post_office_instruction
-    if selfie_required
-      t('doc_auth.info.verify_at_post_office_instruction_selfie')
-    else
-      t('doc_auth.info.verify_at_post_office_instruction')
-    end
+    t('doc_auth.info.verify_at_post_office_instruction')
   end
 
   def post_office_description
-    if mobile_required
-      t('doc_auth.info.verify_at_post_office_description_mobile')
+    if passport_allowed
+      t('doc_auth.info.verify_at_post_office_description_passport_html')
     else
-      t('doc_auth.info.verify_at_post_office_description')
+      ''
     end
+  end
+
+  def post_office_submit
+    t('forms.buttons.continue_ipp')
   end
 end

--- a/app/presenters/idv/welcome_presenter.rb
+++ b/app/presenters/idv/welcome_presenter.rb
@@ -14,8 +14,9 @@ module Idv
 
     attr_accessor :url_options
 
-    def initialize(decorated_sp_session)
+    def initialize(decorated_sp_session:, passport_allowed:)
       @decorated_sp_session = decorated_sp_session
+      @passport_allowed = passport_allowed
       @url_options = {}
     end
 
@@ -45,7 +46,7 @@ module Idv
     def bullet_points
       [
         bullet_point(
-          t('doc_auth.instructions.bullet1'),
+          id_type_copy,
           t('doc_auth.instructions.text1'),
         ),
 
@@ -68,10 +69,16 @@ module Idv
 
     private
 
-    attr_accessor :decorated_sp_session
+    attr_reader :decorated_sp_session, :passport_allowed
 
     def current_user
       decorated_sp_session&.current_user
+    end
+
+    def id_type_copy
+      return t('doc_auth.instructions.bullet1b') if passport_allowed
+
+      t('doc_auth.instructions.bullet1a')
     end
 
     def bullet_point(bullet, text)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -2316,11 +2316,15 @@ module AnalyticsEvents
   # User submits IdV welcome screen
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
+  # @param [String] doc_auth_vendor Vendor used for document capture
+  # @param [Boolean] passport_allowed Whether passport is allowed for document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_welcome_submitted(
     step:,
     analytics_id:,
+    doc_auth_vendor:,
+    passport_allowed:,
     opted_in_to_in_person_proofing: nil,
     skip_hybrid_handoff: nil,
     **extra
@@ -2329,6 +2333,8 @@ module AnalyticsEvents
       'IdV: doc auth welcome submitted',
       step:,
       analytics_id:,
+      doc_auth_vendor:,
+      passport_allowed:,
       opted_in_to_in_person_proofing:,
       skip_hybrid_handoff:,
       **extra,
@@ -2338,11 +2344,15 @@ module AnalyticsEvents
   # User visits IdV welcome screen
   # @param [String] step Current IdV step
   # @param [String] analytics_id Current IdV flow identifier
+  # @param [String] doc_auth_vendor Vendor used for document capture
+  # @param [Boolean] passport_allowed Whether passport is allowed for document capture
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   def idv_doc_auth_welcome_visited(
     step:,
     analytics_id:,
+    doc_auth_vendor:,
+    passport_allowed:,
     opted_in_to_in_person_proofing: nil,
     skip_hybrid_handoff: nil,
     **extra
@@ -2351,6 +2361,8 @@ module AnalyticsEvents
       'IdV: doc auth welcome visited',
       step:,
       analytics_id:,
+      doc_auth_vendor:,
+      passport_allowed:,
       skip_hybrid_handoff:,
       opted_in_to_in_person_proofing:,
       **extra,

--- a/app/views/idv/how_to_verify/show.html.erb
+++ b/app/views/idv/how_to_verify/show.html.erb
@@ -9,7 +9,7 @@
 
 <% self.title = @presenter.header_text %>
 
-<%= render PageHeadingComponent.new.with_content(@presenter.header_text) %>
+<%= render PageHeadingComponent.new(id: 'how-to-verify-info').with_content(@presenter.header_text) %>
 
 <% if defined?(error) %>
   <%= render AlertComponent.new(
@@ -21,7 +21,6 @@
   <% end %>
 <% end %>
 
-<p id='how-to-verify-info' class='hidden'><%= @presenter.how_to_verify_info %></p>
 <div role="group" aria-labelledby="how-to-verify-info" class="border-bottom border-primary-light grid-row">
   <div class="grid-col-12 tablet:grid-col-auto margin-top-3">
     <%= image_tag(

--- a/app/views/idv/how_to_verify/show.html.erb
+++ b/app/views/idv/how_to_verify/show.html.erb
@@ -7,9 +7,9 @@
       ) %>
 <% end %>
 
-<% self.title = t('doc_auth.headings.how_to_verify') %>
+<% self.title = @presenter.header_text %>
 
-<%= render PageHeadingComponent.new.with_content(t('doc_auth.headings.how_to_verify')) %>
+<%= render PageHeadingComponent.new.with_content(@presenter.header_text) %>
 
 <% if defined?(error) %>
   <%= render AlertComponent.new(
@@ -21,67 +21,80 @@
   <% end %>
 <% end %>
 
-<p id='how-to-verify-info' class='margin-bottom-1'><%= @presenter.how_to_verify_info %></p>
-  <div role="group" aria-labelledby="how-to-verify-info" class="border-bottom border-primary-light grid-row">
-    <div class="grid-col-12 tablet:grid-col-auto margin-top-3">
-      <%= image_tag(
-            asset_url(@presenter.asset_url),
-            width: 88,
-            height: 88,
-            alt: @presenter.alt_text,
-          ) %>
-    </div>
-    <div class="grid-col-12 tablet:grid-col-fill">
-    <%= simple_form_for(
-          @idv_how_to_verify_form,
-          html: {
-            id: nil,
-            aria: { label: @presenter.submit },
-            class: 'margin-top-3',
-          },
-          method: :put,
-          url: idv_how_to_verify_url,
-        ) do |f|
-    %>
-    <%= f.hidden_field(
-          :selection,
-          value: Idv::HowToVerifyForm::REMOTE,
+<p id='how-to-verify-info' class='hidden'><%= @presenter.how_to_verify_info %></p>
+<div role="group" aria-labelledby="how-to-verify-info" class="border-bottom border-primary-light grid-row">
+  <div class="grid-col-12 tablet:grid-col-auto margin-top-3">
+    <%= image_tag(
+          asset_url(@presenter.online_asset_url),
+          width: 88,
+          height: 88,
+          alt: @presenter.online_asset_alt_text,
         ) %>
-    <%= f.label(
-          :selection_remote,
-        ) do %>
-            <% if @mobile_required %>
-                <span class='usa-tag usa-tag--informative margin-bottom-2 margin-top-1'>
-                  <%= t('doc_auth.tips.mobile_phone_required') %>
-                </span>
-            <% end %>
-            <h2 class="margin-top-0"><%= @presenter.verify_online_text %></h2>
-            <div>
-              <p><%= @presenter.verify_online_instruction %></p>
-              <p><%= @presenter.verify_online_description %></p>
-            </div>
-        <% end %>
-        <%= f.submit @presenter.submit, class: 'display-block margin-top-3 margin-bottom-5' %>
-    <% end %>
-    </div>
   </div>
-<div role="group" aria-labelledby="how-to-verify-info" class="grid-row">
-<div class="grid-col-12 tablet:grid-col-auto">
-  <%= image_tag(
-        asset_url('idv/in-person.svg'),
-        width: 88,
-        height: 88,
-        class: 'margin-right-1 margin-top-3',
-        alt: t('image_description.post_office'),
+  <div class="grid-col-12 tablet:grid-col-fill">
+  <%= simple_form_for(
+        @idv_how_to_verify_form,
+        html: {
+          id: nil,
+          aria: { label: @presenter.online_submit },
+          class: 'margin-top-3',
+        },
+        method: :put,
+        url: idv_how_to_verify_url,
+      ) do |f|
+  %>
+  <%= f.hidden_field(
+        :selection,
+        value: Idv::HowToVerifyForm::REMOTE,
       ) %>
+  <%= f.label(
+        :selection_remote,
+      ) do %>
+          <% if @mobile_required %>
+              <span class='usa-tag usa-tag--informative margin-bottom-2 margin-top-1'>
+                <%= t('doc_auth.tips.mobile_phone_required') %>
+              </span>
+          <% end %>
+          <h2 class="margin-top-0"><%= @presenter.verify_online_text %></h2>
+          <div>
+            <p><%= @presenter.verify_online_instruction %>
+               <%= @presenter.verify_online_description %></p>
+            <p class="margin-top-2">
+              <%= new_tab_link_to(
+                    t('doc_auth.info.verify_online_link_text'),
+                    help_center_redirect_path(
+                      category: 'verify-your-identity',
+                      article: 'overview',
+                      flow: :idv,
+                      step: :how_to_verify,
+                      location: 'troubleshooting_options',
+                    ),
+                  ) %>
+            </p>
+          </div>
+      <% end %>
+      <%= f.submit @presenter.online_submit, class: 'display-block margin-top-3 margin-bottom-5' %>
+  <% end %>
+  </div>
 </div>
+
+<div role="group" aria-labelledby="how-to-verify-info" class="grid-row">
+  <div class="grid-col-12 tablet:grid-col-auto">
+    <%= image_tag(
+          asset_url(@presenter.post_office_asset_url),
+          width: 88,
+          height: 88,
+          class: 'margin-right-1 margin-top-3',
+          alt: @presenter.post_office_asset_alt_text,
+        ) %>
+  </div>
   <div class="grid-col-12 tablet:grid-col-fill">
     <%= simple_form_for(
           @idv_how_to_verify_form,
           html: {
             id: nil,
             class: 'margin-top-3',
-            aria: { label: t('forms.buttons.continue_ipp') },
+            aria: { label: @presenter.post_office_submit },
           },
           method: :put,
           url: idv_how_to_verify_url,
@@ -94,10 +107,22 @@
       <%= f.label(
             :selection_ipp,
           ) do %>
-            <h3 class="h2 margin-top-0"><%= t('doc_auth.headings.verify_at_post_office') %></h3>
+            <h2 class="margin-top-0"><%= @presenter.verify_at_post_office_text %></h2>
             <div>
-              <p><%= @presenter.post_office_instruction %></p>
-              <p><%= @presenter.post_office_description %></p>
+              <p><%= @presenter.post_office_instruction %>
+                 <%= @presenter.post_office_description %></p>
+              <p class="margin-top-2">
+                <%= new_tab_link_to(
+                      t('doc_auth.info.verify_at_post_office_link_text'),
+                      help_center_redirect_path(
+                        category: 'verify-your-identity',
+                        article: 'verify-your-identity-in-person',
+                        flow: :idv,
+                        step: :how_to_verify,
+                        location: 'troubleshooting_options',
+                      ),
+                    ) %>
+              </p>
             </div>
           <% end %>
       <%= f.submit t('forms.buttons.continue_ipp'), class: 'display-block margin-top-3 margin-bottom-5', outline: true %>
@@ -105,33 +130,4 @@
   </div>
 </div>
 
-<%= render(
-      'shared/troubleshooting_options',
-      heading_tag: :h3,
-      heading: t('doc_auth.info.how_to_verify_troubleshooting_options_header'),
-      options: [
-        {
-          url: help_center_redirect_path(
-            category: 'verify-your-identity',
-            article: 'overview',
-            flow: :idv,
-            step: :how_to_verify,
-            location: 'troubleshooting_options',
-          ),
-          text: t('doc_auth.info.verify_online_link_text'),
-          new_tab: true,
-        },
-        {
-          url: help_center_redirect_path(
-            category: 'verify-your-identity',
-            article: 'verify-your-identity-in-person',
-            flow: :idv,
-            step: :how_to_verify,
-            location: 'troubleshooting_options',
-          ),
-          text: t('doc_auth.info.verify_at_post_office_link_text'),
-          new_tab: true,
-        },
-      ],
-    ) %>
 <%= render 'idv/doc_auth/cancel', step: 'how_to_verify' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -604,7 +604,7 @@ doc_auth.headings.document_capture_front: Front of your ID
 doc_auth.headings.document_capture_selfie: Photo of your face
 doc_auth.headings.document_capture_subheader_selfie: Add a photo of your face
 doc_auth.headings.front: Front of your driver’s license or state ID
-doc_auth.headings.how_to_verify: Choose how you want to verify your identity
+doc_auth.headings.how_to_verify: Choose how to verify your ID
 doc_auth.headings.hybrid_handoff: How would you like to add your ID?
 doc_auth.headings.hybrid_handoff_selfie: Enter your phone number to switch devices
 doc_auth.headings.interstitial: We are processing your images
@@ -620,7 +620,7 @@ doc_auth.headings.ssn_update: Update your Social Security number
 doc_auth.headings.text_message: We sent a message to your phone
 doc_auth.headings.upload_from_computer: Continue on this computer
 doc_auth.headings.upload_from_phone: Use your phone to take photos
-doc_auth.headings.verify_at_post_office: Verify your identity at a Post Office
+doc_auth.headings.verify_at_post_office: Go to a participating Post Office
 doc_auth.headings.verify_identity: Verify your identity
 doc_auth.headings.verify_online: Verify your identity online
 doc_auth.headings.verify_online_mobile: Verify your identity online using your phone
@@ -645,9 +645,6 @@ doc_auth.info.exit.with_sp: Exit %{app_name} and return to %{sp_name}
 doc_auth.info.exit.without_sp: Exit identity verification and go to your account page
 doc_auth.info.getting_started_html: '%{sp_name} needs to make sure you are you — not someone pretending to be you. %{link_html}'
 doc_auth.info.getting_started_learn_more: Learn more about verifying your identity
-doc_auth.info.how_to_verify: You have the option to verify your identity online, or in person at a participating Post Office.
-doc_auth.info.how_to_verify_mobile: You have the option to verify your identity online with your phone, or in person at a participating Post Office.
-doc_auth.info.how_to_verify_troubleshooting_options_header: Want to learn more about how to verify your identity?
 doc_auth.info.hybrid_handoff: We’ll collect information about you by reading your state‑issued ID.
 doc_auth.info.hybrid_handoff_ipp_html: '<strong>Don’t have a mobile phone?</strong> You can verify your identity at a United States Post Office instead.'
 doc_auth.info.id_types_learn_more: Learn more about which ID types you can use
@@ -683,20 +680,18 @@ doc_auth.info.stepping_up_html: Verify your identity again to access this servic
 doc_auth.info.tag: Recommended
 doc_auth.info.upload_from_computer: Don’t have a phone? Upload photos of your ID from this computer.
 doc_auth.info.upload_from_phone: You won’t have to sign in again, and you’ll switch back to this computer after you take photos. Your mobile phone must have a camera and a web browser.
-doc_auth.info.verify_at_post_office_description: This option is better if you don’t have a phone to take photos of your ID.
-doc_auth.info.verify_at_post_office_description_mobile: Choose this option if you don’t have a phone to take pictures.
-doc_auth.info.verify_at_post_office_instruction: You’ll enter your ID information online, and verify your identity in person at a participating Post Office.
-doc_auth.info.verify_at_post_office_instruction_selfie: You’ll enter your ID information online, and verify your identity in person at a participating Post Office.
+doc_auth.info.verify_at_post_office_description_passport_html: <strong>You can only use a U.S. driver’s license or state ID.</strong> You cannot use a U.S. passport book for this option.
+doc_auth.info.verify_at_post_office_instruction: Enter your information online, then verify your identity in person at a participating Post Office.
 doc_auth.info.verify_at_post_office_link_text: Learn more about verifying in person
 doc_auth.info.verify_identity: We’ll ask for your ID, phone number, and other personal information to verify your identity against public records.
-doc_auth.info.verify_online_description: This option is better if you have a phone to take photos of your ID.
-doc_auth.info.verify_online_description_mobile: Choose this option if you have a phone to take pictures.
-doc_auth.info.verify_online_instruction: You’ll take photos of your ID to verify your identity fully online. Most users finish this process in one sitting.
-doc_auth.info.verify_online_instruction_mobile_no_selfie: You’ll take photos of your ID using a phone. Most users finish this process in one sitting.
-doc_auth.info.verify_online_instruction_selfie: You’ll take photos of your ID and a photo of yourself using a phone. Most users finish this process in one sitting.
+doc_auth.info.verify_online_description_passport: You can use a U.S. passport book, U.S. driver’s license or state ID.
+doc_auth.info.verify_online_instruction: You’ll add photos of your ID and verify your identity fully online.
+doc_auth.info.verify_online_instruction_mobile_no_selfie: You’ll take photos of your ID using a phone.
+doc_auth.info.verify_online_instruction_selfie: You’ll take photos of your ID and yourself using a phone.
 doc_auth.info.verify_online_link_text: Learn more about verifying online
 doc_auth.info.you_entered: 'You entered:'
-doc_auth.instructions.bullet1: Have a driver’s license or state ID
+doc_auth.instructions.bullet1a: Have a driver’s license or state ID
+doc_auth.instructions.bullet1b: Have a U.S. passport book, U.S. driver’s license or state ID
 doc_auth.instructions.bullet2: Enter your Social Security number
 doc_auth.instructions.bullet3: Match to your phone number
 doc_auth.instructions.bullet4: Re-enter your %{app_name} password
@@ -876,8 +871,8 @@ forms.buttons.cancel: Yes, cancel
 forms.buttons.confirm: Confirm
 forms.buttons.continue: Continue
 forms.buttons.continue_ipp: Continue in person
-forms.buttons.continue_remote: Continue online
-forms.buttons.continue_remote_mobile: Continue on your phone
+forms.buttons.continue_online: Continue online
+forms.buttons.continue_online_mobile: Continue on your phone
 forms.buttons.delete: Delete
 forms.buttons.disable: Delete
 forms.buttons.edit: Edit

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -631,7 +631,7 @@ doc_auth.headings.ssn_update: Actualice su número de Seguro Social
 doc_auth.headings.text_message: Enviamos un mensaje a su teléfono
 doc_auth.headings.upload_from_computer: Continúe en esta computadora
 doc_auth.headings.upload_from_phone: Utilice su teléfono para tomar fotos
-doc_auth.headings.verify_at_post_office: Verifique su identidad en una oficina de correos
+doc_auth.headings.verify_at_post_office: Vaya a una oficina de correos participante
 doc_auth.headings.verify_identity: Verifique su identidad
 doc_auth.headings.verify_online: Verifique su identidad en línea
 doc_auth.headings.verify_online_mobile: Verifique su identidad en línea con su teléfono
@@ -656,9 +656,6 @@ doc_auth.info.exit.with_sp: Salir de %{app_name} y volver a %{sp_name}
 doc_auth.info.exit.without_sp: Salga de la verificación de identidad y vaya a la página de su cuenta
 doc_auth.info.getting_started_html: '%{sp_name} necesita asegurarse de que se trata de usted y no de alguien que se hace pasar por usted. %{link_html}'
 doc_auth.info.getting_started_learn_more: Obtenga más información sobre la verificación de su identidad
-doc_auth.info.how_to_verify: Tiene la opción de verificar su identidad en línea, o en persona en una oficina de correos participante.
-doc_auth.info.how_to_verify_mobile: Tiene la opción de verificar su identidad en línea con su teléfono, o en persona en una oficina de correos participante.
-doc_auth.info.how_to_verify_troubleshooting_options_header: ¿Desea obtener más información sobre cómo verificar su identidad?
 doc_auth.info.hybrid_handoff: Recopilaremos información sobre usted leyendo su identificación emitida por el estado.
 doc_auth.info.hybrid_handoff_ipp_html: '<strong>¿No tiene un teléfono móvil?</strong> Puede verificar su identidad en una oficina de correos de los Estados Unidos.'
 doc_auth.info.id_types_learn_more: Obtenga más información acerca de los tipos de identificación que puede usar
@@ -694,20 +691,18 @@ doc_auth.info.stepping_up_html: Verifique de nuevo su identidad para acceder a e
 doc_auth.info.tag: Recomendado
 doc_auth.info.upload_from_computer: '¿No tiene un teléfono? Cargue fotos de su identificación desde esta computadora.'
 doc_auth.info.upload_from_phone: No tendrá que volver a iniciar sesión y volverá a esta computadora después de tomar las fotos. Su teléfono móvil debe tener una cámara y un navegador web.
-doc_auth.info.verify_at_post_office_description: Esta opción es mejor si no tiene un teléfono para tomar fotografías de su identificación.
-doc_auth.info.verify_at_post_office_description_mobile: Elija esta opción si no tiene un teléfono para tomar fotografías.
-doc_auth.info.verify_at_post_office_instruction: Ingresará la información de su identificación en línea, y verificará su identidad en persona en una oficina de correos participante.
-doc_auth.info.verify_at_post_office_instruction_selfie: Ingresará la información de su identificación en línea, y verificará su identidad en persona en una oficina de correos participante.
+doc_auth.info.verify_at_post_office_description_passport_html: <strong>Solo puede usar una licencia de conducir de los EE. UU. o una identificación estatal.</strong> Para esta opción, no puede usar un pasaporte estadounidense.
+doc_auth.info.verify_at_post_office_instruction: Ingrese su información en línea, y verifique su identidad en persona en una oficina de correos participante.
 doc_auth.info.verify_at_post_office_link_text: Obtenga más información sobre la verificación en persona
 doc_auth.info.verify_identity: Le pediremos su identificación, número de teléfono y otros datos personales para verificar su identidad comparándola con los registros públicos.
-doc_auth.info.verify_online_description: Esta opción es mejor si tiene un teléfono para tomar fotografías de su identificación.
-doc_auth.info.verify_online_description_mobile: Elija esta opción si tiene un teléfono para tomar fotografías.
-doc_auth.info.verify_online_instruction: Tomará fotografías de su identificación para verificar su identidad por completo en línea. La mayoría de los usuarios logran terminar este proceso en una sola sesión.
-doc_auth.info.verify_online_instruction_mobile_no_selfie: Tomará fotografías de su identificación con un teléfono. La mayoría de los usuarios logran terminar este proceso en una sola sesión.
-doc_auth.info.verify_online_instruction_selfie: Tomará con un teléfono fotos de su identificación y una foto de usted. La mayoría de los usuarios logran terminar este proceso en una sola sesión.
+doc_auth.info.verify_online_description_passport: Puede usar un pasaporte estadounidense, una licencia de conducir de los EE. UU. o una identificación estatal.
+doc_auth.info.verify_online_instruction: Agregará fotografías de su identificación y verificará su identidad por completo en línea.
+doc_auth.info.verify_online_instruction_mobile_no_selfie: Tomará fotografías de su identificación con un teléfono.
+doc_auth.info.verify_online_instruction_selfie: Tomará fotografías de su identificación y de usted con un teléfono.
 doc_auth.info.verify_online_link_text: Obtenga más información sobre la verificación en línea
 doc_auth.info.you_entered: 'Usted ingresó:'
-doc_auth.instructions.bullet1: Tener una licencia de conducir o una tarjeta de identificación estatal
+doc_auth.instructions.bullet1a: Tener una licencia de conducir o una tarjeta de identificación estatal
+doc_auth.instructions.bullet1b: Tener un pasaporte estadounidense, una licencia de conducir de los EE. UU. o una identificación estatal
 doc_auth.instructions.bullet2: Ingresar su número de Seguro Social
 doc_auth.instructions.bullet3: Hacer coincidir su número de teléfono
 doc_auth.instructions.bullet4: Volver a ingresar su contraseña de %{app_name}
@@ -887,8 +882,8 @@ forms.buttons.cancel: Sí, cancelar
 forms.buttons.confirm: Confirmar
 forms.buttons.continue: Continuar
 forms.buttons.continue_ipp: Continúe en persona
-forms.buttons.continue_remote: Continúe en línea
-forms.buttons.continue_remote_mobile: Continúe en su teléfono
+forms.buttons.continue_online: Continúe en línea
+forms.buttons.continue_online_mobile: Continúe en su teléfono
 forms.buttons.delete: Eliminar
 forms.buttons.disable: Eliminar
 forms.buttons.edit: Editar

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -620,7 +620,7 @@ doc_auth.headings.ssn_update: Mettre à jour votre numéro de sécurité sociale
 doc_auth.headings.text_message: Nous avons envoyé un message à votre téléphone
 doc_auth.headings.upload_from_computer: Continuer sur cet ordinateur
 doc_auth.headings.upload_from_phone: Utiliser votre téléphone pour prendre des photos
-doc_auth.headings.verify_at_post_office: Confirmer votre identité en personne dans un bureau de poste
+doc_auth.headings.verify_at_post_office: Vous rendre à un bureau de poste participant
 doc_auth.headings.verify_identity: Confirmer votre identité
 doc_auth.headings.verify_online: Confirmer votre identité en ligne
 doc_auth.headings.verify_online_mobile: Confirmer votre identité en ligne à l’aide de votre téléphone
@@ -645,9 +645,6 @@ doc_auth.info.exit.with_sp: Quitter %{app_name} et revenir à %{sp_name}
 doc_auth.info.exit.without_sp: Quitter la vérification d’identité et accéder à la page de votre compte
 doc_auth.info.getting_started_html: '%{sp_name} doit s’assurer qu’il s’agit bien de vous et non de quelqu’un qui se fait passer pour vous. %{link_html}'
 doc_auth.info.getting_started_learn_more: En savoir plus sur la vérification de votre identité
-doc_auth.info.how_to_verify: Vous pouvez confirmer votre identité en ligne ou en personne dans un bureau de poste participant.
-doc_auth.info.how_to_verify_mobile: Vous avez la possibilité de confirmer votre identité en ligne avec votre téléphone ou en personne dans un bureau de poste participant.
-doc_auth.info.how_to_verify_troubleshooting_options_header: Vous voulez en savoir plus sur la façon de confirmer votre identité?
 doc_auth.info.hybrid_handoff: Nous recueillerons des informations vous concernant en lisant votre pièce d’identité délivrée par un État.
 doc_auth.info.hybrid_handoff_ipp_html: '<strong>Vous n’avez pas de téléphone portable?</strong> Vous pouvez confirmer votre identité dans un bureau de poste américain participant.'
 doc_auth.info.id_types_learn_more: En savoir plus sur les types de pièces d’identité que vous pouvez utiliser
@@ -683,20 +680,18 @@ doc_auth.info.stepping_up_html: Veuillez confirmer à nouveau votre identité po
 doc_auth.info.tag: Recommandation
 doc_auth.info.upload_from_computer: Vous n’avez pas de téléphone ? Téléchargez les photos de votre pièce d’identité depuis cet ordinateur.
 doc_auth.info.upload_from_phone: Vous n’aurez pas à vous reconnecter. Vous reviendrez sur cet ordinateur après avoir pris des photos. Votre téléphone portable doit être équipé d’un appareil photo et d’un navigateur web.
-doc_auth.info.verify_at_post_office_description: Cette option est préférable si vous n’avez pas de téléphone permettant de prendre des photos de votre pièce d’identité.
-doc_auth.info.verify_at_post_office_description_mobile: Choisissez cette option si vous ne disposez pas d’un téléphone permettant de prendre des photos.
-doc_auth.info.verify_at_post_office_instruction: Vous saisirez vos données d’identification en ligne et confirmerez votre identité en personne dans un bureau de poste participant.
-doc_auth.info.verify_at_post_office_instruction_selfie: Vous saisirez vos données d’identification en ligne et confirmez votre identité en personne dans un bureau de poste participant.
+doc_auth.info.verify_at_post_office_description_passport_html: <strong>Vous pouvez seulement utiliser un permis de conduire ou une carte d’identité d’un État des États-Unis.</strong> Le passeport des États-Unis n’est pas accepté dans ce cas.
+doc_auth.info.verify_at_post_office_instruction: Saisissez vos renseignements en ligne puis confirmez votre identité en personne dans un bureau de poste participant.
 doc_auth.info.verify_at_post_office_link_text: En savoir plus sur la vérification en personne
 doc_auth.info.verify_identity: Nous vous demanderons votre pièce d’identité, numéro de téléphone et d’autres renseignements personnels afin de confirmer votre identité par rapport aux registres publics.
-doc_auth.info.verify_online_description: Cette option est préférable si vous disposez d’un téléphone permettant de prendre des photos de votre pièce d’identité.
-doc_auth.info.verify_online_description_mobile: Choisissez cette option si vous disposez d’un téléphone permettant de prendre des photos.
-doc_auth.info.verify_online_instruction: Vous prendrez des photos de votre pièce d’identité pour confirmer votre identité entièrement en ligne. La plupart des utilisateurs y parviennent en une seule prise.
-doc_auth.info.verify_online_instruction_mobile_no_selfie: Vous prendrez des photos de votre pièce d’identité à l’aide d’un téléphone. La plupart des utilisateurs effectuent l’ensemble du processus en une seule fois.
-doc_auth.info.verify_online_instruction_selfie: Vous prendrez des photos de votre pièce d’identité et une photo de vous-même avec un téléphone. La plupart des utilisateurs y parviennent en une seule prise.
+doc_auth.info.verify_online_description_passport: Vous pouvez utiliser un passeport, un permis de conduire une carte d’identité d’un État des États-Unis.
+doc_auth.info.verify_online_instruction: Vous téléverserez des photos de votre pièce d’identité pour confirmer votre identité entièrement en ligne.
+doc_auth.info.verify_online_instruction_mobile_no_selfie: Vous prendrez des photos de votre pièce d’identité à l’aide d’un téléphone.
+doc_auth.info.verify_online_instruction_selfie: Vous prendrez des photos de votre pièce d’identité et une photo de vous-même avec un téléphone.
 doc_auth.info.verify_online_link_text: En savoir plus sur la vérification en ligne
 doc_auth.info.you_entered: 'Vous avez saisi :'
-doc_auth.instructions.bullet1: Présenter votre permis de conduire ou votre carte d’identité d’un État
+doc_auth.instructions.bullet1a: Présenter votre permis de conduire ou votre carte d’identité d’un État
+doc_auth.instructions.bullet1b: Munissez-vous d’un passeport, d’un permis de conduire ou d’une carte d’identité d’un État des États-Unis
 doc_auth.instructions.bullet2: Saisir votre numéro de sécurité sociale
 doc_auth.instructions.bullet3: Vérifier la correspondance avec votre numéro de téléphone
 doc_auth.instructions.bullet4: Saisir à nouveau votre mot de passe %{app_name}
@@ -876,8 +871,8 @@ forms.buttons.cancel: Oui, annuler
 forms.buttons.confirm: Confirmer
 forms.buttons.continue: Suite
 forms.buttons.continue_ipp: Continuer en personne
-forms.buttons.continue_remote: Continuer en ligne
-forms.buttons.continue_remote_mobile: Continuer sur votre téléphone
+forms.buttons.continue_online: Continuer en ligne
+forms.buttons.continue_online_mobile: Continuer sur votre téléphone
 forms.buttons.delete: Supprimer
 forms.buttons.disable: Supprimer
 forms.buttons.edit: Modifier

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -615,7 +615,7 @@ doc_auth.headings.document_capture_front: 你身份证件的正面
 doc_auth.headings.document_capture_selfie: 你面部照片
 doc_auth.headings.document_capture_subheader_selfie: 添加您面部照片
 doc_auth.headings.front: 驾照或州政府颁发身份证件的正面
-doc_auth.headings.how_to_verify: 选择你想如何验证身份
+doc_auth.headings.how_to_verify: 选择如何验证你的身份证件
 doc_auth.headings.hybrid_handoff: 你想怎么添加身份证件？
 doc_auth.headings.hybrid_handoff_selfie: 输入电话号码来切换设备
 doc_auth.headings.interstitial: 我们正在处理你的图像
@@ -631,7 +631,7 @@ doc_auth.headings.ssn_update: 更新你的社会保障号码
 doc_auth.headings.text_message: 我们给你的手机发了短信
 doc_auth.headings.upload_from_computer: 在这台电脑上继续
 doc_auth.headings.upload_from_phone: 使用手机拍照
-doc_auth.headings.verify_at_post_office: 去邮局验证身份
+doc_auth.headings.verify_at_post_office: 到一个参与本项目的邮局去
 doc_auth.headings.verify_identity: 验证你的身份
 doc_auth.headings.verify_online: 在网上验证身份
 doc_auth.headings.verify_online_mobile: 使用手机在网上验证你的身份
@@ -656,9 +656,6 @@ doc_auth.info.exit.with_sp: 退出 %{app_name} 并返回 %{sp_name}
 doc_auth.info.exit.without_sp: 退出身份验证并到你的账户页面
 doc_auth.info.getting_started_html: '%{sp_name} 需要确保你是你，而不是别人冒充你。 了解更多有关验证你身份的信息 %{link_html}'
 doc_auth.info.getting_started_learn_more: 了解有关验证你身份的更多信息
-doc_auth.info.how_to_verify: 你可以选择在网上验证身份或者到参与本项目的邮局亲身验证身份。
-doc_auth.info.how_to_verify_mobile: 你可以选择用你的手机在网上验证身份或者到参与本项目的邮局亲身验证身份。
-doc_auth.info.how_to_verify_troubleshooting_options_header: 想对验证身份获得更多了解吗？
 doc_auth.info.hybrid_handoff: 我们将通过读取州政府颁发给你的身份证件来收集你的信息。
 doc_auth.info.hybrid_handoff_ipp_html: '<strong>没有手机？</strong>你可以去一个美国邮局验证身份。'
 doc_auth.info.id_types_learn_more: 了解有关你能使用的身份证件类型的更多信息
@@ -694,20 +691,18 @@ doc_auth.info.stepping_up_html: 再次验证你的身份以使用这项服务。
 doc_auth.info.tag: 建议
 doc_auth.info.upload_from_computer: 没有手机？从该电脑上传你身份证件的照片。
 doc_auth.info.upload_from_phone: 你不必重新登录，而且拍完照后可以转回到该电脑。你的手机必须带有相机和网络浏览器。
-doc_auth.info.verify_at_post_office_description: 如果你没有手机拍身份证件照片，这一选项更好。
-doc_auth.info.verify_at_post_office_description_mobile: 如果你没有手机可以拍照，请选择该选项
-doc_auth.info.verify_at_post_office_instruction: 你在网上输入身份证件信息，然后到一个参与本项目的邮局去亲身验证身份。
-doc_auth.info.verify_at_post_office_instruction_selfie: 你在网上输入身份证件信息，然后到一个参与本项目的邮局去亲身验证身份。
+doc_auth.info.verify_at_post_office_description_passport_html: <strong>你只能使用美国驾照或州身份证件。</strong>就这一选项你不能使用美国护照。
+doc_auth.info.verify_at_post_office_instruction: 在网上输入你的信息，然后到一个参与本项目的邮局去亲身验证你的身份。
 doc_auth.info.verify_at_post_office_link_text: 对亲身验证获得更多了解
 doc_auth.info.verify_identity: 我们会要求获得你的身份识别、电话号码和其他个人信息并通过与公共记录核对来验证你的身份。
-doc_auth.info.verify_online_description: 如果你没有移动设备或者无法轻松拍身份证件照片，这一选项更好。
-doc_auth.info.verify_online_description_mobile: 如果你有手机可以拍照，请选择该选项。
-doc_auth.info.verify_online_instruction: 你将拍身份证件的照片来完全在网上验证身份。大多数用户都能轻松完成这样流程。
-doc_auth.info.verify_online_instruction_mobile_no_selfie: 你将使用手机拍摄你的身份证件照片。大多数用户一次就能完成这个流程。
-doc_auth.info.verify_online_instruction_selfie: 你将用手机拍摄身份证件和本人的照片。大多数用户都能轻松完成这一流程。
+doc_auth.info.verify_online_description_passport: 你可以使用美国护照本、美国驾照或州身份证件。
+doc_auth.info.verify_online_instruction: 你将添加自己身份证件的照片来完全在网上验证身份。
+doc_auth.info.verify_online_instruction_mobile_no_selfie: 你将用手机拍摄你的身份证件照片。
+doc_auth.info.verify_online_instruction_selfie: 你将用手机拍摄自己身份证件和你本人的照片。
 doc_auth.info.verify_online_link_text: 对网上验证获得更多了解
 doc_auth.info.you_entered: 你输入了：
-doc_auth.instructions.bullet1: 带上驾照或州身份证件
+doc_auth.instructions.bullet1a: 带上驾照或州身份证件
+doc_auth.instructions.bullet1b: 拥有美国护照本、美国驾照或州身份证件
 doc_auth.instructions.bullet2: 输入你的社会保障号码
 doc_auth.instructions.bullet3: 与你电话号码匹配
 doc_auth.instructions.bullet4: 重新输入你 %{app_name} 密码
@@ -887,8 +882,8 @@ forms.buttons.cancel: 是的，取消
 forms.buttons.confirm: 确认
 forms.buttons.continue: 继续
 forms.buttons.continue_ipp: 继续亲身验证
-forms.buttons.continue_remote: 继续在网上验证
-forms.buttons.continue_remote_mobile: 在手机上继续
+forms.buttons.continue_online: 继续在网上验证
+forms.buttons.continue_online_mobile: 在手机上继续
 forms.buttons.delete: 删除
 forms.buttons.disable: 删除
 forms.buttons.edit: 编辑

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -2,10 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Idv::WelcomeController do
   let(:user) { create(:user) }
+  let(:dos_api_status) { nil }
 
   before do
     stub_sign_in(user)
     stub_analytics
+    stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+      .to_return({ status: 200, body: { status: dos_api_status }.to_json })
   end
 
   describe '#step_info' do
@@ -158,11 +161,8 @@ RSpec.describe Idv::WelcomeController do
     end
 
     context 'passports enabled' do
-      let(:dos_api_status) { nil }
       before do
         allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled).and_return(true)
-        stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
-          .to_return({ status: 200, body: { status: dos_api_status }.to_json })
       end
 
       context 'passport api is down' do
@@ -179,6 +179,13 @@ RSpec.describe Idv::WelcomeController do
 
       context 'passport api is up and running' do
         let(:dos_api_status) { 'UP' }
+        let(:passport_bucket) { :default }
+
+        before do
+          allow(subject).to receive(:ab_test_bucket).and_call_original
+          allow(subject).to receive(:ab_test_bucket).with(:DOC_AUTH_PASSPORT)
+            .and_return(passport_bucket)
+        end
 
         it 'passport allowed is false in idv session' do
           get :show
@@ -187,11 +194,7 @@ RSpec.describe Idv::WelcomeController do
         end
 
         context 'user is AB bucketed to allow passports' do
-          before do
-            allow(subject).to receive(:ab_test_bucket).and_call_original
-            allow(subject).to receive(:ab_test_bucket).with(:DOC_AUTH_PASSPORT)
-              .and_return(:passport_allowed)
-          end
+          let(:passport_bucket) { :passport_allowed }
 
           it 'passport allowed is true in idv session' do
             get :show

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Idv::WelcomeController do
       {
         step: 'welcome',
         analytics_id: 'Doc Auth',
+        doc_auth_vendor: 'mock',
       }
     end
 
@@ -228,6 +229,7 @@ RSpec.describe Idv::WelcomeController do
       {
         step: 'welcome',
         analytics_id: 'Doc Auth',
+        doc_auth_vendor: 'mock',
       }
     end
 

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -209,10 +209,10 @@ RSpec.feature 'Analytics Regression', :js do
     {
       'IdV: intro visited' => {},
       'IdV: doc auth welcome visited' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth welcome submitted' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth agreement visited' => {
         step: 'agreement', analytics_id: 'Doc Auth'
@@ -330,10 +330,10 @@ RSpec.feature 'Analytics Regression', :js do
     {
       'IdV: intro visited' => {},
       'IdV: doc auth welcome visited' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth welcome submitted' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth agreement visited' => {
         step: 'agreement', analytics_id: 'Doc Auth'
@@ -455,10 +455,10 @@ RSpec.feature 'Analytics Regression', :js do
     {
       'IdV: intro visited' => {},
       'IdV: doc auth welcome visited' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth welcome submitted' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth agreement visited' => {
         step: 'agreement', analytics_id: 'Doc Auth'
@@ -557,10 +557,10 @@ RSpec.feature 'Analytics Regression', :js do
   let(:in_person_path_events) do
     {
       'IdV: doc auth welcome visited' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth welcome submitted' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth agreement visited' => {
         step: 'agreement', analytics_id: 'Doc Auth'
@@ -696,10 +696,10 @@ RSpec.feature 'Analytics Regression', :js do
     {
       'IdV: intro visited' => {},
       'IdV: doc auth welcome visited' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth welcome submitted' => {
-        step: 'welcome', analytics_id: 'Doc Auth'
+        step: 'welcome', analytics_id: 'Doc Auth', doc_auth_vendor: 'mock'
       },
       'IdV: doc auth agreement visited' => {
         step: 'agreement', analytics_id: 'Doc Auth'

--- a/spec/features/idv/doc_auth/how_to_verify_spec.rb
+++ b/spec/features/idv/doc_auth/how_to_verify_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature 'how to verify step', js: true do
         expect(page).to have_current_path(idv_how_to_verify_path)
 
         # Choose remote option
-        click_on t('forms.buttons.continue_remote')
+        click_on t('forms.buttons.continue_online')
         expect(page).to have_current_path(idv_hybrid_handoff_url)
 
         # go back and choose in person option
@@ -197,7 +197,7 @@ RSpec.feature 'how to verify step', js: true do
     context 'Going back from Hybrid Handoff with opt in disabled midstream' do
       let(:in_person_proofing_opt_in_enabled) { true }
       before do
-        click_on t('forms.buttons.continue_remote')
+        click_on t('forms.buttons.continue_online')
       end
 
       it 'should not be bounced back to How to Verify with opt in disabled midstream' do
@@ -222,7 +222,7 @@ RSpec.feature 'how to verify step', js: true do
     context 'Going back from Hybrid Handoff with opt in enabled the whole time' do
       let(:in_person_proofing_opt_in_enabled) { true }
       before do
-        click_on t('forms.buttons.continue_remote')
+        click_on t('forms.buttons.continue_online')
       end
 
       it 'should be bounced back to How to Verify' do

--- a/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
+++ b/spec/features/idv/doc_auth/hybrid_handoff_spec.rb
@@ -385,7 +385,7 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
           end
           describe 'when selfie is required by sp' do
             before do
-              click_on t('forms.buttons.continue_remote_mobile')
+              click_on t('forms.buttons.continue_online_mobile')
             end
             it 'shows selfie version of top content and ipp option section' do
               verify_handoff_page_selfie_version_content(page)
@@ -396,7 +396,7 @@ RSpec.feature 'hybrid_handoff step for ipp, selfie variances', js: true do
           describe 'when selfie is not required by sp' do
             let(:facial_match_required) { false }
             before do
-              click_on t('forms.buttons.continue_remote')
+              click_on t('forms.buttons.continue_online')
             end
             it 'shows non selfie version of top content and upload section,
                 no ipp option section' do

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe 'In Person Proofing', js: true do
         visit idv_how_to_verify_url
 
         # choose remote
-        click_on t('forms.buttons.continue_remote')
+        click_on t('forms.buttons.continue_online')
         complete_hybrid_handoff_step
         complete_document_capture_step(with_selfie: false)
 
@@ -292,7 +292,7 @@ RSpec.describe 'In Person Proofing', js: true do
 
     it 'allows the user to successfully complete remote identity verification' do
       # choose remote
-      click_on t('forms.buttons.continue_remote')
+      click_on t('forms.buttons.continue_online')
       complete_hybrid_handoff_step
       complete_document_capture_step(with_selfie: false)
 
@@ -357,7 +357,7 @@ RSpec.describe 'In Person Proofing', js: true do
           complete_doc_auth_steps_before_hybrid_handoff_step
 
           # choose remote
-          click_on t('forms.buttons.continue_remote')
+          click_on t('forms.buttons.continue_online')
           click_send_link
 
           expect(page).to have_content(t('doc_auth.headings.text_message'))
@@ -374,7 +374,7 @@ RSpec.describe 'In Person Proofing', js: true do
             visit idv_how_to_verify_url
 
             # choose remote
-            click_on t('forms.buttons.continue_remote')
+            click_on t('forms.buttons.continue_online')
             complete_hybrid_handoff_step
             successful_response = instance_double(
               Faraday::Response,

--- a/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
+++ b/spec/features/idv/steps/in_person_opt_in_ipp_spec.rb
@@ -487,7 +487,7 @@ RSpec.describe 'In Person Proofing - Opt-in IPP ', js: true do
       sign_in_via_branded_page(user)
       complete_welcome_step
       complete_agreement_step
-      click_on t('forms.buttons.continue_remote')
+      click_on t('forms.buttons.continue_online')
       expect(page).to have_current_path(idv_hybrid_handoff_url)
       complete_hybrid_handoff_step
       complete_document_capture_step

--- a/spec/presenters/idv/welcome_presenter_spec.rb
+++ b/spec/presenters/idv/welcome_presenter_spec.rb
@@ -1,14 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Idv::WelcomePresenter do
-  subject(:presenter) { Idv::WelcomePresenter.new(decorated_sp_session) }
+  subject(:presenter) { Idv::WelcomePresenter.new(decorated_sp_session:, passport_allowed:) }
 
   let(:sp) { build(:service_provider) }
-
   let(:sp_session) { {} }
-
   let(:view_context) { ActionController::Base.new.view_context }
-
+  let(:user) { build(:user) }
   let(:decorated_sp_session) do
     ServiceProviderSession.new(
       sp: sp,
@@ -17,8 +15,7 @@ RSpec.describe Idv::WelcomePresenter do
       service_provider_request: nil,
     )
   end
-
-  let(:user) { build(:user) }
+  let(:passport_allowed) { false }
 
   before do
     allow(view_context).to receive(:current_user).and_return(user)
@@ -63,9 +60,9 @@ RSpec.describe Idv::WelcomePresenter do
   end
 
   describe 'the bullet points' do
-    it 'uses the bullet point 1 header' do
+    it 'uses the bullet point 1a header' do
       expect(presenter.bullet_points[0].bullet).to eq(
-        t('doc_auth.instructions.bullet1'),
+        t('doc_auth.instructions.bullet1a'),
       )
     end
 
@@ -109,6 +106,16 @@ RSpec.describe Idv::WelcomePresenter do
       expect(presenter.bullet_points[3].text).to eq(
         t('doc_auth.instructions.text4'),
       )
+    end
+
+    context 'when the user is allowed to use a passport' do
+      let(:passport_allowed) { true }
+
+      it 'uses the bullet point 1b header' do
+        expect(presenter.bullet_points[0].bullet).to eq(
+          t('doc_auth.instructions.bullet1b'),
+        )
+      end
     end
   end
 end

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -85,7 +85,7 @@ module DocAuthHelper
     # JavaScript-enabled mobile devices will skip directly to document capture, so stop as complete.
     return if page.current_path == idv_document_capture_path
     if IdentityConfig.store.in_person_proofing_opt_in_enabled
-      click_on t('forms.buttons.continue_remote')
+      click_on t('forms.buttons.continue_online')
     end
     complete_hybrid_handoff_step
     expect_page_to_have_no_accessibility_violations(page) if expect_accessible
@@ -98,9 +98,9 @@ module DocAuthHelper
     complete_agreement_step
     if remote
       if facial_match_required
-        click_on t('forms.buttons.continue_remote_mobile')
+        click_on t('forms.buttons.continue_online_mobile')
       else
-        click_on t('forms.buttons.continue_remote')
+        click_on t('forms.buttons.continue_online')
       end
     else
       click_on t('forms.buttons.continue_ipp')

--- a/spec/views/idv/how_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/how_to_verify/show.html.erb_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
   selection = Idv::HowToVerifyForm::IPP
   let(:mobile_required) { false }
   let(:selfie_check_required) { false }
+  let(:passport_allowed) { false }
   let(:presenter) do
     Idv::HowToVerifyPresenter.new(
       mobile_required: mobile_required,
       selfie_check_required: selfie_check_required,
+      passport_allowed:,
     )
   end
   let(:idv_how_to_verify_form) { Idv::HowToVerifyForm.new(selection: selection) }
@@ -41,14 +43,11 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     end
 
     it 'renders a button for remote and ipp' do
-      expect(rendered).to have_button(t('forms.buttons.continue_remote'))
+      expect(rendered).to have_button(t('forms.buttons.continue_online'))
       expect(rendered).to have_button(t('forms.buttons.continue_ipp'))
     end
 
-    it 'renders a troubleshooting section' do
-      expect(rendered).to have_content(
-        t('doc_auth.info.how_to_verify_troubleshooting_options_header'),
-      )
+    it 'renders troubleshooting links' do
       expect(rendered).to have_link(t('doc_auth.info.verify_online_link_text'))
       expect(rendered).to have_link(t('doc_auth.info.verify_at_post_office_link_text'))
     end
@@ -58,13 +57,26 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     end
 
     it 'renders non-selfie specific content' do
-      expect(rendered).to have_content(t('doc_auth.info.how_to_verify'))
       expect(rendered).not_to have_content(t('doc_auth.tips.mobile_phone_required'))
       expect(rendered).to have_content(t('doc_auth.headings.verify_online'))
       expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction'))
-      expect(rendered).to have_content(t('doc_auth.info.verify_online_description'))
+      expect(rendered).not_to have_content(t('doc_auth.info.verify_online_description_passport'))
       expect(rendered).to have_content(t('doc_auth.info.verify_at_post_office_instruction'))
-      expect(rendered).to have_content(t('doc_auth.info.verify_at_post_office_description'))
+      expect(rendered).not_to have_content(
+        strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+      )
+    end
+
+    context 'when passport is allowed' do
+      let(:passport_allowed) { true }
+
+      it 'renders passport specific content' do
+        expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction'))
+        expect(rendered).to have_content(t('doc_auth.info.verify_online_description_passport'))
+        expect(rendered).to have_content(
+          strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+        )
+      end
     end
   end
 
@@ -95,14 +107,11 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     end
 
     it 'renders a button for remote and ipp' do
-      expect(rendered).to have_button(t('forms.buttons.continue_remote_mobile'))
+      expect(rendered).to have_button(t('forms.buttons.continue_online_mobile'))
       expect(rendered).to have_button(t('forms.buttons.continue_ipp'))
     end
 
-    it 'renders a troubleshooting section' do
-      expect(rendered).to have_content(
-        t('doc_auth.info.how_to_verify_troubleshooting_options_header'),
-      )
+    it 'renders troubleshooting links' do
       expect(rendered).to have_link(t('doc_auth.info.verify_online_link_text'))
       expect(rendered).to have_link(t('doc_auth.info.verify_at_post_office_link_text'))
     end
@@ -117,20 +126,43 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
       )
     end
 
+    context 'when passport is allowed' do
+      let(:passport_allowed) { true }
+
+      it 'renders passport specific content' do
+        expect(rendered).to have_content(
+          t('doc_auth.info.verify_online_instruction_mobile_no_selfie'),
+        )
+        expect(rendered).to have_content(t('doc_auth.info.verify_online_description_passport'))
+        expect(rendered).to have_content(
+          strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+        )
+      end
+    end
+
     context 'when selfie is required' do
       let(:selfie_check_required) { true }
 
       it 'renders selfie specific content' do
-        expect(rendered).to have_content(t('doc_auth.info.how_to_verify_mobile'))
         expect(rendered).to have_content(t('doc_auth.tips.mobile_phone_required'))
         expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
-        expect(rendered).to have_content(t('doc_auth.info.verify_online_description_mobile'))
-        expect(rendered).to have_content(
-          t('doc_auth.info.verify_at_post_office_instruction_selfie'),
+        expect(rendered).not_to have_content(t('doc_auth.info.verify_online_description_passport'))
+        expect(rendered).to have_content(t('doc_auth.info.verify_at_post_office_instruction'))
+        expect(rendered).not_to have_content(
+          strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
         )
-        expect(rendered).to have_content(
-          t('doc_auth.info.verify_at_post_office_description_mobile'),
-        )
+      end
+
+      context 'when passport is allowed' do
+        let(:passport_allowed) { true }
+
+        it 'renders passport specific content' do
+          expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
+          expect(rendered).to have_content(t('doc_auth.info.verify_online_description_passport'))
+          expect(rendered).to have_content(
+            strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+          )
+        end
       end
     end
   end

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'idv/welcome/show.html.erb' do
   let(:sp_session) { {} }
   let(:view_context) { ActionController::Base.new.view_context }
   let(:sp) { build(:service_provider) }
+  let(:passport_allowed) { false }
 
   before do
     allow(view_context).to receive(:current_user).and_return(user)
@@ -17,7 +18,7 @@ RSpec.describe 'idv/welcome/show.html.erb' do
       sp_session: sp_session,
       service_provider_request: nil,
     )
-    presenter = Idv::WelcomePresenter.new(decorated_sp_session)
+    presenter = Idv::WelcomePresenter.new(decorated_sp_session:, passport_allowed:)
     assign(:presenter, presenter)
     assign(:current_user, user)
     render
@@ -40,7 +41,7 @@ RSpec.describe 'idv/welcome/show.html.erb' do
           link_html: '',
         ),
       )
-      expect(rendered).to have_content(t('doc_auth.instructions.bullet1'))
+      expect(rendered).to have_content(t('doc_auth.instructions.bullet1a'))
       expect(rendered).to have_link(
         t('doc_auth.info.getting_started_learn_more'),
         href: help_center_redirect_path(
@@ -51,6 +52,14 @@ RSpec.describe 'idv/welcome/show.html.erb' do
           location: 'intro_paragraph',
         ),
       )
+    end
+  end
+
+  context 'when a user has the passport option' do
+    let(:passport_allowed) { true }
+
+    it 'renders the modified bullet point' do
+      expect(rendered).to have_content(t('doc_auth.instructions.bullet1b'))
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15435](https://cm-jira.usa.gov/browse/LG-15435)

## 🛠 Summary of changes

Updates copy on the IdV Welcome page, conditionally saying passports are an option.
Updates copy on the IdV How to Verify page, conditionally saying passports may be used for online verification, but not for In Person.
Updated translations with new copy.

## 📜 Testing Plan

### Identity-verified
- [ ] Go to a server running the branch from a SP requesting identity verified and again requesting IAL2 (biometric comparison). Example using the `solipet` environment:
  - [solipet:identity-verified](https://idp.solipet.identitysandbox.gov/openid_connect/authorize?client_id=urn%3Agov%3Agsa%3Aopenidconnect%3Asp%3Asinatra-test&nonce=ad07e9d47b2e244257ec41dbb8198e72&prompt=select_account&redirect_uri=https%3A%2F%2Fsp-oidc-sinatra.test.identitysandbox.gov%2Fauth%2Fresult&response_type=code&scope=openid+email+profile+social_security_number+phone+address+x509&state=3e4ef06285903b7942f2f3113652c97e&vtm=https%3A%2F%2Fdeveloper.login.gov%2Fvot-trust-framework&vtr=%5B%22C1.P1%22%5D)
- [ ] Create an account, if necessary, and sign in
- [ ] From the welcome screen,
  - confirm that passports are shown as an option
- [ ] Continue to the How To Verify screen and
  - confirm that passports are shown as an option for Online
  - confirm that the user is told passports are not available for In Person

### IAL2
- [ ] Go to a server running the branch from a SP requesting IAL2 (biometric comparison). Example using the `solipet` environment:
  - [solipet:IAL2](https://idp.solipet.identitysandbox.gov/openid_connect/authorize?client_id=urn%3Agov%3Agsa%3Aopenidconnect%3Asp%3Asinatra-test&nonce=ad07e9d47b2e244257ec41dbb8198e72&prompt=select_account&redirect_uri=https%3A%2F%2Fsp-oidc-sinatra.test.identitysandbox.gov%2Fauth%2Fresult&response_type=code&scope=openid+email+profile+social_security_number+phone+address+x509&state=3e4ef06285903b7942f2f3113652c97e&vtm=https%3A%2F%2Fdeveloper.login.gov%2Fvot-trust-framework&vtr=%5B%22C1.P1.Pb%22%5D)
- [ ] Create an account, if necessary, and sign in
- [ ] From the welcome screen,
  - confirm that passports are not shown as an option
- [ ] Continue to the How To Verify screen and
  - confirm that passports are not mentioned for either Online or In Person

## 👀 Screenshots
<details>
<summary>Before:</summary>

| Welcome | How To Verify |
| --- | --- |
| <img width="1000" alt="LG-15435-before-welcome" src="https://github.com/user-attachments/assets/47a77a11-716a-46eb-8218-9512ceabaf3f" /> | <img width="1000" alt="LG-15435-before-how-to-verify" src="https://github.com/user-attachments/assets/773240f2-d89b-4c36-9603-bdd7b5826e34" /> |

</details>

<details>
<summary>After - Identity-verified:</summary>

| Welcome | How To Verify |
| --- | --- |
| <img width="912" alt="LG-15435-identity-verified-welcome" src="https://github.com/user-attachments/assets/52860fd2-a890-46e6-ab2e-c3cc001d522a" /> | <img width="912" alt="LG-15435-identity-verified-how-to-verify" src="https://github.com/user-attachments/assets/5b856c28-3e0b-4d9d-8bd0-2ea6763c7baf" /> |

</details>

<details>
<summary>After - IAL2:</summary>

| Welcome | How To Verify |
| --- | --- |
| <img width="912" alt="LG-15435-ial2-welcome" src="https://github.com/user-attachments/assets/17f3950f-fee0-4f3b-ad11-5881129c2adc" /> | <img width="912" alt="LG-15435-ial2-how-to-verify" src="https://github.com/user-attachments/assets/fe8ce09c-b62a-4207-872d-1aecc5dfc3d5" /> |

</details>

