### PR TITLE
Improve InPersonEnrollment test that is flaky around DST changes

### DIFF
--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -414,7 +414,9 @@ RSpec.describe InPersonEnrollment, type: :model do
     end
 
     it 'days_to_due_date returns the number of days left until the due date' do
-      freeze_time do
+      # This test can be flaky when the enrollment due date range runs across a DST time change.
+      # Because of that, a specific time that's less likely to have time changes is used.
+      travel_to(Time.zone.local(2025, 1, 1, 10, 0, 0)) do
         enrollment = create(
           :in_person_enrollment,
           enrollment_established_at: (validity_in_days - 3).days.ago,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-12897](https://cm-jira.usa.gov/browse/LG-12897)

## 🛠 Summary of changes

[Last year](https://gsa-tts.slack.com/archives/C04GA9WQ85B/p1711724402126509) around the end of March, we had a flaky test failure due to DST change, and it happened again [this year](https://gsa-tts.slack.com/archives/C04GA9WQ85B/p1743426907691619). This PR sets a specific time for the test so that it is less likely to fail due to the time of year. Time changes aren't super impactful on the behavior, so it should be fine to fix this in the test only.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
