### PR TITLE
LG-15945 Update status_check_completed_at for skipped enrollments

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3553,6 +3553,20 @@ module AnalyticsEvents
   # @param [Float] minutes_since_last_status_update
   # @param [Float] minutes_to_completion
   # @param [String] issuer
+  # @param [Boolean] response_present
+  # @param [Boolean] fraud_suspected
+  # @param [String] primary_id_type
+  # @param [String] secondary_id_type
+  # @param [String] failure_reason
+  # @param [String] transaction_end_date_time
+  # @param [String] transaction_start_date_time
+  # @param [String] status
+  # @param [String] assurance_level
+  # @param [String] proofing_post_office
+  # @param [String] proofing_city
+  # @param [String] proofing_state
+  # @param [String] scan_count
+  # @param [String] response_message
   def idv_in_person_usps_proofing_results_job_enrollment_skipped(
     enrollment_code:,
     enrollment_id:,
@@ -3564,6 +3578,20 @@ module AnalyticsEvents
     minutes_since_last_status_update:,
     minutes_to_completion:,
     issuer:,
+    response_present:,
+    fraud_suspected: nil,
+    primary_id_type: nil,
+    secondary_id_type: nil,
+    failure_reason: nil,
+    transaction_end_date_time: nil,
+    transaction_start_date_time: nil,
+    status: nil,
+    assurance_level: nil,
+    proofing_post_office: nil,
+    proofing_city: nil,
+    proofing_state: nil,
+    scan_count: nil,
+    response_message: nil,
     **extra
   )
     track_event(
@@ -3578,6 +3606,20 @@ module AnalyticsEvents
       minutes_since_last_status_update:,
       minutes_to_completion:,
       issuer:,
+      response_present:,
+      fraud_suspected:,
+      primary_id_type:,
+      secondary_id_type:,
+      failure_reason:,
+      transaction_end_date_time:,
+      transaction_start_date_time:,
+      status:,
+      assurance_level:,
+      proofing_post_office:,
+      proofing_city:,
+      proofing_state:,
+      scan_count:,
+      response_message:,
       **extra,
     )
   end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -1374,122 +1374,129 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
             ).and_return(true)
           end
 
-          context 'when the enrollment has a deactivation reason of password_reset' do
-            let(:deactivation_reason) { 'password_reset' }
-            let(:in_person_verification_pending_at) do
-              enrollment.profile.in_person_verification_pending_at
-            end
-
-            before do
-              enrollment.profile.update(deactivation_reason: deactivation_reason)
-              stub_request_passed_proofing_results
-              allow(analytics).to receive(
-                :idv_in_person_usps_proofing_results_job_enrollment_skipped,
-              )
-              allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_exception)
-              subject.perform(current_time)
-            end
-
-            it 'logs the job started analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_started,
-              ).with(
-                enrollments_count: 1,
-                reprocess_delay_minutes: 5,
-                job_name: described_class.name,
-              )
-            end
-
-            it 'updates the enrollment status check timestamps' do
-              expect(enrollment.reload).to have_attributes(
-                status_check_attempted_at: current_time,
-                last_batch_claimed_at: current_time,
-              )
-            end
-
-            it 'logs the job enrollment skipped analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_enrollment_skipped,
-              ).with(
-                **enrollment_analytics,
-                minutes_to_completion: nil,
-                reason: "Profile has a deactivation reason of #{deactivation_reason}",
-                job_name: described_class.name,
-              )
-            end
-
-            it 'does not cancel the enrollment' do
-              expect(enrollment.reload).to have_attributes(
-                status: 'pending',
-              )
-            end
-
-            it "does not update the enrollment's profile" do
-              expect(enrollment.reload.profile).to have_attributes(
-                active: false,
-                deactivation_reason:,
-                in_person_verification_pending_at:,
-              )
-            end
-
-            it 'logs the job completed analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_completed,
-              ).with(
-                **default_job_completion_analytics,
-                enrollments_checked: 1,
-                enrollments_skipped: 1,
-              )
-            end
-          end
-
           context 'when the USPS proofing results is not a hash' do
-            before do
-              stub_request_proofing_results(
-                status_code: 200,
-                body: ['I am not what you think I am'],
-              )
-              allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_exception)
-              subject.perform(current_time)
+            context 'when the enrollment has a deactivation reason of password reset' do
+              let(:deactivation_reason) { 'password_reset' }
+              let(:in_person_verification_pending_at) do
+                enrollment.profile.in_person_verification_pending_at
+              end
+
+              before do
+                enrollment.profile.update(deactivation_reason: deactivation_reason)
+                stub_request_proofing_results(
+                  status_code: 200,
+                  body: ['I am not what you think I am'],
+                )
+                allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_exception)
+                allow(analytics).to receive(
+                  :idv_in_person_usps_proofing_results_job_enrollment_skipped,
+                )
+                allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_exception)
+                subject.perform(current_time)
+              end
+
+              it 'logs the job started analytic' do
+                expect(analytics).to have_received(
+                  :idv_in_person_usps_proofing_results_job_started,
+                ).with(
+                  enrollments_count: 1,
+                  reprocess_delay_minutes: 5,
+                  job_name: described_class.name,
+                )
+              end
+
+              it 'updates the enrollment status check timestamps' do
+                expect(enrollment.reload).to have_attributes(
+                  status_check_attempted_at: current_time,
+                  last_batch_claimed_at: current_time,
+                  status_check_completed_at: current_time,
+                )
+              end
+
+              it 'logs the job enrollment skipped analytic' do
+                expect(analytics).to have_received(
+                  :idv_in_person_usps_proofing_results_job_enrollment_skipped,
+                ).with(
+                  **enrollment_analytics,
+                  minutes_to_completion: nil,
+                  reason: "Profile has a deactivation reason of #{deactivation_reason}",
+                  job_name: described_class.name,
+                )
+              end
+
+              it 'does not cancel the enrollment' do
+                expect(enrollment.reload).to have_attributes(
+                  status: 'pending',
+                )
+              end
+
+              it "does not update the enrollment's profile" do
+                expect(enrollment.reload.profile).to have_attributes(
+                  active: false,
+                  deactivation_reason:,
+                  in_person_verification_pending_at:,
+                )
+              end
+
+              it 'logs the job completed analytic' do
+                expect(analytics).to have_received(
+                  :idv_in_person_usps_proofing_results_job_completed,
+                ).with(
+                  **default_job_completion_analytics,
+                  enrollments_checked: 1,
+                  enrollments_skipped: 1,
+                )
+              end
             end
 
-            it 'logs the job started analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_started,
-              ).with(
-                enrollments_count: 1,
-                reprocess_delay_minutes: 5,
-                job_name: described_class.name,
-              )
-            end
+            context 'when the enrollment does not have a deactivation reason' do
+              before do
+                stub_request_proofing_results(
+                  status_code: 200,
+                  body: ['I am not what you think I am'],
+                )
+                allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_exception)
+                subject.perform(current_time)
+              end
 
-            it 'logs the job exception analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_exception,
-              ).with(
-                **enrollment_analytics,
-                minutes_to_completion: nil,
-                reason: 'Bad response structure',
-                job_name: described_class.name,
-              )
-            end
+              it 'logs the job started analytic' do
+                expect(analytics).to have_received(
+                  :idv_in_person_usps_proofing_results_job_started,
+                ).with(
+                  enrollments_count: 1,
+                  reprocess_delay_minutes: 5,
+                  job_name: described_class.name,
+                )
+              end
 
-            it 'updates the enrollment status check timestamps' do
-              expect(enrollment.reload).to have_attributes(
-                status_check_attempted_at: current_time,
-                last_batch_claimed_at: current_time,
-              )
-            end
+              it 'logs the job exception analytic' do
+                expect(analytics).to have_received(
+                  :idv_in_person_usps_proofing_results_job_exception,
+                ).with(
+                  **enrollment_analytics,
+                  minutes_to_completion: nil,
+                  reason: 'Bad response structure',
+                  job_name: described_class.name,
+                )
+              end
 
-            it 'logs the job completed analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_completed,
-              ).with(
-                **default_job_completion_analytics,
-                enrollments_checked: 1,
-                enrollments_errored: 1,
-                percent_enrollments_errored: 100.0,
-              )
+              it 'updates the enrollment status check timestamps' do
+                expect(enrollment.reload).to have_attributes(
+                  status_check_attempted_at: current_time,
+                  last_batch_claimed_at: current_time,
+                )
+              end
+
+              it 'logs the job completed analytic' do
+                expect(analytics).to have_received(
+                  :idv_in_person_usps_proofing_results_job_completed,
+                ).with(
+                  **default_job_completion_analytics,
+                  enrollments_checked: 1,
+                  enrollments_errored: 1,
+                  percent_enrollments_errored: 100.0,
+                )
+              end
             end
           end
 
@@ -1536,6 +1543,77 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                 response_message: response_body[:responseMessage],
                 response_present: true,
               }
+            end
+
+            context 'when the enrollment has a deactivation reason of password_reset' do
+              let(:deactivation_reason) { 'password_reset' }
+              let(:in_person_verification_pending_at) do
+                enrollment.profile.in_person_verification_pending_at
+              end
+
+              before do
+                enrollment.profile.update(deactivation_reason: deactivation_reason)
+                stub_request_proofing_results(status_code: 200, body: response_body)
+                allow(analytics).to receive(
+                  :idv_in_person_usps_proofing_results_job_enrollment_skipped,
+                )
+                allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_exception)
+                subject.perform(current_time)
+              end
+
+              it 'logs the job started analytic' do
+                expect(analytics).to have_received(
+                  :idv_in_person_usps_proofing_results_job_started,
+                ).with(
+                  enrollments_count: 1,
+                  reprocess_delay_minutes: 5,
+                  job_name: described_class.name,
+                )
+              end
+
+              it 'updates the enrollment status check timestamps' do
+                expect(enrollment.reload).to have_attributes(
+                  status_check_attempted_at: current_time,
+                  last_batch_claimed_at: current_time,
+                  status_check_completed_at: current_time,
+                )
+              end
+
+              it 'logs the job enrollment skipped analytic' do
+                expect(analytics).to have_received(
+                  :idv_in_person_usps_proofing_results_job_enrollment_skipped,
+                ).with(
+                  **enrollment_analytics,
+                  **response_analytics,
+                  minutes_to_completion: nil,
+                  reason: "Profile has a deactivation reason of #{deactivation_reason}",
+                  job_name: described_class.name,
+                )
+              end
+
+              it 'does not cancel the enrollment' do
+                expect(enrollment.reload).to have_attributes(
+                  status: 'pending',
+                )
+              end
+
+              it "does not update the enrollment's profile" do
+                expect(enrollment.reload.profile).to have_attributes(
+                  active: false,
+                  deactivation_reason:,
+                  in_person_verification_pending_at:,
+                )
+              end
+
+              it 'logs the job completed analytic' do
+                expect(analytics).to have_received(
+                  :idv_in_person_usps_proofing_results_job_completed,
+                ).with(
+                  **default_job_completion_analytics,
+                  enrollments_checked: 1,
+                  enrollments_skipped: 1,
+                )
+              end
             end
 
             context 'when the InPersonEnrollment has fraud results pending' do
@@ -2740,133 +2818,64 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
           end
         end
 
-        context 'when the enrollment has a profile with a deactivation reason' do
-          context 'when the profile deactivation reason is "encryption_error"' do
-            let(:deactivation_reason) { 'encryption_error' }
+        context 'when the enrollment has a profile with a deactivation reason "encryption_error"' do
+          let(:deactivation_reason) { 'encryption_error' }
 
-            before do
-              enrollment.profile.update(deactivation_reason: deactivation_reason)
-              allow(analytics).to receive(
-                :idv_in_person_usps_proofing_results_job_enrollment_updated,
-              )
-              subject.perform(current_time)
-            end
-
-            it 'logs the job started analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_started,
-              ).with(
-                enrollments_count: 1,
-                reprocess_delay_minutes: 5,
-                job_name: described_class.name,
-              )
-            end
-
-            it 'logs the job enrollment updated analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_enrollment_updated,
-              ).with(
-                **enrollment_analytics,
-                response_present: false,
-                passed: false,
-                reason: "Profile has a deactivation reason of #{deactivation_reason}",
-                job_name: described_class.name,
-                tmx_status: nil,
-                profile_age_in_seconds: enrollment.profile&.profile_age_in_seconds,
-                enhanced_ipp: false,
-              )
-            end
-
-            it 'cancels the enrollment' do
-              expect(enrollment.reload).to have_attributes(
-                status: 'cancelled',
-              )
-            end
-
-            it "deactivates the enrollment's profile" do
-              expect(enrollment.reload.profile).to have_attributes(
-                active: false,
-                deactivation_reason: 'encryption_error',
-                in_person_verification_pending_at: nil,
-              )
-            end
-
-            it 'logs the job completed analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_completed,
-              ).with(
-                **default_job_completion_analytics,
-                enrollments_checked: 1,
-                enrollments_cancelled: 1,
-              )
-            end
+          before do
+            enrollment.profile.update(deactivation_reason: deactivation_reason)
+            allow(analytics).to receive(
+              :idv_in_person_usps_proofing_results_job_enrollment_updated,
+            )
+            subject.perform(current_time)
           end
 
-          context 'when the deactivation reason is "password_reset"' do
-            let(:deactivation_reason) { 'password_reset' }
-            let(:in_person_verification_pending_at) do
-              enrollment.profile.in_person_verification_pending_at
-            end
+          it 'logs the job started analytic' do
+            expect(analytics).to have_received(
+              :idv_in_person_usps_proofing_results_job_started,
+            ).with(
+              enrollments_count: 1,
+              reprocess_delay_minutes: 5,
+              job_name: described_class.name,
+            )
+          end
 
-            before do
-              enrollment.profile.update(deactivation_reason: deactivation_reason)
-              allow(InPersonEnrollment).to receive(:needs_usps_status_check).and_return(
-                InPersonEnrollment.where(id: enrollment.id),
-              )
-              allow(analytics).to receive(
-                :idv_in_person_usps_proofing_results_job_enrollment_skipped,
-              )
-              stub_request_passed_proofing_results
-              allow(analytics).to receive(
-                :idv_in_person_usps_proofing_results_job_enrollment_incomplete,
-              )
-              subject.perform(current_time)
-            end
+          it 'logs the job enrollment updated analytic' do
+            expect(analytics).to have_received(
+              :idv_in_person_usps_proofing_results_job_enrollment_updated,
+            ).with(
+              **enrollment_analytics,
+              response_present: false,
+              passed: false,
+              reason: "Profile has a deactivation reason of #{deactivation_reason}",
+              job_name: described_class.name,
+              tmx_status: nil,
+              profile_age_in_seconds: enrollment.profile&.profile_age_in_seconds,
+              enhanced_ipp: false,
+            )
+          end
 
-            it 'logs the job started analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_started,
-              ).with(
-                enrollments_count: 1,
-                reprocess_delay_minutes: 5,
-                job_name: described_class.name,
-              )
-            end
+          it 'cancels the enrollment' do
+            expect(enrollment.reload).to have_attributes(
+              status: 'cancelled',
+            )
+          end
 
-            it 'logs the job enrollment skipped analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_enrollment_skipped,
-              ).with(
-                **enrollment_analytics,
-                minutes_to_completion: nil,
-                reason: "Profile has a deactivation reason of #{deactivation_reason}",
-                job_name: described_class.name,
-              )
-            end
+          it "deactivates the enrollment's profile" do
+            expect(enrollment.reload.profile).to have_attributes(
+              active: false,
+              deactivation_reason: 'encryption_error',
+              in_person_verification_pending_at: nil,
+            )
+          end
 
-            it 'does not cancel the enrollment' do
-              expect(enrollment.reload).to have_attributes(
-                status: 'pending',
-              )
-            end
-
-            it "does not update the enrollment's profile" do
-              expect(enrollment.reload.profile).to have_attributes(
-                active: false,
-                deactivation_reason:,
-                in_person_verification_pending_at:,
-              )
-            end
-
-            it 'logs the job completed analytic' do
-              expect(analytics).to have_received(
-                :idv_in_person_usps_proofing_results_job_completed,
-              ).with(
-                **default_job_completion_analytics,
-                enrollments_checked: 1,
-                enrollments_skipped: 1,
-              )
-            end
+          it 'logs the job completed analytic' do
+            expect(analytics).to have_received(
+              :idv_in_person_usps_proofing_results_job_completed,
+            ).with(
+              **default_job_completion_analytics,
+              enrollments_checked: 1,
+              enrollments_cancelled: 1,
+            )
           end
         end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15945](https://cm-jira.usa.gov/browse/LG-15945)


## 🛠 Summary of changes

- Update the status_check_completed_at enrollment timestamp when an enrollment is skipped during the `get_usps_proofing_results_job`
- Add the response analytics to the enrollment_skipped event

## 📜 Testing Plan

- [x] Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the ready to verify page.
- [x] Logout
- [x] Reset the password of the user.
- [x] Run the GetUspsProofingResultsJob
- [x] Ensure the enrollments `status_check_compelted_at` timestamp is updated to current time
- [x] Ensure enrollment skipped event is logged with the USPS response data in the event properties
  - Analytics found here https://github.com/18F/identity-idp/blob/abea53e220970ecbbe6b8c0d02ee7f440cda41a4/app/jobs/get_usps_proofing_results_job.rb#L682-L701
- [x] Ensure GetUspsProofingResultsJob: Job complete event contains enrollment_skipped count

