### PR TITLE
Add more enrollment events

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -78,8 +78,13 @@ module TwoFactorAuthenticatableMethods
     authenticate_user!(force: true)
   end
 
-  def handle_second_factor_locked_user(type:)
+  def handle_second_factor_locked_user(type:, context: nil)
     analytics.multi_factor_auth_max_attempts
+
+    if context && UserSessionContext.confirmation_context?(context)
+      attempts_api_tracker.mfa_enroll_code_rate_limited(mfa_device_type: type)
+    end
+
     event = PushNotification::MfaLimitAccountLockedEvent.new(user: current_user)
     PushNotification::HttpPush.deliver(event)
     handle_max_attempts(type + '_login_attempts')
@@ -150,22 +155,21 @@ module TwoFactorAuthenticatableMethods
     user_session.dig(:mfa_attempts, :attempts)
   end
 
-  # Method will be renamed in the next refactor.
   # You can pass in any "type" with a corresponding I18n key in
   # two_factor_authentication.invalid_#{type}
-  def handle_invalid_otp(type:)
+  def handle_invalid_mfa(type:, context:)
     update_invalid_user
 
-    flash.now[:error] = invalid_otp_error(type)
+    flash.now[:error] = invalid_error(type)
 
     if current_user.locked_out?
-      handle_second_factor_locked_user(type:)
+      handle_second_factor_locked_user(type:, context:)
     else
       render_show_after_invalid
     end
   end
 
-  def invalid_otp_error(type)
+  def invalid_error(type)
     case type
     when 'otp'
       [t('two_factor_authentication.invalid_otp'),

--- a/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/backup_code_verification_controller.rb
@@ -54,7 +54,7 @@ module TwoFactorAuthentication
       flash.now[:error] = result.first_error_message
 
       if current_user.locked_out?
-        handle_second_factor_locked_user(type: 'backup_code')
+        handle_second_factor_locked_user(type: 'backup_code', context:)
       else
         render_show_after_invalid
       end

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -52,7 +52,7 @@ module TwoFactorAuthentication
         reset_otp_session_data
         user_session.delete(:mfa_attempts)
       else
-        handle_invalid_otp(type: 'otp')
+        handle_invalid_mfa(type: 'otp', context:)
       end
     end
 

--- a/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/personal_key_verification_controller.rb
@@ -58,7 +58,7 @@ module TwoFactorAuthentication
 
         handle_valid_otp
       else
-        handle_invalid_otp(type: 'personal_key')
+        handle_invalid_mfa(type: 'personal_key', context:)
       end
     end
 

--- a/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/piv_cac_verification_controller.rb
@@ -64,7 +64,7 @@ module TwoFactorAuthentication
       update_invalid_user
 
       if current_user.locked_out?
-        handle_second_factor_locked_user(type: 'piv_cac')
+        handle_second_factor_locked_user(type: 'piv_cac', context:)
       elsif redirect_for_piv_cac_mismatch_replacement?
         redirect_to login_two_factor_piv_cac_mismatch_url
       else

--- a/app/controllers/two_factor_authentication/totp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/totp_verification_controller.rb
@@ -32,7 +32,7 @@ module TwoFactorAuthentication
         handle_remember_device_preference(params[:remember_device])
         redirect_to after_sign_in_path_for(current_user)
       else
-        handle_invalid_otp(type: 'totp')
+        handle_invalid_mfa(type: 'totp', context:)
       end
     end
 

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -50,6 +50,12 @@ module Users
           errors: result.errors,
           success: false,
         )
+
+        if @platform_authenticator
+          attempts_api_tracker.mfa_enroll_webauthn_platform(success: false)
+        else
+          attempts_api_tracker.mfa_enroll_webauthn_roaming(success: false)
+        end
       end
 
       flash_error(result.errors) unless result.success?
@@ -74,6 +80,12 @@ module Users
       )
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)
+      if @platform_authenticator
+        attempts_api_tracker.mfa_enroll_webauthn_platform(success: result.success?)
+      else
+        attempts_api_tracker.mfa_enroll_webauthn_roaming(success: result.success?)
+      end
+
       if result.success?
         process_valid_webauthn(form)
         user_session.delete(:mfa_attempts)

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -39,9 +39,9 @@ module AttemptsApi
       )
     end
 
-    # Tracks when user submits registration password
     # @param [Boolean] success
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # Tracks when user submits registration password
     def user_registration_password_submitted(
       success:,
       failure_reason: nil
@@ -50,6 +50,24 @@ module AttemptsApi
         'user-registration-password-submitted',
         success:,
         failure_reason:,
+      )
+    end
+
+    # @param [Boolean] success
+    # Tracks when the user has attempted to enroll the WebAuthn-Platform MFA method to their account
+    def mfa_enroll_webauthn_platform(success:)
+      track_event(
+        'mfa-enroll-webauthn-platform',
+        success:,
+      )
+    end
+
+    # @param [Boolean] success
+    # Tracks when the user has attempted to enroll the WebAuthn MFA method to their account
+    def mfa_enroll_webauthn_roaming(success:)
+      track_event(
+        'mfa-enroll-webauthn-roaming',
+        success:,
       )
     end
   end

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -29,6 +29,16 @@ module AttemptsApi
       )
     end
 
+    # @param [String<'backup_code', 'otp', 'piv_cac', 'totp'>] mfa_device_type
+    # The user has exceeded the rate limit during enrollment
+    # and account has been locked
+    def mfa_enroll_code_rate_limited(mfa_device_type:)
+      track_event(
+        'mfa-enroll-code-rate-limited',
+        mfa_device_type:,
+      )
+    end
+
     # Tracks when user submits registration password
     # @param [Boolean] success
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason

--- a/docs/attempts-api/schemas/events/RegistrationEvents.yml
+++ b/docs/attempts-api/schemas/events/RegistrationEvents.yml
@@ -3,8 +3,8 @@ properties:
     $ref: './registration/MfaEnrollBackupCode.yml'
   mfa-enroll-phone-otp-sent:
     $ref: './registration/MfaEnrollPhoneOtpSent.yml'
-  mfa-enroll-phone-otp-code-rate-limited:
-    $ref: './registration/MfaEnrollPhoneOtpCodeRateLimited.yml'
+  mfa-enroll-code-rate-limited:
+    $ref: './registration/MfaEnrollCodeRateLimited.yml'
   mfa-enroll-phone-otp-sent-rate-limited:
     $ref: './registration/MfaEnrollPhoneOtpSentRateLimited.yml'
   mfa-enroll-phone-otp-submitted:

--- a/docs/attempts-api/schemas/events/registration/MfaEnrollCodeRateLimited.yml
+++ b/docs/attempts-api/schemas/events/registration/MfaEnrollCodeRateLimited.yml
@@ -7,4 +7,7 @@ allOf:
       mfa_device_type:
         type: string
         enum: 
+          - backup_code
           - otp
+          - personal_key
+          - piv_cac

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -185,28 +185,63 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
         expect(subject.user_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION]).to eq true
       end
 
-      it 'tracks the max attempts event' do
-        user.second_factor_attempts_count =
-          IdentityConfig.store.login_otp_confirmation_max_attempts - 1
-        user.save
+      context 'when the attempts are rate limited' do
+        before do
+          user.second_factor_attempts_count =
+            IdentityConfig.store.login_otp_confirmation_max_attempts - 1
+          user.save
 
-        stub_analytics
+          stub_analytics
+          stub_attempts_tracker
+        end
 
-        expect(PushNotification::HttpPush).to receive(:deliver)
-          .with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
+        context 'with authentication context' do
+          it 'tracks the max attempts event' do
+            expect(PushNotification::HttpPush).to receive(:deliver)
+              .with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 
-        post :create, params: payload
+            post :create, params: payload
 
-        expect(@analytics).to have_logged_event(
-          'Multi-Factor Authentication',
-          success: false,
-          error_details: { backup_code: { invalid: true } },
-          multi_factor_auth_method: 'backup_code',
-          enabled_mfa_methods_count: 1,
-          new_device: true,
-          attempts: 1,
-        )
-        expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication',
+              success: false,
+              error_details: { backup_code: { invalid: true } },
+              multi_factor_auth_method: 'backup_code',
+              enabled_mfa_methods_count: 1,
+              new_device: true,
+              attempts: 1,
+            )
+            expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          end
+        end
+
+        context 'with confirmation context' do
+          before do
+            allow(UserSessionContext).to receive(:confirmation_context?).and_return true
+          end
+
+          it 'tracks the max attempts event' do
+            expect(@attempts_api_tracker).to receive(:mfa_enroll_code_rate_limited).with(
+              mfa_device_type: 'backup_code',
+            )
+
+            expect(PushNotification::HttpPush).to receive(:deliver)
+              .with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
+
+            post :create, params: payload
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication',
+              success: false,
+              error_details: { backup_code: { invalid: true } },
+              multi_factor_auth_method: 'backup_code',
+              enabled_mfa_methods_count: 1,
+              new_device: true,
+              attempts: 1,
+            )
+            expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          end
+        end
       end
 
       it 'records unsuccessful 2fa event' do

--- a/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/backup_code_verification_controller_spec.rb
@@ -211,7 +211,9 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
               new_device: true,
               attempts: 1,
             )
-            expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication: max attempts reached',
+            )
           end
         end
 
@@ -239,7 +241,9 @@ RSpec.describe TwoFactorAuthentication::BackupCodeVerificationController do
               new_device: true,
               attempts: 1,
             )
-            expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication: max attempts reached',
+            )
           end
         end
       end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -269,7 +269,9 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
             in_account_creation_flow: false,
             attempts: 1,
           )
-          expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication: max attempts reached',
+          )
         end
       end
 
@@ -306,7 +308,9 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
             in_account_creation_flow: false,
             attempts: 2,
           )
-          expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication: max attempts reached',
+          )
         end
       end
     end

--- a/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/otp_verification_controller_spec.rb
@@ -236,36 +236,78 @@ RSpec.describe TwoFactorAuthentication::OtpVerificationController do
         )
       end
 
-      it 'tracks the event' do
+      before do
         sign_in_before_2fa(user)
         controller.user_session[:mfa_selections] = ['sms']
 
         stub_analytics
+        stub_attempts_tracker
+      end
 
-        expect(PushNotification::HttpPush).to receive(:deliver)
-          .with(PushNotification::MfaLimitAccountLockedEvent.new(user: controller.current_user))
+      context 'with authentication context' do
+        it 'tracks the event' do
+          expect(PushNotification::HttpPush).to receive(:deliver)
+            .with(PushNotification::MfaLimitAccountLockedEvent.new(user: controller.current_user))
 
-        post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
+          post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
 
-        expect(@analytics).to have_logged_event(
-          'Multi-Factor Authentication',
-          success: false,
-          error_details: { code: { wrong_length: true, incorrect: true } },
-          confirmation_for_add_phone: false,
-          context: 'authentication',
-          multi_factor_auth_method: 'sms',
-          multi_factor_auth_method_created_at: user.default_phone_configuration.created_at
-            .strftime('%s%L'),
-          new_device: true,
-          phone_configuration_id: user.default_phone_configuration.id,
-          area_code: parsed_phone.area_code,
-          country_code: parsed_phone.country,
-          phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
-          enabled_mfa_methods_count: 1,
-          in_account_creation_flow: false,
-          attempts: 1,
-        )
-        expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication',
+            success: false,
+            error_details: { code: { wrong_length: true, incorrect: true } },
+            confirmation_for_add_phone: false,
+            context: 'authentication',
+            multi_factor_auth_method: 'sms',
+            multi_factor_auth_method_created_at: user.default_phone_configuration.created_at
+              .strftime('%s%L'),
+            new_device: true,
+            phone_configuration_id: user.default_phone_configuration.id,
+            area_code: parsed_phone.area_code,
+            country_code: parsed_phone.country,
+            phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+            enabled_mfa_methods_count: 1,
+            in_account_creation_flow: false,
+            attempts: 1,
+          )
+          expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+        end
+      end
+
+      context 'with confirmation context' do
+        before do
+          allow(UserSessionContext).to receive(:confirmation_context?).and_return true
+        end
+
+        it 'tracks the event' do
+          expect(@attempts_api_tracker).to receive(:mfa_enroll_code_rate_limited).with(
+            mfa_device_type: 'otp',
+          )
+
+          expect(PushNotification::HttpPush).to receive(:deliver)
+            .with(PushNotification::MfaLimitAccountLockedEvent.new(user: controller.current_user))
+
+          post :create, params: { code: '12345', otp_delivery_preference: 'sms' }
+
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication',
+            success: false,
+            error_details: { code: { wrong_length: true, incorrect: true } },
+            confirmation_for_add_phone: false,
+            context: 'authentication',
+            multi_factor_auth_method: 'sms',
+            multi_factor_auth_method_created_at: user.default_phone_configuration.created_at
+              .strftime('%s%L'),
+            new_device: true,
+            phone_configuration_id: user.default_phone_configuration.id,
+            area_code: parsed_phone.area_code,
+            country_code: parsed_phone.country,
+            phone_fingerprint: Pii::Fingerprinter.fingerprint(parsed_phone.e164),
+            enabled_mfa_methods_count: 1,
+            in_account_creation_flow: false,
+            attempts: 2,
+          )
+          expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+        end
       end
     end
 

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -209,8 +209,8 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
         stub_sign_in_before_2fa(user)
       end
 
-      it 'calls handle_invalid_otp' do
-        expect(subject).to receive(:handle_invalid_otp).and_call_original
+      it 'calls handle_invalid_mfa' do
+        expect(subject).to receive(:handle_invalid_mfa).and_call_original
 
         post :create, params: payload
 
@@ -225,30 +225,69 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
         expect(flash[:error]).to eq t('two_factor_authentication.invalid_personal_key')
       end
 
-      it 'tracks the max attempts event' do
-        user.second_factor_attempts_count =
-          IdentityConfig.store.login_otp_confirmation_max_attempts - 1
-        user.save
-        personal_key_generated_at = controller.current_user
-          .encrypted_recovery_code_digest_generated_at
-        stub_analytics
+      context 'when the attempts are rate limited' do
+        let(:personal_key_generated_at) do
+          controller.current_user
+            .encrypted_recovery_code_digest_generated_at
+        end
+        before do
+          user.second_factor_attempts_count =
+            IdentityConfig.store.login_otp_confirmation_max_attempts - 1
+          user.save
 
-        expect(PushNotification::HttpPush).to receive(:deliver)
-          .with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
+          stub_analytics
+          stub_attempts_tracker
+        end
 
-        post :create, params: payload
+        context 'with authentication context' do
+          it 'tracks the max attempts event' do
+            expect(PushNotification::HttpPush).to receive(:deliver)
+              .with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
 
-        expect(@analytics).to have_logged_event(
-          'Multi-Factor Authentication',
-          success: false,
-          error_details: { personal_key: { personal_key_incorrect: true } },
-          enabled_mfa_methods_count: 1,
-          multi_factor_auth_method: 'personal-key',
-          multi_factor_auth_method_created_at: personal_key_generated_at.strftime('%s%L'),
-          new_device: true,
-          attempts: 1,
-        )
-        expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+            post :create, params: payload
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication',
+              success: false,
+              error_details: { personal_key: { personal_key_incorrect: true } },
+              enabled_mfa_methods_count: 1,
+              multi_factor_auth_method: 'personal-key',
+              multi_factor_auth_method_created_at: personal_key_generated_at.strftime('%s%L'),
+              new_device: true,
+              attempts: 1,
+            )
+            expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          end
+        end
+
+        context 'with confirmation context' do
+          before do
+            allow(UserSessionContext).to receive(:confirmation_context?).and_return true
+          end
+
+          it 'tracks the max attempts event' do
+            expect(@attempts_api_tracker).to receive(:mfa_enroll_code_rate_limited).with(
+              mfa_device_type: 'personal_key',
+            )
+
+            expect(PushNotification::HttpPush).to receive(:deliver)
+              .with(PushNotification::MfaLimitAccountLockedEvent.new(user: subject.current_user))
+
+            post :create, params: payload
+
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication',
+              success: false,
+              error_details: { personal_key: { personal_key_incorrect: true } },
+              enabled_mfa_methods_count: 1,
+              multi_factor_auth_method: 'personal-key',
+              multi_factor_auth_method_created_at: personal_key_generated_at.strftime('%s%L'),
+              new_device: true,
+              attempts: 1,
+            )
+            expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          end
+        end
       end
 
       it 'records unsuccessful 2fa event' do

--- a/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/personal_key_verification_controller_spec.rb
@@ -256,7 +256,9 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
               new_device: true,
               attempts: 1,
             )
-            expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication: max attempts reached',
+            )
           end
         end
 
@@ -285,7 +287,9 @@ RSpec.describe TwoFactorAuthentication::PersonalKeyVerificationController do
               new_device: true,
               attempts: 1,
             )
-            expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+            expect(@analytics).to have_logged_event(
+              'Multi-Factor Authentication: max attempts reached',
+            )
           end
         end
       end

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -305,7 +305,9 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
             new_device: true,
             attempts: 1,
           )
-          expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication: max attempts reached',
+          )
         end
       end
 
@@ -335,7 +337,9 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
             new_device: true,
             attempts: 1,
           )
-          expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication: max attempts reached',
+          )
         end
       end
     end

--- a/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/totp_verification_controller_spec.rb
@@ -184,7 +184,9 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
             new_device: true,
             attempts: 1,
           )
-          expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication: max attempts reached',
+          )
         end
       end
 
@@ -210,7 +212,9 @@ RSpec.describe TwoFactorAuthentication::TotpVerificationController do
             new_device: true,
             attempts: 1,
           )
-          expect(@analytics).to have_logged_event('Multi-Factor Authentication: max attempts reached')
+          expect(@analytics).to have_logged_event(
+            'Multi-Factor Authentication: max attempts reached',
+          )
         end
       end
     end


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[155](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/155)

## 🛠 Summary of changes
This change adds these events:

- mfa-enroll-code-rate-limited
- mfa-enroll-webauthn-platform  
- mfa-enroll-webauthn-roaming

it also:
- completes a refactor of a method name that has been a TODO for several years
- updates the name of a confusingly named event


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
