### PR TITLE
Lg 15915 fill choose id type on back

### DIFF
--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -10,12 +10,21 @@ module Idv
       if chosen_id_type == 'passport'
         document_capture_session.update!(passport_status: 'requested')
       else
-        document_capture_session.update!(passport_status: 'allowed')
+        document_capture_session.update!(passport_status: 'allowed - not selected')
       end
     end
 
     def choose_id_type_form_params
       params.require(:doc_auth).permit(:choose_id_type_preference)
+    end
+
+    def auto_check_value
+      case document_capture_session.passport_status
+      when 'requested'
+        :passport
+      when 'allowed - not selected'
+        :drivers_license
+      end
     end
   end
 end

--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -10,7 +10,7 @@ module Idv
       if chosen_id_type == 'passport'
         document_capture_session.update!(passport_status: 'requested')
       else
-        document_capture_session.update!(passport_status: 'allowed - not selected')
+        document_capture_session.update!(passport_status: 'not_requested')
       end
     end
 
@@ -22,7 +22,7 @@ module Idv
       case document_capture_session.passport_status
       when 'requested'
         :passport
-      when 'allowed - not selected'
+      when 'not_requested'
         :drivers_license
       end
     end

--- a/app/controllers/idv/choose_id_type_controller.rb
+++ b/app/controllers/idv/choose_id_type_controller.rb
@@ -12,7 +12,9 @@ module Idv
     def show
       analytics.idv_doc_auth_choose_id_type_visited(**analytics_arguments)
       render 'idv/shared/choose_id_type',
-             locals: { form_url: idv_choose_id_type_path, is_hybrid: false },
+             locals: { form_url: idv_choose_id_type_path,
+                       is_hybrid: false,
+                       auto_check_value: auto_check_value },
              layout: true
     end
 

--- a/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
@@ -14,7 +14,9 @@ module Idv
       def show
         analytics.idv_doc_auth_choose_id_type_visited(**analytics_arguments)
         render 'idv/shared/choose_id_type',
-               locals: { form_url: idv_hybrid_mobile_choose_id_type_path, is_hybrid: true }
+               locals: { form_url: idv_hybrid_mobile_choose_id_type_path,
+                         is_hybrid: true,
+                         auto_check_value: auto_check_value }
       end
 
       def update

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -8,7 +8,7 @@ class DocumentCaptureSession < ApplicationRecord
 
   PASSPORT_STATUSES = [
     'allowed',
-    'allowed - not selected',
+    'not_requested',
     'requested',
   ].freeze
 

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -8,6 +8,7 @@ class DocumentCaptureSession < ApplicationRecord
 
   PASSPORT_STATUSES = [
     'allowed',
+    'allowed - not selected',
     'requested',
   ].freeze
 

--- a/app/views/idv/shared/choose_id_type.html.erb
+++ b/app/views/idv/shared/choose_id_type.html.erb
@@ -50,6 +50,7 @@
             name: :choose_id_type_preference,
             required: true,
             wrapper: :uswds_radio_buttons,
+            checked: auto_check_value,
             error_messages: { valueMissing: t('doc_auth.errors.choose_id_type_check') },
           ) %>
   <%= f.submit t('forms.buttons.continue'), class: 'margin-y-2' %>

--- a/spec/controllers/idv/hybrid_mobile/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/choose_id_type_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Idv::HybridMobile::ChooseIdTypeController do
     context 'user chooses drivers_license' do
       it 'maintains passport_status as allowed and redirects to correct vendor' do
         put :update, params: params
-        expect(document_capture_session.passport_status).to eq('allowed')
+        expect(document_capture_session.passport_status).to eq('allowed - not selected')
         expect(response).to redirect_to idv_hybrid_mobile_document_capture_url
       end
     end

--- a/spec/controllers/idv/hybrid_mobile/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/choose_id_type_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Idv::HybridMobile::ChooseIdTypeController do
     context 'user chooses drivers_license' do
       it 'maintains passport_status as allowed and redirects to correct vendor' do
         put :update, params: params
-        expect(document_capture_session.passport_status).to eq('allowed - not selected')
+        expect(document_capture_session.passport_status).to eq('not_requested')
         expect(response).to redirect_to idv_hybrid_mobile_document_capture_url
       end
     end

--- a/spec/features/idv/doc_auth/choose_id_type_spec.rb
+++ b/spec/features/idv/doc_auth/choose_id_type_spec.rb
@@ -30,7 +30,10 @@ RSpec.feature 'choose id type step error checking' do
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
       visit idv_choose_id_type_url
-      expect(page).to have_checked_field('choose_id_type_preference', with: 'passport')
+      expect(page).to have_checked_field(
+        'doc_auth_choose_id_type_preference_passport',
+        visible: :all,
+      )
     end
   end
 
@@ -48,7 +51,10 @@ RSpec.feature 'choose id type step error checking' do
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
       visit idv_choose_id_type_url
-      expect(page).to have_checked_field('choose_id_type_preference', with: 'drivers_license')
+      expect(page).to have_checked_field(
+        'doc_auth_choose_id_type_preference_drivers_license',
+        visible: :all,
+      )
     end
   end
 end

--- a/spec/features/idv/doc_auth/choose_id_type_spec.rb
+++ b/spec/features/idv/doc_auth/choose_id_type_spec.rb
@@ -29,6 +29,8 @@ RSpec.feature 'choose id type step error checking' do
       choose(t('doc_auth.forms.id_type_preference.passport'))
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
+      visit idv_choose_id_type_url
+      expect(page).to have_checked_field('doc_auth[choose_id_type_preference]', with: 'passport')
     end
   end
 
@@ -45,6 +47,11 @@ RSpec.feature 'choose id type step error checking' do
       choose(t('doc_auth.forms.id_type_preference.drivers_license'))
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
+      visit idv_choose_id_type_url
+      expect(page).to have_checked_field(
+        'doc_auth[choose_id_type_preference]',
+        with: 'drivers_license',
+      )
     end
   end
 end

--- a/spec/features/idv/doc_auth/choose_id_type_spec.rb
+++ b/spec/features/idv/doc_auth/choose_id_type_spec.rb
@@ -29,6 +29,8 @@ RSpec.feature 'choose id type step error checking' do
       choose(t('doc_auth.forms.id_type_preference.passport'))
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
+      visit(idv_choose_id_type_url)
+      expect(page).to have_checked_field(t('doc_auth.forms.id_type_preference.passport'))
     end
   end
 
@@ -45,6 +47,8 @@ RSpec.feature 'choose id type step error checking' do
       choose(t('doc_auth.forms.id_type_preference.drivers_license'))
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
+      visit(idv_choose_id_type_url)
+      expect(page).to have_checked_field(t('doc_auth.forms.id_type_preference.drivers_license'))
     end
   end
 end

--- a/spec/features/idv/doc_auth/choose_id_type_spec.rb
+++ b/spec/features/idv/doc_auth/choose_id_type_spec.rb
@@ -29,8 +29,6 @@ RSpec.feature 'choose id type step error checking' do
       choose(t('doc_auth.forms.id_type_preference.passport'))
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
-      visit(idv_choose_id_type_url)
-      expect(page).to have_checked_field(t('doc_auth.forms.id_type_preference.passport'))
     end
   end
 
@@ -47,8 +45,6 @@ RSpec.feature 'choose id type step error checking' do
       choose(t('doc_auth.forms.id_type_preference.drivers_license'))
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
-      visit(idv_choose_id_type_url)
-      expect(page).to have_checked_field(t('doc_auth.forms.id_type_preference.drivers_license'))
     end
   end
 end

--- a/spec/features/idv/doc_auth/choose_id_type_spec.rb
+++ b/spec/features/idv/doc_auth/choose_id_type_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'choose id type step error checking' do
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
       visit idv_choose_id_type_url
-      expect(page).to have_checked_field('doc_auth[choose_id_type_preference]', with: 'passport')
+      expect(page).to have_checked_field('choose_id_type_preference', with: 'passport')
     end
   end
 
@@ -48,10 +48,7 @@ RSpec.feature 'choose id type step error checking' do
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_document_capture_url)
       visit idv_choose_id_type_url
-      expect(page).to have_checked_field(
-        'doc_auth[choose_id_type_preference]',
-        with: 'drivers_license',
-      )
+      expect(page).to have_checked_field('choose_id_type_preference', with: 'drivers_license')
     end
   end
 end

--- a/spec/features/idv/hybrid_mobile/hybrid_choose_id_type_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_choose_id_type_spec.rb
@@ -42,6 +42,11 @@ RSpec.feature 'mobile hybrid flow choose id type', :js do
       choose(t('doc_auth.forms.id_type_preference.passport'))
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+      visit idv_hybrid_mobile_choose_id_type_url
+      expect(page).to have_checked_field(
+        'doc_auth_choose_id_type_preference_passport',
+        visible: :all,
+      )
     end
   end
 
@@ -62,6 +67,11 @@ RSpec.feature 'mobile hybrid flow choose id type', :js do
       choose(t('doc_auth.forms.id_type_preference.drivers_license'))
       click_on t('forms.buttons.continue')
       expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
+      visit idv_hybrid_mobile_choose_id_type_url
+      expect(page).to have_checked_field(
+        'doc_auth_choose_id_type_preference_drivers_license',
+        visible: :all,
+      )
     end
   end
 end


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-15915](https://cm-jira.usa.gov/browse/LG-15915)

## 🛠 Summary of changes

Adding check for previous form submission to auto-populate choose id type screen.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - in application.yml set `doc_auth_passports_enabled` to true and `doc_auth_passports_percent` to 100.
- [ ] Step 2 - Go through idv (standard and hybrid), once at choose id type screen select either option and continue to doc capture page.
- [ ] Step 3 - Go back to choose if type page (either by the browser back button or url route) and verify your selected id type is selected.
- [ ] Step 4 - Repeat for the other id type you did not select in the first pass.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
