### PR TITLE
LG-15489: Add countdown on "Account temporarily locked" screen

### DIFF
--- a/app/views/two_factor_authentication/_locked.html.erb
+++ b/app/views/two_factor_authentication/_locked.html.erb
@@ -14,6 +14,14 @@
         ) %>
   </p>
 
+  <div class="usa-sr-only" role="timer" aria-live="polite" aria-atomic="true">
+    <%= render CountdownComponent.new(
+          expiration: presenter.user.lockout_time_expiration,
+          update_interval: 30.seconds,
+        )
+    %>
+  </div>
+
   <% c.with_troubleshooting_options do |tc| %>
     <% tc.with_header { t('components.troubleshooting_options.default_heading') } %>
     <% tc.with_option(

--- a/app/views/two_factor_authentication/_locked.html.erb
+++ b/app/views/two_factor_authentication/_locked.html.erb
@@ -5,7 +5,7 @@
 
   <p><%= presenter.locked_reason %></p>
 
-  <p>
+  <p aria-hidden="true">
     <%= t(
           'two_factor_authentication.please_try_again_html',
           countdown: render(

--- a/app/views/two_factor_authentication/_locked.html.erb
+++ b/app/views/two_factor_authentication/_locked.html.erb
@@ -15,11 +15,14 @@
   </p>
 
   <div class="usa-sr-only" role="timer" aria-live="polite" aria-atomic="true">
-    <%= render CountdownComponent.new(
-          expiration: presenter.user.lockout_time_expiration,
-          update_interval: 30.seconds,
-        )
-    %>
+    <%= t(
+          'two_factor_authentication.please_try_again_html',
+          countdown: render(
+            CountdownComponent.new(
+              expiration: presenter.user.lockout_time_expiration,
+              update_interval: 30.seconds),
+          ),
+        ) %>
   </div>
 
   <% c.with_troubleshooting_options do |tc| %>

--- a/app/views/two_factor_authentication/_locked.html.erb
+++ b/app/views/two_factor_authentication/_locked.html.erb
@@ -16,7 +16,7 @@
           ),
         ) %>
   </p>
-∂
+
   <% c.with_troubleshooting_options do |tc| %>
     <% tc.with_header { t('components.troubleshooting_options.default_heading') } %>
     <% tc.with_option(

--- a/app/views/two_factor_authentication/_locked.html.erb
+++ b/app/views/two_factor_authentication/_locked.html.erb
@@ -20,7 +20,8 @@
           countdown: render(
             CountdownComponent.new(
               expiration: presenter.user.lockout_time_expiration,
-              update_interval: 30.seconds),
+              update_interval: 30.seconds,
+            ),
           ),
         ) %>
   </div>

--- a/app/views/two_factor_authentication/_locked.html.erb
+++ b/app/views/two_factor_authentication/_locked.html.erb
@@ -5,16 +5,7 @@
 
   <p><%= presenter.locked_reason %></p>
 
-  <p aria-hidden="true">
-    <%= t(
-          'two_factor_authentication.please_try_again_html',
-          countdown: render(
-            CountdownComponent.new(expiration: presenter.user.lockout_time_expiration),
-          ),
-        ) %>
-  </p>
-
-  <div class="usa-sr-only" role="timer" aria-live="polite" aria-atomic="true">
+  <p role="timer" aria-live="polite" aria-atomic="true">
     <%= t(
           'two_factor_authentication.please_try_again_html',
           countdown: render(
@@ -24,8 +15,8 @@
             ),
           ),
         ) %>
-  </div>
-
+  </p>
+∂
   <% c.with_troubleshooting_options do |tc| %>
     <% tc.with_header { t('components.troubleshooting_options.default_heading') } %>
     <% tc.with_option(


### PR DESCRIPTION
## 🎫 Ticket
[LG-15489: Add countdown on "Account temporarily locked" screen](https://cm-jira.usa.gov/browse/LG-15849)

## 🛠 Summary of changes

This ticket addresses a bug where the countdown was not announcing the time remaining

## 📜 Testing Plan

These steps apply for a newly created account or an existing account
- [ ] On the "Authentication method setup" screen, select "Text or voice message
- [ ] Enter a phone number
- [ ] Click "Send another code" every 15 seconds until redirected to the "Account temporarily locked" screen
- [ ] Observe that the announcement is made every 30 seconds. For this step, you **must** turn on your screen reader.

## 👀 Screenshots


https://github.com/user-attachments/assets/84724c0b-1af4-4263-8f0a-b7208ba787f5






