### PR TITLE
Fix default AAL overriding specified AAL value

### DIFF
--- a/app/controllers/concerns/remember_device_concern.rb
+++ b/app/controllers/concerns/remember_device_concern.rb
@@ -57,7 +57,6 @@ module RememberDeviceConcern
     aal_1_expiration = IdentityConfig.store.remember_device_expiration_hours_aal_1.hours
     aal_2_expiration = IdentityConfig.store.remember_device_expiration_minutes_aal_2.minutes
 
-    return aal_2_expiration if sp_aal > 1
     return aal_2_expiration if sp_ial > 1
     return aal_2_expiration if resolved_authn_context_result&.aal2?
 
@@ -65,10 +64,6 @@ module RememberDeviceConcern
   end
 
   private
-
-  def sp_aal
-    current_sp&.default_aal || 1
-  end
 
   def sp_ial
     current_sp&.ial || 1

--- a/spec/controllers/concerns/remember_device_concern_spec.rb
+++ b/spec/controllers/concerns/remember_device_concern_spec.rb
@@ -45,7 +45,15 @@ RSpec.describe RememberDeviceConcern do
     context 'with an AAL2 sp' do
       let(:sp) { build(:service_provider, default_aal: 2) }
 
-      it { expect(test_controller.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+      context 'requesting AAL1' do
+        let(:raw_session) { { acr_values: Saml::Idp::Constants::AAL1_AUTHN_CONTEXT_CLASSREF } }
+        it { expect(test_controller.mfa_expiration_interval).to eq(expected_aal_1_expiration) }
+      end
+
+      context 'not requesting AAL' do
+        let(:raw_session) { { acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF } }
+        it { expect(test_controller.mfa_expiration_interval).to eq(expected_aal_2_expiration) }
+      end
     end
 
     context 'with an IAL2 sp' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[!158](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/158)

## 🛠 Summary of changes

This PR addresses a bug where if a service provider has a `default_aal` of 2 and requests `urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo` as their AAL, the MFA expiration interval will be at the AAL2 level. A requested value should always override the default, resulting in the current unexpected behavior of not being able to use remembered device if the service provider explicitly allows it in the request (if they have `default_aal` of 2).

This issue stems from #6252 where we started using the requested or resolved AAL value for MFA expiration interval calculation, but left the `default_aal` check. The resolved AAL will fall back to the service provider's `default_aal`, so we should be able to only use the resolved value to fix the bug we're seeing currently.