### PR TITLE
Send only first part of last name to AAMVA for DC, WV

### DIFF
--- a/app/services/proofing/aamva/request/verification_request.rb
+++ b/app/services/proofing/aamva/request/verification_request.rb
@@ -277,7 +277,7 @@ module Proofing
             state_id_number: state_id_number,
             state_id_jurisdiction: message_destination_id,
             first_name: applicant.first_name,
-            last_name: applicant.last_name,
+            last_name: last_name,
             dob: applicant.dob,
             address1: applicant.address1,
             city: applicant.city,
@@ -292,6 +292,15 @@ module Proofing
               applicant.state_id_data.state_id_number.rjust(8, '0')
             else
               applicant.state_id_data.state_id_number
+          end
+        end
+
+        def last_name
+          case applicant.state_id_data.state_id_jurisdiction
+          when 'DC', 'WV'
+            applicant.state_id_data.last_name.split(' ').first
+          else
+            applicant.state_id_data.last_name
           end
         end
 


### PR DESCRIPTION
👋 hi friends, it's been a while!

## Background

My new job also works with AAMVA, and a colleague let me know about a new bug he discovered. For DC and WV apparently the backend processors for only process matches up to the first "word" of a last name. So for a user whose last name is "McFirst McSecond", we need to send "McFirst" only to get a match in those states. It's undocumented and discovered through customer data.

## 🛠 Summary of changes

Updates `Aamva::VerificationRequest` to only send the first part of last names in DC and WV

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] If possible, get ahold of customer data in DC or WV for somebody with a space-separated multi-word last name. Then verify via the Rails console that there is match when `last_name.split(' ').first` is sent as the last name
  - Could probably patch the "Johnny Proofs" data in `aamva_test.rb` https://github.com/18F/identity-idp/blob/0e6cfb3b5ce8062af35e607f26547fec6d1e8e8e/lib/aamva_test.rb#L27



