### PR TITLE
Login completed and initiated events

### DIFF
--- a/app/controllers/concerns/saml_idp_logout_concern.rb
+++ b/app/controllers/concerns/saml_idp_logout_concern.rb
@@ -62,6 +62,8 @@ module SamlIdpLogoutConcern
 
   def track_logout_event
     sp_initiated = saml_request.present?
+    attempts_api_tracker.logout_initiated(success: true)
+
     analytics.logout_initiated(
       sp_initiated: sp_initiated,
       oidc: false,

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -236,6 +236,8 @@ module OpenidConnect
         acr_values: sp_session[:acr_values],
         sign_in_duration_seconds:,
       )
+
+      attempts_api_tracker.login_completed
       track_billing_events
     end
 

--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -23,6 +23,10 @@ module OpenidConnect
         original_method: session[:original_method],
       )
 
+      attempts_api_tracker.logout_initiated(
+        success: result.success?,
+      )
+
       if result.success? && redirect_uri
         handle_successful_logout_request(result, redirect_uri)
       else
@@ -46,6 +50,9 @@ module OpenidConnect
       redirect_uri = result.extra[:redirect_uri]
 
       analytics.oidc_logout_submitted(**to_event(result))
+      attempts_api_tracker.logout_initiated(
+        success: result.success?,
+      )
 
       if result.success? && redirect_uri
         handle_logout(result, redirect_uri)

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -222,6 +222,8 @@ class SamlIdpController < ApplicationController
       acr_values: sp_session[:acr_values],
       sign_in_duration_seconds:,
     )
+
+    attempts_api_tracker.login_completed
     track_billing_events
   end
 

--- a/app/controllers/sign_out_controller.rb
+++ b/app/controllers/sign_out_controller.rb
@@ -5,6 +5,8 @@ class SignOutController < ApplicationController
 
   def destroy
     analytics.logout_initiated(method: 'cancel link')
+    attempts_api_tracker.logout_initiated(success: true)
+
     url_after_cancellation = decorated_sp_session.cancel_link_url
     sign_out
     flash[:success] = t('devise.sessions.signed_out')

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -57,6 +57,7 @@ module Users
         redirect_to root_path
       else
         analytics.logout_initiated(sp_initiated: false, oidc: false)
+        attempts_api_tracker.logout_initiated(success: true)
         super
       end
     end

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -31,6 +31,11 @@ module AttemptsApi
       )
     end
 
+    # A user has successfully logged in and is being handed off to integration
+    def login_completed
+      track_event('login-completed')
+    end
+
     # @param [Boolean] success
     # A user has attempted to enroll the Backup Codes MFA method to their account
     def mfa_enroll_backup_code(success:)

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -25,7 +25,7 @@ module AttemptsApi
     # A logged-in user has attempted to change their password
     def logged_in_password_change(success:, failure_reason: nil)
       track_event(
-        :logged_in_password_change,
+        'logged-in-password-change',
         success: success,
         failure_reason:,
       )

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -37,6 +37,15 @@ module AttemptsApi
     end
 
     # @param [Boolean] success
+    # A user has initiated a logout event
+    def logout_initiated(success:)
+      track_event(
+        'logout-initiated',
+        success:,
+      )
+    end
+
+    # @param [Boolean] success
     # A user has attempted to enroll the Backup Codes MFA method to their account
     def mfa_enroll_backup_code(success:)
       track_event(

--- a/docs/attempts-api/schemas/events/sign-in/LogoutInitiated.yml
+++ b/docs/attempts-api/schemas/events/sign-in/LogoutInitiated.yml
@@ -2,3 +2,8 @@ description:  The user has logged out of their account.
 allOf:
   - $ref: '../shared/EventProperties.yml'
   - type: object
+    properties:
+      success:
+        type: boolean
+        description: |
+          Indicates whether the logout was successfully initiated

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -112,6 +112,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
           it 'tracks IAL1 authentication event' do
             travel_to now + 15.seconds
             stub_analytics
+            stub_attempts_tracker
+
+            expect(@attempts_api_tracker).to receive(:login_completed)
 
             IdentityLinker.new(user, service_provider).link_identity(ial: 1)
             user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
@@ -166,6 +169,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
           it 'tracks IAL1 authentication event' do
             travel_to now + 15.seconds
             stub_analytics
+            stub_attempts_tracker
+
+            expect(@attempts_api_tracker).to receive(:login_completed)
 
             IdentityLinker.new(user, service_provider).link_identity(ial: 1)
             user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
@@ -261,6 +267,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
             it 'tracks IAL2 authentication event' do
               travel_to now + 15.seconds
               stub_analytics
+              stub_attempts_tracker
+
+              expect(@attempts_api_tracker).to receive(:login_completed)
 
               IdentityLinker.new(user, service_provider).link_identity(ial: 2)
               user.identities.last.update!(
@@ -577,6 +586,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
               it 'tracks IAL2 authentication event' do
                 travel_to now + 15.seconds
                 stub_analytics
+                stub_attempts_tracker
+
+                expect(@attempts_api_tracker).to receive(:login_completed)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 2)
                 user.identities.last.update!(
@@ -651,6 +663,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
               it 'tracks IAL1 authentication event' do
                 travel_to now + 15.seconds
                 stub_analytics
+                stub_attempts_tracker
+
+                expect(@attempts_api_tracker).to receive(:login_completed)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -727,6 +742,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
               it 'tracks IAL1 authentication event' do
                 travel_to now + 15.seconds
                 stub_analytics
+                stub_attempts_tracker
+
+                expect(@attempts_api_tracker).to receive(:login_completed)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -860,6 +878,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
           it 'tracks IAL1 authentication event' do
             travel_to now + 15.seconds
             stub_analytics
+            stub_attempts_tracker
+
+            expect(@attempts_api_tracker).to receive(:login_completed)
             IdentityLinker.new(user, service_provider).link_identity(ial: 1)
             user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
 
@@ -911,6 +932,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
           it 'tracks IAL1 authentication event' do
             travel_to now + 15.seconds
             stub_analytics
+            stub_attempts_tracker
+
+            expect(@attempts_api_tracker).to receive(:login_completed)
 
             IdentityLinker.new(user, service_provider).link_identity(ial: 1)
             user.identities.last.update!(verified_attributes: %w[given_name family_name birthdate])
@@ -1007,6 +1031,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
             it 'tracks IAL2 authentication event' do
               travel_to now + 15.seconds
               stub_analytics
+              stub_attempts_tracker
+
+              expect(@attempts_api_tracker).to receive(:login_completed)
 
               IdentityLinker.new(user, service_provider).link_identity(ial: 2)
               user.identities.last.update!(
@@ -1363,6 +1390,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
               it 'tracks IAL2 authentication event' do
                 travel_to now + 15.seconds
                 stub_analytics
+                stub_attempts_tracker
+
+                expect(@attempts_api_tracker).to receive(:login_completed)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 2)
                 user.identities.last.update!(
@@ -1437,6 +1467,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
               it 'tracks IAL1 authentication event' do
                 travel_to now + 15.seconds
                 stub_analytics
+                stub_attempts_tracker
+
+                expect(@attempts_api_tracker).to receive(:login_completed)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(
@@ -1513,6 +1546,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
               it 'tracks IAL1 authentication event' do
                 travel_to now + 15.seconds
                 stub_analytics
+                stub_attempts_tracker
+
+                expect(@attempts_api_tracker).to receive(:login_completed)
 
                 IdentityLinker.new(user, service_provider).link_identity(ial: 1)
                 user.identities.last.update!(

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -84,6 +84,9 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'tracks events' do
             stub_analytics
+            stub_attempts_tracker
+
+            expect(@attempts_api_tracker).to receive(:logout_initiated).with(success: true)
 
             action
 
@@ -661,6 +664,9 @@ RSpec.describe OpenidConnect::LogoutController do
 
           it 'tracks events' do
             stub_analytics
+            stub_attempts_tracker
+
+            expect(@attempts_api_tracker).to receive(:logout_initiated).with(success: true)
 
             action
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe SamlIdpController do
 
     it 'tracks the event when idp initiated' do
       stub_analytics
+      stub_attempts_tracker
+
+      expect(@attempts_api_tracker).to receive(:logout_initiated).with(success: true)
 
       delete :logout, params: { path_year: path_year }
 
@@ -71,6 +74,9 @@ RSpec.describe SamlIdpController do
     it 'tracks the event when sp initiated' do
       allow(controller).to receive(:saml_request).and_return(FakeSamlLogoutRequest.new)
       stub_analytics
+      stub_attempts_tracker
+
+      expect(@attempts_api_tracker).to receive(:logout_initiated).with(success: true)
 
       delete :logout, params: { SAMLRequest: 'foo', path_year: path_year }
 
@@ -84,6 +90,9 @@ RSpec.describe SamlIdpController do
 
     it 'tracks the event when the saml request is invalid' do
       stub_analytics
+      stub_attempts_tracker
+
+      expect(@attempts_api_tracker).to receive(:logout_initiated).with(success: true)
 
       delete :logout, params: { SAMLRequest: 'foo', path_year: path_year }
 
@@ -147,6 +156,9 @@ RSpec.describe SamlIdpController do
 
       it 'tracks the request' do
         stub_analytics
+        stub_attempts_tracker
+
+        expect(@attempts_api_tracker).to receive(:logout_initiated).with(success: true)
 
         delete :logout, params: UriService.params(
           OneLogin::RubySaml::Logoutrequest.new.create(wrong_cert_settings),

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -870,6 +870,9 @@ RSpec.describe SamlIdpController do
 
       it 'tracks IAL2 authentication events' do
         stub_analytics
+        stub_attempts_tracker
+
+        expect(@attempts_api_tracker).to receive(:login_completed)
 
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
         saml_get_auth(ial2_settings)
@@ -1027,6 +1030,9 @@ RSpec.describe SamlIdpController do
 
       it 'tracks IAL2 authentication events' do
         stub_analytics
+        stub_attempts_tracker
+
+        expect(@attempts_api_tracker).to receive(:login_completed)
 
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
         saml_get_auth(ialmax_settings)
@@ -2734,6 +2740,9 @@ RSpec.describe SamlIdpController do
       it 'tracks the authentication without IdV redirection event' do
         user = create(:user, :fully_registered)
         stub_analytics
+        stub_attempts_tracker
+
+        expect(@attempts_api_tracker).to receive(:login_completed)
         session[:sign_in_flow] = :sign_in
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
 
@@ -2784,6 +2793,9 @@ RSpec.describe SamlIdpController do
       it 'tracks the authentication with finish_profile==true' do
         user = create(:user, :fully_registered)
         stub_analytics
+        stub_attempts_tracker
+
+        expect(@attempts_api_tracker).to receive(:login_completed)
         session[:sign_in_flow] = :sign_in
         allow(controller).to receive(:identity_needs_verification?).and_return(false)
         allow(controller).to receive(:user_has_pending_profile?).and_return(true)

--- a/spec/controllers/sign_out_controller_spec.rb
+++ b/spec/controllers/sign_out_controller_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe SignOutController do
     it 'tracks the event' do
       stub_sign_in_before_2fa
       stub_analytics
+      stub_attempts_tracker
+
+      allow(@attempts_api_tracker).to receive(:logout_initiated).with(success: true)
       allow(controller.decorated_sp_session).to receive(:cancel_link_url).and_return('foo')
 
       get :destroy

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -52,6 +52,9 @@ RSpec.describe Users::SessionsController, devise: true do
   describe 'GET /logout' do
     it 'does not log user out and redirects to root' do
       sign_in_as_user
+      stub_attempts_tracker
+
+      expect(@attempts_api_tracker).to_not receive(:logout_initiated)
       get :destroy
       expect(controller.current_user).to_not be nil
       expect(response).to redirect_to root_url
@@ -62,6 +65,11 @@ RSpec.describe Users::SessionsController, devise: true do
     it 'tracks a logout event' do
       stub_analytics
       sign_in_as_user
+      stub_attempts_tracker
+
+      expect(@attempts_api_tracker).to receive(:logout_initiated).with(
+        success: true,
+      )
 
       delete :destroy
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -467,6 +467,11 @@ RSpec.feature 'Sign Up' do
     freeze_time do
       analytics = FakeAnalytics.new
       allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(analytics)
+      attempts_api_tracker = AttemptsApiTrackingHelper::FakeAttemptsTracker.new
+      allow_any_instance_of(ApplicationController).to receive(:attempts_api_tracker).and_return(
+        attempts_api_tracker,
+      )
+      expect(attempts_api_tracker).to receive(:login_completed)
 
       visit_idp_from_sp_with_ial1(:oidc)
       travel_to Time.zone.now + 15.seconds

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -36,6 +36,13 @@ RSpec.shared_examples 'signing in from service provider' do |sp|
       user = create(:user, :fully_registered)
       analytics = FakeAnalytics.new(user:)
       allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(analytics)
+      if sp == :oidc
+        attempts_api_tracker = AttemptsApiTrackingHelper::FakeAttemptsTracker.new
+        allow_any_instance_of(ApplicationController).to receive(:attempts_api_tracker).and_return(
+          attempts_api_tracker,
+        )
+        expect(attempts_api_tracker).to receive(:login_completed)
+      end
 
       visit_idp_from_sp_with_ial1(sp)
       travel_to Time.zone.now + 15.seconds

--- a/spec/support/shared_examples/sign_in.rb
+++ b/spec/support/shared_examples/sign_in.rb
@@ -36,13 +36,11 @@ RSpec.shared_examples 'signing in from service provider' do |sp|
       user = create(:user, :fully_registered)
       analytics = FakeAnalytics.new(user:)
       allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(analytics)
-      if sp == :oidc
-        attempts_api_tracker = AttemptsApiTrackingHelper::FakeAttemptsTracker.new
-        allow_any_instance_of(ApplicationController).to receive(:attempts_api_tracker).and_return(
-          attempts_api_tracker,
-        )
-        expect(attempts_api_tracker).to receive(:login_completed)
-      end
+      attempts_api_tracker = AttemptsApiTrackingHelper::FakeAttemptsTracker.new
+      allow_any_instance_of(ApplicationController).to receive(:attempts_api_tracker).and_return(
+        attempts_api_tracker,
+      )
+      expect(attempts_api_tracker).to receive(:login_completed)
 
       visit_idp_from_sp_with_ial1(sp)
       travel_to Time.zone.now + 15.seconds


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[157](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/157)

## 🛠 Summary of changes
This change adds two new events:
- login-completed
- logout-initiated

There are a handful more sign-in events, but those are all MFA-submitted events. While beginning that process, I noticed that our multiauth verification methods were collapsed [into here](https://github.com/18F/identity-idp/blob/main/app/controllers/concerns/two_factor_authenticatable_methods.rb#L20-L28) into one class. It makes sense to similarly collaps the different events into a single mfa-submitted event that includes a type rather than a [bunch of different types of mfa submitted events](https://github.com/18F/identity-idp/blob/main/docs/attempts-api/schemas/events/SignInEvents.yml#L20-L28)

For the next PR, I will make that update to the openapi spec as well as create the event.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
