### PR TITLE
Always require confirmation of user logout in OIDC Logout

### DIFF
--- a/app/controllers/openid_connect/logout_controller.rb
+++ b/app/controllers/openid_connect/logout_controller.rb
@@ -90,12 +90,6 @@ module OpenidConnect
       override_form_action_csp(uris)
     end
 
-    def require_logout_confirmation?
-      (logout_params[:id_token_hint].nil? || IdentityConfig.store.reject_id_token_hint_in_logout) &&
-        logout_params[:client_id] &&
-        current_user
-    end
-
     # @return [OpenidConnectLogoutForm]
     def build_logout_form
       OpenidConnectLogoutForm.new(
@@ -108,12 +102,13 @@ module OpenidConnect
     # @param redirect_uri [String] The URL to redirect the user to after logout
     def handle_successful_logout_request(result, redirect_uri)
       apply_logout_secure_headers_override(redirect_uri, @logout_form.service_provider)
-      if require_logout_confirmation?
+      if current_user.present?
         analytics.oidc_logout_visited(**to_event(result))
 
         @params = {
           client_id: logout_params[:client_id],
           post_logout_redirect_uri: logout_params[:post_logout_redirect_uri],
+          id_token_hint: logout_params[:id_token_hint],
         }
         @params[:state] = logout_params[:state] if !logout_params[:state].nil?
         @service_provider_name = @logout_form.service_provider&.friendly_name

--- a/spec/controllers/openid_connect/logout_controller_spec.rb
+++ b/spec/controllers/openid_connect/logout_controller_spec.rb
@@ -59,30 +59,9 @@ RSpec.describe OpenidConnect::LogoutController do
         before { stub_sign_in(user) }
 
         context 'with valid params' do
-          it 'destroys the session' do
-            expect(controller).to receive(:sign_out).and_call_original
+          render_views
 
-            action
-          end
-
-          it 'redirects back to the client if server-side redirect is enabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect)
-              .and_return('server_side')
-            action
-
-            expect(response).to redirect_to(/^#{post_logout_redirect_uri}/)
-          end
-
-          it 'renders JS client-side redirect if client-side JS redirect is enabled' do
-            allow(IdentityConfig.store).to receive(:openid_connect_redirect)
-              .and_return('client_side_js')
-            action
-
-            expect(controller).to render_template('openid_connect/shared/redirect_js')
-            expect(assigns(:oidc_redirect_uri)).to start_with(post_logout_redirect_uri)
-          end
-
-          it 'tracks events' do
+          it 'renders logout confirmation page' do
             stub_analytics
 
             action
@@ -99,7 +78,7 @@ RSpec.describe OpenidConnect::LogoutController do
               ),
             )
             expect(@analytics).to have_logged_event(
-              'Logout Initiated',
+              'OIDC Logout Page Visited',
               success: true,
               client_id: service_provider.issuer,
               client_id_parameter_present: false,
@@ -107,10 +86,11 @@ RSpec.describe OpenidConnect::LogoutController do
               sp_initiated: true,
               oidc: true,
             )
-
             expect(@analytics).to_not have_logged_event(
               :sp_integration_errors_present,
             )
+            expect(response).to render_template(:confirm_logout)
+            expect(response.body).to include service_provider.friendly_name
           end
         end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[!159](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/159)

## 🛠 Summary of changes

Following #6936 and #7017, we added support for the OpenID Logout `client_id` parameter as a step to deprecating the `id_token_hint` parameter. Part of the [OpenID Connect RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) includes:

> Logout requests without a valid id_token_hint value are a potential means of denial of service; therefore, OPs should obtain explicit confirmation from the End-User before acting upon them.

> At the Logout Endpoint, the OP SHOULD ask the End-User whether to log out of the OP as well. Furthermore, the OP MUST ask the End-User this question if an id_token_hint was not provided or if the supplied ID Token does not belong to the current OP session with the RP and/or currently logged in End-User. If the End-User says "yes", then the OP MUST log out the End-User.

Currently, we require user confirmation for the former case when the request is not using `id_token_hint`, and requests using the deprecated `id_token_hint` do not. This behavior is both inconsistent and does not meet the SHOULD recommendation from the specification.

This PR changes the behavior so that users need to confirm they want to be logged out before they are logged out.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
