### PR TITLE
Em/15947 cancel skipped enrollments

### DIFF
--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -163,13 +163,13 @@ class GetUspsProofingResultsJob < ApplicationJob
   def cancel_abandoned_password_reset_enrollments(enrollment)
     if enrollment.minutes_since_last_status_update > PASSWORD_RESET_EXPIRATION * MINUTES_PER_DAY
       enrollment.cancel
+      analytics(user: enrollment.user)
+        .idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled(
+          **enrollment_analytics_attributes(enrollment, complete: false),
+          reason: 'Enrollment was cancelled after spending more than 90 days in password reset',
+          job_name: self.class.name,
+        )
     end
-    analytics(user: enrollment.user)
-      .idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled(
-        **enrollment_analytics_attributes(enrollment, complete: false),
-        reason: 'Enrollment was cancelled after spending more than 90 days in password reset',
-        job_name: self.class.name,
-      )
   end
 
   def passed_with_unsupported_secondary_id_type?(enrollment, response)

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -166,7 +166,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       analytics(user: enrollment.user)
         .idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled(
           **enrollment_analytics_attributes(enrollment, complete: false),
-          reason: 'Enrollment was cancelled after spending more than 90 days in password reset',
+          reason: 'Enrollment cancelled after spending over 90 days in password reset',
           job_name: self.class.name,
         )
     end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3542,7 +3542,6 @@ module AnalyticsEvents
   end
 
   # Tracks skipped enrollments during the execution of the GetUspsProofingResultsJob
-  #
   # @param [String] enrollment_code The in-person enrollment code.
   # @param [String] enrollment_id The in-person enrollment ID.
   # @param [String] reason The reason for skipping the enrollment.
@@ -3620,6 +3619,46 @@ module AnalyticsEvents
       proofing_state:,
       scan_count:,
       response_message:,
+      **extra,
+    )
+  end
+
+  # Tracks enrollments that were cancelled after spending over 90 days in password reset.
+  # @param [String] enrollment_code The in-person enrollment code.
+  # @param [String] enrollment_id The in-person enrollment ID.
+  # # @param [String] reason The reason for cancelling the enrollment.
+  # @param [String] job_name The class name of the job.
+  # @param [Float] minutes_since_established
+  # @param [Float] minutes_since_last_status_check
+  # @param [Float] minutes_since_last_status_check_completed
+  # @param [Float] minutes_since_last_status_update
+  # @param [Float] minutes_to_completion
+  # @param [String] issuer
+  def idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled(
+    enrollment_code:,
+    enrollment_id:,
+    reason:,
+    job_name:,
+    minutes_since_established:,
+    minutes_since_last_status_check:,
+    minutes_since_last_status_check_completed:,
+    minutes_since_last_status_update:,
+    minutes_to_completion:,
+    issuer:,
+    **extra
+  )
+    track_event(
+      :idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled,
+      enrollment_code:,
+      enrollment_id:,
+      reason:,
+      job_name:,
+      minutes_since_established:,
+      minutes_since_last_status_check:,
+      minutes_since_last_status_check_completed:,
+      minutes_since_last_status_update:,
+      minutes_to_completion:,
+      issuer:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3623,46 +3623,6 @@ module AnalyticsEvents
     )
   end
 
-  # Tracks enrollments that were cancelled after spending over 90 days in password reset.
-  # @param [String] enrollment_code The in-person enrollment code.
-  # @param [String] enrollment_id The in-person enrollment ID.
-  # # @param [String] reason The reason for cancelling the enrollment.
-  # @param [String] job_name The class name of the job.
-  # @param [Float] minutes_since_established
-  # @param [Float] minutes_since_last_status_check
-  # @param [Float] minutes_since_last_status_check_completed
-  # @param [Float] minutes_since_last_status_update
-  # @param [Float] minutes_to_completion
-  # @param [String] issuer
-  def idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled(
-    enrollment_code:,
-    enrollment_id:,
-    reason:,
-    job_name:,
-    minutes_since_established:,
-    minutes_since_last_status_check:,
-    minutes_since_last_status_check_completed:,
-    minutes_since_last_status_update:,
-    minutes_to_completion:,
-    issuer:,
-    **extra
-  )
-    track_event(
-      :idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled,
-      enrollment_code:,
-      enrollment_id:,
-      reason:,
-      job_name:,
-      minutes_since_established:,
-      minutes_since_last_status_check:,
-      minutes_since_last_status_check_completed:,
-      minutes_since_last_status_update:,
-      minutes_to_completion:,
-      issuer:,
-      **extra,
-    )
-  end
-
   # Tracks individual enrollments that are updated during GetUspsProofingResultsJob
   # @param [String] enrollment_code
   # @param [String] enrollment_id
@@ -3686,7 +3646,7 @@ module AnalyticsEvents
   # @param [String] response_message
   # @param [Boolean] passed did this enrollment pass or fail?
   # @param [String] reason why did this enrollment pass or fail?
-  # @param [String] tmx_status the tmx_status of the enrollment profile profile
+  # @param [String] tmx_status the tmx_status of the enrollment profile
   # @param [Integer] profile_age_in_seconds How many seconds have passed since profile created
   # @param [Boolean] response_present
   # @param [String] job_name
@@ -3843,6 +3803,46 @@ module AnalyticsEvents
       response_message:,
       response_status_code:,
       job_name:,
+      issuer:,
+      **extra,
+    )
+  end
+
+  # Tracks enrollments that were cancelled after spending over 90 days in password reset.
+  # @param [String] enrollment_code The in-person enrollment code.
+  # @param [String] enrollment_id The in-person enrollment ID.
+  # @param [String] reason The reason for cancelling the enrollment.
+  # @param [String] job_name The class name of the job.
+  # @param [Float] minutes_since_established
+  # @param [Float] minutes_since_last_status_check
+  # @param [Float] minutes_since_last_status_check_completed
+  # @param [Float] minutes_since_last_status_update
+  # @param [Float] minutes_to_completion
+  # @param [String] issuer
+  def idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled(
+    enrollment_code:,
+    enrollment_id:,
+    reason:,
+    job_name:,
+    minutes_since_established:,
+    minutes_since_last_status_check:,
+    minutes_since_last_status_check_completed:,
+    minutes_since_last_status_update:,
+    minutes_to_completion:,
+    issuer:,
+    **extra
+  )
+    track_event(
+      :idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled,
+      enrollment_code:,
+      enrollment_id:,
+      reason:,
+      job_name:,
+      minutes_since_established:,
+      minutes_since_last_status_check:,
+      minutes_since_last_status_check_completed:,
+      minutes_since_last_status_update:,
+      minutes_to_completion:,
       issuer:,
       **extra,
     )


### PR DESCRIPTION
## 🎫 Ticket
[LG-15947: Cancel skipped enrollments after 90 days](https://cm-jira.usa.gov/browse/LG-15947)

## 🛠 Summary of changes
- If a user creates a pending enrollment, logs out, resets their password, and then doesn't log back in for 90 days or more.....
-- the enrollment will be cancelled.
-- an analytic event will be logged.

## 📜 Testing Plan

- [ ] Locally run `make watch_events`. 
- [ ] Navigate to the oidc sinatra sample app and choose the Identity Verified level of service.
- [ ] Create an account.
- [ ] Go through ID-IPP and generate a barcode.
- [ ] Log out of idp.
- [ ] Reset your account password.
- [ ] Open `rails console` and select the most recently created pending enrollment, `enrollment`.
- [ ] Update the enrollment's `status_updated_at` field to be more than 90 days in the past.
- [ ]  Run the `GetUspsProofingResultsJob`
- [ ] Navigate back to the terminal tab where you're running `make watch_events`.  Confirm that the new analytic event, `idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled`, was logged.
- [ ] In rails console, reload `enrollment` and confirm that the status is `cancelled`.
