### PR TITLE
Update pivcac to use standard errors

### DIFF
--- a/app/forms/concerns/piv_cac_form_helpers.rb
+++ b/app/forms/concerns/piv_cac_form_helpers.rb
@@ -23,7 +23,7 @@ module PivCacFormHelpers
       self.error_type = possible_error
       errors.add(
         :token, I18n.t('headings.piv_cac.certificate.invalid'),
-        type: possible_error.match(/\.(.*)/)[1].to_sym
+        type: possible_error.split('.').last.to_sym
       )
       false
     else

--- a/app/forms/concerns/piv_cac_form_helpers.rb
+++ b/app/forms/concerns/piv_cac_form_helpers.rb
@@ -21,6 +21,10 @@ module PivCacFormHelpers
     possible_error = @data['error']
     if possible_error
       self.error_type = possible_error
+      errors.add(
+        :token, I18n.t('headings.piv_cac.certificate.invalid'),
+        type: possible_error.match(/\.(.*)/)[1].to_sym
+      )
       false
     else
       self.x509_dn_uuid = @data['uuid']
@@ -35,6 +39,10 @@ module PivCacFormHelpers
       true
     else
       self.error_type = 'token.invalid'
+      errors.add(
+        :token, I18n.t('headings.piv_cac.certificate.invalid'),
+        type: :invalid
+      )
       false
     end
   end

--- a/app/forms/user_piv_cac_login_form.rb
+++ b/app/forms/user_piv_cac_login_form.rb
@@ -18,9 +18,8 @@ class UserPivCacLoginForm
   def submit
     success = valid? && valid_submission?
 
-    errors = error_type ? { type: error_type } : {}
-    response_hash = { success: success, errors: errors }
-    response_hash[:extra] = { key_id: key_id }
+    response_hash = { success:, errors: }
+    response_hash[:extra] = { key_id: }
     FormResponse.new(**response_hash)
   end
 
@@ -38,6 +37,10 @@ class UserPivCacLoginForm
       true
     else
       self.error_type = 'user.not_found'
+      errors.add(
+        :user, I18n.t('headings.piv_cac_setup.already_associated'),
+        type: :not_found
+      )
       false
     end
   end

--- a/app/forms/user_piv_cac_setup_form.rb
+++ b/app/forms/user_piv_cac_setup_form.rb
@@ -17,10 +17,9 @@ class UserPivCacSetupForm
   def submit
     success = valid? && valid_submission?
 
-    errors = error_type ? { type: error_type } : {}
     FormResponse.new(
       success: success && process_valid_submission,
-      errors: errors,
+      errors:,
       extra: extra_analytics_attributes,
     )
   end
@@ -52,6 +51,10 @@ class UserPivCacSetupForm
     self.x509_issuer = @data['issuer']
     if PivCacConfiguration.exists?(x509_dn_uuid: x509_dn_uuid)
       self.error_type = 'piv_cac.already_associated'
+      errors.add(
+        :piv_cac, I18n.t('headings.piv_cac_setup.already_associated'),
+        type: :already_associated
+      )
       false
     else
       true

--- a/app/forms/user_piv_cac_verification_form.rb
+++ b/app/forms/user_piv_cac_verification_form.rb
@@ -13,11 +13,10 @@ class UserPivCacVerificationForm
 
   def submit
     success = valid? && valid_submission?
-    errors = error_type ? { type: error_type } : {}
 
     FormResponse.new(
-      success: success,
-      errors: errors,
+      success:,
+      errors:,
       extra: extra_analytics_attributes,
     )
   end
@@ -40,6 +39,10 @@ class UserPivCacVerificationForm
       true
     else
       self.error_type = 'user.piv_cac_mismatch'
+      errors.add(
+        :user, I18n.t('headings.piv_cac_setup.already_associated'),
+        type: :piv_cac_mismatch
+      )
       false
     end
   end
@@ -49,6 +52,10 @@ class UserPivCacVerificationForm
       true
     else
       self.error_type = 'user.no_piv_cac_associated'
+      errors.add(
+        :user, I18n.t('headings.piv_cac_login.account_not_found'),
+        type: :no_piv_cac_associated
+      )
       false
     end
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6692,17 +6692,18 @@ module AnalyticsEvents
 
   # @identity.idp.previous_event_name PIV/CAC login
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
+  # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
+
   # @param [String, nil] key_id PIV/CAC key_id from PKI service
   # @param [Boolean] new_device Whether the user is authenticating from a new device
   # Tracks piv cac login event
-  def piv_cac_login(success:, errors:, key_id:, new_device:, **extra)
+  def piv_cac_login(success:, key_id:, new_device:, error_details: nil, **extra)
     track_event(
       :piv_cac_login,
       success:,
-      errors:,
       key_id:,
       new_device:,
+      error_details:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6693,7 +6693,6 @@ module AnalyticsEvents
   # @identity.idp.previous_event_name PIV/CAC login
   # @param [Boolean] success Whether form validation was successful
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-
   # @param [String, nil] key_id PIV/CAC key_id from PKI service
   # @param [Boolean] new_device Whether the user is authenticating from a new device
   # Tracks piv cac login event

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
           expect(@analytics).to have_logged_event(
             'Multi-Factor Authentication',
             success: false,
-            errors: { type: 'token.invalid' },
+            error_details: { token: { invalid: true } },
             context: 'authentication',
             multi_factor_auth_method: 'piv_cac',
             enabled_mfa_methods_count: 2,
@@ -334,7 +334,7 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
           expect(@analytics).to have_logged_event(
             'Multi-Factor Authentication',
             success: false,
-            errors: { type: 'token.invalid' },
+            error_details: { token: { invalid: true } },
             context: 'authentication',
             multi_factor_auth_method: 'piv_cac',
             enabled_mfa_methods_count: 2,

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Users::PivCacLoginController do
           expect(@analytics).to have_logged_event(
             :piv_cac_login,
             success: false,
+            error_details: { nonce: { blank: true } },
           )
         end
 
@@ -78,8 +79,8 @@ RSpec.describe Users::PivCacLoginController do
 
             expect(@analytics).to have_logged_event(
               :piv_cac_login,
-              errors: {
-                type: 'user.not_found',
+              error_details: {
+                user: { not_found: true },
               },
               success: false,
             )

--- a/spec/forms/user_piv_cac_login_form_spec.rb
+++ b/spec/forms/user_piv_cac_login_form_spec.rb
@@ -27,11 +27,10 @@ RSpec.describe UserPivCacLoginForm do
       end
 
       it 'returns FormResponse with success: true' do
-        result = form.submit
-
-        expect(result.success?).to eq true
-        expect(result.errors).to eq({})
-        expect(result.extra).to eq({ key_id: 'foo' })
+        expect(form.submit.to_h).to eq(
+          success: true,
+          key_id: 'foo',
+        )
       end
     end
 
@@ -42,11 +41,12 @@ RSpec.describe UserPivCacLoginForm do
       end
 
       it 'returns FormResponse with success: false' do
-        result = form.submit
-
-        expect(result.success?).to eq false
-        expect(result.errors).to eq({ type: 'token.bad' })
-        expect(result.extra).to eq({ key_id: 'foo' })
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { bad: true } },
+          key_id: 'foo',
+        )
+        expect(form.error_type).to eq 'token.bad'
       end
     end
 
@@ -58,11 +58,12 @@ RSpec.describe UserPivCacLoginForm do
       let(:bad_nonce) { nonce + 'X' }
 
       it 'returns FormResponse with success: false' do
-        result = form.submit
-
-        expect(result.success?).to eq false
-        expect(result.errors).to eq({ type: 'token.invalid' })
-        expect(result.extra).to eq({ key_id: 'foo' })
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { invalid: true } },
+          key_id: 'foo',
+        )
+        expect(form.error_type).to eq 'token.invalid'
       end
     end
 
@@ -70,9 +71,11 @@ RSpec.describe UserPivCacLoginForm do
       let(:token) {}
 
       it 'returns FormResponse with success: false' do
-        result = form.submit
-
-        expect(result.success?).to eq false
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { blank: true } },
+          key_id: nil,
+        )
       end
     end
   end

--- a/spec/forms/user_piv_cac_setup_form_spec.rb
+++ b/spec/forms/user_piv_cac_setup_form_spec.rb
@@ -25,12 +25,11 @@ RSpec.describe UserPivCacSetupForm do
       end
 
       it 'returns FormResponse with success: true' do
-        result = instance_double(FormResponse)
-        extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
-
-        expect(FormResponse).to receive(:new)
-          .with(success: true, errors: {}, extra: extra).and_return(result)
-        expect(form.submit).to eq result
+        expect(form.submit.to_h).to eq(
+          success: true,
+          multi_factor_auth_method: 'piv_cac',
+          key_id: 'foo',
+        )
         user.reload
         expect(TwoFactorAuthentication::PivCacPolicy.new(user).enabled?).to eq true
         expect(user.piv_cac_configurations.first.x509_dn_uuid).to eq x509_dn_uuid
@@ -47,12 +46,11 @@ RSpec.describe UserPivCacSetupForm do
         let(:user) { create(:user, :with_piv_or_cac) }
 
         it 'returns FormResponse with success: true' do
-          result = instance_double(FormResponse)
-          extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
-
-          expect(FormResponse).to receive(:new)
-            .with(success: true, errors: {}, extra: extra).and_return(result)
-          expect(form.submit).to eq result
+          expect(form.submit.to_h).to eq(
+            success: true,
+            multi_factor_auth_method: 'piv_cac',
+            key_id: 'foo',
+          )
           expect(TwoFactorAuthentication::PivCacPolicy.new(user.reload).enabled?).to eq true
         end
       end
@@ -62,13 +60,13 @@ RSpec.describe UserPivCacSetupForm do
         let(:x509_dn_uuid) { other_user.piv_cac_configurations.first.x509_dn_uuid }
 
         it 'returns FormResponse with success: false' do
-          result = instance_double(FormResponse)
-          extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
+          expect(form.submit.to_h).to eq(
+            success: false,
+            error_details: { piv_cac: { already_associated: true } },
+            multi_factor_auth_method: 'piv_cac',
+            key_id: 'foo',
+          )
 
-          expect(FormResponse).to receive(:new)
-            .with(success: false, errors: { type: 'piv_cac.already_associated' },
-                  extra: extra).and_return(result)
-          expect(form.submit).to eq result
           expect(TwoFactorAuthentication::PivCacPolicy.new(user.reload).enabled?).to eq false
           expect(form.error_type).to eq 'piv_cac.already_associated'
         end
@@ -82,12 +80,13 @@ RSpec.describe UserPivCacSetupForm do
       end
 
       it 'returns FormResponse with success: false' do
-        result = instance_double(FormResponse)
-        extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { bad: true } },
+          multi_factor_auth_method: 'piv_cac',
+          key_id: 'foo',
+        )
 
-        expect(FormResponse).to receive(:new)
-          .with(success: false, errors: { type: 'token.bad' }, extra: extra).and_return(result)
-        expect(form.submit).to eq result
         expect(TwoFactorAuthentication::PivCacPolicy.new(user.reload).enabled?).to eq false
         expect(form.error_type).to eq 'token.bad'
       end
@@ -101,12 +100,12 @@ RSpec.describe UserPivCacSetupForm do
       let(:bad_nonce) { nonce + 'X' }
 
       it 'returns FormResponse with success: false' do
-        result = instance_double(FormResponse)
-        extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
-
-        expect(FormResponse).to receive(:new)
-          .with(success: false, errors: { type: 'token.invalid' }, extra: extra).and_return(result)
-        expect(form.submit).to eq result
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { invalid: true } },
+          multi_factor_auth_method: 'piv_cac',
+          key_id: 'foo',
+        )
         expect(form.error_type).to eq 'token.invalid'
       end
     end
@@ -115,12 +114,12 @@ RSpec.describe UserPivCacSetupForm do
       let(:token) {}
 
       it 'returns FormResponse with success: false' do
-        result = instance_double(FormResponse)
-        extra = { multi_factor_auth_method: 'piv_cac', key_id: nil }
-
-        expect(FormResponse).to receive(:new)
-          .with(success: false, errors: {}, extra: extra).and_return(result)
-        expect(form.submit).to eq result
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { blank: true } },
+          multi_factor_auth_method: 'piv_cac',
+          key_id: nil,
+        )
         expect(TwoFactorAuthentication::PivCacPolicy.new(user.reload).enabled?).to eq false
       end
     end

--- a/spec/forms/user_piv_cac_verification_form_spec.rb
+++ b/spec/forms/user_piv_cac_verification_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe UserPivCacVerificationForm do
           result = form.submit
           expect(result.to_h).to eq(
             success: false,
-            errors: { type: 'user.no_piv_cac_associated' },
+            error_details: { user: { no_piv_cac_associated: true } },
             piv_cac_configuration_id: nil,
             multi_factor_auth_method_created_at: nil,
             piv_cac_configuration_dn_uuid: nil,
@@ -49,7 +49,7 @@ RSpec.describe UserPivCacVerificationForm do
 
           expect(result.to_h).to eq(
             success: false,
-            errors: { type: 'user.piv_cac_mismatch' },
+            error_details: { user: { piv_cac_mismatch: true } },
             multi_factor_auth_method_created_at: nil,
             piv_cac_configuration_id: nil,
             piv_cac_configuration_dn_uuid: 'some-random-uuid',
@@ -69,7 +69,6 @@ RSpec.describe UserPivCacVerificationForm do
           result = form.submit
           expect(result.to_h).to eq(
             success: true,
-            errors: nil,
             piv_cac_configuration_id: piv_cac_configuration.id,
             multi_factor_auth_method_created_at: piv_cac_configuration.created_at.strftime('%s%L'),
             key_id: 'foo',
@@ -86,7 +85,7 @@ RSpec.describe UserPivCacVerificationForm do
             result = form.submit
             expect(result.to_h).to eq(
               success: false,
-              errors: { type: 'token.invalid' },
+              error_details: { token: { invalid: true } },
               piv_cac_configuration_id: nil,
               multi_factor_auth_method_created_at: nil,
               piv_cac_configuration_dn_uuid: nil,
@@ -112,7 +111,7 @@ RSpec.describe UserPivCacVerificationForm do
         expect(form.error_type).to eq 'token.bad'
         expect(result.to_h).to eq(
           success: false,
-          errors: { type: 'token.bad' },
+          error_details: { token: { bad: true } },
           multi_factor_auth_method_created_at: nil,
           piv_cac_configuration_dn_uuid: nil,
           piv_cac_configuration_id: nil,
@@ -130,7 +129,7 @@ RSpec.describe UserPivCacVerificationForm do
 
         expect(result.to_h).to eq(
           success: false,
-          errors: nil,
+          error_details: { token: { blank: true } },
           multi_factor_auth_method_created_at: nil,
           piv_cac_configuration_id: nil,
           piv_cac_configuration_dn_uuid: nil,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[162](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/162)

## 🛠 Summary of changes
This code change:

- Adds more standard errors to the different pivcac forms
- Prevents the errors from being overwritten by event_type
- makes some tests a little more expressive

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
