### PR TITLE
Deploy RC 468 to Production

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -478,7 +478,7 @@ GEM
     pg (1.5.9)
     pg_query (5.1.0)
       google-protobuf (>= 3.22.3)
-    phonelib (0.10.6)
+    phonelib (0.10.7)
     pkcs11 (0.3.4)
     premailer (1.27.0)
       addressable

--- a/app/forms/concerns/piv_cac_form_helpers.rb
+++ b/app/forms/concerns/piv_cac_form_helpers.rb
@@ -21,6 +21,10 @@ module PivCacFormHelpers
     possible_error = @data['error']
     if possible_error
       self.error_type = possible_error
+      errors.add(
+        :token, I18n.t('headings.piv_cac.certificate.invalid'),
+        type: possible_error.split('.').last.to_sym
+      )
       false
     else
       self.x509_dn_uuid = @data['uuid']
@@ -35,6 +39,10 @@ module PivCacFormHelpers
       true
     else
       self.error_type = 'token.invalid'
+      errors.add(
+        :token, I18n.t('headings.piv_cac.certificate.invalid'),
+        type: :invalid
+      )
       false
     end
   end

--- a/app/forms/user_piv_cac_login_form.rb
+++ b/app/forms/user_piv_cac_login_form.rb
@@ -18,9 +18,8 @@ class UserPivCacLoginForm
   def submit
     success = valid? && valid_submission?
 
-    errors = error_type ? { type: error_type } : {}
-    response_hash = { success: success, errors: errors }
-    response_hash[:extra] = { key_id: key_id }
+    response_hash = { success:, errors: }
+    response_hash[:extra] = { key_id: }
     FormResponse.new(**response_hash)
   end
 
@@ -38,6 +37,10 @@ class UserPivCacLoginForm
       true
     else
       self.error_type = 'user.not_found'
+      errors.add(
+        :user, I18n.t('headings.piv_cac_setup.already_associated'),
+        type: :not_found
+      )
       false
     end
   end

--- a/app/forms/user_piv_cac_setup_form.rb
+++ b/app/forms/user_piv_cac_setup_form.rb
@@ -17,10 +17,9 @@ class UserPivCacSetupForm
   def submit
     success = valid? && valid_submission?
 
-    errors = error_type ? { type: error_type } : {}
     FormResponse.new(
       success: success && process_valid_submission,
-      errors: errors,
+      errors:,
       extra: extra_analytics_attributes,
     )
   end
@@ -52,6 +51,10 @@ class UserPivCacSetupForm
     self.x509_issuer = @data['issuer']
     if PivCacConfiguration.exists?(x509_dn_uuid: x509_dn_uuid)
       self.error_type = 'piv_cac.already_associated'
+      errors.add(
+        :piv_cac, I18n.t('headings.piv_cac_setup.already_associated'),
+        type: :already_associated
+      )
       false
     else
       true

--- a/app/forms/user_piv_cac_verification_form.rb
+++ b/app/forms/user_piv_cac_verification_form.rb
@@ -13,11 +13,10 @@ class UserPivCacVerificationForm
 
   def submit
     success = valid? && valid_submission?
-    errors = error_type ? { type: error_type } : {}
 
     FormResponse.new(
-      success: success,
-      errors: errors,
+      success:,
+      errors:,
       extra: extra_analytics_attributes,
     )
   end
@@ -40,6 +39,10 @@ class UserPivCacVerificationForm
       true
     else
       self.error_type = 'user.piv_cac_mismatch'
+      errors.add(
+        :user, I18n.t('headings.piv_cac_setup.already_associated'),
+        type: :piv_cac_mismatch
+      )
       false
     end
   end
@@ -49,6 +52,10 @@ class UserPivCacVerificationForm
       true
     else
       self.error_type = 'user.no_piv_cac_associated'
+      errors.add(
+        :user, I18n.t('headings.piv_cac_login.account_not_found'),
+        type: :no_piv_cac_associated
+      )
       false
     end
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3586,7 +3586,6 @@ module AnalyticsEvents
   end
 
   # Tracks skipped enrollments during the execution of the GetUspsProofingResultsJob
-  #
   # @param [String] enrollment_code The in-person enrollment code.
   # @param [String] enrollment_id The in-person enrollment ID.
   # @param [String] reason The reason for skipping the enrollment.
@@ -3691,7 +3690,7 @@ module AnalyticsEvents
   # @param [String] response_message
   # @param [Boolean] passed did this enrollment pass or fail?
   # @param [String] reason why did this enrollment pass or fail?
-  # @param [String] tmx_status the tmx_status of the enrollment profile profile
+  # @param [String] tmx_status the tmx_status of the enrollment profile
   # @param [Integer] profile_age_in_seconds How many seconds have passed since profile created
   # @param [Boolean] response_present
   # @param [String] job_name
@@ -3848,6 +3847,46 @@ module AnalyticsEvents
       response_message:,
       response_status_code:,
       job_name:,
+      issuer:,
+      **extra,
+    )
+  end
+
+  # Tracks enrollments that were cancelled after spending over 90 days in password reset.
+  # @param [String] enrollment_code The in-person enrollment code.
+  # @param [String] enrollment_id The in-person enrollment ID.
+  # @param [String] reason The reason for cancelling the enrollment.
+  # @param [String] job_name The class name of the job.
+  # @param [Float] minutes_since_established
+  # @param [Float] minutes_since_last_status_check
+  # @param [Float] minutes_since_last_status_check_completed
+  # @param [Float] minutes_since_last_status_update
+  # @param [Float] minutes_to_completion
+  # @param [String] issuer
+  def idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled(
+    enrollment_code:,
+    enrollment_id:,
+    reason:,
+    job_name:,
+    minutes_since_established:,
+    minutes_since_last_status_check:,
+    minutes_since_last_status_check_completed:,
+    minutes_since_last_status_update:,
+    minutes_to_completion:,
+    issuer:,
+    **extra
+  )
+    track_event(
+      :idv_in_person_usps_proofing_results_job_password_reset_enrollment_cancelled,
+      enrollment_code:,
+      enrollment_id:,
+      reason:,
+      job_name:,
+      minutes_since_established:,
+      minutes_since_last_status_check:,
+      minutes_since_last_status_check_completed:,
+      minutes_since_last_status_update:,
+      minutes_to_completion:,
       issuer:,
       **extra,
     )

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6692,17 +6692,17 @@ module AnalyticsEvents
 
   # @identity.idp.previous_event_name PIV/CAC login
   # @param [Boolean] success Whether form validation was successful
-  # @param [Hash] errors Errors resulting from form validation
+  # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
   # @param [String, nil] key_id PIV/CAC key_id from PKI service
   # @param [Boolean] new_device Whether the user is authenticating from a new device
   # Tracks piv cac login event
-  def piv_cac_login(success:, errors:, key_id:, new_device:, **extra)
+  def piv_cac_login(success:, key_id:, new_device:, error_details: nil, **extra)
     track_event(
       :piv_cac_login,
       success:,
-      errors:,
       key_id:,
       new_device:,
+      error_details:,
       **extra,
     )
   end

--- a/app/views/two_factor_authentication/_locked.html.erb
+++ b/app/views/two_factor_authentication/_locked.html.erb
@@ -5,11 +5,14 @@
 
   <p><%= presenter.locked_reason %></p>
 
-  <p>
+  <p role="timer" aria-live="polite" aria-atomic="true">
     <%= t(
           'two_factor_authentication.please_try_again_html',
           countdown: render(
-            CountdownComponent.new(expiration: presenter.user.lockout_time_expiration),
+            CountdownComponent.new(
+              expiration: presenter.user.lockout_time_expiration,
+              update_interval: 30.seconds,
+            ),
           ),
         ) %>
   </p>

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -206,6 +206,7 @@ in_person_outage_emailed_by_date: 'November 1, 2024'
 in_person_outage_expected_update_date: 'October 31, 2024'
 in_person_outage_message_enabled: false
 in_person_passports_enabled: true
+in_person_password_reset_expiration_days: 90
 in_person_proofing_enabled: false
 in_person_proofing_enforce_tmx: false
 in_person_proofing_opt_in_enabled: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -226,6 +226,7 @@ module IdentityConfig
     config.add(:in_person_enrollments_ready_job_visibility_timeout_seconds, type: :integer)
     config.add(:in_person_enrollments_ready_job_wait_time_seconds, type: :integer)
     config.add(:in_person_opt_in_available_completion_survey_url, type: :string)
+    config.add(:in_person_password_reset_expiration_days, type: :integer)
     config.add(:in_person_outage_emailed_by_date, type: :string)
     config.add(:in_person_outage_expected_update_date, type: :string)
     config.add(:in_person_outage_message_enabled, type: :boolean)

--- a/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication/piv_cac_verification_controller_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
           expect(@analytics).to have_logged_event(
             'Multi-Factor Authentication',
             success: false,
-            errors: { type: 'token.invalid' },
+            error_details: { token: { invalid: true } },
             context: 'authentication',
             multi_factor_auth_method: 'piv_cac',
             enabled_mfa_methods_count: 2,
@@ -334,7 +334,7 @@ RSpec.describe TwoFactorAuthentication::PivCacVerificationController do
           expect(@analytics).to have_logged_event(
             'Multi-Factor Authentication',
             success: false,
-            errors: { type: 'token.invalid' },
+            error_details: { token: { invalid: true } },
             context: 'authentication',
             multi_factor_auth_method: 'piv_cac',
             enabled_mfa_methods_count: 2,

--- a/spec/controllers/users/piv_cac_login_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_login_controller_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Users::PivCacLoginController do
           expect(@analytics).to have_logged_event(
             :piv_cac_login,
             success: false,
+            error_details: { nonce: { blank: true } },
           )
         end
 
@@ -78,8 +79,8 @@ RSpec.describe Users::PivCacLoginController do
 
             expect(@analytics).to have_logged_event(
               :piv_cac_login,
-              errors: {
-                type: 'user.not_found',
+              error_details: {
+                user: { not_found: true },
               },
               success: false,
             )

--- a/spec/forms/user_piv_cac_login_form_spec.rb
+++ b/spec/forms/user_piv_cac_login_form_spec.rb
@@ -27,11 +27,10 @@ RSpec.describe UserPivCacLoginForm do
       end
 
       it 'returns FormResponse with success: true' do
-        result = form.submit
-
-        expect(result.success?).to eq true
-        expect(result.errors).to eq({})
-        expect(result.extra).to eq({ key_id: 'foo' })
+        expect(form.submit.to_h).to eq(
+          success: true,
+          key_id: 'foo',
+        )
       end
     end
 
@@ -42,11 +41,12 @@ RSpec.describe UserPivCacLoginForm do
       end
 
       it 'returns FormResponse with success: false' do
-        result = form.submit
-
-        expect(result.success?).to eq false
-        expect(result.errors).to eq({ type: 'token.bad' })
-        expect(result.extra).to eq({ key_id: 'foo' })
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { bad: true } },
+          key_id: 'foo',
+        )
+        expect(form.error_type).to eq 'token.bad'
       end
     end
 
@@ -58,11 +58,12 @@ RSpec.describe UserPivCacLoginForm do
       let(:bad_nonce) { nonce + 'X' }
 
       it 'returns FormResponse with success: false' do
-        result = form.submit
-
-        expect(result.success?).to eq false
-        expect(result.errors).to eq({ type: 'token.invalid' })
-        expect(result.extra).to eq({ key_id: 'foo' })
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { invalid: true } },
+          key_id: 'foo',
+        )
+        expect(form.error_type).to eq 'token.invalid'
       end
     end
 
@@ -70,9 +71,11 @@ RSpec.describe UserPivCacLoginForm do
       let(:token) {}
 
       it 'returns FormResponse with success: false' do
-        result = form.submit
-
-        expect(result.success?).to eq false
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { blank: true } },
+          key_id: nil,
+        )
       end
     end
   end

--- a/spec/forms/user_piv_cac_setup_form_spec.rb
+++ b/spec/forms/user_piv_cac_setup_form_spec.rb
@@ -25,12 +25,11 @@ RSpec.describe UserPivCacSetupForm do
       end
 
       it 'returns FormResponse with success: true' do
-        result = instance_double(FormResponse)
-        extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
-
-        expect(FormResponse).to receive(:new)
-          .with(success: true, errors: {}, extra: extra).and_return(result)
-        expect(form.submit).to eq result
+        expect(form.submit.to_h).to eq(
+          success: true,
+          multi_factor_auth_method: 'piv_cac',
+          key_id: 'foo',
+        )
         user.reload
         expect(TwoFactorAuthentication::PivCacPolicy.new(user).enabled?).to eq true
         expect(user.piv_cac_configurations.first.x509_dn_uuid).to eq x509_dn_uuid
@@ -47,12 +46,11 @@ RSpec.describe UserPivCacSetupForm do
         let(:user) { create(:user, :with_piv_or_cac) }
 
         it 'returns FormResponse with success: true' do
-          result = instance_double(FormResponse)
-          extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
-
-          expect(FormResponse).to receive(:new)
-            .with(success: true, errors: {}, extra: extra).and_return(result)
-          expect(form.submit).to eq result
+          expect(form.submit.to_h).to eq(
+            success: true,
+            multi_factor_auth_method: 'piv_cac',
+            key_id: 'foo',
+          )
           expect(TwoFactorAuthentication::PivCacPolicy.new(user.reload).enabled?).to eq true
         end
       end
@@ -62,13 +60,13 @@ RSpec.describe UserPivCacSetupForm do
         let(:x509_dn_uuid) { other_user.piv_cac_configurations.first.x509_dn_uuid }
 
         it 'returns FormResponse with success: false' do
-          result = instance_double(FormResponse)
-          extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
+          expect(form.submit.to_h).to eq(
+            success: false,
+            error_details: { piv_cac: { already_associated: true } },
+            multi_factor_auth_method: 'piv_cac',
+            key_id: 'foo',
+          )
 
-          expect(FormResponse).to receive(:new)
-            .with(success: false, errors: { type: 'piv_cac.already_associated' },
-                  extra: extra).and_return(result)
-          expect(form.submit).to eq result
           expect(TwoFactorAuthentication::PivCacPolicy.new(user.reload).enabled?).to eq false
           expect(form.error_type).to eq 'piv_cac.already_associated'
         end
@@ -82,12 +80,13 @@ RSpec.describe UserPivCacSetupForm do
       end
 
       it 'returns FormResponse with success: false' do
-        result = instance_double(FormResponse)
-        extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { bad: true } },
+          multi_factor_auth_method: 'piv_cac',
+          key_id: 'foo',
+        )
 
-        expect(FormResponse).to receive(:new)
-          .with(success: false, errors: { type: 'token.bad' }, extra: extra).and_return(result)
-        expect(form.submit).to eq result
         expect(TwoFactorAuthentication::PivCacPolicy.new(user.reload).enabled?).to eq false
         expect(form.error_type).to eq 'token.bad'
       end
@@ -101,12 +100,12 @@ RSpec.describe UserPivCacSetupForm do
       let(:bad_nonce) { nonce + 'X' }
 
       it 'returns FormResponse with success: false' do
-        result = instance_double(FormResponse)
-        extra = { multi_factor_auth_method: 'piv_cac', key_id: 'foo' }
-
-        expect(FormResponse).to receive(:new)
-          .with(success: false, errors: { type: 'token.invalid' }, extra: extra).and_return(result)
-        expect(form.submit).to eq result
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { invalid: true } },
+          multi_factor_auth_method: 'piv_cac',
+          key_id: 'foo',
+        )
         expect(form.error_type).to eq 'token.invalid'
       end
     end
@@ -115,12 +114,12 @@ RSpec.describe UserPivCacSetupForm do
       let(:token) {}
 
       it 'returns FormResponse with success: false' do
-        result = instance_double(FormResponse)
-        extra = { multi_factor_auth_method: 'piv_cac', key_id: nil }
-
-        expect(FormResponse).to receive(:new)
-          .with(success: false, errors: {}, extra: extra).and_return(result)
-        expect(form.submit).to eq result
+        expect(form.submit.to_h).to eq(
+          success: false,
+          error_details: { token: { blank: true } },
+          multi_factor_auth_method: 'piv_cac',
+          key_id: nil,
+        )
         expect(TwoFactorAuthentication::PivCacPolicy.new(user.reload).enabled?).to eq false
       end
     end

--- a/spec/forms/user_piv_cac_verification_form_spec.rb
+++ b/spec/forms/user_piv_cac_verification_form_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe UserPivCacVerificationForm do
           result = form.submit
           expect(result.to_h).to eq(
             success: false,
-            errors: { type: 'user.no_piv_cac_associated' },
+            error_details: { user: { no_piv_cac_associated: true } },
             piv_cac_configuration_id: nil,
             multi_factor_auth_method_created_at: nil,
             piv_cac_configuration_dn_uuid: nil,
@@ -49,7 +49,7 @@ RSpec.describe UserPivCacVerificationForm do
 
           expect(result.to_h).to eq(
             success: false,
-            errors: { type: 'user.piv_cac_mismatch' },
+            error_details: { user: { piv_cac_mismatch: true } },
             multi_factor_auth_method_created_at: nil,
             piv_cac_configuration_id: nil,
             piv_cac_configuration_dn_uuid: 'some-random-uuid',
@@ -69,7 +69,6 @@ RSpec.describe UserPivCacVerificationForm do
           result = form.submit
           expect(result.to_h).to eq(
             success: true,
-            errors: nil,
             piv_cac_configuration_id: piv_cac_configuration.id,
             multi_factor_auth_method_created_at: piv_cac_configuration.created_at.strftime('%s%L'),
             key_id: 'foo',
@@ -86,7 +85,7 @@ RSpec.describe UserPivCacVerificationForm do
             result = form.submit
             expect(result.to_h).to eq(
               success: false,
-              errors: { type: 'token.invalid' },
+              error_details: { token: { invalid: true } },
               piv_cac_configuration_id: nil,
               multi_factor_auth_method_created_at: nil,
               piv_cac_configuration_dn_uuid: nil,
@@ -112,7 +111,7 @@ RSpec.describe UserPivCacVerificationForm do
         expect(form.error_type).to eq 'token.bad'
         expect(result.to_h).to eq(
           success: false,
-          errors: { type: 'token.bad' },
+          error_details: { token: { bad: true } },
           multi_factor_auth_method_created_at: nil,
           piv_cac_configuration_dn_uuid: nil,
           piv_cac_configuration_id: nil,
@@ -130,7 +129,7 @@ RSpec.describe UserPivCacVerificationForm do
 
         expect(result.to_h).to eq(
           success: false,
-          errors: nil,
+          error_details: { token: { blank: true } },
           multi_factor_auth_method_created_at: nil,
           piv_cac_configuration_id: nil,
           piv_cac_configuration_dn_uuid: nil,


### PR DESCRIPTION
## Bug Fixes
- accessibility: Add countdown announcement on account temporarily locked screen ([#12040](https://github.com/18F/identity-idp/pull/12040))

## Internal
- Analytics: Add standard error handling for pivcac forms ([#12060](https://github.com/18F/identity-idp/pull/12060))
- Dependencies: Update dependencies to latest versions ([#12058](https://github.com/18F/identity-idp/pull/12058))
- In-Person Proofing: Cancel enrollments that linger in password reset state ([#12050](https://github.com/18F/identity-idp/pull/12050))
