### PR TITLE
LG-16042: Display partner logo or name at top of reminder emails

### DIFF
--- a/app/controllers/idv/in_person/ready_to_verify_controller.rb
+++ b/app/controllers/idv/in_person/ready_to_verify_controller.rb
@@ -21,7 +21,6 @@ module Idv
         analytics.idv_in_person_ready_to_verify_visit(**opt_in_analytics_properties)
         @presenter = ReadyToVerifyPresenter.new(
           enrollment: enrollment,
-          is_enhanced_ipp: @is_enhanced_ipp,
         )
       end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -300,19 +300,16 @@ class UserMailer < ActionMailer::Base
       code: enrollment.enrollment_code,
     ).image_data
 
-    @is_enhanced_ipp = enrollment.enhanced_ipp?
-
     with_user_locale(user) do
       @hide_title = IdentityConfig.store.in_person_outage_message_enabled &&
                     IdentityConfig.store.in_person_outage_emailed_by_date.present? &&
                     IdentityConfig.store.in_person_outage_expected_update_date.present?
-      @header = @is_enhanced_ipp ?
-      t('in_person_proofing.headings.barcode_eipp') : t('in_person_proofing.headings.barcode')
       @presenter = Idv::InPerson::ReadyToVerifyPresenter.new(
         enrollment: enrollment,
         barcode_image_url: attachments['barcode.png'].url,
-        is_enhanced_ipp: @is_enhanced_ipp,
       )
+      @header = @presenter.enhanced_ipp? ?
+      t('in_person_proofing.headings.barcode_eipp') : t('in_person_proofing.headings.barcode')
 
       if enrollment&.service_provider&.logo_is_email_compatible?
         @logo_url = enrollment.service_provider.logo_url
@@ -333,13 +330,10 @@ class UserMailer < ActionMailer::Base
       code: enrollment.enrollment_code,
     ).image_data
 
-    @is_enhanced_ipp = enrollment.enhanced_ipp?
-
     with_user_locale(user) do
       @presenter = Idv::InPerson::ReadyToVerifyPresenter.new(
         enrollment: enrollment,
         barcode_image_url: attachments['barcode.png'].url,
-        is_enhanced_ipp: @is_enhanced_ipp,
       )
       if enrollment&.service_provider&.logo_is_email_compatible?
         @logo_url = enrollment.service_provider.logo_url

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -341,10 +341,17 @@ class UserMailer < ActionMailer::Base
         barcode_image_url: attachments['barcode.png'].url,
         is_enhanced_ipp: @is_enhanced_ipp,
       )
+      if enrollment&.service_provider&.logo_is_email_compatible?
+        @logo_url = enrollment.service_provider.logo_url
+      else
+        @logo_url = nil
+      end
+      @sp_name = @presenter.sp_name
       @header = t(
         'user_mailer.in_person_ready_to_verify_reminder.heading',
         count: @presenter.days_remaining,
       )
+
       mail(
         to: email_address.email,
         subject: t(

--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -9,13 +9,12 @@ module Idv
 
       attr_reader :barcode_image_url
 
-      delegate :selected_location_details, :enrollment_code, to: :enrollment
+      delegate :selected_location_details, :enrollment_code, :enhanced_ipp?, to: :enrollment
 
-      def initialize(enrollment:, barcode_image_url: nil, sp_name: nil, is_enhanced_ipp: false)
+      def initialize(enrollment:, barcode_image_url: nil, sp_name: nil)
         @enrollment = enrollment
         @barcode_image_url = barcode_image_url
         @sp_name = sp_name
-        @is_enhanced_ipp = is_enhanced_ipp
       end
 
       # Reminder is exclusive of the day the email is sent (1 less than days_to_due_date)
@@ -70,7 +69,7 @@ module Idv
       end
 
       def barcode_heading_text
-        if @is_enhanced_ipp
+        if enhanced_ipp?
           t('in_person_proofing.headings.barcode_eipp')
         else
           t('in_person_proofing.headings.barcode')
@@ -78,7 +77,7 @@ module Idv
       end
 
       def state_id_heading_text
-        if @is_enhanced_ipp
+        if enhanced_ipp?
           t('in_person_proofing.process.state_id.heading_eipp')
         else
           t('in_person_proofing.process.state_id.heading')
@@ -86,7 +85,7 @@ module Idv
       end
 
       def state_id_info
-        if @is_enhanced_ipp
+        if enhanced_ipp?
           t('in_person_proofing.process.state_id.info_eipp')
         else
           t('in_person_proofing.process.state_id.info')

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -37,14 +37,13 @@ module UspsInPersonProofing
           enhanced_ipp: enrollment.enhanced_ipp?,
         )
 
-        send_ready_to_verify_email(user, enrollment, is_enhanced_ipp: is_enhanced_ipp)
+        send_ready_to_verify_email(user, enrollment)
       end
 
-      def send_ready_to_verify_email(user, enrollment, is_enhanced_ipp:)
+      def send_ready_to_verify_email(user, enrollment)
         user.confirmed_email_addresses.each do |email_address|
           UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
             enrollment: enrollment,
-            is_enhanced_ipp: is_enhanced_ipp,
           ).deliver_now_or_later
         end
       end

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -24,7 +24,7 @@
 <% end %>
 
 <%# Tag for GSA Enhanced Pilot Barcode %>
-<% if @is_enhanced_ipp %>
+<% if @presenter.enhanced_ipp? %>
   <div class="text-center margin-y-4">
     <span class="usa-tag usa-tag--informative">
       <%= t('in_person_proofing.body.barcode.eipp_tag') %>
@@ -49,7 +49,7 @@
 <% end %>
 
 <%# Enhanced IPP Only - What to bring section %>
-<% if @is_enhanced_ipp %>
+<% if @presenter.enhanced_ipp? %>
   <section class="border-1px rounded-xl border-primary-light padding-4 padding-2 margin-bottom-4">
     <%# What to bring to the Post Office %>
     <h2 class="margin-top-0 margin-bottom-2"><%= t('in_person_proofing.headings.barcode_what_to_bring') %></h2>
@@ -186,7 +186,7 @@
     <% end %>
   <% end %>
 
-  <% if !@is_enhanced_ipp %>
+  <% if !@presenter.enhanced_ipp? %>
     <p class="margin-top-3 margin-bottom-0">
       <%= t('in_person_proofing.body.barcode.questions') %>
       <%= render ClickObserverComponent.new(event_name: 'IdV: user clicked what to bring link on ready to verify page') do %>
@@ -228,7 +228,7 @@
   </section>
 <% end %>
 
-<% if !@is_enhanced_ipp %>
+<% if !@presenter.enhanced_ipp? %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
   <p class="margin-bottom-4">
     <%= t(

--- a/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
@@ -15,7 +15,7 @@
 <% end %>
 
 <%# Tag for GSA Enhanced Pilot Barcode %>
-<% if @is_enhanced_ipp %>
+<% if @presenter.enhanced_ipp? %>
   <div class="text-center margin-y-4">
     <span class="usa-tag usa-tag--informative">
       <%= t('in_person_proofing.body.barcode.eipp_tag') %>
@@ -48,7 +48,7 @@
 </table>
 
 <%# Enhanced IPP Only - What to bring to the Post Office %>
-<% if @is_enhanced_ipp %>
+<% if @presenter.enhanced_ipp? %>
   <section class="border-1px radius-lg border-primary-light padding-4 margin-bottom-4">
     <%# What to bring to the Post Office %>
     <h2 class="margin-bottom-2"><%= t('in_person_proofing.headings.barcode_what_to_bring') %></h2>
@@ -237,7 +237,7 @@
     </tr>
   </table>
 
-  <% if !@is_enhanced_ipp %>
+  <% if !@presenter.enhanced_ipp? %>
     <p class="margin-bottom-0 padding-bottom-4">
       <%= t('in_person_proofing.body.barcode.questions') %>
       <%= link_to(
@@ -275,7 +275,7 @@
   </div>
 <% end %>
 
-<% if !@is_enhanced_ipp %>
+<% if !@presenter.enhanced_ipp? %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
   <p class="margin-bottom-4">
     <%= t(

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -185,14 +185,12 @@ class UserMailerPreview < ActionMailer::Preview
   def in_person_ready_to_verify
     UserMailer.with(user: user, email_address: email_address_record).in_person_ready_to_verify(
       enrollment: in_person_enrollment_id_ipp,
-      is_enhanced_ipp: false,
     )
   end
 
   def in_person_ready_to_verify_enhanced_ipp_enabled
     UserMailer.with(user: user, email_address: email_address_record).in_person_ready_to_verify(
       enrollment: in_person_enrollment_enhanced_ipp,
-      is_enhanced_ipp: true,
     )
   end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -857,7 +857,6 @@ RSpec.describe UserMailer, type: :mailer do
       let(:mail) do
         UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
           enrollment: enrollment,
-          is_enhanced_ipp:,
         )
       end
 
@@ -914,12 +913,10 @@ RSpec.describe UserMailer, type: :mailer do
       end
 
       context 'Need to change location section' do
-        context 'when Enhanced IPP is not enabled' do
-          let(:is_enhanced_ipp) { false }
+        context 'when enrollment is not enhanced ipp' do
           let(:mail) do
             UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
-              enrollment: enhanced_ipp_enrollment,
-              is_enhanced_ipp: is_enhanced_ipp,
+              enrollment: enrollment,
             )
           end
           it 'renders the change location heading' do
@@ -939,12 +936,10 @@ RSpec.describe UserMailer, type: :mailer do
           end
         end
 
-        context 'when Enhanced IPP is enabled' do
-          let(:is_enhanced_ipp) { true }
+        context 'when enrollment is enhanced ipp' do
           let(:mail) do
             UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
               enrollment: enhanced_ipp_enrollment,
-              is_enhanced_ipp: is_enhanced_ipp,
             )
           end
 
@@ -1066,7 +1061,6 @@ RSpec.describe UserMailer, type: :mailer do
         let(:mail) do
           UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
             enrollment: enhanced_ipp_enrollment,
-            is_enhanced_ipp:,
           )
         end
 

--- a/spec/support/shared_examples_for_mailer_template.rb
+++ b/spec/support/shared_examples_for_mailer_template.rb
@@ -1,0 +1,28 @@
+RSpec.shared_examples 'a barcode email' do |service_provider_name|
+  context 'when the partner agency logo is a png' do
+    let(:logo) { 'gsa.png' }
+    let(:logo_url) { '/assets/sp-logos/gsa.png' }
+
+    it 'displays the partner agency logo' do
+      expect(rendered).to have_css("img[src*='gsa.png']")
+    end
+  end
+
+  context 'when the partner agency logo is a svg' do
+    let(:logo) { 'generic.svg' }
+    let(:logo_url) { nil }
+
+    it 'displays the partner agency name' do
+      expect(rendered).to have_content(service_provider_name)
+    end
+  end
+
+  context 'when there is no partner agency logo' do
+    let(:logo) { nil }
+    let(:logo_url) { nil }
+
+    it 'displays the partner agency name' do
+      expect(rendered).to have_content(service_provider_name)
+    end
+  end
+end

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -22,11 +22,19 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
       user: user
     )
   end
-  let(:is_enhanced_ipp) { false }
+  let(:enhanced_ipp_enrollment) do
+    build(
+      :in_person_enrollment, :pending, :enhanced_ipp,
+      current_address_matches_id: current_address_matches_id,
+      profile: profile,
+      selected_location_details: selected_location_details,
+      service_provider: service_provider,
+      user: user
+    )
+  end
   let(:presenter) do
     Idv::InPerson::ReadyToVerifyPresenter.new(
       enrollment: enrollment,
-      is_enhanced_ipp: is_enhanced_ipp,
     )
   end
   let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP }
@@ -190,12 +198,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
   end
 
   context 'what to expect section' do
-    context 'when Enhanced IPP is not enabled' do
-      let(:is_enhanced_ipp) { false }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
-
+    context 'when the enrollment is ID-IPP' do
       it 'conditionally renders content applicable to ID-IPP' do
         render
 
@@ -213,11 +216,8 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
       end
     end
 
-    context 'when Enhanced IPP is enabled' do
-      let(:is_enhanced_ipp) { true }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
+    context 'when the enrollment is enhanced IPP' do
+      let(:enrollment) { enhanced_ipp_enrollment }
 
       it 'conditionally renders content applicable to EIPP' do
         render
@@ -261,23 +261,16 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
   end
 
   context 'GSA Enhanced Pilot Barcode tag' do
-    context 'when Enhanced IPP is enabled' do
-      let(:is_enhanced_ipp) { true }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
+    context 'when the enrollment is enhanced IPP' do
+      let(:enrollment) { enhanced_ipp_enrollment }
+
       it 'renders GSA Enhanced Pilot Barcode tag' do
         render
 
         expect(rendered).to have_content(t('in_person_proofing.body.barcode.eipp_tag'))
       end
     end
-    context 'when Enhanced IPP is not enabled' do
-      let(:is_enhanced_ipp) { false }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
-
+    context 'when the enrollment is ID-IPP' do
       it 'does not render GSA Enhanced Pilot Barcode tag' do
         render
 
@@ -287,11 +280,8 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
   end
 
   context 'What to bring to the Post Office section' do
-    context 'when Enhanced IPP is enabled' do
-      let(:is_enhanced_ipp) { true }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
+    context 'when the enrollment is enhanced IPP' do
+      let(:enrollment) { enhanced_ipp_enrollment }
 
       it 'displays heading and body' do
         render
@@ -348,12 +338,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
       end
     end
 
-    context 'when Enhanced IPP is not enabled' do
-      let(:is_enhanced_ipp) { false }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
-
+    context 'when the enrollment is ID-IPP' do
       it 'template does not display Enhanced In-Person Proofing what to bring content' do
         render
 
@@ -392,12 +377,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
   end
 
   context 'Need to Change Location section' do
-    context 'when Enhanced IPP is not enabled' do
-      let(:is_enhanced_ipp) { false }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
-
+    context 'when the enrollment is ID-IPP' do
       it 'renders the change location heading' do
         render
 
@@ -420,10 +400,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
     end
 
     context 'when Enhanced IPP is enabled' do
-      let(:is_enhanced_ipp) { true }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
+      let(:enrollment) { enhanced_ipp_enrollment }
 
       it 'does not render the change location heading' do
         render

--- a/spec/views/layouts/mailer.html.erb_spec.rb
+++ b/spec/views/layouts/mailer.html.erb_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'layouts/mailer.html.erb' do
     end
   end
 
-  context 'in-person proofing ready to verify emails' do
+  context 'in-person proofing' do
     let(:user) { create(:user, :with_pending_in_person_enrollment) }
     let(:sp_name) { 'Friendly Service Provider' }
     let(:service_provider) do
@@ -63,93 +63,38 @@ RSpec.describe 'layouts/mailer.html.erb' do
     end
     let(:enrollment) { create(:in_person_enrollment, :pending, service_provider: service_provider) }
 
-    before do
-      @mail = UserMailer.with(
-        user: user,
-        email_address: user.email_addresses.first,
-      ).in_person_ready_to_verify(enrollment:)
-      allow(view).to receive(:message).and_return(@mail)
-      allow(view).to receive(:attachments).and_return(@mail.attachments)
-      @sp_name = sp_name
-      @logo_url = logo_url
+    context 'ready to verify emails' do
+      before do
+        @mail = UserMailer.with(
+          user: user,
+          email_address: user.email_addresses.first,
+        ).in_person_ready_to_verify(enrollment:)
+        allow(view).to receive(:message).and_return(@mail)
+        allow(view).to receive(:attachments).and_return(@mail.attachments)
+        @sp_name = sp_name
+        @logo_url = logo_url
 
-      render
-    end
-
-    context 'when the partner agency logo is a png' do
-      let(:logo) { 'gsa.png' }
-      let(:logo_url) { '/assets/sp-logos/gsa.png' }
-
-      it 'displays the partner agency logo' do
-        expect(rendered).to have_css("img[src*='gsa.png']")
+        render
       end
+
+      it_behaves_like 'a barcode email', @sp_name
     end
 
-    context 'when the partner agency logo is a svg' do
-      let(:logo) { 'generic.svg' }
-      let(:logo_url) { nil }
+    context 'ready to verify reminder emails' do
+      before do
+        @mail = UserMailer.with(
+          user: user,
+          email_address: user.email_addresses.first,
+        ).in_person_ready_to_verify_reminder(enrollment:)
+        allow(view).to receive(:message).and_return(@mail)
+        allow(view).to receive(:attachments).and_return(@mail.attachments)
+        @sp_name = sp_name
+        @logo_url = logo_url
 
-      it 'displays the partner agency name' do
-        expect(rendered).to have_content('Friendly Service Provider')
+        render
       end
-    end
 
-    context 'when there is no partner agency logo' do
-      let(:logo) { nil }
-      let(:logo_url) { nil }
-
-      it 'displays the partner agency name' do
-        expect(rendered).to have_content('Friendly Service Provider')
-      end
-    end
-  end
-
-  context 'in-person proofing ready to verify reminder emails' do
-    let(:user) { create(:user, :with_pending_in_person_enrollment) }
-    let(:sp_name) { 'Friendly Service Provider' }
-    let(:service_provider) do
-      create(:service_provider, logo: logo, friendly_name: sp_name)
-    end
-    let(:enrollment) { create(:in_person_enrollment, :pending, service_provider: service_provider) }
-
-    before do
-      @mail = UserMailer.with(
-        user: user,
-        email_address: user.email_addresses.first,
-      ).in_person_ready_to_verify_reminder(enrollment:)
-      allow(view).to receive(:message).and_return(@mail)
-      allow(view).to receive(:attachments).and_return(@mail.attachments)
-      @sp_name = sp_name
-      @logo_url = logo_url
-
-      render
-    end
-
-    context 'when the partner agency logo is a png' do
-      let(:logo) { 'gsa.png' }
-      let(:logo_url) { '/assets/sp-logos/gsa.png' }
-
-      it 'displays the partner agency logo' do
-        expect(rendered).to have_css("img[src*='gsa.png']")
-      end
-    end
-
-    context 'when the partner agency logo is a svg' do
-      let(:logo) { 'generic.svg' }
-      let(:logo_url) { nil }
-
-      it 'displays the partner agency name' do
-        expect(rendered).to have_content('Friendly Service Provider')
-      end
-    end
-
-    context 'when there is no partner agency logo' do
-      let(:logo) { nil }
-      let(:logo_url) { nil }
-
-      it 'displays the partner agency name' do
-        expect(rendered).to have_content('Friendly Service Provider')
-      end
+      it_behaves_like 'a barcode email', @sp_name
     end
   end
 end

--- a/spec/views/layouts/mailer.html.erb_spec.rb
+++ b/spec/views/layouts/mailer.html.erb_spec.rb
@@ -103,4 +103,53 @@ RSpec.describe 'layouts/mailer.html.erb' do
       end
     end
   end
+
+  context 'in-person proofing ready to verify reminder emails' do
+    let(:user) { create(:user, :with_pending_in_person_enrollment) }
+    let(:sp_name) { 'Friendly Service Provider' }
+    let(:service_provider) do
+      create(:service_provider, logo: logo, friendly_name: sp_name)
+    end
+    let(:enrollment) { create(:in_person_enrollment, :pending, service_provider: service_provider) }
+
+    before do
+      @mail = UserMailer.with(
+        user: user,
+        email_address: user.email_addresses.first,
+      ).in_person_ready_to_verify_reminder(enrollment:)
+      allow(view).to receive(:message).and_return(@mail)
+      allow(view).to receive(:attachments).and_return(@mail.attachments)
+      @sp_name = sp_name
+      @logo_url = logo_url
+
+      render
+    end
+
+    context 'when the partner agency logo is a png' do
+      let(:logo) { 'gsa.png' }
+      let(:logo_url) { '/assets/sp-logos/gsa.png' }
+
+      it 'displays the partner agency logo' do
+        expect(rendered).to have_css("img[src*='gsa.png']")
+      end
+    end
+
+    context 'when the partner agency logo is a svg' do
+      let(:logo) { 'generic.svg' }
+      let(:logo_url) { nil }
+
+      it 'displays the partner agency name' do
+        expect(rendered).to have_content('Friendly Service Provider')
+      end
+    end
+
+    context 'when there is no partner agency logo' do
+      let(:logo) { nil }
+      let(:logo_url) { nil }
+
+      it 'displays the partner agency name' do
+        expect(rendered).to have_content('Friendly Service Provider')
+      end
+    end
+  end
 end

--- a/spec/views/layouts/mailer.html.erb_spec.rb
+++ b/spec/views/layouts/mailer.html.erb_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'layouts/mailer.html.erb' do
       @mail = UserMailer.with(
         user: user,
         email_address: user.email_addresses.first,
-      ).in_person_ready_to_verify(enrollment:, is_enhanced_ipp: false)
+      ).in_person_ready_to_verify(enrollment:)
       allow(view).to receive(:message).and_return(@mail)
       allow(view).to receive(:attachments).and_return(@mail.attachments)
       @sp_name = sp_name


### PR DESCRIPTION
## 🎫 Ticket
[LG-16042: Eng: Add Partner logo/name to the barcode reminder emails](https://cm-jira.usa.gov/browse/LG-16042)

## 🛠 Summary of changes
- Ready to verify reminder emails have been updated.
- If the service provider has a png logo, the service provider *logo* will display at the top of the email.
- If the service provider has a svg logo, the service provider *name* will display at the top of the email.

## 📜 Testing Plan
- [x] Go to http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify_reminder on your local machine and confirm you see a service provider *logo* to the right of the Login.gov logo. (This is an example of a service provider with a  png logo.)
- [x] Go to http://localhost:3000/rails/mailers/user_mailer/in_person_ready_to_verify_reminder_enhanced_ipp_enabled on your local machine and confirm you see a service provider *name* to the right of the Login.gov logo. (This is an example of a service provider with a svg logo.)
- [ ] Run automated tests.

## 👀 Screenshots
If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Service Provider with a png logo:</summary>

![16042ServiceProviderPNGLogo](https://github.com/user-attachments/assets/92360a29-e66f-49fc-a5bb-f4bbe828a643)

</details>

<details>
<summary>Service Provider with a svg logo:</summary>

![16042ServiceProviderSVGLogo](https://github.com/user-attachments/assets/54dcc134-4e97-4a9c-9899-4f91676abeb0)

</details>