### PR TITLE
Lg-16000 implement vendor outage error for dos api

### DIFF
--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -37,5 +37,15 @@ module Idv
       response = request.fetch(analytics)
       response.success?
     end
+
+    def locals_attrs(analytics:, presenter:, url_for: nil)
+      dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
+      {
+        presenter:,
+        url_for:,
+        dos_passport_api_down:,
+        auto_check_value: dos_passport_api_down ? :drivers_license : selected_id_type,
+      }
+    end
   end
 end

--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -18,7 +18,7 @@ module Idv
       params.require(:doc_auth).permit(:choose_id_type_preference)
     end
 
-    def auto_check_value
+    def selected_id_type
       case document_capture_session.passport_status
       when 'requested'
         :passport

--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -26,5 +26,16 @@ module Idv
         :drivers_license
       end
     end
+
+    def dos_passport_api_healthy?(
+      analytics:,
+      endpoint: IdentityConfig.store.dos_passport_composite_healthcheck_endpoint
+    )
+      return true if endpoint.blank?
+
+      request = DocAuth::Dos::Requests::HealthCheckRequest.new(endpoint:)
+      response = request.fetch(analytics)
+      response.success?
+    end
   end
 end

--- a/app/controllers/concerns/idv_step_concern.rb
+++ b/app/controllers/concerns/idv_step_concern.rb
@@ -85,17 +85,6 @@ module IdvStepConcern
     end
   end
 
-  def dos_passport_api_healthy?(
-    analytics:,
-    endpoint: IdentityConfig.store.dos_passport_composite_healthcheck_endpoint
-  )
-    return true if endpoint.blank?
-
-    request = DocAuth::Dos::Requests::HealthCheckRequest.new(endpoint:)
-    response = request.fetch(analytics)
-    response.success?
-  end
-
   private
 
   def extra_analytics_properties

--- a/app/controllers/idv/choose_id_type_controller.rb
+++ b/app/controllers/idv/choose_id_type_controller.rb
@@ -11,13 +11,13 @@ module Idv
 
     def show
       analytics.idv_doc_auth_choose_id_type_visited(**analytics_arguments)
-      dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
-      auto_check_value = dos_passport_api_down ? :drivers_license : selected_id_type
+
       render 'idv/shared/choose_id_type',
-             locals: { presenter: Idv::ChooseIdTypePresenter.new,
-                       url_for: idv_choose_id_type_path,
-                       auto_check_value: auto_check_value,
-                       dos_passport_api_down: },
+             locals: locals_attrs(
+               analytics:,
+               presenter: Idv::ChooseIdTypePresenter.new,
+               url_for: idv_choose_id_type_path,
+             ),
              layout: true
     end
 

--- a/app/controllers/idv/choose_id_type_controller.rb
+++ b/app/controllers/idv/choose_id_type_controller.rb
@@ -12,6 +12,7 @@ module Idv
     def show
       analytics.idv_doc_auth_choose_id_type_visited(**analytics_arguments)
       dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
+      auto_check_value = dos_passport_api_down ? :drivers_license : selected_id_type
       render 'idv/shared/choose_id_type',
              locals: { presenter: Idv::ChooseIdTypePresenter.new,
                        form_url: idv_choose_id_type_path,

--- a/app/controllers/idv/choose_id_type_controller.rb
+++ b/app/controllers/idv/choose_id_type_controller.rb
@@ -15,8 +15,7 @@ module Idv
       auto_check_value = dos_passport_api_down ? :drivers_license : selected_id_type
       render 'idv/shared/choose_id_type',
              locals: { presenter: Idv::ChooseIdTypePresenter.new,
-                       form_url: idv_choose_id_type_path,
-                       is_hybrid: false,
+                       url_for: idv_choose_id_type_path,
                        auto_check_value: auto_check_value,
                        dos_passport_api_down: },
              layout: true

--- a/app/controllers/idv/choose_id_type_controller.rb
+++ b/app/controllers/idv/choose_id_type_controller.rb
@@ -11,11 +11,13 @@ module Idv
 
     def show
       analytics.idv_doc_auth_choose_id_type_visited(**analytics_arguments)
+      dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
       render 'idv/shared/choose_id_type',
-             locals: {
-               presenter: Idv::ChooseIdTypePresenter.new,
-               auto_check_value: auto_check_value,
-             },
+             locals: { presenter: Idv::ChooseIdTypePresenter.new,
+                       form_url: idv_choose_id_type_path,
+                       is_hybrid: false,
+                       auto_check_value: auto_check_value,
+                       dos_passport_api_down: },
              layout: true
     end
 

--- a/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
@@ -14,6 +14,7 @@ module Idv
       def show
         analytics.idv_doc_auth_choose_id_type_visited(**analytics_arguments)
         dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
+        auto_check_value = dos_passport_api_down ? :drivers_license : selected_id_type
         render 'idv/shared/choose_id_type',
                locals: { presenter: Idv::HybridMobile::ChooseIdTypePresenter.new,
                          form_url: idv_hybrid_mobile_choose_id_type_path,

--- a/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
@@ -13,13 +13,13 @@ module Idv
 
       def show
         analytics.idv_doc_auth_choose_id_type_visited(**analytics_arguments)
-        dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
-        auto_check_value = dos_passport_api_down ? :drivers_license : selected_id_type
+
         render 'idv/shared/choose_id_type',
-               locals: { presenter: Idv::HybridMobile::ChooseIdTypePresenter.new,
-                         url_for: idv_hybrid_mobile_choose_id_type_path,
-                         auto_check_value: auto_check_value,
-                         dos_passport_api_down: }
+               locals: locals_attrs(
+                 analytics:,
+                 presenter: Idv::HybridMobile::ChooseIdTypePresenter.new,
+                 url_for: idv_hybrid_mobile_choose_id_type_path,
+               )
       end
 
       def update

--- a/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
@@ -13,9 +13,13 @@ module Idv
 
       def show
         analytics.idv_doc_auth_choose_id_type_visited(**analytics_arguments)
+        dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
         render 'idv/shared/choose_id_type',
                locals: { presenter: Idv::HybridMobile::ChooseIdTypePresenter.new,
-                         auto_check_value: auto_check_value }
+                         form_url: idv_hybrid_mobile_choose_id_type_path,
+                         is_hybrid: true,
+                         auto_check_value: auto_check_value,
+                         dos_passport_api_down: }
       end
 
       def update

--- a/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
@@ -17,8 +17,7 @@ module Idv
         auto_check_value = dos_passport_api_down ? :drivers_license : selected_id_type
         render 'idv/shared/choose_id_type',
                locals: { presenter: Idv::HybridMobile::ChooseIdTypePresenter.new,
-                         form_url: idv_hybrid_mobile_choose_id_type_path,
-                         is_hybrid: true,
+                         url_for: idv_hybrid_mobile_choose_id_type_path,
                          auto_check_value: auto_check_value,
                          dos_passport_api_down: }
       end

--- a/app/controllers/idv/in_person/choose_id_type_controller.rb
+++ b/app/controllers/idv/in_person/choose_id_type_controller.rb
@@ -12,6 +12,7 @@ class Idv::InPerson::ChooseIdTypeController < ApplicationController
            locals: {
              presenter: Idv::InPerson::ChooseIdTypePresenter.new,
              auto_check_value: '',
+             dos_passport_api_down: false,
            },
            layout: true
   end

--- a/app/controllers/idv/in_person/choose_id_type_controller.rb
+++ b/app/controllers/idv/in_person/choose_id_type_controller.rb
@@ -3,16 +3,19 @@
 class Idv::InPerson::ChooseIdTypeController < ApplicationController
   include Idv::AvailabilityConcern
   include IdvStepConcern
+  include Idv::ChooseIdTypeConcern
 
   before_action :confirm_step_allowed
 
   def show
     analytics.idv_in_person_proofing_choose_id_type_visited(**analytics_arguments)
+    dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
+    auto_check_value = dos_passport_api_down ? :drivers_license : ''
     render 'idv/shared/choose_id_type',
            locals: {
              presenter: Idv::InPerson::ChooseIdTypePresenter.new,
-             auto_check_value: '',
-             dos_passport_api_down: false,
+             auto_check_value: auto_check_value,
+             dos_passport_api_down:,
            },
            layout: true
   end

--- a/app/controllers/idv/in_person/choose_id_type_controller.rb
+++ b/app/controllers/idv/in_person/choose_id_type_controller.rb
@@ -10,7 +10,7 @@ class Idv::InPerson::ChooseIdTypeController < ApplicationController
   def show
     analytics.idv_in_person_proofing_choose_id_type_visited(**analytics_arguments)
     dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
-    auto_check_value = dos_passport_api_down ? :drivers_license : ''
+    auto_check_value = dos_passport_api_down ? :drivers_license : selected_id_type
     render 'idv/shared/choose_id_type',
            locals: {
              presenter: Idv::InPerson::ChooseIdTypePresenter.new,

--- a/app/controllers/idv/in_person/choose_id_type_controller.rb
+++ b/app/controllers/idv/in_person/choose_id_type_controller.rb
@@ -9,14 +9,9 @@ class Idv::InPerson::ChooseIdTypeController < ApplicationController
 
   def show
     analytics.idv_in_person_proofing_choose_id_type_visited(**analytics_arguments)
-    dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
-    auto_check_value = dos_passport_api_down ? :drivers_license : selected_id_type
+
     render 'idv/shared/choose_id_type',
-           locals: {
-             presenter: Idv::InPerson::ChooseIdTypePresenter.new,
-             auto_check_value: auto_check_value,
-             dos_passport_api_down:,
-           },
+           locals: locals_attrs(analytics:, presenter: Idv::InPerson::ChooseIdTypePresenter.new),
            layout: true
   end
 

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -6,6 +6,7 @@ module Idv
     include IdvStepConcern
     include StepIndicatorConcern
     include DocAuthVendorConcern
+    include Idv::ChooseIdTypeConcern
 
     before_action :confirm_step_allowed
     before_action :confirm_not_rate_limited

--- a/app/views/idv/shared/choose_id_type.html.erb
+++ b/app/views/idv/shared/choose_id_type.html.erb
@@ -16,6 +16,12 @@
     <% end %>
 <% end %>
 
+<% if dos_passport_api_down %>
+    <%= render AlertComponent.new(type: :error, class: 'margin-bottom-4') do %>
+    <%= t('doc_auth.info.dos_passport_api_down_message') %>
+    <% end %>
+<% end %>
+
 <%= render PageHeadingComponent.new do %>
   <%= t('doc_auth.headings.choose_id_type') %>
 <% end %>
@@ -42,7 +48,7 @@
             as: :radio_buttons,
             collection: [
               [t('doc_auth.forms.id_type_preference.drivers_license'), :drivers_license],
-              [t('doc_auth.forms.id_type_preference.passport'), :passport],
+              [t('doc_auth.forms.id_type_preference.passport'), :passport, disabled: dos_passport_api_down],
             ],
             form: f,
             input_html: { class: 'usa-radio__input--tile' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -650,6 +650,7 @@ doc_auth.info.capture_status_none: Align
 doc_auth.info.capture_status_small_document: Move Closer
 doc_auth.info.capture_status_tap_to_capture: Tap to Capture
 doc_auth.info.choose_id_type: Select the type of document that you have. You’ll need to take photos of your ID to verify your identity.
+doc_auth.info.dos_passport_api_down_message: We cannot accept passports at this time. You can use a driver’s license or state ID, or try again later.
 doc_auth.info.exit.with_sp: Exit %{app_name} and return to %{sp_name}
 doc_auth.info.exit.without_sp: Exit identity verification and go to your account page
 doc_auth.info.getting_started_html: '%{sp_name} needs to make sure you are you — not someone pretending to be you. %{link_html}'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -661,6 +661,7 @@ doc_auth.info.capture_status_none: Alinear
 doc_auth.info.capture_status_small_document: Acercar
 doc_auth.info.capture_status_tap_to_capture: Tocar para capturar
 doc_auth.info.choose_id_type: Seleccione el tipo de documento que tenga. Tendrá que tomar fotografías de su identificación para verificar su identidad.
+doc_auth.info.dos_passport_api_down_message: No podemos aceptar pasaportes por ahora. Puede usar una licencia de conducir o identificación estatal, o bien vuelva a intentarlo más tarde.
 doc_auth.info.exit.with_sp: Salir de %{app_name} y volver a %{sp_name}
 doc_auth.info.exit.without_sp: Salga de la verificación de identidad y vaya a la página de su cuenta
 doc_auth.info.getting_started_html: '%{sp_name} necesita asegurarse de que se trata de usted y no de alguien que se hace pasar por usted. %{link_html}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -650,6 +650,7 @@ doc_auth.info.capture_status_none: Alignez
 doc_auth.info.capture_status_small_document: Approchez-vous
 doc_auth.info.capture_status_tap_to_capture: Appuyez pour prendre la photo
 doc_auth.info.choose_id_type: Sélectionnez le type de document dont vous disposez. Vous devrez prendre des photos de votre pièce d’identité pour confirmer votre identité.
+doc_auth.info.dos_passport_api_down_message: Nous ne pouvons actuellement pas accepter les passeports. Vous pouvez utiliser un permis de conduire, une carte d’identité d’un État ou réessayer ultérieurement.
 doc_auth.info.exit.with_sp: Quitter %{app_name} et revenir à %{sp_name}
 doc_auth.info.exit.without_sp: Quitter la vérification d’identité et accéder à la page de votre compte
 doc_auth.info.getting_started_html: '%{sp_name} doit s’assurer qu’il s’agit bien de vous et non de quelqu’un qui se fait passer pour vous. %{link_html}'

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -661,6 +661,7 @@ doc_auth.info.capture_status_none: 对齐
 doc_auth.info.capture_status_small_document: 靠近一些
 doc_auth.info.capture_status_tap_to_capture: 点击来扫描
 doc_auth.info.choose_id_type: 选择你具备的身份证件类型你将需要拍你身份证件的照片来验证身份。
+doc_auth.info.dos_passport_api_down_message: 我们目前不能接受护照。你可以使用驾照或州ID，或稍后再试。
 doc_auth.info.exit.with_sp: 退出 %{app_name} 并返回 %{sp_name}
 doc_auth.info.exit.without_sp: 退出身份验证并到你的账户页面
 doc_auth.info.getting_started_html: '%{sp_name} 需要确保你是你，而不是别人冒充你。 了解更多有关验证你身份的信息 %{link_html}'

--- a/spec/controllers/idv/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/choose_id_type_controller_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Idv::ChooseIdTypeController do
   end
 
   before do
+    stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+      .to_return({ status: 200, body: { status: 'UP' }.to_json })
     stub_sign_in(user)
     subject.idv_session.document_capture_session_uuid = document_capture_session.uuid
     stub_up_to(:hybrid_handoff, idv_session: subject.idv_session)

--- a/spec/controllers/idv/hybrid_mobile/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/choose_id_type_controller_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Idv::HybridMobile::ChooseIdTypeController do
   let(:session_uuid) { document_capture_session.uuid }
 
   before do
+    stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+      .to_return({ status: 200, body: { status: 'UP' }.to_json })
     stub_analytics
     session[:doc_capture_user_id] = user&.id
     session[:document_capture_session_uuid] = document_capture_session_uuid

--- a/spec/controllers/idv/in_person/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/in_person/choose_id_type_controller_spec.rb
@@ -4,12 +4,16 @@ RSpec.describe Idv::InPerson::ChooseIdTypeController do
   include FlowPolicyHelper
 
   let(:user) { create(:user) }
+  let(:document_capture_session) do
+    create(:document_capture_session, user:, passport_status: 'allowed')
+  end
   let(:idv_session) { subject.idv_session }
 
   before do
     stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
       .to_return({ status: 200, body: { status: 'UP' }.to_json })
     stub_sign_in(user)
+    subject.idv_session.document_capture_session_uuid = document_capture_session.uuid
     stub_up_to(:hybrid_handoff, idv_session: subject.idv_session)
     allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
     stub_analytics

--- a/spec/controllers/idv/in_person/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/in_person/choose_id_type_controller_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Idv::InPerson::ChooseIdTypeController do
   let(:idv_session) { subject.idv_session }
 
   before do
+    stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+      .to_return({ status: 200, body: { status: 'UP' }.to_json })
     stub_sign_in(user)
     stub_up_to(:hybrid_handoff, idv_session: subject.idv_session)
     allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)

--- a/spec/features/idv/doc_auth/choose_id_type_spec.rb
+++ b/spec/features/idv/doc_auth/choose_id_type_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature 'choose id type step error checking' do
         complete_doc_auth_steps_before_hybrid_handoff_step
       end
 
-      it 'shows choose id type screen and continues after passport option' do
+      it 'shows choose id type screen with passport field disabled' do
         expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
         stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
           .to_return({ status: 200, body: { status: 'DOWN' }.to_json })

--- a/spec/features/idv/doc_auth/choose_id_type_spec.rb
+++ b/spec/features/idv/doc_auth/choose_id_type_spec.rb
@@ -4,57 +4,94 @@ RSpec.feature 'choose id type step error checking' do
   include DocAuthHelper
   include AbTestsHelper
 
-  before do
-    allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled).and_return(true)
-    allow(IdentityConfig.store).to receive(:doc_auth_passports_percent).and_return(100)
-    stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
-      .to_return({ status: 200, body: { status: 'UP' }.to_json })
-    reload_ab_tests
-    sign_in_and_2fa_user
-  end
-
-  after do
-    reload_ab_tests
-  end
-
-  context 'desktop flow', :js do
+  context 'happy path' do
     before do
-      complete_doc_auth_steps_before_hybrid_handoff_step
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_percent).and_return(100)
+      stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+        .to_return({ status: 200, body: { status: 'UP' }.to_json })
+      reload_ab_tests
+      sign_in_and_2fa_user
     end
 
-    it 'shows choose id type screen and continues after passport option' do
-      expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
-      click_on t('forms.buttons.upload_photos')
-      expect(page).to have_current_path(idv_choose_id_type_url)
-      choose(t('doc_auth.forms.id_type_preference.passport'))
-      click_on t('forms.buttons.continue')
-      expect(page).to have_current_path(idv_document_capture_url)
-      visit idv_choose_id_type_url
-      expect(page).to have_checked_field(
-        'doc_auth_choose_id_type_preference_passport',
-        visible: :all,
-      )
+    after do
+      reload_ab_tests
+    end
+
+    context 'desktop flow', :js do
+      before do
+        complete_doc_auth_steps_before_hybrid_handoff_step
+      end
+
+      it 'shows choose id type screen and continues after passport option' do
+        expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
+        click_on t('forms.buttons.upload_photos')
+        expect(page).to have_current_path(idv_choose_id_type_url)
+        choose(t('doc_auth.forms.id_type_preference.passport'))
+        click_on t('forms.buttons.continue')
+        expect(page).to have_current_path(idv_document_capture_url)
+        visit idv_choose_id_type_url
+        expect(page).to have_checked_field(
+          'doc_auth_choose_id_type_preference_passport',
+          visible: :all,
+        )
+      end
+    end
+
+    context 'mobile flow', :js, driver: :headless_chrome_mobile do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+        complete_doc_auth_steps_before_agreement_step
+        complete_agreement_step
+      end
+
+      it 'shows choose id type screen and continues after drivers license option' do
+        expect(page).to have_current_path(idv_choose_id_type_url)
+        choose(t('doc_auth.forms.id_type_preference.drivers_license'))
+        click_on t('forms.buttons.continue')
+        expect(page).to have_current_path(idv_document_capture_url)
+        visit idv_choose_id_type_url
+        expect(page).to have_checked_field(
+          'doc_auth_choose_id_type_preference_drivers_license',
+          visible: :all,
+        )
+      end
     end
   end
 
-  context 'mobile flow', :js, driver: :headless_chrome_mobile do
+  context 'api health check failure after welcome step' do
     before do
-      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-      allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
-      complete_doc_auth_steps_before_agreement_step
-      complete_agreement_step
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_percent).and_return(100)
+      stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+        .to_return({ status: 200, body: { status: 'UP' }.to_json })
+      reload_ab_tests
+      sign_in_and_2fa_user
     end
 
-    it 'shows choose id type screen and continues after drivers license option' do
-      expect(page).to have_current_path(idv_choose_id_type_url)
-      choose(t('doc_auth.forms.id_type_preference.drivers_license'))
-      click_on t('forms.buttons.continue')
-      expect(page).to have_current_path(idv_document_capture_url)
-      visit idv_choose_id_type_url
-      expect(page).to have_checked_field(
-        'doc_auth_choose_id_type_preference_drivers_license',
-        visible: :all,
-      )
+    after do
+      reload_ab_tests
+    end
+
+    context 'desktop flow', :js do
+      before do
+        complete_doc_auth_steps_before_hybrid_handoff_step
+      end
+
+      it 'shows choose id type screen and continues after passport option' do
+        expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
+        stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+          .to_return({ status: 200, body: { status: 'DOWN' }.to_json })
+        click_on t('forms.buttons.upload_photos')
+        expect(page).to have_current_path(idv_choose_id_type_url)
+        # expect radio button field 'doc_auth_choose_id_type_preference_passport' to be disabled
+        expect(page).to have_field(
+          'doc_auth_choose_id_type_preference_passport',
+          visible: :all,
+          disabled: true,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16000](https://cm-jira.usa.gov/browse/LG-16000)


## 🛠 Summary of changes

Call health check api on choose id type screen, disable passport option and show alert text described in ticket.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes. Test process involves editing `application.yml` halfway through a idv flow. The reason for this is to let the health check pass for the welcome controller and fail for the choose id type controllers (tested on the specs)

- [ ] Step 1 - Ensure specs pass and test functionality
Next steps for manual testing
- [ ] Step 2 - For manual testing, Set following

> doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100

- [ ] Step 3 - Go through Doc Auth (Hybrid and standard). Once on the hybrid handoff page (or before selecting upload photos on standard), set `dos_passport_composite_healthcheck_endpoint` to a dummy value (Ex: `"http://localhost:3000/healthcheck"`)
- [ ] Step 4 - KEEP PAGE OPEN and refresh rails server, stop server and re run `make run`. 
- [ ] Step 5 - Continue doc auth (either link sent or upload photos).
- [ ] Step 6 - Once on choose id type screen confirm passport option is disabled and alert text is shown.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>After:</summary>
<img width="652" alt="Screenshot 2025-04-22 at 9 23 28 AM" src="https://github.com/user-attachments/assets/b91de27d-a936-46bf-982f-46cce8dca6ae" />
<img width="739" alt="Screenshot 2025-04-22 at 9 23 48 AM" src="https://github.com/user-attachments/assets/ab88008a-62a1-4734-af7c-5d791f3a50c4" />
<img width="711" alt="Screenshot 2025-04-22 at 9 24 10 AM" src="https://github.com/user-attachments/assets/b5e93913-d7fa-44c4-aa93-3b2aa9eb43ed" />
<img width="723" alt="Screenshot 2025-04-22 at 9 24 29 AM" src="https://github.com/user-attachments/assets/cabf7cdb-47f1-4fc1-a9f4-26bcab8ba1e0" />
<img width="687" alt="Screenshot 2025-04-22 at 9 27 20 AM" src="https://github.com/user-attachments/assets/df177db3-3316-475f-ab14-aec86691ac73" />
<img width="710" alt="Screenshot 2025-04-22 at 9 27 51 AM" src="https://github.com/user-attachments/assets/3de07518-ffbf-4cf0-8a79-091de357b659" />
<img width="658" alt="Screenshot 2025-04-22 at 9 28 20 AM" src="https://github.com/user-attachments/assets/bbe592d4-6726-4016-8e0b-56496f5c0c5b" />
<img width="574" alt="Screenshot 2025-04-22 at 9 28 48 AM" src="https://github.com/user-attachments/assets/fd1efbe3-dbbc-4f8b-9b97-d0952e5675d0" />


</details>

