### PR TITLE
Update valid_email gem to 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,8 +79,7 @@ gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false
 gem 'strong_migrations', '>= 0.4.2'
 gem 'terminal-table', require: false
-# until a release includes https://github.com/hallelujah/valid_email/pull/126
-gem 'valid_email', '>= 0.1.3', github: 'hallelujah/valid_email', ref: '486b860'
+gem 'valid_email', '>= 0.1.3'
 gem 'view_component', '~> 3.0'
 gem 'webauthn', '~> 2.5.2'
 gem 'xmldsig', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,16 +61,6 @@ GIT
       pkcs11
 
 GIT
-  remote: https://github.com/hallelujah/valid_email.git
-  revision: 486b860fb40281d1ba99ec7621505abc5c9ad5bb
-  ref: 486b860
-  specs:
-    valid_email (0.2.0)
-      activemodel
-      mail (>= 2.6.1)
-      simpleidn
-
-GIT
   remote: https://github.com/rack/rack-attack.git
   revision: d9fedfae4f7f6409f33857763391f4e18a6d7467
   ref: d9fedfae4f7f6409f33857763391f4e18a6d7467
@@ -406,7 +396,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.6)
+    logger (1.7.0)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -441,7 +431,7 @@ GEM
     mini_histogram (0.3.1)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
-    minitest (5.25.4)
+    minitest (5.25.5)
     msgpack (1.8.0)
     multiset (0.5.3)
     net-http (0.6.0)
@@ -457,7 +447,7 @@ GEM
       timeout
     net-sftp (3.0.0)
       net-ssh (>= 5.0.0, < 7.0.0)
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     net-ssh (6.1.0)
     newrelic_rpm (9.7.0)
@@ -711,6 +701,10 @@ GEM
     uniform_notifier (1.16.0)
     uri (1.0.3)
     useragent (0.16.11)
+    valid_email (0.2.1)
+      activemodel
+      mail (>= 2.6.1)
+      simpleidn
     view_component (3.21.0)
       activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
@@ -875,7 +869,7 @@ DEPENDENCIES
   strong_migrations (>= 0.4.2)
   tableparser
   terminal-table
-  valid_email (>= 0.1.3)!
+  valid_email (>= 0.1.3)
   view_component (~> 3.0)
   webauthn (~> 2.5.2)
   webmock


### PR DESCRIPTION
The reason why we were pointing to a specific commit in the valid_email repo
was to take advantage of a feature that wasn't yet included in a Rubygems release:

https://github.com/hallelujah/valid_email/pull/126

Since then, version 0.2.1 was released and it includes that feature.

## 🛠 Summary of changes

Updates the valid_email gem to version 0.2.1

## 📜 Testing Plan

Run `bundle open valid_email` locally, and verify that the `ban_partial_disposable_email?` method is defined in `validate_email.rb`. And in `ban_disposable_email_validator.rb`, verify that the validate_each method looks like this:
```
def validate_each(record, attribute, value)
    # Check if part of domain is in disposable_email_services yml list
    if options[:partial]
      r = ValidateEmail.ban_partial_disposable_email?(value)
      record.errors.add attribute, (options[:message] ||
        I18n.t(:invalid, :scope => "valid_email.validations.email")) unless r

      r
    else
      r = ValidateEmail.ban_disposable_email?(value)
      record.errors.add attribute, (options[:message] ||
        I18n.t(:invalid, :scope => "valid_email.validations.email")) unless r

      r
    end
  end
```
