### PR TITLE
Allow tid param for session_id

### DIFF
--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -12,7 +12,7 @@ class ServiceProviderSession
   end
 
   def attempts_api_session_id
-    request_url_params['attempts_api_session_id']
+    request_url_params['attempts_api_session_id'] || request_url_params['tid']
   end
 
   def remember_device_default

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -219,6 +219,14 @@ RSpec.describe ServiceProviderSession do
       it 'returns nil' do
         expect(subject.attempts_api_session_id).to be nil
       end
+
+      context 'with a tid in the request_url_params' do
+        let(:url) { 'https://example.com/auth?param0=p0&param1=p1&tid=abc123' }
+
+        it 'returns the value in the tid param' do
+          expect(subject.attempts_api_session_id).to eq 'abc123'
+        end
+      end
     end
 
     context 'with an attempts_api_session_id in the request_url_params' do
@@ -226,6 +234,14 @@ RSpec.describe ServiceProviderSession do
 
       it 'returns the value in the attempts_api_session_id param' do
         expect(subject.attempts_api_session_id).to eq 'abc123'
+      end
+
+      context 'with a tid in the request_url_params' do
+        let(:url) { 'https://example.com/auth?param0=p0&tid=abc123&attempts_api_session_id=not-tid' }
+
+        it 'returns the value in attempts_api_session_id param' do
+          expect(subject.attempts_api_session_id).to eq 'not-tid'
+        end
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket


## 🛠 Summary of changes
The IRS currently uses a param `tid` across all their systems. They requested that they be able to rely on that value, rather than adding a second, identical `attempts_api_session_id`. I am updating the code to allow that as a fallback.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
