### PR TITLE
Em/14237 improve enrollment factory

### DIFF
--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Idv::EnterPasswordController do
 
       context 'with in person profile' do
         let!(:enrollment) do
-          create(:in_person_enrollment, :establishing, user: user, profile: nil)
+          create(:in_person_enrollment, :establishing, user: user)
         end
 
         before do
@@ -1034,7 +1034,7 @@ RSpec.describe Idv::EnterPasswordController do
     context 'user is going through enhanced ipp' do
       let(:is_enhanced_ipp) { true }
       let!(:enrollment) do
-        create(:in_person_enrollment, :establishing, user: user, profile: nil)
+        create(:in_person_enrollment, :establishing, user: user)
       end
       before do
         authn_context_result = Vot::Parser.new(vector_of_trust: 'Pe').parse

--- a/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
@@ -83,11 +83,16 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
           end
 
           context 'in_person_proofing_enforce_tmx enabled, pending fraud review,
-          enrollment not passed' do
+          enrollment not processed by USPS' do
+            let(:user) { create(:user) }
             let(:in_person_proofing_enforce_tmx) { true }
-            let!(:profile) { create(:profile, fraud_review_pending_at: 1.day.ago, user: user) }
-            let!(:enrollment) do
-              create(:in_person_enrollment, :pending, user: user, profile: profile)
+            let!(:profile) do
+              create(
+                :profile,
+                :in_person_verification_pending,
+                fraud_review_pending_at: 1.day.ago,
+                user: user,
+              )
             end
 
             it 'does not redirect to please call' do

--- a/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
             let(:in_person_proofing_enforce_tmx) { true }
             let!(:profile) { create(:profile, fraud_review_pending_at: 1.day.ago, user: user) }
             let!(:enrollment) do
-              create(:in_person_enrollment, :establishing, user: user, profile: profile)
+              create(:in_person_enrollment, :pending, user: user, profile: profile)
             end
 
             it 'does not redirect to please call' do

--- a/spec/controllers/idv/in_person_controller_spec.rb
+++ b/spec/controllers/idv/in_person_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Idv::InPersonController do
 
         context 'with establishing in-person enrollment' do
           before do
-            create(:in_person_enrollment, :establishing, user: user, profile: nil)
+            create(:in_person_enrollment, :establishing, user: user)
           end
 
           it 'initializes the in-person session' do

--- a/spec/controllers/idv/link_sent_poll_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_poll_controller_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Idv::LinkSentPollController do
     context 'when user opted for in-person proofing' do
       before do
         allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-        create(:in_person_enrollment, :establishing, user: user, profile: nil)
+        create(:in_person_enrollment, :establishing, user: user)
       end
 
       it 'returns success with redirect' do

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     sponsor_id { IdentityConfig.store.usps_ipp_sponsor_id }
 
     trait :establishing do
+      profile { nil }
       status { :establishing }
     end
 

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -23,6 +23,7 @@ FactoryBot.define do
           :in_person_verification_pending,
           user: user,
           in_person_enrollment: instance,
+          in_person_verification_pending_at: Time.zone.now,
         )
       end
     end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Idv::Session do
 
       context 'when the user has an establishing in person enrollment' do
         let!(:enrollment) do
-          create(:in_person_enrollment, :establishing, user: user, profile: nil)
+          create(:in_person_enrollment, :establishing, user: user)
         end
         let(:profile) { subject.profile }
 


### PR DESCRIPTION
## 🎫 Ticket
[LG-14237: Identify and fix inconsistencies in the in_person_enrollments factory](https://cm-jira.usa.gov/browse/LG-14237)


## 🛠 Summary of changes
- Establishing enrollments created with the "establishing" trait won't have associated profiles.
- Pending in_person_enrollments created via factorybot will have a timestamp set for `in_person_verification_pending_at`


## 📜 Testing Plan
- [ ] Run automated tests.