### PR TITLE
Remove unnecessary config check when checking for pending migrations

### DIFF
--- a/lib/tasks/check_for_pending_migrations.rake
+++ b/lib/tasks/check_for_pending_migrations.rake
@@ -7,10 +7,6 @@ namespace :db do
 
     if Identity::Hostdata.instance_role == 'migration'
       warn('Skipping pending migration check on migration instance')
-    elsif Identity::Hostdata.host_config.dig(
-      :default_attributes, :login_dot_gov, :idp_run_migrations
-    )
-      warn('Skipping pending migration check, idp_run_migrations=true')
     else
       ActiveRecord::Migration.check_all_pending!
     end


### PR DESCRIPTION
## 🛠 Summary of changes

Discussion [here](https://gsa-tts.slack.com/archives/C03N6KQBAKS/p1744746769681479) had me looking at this rake task, and I saw that we were using a config option that's no longer used as of [!4858](https://gitlab.login.gov/lg/identity-devops/-/merge_requests/4858). This PR removes it.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
