### PR TITLE
LG-16022 Create daily ssa accounts report capability

### DIFF
--- a/app/services/duplicate_accounts_report.rb
+++ b/app/services/duplicate_accounts_report.rb
@@ -36,8 +36,7 @@ class DuplicateAccountsReport
     SQL
 
     ActiveRecord::Base.connection.execute(
-      ActiveRecord::Base.send(
-        :sanitize_sql_array,
+      ApplicationRecord.sanitize_sql_array(
         [
           query,
           sp_array,

--- a/app/services/duplicate_accounts_report.rb
+++ b/app/services/duplicate_accounts_report.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class DuplicateAccountsReport
+  def initialize(service_provider_arr)
+    @service_provider_arr = service_provider_arr
+  end
+
+  def self.call(service_provider_arr)
+    identities_sql(service_provider_arr)
+  end
+
+  def self.identities_sql(sp_array)
+    query = <<-SQL
+      WITH non_unique_ssn_signatures AS (
+        SELECT ssn_signature
+        FROM profiles
+        GROUP BY ssn_signature
+        HAVING COUNT(*) > 1
+      )
+      SELECT 
+        i.service_provider,
+        u.uuid,
+        u.updated_at,
+        sp.friendly_name,
+        p.activated_at,
+        p.ssn_signature
+      FROM identities i
+      JOIN users u ON i.user_id = u.id
+      JOIN service_providers sp ON i.service_provider = sp.issuer
+      JOIN profiles p ON u.id = p.user_id
+      JOIN non_unique_ssn_signatures nus ON p.ssn_signature = nus.ssn_signature
+      WHERE 
+        i.service_provider IN (?)
+        AND i.ial = 2
+        AND i.last_authenticated_at BETWEEN ? AND ?
+    SQL
+
+    ActiveRecord::Base.connection.execute(
+      ActiveRecord::Base.send(
+        :sanitize_sql_array,
+        [
+          query,
+          sp_array,
+          Date.yesterday.beginning_of_day,
+          Date.yesterday.end_of_day,
+        ],
+      ),
+    )
+  end
+end

--- a/app/services/duplicate_accounts_report.rb
+++ b/app/services/duplicate_accounts_report.rb
@@ -33,6 +33,7 @@ class DuplicateAccountsReport
         i.service_provider IN (?)
         AND i.ial = 2
         AND i.last_authenticated_at BETWEEN ? AND ?
+        AND p.active
     SQL
 
     ActiveRecord::Base.connection.execute(

--- a/app/services/duplicate_accounts_report.rb
+++ b/app/services/duplicate_accounts_report.rb
@@ -20,7 +20,7 @@ class DuplicateAccountsReport
       SELECT 
         i.service_provider,
         u.uuid,
-        u.updated_at,
+        i.last_authenticated_at,
         sp.friendly_name,
         p.activated_at,
         p.ssn_signature

--- a/lib/tasks/duplicate_accounts.rake
+++ b/lib/tasks/duplicate_accounts.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :duplicate_accounts do
+  task :report, %i[service_provider] => [:environment] do |_task, args|
+    ActiveRecord::Base.connection.execute('SET statement_timeout = 0')
+    puts 'User uuid, Service Provider, Agency, Latest Activity, Profile Activated'
+
+    rows = DuplicateAccountsReport.call(args[:service_provider])
+    rows.each do |row|
+      row_str = "#{row['uuid']}, "\
+                "#{row['service_provider']}, "\
+                "#{row['friendly_name']}, "\
+                "#{row['updated_at']}, "\
+                "#{row['activated_at']}"
+      puts row_str
+    end
+  end
+end
+# rake "duplicate_accounts:report["urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost"]"

--- a/lib/tasks/duplicate_accounts.rake
+++ b/lib/tasks/duplicate_accounts.rake
@@ -35,13 +35,13 @@ namespace :duplicate_accounts do
         result['uuid'],
         result['service_provider'],
         result['friendly_name'],
-        result['updated_at'],
+        result['last_authenticated_at'],
         result['activated_at'],
       ]
       result_str = "#{result['uuid']}, "\
                 "#{result['service_provider']}, "\
                 "#{result['friendly_name']}, "\
-                "#{result['updated_at']}, "\
+                "#{result['last_authenticated_at']}, "\
                 "#{result['activated_at']}"
       puts result_str
     end

--- a/lib/tasks/duplicate_accounts.rake
+++ b/lib/tasks/duplicate_accounts.rake
@@ -21,27 +21,31 @@ namespace :duplicate_accounts do
   end
 
   def results_to_csv(results)
-    puts 'result to csv'
-    output_dir = './tmp/duplicate_accounts/'
-    FileUtils.mkdir_p(output_dir)
-    accounts_csv = CSV.open(File.join(output_dir, 'duplicate_accounts.csv'), 'w')
+    if results.count > 0
+      puts 'result to csv'
+      output_dir = './tmp/duplicate_accounts/'
+      FileUtils.mkdir_p(output_dir)
+      accounts_csv = CSV.open(File.join(output_dir, 'duplicate_accounts.csv'), 'w')
 
-    accounts_csv << %w[
-      user_uuid
-      service_provider
-      agency
-      latest_activity
-      profile_activated
-    ]
-
-    results.each do |result|
-      accounts_csv << [
-        result['uuid'],
-        result['service_provider'],
-        result['friendly_name'],
-        result['updated_at'],
-        result['activated_at'],
+      accounts_csv << %w[
+        user_uuid
+        service_provider
+        agency
+        latest_activity
+        profile_activated
       ]
+
+      results.each do |result|
+        accounts_csv << [
+          result['uuid'],
+          result['service_provider'],
+          result['friendly_name'],
+          result['updated_at'],
+          result['activated_at'],
+        ]
+      end
+    else
+      puts 'no results found'
     end
   end
 end

--- a/spec/lib/tasks/duplicate_accounts_rake_spec.rb
+++ b/spec/lib/tasks/duplicate_accounts_rake_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'duplicate accounts rake task' do
+  before do
+    Rake.application.rake_require 'tasks/duplicate_accounts'
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'duplicate_accounts:report' do
+    let(:task) { 'duplicate_accounts:report' }
+
+    context 'with an empty report array' do
+      it 'displays a no results found message' do
+        expect { Rake::Task[task].invoke }.to \
+          output("no results found\n").to_stdout
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/duplicate_accounts_rake_spec.rb
+++ b/spec/lib/tasks/duplicate_accounts_rake_spec.rb
@@ -8,12 +8,30 @@ RSpec.describe 'duplicate accounts rake task' do
   end
 
   describe 'duplicate_accounts:report' do
-    let(:task) { 'duplicate_accounts:report' }
-
     context 'with an empty report array' do
+      let(:task) { 'duplicate_accounts:report' }
       it 'displays a no results found message' do
         expect { Rake::Task[task].invoke }.to \
           output("no results found\n").to_stdout
+      end
+    end
+
+    context 'with a duplicate account shown in report array' do
+      let(:task) { 'duplicate_accounts:report' }
+      let(:results) do
+        [
+          {
+            uuid: 'abc123def456',
+            service_provider: 'AAA:Test:SP:localhost',
+            friendly_name: 'AAA Test SP',
+            latest_activity: Date.yesterday.middle_of_day,
+            activated_at: Date.yesterday.beginning_of_day,
+          },
+        ]
+      end
+      it 'displays a result' do
+        expect { Rake::Task[task].invoke }.to \
+          output("result to csv\n").to_stdout
       end
     end
   end

--- a/spec/services/duplicate_accounts_report_spec.rb
+++ b/spec/services/duplicate_accounts_report_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DuplicateAccountsReport do
           user1 = create_user_with_ssn_signature('hashedssnsignaturekeyone')
           user2 = create_user_with_ssn_signature('hashedssnsignaturekeyone')
 
-          create_service_provider_identity(user2, Date.zone.today)
+          create_service_provider_identity(user2, Time.zone.today)
           create_service_provider_identity(user1, Date.yesterday.middle_of_day)
 
           results = DuplicateAccountsReport.call(issuer)

--- a/spec/services/duplicate_accounts_report_spec.rb
+++ b/spec/services/duplicate_accounts_report_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+RSpec.describe DuplicateAccountsReport do
+  let(:issuer) { 'test_saml_sp_requesting_signed_response_message' }
+
+  def create_user_with_ssn_signature(ssn_signature)
+    create(
+      :user,
+      :fully_registered,
+      profiles: [build(:profile, :active, :verified, ssn_signature: ssn_signature)],
+    )
+  end
+
+  def create_service_provider_identity(user, last_authenticated_at)
+    create(
+      :service_provider_identity,
+      ial: 2,
+      service_provider: issuer,
+      user: user,
+      last_authenticated_at: last_authenticated_at,
+    )
+  end
+
+  describe '#call' do
+    context 'when no records exist' do
+      it 'creates an empty results array' do
+        results = DuplicateAccountsReport.call(issuer)
+        expect(results.count).to eq(0)
+      end
+    end
+
+    context 'when no ssn_signatures match' do
+      it 'creates empty results' do
+        freeze_time do
+          user = create_user_with_ssn_signature('hashedssnsignaturekeytwo')
+          user2 = create_user_with_ssn_signature('hashedssnsignaturekeyzero')
+          create_service_provider_identity(user, Date.yesterday.middle_of_day)
+          create_service_provider_identity(user2, Date.yesterday.middle_of_day)
+
+          results = DuplicateAccountsReport.call(issuer)
+          expect(results.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when duplicate accounts exist' do
+      it 'creates a results array with one record when two users have same SSN signature' do
+        freeze_time do
+          user1 = create_user_with_ssn_signature('hashedssnsignaturekeyone')
+          user2 = create_user_with_ssn_signature('hashedssnsignaturekeyone')
+
+          create_service_provider_identity(user2, Date.zone.today)
+          create_service_provider_identity(user1, Date.yesterday.middle_of_day)
+
+          results = DuplicateAccountsReport.call(issuer)
+          expect(results.count).to eq(1)
+        end
+      end
+
+      it 'creates a results array with three records when multiple users have same SSN signature' do
+        freeze_time do
+          user1 = create_user_with_ssn_signature('hashedssnsignaturekeytwo')
+          user2 = create_user_with_ssn_signature('hashedssnsignaturekeyone')
+          user3 = create_user_with_ssn_signature('hashedssnsignaturekeyone')
+          user4 = create_user_with_ssn_signature('hashedssnsignaturekeyone')
+
+          create_service_provider_identity(user1, Date.yesterday.middle_of_day)
+          create_service_provider_identity(user2, Date.yesterday.middle_of_day)
+          create_service_provider_identity(user3, Date.yesterday.middle_of_day)
+          create_service_provider_identity(user4, Date.yesterday.middle_of_day)
+
+          results = DuplicateAccountsReport.call(issuer)
+          expect(results.count).to eq(3)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

[LG-16022](https://cm-jira.usa.gov/browse/LG-16022)


## 🛠 Summary of changes

Adds a manually-run Rake report that generates a CSV and outputs a comma separated list of accounts that have logged in "yesterday", and share the same ssn_signature (assumed in part to mean they have the same ssn)


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create at least 2 idv test accounts in your local environment. When those are set up add their identity verification using the same mock SSN.
- [ ] Open the rails console and pick one of those test accounts. Update its `last_authenticated_at` value to `Date.yesterday.middle_of_day` 
```
userfoo.identities.last.update(last_authenticated_at: Date.yesterday.middle_of_day)
userfoo.save
```
- [ ] Take note of the `service_provider` string on the profile and exit the console
- [ ] run the rake task: `rake "duplicate_accounts:report["urn:gov:gsa:openidconnect:sp:sinatra"]"`
- [ ] Expect an output to the terminal and a CSV be created in the <site_root>/tmp/duplicate_accounts directory

## 👀 Screenshots

![Screenshot 2025-04-22 at 9 25 15 AM (2)](https://github.com/user-attachments/assets/c2692824-2987-45ae-b3a8-a355eeabeb42)

![Screenshot 2025-04-22 at 9 28 24 AM (2)](https://github.com/user-attachments/assets/41d6b145-f4ae-43f1-af48-0725ad5d8fed)
