### PR TITLE
Deploy RC 469 to Production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,8 +79,7 @@ gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false
 gem 'strong_migrations', '>= 0.4.2'
 gem 'terminal-table', require: false
-# until a release includes https://github.com/hallelujah/valid_email/pull/126
-gem 'valid_email', '>= 0.1.3', github: 'hallelujah/valid_email', ref: '486b860'
+gem 'valid_email', '>= 0.1.3'
 gem 'view_component', '~> 3.0'
 gem 'webauthn', '~> 2.5.2'
 gem 'xmldsig', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,16 +61,6 @@ GIT
       pkcs11
 
 GIT
-  remote: https://github.com/hallelujah/valid_email.git
-  revision: 486b860fb40281d1ba99ec7621505abc5c9ad5bb
-  ref: 486b860
-  specs:
-    valid_email (0.2.0)
-      activemodel
-      mail (>= 2.6.1)
-      simpleidn
-
-GIT
   remote: https://github.com/rack/rack-attack.git
   revision: d9fedfae4f7f6409f33857763391f4e18a6d7467
   ref: d9fedfae4f7f6409f33857763391f4e18a6d7467
@@ -406,7 +396,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.6)
+    logger (1.7.0)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -441,7 +431,7 @@ GEM
     mini_histogram (0.3.1)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
-    minitest (5.25.4)
+    minitest (5.25.5)
     msgpack (1.8.0)
     multiset (0.5.3)
     net-http (0.6.0)
@@ -457,7 +447,7 @@ GEM
       timeout
     net-sftp (3.0.0)
       net-ssh (>= 5.0.0, < 7.0.0)
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     net-ssh (6.1.0)
     newrelic_rpm (9.7.0)
@@ -711,6 +701,10 @@ GEM
     uniform_notifier (1.16.0)
     uri (1.0.3)
     useragent (0.16.11)
+    valid_email (0.2.1)
+      activemodel
+      mail (>= 2.6.1)
+      simpleidn
     view_component (3.21.0)
       activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
@@ -875,7 +869,7 @@ DEPENDENCIES
   strong_migrations (>= 0.4.2)
   tableparser
   terminal-table
-  valid_email (>= 0.1.3)!
+  valid_email (>= 0.1.3)
   view_component (~> 3.0)
   webauthn (~> 2.5.2)
   webmock

--- a/app/controllers/idv/in_person/ready_to_verify_controller.rb
+++ b/app/controllers/idv/in_person/ready_to_verify_controller.rb
@@ -21,7 +21,6 @@ module Idv
         analytics.idv_in_person_ready_to_verify_visit(**opt_in_analytics_properties)
         @presenter = ReadyToVerifyPresenter.new(
           enrollment: enrollment,
-          is_enhanced_ipp: @is_enhanced_ipp,
         )
       end
 

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -12,7 +12,7 @@ class ServiceProviderSession
   end
 
   def attempts_api_session_id
-    request_url_params['attempts_api_session_id']
+    request_url_params['attempts_api_session_id'] || request_url_params['tid']
   end
 
   def remember_device_default

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -295,7 +295,7 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def in_person_ready_to_verify(enrollment:, is_enhanced_ipp:)
+  def in_person_ready_to_verify(enrollment:)
     attachments.inline['barcode.png'] = BarcodeOutputter.new(
       code: enrollment.enrollment_code,
     ).image_data
@@ -304,21 +304,19 @@ class UserMailer < ActionMailer::Base
       @hide_title = IdentityConfig.store.in_person_outage_message_enabled &&
                     IdentityConfig.store.in_person_outage_emailed_by_date.present? &&
                     IdentityConfig.store.in_person_outage_expected_update_date.present?
-      @header = is_enhanced_ipp ?
-      t('in_person_proofing.headings.barcode_eipp') : t('in_person_proofing.headings.barcode')
       @presenter = Idv::InPerson::ReadyToVerifyPresenter.new(
         enrollment: enrollment,
         barcode_image_url: attachments['barcode.png'].url,
-        is_enhanced_ipp: is_enhanced_ipp,
       )
+      @header = @presenter.enhanced_ipp? ?
+      t('in_person_proofing.headings.barcode_eipp') : t('in_person_proofing.headings.barcode')
 
       if enrollment&.service_provider&.logo_is_email_compatible?
         @logo_url = enrollment.service_provider.logo_url
       else
         @logo_url = nil
       end
-      @sp_name = enrollment.service_provider&.friendly_name
-      @is_enhanced_ipp = is_enhanced_ipp
+      @sp_name = @presenter.sp_name
 
       mail(
         to: email_address.email,
@@ -332,18 +330,22 @@ class UserMailer < ActionMailer::Base
       code: enrollment.enrollment_code,
     ).image_data
 
-    @is_enhanced_ipp = enrollment.enhanced_ipp?
-
     with_user_locale(user) do
       @presenter = Idv::InPerson::ReadyToVerifyPresenter.new(
         enrollment: enrollment,
         barcode_image_url: attachments['barcode.png'].url,
-        is_enhanced_ipp: @is_enhanced_ipp,
       )
+      if enrollment&.service_provider&.logo_is_email_compatible?
+        @logo_url = enrollment.service_provider.logo_url
+      else
+        @logo_url = nil
+      end
+      @sp_name = @presenter.sp_name
       @header = t(
         'user_mailer.in_person_ready_to_verify_reminder.heading',
         count: @presenter.days_remaining,
       )
+
       mail(
         to: email_address.email,
         subject: t(

--- a/app/presenters/idv/how_to_verify_presenter.rb
+++ b/app/presenters/idv/how_to_verify_presenter.rb
@@ -85,6 +85,8 @@ class Idv::HowToVerifyPresenter
 
   def post_office_description
     if passport_allowed
+      IdentityConfig.store.in_person_passports_enabled ?
+      t('doc_auth.info.verify_online_description_passport') :
       t('doc_auth.info.verify_at_post_office_description_passport_html')
     else
       ''

--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -9,13 +9,12 @@ module Idv
 
       attr_reader :barcode_image_url
 
-      delegate :selected_location_details, :enrollment_code, to: :enrollment
+      delegate :selected_location_details, :enrollment_code, :enhanced_ipp?, to: :enrollment
 
-      def initialize(enrollment:, barcode_image_url: nil, sp_name: nil, is_enhanced_ipp: false)
+      def initialize(enrollment:, barcode_image_url: nil, sp_name: nil)
         @enrollment = enrollment
         @barcode_image_url = barcode_image_url
         @sp_name = sp_name
-        @is_enhanced_ipp = is_enhanced_ipp
       end
 
       # Reminder is exclusive of the day the email is sent (1 less than days_to_due_date)
@@ -70,7 +69,7 @@ module Idv
       end
 
       def barcode_heading_text
-        if @is_enhanced_ipp
+        if enhanced_ipp?
           t('in_person_proofing.headings.barcode_eipp')
         else
           t('in_person_proofing.headings.barcode')
@@ -78,7 +77,7 @@ module Idv
       end
 
       def state_id_heading_text
-        if @is_enhanced_ipp
+        if enhanced_ipp?
           t('in_person_proofing.process.state_id.heading_eipp')
         else
           t('in_person_proofing.process.state_id.heading')
@@ -86,7 +85,7 @@ module Idv
       end
 
       def state_id_info
-        if @is_enhanced_ipp
+        if enhanced_ipp?
           t('in_person_proofing.process.state_id.info_eipp')
         else
           t('in_person_proofing.process.state_id.info')

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -37,14 +37,13 @@ module UspsInPersonProofing
           enhanced_ipp: enrollment.enhanced_ipp?,
         )
 
-        send_ready_to_verify_email(user, enrollment, is_enhanced_ipp: is_enhanced_ipp)
+        send_ready_to_verify_email(user, enrollment)
       end
 
-      def send_ready_to_verify_email(user, enrollment, is_enhanced_ipp:)
+      def send_ready_to_verify_email(user, enrollment)
         user.confirmed_email_addresses.each do |email_address|
           UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
             enrollment: enrollment,
-            is_enhanced_ipp: is_enhanced_ipp,
           ).deliver_now_or_later
         end
       end

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -24,7 +24,7 @@
 <% end %>
 
 <%# Tag for GSA Enhanced Pilot Barcode %>
-<% if @is_enhanced_ipp %>
+<% if @presenter.enhanced_ipp? %>
   <div class="text-center margin-y-4">
     <span class="usa-tag usa-tag--informative">
       <%= t('in_person_proofing.body.barcode.eipp_tag') %>
@@ -49,7 +49,7 @@
 <% end %>
 
 <%# Enhanced IPP Only - What to bring section %>
-<% if @is_enhanced_ipp %>
+<% if @presenter.enhanced_ipp? %>
   <section class="border-1px rounded-xl border-primary-light padding-4 padding-2 margin-bottom-4">
     <%# What to bring to the Post Office %>
     <h2 class="margin-top-0 margin-bottom-2"><%= t('in_person_proofing.headings.barcode_what_to_bring') %></h2>
@@ -186,7 +186,7 @@
     <% end %>
   <% end %>
 
-  <% if !@is_enhanced_ipp %>
+  <% if !@presenter.enhanced_ipp? %>
     <p class="margin-top-3 margin-bottom-0">
       <%= t('in_person_proofing.body.barcode.questions') %>
       <%= render ClickObserverComponent.new(event_name: 'IdV: user clicked what to bring link on ready to verify page') do %>
@@ -228,7 +228,7 @@
   </section>
 <% end %>
 
-<% if !@is_enhanced_ipp %>
+<% if !@presenter.enhanced_ipp? %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
   <p class="margin-bottom-4">
     <%= t(

--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -24,25 +24,8 @@
       text_tag: 'div',
     ) do %>
   <strong><%= t('in_person_proofing.body.state_id.alert_message') %></strong>
-  <ul class="margin-bottom-0">
-    <% t('in_person_proofing.body.state_id.id_types').each do | id_type | %>
-      <li>
-        <%= id_type %>
-      </li>
-    <% end %>
-  </ul>
-  <p>
-  <%= t('in_person_proofing.body.state_id.questions') %>
-  <%= link_to(
-        help_center_redirect_url(
-          category: 'verify-your-identity',
-          article: 'accepted-identification-documents',
-        ),
-        class: 'display-inline',
-      ) do %>
-    <%= t('in_person_proofing.body.state_id.learn_more_link') %>
-  <% end %>
-</p>
+  <br/>
+  <%= t('in_person_proofing.body.state_id.alert_text') %>
 <% end %>
 <%= simple_form_for form,
                     as: 'identity_doc', # Renaming form as a workaround for aggressive browser autofill assumptions

--- a/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
@@ -15,7 +15,7 @@
 <% end %>
 
 <%# Tag for GSA Enhanced Pilot Barcode %>
-<% if @is_enhanced_ipp %>
+<% if @presenter.enhanced_ipp? %>
   <div class="text-center margin-y-4">
     <span class="usa-tag usa-tag--informative">
       <%= t('in_person_proofing.body.barcode.eipp_tag') %>
@@ -48,7 +48,7 @@
 </table>
 
 <%# Enhanced IPP Only - What to bring to the Post Office %>
-<% if @is_enhanced_ipp %>
+<% if @presenter.enhanced_ipp? %>
   <section class="border-1px radius-lg border-primary-light padding-4 margin-bottom-4">
     <%# What to bring to the Post Office %>
     <h2 class="margin-bottom-2"><%= t('in_person_proofing.headings.barcode_what_to_bring') %></h2>
@@ -237,7 +237,7 @@
     </tr>
   </table>
 
-  <% if !@is_enhanced_ipp %>
+  <% if !@presenter.enhanced_ipp? %>
     <p class="margin-bottom-0 padding-bottom-4">
       <%= t('in_person_proofing.body.barcode.questions') %>
       <%= link_to(
@@ -275,7 +275,7 @@
   </div>
 <% end %>
 
-<% if !@is_enhanced_ipp %>
+<% if !@presenter.enhanced_ipp? %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
   <p class="margin-bottom-4">
     <%= t(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1270,13 +1270,9 @@ in_person_proofing.body.prepare.verify_step_about: 'Complete the steps below to 
 in_person_proofing.body.prepare.verify_step_enter_phone: Enter your primary phone number or the number that you use most often.
 in_person_proofing.body.prepare.verify_step_enter_pii: Enter your name, date of birth, state‑issued ID number, address and Social Security number.
 in_person_proofing.body.prepare.verify_step_post_office: Find a participating Post Office near you.
-in_person_proofing.body.state_id.alert_message: 'Your state‑issued ID must not be expired. Accepted forms of ID are:'
-in_person_proofing.body.state_id.id_types:
-  - State Driver’s License
-  - State Non-Driver’s Identification Card
+in_person_proofing.body.state_id.alert_message: You need a driver’s license or state ID
+in_person_proofing.body.state_id.alert_text: Passports are not accepted in person. Your driver’s license or state ID must not be expired.
 in_person_proofing.body.state_id.info_html: Enter information <strong>exactly as it appears on your state-issued ID.</strong> We will use this information to confirm it matches your ID in person.
-in_person_proofing.body.state_id.learn_more_link: Learn more about accepted forms of ID.
-in_person_proofing.body.state_id.questions: Questions?
 in_person_proofing.form.address.errors.unsupported_chars: 'Our system cannot read the following characters: %{char_list}. Please try again using substitutes for those characters.'
 in_person_proofing.form.address.state_prompt: '- Select -'
 in_person_proofing.form.state_id.address1: Address line 1

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1281,13 +1281,9 @@ in_person_proofing.body.prepare.verify_step_about: 'Siga los siguientes pasos pa
 in_person_proofing.body.prepare.verify_step_enter_phone: Ingrese su número de teléfono principal o el que use con más frecuencia.
 in_person_proofing.body.prepare.verify_step_enter_pii: Ingrese su nombre, fecha de nacimiento, número de identificación emitida por el estado, dirección y número de Seguro Social.
 in_person_proofing.body.prepare.verify_step_post_office: Busque una oficina de correos participantes cercana.
-in_person_proofing.body.state_id.alert_message: 'Su identificación emitida por el estado no debe estar vencida. Se aceptan estas formas de identificación:'
-in_person_proofing.body.state_id.id_types:
-  - Licencia para conducir estatal
-  - Identificación estatal que no sea la licencia para conducir
+in_person_proofing.body.state_id.alert_message: Necesita una licencia de conducir o una identificación estatal
+in_person_proofing.body.state_id.alert_text: No se aceptan los pasaportes para la verificación en persona. Su licencia de conducir o identificación estatal no deben estar vencidas.
 in_person_proofing.body.state_id.info_html: Ingrese la información <strong>exactamente como aparece en su identificación emitida por el estado.</strong> Usaremos esta información para confirmar que coincida con su identificación en persona.
-in_person_proofing.body.state_id.learn_more_link: Obtenga más información sobre las formas de identificación aceptadas.
-in_person_proofing.body.state_id.questions: '¿Tiene alguna pregunta?'
 in_person_proofing.form.address.errors.unsupported_chars: 'Nuestro sistema no puede leer estos caracteres: %{char_list}. Inténtelo de nuevo usando caracteres sustitutos.'
 in_person_proofing.form.address.state_prompt: '- Seleccione -'
 in_person_proofing.form.state_id.address1: Línea de dirección 1

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1270,13 +1270,9 @@ in_person_proofing.body.prepare.verify_step_about: 'Suivez les étapes ci-dessou
 in_person_proofing.body.prepare.verify_step_enter_phone: Saisissez votre numéro de téléphone principal ou celui que vous utilisez le plus souvent.
 in_person_proofing.body.prepare.verify_step_enter_pii: Saisissez votre nom, votre date de naissance, le numéro de votre pièce d’identité délivrée par l’État, votre adresse et votre numéro de sécurité sociale.
 in_person_proofing.body.prepare.verify_step_post_office: Trouver un bureau de poste participant près de chez vous.
-in_person_proofing.body.state_id.alert_message: 'Votre pièce d’identité délivrée par un État ne doit pas être périmée. Les pièces d’identité acceptées sont les suivantes :'
-in_person_proofing.body.state_id.id_types:
-  - Permis de conduire national
-  - Carte d’identité nationale de non-conducteur
+in_person_proofing.body.state_id.alert_message: Vous avez besoin d’un permis de conduire ou d’une carte d’identité délivrée par un État.
+in_person_proofing.body.state_id.alert_text: Les passeports ne sont pas acceptés pour la vérification d’identité en personne. Votre permis de conduire ou carte d’identité délivrée par un État doit être en cours de validité.
 in_person_proofing.body.state_id.info_html: Saisissez les informations <strong>exactement comme elles figurent sur votre pièce d’identité</strong>. Nous utiliserons ces informations pour confirmer qu’elles correspondent à votre pièce d’identité en personne.
-in_person_proofing.body.state_id.learn_more_link: En savoir plus sur les pièces d’identité acceptées.
-in_person_proofing.body.state_id.questions: Des questions ?
 in_person_proofing.form.address.errors.unsupported_chars: 'Notre système ne parvient pas à lire les caractères suivants : %{char_list}. Veuillez réessayer en utilisant d’autres caractères.'
 in_person_proofing.form.address.state_prompt: '- Sélectionnez -'
 in_person_proofing.form.state_id.address1: Adresse ligne 1

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1283,13 +1283,9 @@ in_person_proofing.body.prepare.verify_step_about: 完成以下步骤来生成�
 in_person_proofing.body.prepare.verify_step_enter_phone: 输入你的主要电话号码或者你最常使用的号码。
 in_person_proofing.body.prepare.verify_step_enter_pii: 输入你的姓名、生日、州政府颁发的身份证件号、地址以及社会保障号码。
 in_person_proofing.body.prepare.verify_step_post_office: 找到你附件的参与邮局。
-in_person_proofing.body.state_id.alert_message: 州政府颁发给你的身份证件必须尚未过期。系统接受的身份证件包括：
-in_person_proofing.body.state_id.id_types:
-  - 州驾照
-  - 州非驾照身份卡
+in_person_proofing.body.state_id.alert_message: 你需要驾照或州身份证件。
+in_person_proofing.body.state_id.alert_text: 亲身验证时不能用护照。你的驾照或州身份证件不得过期。
 in_person_proofing.body.state_id.info_html: 输入 <strong> 与州政府颁发的身份证件上完全一致的信息</strong>我们将使用该信息来确认与你亲身出现所持身份证件上信息的一致性。
-in_person_proofing.body.state_id.learn_more_link: 了解更多有关哪些身份证件可被接受的信息。
-in_person_proofing.body.state_id.questions: 有问题吗？
 in_person_proofing.form.address.errors.unsupported_chars: 我们的系统无法读取以下字符： %{char_list}. 请替换那些字符后再试一次。
 in_person_proofing.form.address.state_prompt: '- 选择 -'
 in_person_proofing.form.state_id.address1: 地址第 1 行

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -219,6 +219,14 @@ RSpec.describe ServiceProviderSession do
       it 'returns nil' do
         expect(subject.attempts_api_session_id).to be nil
       end
+
+      context 'with a tid in the request_url_params' do
+        let(:url) { 'https://example.com/auth?param0=p0&param1=p1&tid=abc123' }
+
+        it 'returns the value in the tid param' do
+          expect(subject.attempts_api_session_id).to eq 'abc123'
+        end
+      end
     end
 
     context 'with an attempts_api_session_id in the request_url_params' do
@@ -226,6 +234,14 @@ RSpec.describe ServiceProviderSession do
 
       it 'returns the value in the attempts_api_session_id param' do
         expect(subject.attempts_api_session_id).to eq 'abc123'
+      end
+
+      context 'with a tid in the request_url_params' do
+        let(:url) { 'https://example.com/auth?param0=p0&tid=abc123&attempts_api_session_id=not-tid' }
+
+        it 'returns the value in attempts_api_session_id param' do
+          expect(subject.attempts_api_session_id).to eq 'not-tid'
+        end
       end
     end
   end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -185,14 +185,12 @@ class UserMailerPreview < ActionMailer::Preview
   def in_person_ready_to_verify
     UserMailer.with(user: user, email_address: email_address_record).in_person_ready_to_verify(
       enrollment: in_person_enrollment_id_ipp,
-      is_enhanced_ipp: false,
     )
   end
 
   def in_person_ready_to_verify_enhanced_ipp_enabled
     UserMailer.with(user: user, email_address: email_address_record).in_person_ready_to_verify(
       enrollment: in_person_enrollment_enhanced_ipp,
-      is_enhanced_ipp: true,
     )
   end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -857,7 +857,6 @@ RSpec.describe UserMailer, type: :mailer do
       let(:mail) do
         UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
           enrollment: enrollment,
-          is_enhanced_ipp:,
         )
       end
 
@@ -914,12 +913,10 @@ RSpec.describe UserMailer, type: :mailer do
       end
 
       context 'Need to change location section' do
-        context 'when Enhanced IPP is not enabled' do
-          let(:is_enhanced_ipp) { false }
+        context 'when enrollment is not enhanced ipp' do
           let(:mail) do
             UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
-              enrollment: enhanced_ipp_enrollment,
-              is_enhanced_ipp: is_enhanced_ipp,
+              enrollment: enrollment,
             )
           end
           it 'renders the change location heading' do
@@ -939,12 +936,10 @@ RSpec.describe UserMailer, type: :mailer do
           end
         end
 
-        context 'when Enhanced IPP is enabled' do
-          let(:is_enhanced_ipp) { true }
+        context 'when enrollment is enhanced ipp' do
           let(:mail) do
             UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
               enrollment: enhanced_ipp_enrollment,
-              is_enhanced_ipp: is_enhanced_ipp,
             )
           end
 
@@ -1066,7 +1061,6 @@ RSpec.describe UserMailer, type: :mailer do
         let(:mail) do
           UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
             enrollment: enhanced_ipp_enrollment,
-            is_enhanced_ipp:,
           )
         end
 

--- a/spec/support/shared_examples_for_mailer_template.rb
+++ b/spec/support/shared_examples_for_mailer_template.rb
@@ -1,0 +1,28 @@
+RSpec.shared_examples 'a barcode email' do |service_provider_name|
+  context 'when the partner agency logo is a png' do
+    let(:logo) { 'gsa.png' }
+    let(:logo_url) { '/assets/sp-logos/gsa.png' }
+
+    it 'displays the partner agency logo' do
+      expect(rendered).to have_css("img[src*='gsa.png']")
+    end
+  end
+
+  context 'when the partner agency logo is a svg' do
+    let(:logo) { 'generic.svg' }
+    let(:logo_url) { nil }
+
+    it 'displays the partner agency name' do
+      expect(rendered).to have_content(service_provider_name)
+    end
+  end
+
+  context 'when there is no partner agency logo' do
+    let(:logo) { nil }
+    let(:logo_url) { nil }
+
+    it 'displays the partner agency name' do
+      expect(rendered).to have_content(service_provider_name)
+    end
+  end
+end

--- a/spec/views/idv/how_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/how_to_verify/show.html.erb_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
   let(:idv_how_to_verify_form) { Idv::HowToVerifyForm.new(selection: selection) }
 
   before do
+    allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(false)
     allow(view).to receive(:user_signing_up?).and_return(false)
     assign(:presenter, presenter)
     assign :idv_how_to_verify_form, idv_how_to_verify_form
@@ -23,10 +24,10 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     before do
       @mobile_required = mobile_required
       @selfie_required = selfie_check_required
-      render
     end
 
     it 'renders a step indicator with Getting started as the current step' do
+      render
       expect(view.content_for(:pre_flash_content)).to have_css(
         '.step-indicator__step--current',
         text: t('step_indicator.flows.idv.getting_started'),
@@ -34,29 +35,35 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     end
 
     it 'renders a title' do
+      render
       expect(rendered).to have_content(t('doc_auth.headings.how_to_verify'))
     end
 
     it 'renders two options for verifying your identity' do
+      render
       expect(rendered).to have_content(t('doc_auth.headings.verify_online'))
       expect(rendered).to have_content(t('doc_auth.headings.verify_at_post_office'))
     end
 
     it 'renders a button for remote and ipp' do
+      render
       expect(rendered).to have_button(t('forms.buttons.continue_online'))
       expect(rendered).to have_button(t('forms.buttons.continue_ipp'))
     end
 
     it 'renders troubleshooting links' do
+      render
       expect(rendered).to have_link(t('doc_auth.info.verify_online_link_text'))
       expect(rendered).to have_link(t('doc_auth.info.verify_at_post_office_link_text'))
     end
 
     it 'renders a cancel link' do
+      render
       expect(rendered).to have_link(t('links.cancel'))
     end
 
     it 'renders non-selfie specific content' do
+      render
       expect(rendered).not_to have_content(t('doc_auth.tips.mobile_phone_required'))
       expect(rendered).to have_content(t('doc_auth.headings.verify_online'))
       expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction'))
@@ -70,12 +77,35 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     context 'when passport is allowed' do
       let(:passport_allowed) { true }
 
-      it 'renders passport specific content' do
-        expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction'))
-        expect(rendered).to have_content(t('doc_auth.info.verify_online_description_passport'))
-        expect(rendered).to have_content(
-          strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
-        )
+      context 'when in person passports is disabled' do
+        it 'renders passport specific content to verify your identity online' do
+          render
+          expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction'))
+          expect(rendered).to have_content(
+            t('doc_auth.info.verify_online_description_passport'),
+          ).once
+          expect(rendered).to have_content(
+            strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+          )
+        end
+      end
+
+      context 'when in person passports is enabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(true)
+        end
+
+        it 'renders passport specific content to verify your identity online and in person' do
+          render
+
+          expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction'))
+          expect(rendered).to have_content(
+            t('doc_auth.info.verify_online_description_passport'),
+          ).twice
+          expect(rendered).not_to have_content(
+            strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+          )
+        end
       end
     end
   end
@@ -87,10 +117,10 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     before do
       @selfie_required = selfie_check_required
       @mobile_required = mobile_required
-      render
     end
 
     it 'renders a step indicator with Getting started as the current step' do
+      render
       expect(view.content_for(:pre_flash_content)).to have_css(
         '.step-indicator__step--current',
         text: t('step_indicator.flows.idv.getting_started'),
@@ -98,29 +128,35 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     end
 
     it 'renders a title' do
+      render
       expect(rendered).to have_content(t('doc_auth.headings.how_to_verify'))
     end
 
     it 'renders two options for verifying your identity' do
+      render
       expect(rendered).to have_content(t('doc_auth.headings.verify_online_mobile'))
       expect(rendered).to have_content(t('doc_auth.headings.verify_at_post_office'))
     end
 
     it 'renders a button for remote and ipp' do
+      render
       expect(rendered).to have_button(t('forms.buttons.continue_online_mobile'))
       expect(rendered).to have_button(t('forms.buttons.continue_ipp'))
     end
 
     it 'renders troubleshooting links' do
+      render
       expect(rendered).to have_link(t('doc_auth.info.verify_online_link_text'))
       expect(rendered).to have_link(t('doc_auth.info.verify_at_post_office_link_text'))
     end
 
     it 'renders a cancel link' do
+      render
       expect(rendered).to have_link(t('links.cancel'))
     end
 
     it 'renders mobile specific content' do
+      render
       expect(rendered).to have_content(
         t('doc_auth.info.verify_online_instruction_mobile_no_selfie'),
       )
@@ -129,14 +165,38 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
     context 'when passport is allowed' do
       let(:passport_allowed) { true }
 
-      it 'renders passport specific content' do
-        expect(rendered).to have_content(
-          t('doc_auth.info.verify_online_instruction_mobile_no_selfie'),
-        )
-        expect(rendered).to have_content(t('doc_auth.info.verify_online_description_passport'))
-        expect(rendered).to have_content(
-          strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
-        )
+      context 'when in person passports is disabled' do
+        it 'renders passport specific content to verify your identity online' do
+          render
+          expect(rendered).to have_content(
+            t('doc_auth.info.verify_online_instruction_mobile_no_selfie'),
+          )
+          expect(rendered).to have_content(
+            t('doc_auth.info.verify_online_description_passport'),
+          ).once
+          expect(rendered).to have_content(
+            strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+          )
+        end
+      end
+
+      context 'when in person passports is enabled' do
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(true)
+        end
+
+        it 'renders passport specific content to verify your identity online and in person' do
+          render
+          expect(rendered).to have_content(
+            t('doc_auth.info.verify_online_instruction_mobile_no_selfie'),
+          )
+          expect(rendered).to have_content(
+            t('doc_auth.info.verify_online_description_passport'),
+          ).twice
+          expect(rendered).not_to have_content(
+            strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+          )
+        end
       end
     end
 
@@ -144,6 +204,7 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
       let(:selfie_check_required) { true }
 
       it 'renders selfie specific content' do
+        render
         expect(rendered).to have_content(t('doc_auth.tips.mobile_phone_required'))
         expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
         expect(rendered).not_to have_content(t('doc_auth.info.verify_online_description_passport'))
@@ -156,12 +217,33 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
       context 'when passport is allowed' do
         let(:passport_allowed) { true }
 
-        it 'renders passport specific content' do
-          expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
-          expect(rendered).to have_content(t('doc_auth.info.verify_online_description_passport'))
-          expect(rendered).to have_content(
-            strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
-          )
+        context 'when in person passports is disabled' do
+          it 'renders passport specific content to verify your identity online' do
+            render
+            expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
+            expect(rendered).to have_content(
+              t('doc_auth.info.verify_online_description_passport'),
+            ).once
+            expect(rendered).to have_content(
+              strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+            )
+          end
+        end
+
+        context 'when in person passports is enabled' do
+          before do
+            allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(true)
+          end
+          it 'renders passport specific content to verify your identity online and in person' do
+            render
+            expect(rendered).to have_content(t('doc_auth.info.verify_online_instruction_selfie'))
+            expect(rendered).to have_content(
+              t('doc_auth.info.verify_online_description_passport'),
+            ).twice
+            expect(rendered).not_to have_content(
+              strip_tags(t('doc_auth.info.verify_at_post_office_description_passport_html')),
+            )
+          end
         end
       end
     end

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -22,11 +22,19 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
       user: user
     )
   end
-  let(:is_enhanced_ipp) { false }
+  let(:enhanced_ipp_enrollment) do
+    build(
+      :in_person_enrollment, :pending, :enhanced_ipp,
+      current_address_matches_id: current_address_matches_id,
+      profile: profile,
+      selected_location_details: selected_location_details,
+      service_provider: service_provider,
+      user: user
+    )
+  end
   let(:presenter) do
     Idv::InPerson::ReadyToVerifyPresenter.new(
       enrollment: enrollment,
-      is_enhanced_ipp: is_enhanced_ipp,
     )
   end
   let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP }
@@ -190,12 +198,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
   end
 
   context 'what to expect section' do
-    context 'when Enhanced IPP is not enabled' do
-      let(:is_enhanced_ipp) { false }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
-
+    context 'when the enrollment is ID-IPP' do
       it 'conditionally renders content applicable to ID-IPP' do
         render
 
@@ -213,11 +216,8 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
       end
     end
 
-    context 'when Enhanced IPP is enabled' do
-      let(:is_enhanced_ipp) { true }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
+    context 'when the enrollment is enhanced IPP' do
+      let(:enrollment) { enhanced_ipp_enrollment }
 
       it 'conditionally renders content applicable to EIPP' do
         render
@@ -261,23 +261,16 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
   end
 
   context 'GSA Enhanced Pilot Barcode tag' do
-    context 'when Enhanced IPP is enabled' do
-      let(:is_enhanced_ipp) { true }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
+    context 'when the enrollment is enhanced IPP' do
+      let(:enrollment) { enhanced_ipp_enrollment }
+
       it 'renders GSA Enhanced Pilot Barcode tag' do
         render
 
         expect(rendered).to have_content(t('in_person_proofing.body.barcode.eipp_tag'))
       end
     end
-    context 'when Enhanced IPP is not enabled' do
-      let(:is_enhanced_ipp) { false }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
-
+    context 'when the enrollment is ID-IPP' do
       it 'does not render GSA Enhanced Pilot Barcode tag' do
         render
 
@@ -287,11 +280,8 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
   end
 
   context 'What to bring to the Post Office section' do
-    context 'when Enhanced IPP is enabled' do
-      let(:is_enhanced_ipp) { true }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
+    context 'when the enrollment is enhanced IPP' do
+      let(:enrollment) { enhanced_ipp_enrollment }
 
       it 'displays heading and body' do
         render
@@ -348,12 +338,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
       end
     end
 
-    context 'when Enhanced IPP is not enabled' do
-      let(:is_enhanced_ipp) { false }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
-
+    context 'when the enrollment is ID-IPP' do
       it 'template does not display Enhanced In-Person Proofing what to bring content' do
         render
 
@@ -392,12 +377,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
   end
 
   context 'Need to Change Location section' do
-    context 'when Enhanced IPP is not enabled' do
-      let(:is_enhanced_ipp) { false }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
-
+    context 'when the enrollment is ID-IPP' do
       it 'renders the change location heading' do
         render
 
@@ -420,10 +400,7 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
     end
 
     context 'when Enhanced IPP is enabled' do
-      let(:is_enhanced_ipp) { true }
-      before do
-        @is_enhanced_ipp = is_enhanced_ipp
-      end
+      let(:enrollment) { enhanced_ipp_enrollment }
 
       it 'does not render the change location heading' do
         render

--- a/spec/views/layouts/mailer.html.erb_spec.rb
+++ b/spec/views/layouts/mailer.html.erb_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'layouts/mailer.html.erb' do
     end
   end
 
-  context 'in-person proofing ready to verify emails' do
+  context 'in-person proofing' do
     let(:user) { create(:user, :with_pending_in_person_enrollment) }
     let(:sp_name) { 'Friendly Service Provider' }
     let(:service_provider) do
@@ -63,44 +63,38 @@ RSpec.describe 'layouts/mailer.html.erb' do
     end
     let(:enrollment) { create(:in_person_enrollment, :pending, service_provider: service_provider) }
 
-    before do
-      @mail = UserMailer.with(
-        user: user,
-        email_address: user.email_addresses.first,
-      ).in_person_ready_to_verify(enrollment:, is_enhanced_ipp: false)
-      allow(view).to receive(:message).and_return(@mail)
-      allow(view).to receive(:attachments).and_return(@mail.attachments)
-      @sp_name = sp_name
-      @logo_url = logo_url
+    context 'ready to verify emails' do
+      before do
+        @mail = UserMailer.with(
+          user: user,
+          email_address: user.email_addresses.first,
+        ).in_person_ready_to_verify(enrollment:)
+        allow(view).to receive(:message).and_return(@mail)
+        allow(view).to receive(:attachments).and_return(@mail.attachments)
+        @sp_name = sp_name
+        @logo_url = logo_url
 
-      render
+        render
+      end
+
+      it_behaves_like 'a barcode email', @sp_name
     end
 
-    context 'when the partner agency logo is a png' do
-      let(:logo) { 'gsa.png' }
-      let(:logo_url) { '/assets/sp-logos/gsa.png' }
+    context 'ready to verify reminder emails' do
+      before do
+        @mail = UserMailer.with(
+          user: user,
+          email_address: user.email_addresses.first,
+        ).in_person_ready_to_verify_reminder(enrollment:)
+        allow(view).to receive(:message).and_return(@mail)
+        allow(view).to receive(:attachments).and_return(@mail.attachments)
+        @sp_name = sp_name
+        @logo_url = logo_url
 
-      it 'displays the partner agency logo' do
-        expect(rendered).to have_css("img[src*='gsa.png']")
+        render
       end
-    end
 
-    context 'when the partner agency logo is a svg' do
-      let(:logo) { 'generic.svg' }
-      let(:logo_url) { nil }
-
-      it 'displays the partner agency name' do
-        expect(rendered).to have_content('Friendly Service Provider')
-      end
-    end
-
-    context 'when there is no partner agency logo' do
-      let(:logo) { nil }
-      let(:logo_url) { nil }
-
-      it 'displays the partner agency name' do
-        expect(rendered).to have_content('Friendly Service Provider')
-      end
+      it_behaves_like 'a barcode email', @sp_name
     end
   end
 end


### PR DESCRIPTION
## User-Facing Improvements
- In-Person Proofing: Include service provider logo or name in reminder emails ([#12069](https://github.com/18F/identity-idp/pull/12069))

## Internal
- Maintenance: Update valid_email gem ([#12077](https://github.com/18F/identity-idp/pull/12077))

## Upcoming Features
- Attempts API: Allow tid param for session_id (#12078) ([#12078](https://github.com/18F/identity-idp/pull/12078))
- Doc Auth: Updating text for ipp for required ID type (#12068) ([#12068](https://github.com/18F/identity-idp/pull/12068))
- In-person proofing: Display IPP passport content on How to Verify View if in_person_passport_enabled is true ([#12067](https://github.com/18F/identity-idp/pull/12067))
