### PR TITLE
Add IPP event

### DIFF
--- a/app/controllers/idv/in_person/ready_to_verify_controller.rb
+++ b/app/controllers/idv/in_person/ready_to_verify_controller.rb
@@ -19,6 +19,7 @@ module Idv
       def show
         @is_enhanced_ipp = resolved_authn_context_result.enhanced_ipp?
         analytics.idv_in_person_ready_to_verify_visit(**opt_in_analytics_properties)
+        attempts_api_tracker.idv_ipp_ready_to_verify_visit
         @presenter = ReadyToVerifyPresenter.new(
           enrollment: enrollment,
         )

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -11,6 +11,11 @@ module AttemptsApi
       )
     end
 
+    # A user is transferred to the in-person proofing workflow
+    def idv_ipp_ready_to_verify_visit
+      track_event('idv-ipp-ready-to-verify-visit')
+    end
+
     # @param [Boolean] success True if the entered code matched the sent code
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason if code did not match
     # A user that requested to verify their address by mail entered the code contained in the letter

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvIppReadyToVerifyVisit.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvIppReadyToVerifyVisit.yml
@@ -1,5 +1,5 @@
 description: |
-  When the user submits the security code that they received on their phone to verify their phone or address during identity proofing.
+  When the user transfers to the in-person proofing workflow.
 allOf:
   - $ref: '../shared/EventProperties.yml'
   - type: object

--- a/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ready_to_verify_controller_spec.rb
@@ -50,6 +50,9 @@ RSpec.describe Idv::InPerson::ReadyToVerifyController do
           end
 
           it 'logs analytics' do
+            stub_attempts_tracker
+            expect(@attempts_api_tracker).to receive(:idv_ipp_ready_to_verify_visit)
+
             response
 
             expect(@analytics).to have_logged_event('IdV: in person ready to verify visited')


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[163](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/163)

## 🛠 Summary of changes
This is an event that did not exist in the initial implementation of the Attempts API. It is capturing the "Transfer to Supervised Remote Process" milestone.

This change:
- adds the event
- adds tests
- also updates the event description, which was incorrect

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
