### PR TITLE
LG-15974: Add document_type column to in_person_enrollments table

### DIFF
--- a/db/primary_migrate/20250422182109_add_document_type_to_in_person_enrollments.rb
+++ b/db/primary_migrate/20250422182109_add_document_type_to_in_person_enrollments.rb
@@ -1,0 +1,5 @@
+class AddDocumentTypeToInPersonEnrollments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :in_person_enrollments, :document_type, :integer, comment: 'sensitive=false'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_16_181519) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_22_182109) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -347,6 +347,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_16_181519) do
     t.datetime "last_batch_claimed_at", comment: "sensitive=false"
     t.string "sponsor_id", null: false, comment: "sensitive=false"
     t.string "doc_auth_result", comment: "sensitive=false"
+    t.integer "document_type", comment: "sensitive=false"
     t.index ["profile_id"], name: "index_in_person_enrollments_on_profile_id"
     t.index ["ready_for_status_check"], name: "index_in_person_enrollments_on_ready_for_status_check", where: "(ready_for_status_check = true)"
     t.index ["status_check_attempted_at"], name: "index_in_person_enrollments_on_status_check_attempted_at", where: "(status = 1)"


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15974](https://cm-jira.usa.gov/browse/LG-15974)
- Sub-task [LG-16126](https://cm-jira.usa.gov/browse/LG-16126)


## 🛠 Summary of changes

Adds a new, unindexed `document_type` column to in_person_enrollments to pass along the type of photo ID used for an in-person proofing enrollment to our vendors.