### PR TITLE
LG-15974: Set document type on new IPP enrollments

### DIFF
--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -160,11 +160,7 @@ module Idv
       end
 
       def enrollment
-        current_user.establishing_in_person_enrollment || InPersonEnrollment.find_or_initialize_by(
-          user: current_user,
-          status: :establishing,
-          profile: nil,
-        )
+        current_user.establishing_in_person_enrollment
       end
 
       def form

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -52,6 +52,7 @@ module Idv
             redirect_url = idv_in_person_ssn_url
           end
 
+          enrollment.update!(document_type: :state_id)
           idv_session.doc_auth_vendor = Idp::Constants::Vendors::USPS
 
           analytics.idv_in_person_proofing_state_id_submitted(
@@ -155,6 +156,14 @@ module Idv
             :day,
             :year,
           ],
+        )
+      end
+
+      def enrollment
+        current_user.establishing_in_person_enrollment || InPersonEnrollment.find_or_initialize_by(
+          user: current_user,
+          status: :establishing,
+          profile: nil,
         )
       end
 

--- a/app/controllers/idv/in_person/usps_locations_controller.rb
+++ b/app/controllers/idv/in_person/usps_locations_controller.rb
@@ -61,6 +61,7 @@ module Idv
           issuer: current_sp&.issuer,
           doc_auth_result: document_capture_session&.last_doc_auth_result,
           sponsor_id: enrollment_sponsor_id,
+          document_type: nil,
         )
 
         render json: { success: true }, status: :ok

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -36,6 +36,7 @@ class InPersonEnrollment < ApplicationRecord
   DOCUMENT_TYPE_STATE_ID = 'state_id'
   DOCUMENT_TYPE_PASSPORT_BOOK = 'passport_book'
 
+  # This will always be nil in the Verify-by-Mail (GPO) flow.
   enum :document_type, {
     DOCUMENT_TYPE_STATE_ID.to_sym => 0,
     DOCUMENT_TYPE_PASSPORT_BOOK.to_sym => 1,

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -33,6 +33,14 @@ class InPersonEnrollment < ApplicationRecord
     STATUS_IN_FRAUD_REVIEW.to_sym => 6,
   }
 
+  DOCUMENT_TYPE_STATE_ID = 'state_id'
+  DOCUMENT_TYPE_PASSPORT_BOOK = 'passport_book'
+
+  enum :document_type, {
+    DOCUMENT_TYPE_STATE_ID.to_sym => 0,
+    DOCUMENT_TYPE_PASSPORT_BOOK.to_sym => 1,
+  }
+
   validate :profile_belongs_to_user
 
   before_save(:on_status_updated, if: :will_save_change_to_status?)

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Idv::InPerson::StateIdController do
   include InPersonHelper
 
   let(:user) { build(:user) }
-  let(:enrollment) { InPersonEnrollment.new }
+  let(:enrollment) { create(:in_person_enrollment, :establishing, user: user) }
 
   before do
     stub_sign_in(user)
@@ -200,6 +200,7 @@ RSpec.describe Idv::InPerson::StateIdController do
 
         expect(subject.idv_session.ssn).to eq(nil)
         expect(subject.idv_session.doc_auth_vendor).to eq(nil)
+        expect(enrollment.document_type).to eq(nil)
         expect(subject.extra_view_variables[:updating_state_id]).to eq(false)
         expect(response).to render_template :show
       end
@@ -208,6 +209,7 @@ RSpec.describe Idv::InPerson::StateIdController do
         subject.idv_session.ssn = '123-45-6789'
         put :update, params: invalid_params
 
+        expect(enrollment.document_type).to eq(nil)
         expect(subject.extra_view_variables[:updating_state_id]).to eq(true)
         expect(response).to render_template :show
       end
@@ -240,6 +242,12 @@ RSpec.describe Idv::InPerson::StateIdController do
         put :update, params: params
 
         expect(subject.idv_session.doc_auth_vendor).to eq(Idp::Constants::Vendors::USPS)
+      end
+
+      it 'sets the enrollment document type' do
+        put :update, params: params
+
+        expect(enrollment.document_type).to eq(InPersonEnrollment::DOCUMENT_TYPE_STATE_ID)
       end
     end
 

--- a/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
+++ b/spec/controllers/idv/in_person/usps_locations_controller_spec.rb
@@ -4,18 +4,21 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
   let(:user) { create(:user) }
   let(:sp) { nil }
   let(:in_person_proofing_enabled) { true }
+
   let(:address) do
     UspsInPersonProofing::Applicant.new(
       address: '1600 Pennsylvania Ave',
       city: 'Washington', state: 'DC', zip_code: '20500'
     )
   end
+
   let(:fake_address) do
     UspsInPersonProofing::Applicant.new(
       address: '742 Evergreen Terrace',
       city: 'Springfield', state: 'MO', zip_code: '89011'
     )
   end
+
   let(:selected_location) do
     {
       usps_location: {
@@ -40,6 +43,7 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
   describe '#index' do
     let(:locale) { nil }
     let(:proofer) { double('Proofer') }
+
     let(:locations) do
       [
         UspsInPersonProofing::PostOffice.new(
@@ -80,6 +84,7 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
         ),
       ]
     end
+
     subject(:response) do
       post :index, params: { locale: locale,
                              address: { street_address: '1600 Pennsylvania Ave',
@@ -230,6 +235,7 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
 
     context 'with failed connection to Faraday' do
       let(:exception) { Faraday::ConnectionFailed.new }
+
       subject(:response) do
         post :index,
              params: { address: { street_address: '742 Evergreen Terrace',
@@ -358,6 +364,7 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
   describe '#update' do
     let(:enrollment) { InPersonEnrollment.last }
     let(:sp) { create(:service_provider, ial: 2) }
+
     subject(:response) { put :update, params: selected_location }
 
     context 'when legacy request body is sent with location data' do
@@ -415,6 +422,7 @@ RSpec.describe Idv::InPerson::UspsLocationsController do
         expect(enrollment.status).to eq('establishing')
         expect(enrollment.profile).to be_nil
         expect(enrollment.sponsor_id).to eq(IdentityConfig.store.usps_ipp_sponsor_id)
+        expect(enrollment.document_type).to eq(nil)
         expect(enrollment.selected_location_details).to eq(
           selected_location[:usps_location].as_json,
         )

--- a/spec/factories/in_person_enrollments.rb
+++ b/spec/factories/in_person_enrollments.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     unique_id { InPersonEnrollment.generate_unique_id }
     user { association :user, :fully_registered }
     sponsor_id { IdentityConfig.store.usps_ipp_sponsor_id }
+    document_type { nil }
 
     trait :establishing do
       profile { nil }
@@ -70,6 +71,10 @@ FactoryBot.define do
 
     trait :enhanced_ipp do
       sponsor_id { IdentityConfig.store.usps_eipp_sponsor_id }
+    end
+
+    trait :state_id do
+      document_type { :state_id }
     end
   end
 end

--- a/spec/features/idv/end_to_end_idv_spec.rb
+++ b/spec/features/idv/end_to_end_idv_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Identity verification', :js do
         .update(in_person_proofing_enabled: true)
     end
 
-    scenario 'In person proofing', allow_browser_log: true do
+    scenario 'In person proofing with state ID', allow_browser_log: true do
       visit_idp_from_sp_with_ial2(sp)
       user = sign_up_and_2fa_ial1_user
 

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -218,9 +218,10 @@ module InPersonHelper
     end
   end
 
-  def mark_in_person_enrollment_passed(user)
+  def mark_in_person_enrollment_passed(user, document_type = :state_id)
     enrollment = user.in_person_enrollments.last
     expect(enrollment).to_not be_nil
+    expect(enrollment.document_type.&to_sym).to eq(document_type)
     enrollment.profile.activate_after_passing_in_person
     enrollment.update(status: :passed)
   end

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -221,7 +221,7 @@ module InPersonHelper
   def mark_in_person_enrollment_passed(user, document_type = :state_id)
     enrollment = user.in_person_enrollments.last
     expect(enrollment).to_not be_nil
-    expect(enrollment.document_type.&to_sym).to eq(document_type)
+    expect(enrollment.document_type&.to_sym).to eq(document_type)
     enrollment.profile.activate_after_passing_in_person
     enrollment.update(status: :passed)
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15974](https://cm-jira.usa.gov/browse/LG-15974) - Story

Subtask: [LG-16127: Write ID type to InPersonEnrollment.document_type](https://cm-jira.usa.gov/browse/LG-16127)


## 🛠 Summary of changes

- This work enables writing `document_type` on the `InPersonEnrollment` model on _successful_ submission of the `StateIdForm` in the state id controller.
- On "undo" or backwards navigation, which will take the applicant back to the "Pick a post office screen", the `enrollment.document_type` should set or reset to nil.
- Cancelling the enrollment after successful submission of the state ID information does not clear the `document_type` field.

## 📜 Testing Plan

**Notes:**
This will be standard behavior for IPP flow and is not predicated on passports being enabled globally or for IPP specifically. 


### Standard Flow

#### IPP State ID Success

- [ ] Start standard IPP flow up to the SSN screen
- [ ] Confirm enrollment has non-nil `document_type` and that it is set to `:state_id` via rails console (`InPersonEnrollment.last`)

#### IPP State ID back navigation

- [ ] Start standard IPP flow up to the SSN screen
- [ ] Confirm enrollment has nil selected location via rails console (`InPersonEnrollment.last`)

### Hybrid Flow

#### IPP State ID Success Case

- [ ] Start remote flow and fail remote proofing in order to jump to IPP
- [ ] Follow the flow up to submit SSN screen
- [ ] Confirm enrollment has non-nil `document_type` and that it is set to `:state_id` via rails console (`InPersonEnrollment.last`)


### Hybrid and Standard Flows

#### IPP cancellation before submit State ID info
- [ ] Start either flow and follow it up to submit State ID info screen
- [ ] Cancel IdV and go back to the account page
- [ ] Confirm enrollment has nil `document_type` via rails console (`InPersonEnrollment.last`)

#### IPP cancellation after submit State ID info
- [ ] Start either flow and follow it up to submit SSN screen
- [ ] Cancel the IdV and go back to the account page
- [ ] Confirm enrollment has non-nil `document_type` and that it is set to `:state_id` via rails console (`InPersonEnrollment.last`)
