### PR TITLE
LG-15988: Add second DOS health check after post office selection

### DIFF
--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -3,6 +3,7 @@
 module Idv
   class InPersonController < ApplicationController
     include Idv::AvailabilityConcern
+    include Idv::ChooseIdTypeConcern
     include RenderConditionConcern
     include IdvStepConcern
 

--- a/app/controllers/idv/in_person_controller.rb
+++ b/app/controllers/idv/in_person_controller.rb
@@ -14,7 +14,7 @@ module Idv
     before_action :set_usps_form_presenter
 
     def index
-      if idv_session.in_person_passports_allowed?
+      if idv_session.in_person_passports_allowed? && dos_passport_api_healthy?(analytics:)
         redirect_to idv_in_person_choose_id_type_url
       else
         redirect_to idv_in_person_state_id_url

--- a/spec/features/idv/in_person/passport_scenario_spec.rb
+++ b/spec/features/idv/in_person/passport_scenario_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'In Person Proofing Passports', js: true do
       allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled).and_return(true)
       allow(IdentityConfig.store).to receive(:doc_auth_passports_percent).and_return(100)
       stub_health_check_settings
-      stub_health_check_endpoints
+      stub_health_check_endpoints_success
     end
 
     context 'when in person passports are enabled' do
@@ -33,7 +33,7 @@ RSpec.describe 'In Person Proofing Passports', js: true do
         allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(true)
       end
 
-      it 'allows the user to accesss in person passport content' do
+      it 'allows the user to access in person passport content' do
         reload_ab_tests
         visit_idp_from_sp_with_ial2(service_provider)
         sign_in_live_with_2fa(user)
@@ -63,6 +63,210 @@ RSpec.describe 'In Person Proofing Passports', js: true do
         expect(page).to have_content t('in_person_proofing.info.choose_id_type')
         expect(page).to have_content t('doc_auth.forms.id_type_preference.drivers_license')
         expect(page).to have_content t('doc_auth.forms.id_type_preference.passport')
+      end
+
+      context 'when the first DOS health check fails on the welcome page' do
+        before do
+          stub_composite_health_check_endpoint_failure
+        end
+
+        it 'does not allow the user to access passport content' do
+          reload_ab_tests
+          visit_idp_from_sp_with_ial2(service_provider)
+          sign_in_live_with_2fa(user)
+
+          expect(page).to have_current_path(idv_welcome_path)
+          expect(page).to have_content t(
+            'doc_auth.headings.welcome',
+            sp_name: service_provider_name,
+          )
+          expect(page).to have_content t('doc_auth.instructions.bullet1a')
+
+          complete_welcome_step
+
+          expect(page).to have_current_path(idv_agreement_path)
+          complete_agreement_step
+
+          expect(page).to have_current_path(idv_how_to_verify_path)
+
+          click_on t('forms.buttons.continue_ipp')
+
+          expect(page).to have_current_path(idv_document_capture_path(step: 'how_to_verify'))
+
+          click_on t('forms.buttons.continue')
+          complete_location_step(user)
+
+          expect(page).to have_current_path(idv_in_person_state_id_url)
+
+          expect(page).to have_content strip_nbsp(
+            t('in_person_proofing.headings.state_id_milestone_2'),
+          )
+        end
+      end
+
+      context 'when the second DOS health check fails after the user selects a post office' do
+        before do
+          stub_health_check_settings
+          # The first health check passes
+          stub_health_check_endpoints_success
+        end
+
+        it 'directs the user to the state id page' do
+          reload_ab_tests
+          visit_idp_from_sp_with_ial2(service_provider)
+          sign_in_live_with_2fa(user)
+
+          expect(page).to have_current_path(idv_welcome_path)
+          expect(page).to have_content t(
+            'doc_auth.headings.welcome',
+            sp_name: service_provider_name,
+          )
+          expect(page).to have_content t('doc_auth.instructions.bullet1b')
+
+          complete_welcome_step
+
+          expect(page).to have_current_path(idv_agreement_path)
+          complete_agreement_step
+
+          expect(page).to have_current_path(idv_how_to_verify_path)
+          expect(page).to have_content t('doc_auth.info.verify_online_description_passport')
+
+          click_on t('forms.buttons.continue_ipp')
+
+          expect(page).to have_current_path(idv_document_capture_path(step: 'how_to_verify'))
+
+          click_on t('forms.buttons.continue')
+          # The second health check fails
+          stub_composite_health_check_endpoint_failure
+          complete_location_step(user)
+
+          expect(page).to have_current_path(idv_in_person_state_id_url)
+
+          expect(page).to have_content strip_nbsp(
+            t('in_person_proofing.headings.state_id_milestone_2'),
+          )
+        end
+      end
+
+      context 'when the user is in the hybrid flow' do
+        before do
+          allow(Telephony).to receive(:send_doc_auth_link).and_wrap_original do |impl, config|
+            @sms_link = config[:link]
+            impl.call(**config)
+          end.at_least(1).times
+
+          allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(true)
+        end
+
+        context 'when second DOS health check passes after user selects post office on mobile' do
+          it 'directs the user to the choose id page on desktop' do
+            perform_in_browser(:desktop) do
+              reload_ab_tests
+              visit_idp_from_sp_with_ial2(service_provider)
+              sign_in_live_with_2fa(user)
+
+              expect(page).to have_current_path(idv_welcome_path)
+              expect(page).to have_content t(
+                'doc_auth.headings.welcome',
+                sp_name: service_provider_name,
+              )
+              expect(page).to have_content t('doc_auth.instructions.bullet1b')
+
+              complete_welcome_step
+
+              expect(page).to have_current_path(idv_agreement_path)
+              complete_agreement_step
+
+              expect(page).to have_current_path(idv_how_to_verify_path)
+              expect(page).to have_content t('doc_auth.info.verify_online_description_passport')
+              # choose remote verification
+              click_on t('forms.buttons.continue_online')
+              click_send_link
+
+              expect(page).to have_content(t('doc_auth.headings.text_message'))
+            end
+
+            perform_in_browser(:mobile) do
+              # doc auth page
+              visit @sms_link
+              # expect to see the choose id type page
+              expect(page).to have_current_path(idv_hybrid_mobile_choose_id_type_path)
+              # choose passport
+              choose(t('doc_auth.forms.id_type_preference.passport'))
+              click_on t('forms.buttons.continue')
+              mock_doc_auth_attention_with_barcode
+              attach_and_submit_passport_image
+
+              # error page
+              click_button t('in_person_proofing.body.cta.button')
+              # prepare page
+              expect(page).to(have_content(t('in_person_proofing.body.prepare.verify_step_about')))
+              click_idv_continue
+              complete_location_step
+              expect(page).to have_content(t('in_person_proofing.headings.switch_back'))
+            end
+
+            perform_in_browser(:desktop) do
+              expect(page).to have_current_path(idv_in_person_choose_id_type_path)
+            end
+          end
+        end
+
+        context 'when second DOS health check fails after user selects post office on mobile' do
+          it 'directs the user to the state id page on desktop' do
+            perform_in_browser(:desktop) do
+              reload_ab_tests
+              visit_idp_from_sp_with_ial2(service_provider)
+              sign_in_live_with_2fa(user)
+
+              expect(page).to have_current_path(idv_welcome_path)
+              expect(page).to have_content t(
+                'doc_auth.headings.welcome',
+                sp_name: service_provider_name,
+              )
+              expect(page).to have_content t('doc_auth.instructions.bullet1b')
+
+              complete_welcome_step
+
+              expect(page).to have_current_path(idv_agreement_path)
+              complete_agreement_step
+
+              expect(page).to have_current_path(idv_how_to_verify_path)
+              expect(page).to have_content t('doc_auth.info.verify_online_description_passport')
+              # choose remote verification
+              click_on t('forms.buttons.continue_online')
+              click_send_link
+
+              expect(page).to have_content(t('doc_auth.headings.text_message'))
+            end
+
+            perform_in_browser(:mobile) do
+              # doc auth page
+              visit @sms_link
+              # expect to see the choose id type page
+              expect(page).to have_current_path(idv_hybrid_mobile_choose_id_type_path)
+              # choose passport
+              choose(t('doc_auth.forms.id_type_preference.passport'))
+              click_on t('forms.buttons.continue')
+              mock_doc_auth_attention_with_barcode
+              attach_and_submit_passport_image
+
+              # error page
+              click_button t('in_person_proofing.body.cta.button')
+              # prepare page
+              expect(page).to(have_content(t('in_person_proofing.body.prepare.verify_step_about')))
+              click_idv_continue
+              # second health check fails
+              stub_composite_health_check_endpoint_failure
+              complete_location_step
+              expect(page).to have_content(t('in_person_proofing.headings.switch_back'))
+            end
+
+            perform_in_browser(:desktop) do
+              expect(page).to have_current_path(idv_in_person_state_id_path)
+            end
+          end
+        end
       end
     end
 

--- a/spec/fixtures/dos/healthcheck/composite_health_fail.json
+++ b/spec/fixtures/dos/healthcheck/composite_health_fail.json
@@ -1,0 +1,23 @@
+{
+  "name": "Passport Match Process API",
+  "status": "DOWN",
+  "environment": "dev-share",
+  "responseTimeMs": 144,
+  "comments": "DOWN",
+  "downstreamHealth": [
+    {
+      "name": "ViPRR System API",
+      "status": "DOWN",
+      "environment": "dev-share",
+      "comments": "DOWN",
+      "downstreamHealth": null
+    },
+    {
+      "name": "Passport Match System API",
+      "status": "DOWN",
+      "environment": "psdd-dev-share",
+      "comments": "DOWN",
+      "downstreamHealth": null
+    }
+  ]
+}

--- a/spec/services/doc_auth/dos/requests/health_check_request_spec.rb
+++ b/spec/services/doc_auth/dos/requests/health_check_request_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DocAuth::Dos::Requests::HealthCheckRequest do
 
   before do
     stub_health_check_settings
-    stub_health_check_endpoints
+    stub_health_check_endpoints_success
   end
 
   shared_examples 'a DOS healthcheck endpoint' do |endpoint, success_body|

--- a/spec/services/doc_auth/dos/responses/health_check_response_spec.rb
+++ b/spec/services/doc_auth/dos/responses/health_check_response_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DocAuth::Dos::Responses::HealthCheckResponse do
 
   context 'when initialized from a successful general health check response' do
     before do
-      stub_health_check_endpoints
+      stub_health_check_endpoints_success
     end
 
     let(:faraday_response) do
@@ -61,7 +61,7 @@ RSpec.describe DocAuth::Dos::Responses::HealthCheckResponse do
 
   context 'when initialized from a successful composite health check response' do
     before do
-      stub_health_check_endpoints
+      stub_health_check_endpoints_success
     end
 
     let(:faraday_response) do

--- a/spec/support/features/document_capture_step_helper.rb
+++ b/spec/support/features/document_capture_step_helper.rb
@@ -18,6 +18,15 @@ module DocumentCaptureStepHelper
     attach_file t('doc_auth.headings.document_capture_back'), file, make_visible: true
   end
 
+  def attach_and_submit_passport_image
+    attach_passport_image
+    submit_images
+  end
+
+  def attach_passport_image(file = Rails.root.join('app', 'assets', 'images', 'email', 'logo.png'))
+    attach_file t('doc_auth.headings.document_capture_passport'), file, make_visible: true
+  end
+
   def attach_liveness_images(
     file = Rails.root.join(
       'spec', 'fixtures',

--- a/spec/support/passport_api_helpers.rb
+++ b/spec/support/passport_api_helpers.rb
@@ -8,12 +8,17 @@ module PassportApiHelpers
         .and_return(composite_health_check_endpoint)
     end
 
-    def stub_health_check_endpoints
+    def stub_health_check_endpoints_success
       stub_request(:get, general_health_check_endpoint)
         .to_return_json(body: successful_api_general_health_check_body)
 
       stub_request(:get, composite_health_check_endpoint)
         .to_return_json(body: successful_api_composite_health_check_body)
+    end
+
+    def stub_composite_health_check_endpoint_failure
+      stub_request(:get, composite_health_check_endpoint)
+        .to_return_json(body: failed_api_composite_health_check_body)
     end
 
     def general_health_check_endpoint
@@ -41,6 +46,17 @@ module PassportApiHelpers
           Rails.root.join(
             'spec', 'fixtures', 'dos', 'healthcheck',
             'composite_health_success.json'
+          ),
+        ),
+      )
+    end
+
+    def failed_api_composite_health_check_body
+      JSON.parse(
+        File.read(
+          Rails.root.join(
+            'spec', 'fixtures', 'dos', 'healthcheck',
+            'composite_health_fail.json'
           ),
         ),
       )


### PR DESCRIPTION
## 🎫 Ticket
[LG-15988: Add DoS health check (2nd check) after post office selection](https://cm-jira.usa.gov/browse/LG-15988)


## 🛠 Summary of changes
- After the user selects a post office location.....
- there is a second Department of State health check
- if the health check passes, the user gets directed to the "choose your ID type" page
- if the health check fails, then the user gets directed to the "state ID" page



## 📜 Testing Plan
(Shout out to @shanechesnutt-ft, I based a lot of this on your very thorough test plan for PR #12084.)
- Please test both hybrid and standard flow.

**Scenario: Global passports and In-Person Passports are enabled**
The second DOS health check succeeds.
Setup below: 
```
  in_person_proofing_enabled: true
  in_person_proofing_opt_in_enabled: true
  in_person_passports_enabled: true
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100
```

- [ ] Login through the oidc sinatra application and select the Identity Verified level of service.
- [ ] Create a new account
- [ ] Begin the ID-IPP flow and navigate to the post office selection page
- [ ] Select a post office
- [ ] Ensure user is navigated to the choose ID type page

**Scenario: Global passports are enabled and in-person passports is disabled**
There is no second DOS health check.
Setup below:
```
  in_person_proofing_enabled: true
  in_person_proofing_opt_in_enabled: true
  in_person_passports_enabled: false
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100
```
- [ ] Login through the oidc sinatra application and select the Identity Verified level of service.
- [ ] Create a new account
- [ ] Begin the ID-IPP flow and navigate to the post office selection page
- [ ] Select a post office
- [ ] Ensure user is navigated to the state ID page