### PR TITLE
LG-16050 Add submit logic to IPP choose id type controller

### DIFF
--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -38,11 +38,11 @@ module Idv
       response.success?
     end
 
-    def locals_attrs(analytics:, presenter:, url_for: nil)
+    def locals_attrs(analytics:, presenter:, form_submit_url: nil)
       dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
       {
         presenter:,
-        url_for:,
+        form_submit_url:,
         dos_passport_api_down:,
         auto_check_value: dos_passport_api_down ? :drivers_license : selected_id_type,
       }

--- a/app/controllers/idv/choose_id_type_controller.rb
+++ b/app/controllers/idv/choose_id_type_controller.rb
@@ -16,7 +16,7 @@ module Idv
              locals: locals_attrs(
                analytics:,
                presenter: Idv::ChooseIdTypePresenter.new,
-               url_for: idv_choose_id_type_path,
+               form_submit_url: idv_choose_id_type_path,
              ),
              layout: true
     end

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -60,7 +60,7 @@ module Idv
       Idv::StepInfo.new(
         key: :document_capture,
         controller: self,
-        next_steps: [:ssn, :ipp_state_id],
+        next_steps: [:ssn, :ipp_state_id, :ipp_choose_id_type],
         preconditions: ->(idv_session:, user:) {
           idv_session.flow_path == 'standard' && (
             # mobile

--- a/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/choose_id_type_controller.rb
@@ -18,7 +18,7 @@ module Idv
                locals: locals_attrs(
                  analytics:,
                  presenter: Idv::HybridMobile::ChooseIdTypePresenter.new,
-                 url_for: idv_hybrid_mobile_choose_id_type_path,
+                 form_submit_url: idv_hybrid_mobile_choose_id_type_path,
                )
       end
 

--- a/app/controllers/idv/in_person/choose_id_type_controller.rb
+++ b/app/controllers/idv/in_person/choose_id_type_controller.rb
@@ -11,22 +11,48 @@ class Idv::InPerson::ChooseIdTypeController < ApplicationController
     analytics.idv_in_person_proofing_choose_id_type_visited(**analytics_arguments)
 
     render 'idv/shared/choose_id_type',
-           locals: locals_attrs(analytics:, presenter: Idv::InPerson::ChooseIdTypePresenter.new),
+           locals: locals_attrs(
+             analytics:,
+             presenter: Idv::InPerson::ChooseIdTypePresenter.new,
+             form_submit_url: idv_in_person_choose_id_type_url,
+           ),
            layout: true
   end
 
   def update
+    clear_future_steps!
+
+    form = Idv::ChooseIdTypeForm.new
+    result = form.submit(allowed_params)
+
+    analytics.idv_in_person_proofing_choose_id_type_submitted(
+      **analytics_arguments
+        .merge(**result.to_h)
+        .merge(chosen_id_type: form.chosen_id_type),
+    )
+
+    if result.success?
+      set_chosen_id_type
+      redirect_to chosen_id_type_url(form.chosen_id_type)
+    else
+      redirect_to idv_in_person_choose_id_type_url
+    end
   end
 
   def self.step_info
     Idv::StepInfo.new(
       key: :ipp_choose_id_type,
       controller: self,
-      next_steps: [],
+      next_steps: [:ipp_state_id],
       preconditions: ->(idv_session:, user:) {
         idv_session.in_person_passports_allowed? && user.has_establishing_in_person_enrollment?
       },
-      undo_step: -> {},
+      undo_step: ->(idv_session:, user:) do
+        if idv_session.document_capture_session_uuid
+          DocumentCaptureSession.find_by(uuid: idv_session.document_capture_session_uuid)
+            &.update!(passport_status: idv_session.passport_allowed ? 'allowed' : nil)
+        end
+      end,
     )
   end
 
@@ -39,5 +65,24 @@ class Idv::InPerson::ChooseIdTypeController < ApplicationController
       analytics_id: 'In Person Proofing',
     }.merge(ab_test_analytics_buckets)
       .merge(extra_analytics_properties)
+  end
+
+  def allowed_params
+    choose_id_type_form_params
+  end
+
+  def chosen_id_type_url(type)
+    id_type_to_route_url[type]
+  end
+
+  def id_type_to_route_url
+    {
+      'passport' => idv_in_person_passport_url,
+      'drivers_license' => idv_in_person_state_id_url,
+    }
+  end
+
+  def set_chosen_id_type
+    set_passport_requested
   end
 end

--- a/app/controllers/idv/in_person/passport_controller.rb
+++ b/app/controllers/idv/in_person/passport_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Idv::InPerson::PassportController < ApplicationController
+  def show
+  end
+end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3115,6 +3115,39 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Boolean] success
+  # @param ["hybrid","standard"] flow_path Document capture user flow
+  # @param [String] step Current IdV step
+  # @param [String] analytics_id Current IdV flow identifier
+  # @param ['drivers_license', 'passport'] chosen_id_type Chosen id type of the user
+  # @param [Boolean] opted_in_to_in_person_proofing Whether user opted into in person proofing
+  # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
+  # @param [Hash] error_details
+  def idv_in_person_proofing_choose_id_type_submitted(
+    success:,
+    flow_path:,
+    step:,
+    analytics_id:,
+    chosen_id_type:,
+    opted_in_to_in_person_proofing: nil,
+    skip_hybrid_handoff: nil,
+    error_details: nil,
+    **extra
+  )
+    track_event(
+      :idv_in_person_proofing_choose_id_type_submitted,
+      success:,
+      flow_path:,
+      step:,
+      analytics_id:,
+      chosen_id_type:,
+      opted_in_to_in_person_proofing:,
+      skip_hybrid_handoff:,
+      error_details:,
+      **extra,
+    )
+  end
+
   # @param ["hybrid","standard"] flow_path Document capture user flow
   # @param [String] step Current IdV step
   # @param [String] analytics_id

--- a/app/views/idv/shared/choose_id_type.html.erb
+++ b/app/views/idv/shared/choose_id_type.html.erb
@@ -41,7 +41,7 @@
 
 <%= simple_form_for(
       :doc_auth,
-      url: url_for,
+      url: form_submit_url,
       method: :put,
     ) do |f| %>
       <%= render ValidatedFieldComponent.new(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -444,6 +444,7 @@ Rails.application.routes.draw do
       put '/in_person' => 'in_person#update'
       get '/in_person/choose_id_type' => 'in_person/choose_id_type#show'
       put '/in_person/choose_id_type' => 'in_person/choose_id_type#update'
+      get '/in_person/passport' => 'in_person/passport#show'
       get '/in_person/ready_to_verify' => 'in_person/ready_to_verify#show',
           as: :in_person_ready_to_verify
       post '/in_person/usps_locations' => 'in_person/usps_locations#index'

--- a/spec/controllers/concerns/idv/choose_id_type_concern_spec.rb
+++ b/spec/controllers/concerns/idv/choose_id_type_concern_spec.rb
@@ -1,0 +1,228 @@
+require 'rails_helper'
+
+RSpec.describe Idv::ChooseIdTypeConcern, :controller do
+  controller ApplicationController do
+    include Idv::ChooseIdTypeConcern
+  end
+
+  subject { controller }
+
+  let(:analytics) { FakeAnalytics.new }
+  let(:document_capture_session) { double(DocumentCaptureSession) }
+  let(:parameters) do
+    ActionController::Parameters.new(
+      {
+        doc_auth: {
+          choose_id_type_preference: id_type,
+        },
+      },
+    )
+  end
+
+  before do
+    allow(controller).to receive(:document_capture_session).and_return(document_capture_session)
+  end
+
+  describe '#chosen_id_type' do
+    let(:id_type) { 'passport' }
+
+    before do
+      allow(controller).to receive(:params).and_return(parameters)
+    end
+
+    it 'returns the choose_id_type_prefence from params' do
+      expect(subject.chosen_id_type).to eq(id_type)
+    end
+  end
+
+  describe '#set_passport_requested' do
+    before do
+      allow(document_capture_session).to receive(:update!)
+    end
+
+    context 'when chosen_id_type is "passport"' do
+      let(:id_type) { 'passport' }
+
+      before do
+        allow(controller).to receive(:params).and_return(parameters)
+        subject.set_passport_requested
+      end
+
+      it 'updates the document_capture_session passport status to "requested"' do
+        expect(document_capture_session).to have_received(:update!).with(
+          passport_status: 'requested',
+        )
+      end
+    end
+
+    context 'when chosen_id_type is not "passport"' do
+      let(:id_type) { 'drivers_license' }
+
+      before do
+        allow(controller).to receive(:params).and_return(parameters)
+        subject.set_passport_requested
+      end
+
+      it 'updates the document_capture_session passport status to "not_requested"' do
+        expect(document_capture_session).to have_received(:update!).with(
+          passport_status: 'not_requested',
+        )
+      end
+    end
+  end
+
+  describe '#choose_id_type_form_params' do
+    context 'when the parameters has allowed params' do
+      let(:id_type) { 'passport' }
+
+      before do
+        allow(controller).to receive(:params).and_return(parameters)
+      end
+
+      it 'returns the allowed choose_id_type form params' do
+        expect(subject.choose_id_type_form_params).to have_key(:choose_id_type_preference)
+      end
+    end
+
+    context 'when the parameters has non allowed params' do
+      let(:invalid_params) do
+        ActionController::Parameters.new(
+          {
+            doc_auth: {
+              invalid: 'I am error',
+            },
+          },
+        )
+      end
+
+      before do
+        allow(controller).to receive(:params).and_return(invalid_params)
+      end
+
+      it 'does not return invalid choose_id_type form params' do
+        expect(subject.choose_id_type_form_params).to_not have_key(:invalid)
+      end
+    end
+  end
+
+  describe '#selected_id_type' do
+    before do
+      allow(document_capture_session).to receive(:passport_status).and_return(passport_status)
+    end
+
+    context 'when the document capture session passport status is "requested"' do
+      let(:passport_status) { 'requested' }
+
+      it 'returns :passport' do
+        expect(subject.selected_id_type).to eq(:passport)
+      end
+    end
+
+    context 'when the document capture session passport status is "not_requested"' do
+      let(:passport_status) { 'not_requested' }
+
+      it 'returns :drivers_license' do
+        expect(subject.selected_id_type).to eq(:drivers_license)
+      end
+    end
+
+    context 'when the document capture session passport status is "allowed"' do
+      let(:passport_status) { 'allowed' }
+
+      it 'returns nil' do
+        expect(subject.selected_id_type).to be_nil
+      end
+    end
+  end
+
+  describe '#dos_passport_api_healthy?' do
+    context 'when the endpoint is set' do
+      let(:request) { double(DocAuth::Dos::Requests::HealthCheckRequest) }
+      let(:response) { double(DocAuth::Dos::Responses::HealthCheckResponse) }
+
+      before do
+        allow(IdentityConfig.store).to receive(
+          :dos_passport_composite_healthcheck_endpoint,
+        ).and_return('http://dostest.com/status')
+        allow(DocAuth::Dos::Requests::HealthCheckRequest).to receive(:new).and_return(request)
+        allow(request).to receive(:fetch).with(analytics).and_return(response)
+      end
+
+      context 'when the dos response is successful' do
+        before do
+          allow(response).to receive(:success?).and_return(true)
+        end
+
+        it 'returns true' do
+          expect(subject.dos_passport_api_healthy?(analytics:)).to be(true)
+        end
+      end
+
+      context 'when the dos response is a failure' do
+        before do
+          allow(response).to receive(:success?).and_return(false)
+        end
+
+        it 'returns false' do
+          expect(subject.dos_passport_api_healthy?(analytics:)).to be(false)
+        end
+      end
+    end
+
+    context 'when the endpoint is an empty string' do
+      it 'returns true' do
+        expect(subject.dos_passport_api_healthy?(analytics:, endpoint: '')).to be(true)
+      end
+    end
+  end
+
+  describe '#locals_attrs' do
+    let(:presenter) { double(Idv::ChooseIdTypePresenter) }
+    let(:form_submit_url) { '/verify/choose_id_type' }
+    let(:request) { double(DocAuth::Dos::Requests::HealthCheckRequest) }
+    let(:response) { double(DocAuth::Dos::Responses::HealthCheckResponse) }
+
+    before do
+      allow(IdentityConfig.store).to receive(
+        :dos_passport_composite_healthcheck_endpoint,
+      ).and_return('http://dostest.com/status')
+      allow(DocAuth::Dos::Requests::HealthCheckRequest).to receive(:new).and_return(request)
+      allow(request).to receive(:fetch).with(analytics).and_return(response)
+    end
+
+    context 'when the dos passport api is healthy' do
+      before do
+        allow(response).to receive(:success?).and_return(true)
+        allow(document_capture_session).to receive(:passport_status).and_return('requested')
+      end
+
+      it 'returns expected local attributes' do
+        expect(
+          subject.locals_attrs(analytics:, presenter:, form_submit_url:),
+        ).to include(
+          presenter:,
+          form_submit_url:,
+          dos_passport_api_down: false,
+          auto_check_value: :passport,
+        )
+      end
+    end
+
+    context 'when the dos passport api is not healthy' do
+      before do
+        allow(response).to receive(:success?).and_return(false)
+      end
+
+      it 'returns expected local attributes' do
+        expect(
+          subject.locals_attrs(analytics:, presenter:, form_submit_url:),
+        ).to include(
+          presenter:,
+          form_submit_url:,
+          dos_passport_api_down: true,
+          auto_check_value: :drivers_license,
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/idv/in_person/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/in_person/choose_id_type_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Idv::InPerson::ChooseIdTypeController do
       .to_return({ status: 200, body: { status: 'UP' }.to_json })
     stub_sign_in(user)
     subject.idv_session.document_capture_session_uuid = document_capture_session.uuid
-    stub_up_to(:hybrid_handoff, idv_session: subject.idv_session)
+    stub_up_to(:ipp, idv_session: subject.idv_session)
     allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
     stub_analytics
   end
@@ -106,7 +106,7 @@ RSpec.describe Idv::InPerson::ChooseIdTypeController do
           expect(response).to be_redirect
         end
 
-        it 'does not log the idv_in_person_proofing_choose_id_type event' do
+        it 'does not log the idv_in_person_proofing_choose_id_type_visited event' do
           expect(@analytics).to_not have_logged_event(
             :idv_in_person_proofing_choose_id_type_visited,
           )
@@ -122,7 +122,7 @@ RSpec.describe Idv::InPerson::ChooseIdTypeController do
           expect(response).to be_redirect
         end
 
-        it 'does not log the idv_in_person_proofing_choose_id_type event' do
+        it 'does not log the idv_in_person_proofing_choose_id_type_visited event' do
           expect(@analytics).to_not have_logged_event(
             :idv_in_person_proofing_choose_id_type_visited,
           )
@@ -140,12 +140,135 @@ RSpec.describe Idv::InPerson::ChooseIdTypeController do
       context 'when the user has an existing establishing enrollment' do
         let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user) }
 
-        before do
-          put :update
+        context 'when the form submission is successful' do
+          context 'when the chosen ID type is "passport"' do
+            let(:chosen_id_type) { 'passport' }
+            let(:params) do
+              {
+                doc_auth: {
+                  choose_id_type_preference: chosen_id_type,
+                },
+              }
+            end
+            let(:analytics_arguments) do
+              {
+                flow_path: 'standard',
+                step: 'choose_id_type',
+                analytics_id: 'In Person Proofing',
+                skip_hybrid_handoff: false,
+                opted_in_to_in_person_proofing: true,
+                chosen_id_type: chosen_id_type,
+                success: true,
+              }
+            end
+
+            before do
+              subject.idv_session.opted_in_to_in_person_proofing =
+                analytics_arguments[:opted_in_to_in_person_proofing]
+              subject.idv_session.skip_hybrid_handoff = analytics_arguments[:skip_hybrid_handoff]
+              put :update, params: params
+            end
+
+            it 'logs the idv_in_person_proofing_choose_id_type_submitted event' do
+              expect(@analytics).to have_logged_event(
+                :idv_in_person_proofing_choose_id_type_submitted, analytics_arguments
+              )
+            end
+
+            it 'updates the passport status to "requested" in document capture session' do
+              expect(controller.document_capture_session.passport_status).to eq('requested')
+            end
+
+            it 'redirects to the in person passport page' do
+              expect(response).to redirect_to(idv_in_person_passport_path)
+            end
+          end
+
+          context 'when the chosen ID type is "drivers_license"' do
+            let(:chosen_id_type) { 'drivers_license' }
+            let(:params) do
+              {
+                doc_auth: {
+                  choose_id_type_preference: chosen_id_type,
+                },
+              }
+            end
+            let(:analytics_arguments) do
+              {
+                flow_path: 'standard',
+                step: 'choose_id_type',
+                analytics_id: 'In Person Proofing',
+                skip_hybrid_handoff: false,
+                opted_in_to_in_person_proofing: true,
+                chosen_id_type: chosen_id_type,
+                success: true,
+              }
+            end
+
+            before do
+              subject.idv_session.opted_in_to_in_person_proofing =
+                analytics_arguments[:opted_in_to_in_person_proofing]
+              subject.idv_session.skip_hybrid_handoff = analytics_arguments[:skip_hybrid_handoff]
+              put :update, params: params
+            end
+
+            it 'logs the idv_in_person_proofing_choose_id_type_submitted event' do
+              expect(@analytics).to have_logged_event(
+                :idv_in_person_proofing_choose_id_type_submitted, analytics_arguments
+              )
+            end
+
+            it 'updates the passport status to "not_requested" in document capture session' do
+              expect(controller.document_capture_session.passport_status).to eq('not_requested')
+            end
+
+            it 'redirects to the in person state ID page' do
+              expect(response).to redirect_to(idv_in_person_state_id_path)
+            end
+          end
         end
 
-        it 'returns a no_content response' do
-          expect(response).to be_no_content
+        context 'when the form submission is not successful' do
+          let(:params) do
+            {
+              doc_auth: {
+                choose_id_type_preference: '',
+              },
+            }
+          end
+          let(:analytics_arguments) do
+            {
+              flow_path: 'standard',
+              step: 'choose_id_type',
+              analytics_id: 'In Person Proofing',
+              skip_hybrid_handoff: false,
+              opted_in_to_in_person_proofing: true,
+              chosen_id_type: '',
+              success: false,
+              error_details: { chosen_id_type: { invalid: true } },
+            }
+          end
+
+          before do
+            subject.idv_session.opted_in_to_in_person_proofing =
+              analytics_arguments[:opted_in_to_in_person_proofing]
+            subject.idv_session.skip_hybrid_handoff = analytics_arguments[:skip_hybrid_handoff]
+            put :update, params: params
+          end
+
+          it 'logs the idv_in_person_proofing_choose_id_type_submitted event' do
+            expect(@analytics).to have_logged_event(
+              :idv_in_person_proofing_choose_id_type_submitted, analytics_arguments
+            )
+          end
+
+          it 'does not update the passport status in document_capture_session' do
+            expect(controller.document_capture_session.passport_status).to eq('allowed')
+          end
+
+          it 'redirects to the in in person choose id type page' do
+            expect(response).to redirect_to(idv_in_person_choose_id_type_path)
+          end
         end
       end
 
@@ -192,6 +315,47 @@ RSpec.describe Idv::InPerson::ChooseIdTypeController do
   describe '.step_info' do
     it 'returns a valid StepInfo Object' do
       expect(described_class.step_info).to be_valid
+    end
+
+    context 'undo_step' do
+      before do
+        subject.document_capture_session.update!(passport_status: 'requested')
+      end
+
+      context 'when idv session has a document capture session uuid' do
+        context 'when passports are allowed in idv session' do
+          before do
+            subject.idv_session.passport_allowed = true
+            described_class.step_info.undo_step.call(idv_session: subject.idv_session, user:)
+          end
+
+          it 'sets passport status to "allowed" in the document capture session' do
+            expect(subject.document_capture_session.reload.passport_status).to eq('allowed')
+          end
+        end
+
+        context 'when passports are not allowed in idv session' do
+          before do
+            subject.idv_session.passport_allowed = false
+            described_class.step_info.undo_step.call(idv_session: subject.idv_session, user:)
+          end
+
+          it 'sets passport status to nil in the document capture session' do
+            expect(subject.document_capture_session.reload.passport_status).to eq(nil)
+          end
+        end
+      end
+
+      context 'when idv session does not have a document capture session uuid' do
+        before do
+          subject.idv_session.document_capture_session_uuid = nil
+          described_class.step_info.undo_step.call(idv_session: subject.idv_session, user:)
+        end
+
+        it 'does not update the passport status in the document capture session' do
+          expect(subject.document_capture_session.reload.passport_status).to eq('requested')
+        end
+      end
     end
   end
 end

--- a/spec/features/idv/in_person/passport_scenario_spec.rb
+++ b/spec/features/idv/in_person/passport_scenario_spec.rb
@@ -33,36 +33,85 @@ RSpec.describe 'In Person Proofing Passports', js: true do
         allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(true)
       end
 
-      it 'allows the user to accesss in person passport content' do
-        reload_ab_tests
-        visit_idp_from_sp_with_ial2(service_provider)
-        sign_in_live_with_2fa(user)
+      context 'when the user chooses the state_id path during enrollment creation' do
+        it 'creates a state_id enrollment' do
+          reload_ab_tests
+          visit_idp_from_sp_with_ial2(service_provider)
+          sign_in_live_with_2fa(user)
 
-        expect(page).to have_current_path(idv_welcome_path)
-        expect(page).to have_content t('doc_auth.headings.welcome', sp_name: service_provider_name)
-        expect(page).to have_content t('doc_auth.instructions.bullet1b')
+          expect(page).to have_current_path(idv_welcome_path)
+          expect(page).to have_content t(
+            'doc_auth.headings.welcome',
+            sp_name: service_provider_name,
+          )
+          expect(page).to have_content t('doc_auth.instructions.bullet1b')
 
-        complete_welcome_step
+          complete_welcome_step
 
-        expect(page).to have_current_path(idv_agreement_path)
-        complete_agreement_step
+          expect(page).to have_current_path(idv_agreement_path)
+          complete_agreement_step
 
-        expect(page).to have_current_path(idv_how_to_verify_path)
-        expect(page).to have_content t('doc_auth.info.verify_online_description_passport')
+          expect(page).to have_current_path(idv_how_to_verify_path)
+          expect(page).to have_content t('doc_auth.info.verify_online_description_passport')
 
-        click_on t('forms.buttons.continue_ipp')
+          click_on t('forms.buttons.continue_ipp')
 
-        expect(page).to have_current_path(idv_document_capture_path(step: 'how_to_verify'))
+          expect(page).to have_current_path(idv_document_capture_path(step: 'how_to_verify'))
 
-        click_on t('forms.buttons.continue')
-        complete_location_step(user)
+          click_on t('forms.buttons.continue')
+          complete_location_step(user)
 
-        expect(page).to have_current_path(idv_in_person_choose_id_type_path)
+          expect(page).to have_current_path(idv_in_person_choose_id_type_path)
 
-        expect(page).to have_content t('doc_auth.headings.choose_id_type')
-        expect(page).to have_content t('in_person_proofing.info.choose_id_type')
-        expect(page).to have_content t('doc_auth.forms.id_type_preference.drivers_license')
-        expect(page).to have_content t('doc_auth.forms.id_type_preference.passport')
+          expect(page).to have_content t('doc_auth.headings.choose_id_type')
+          expect(page).to have_content t('in_person_proofing.info.choose_id_type')
+          expect(page).to have_content t('doc_auth.forms.id_type_preference.drivers_license')
+          expect(page).to have_content t('doc_auth.forms.id_type_preference.passport')
+
+          choose t('doc_auth.forms.id_type_preference.drivers_license')
+          click_on t('forms.buttons.continue')
+
+          expect(page).to have_current_path(idv_in_person_state_id_path)
+        end
+      end
+
+      context 'when the user chooses the passport path during enrollment creation' do
+        it 'creates a passport enrollment' do
+          reload_ab_tests
+          visit_idp_from_sp_with_ial2(service_provider)
+          sign_in_live_with_2fa(user)
+
+          expect(page).to have_current_path(idv_welcome_path)
+          expect(page).to have_content t(
+            'doc_auth.headings.welcome',
+            sp_name: service_provider_name,
+          )
+          expect(page).to have_content t('doc_auth.instructions.bullet1b')
+
+          complete_welcome_step
+
+          expect(page).to have_current_path(idv_agreement_path)
+          complete_agreement_step
+
+          expect(page).to have_current_path(idv_how_to_verify_path)
+          expect(page).to have_content t('doc_auth.info.verify_online_description_passport')
+
+          click_on t('forms.buttons.continue_ipp')
+
+          expect(page).to have_current_path(idv_document_capture_path(step: 'how_to_verify'))
+
+          click_on t('forms.buttons.continue')
+          complete_location_step(user)
+
+          expect(page).to have_current_path(idv_in_person_choose_id_type_path)
+
+          expect(page).to have_content t('doc_auth.headings.choose_id_type')
+          expect(page).to have_content t('in_person_proofing.info.choose_id_type')
+          expect(page).to have_content t('doc_auth.forms.id_type_preference.drivers_license')
+          expect(page).to have_content t('doc_auth.forms.id_type_preference.passport')
+
+          choose t('doc_auth.forms.id_type_preference.passport')
+        end
       end
     end
 

--- a/spec/support/flow_policy_helper.rb
+++ b/spec/support/flow_policy_helper.rb
@@ -25,6 +25,10 @@ module FlowPolicyHelper
       idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
     when :document_capture
       idv_session.pii_from_doc = Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
+    when :ipp
+      idv_session.send(:user_session)['idv/in_person'] = {
+        pii_from_user: {},
+      }
     when :ipp_state_id
       idv_session.send(:user_session)['idv/in_person'] = {
         pii_from_user: Idp::Constants::MOCK_IPP_APPLICANT.dup,
@@ -78,6 +82,8 @@ module FlowPolicyHelper
       %i[welcome agreement how_to_verify hybrid_handoff link_sent]
     when :document_capture
       %i[welcome agreement how_to_verify hybrid_handoff document_capture]
+    when :ipp
+      %i[welcome agreement how_to_verify hybrid_handoff ipp]
     when :ipp_state_id
       %i[welcome agreement how_to_verify hybrid_handoff ipp_state_id]
     when :ipp_address


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16050](https://cm-jira.usa.gov/browse/LG-16050)

## 🛠 Summary of changes

Added submit logic to the in-person choose id type controller

## 📜 Testing Plan

Setup: Ensure the following environment variables are set for passport to work in IPP.

```text
  in_person_proofing_enabled: true
  in_person_proofing_opt_in_enabled: true
  in_person_passports_enabled: true
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100
```

**Scenario: User selects passport option on the choose ID type page**
- [ ]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [ ] Create a new account
- [ ] Complete the ID-IPP flow reaching the choose ID type page
- [ ] Choose the **U.S. passport book** option
- [ ] Clicks submit
- [ ] Ensure user is taken to the /verify/in_person/passport url. (Currently a 404)

**Scenario: User selects state-id option on the choose ID type page**
- [ ]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [ ] Create a new account
- [ ] Complete the ID-IPP flow reaching the choose ID type page
- [ ] Choose the **U.S. driver’s license or state ID** option
- [ ] Clicks submit
- [ ] Ensure user is taken to the /verify/in_person/state_id url

**Scenario: User selects no ID type o the choose ID type page**
- [ ]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [ ] Create a new account
- [ ] Complete the ID-IPP flow reaching the choose ID type page
- [ ] Clicks submit
- [ ] The **Select the type of document that you have** error appears on the form 

## 👀 Screenshots

<details>
<summary>Choose ID type page</summary>
<img width="660" alt="Screenshot 2025-04-29 at 11 05 29 AM" src="https://github.com/user-attachments/assets/06263b4b-549a-41a3-a5c4-a2f8863c4467" />
</details>

<details>
<summary>Choose ID type page: State-ID selected</summary>
<img width="660" alt="Screenshot 2025-04-29 at 11 05 58 AM" src="https://github.com/user-attachments/assets/3cf219d6-00f1-4202-8266-a451482f1546" />
</details>

<details>
<summary>Choose ID type page: Passport selected</summary>
<img width="660" alt="Screenshot 2025-04-29 at 2 44 06 PM" src="https://github.com/user-attachments/assets/0ec839e4-1770-4e0c-b5bd-9f9c94ddbcbe" />
</details>

<details>
<summary>Choose ID type page: Error (No Selection)</summary>
<img width="660" alt="Screenshot 2025-04-29 at 11 05 49 AM" src="https://github.com/user-attachments/assets/6baa74f3-2039-42ac-8c81-2c18381d10f8" />
</details>

