### PR TITLE
Account recovery events

### DIFF
--- a/app/controllers/account_reset/delete_account_controller.rb
+++ b/app/controllers/account_reset/delete_account_controller.rb
@@ -31,7 +31,12 @@ module AccountReset
     def delete
       granted_token = session.delete(:granted_token)
       result = AccountReset::DeleteAccount.new(granted_token, request, analytics).call
+
       analytics.account_reset_delete(**result.to_h.except(:email))
+      attempts_api_tracker.account_reset_account_deleted(
+        success: result.success?,
+        failure_reason: attempts_api_tracker.parse_failure_reason(result),
+      )
 
       if result.success?
         handle_successful_deletion(result)

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -31,6 +31,11 @@ module Users
         result = PasswordResetTokenValidator.new(token_user).submit
 
         analytics.password_reset_token(**result)
+        attempts_api_tracker.forgot_password_email_confirmed(
+          success: result.success?,
+          failure_reason: attempts_api_tracker.parse_failure_reason(result),
+        )
+
         if result.success?
           @reset_password_form = ResetPasswordForm.new(user: build_user)
           @forbidden_passwords = forbidden_passwords(token_user.email_addresses)
@@ -47,6 +52,10 @@ module Users
       result = @reset_password_form.submit(user_params)
 
       analytics.password_reset_password(**result)
+      attempts_api_tracker.forgot_password_new_password_submitted(
+        success: result.success?,
+        failure_reason: attempts_api_tracker.parse_failure_reason(result),
+      )
 
       if result.success?
         session.delete(:reset_password_token)

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -54,6 +54,28 @@ module AttemptsApi
       )
     end
 
+    # @param [Boolean] success True if the link user clicked on is valid and not expired
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # A user clicks the email link to reset their password
+    def forgot_password_email_confirmed(success:, failure_reason: nil)
+      track_event(
+        'forgot-password-email-confirmed',
+        success:,
+        failure_reason:,
+      )
+    end
+
+    # @param [Boolean] success True if new password was successfully submitted
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # A user submits a new password have requesting a password reset
+    def forgot_password_new_password_submitted(success:, failure_reason: nil)
+      track_event(
+        'forgot-password-new-password-submitted',
+        success:,
+        failure_reason:,
+      )
+    end
+
     # A user becomes able to visit the post office for in-person proofing
     def idv_ipp_ready_to_verify_visit
       track_event('idv-ipp-ready-to-verify-visit')
@@ -65,17 +87,6 @@ module AttemptsApi
     def idv_verify_by_mail_enter_code_submitted(success:, failure_reason: nil)
       track_event(
         'idv-verify-by-mail-enter-code-submitted',
-        success:,
-        failure_reason:,
-      )
-    end
-
-    # @param [Boolean] success True if the link user clicked on is valid and not expired
-    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
-    # A user clicks the email link to reset their password
-    def forgot_password_email_confirmed(success:, failure_reason: nil)
-      track_event(
-        'forgot-password-email-confirmed',
         success:,
         failure_reason:,
       )
@@ -105,17 +116,6 @@ module AttemptsApi
       track_event(
         'idv-rate-limited',
         limiter_type:,
-      )
-    end
-
-    # @param [Boolean] success True if new password was successfully submitted
-    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
-    # A user submits a new password have requesting a password reset
-    def forgot_password_new_password_submitted(success:, failure_reason: nil)
-      track_event(
-        'forgot-password-new-password-submitted',
-        success:,
-        failure_reason:,
       )
     end
 
@@ -162,17 +162,6 @@ module AttemptsApi
       )
     end
 
-    # Tracks when user submits registration password
-    # @param [String<'backup_code', 'otp', 'piv_cac', 'totp'>] mfa_device_type
-    # The user has exceeded the rate limit during enrollment
-    # and account has been locked
-    def mfa_enroll_code_rate_limited(mfa_device_type:)
-      track_event(
-        'mfa-enroll-code-rate-limited',
-        mfa_device_type:,
-      )
-    end
-
     # @param [Boolean] success
     # A user has attempted to enroll the TOTP MFA method to their account
     def mfa_enroll_totp(success:)
@@ -182,21 +171,14 @@ module AttemptsApi
       )
     end
 
-    # @param [Boolean] success
-    # Tracks when the user has attempted to enroll the WebAuthn-Platform MFA method to their account
-    def mfa_enroll_webauthn_platform(success:)
+    # Tracks when user submits registration password
+    # @param [String<'backup_code', 'otp', 'piv_cac', 'totp'>] mfa_device_type
+    # The user has exceeded the rate limit during enrollment
+    # and account has been locked
+    def mfa_enroll_code_rate_limited(mfa_device_type:)
       track_event(
-        'mfa-enroll-webauthn-platform',
-        success:,
-      )
-    end
-
-    # @param [Boolean] success
-    # Tracks when the user has attempted to enroll the WebAuthn MFA method to their account
-    def mfa_enroll_webauthn_roaming(success:)
-      track_event(
-        'mfa-enroll-webauthn-roaming',
-        success:,
+        'mfa-enroll-code-rate-limited',
+        mfa_device_type:,
       )
     end
 

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -2,8 +2,8 @@
 
 module AttemptsApi
   module TrackerEvents
-    # param [Boolean] success True if account successfully deleted
-    # param [Hash<Key, Array<String>>] failure_reason displays why account deletion failed
+    # @param [Boolean] success True if account successfully deleted
+    # @param [Hash<Key, Array<String>>] failure_reason displays why account deletion failed
     # Account was successfully deleted after the account reset request was completed
     def account_reset_account_deleted(success:, failure_reason: nil)
       track_event(

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -2,6 +2,17 @@
 
 module AttemptsApi
   module TrackerEvents
+    # param [Boolean] success True if account successfully deleted
+    # param [Hash<Key, Array<String>>] failure_reason displays why account deletion failed
+    # Account was successfully deleted after the account reset request was completed
+    def account_reset_account_deleted(success:, failure_reason: nil)
+      track_event(
+        'account-reset-account-deleted',
+        success:,
+        failure_reason:,
+      )
+    end
+
     # @param [Boolean] success True if the email and password matched
     # A user has submitted an email address and password for authentication
     def email_and_password_auth(success:)
@@ -59,6 +70,17 @@ module AttemptsApi
       )
     end
 
+    # @param [Boolean] success True if the link user clicked on is valid and not expired
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # A user clicks the email link to reset their password
+    def forgot_password_email_confirmed(success:, failure_reason: nil)
+      track_event(
+        'forgot-password-email-confirmed',
+        success:,
+        failure_reason:,
+      )
+    end
+
     # @param [Boolean] resend False indicates this is the initial request
     # User has requested the Address validation letter
     def idv_verify_by_mail_letter_requested(resend:)
@@ -83,6 +105,17 @@ module AttemptsApi
       track_event(
         'idv-rate-limited',
         limiter_type:,
+      )
+    end
+
+    # @param [Boolean] success True if new password was successfully submitted
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # A user submits a new password have requesting a password reset
+    def forgot_password_new_password_submitted(success:, failure_reason: nil)
+      track_event(
+        'forgot-password-new-password-submitted',
+        success:,
+        failure_reason:,
       )
     end
 

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -162,6 +162,17 @@ module AttemptsApi
       )
     end
 
+    # Tracks when user submits registration password
+    # @param [String<'backup_code', 'otp', 'piv_cac', 'totp'>] mfa_device_type
+    # The user has exceeded the rate limit during enrollment
+    # and account has been locked
+    def mfa_enroll_code_rate_limited(mfa_device_type:)
+      track_event(
+        'mfa-enroll-code-rate-limited',
+        mfa_device_type:,
+      )
+    end
+
     # @param [Boolean] success
     # A user has attempted to enroll the TOTP MFA method to their account
     def mfa_enroll_totp(success:)
@@ -171,14 +182,21 @@ module AttemptsApi
       )
     end
 
-    # Tracks when user submits registration password
-    # @param [String<'backup_code', 'otp', 'piv_cac', 'totp'>] mfa_device_type
-    # The user has exceeded the rate limit during enrollment
-    # and account has been locked
-    def mfa_enroll_code_rate_limited(mfa_device_type:)
+    # @param [Boolean] success
+    # Tracks when the user has attempted to enroll the WebAuthn-Platform MFA method to their account
+    def mfa_enroll_webauthn_platform(success:)
       track_event(
-        'mfa-enroll-code-rate-limited',
-        mfa_device_type:,
+        'mfa-enroll-webauthn-platform',
+        success:,
+      )
+    end
+
+    # @param [Boolean] success
+    # Tracks when the user has attempted to enroll the WebAuthn MFA method to their account
+    def mfa_enroll_webauthn_roaming(success:)
+      track_event(
+        'mfa-enroll-webauthn-roaming',
+        success:,
       )
     end
 

--- a/spec/controllers/users/reset_passwords_controller_spec.rb
+++ b/spec/controllers/users/reset_passwords_controller_spec.rb
@@ -5,14 +5,17 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
     t('errors.attributes.password.too_short.other', count: Devise.password_length.first)
   end
   let(:success_properties) { { success: true } }
+
   describe '#edit' do
     let(:user) { instance_double('User', uuid: '123') }
     let(:email_address) { instance_double('EmailAddress') }
+
     before do
       stub_analytics
+      stub_attempts_tracker
     end
 
-    context 'when token isnt stored in session' do
+    context 'when token is passed via the params' do
       it 'redirects to the clean edit password url with token stored in session' do
         get :edit, params: { reset_password_token: 'foo' }
         expect(response).to redirect_to(edit_user_password_url)
@@ -27,6 +30,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
       end
 
       it 'redirects to page where user enters email for password reset token' do
+        expect(@attempts_api_tracker).to receive(:forgot_password_email_confirmed).with(
+          success: false,
+          failure_reason: { user: [:blank] },
+        )
+
         get :edit
 
         expect(@analytics).to have_logged_event(
@@ -58,6 +66,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         end
 
         it 'redirects to page where user enters email for password reset token' do
+          expect(@attempts_api_tracker).to receive(:forgot_password_email_confirmed).with(
+            success: false,
+            failure_reason: { user: [:blank] },
+          )
+
           get :edit
 
           expect(@analytics).to have_logged_event(
@@ -79,6 +92,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         end
 
         it 'redirects to page where user enters email for password reset token' do
+          expect(@attempts_api_tracker).to receive(:forgot_password_email_confirmed).with(
+            success: false,
+            failure_reason: { user: [:token_expired] },
+          )
+
           get :edit
 
           expect(@analytics).to have_logged_event(
@@ -110,6 +128,10 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           forbidden = instance_double(ForbiddenPasswords)
           allow(ForbiddenPasswords).to receive(:new).with(email_address.email).and_return(forbidden)
           expect(forbidden).to receive(:call)
+          expect(@attempts_api_tracker).to receive(:forgot_password_email_confirmed).with(
+            success: true,
+            failure_reason: nil,
+          )
 
           get :edit
 
@@ -133,6 +155,10 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         allow(ForbiddenPasswords).to receive(:new)
           .with(email_address.email).and_return(forbidden)
         expect(forbidden).to receive(:call)
+        expect(@attempts_api_tracker).to receive(:forgot_password_email_confirmed).with(
+          success: true,
+          failure_reason: nil,
+        )
 
         get :edit
         expect(response).to render_template :edit
@@ -142,10 +168,12 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
   end
 
   describe '#update' do
+    before do
+      stub_analytics
+      stub_attempts_tracker
+    end
     context 'user submits new password after token expires' do
       it 'redirects to page where user enters email for password reset token' do
-        stub_analytics
-
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
         user = create(
@@ -160,6 +188,15 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           password_confirmation: 'short',
           reset_password_token: raw_reset_token,
         }
+
+        expect(@attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
+          success: false,
+          failure_reason: {
+            password: [:too_short],
+            password_confirmation: [:too_short],
+            reset_password_token: [:token_expired],
+          },
+        )
 
         get :edit, params: { reset_password_token: raw_reset_token }
         put :update, params: { reset_password_form: params }
@@ -187,8 +224,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
       let(:password_confirmation) { 'short' }
 
       it 'renders edit' do
-        stub_analytics
-
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
         user = create(
@@ -202,6 +237,14 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           password_confirmation: password_confirmation,
           reset_password_token: raw_reset_token,
         }
+
+        expect(@attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
+          success: false,
+          failure_reason: {
+            password: [:too_short],
+            password_confirmation: [:too_short],
+          },
+        )
 
         put :update, params: { reset_password_form: form_params }
 
@@ -227,8 +270,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
       let(:password_confirmation) { 'salty pickles2' }
 
       it 'renders edit' do
-        stub_analytics
-
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
         user = create(
@@ -242,6 +283,13 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           password_confirmation: password_confirmation,
           reset_password_token: raw_reset_token,
         }
+
+        expect(@attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
+          success: false,
+          failure_reason: {
+            password_confirmation: [:mismatch],
+          },
+        )
 
         put :update, params: { reset_password_form: form_params }
 
@@ -279,7 +327,17 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           reset_password_token: raw_reset_token,
         }
 
+        expect(@attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
+          success: true,
+          failure_reason: nil,
+        )
+
         put :update, params: { reset_password_form: form_params }
+
+        expect(@attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
+          success: false,
+          failure_reason: { reset_password_token: [:invalid_token] },
+        )
         put :update, params: { reset_password_form: form_params }
 
         expect(response).to redirect_to new_user_password_path
@@ -291,8 +349,6 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
       let(:password) { 'a really long passw0rd' }
 
       it 'redirects to sign in page' do
-        stub_analytics
-
         raw_reset_token, db_confirmation_token =
           Devise.token_generator.generate(User, :reset_password_token)
 
@@ -318,6 +374,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           }
 
           get :edit, params: { reset_password_token: raw_reset_token }
+
+          expect(@attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
+            success: true,
+            failure_reason: nil,
+          )
           put :update, params: { reset_password_form: params }
 
           expect(@analytics).to have_logged_event(
@@ -364,6 +425,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
           reset_password_token: raw_reset_token,
         }
 
+        expect(@attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
+          success: true,
+          failure_reason: nil,
+        )
+
         put :update, params: { reset_password_form: params }
 
         expect(@analytics).to have_logged_event(
@@ -407,6 +473,11 @@ RSpec.describe Users::ResetPasswordsController, devise: true do
         }
 
         get :edit, params: { reset_password_token: raw_reset_token }
+
+        expect(@attempts_api_tracker).to receive(:forgot_password_new_password_submitted).with(
+          success: true,
+          failure_reason: nil,
+        )
         put :update, params: { reset_password_form: params }
 
         expect(@analytics).to have_logged_event(


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[161](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/161)

## 🛠 Summary of changes
Somehow these changes got lost in the shuffle! I implemented them a couple weeks ago but forgot to put them up for review because I'm doing too much at once.

This change:
- adds `account-reset-account-deleted`
- adds `forgot-password-email-confirmed`
- adds `forgot-password-new-password-submitted`
- adds tests

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
