### PR TITLE
Update net-imap gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,7 +438,7 @@ GEM
       uri
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.5.6)
+    net-imap (0.5.8)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
## 🛠 Summary of changes

To address the vulnerability [here](https://github.com/advisories/GHSA-j3g3-5qv5-52mj), this PR updates our version of `net-imap`. We don't use the IMAP functionality, so our exposure to the vulnerability is limited.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
