### PR TITLE
LG-15936: Bug: captcha_validation_performed is false even though reCAPTCHA was performed

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -227,6 +227,7 @@ module Users
         user_locked_out: user_locked_out?(user),
         rate_limited: rate_limited?,
         captcha_validation_performed: captcha_validation_performed?,
+        device: recaptcha_form.device,
         valid_captcha_result: recaptcha_response.success?,
         sign_in_failure_count: session[:sign_in_failure_count].to_i,
         sp_request_url_present: sp_session[:request_url].present?,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -534,6 +534,7 @@ module AnalyticsEvents
     rate_limited:,
     valid_captcha_result:,
     captcha_validation_performed:,
+    device:,
     sign_in_failure_count:,
     sp_request_url_present:,
     remember_device:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -522,6 +522,7 @@ module AnalyticsEvents
   # @param [Boolean] rate_limited Whether the user has exceeded user IP rate limiting
   # @param [Boolean] valid_captcha_result Whether user passed the reCAPTCHA check or was exempt
   # @param [Boolean] captcha_validation_performed Whether a reCAPTCHA check was performed
+  # @param [String] device Information about device used to sign in
   # @param [String] sign_in_failure_count represents number of prior login failures
   # @param [Boolean] sp_request_url_present if was an SP request URL in the session
   # @param [Boolean] remember_device if the remember device cookie was present
@@ -550,6 +551,7 @@ module AnalyticsEvents
       rate_limited:,
       valid_captcha_result:,
       captcha_validation_performed:,
+      device:,
       sign_in_failure_count:,
       sp_request_url_present:,
       remember_device:,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15936](https://cm-jira.usa.gov/browse/LG-15936)

## 🛠 Summary of changes

This ticket adds logging about the device to `email_and_password_auth` event in the attempt to further investigate why this bug is happening.

While analyzing the CloudWatch logs, there previous `reCAPTCHA verify result received`, I noticed that the `evaluated_as_valid` value returns true as well as the `success` event property. While showing that the evaluation   is successful, the `reasons` property shows "INVALID_REASON_UNSPECIFIED." This might correlate with the `captcha_validation_performed` in the following event. 

So to look at what else can be happening, I dug into the `exempt?` method in the `sign_in_recaptcha` form. In that method, it evaluates to true if:

- reCAPTCHA score threshold is zero
- The user is in the correct A/B test bucket. Users captured in the CW query are already in the bucket
- Whether or not the device is present

The focus is to add the `device` as an event property to see if there is any correlation between the device and recording whether or not `captcha_validation_performed` is returning what is expected.

