### PR TITLE
IdV enrollment complete event

### DIFF
--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -29,6 +29,7 @@ module Idv
 
         prefilled_code = session[:last_gpo_confirmation_code] if FeatureManagement.reveal_gpo_code?
         @gpo_verify_form = GpoVerifyForm.new(
+          attempts_api_tracker:,
           user: current_user,
           pii: pii,
           resolved_authn_context_result: resolved_authn_context_result,
@@ -142,6 +143,7 @@ module Idv
 
       def build_gpo_verify_form
         GpoVerifyForm.new(
+          attempts_api_tracker:,
           user: current_user,
           pii: pii,
           resolved_authn_context_result: resolved_authn_context_result,

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -127,6 +127,7 @@ module Idv
     end
 
     def init_profile
+      reproof = current_user.has_proofed_before?
       profile = idv_session.create_profile_from_applicant_with_password(
         password,
         is_enhanced_ipp: resolved_authn_context_result.enhanced_ipp?,
@@ -143,7 +144,7 @@ module Idv
       end
 
       if profile.active?
-        attempts_api_tracker.idv_enrollment_complete
+        attempts_api_tracker.idv_enrollment_complete(reproof:)
         create_user_event(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           profile: idv_session.profile,

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -143,6 +143,7 @@ module Idv
       end
 
       if profile.active?
+        attempts_api_tracker.idv_enrollment_complete
         create_user_event(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           profile: idv_session.profile,

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -144,11 +144,11 @@ module Idv
       end
 
       if profile.active?
-        attempts_api_tracker.idv_enrollment_complete(reproof:)
         create_user_event(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           profile: idv_session.profile,
         )
+        attempts_api_tracker.idv_enrollment_complete(reproof:)
       end
     end
 

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -9,9 +9,10 @@ class GpoVerifyForm
   validate :validate_pending_profile
 
   attr_accessor :otp, :pii, :pii_attributes
-  attr_reader :user, :resolved_authn_context_result
+  attr_reader :attempts_api_tracker, :user, :resolved_authn_context_result
 
-  def initialize(user:, pii:, resolved_authn_context_result:, otp: nil)
+  def initialize(attempts_api_tracker:, user:, pii:, resolved_authn_context_result:, otp: nil)
+    @attempts_api_tracker = attempts_api_tracker
     @user = user
     @pii = pii
     @resolved_authn_context_result = resolved_authn_context_result
@@ -35,6 +36,7 @@ class GpoVerifyForm
     else
       reset_sensitive_fields
     end
+    attempts_api_tracker.idv_enrollment_complete if pending_profile&.active?
     FormResponse.new(
       success: result,
       errors: errors,

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -22,6 +22,7 @@ class GpoVerifyForm
   def submit
     result = valid?
     fraud_check_failed = pending_profile&.fraud_pending_reason.present?
+    reproof = user.has_proofed_before?
 
     if result
       pending_profile&.remove_gpo_deactivation_reason
@@ -36,7 +37,11 @@ class GpoVerifyForm
     else
       reset_sensitive_fields
     end
-    attempts_api_tracker.idv_enrollment_complete if pending_profile&.active?
+
+    if pending_profile&.active?
+      attempts_api_tracker.idv_enrollment_complete(reproof:)
+    end
+
     FormResponse.new(
       success: result,
       errors: errors,

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -491,6 +491,7 @@ class GetUspsProofingResultsJob < ApplicationJob
 
     unless fraud_result_pending?(enrollment)
       enrollment.profile&.activate_after_passing_in_person
+      attempts_api_tracker(enrollment:).idv_enrollment_complete if enrollment.profile.active?
 
       # send SMS and email
       send_enrollment_status_sms_notification(enrollment: enrollment)
@@ -501,6 +502,18 @@ class GetUspsProofingResultsJob < ApplicationJob
         job_name: self.class.name,
       )
     end
+  end
+
+  def attempts_api_tracker(enrollment:)
+    AttemptsApi::Tracker.new(
+      enabled_for_session: enrollment.service_provider&.attempts_api_enabled?,
+      session_id: nil,
+      request: nil,
+      user: enrollment.user,
+      sp: enrollment.service_provider,
+      cookie_device_uuid: nil,
+      sp_request_uri: nil,
+    )
   end
 
   def handle_passed_with_fraud_review_pending(enrollment, response)

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -490,8 +490,12 @@ class GetUspsProofingResultsJob < ApplicationJob
     )
 
     unless fraud_result_pending?(enrollment)
+      reproof = enrollment.user&.has_proofed_before?
       enrollment.profile&.activate_after_passing_in_person
-      attempts_api_tracker(enrollment:).idv_enrollment_complete if enrollment.profile.active?
+
+      if enrollment.profile&.active?
+        attempts_api_tracker(enrollment:).idv_enrollment_complete(reproof:)
+      end
 
       # send SMS and email
       send_enrollment_status_sms_notification(enrollment: enrollment)

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -76,6 +76,11 @@ module AttemptsApi
       )
     end
 
+    # A userhas completed the identity verification process and has an active profile
+    def idv_enrollment_complete
+      track_event('idv-enrollment-complete')
+    end
+
     # A user becomes able to visit the post office for in-person proofing
     def idv_ipp_ready_to_verify_visit
       track_event('idv-ipp-ready-to-verify-visit')

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -77,7 +77,7 @@ module AttemptsApi
     end
 
     # @param [Boolean] reproof True indicates that the user has proofed previously
-    # A userhas completed the identity verification process and has an active profile
+    # A user has completed the identity verification process and has an active profile
     def idv_enrollment_complete(reproof:)
       track_event(
         'idv-enrollment-complete',

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -76,9 +76,13 @@ module AttemptsApi
       )
     end
 
+    # @param [Boolean] success True indicates that the user has proofed previously
     # A userhas completed the identity verification process and has an active profile
-    def idv_enrollment_complete
-      track_event('idv-enrollment-complete')
+    def idv_enrollment_complete(reproof:)
+      track_event(
+        'idv-enrollment-complete',
+        reproof:,
+      )
     end
 
     # A user becomes able to visit the post office for in-person proofing

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -76,7 +76,7 @@ module AttemptsApi
       )
     end
 
-    # @param [Boolean] success True indicates that the user has proofed previously
+    # @param [Boolean] reproof True indicates that the user has proofed previously
     # A userhas completed the identity verification process and has an active profile
     def idv_enrollment_complete(reproof:)
       track_event(

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvEnrollmentComplete.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvEnrollmentComplete.yml
@@ -3,3 +3,8 @@ description: |
 allOf:
   - $ref: '../shared/EventProperties.yml'
   - type: object
+    properties:
+      reproof:
+        type: boolean
+        description: |
+          When true, indicates that the user has proofed previously

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -275,6 +275,7 @@ class ActionAccount
         profile = nil
         profile_fraud_review_pending_at = nil
         success = false
+        reproof = user.has_proofed_before?
 
         log_texts = []
         if !user.fraud_review_pending?
@@ -287,7 +288,7 @@ class ActionAccount
           success = true
 
           if profile.active?
-            attempts_api_tracker(profile:).idv_enrollment_complete
+            attempts_api_tracker(profile:).idv_enrollment_complete(reproof:)
             UserEventCreator.new(current_user: user)
               .create_out_of_band_user_event(:account_verified)
             UserAlerts::AlertUserAboutAccountVerified.call(profile: profile)

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -287,6 +287,7 @@ class ActionAccount
           success = true
 
           if profile.active?
+            attempts_api_tracker(profile:).idv_enrollment_complete
             UserEventCreator.new(current_user: user)
               .create_out_of_band_user_event(:account_verified)
             UserAlerts::AlertUserAboutAccountVerified.call(profile: profile)
@@ -354,6 +355,18 @@ class ActionAccount
         uuids: users.map(&:uuid),
         messages:,
         table:,
+      )
+    end
+
+    def attempts_api_tracker(profile:)
+      AttemptsApi::Tracker.new(
+        enabled_for_session: profile.initiating_service_provider&.attempts_api_enabled?,
+        session_id: nil,
+        request: nil,
+        user: profile.user,
+        sp: profile.initiating_service_provider,
+        cookie_device_uuid: nil,
+        sp_request_uri: nil,
       )
     end
   end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -399,6 +399,13 @@ RSpec.describe Idv::EnterPasswordController do
         )
       end
 
+      it 'tracks the idv_enrollment_complete event' do
+        stub_attempts_tracker
+        expect(@attempts_api_tracker).to receive(:idv_enrollment_complete)
+
+        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+      end
+
       it 'creates an `account_verified` event once per confirmation' do
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
         events_count = user.events.where(event_type: :account_verified, ip: '0.0.0.0')

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -281,6 +281,13 @@ RSpec.describe Idv::EnterPasswordController do
           in_person_verification_pending: false,
         )
       end
+
+      it 'does not track the idv_enrollment_complete event' do
+        stub_attempts_tracker
+        expect(@attempts_api_tracker).not_to receive(:idv_enrollment_complete).with(reproof: false)
+
+        put :create, params: { user: { password: 'wrong' } }
+      end
     end
 
     it 'redirects to personal key path', :freeze_time do

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe Idv::EnterPasswordController do
 
       it 'tracks the idv_enrollment_complete event' do
         stub_attempts_tracker
-        expect(@attempts_api_tracker).to receive(:idv_enrollment_complete)
+        expect(@attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: false)
 
         put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
       end
@@ -1070,6 +1070,7 @@ RSpec.describe Idv::EnterPasswordController do
 
       context 'with a non-proofed user' do
         it 'does not track a reproofing event during initial proofing' do
+          # TODO: Attempts API Move the idv_reproo event to the initation of the proofing process
           expect(@attempts_api_tracker).not_to receive(:idv_reproof)
 
           put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
@@ -1101,6 +1102,11 @@ RSpec.describe Idv::EnterPasswordController do
 
             it 'tracks a reproofing event upon reproofing' do
               expect(@attempts_api_tracker).to receive(:idv_reproof)
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+            end
+
+            it 'tracks a reproofing event upon reproofing' do
+              expect(@attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: true)
               put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
             end
           end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -3,13 +3,15 @@ require 'rails_helper'
 RSpec.describe GpoVerifyForm do
   subject(:form) do
     GpoVerifyForm.new(
-      user: user,
+      attempts_api_tracker:,
+      user:,
       pii: applicant,
       resolved_authn_context_result: Vot::Parser::Result.no_sp_result,
       otp: entered_otp,
     )
   end
 
+  let(:attempts_api_tracker) { AttemptsApiTrackingHelper::FakeAttemptsTracker.new }
   let(:user) { create(:user, :fully_registered) }
   let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
   let(:entered_otp) { otp }
@@ -151,6 +153,11 @@ RSpec.describe GpoVerifyForm do
           expect(result.extra).to include(fraud_check_failed: true)
         end
 
+        it 'does not track an enrollment event' do
+          expect(attempts_api_tracker).not_to receive(:idv_enrollment_complete)
+          subject.submit
+        end
+
         context 'threatmetrix is not required for verification' do
           before do
             allow(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(:disabled)
@@ -171,6 +178,11 @@ RSpec.describe GpoVerifyForm do
           it 'notes that threatmetrix failed' do
             result = subject.submit
             expect(result.extra).to include(fraud_check_failed: true)
+          end
+
+          it 'tracks an enrollment event' do
+            expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
+            subject.submit
           end
         end
       end
@@ -216,6 +228,11 @@ RSpec.describe GpoVerifyForm do
           expect(result.to_h[:which_letter]).to eq(1)
           expect(result.to_h[:letter_count]).to eq(3)
         end
+
+        it 'tracks an enrollment event' do
+          expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
+          subject.submit
+        end
       end
 
       context 'entered second code' do
@@ -227,6 +244,11 @@ RSpec.describe GpoVerifyForm do
           expect(result.to_h[:which_letter]).to eq(2)
           expect(result.to_h[:letter_count]).to eq(3)
         end
+
+        it 'tracks an enrollment event' do
+          expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
+          subject.submit
+        end
       end
 
       context 'entered third code' do
@@ -237,6 +259,11 @@ RSpec.describe GpoVerifyForm do
 
           expect(result.to_h[:which_letter]).to eq(3)
           expect(result.to_h[:letter_count]).to eq(3)
+        end
+
+        it 'tracks an enrollment event' do
+          expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
+          subject.submit
         end
       end
     end

--- a/spec/forms/gpo_verify_form_spec.rb
+++ b/spec/forms/gpo_verify_form_spec.rb
@@ -181,8 +181,17 @@ RSpec.describe GpoVerifyForm do
           end
 
           it 'tracks an enrollment event' do
-            expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
+            expect(attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: false)
             subject.submit
+          end
+
+          context 'the user has proofed before' do
+            before { create(:profile, :deactivated, user:) }
+
+            it 'tracks an enrollment event with reproof set to true' do
+              expect(attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: true)
+              subject.submit
+            end
           end
         end
       end
@@ -230,7 +239,7 @@ RSpec.describe GpoVerifyForm do
         end
 
         it 'tracks an enrollment event' do
-          expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
+          expect(attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: false)
           subject.submit
         end
       end
@@ -246,7 +255,7 @@ RSpec.describe GpoVerifyForm do
         end
 
         it 'tracks an enrollment event' do
-          expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
+          expect(attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: false)
           subject.submit
         end
       end
@@ -262,7 +271,7 @@ RSpec.describe GpoVerifyForm do
         end
 
         it 'tracks an enrollment event' do
-          expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
+          expect(attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: false)
           subject.submit
         end
       end

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -5,9 +5,8 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
 
   let(:current_time) { Time.zone.now }
   let(:in_person_results_delay_in_hours) { 2 }
-  let(:analytics) do
-    instance_double(Analytics)
-  end
+  let(:analytics) { FakeAnalytics.new }
+  let(:attempts_api_tracker) { AttemptsApiTrackingHelper::FakeAttemptsTracker.new }
   let(:default_job_completion_analytics) do
     {
       enrollments_checked: 0,
@@ -32,6 +31,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
     allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_started)
     allow(analytics).to receive(:idv_in_person_usps_proofing_results_job_completed)
     allow(Analytics).to receive(:new).and_return(analytics)
+    allow(AttemptsApi::Tracker).to receive(:new).and_return(attempts_api_tracker)
     allow(IdentityConfig.store).to receive(:usps_mock_fallback).and_return(false)
     allow(IdentityConfig.store).to receive(:in_person_results_delay_in_hours).and_return(
       in_person_results_delay_in_hours,
@@ -2001,6 +2001,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                         :idv_in_person_usps_proofing_results_job_email_initiated,
                       )
                       allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
+                      allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
                       subject.perform(current_time)
                     end
 
@@ -2045,6 +2046,10 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                         deactivation_reason: nil,
                         in_person_verification_pending_at: nil,
                       )
+                    end
+
+                    it 'tracks the successful enrollment in the attempts api' do
+                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete)
                     end
 
                     it 'sends a proofing sms notification' do
@@ -2222,6 +2227,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                         :idv_in_person_usps_proofing_results_job_email_initiated,
                       )
                       allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
+                      allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
                       subject.perform(current_time)
                     end
 
@@ -2266,6 +2272,10 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                         deactivation_reason: nil,
                         in_person_verification_pending_at: nil,
                       )
+                    end
+
+                    it 'tracks the successful enrollment in the attempts api' do
+                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete)
                     end
 
                     it 'sends a proofing sms notification' do
@@ -2321,6 +2331,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                         :idv_in_person_usps_proofing_results_job_email_initiated,
                       )
                       allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
+                      allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
                       subject.perform(current_time)
                     end
 
@@ -2365,6 +2376,10 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                         deactivation_reason: nil,
                         in_person_verification_pending_at: nil,
                       )
+                    end
+
+                    it 'tracks the successful enrollment in the attempts api' do
+                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete)
                     end
 
                     it 'sends a proofing sms notification' do
@@ -2421,6 +2436,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                         :idv_in_person_usps_proofing_results_job_email_initiated,
                       )
                       allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
+                      allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
                       subject.perform(current_time)
                     end
 
@@ -2465,6 +2481,10 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                         deactivation_reason: nil,
                         in_person_verification_pending_at: nil,
                       )
+                    end
+
+                    it 'tracks the successful enrollment in the attempts api' do
+                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete)
                     end
 
                     it 'sends a proofing sms notification' do

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -2049,7 +2049,9 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                     end
 
                     it 'tracks the successful enrollment in the attempts api' do
-                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete)
+                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete).with(
+                        reproof: false,
+                      )
                     end
 
                     it 'sends a proofing sms notification' do
@@ -2275,7 +2277,9 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                     end
 
                     it 'tracks the successful enrollment in the attempts api' do
-                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete)
+                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete).with(
+                        reproof: false,
+                      )
                     end
 
                     it 'sends a proofing sms notification' do
@@ -2379,7 +2383,9 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                     end
 
                     it 'tracks the successful enrollment in the attempts api' do
-                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete)
+                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete).with(
+                        reproof: false,
+                      )
                     end
 
                     it 'sends a proofing sms notification' do
@@ -2484,7 +2490,9 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                     end
 
                     it 'tracks the successful enrollment in the attempts api' do
-                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete)
+                      expect(attempts_api_tracker).to have_received(:idv_enrollment_complete).with(
+                        reproof: false,
+                      )
                     end
 
                     it 'sends a proofing sms notification' do

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -237,9 +237,11 @@ RSpec.describe ActionAccount do
       let(:user_without_profile) { create(:user) }
 
       let(:analytics) { FakeAnalytics.new }
+      let(:attempts_api_tracker) { AttemptsApiTrackingHelper::FakeAttemptsTracker.new }
 
       before do
         allow(Analytics).to receive(:new).and_return(analytics)
+        allow(AttemptsApi::Tracker).to receive(:new).and_return(attempts_api_tracker)
       end
 
       let(:args) { [user.uuid, user_without_profile.uuid, 'uuid-does-not-exist'] }
@@ -251,6 +253,7 @@ RSpec.describe ActionAccount do
         expect(UserAlerts::AlertUserAboutAccountVerified).to receive(:call).with(
           profile: user.pending_profile,
         )
+        expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
 
         profile_fraud_review_pending_at = user.pending_profile.fraud_review_pending_at
 

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe ActionAccount do
         expect(UserAlerts::AlertUserAboutAccountVerified).to receive(:call).with(
           profile: user.pending_profile,
         )
-        expect(attempts_api_tracker).to receive(:idv_enrollment_complete)
+        expect(attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: false)
 
         profile_fraud_review_pending_at = user.pending_profile.fraud_review_pending_at
 
@@ -287,6 +287,15 @@ RSpec.describe ActionAccount do
           success: false,
           errors: { message: 'Error: Could not find user with that UUID' },
         )
+      end
+
+      context 'when a user has proofed before' do
+        before { create(:profile, :deactivated, user:) }
+
+        it 'creates idv_enrollment_completed_event with reproof set to true' do
+          expect(attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: true)
+          result
+        end
       end
 
       context 'when the user has a pending review from an IPP enrollment' do

--- a/spec/services/gpo_reminder_sender_spec.rb
+++ b/spec/services/gpo_reminder_sender_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe GpoReminderSender do
         .first
     end
 
+    let(:attempts_api_tracker) { AttemptsApiTrackingHelper::FakeAttemptsTracker.new }
     let(:fake_analytics) { FakeAnalytics.new }
     let(:wait_for_reminder) { 14.days }
     let(:time_due_for_reminder) { Time.zone.now - wait_for_reminder }
@@ -173,7 +174,8 @@ RSpec.describe GpoReminderSender do
           ]
 
           GpoVerifyForm.new(
-            user: user,
+            attempts_api_tracker:,
+            user:,
             pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE,
             resolved_authn_context_result: Vot::Parser::Result.no_sp_result.with(
               enhanced_ipp?: is_enhanced_ipp,

--- a/spec/views/idv/by_mail/enter_code/index.html.erb_spec.rb
+++ b/spec/views/idv/by_mail/enter_code/index.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'idv/by_mail/enter_code/index.html.erb' do
   let(:user) do
     create(:user)
   end
+  let(:attempts_api_tracker) { AttemptsApiTrackingHelper::FakeAttemptsTracker.new }
 
   let(:pii) do
     {}
@@ -19,8 +20,9 @@ RSpec.describe 'idv/by_mail/enter_code/index.html.erb' do
     allow(view).to receive(:step_indicator_steps).and_return({})
 
     @gpo_verify_form = GpoVerifyForm.new(
-      user: user,
-      pii: pii,
+      attempts_api_tracker:,
+      user:,
+      pii:,
       resolved_authn_context_result: Vot::Parser::Result.no_sp_result,
       otp: '1234',
     )


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[163](https://gitlab.login.gov/lg-teams/Melba/protocols-backlog/-/issues/163)

## 🛠 Summary of changes
This change adds the `idv-enrollment-complete` event.

This is a new event that was added to fulfill the `Enrollment complete` milestone requirement.
It is a little tricky since there are several different pathways for users to finish their identity proofing journey, two of which are not part of the user flow.

The places where we activate a profile (thereby indicating that a profile's enrollment is "complete") is:

- `EnterPasswordController`-  where a user encrypts their data with their password
- `GpoVerifyForm` - where a user submits their mail code
- `GetUSPSProofingResultsJob` - where a user's IPP job is processed
- `ActionAccount::ReviewPass` - where a user is cleared as valid after a fraud review

I would love to know if I am missing or misinterpreting any of these steps, or if other work should. (I wish I could just put this event on the Profile model's `#active` method, but there isn't a way really to inject the tracker into the Profile like that.) 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
