### PR TITLE
LG-16086 Add address, ssn, and verify info to IPP passport flow

### DIFF
--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -50,7 +50,9 @@ module Idv
           controller: self,
           next_steps: [:ipp_ssn],
           preconditions: ->(idv_session:, user:) {
-            idv_session.ipp_state_id_complete?
+            # Handling passport navigation with checking in_person_passports_allowed? since passport
+            # form is not setup yet. This should be updated during LG-15985 implmentation.
+            idv_session.ipp_state_id_complete? || idv_session.in_person_passports_allowed?
           },
           undo_step: ->(idv_session:, user:) do
             idv_session.invalidate_in_person_address_step!

--- a/app/controllers/idv/in_person/passport_controller.rb
+++ b/app/controllers/idv/in_person/passport_controller.rb
@@ -13,6 +13,10 @@ module Idv
         analytics.idv_in_person_proofing_passport_visited(**analytics_arguments)
       end
 
+      def update
+        redirect_to idv_in_person_address_path
+      end
+
       def extra_view_variables
         {
           form:,

--- a/app/views/idv/in_person/verify_info/_address_section.html.erb
+++ b/app/views/idv/in_person/verify_info/_address_section.html.erb
@@ -1,0 +1,34 @@
+<div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-bottom border-primary-light">
+  <dl class='grid-col-fill margin-y-0'>
+    <div class="padding-y-1">
+      <h2 class="h4 margin-y-0"><%= t('headings.residential_address') %></h2>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:address1] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:address2].presence %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:city] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:state] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:zipcode] %> </dd>
+    </div>
+  </dl>
+  <div class='grid-auto'>
+    <%= link_to(
+          t('idv.buttons.change_label'),
+          idv_in_person_address_url,
+          'aria-label': t('idv.buttons.change_address_label'),
+        ) %>
+  </div>
+</div>

--- a/app/views/idv/in_person/verify_info/_ssn_section.html.erb
+++ b/app/views/idv/in_person/verify_info/_ssn_section.html.erb
@@ -1,0 +1,26 @@
+<div class="grid-row grid-gap grid-gap-2 padding-top-1">
+  <div class='grid-col-fill'>
+    <div class="padding-y-1">
+      <h2 class="h4 margin-y-0"><%= t('headings.ssn') %></h2>
+    </div>
+    <%= t('idv.form.ssn') %>:
+    <%= render(
+          'shared/masked_text',
+          text: SsnFormatter.format(@ssn),
+          masked_text: SsnFormatter.format_masked(@ssn),
+          accessible_masked_text: t(
+            'idv.accessible_labels.masked_ssn',
+            first_number: @ssn[0],
+            last_number: @ssn[-1],
+          ),
+          toggle_label: t('forms.ssn.show'),
+        ) %>
+  </div>
+  <div class='grid-auto'>
+    <%= link_to(
+          t('idv.buttons.change_label'),
+          idv_in_person_ssn_url,
+          'aria-label': t('idv.buttons.change_ssn_label'),
+        ) %>
+  </div>
+</div>

--- a/app/views/idv/in_person/verify_info/_state_id_section.html.erb
+++ b/app/views/idv/in_person/verify_info/_state_id_section.html.erb
@@ -1,0 +1,56 @@
+<div class="grid-row grid-gap grid-gap-2 padding-bottom-1 border-bottom border-primary-light">
+  <dl class="grid-col-fill margin-y-0">
+    <div class="padding-y-1">
+      <h2 class="h4 margin-y-0"><%= t('headings.state_id') %></h2>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.first_name') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:first_name] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.last_name') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:last_name] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.dob') %>: </dt>
+      <dd class="display-inline margin-left-0">
+        <%= I18n.l(Date.parse(@pii[:dob]), format: I18n.t('time.formats.event_date')) %>
+      </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.issuing_state') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:state_id_jurisdiction] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.id_number') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:state_id_number] %> </dd>
+    </div>
+    <div class="margin-top-105">
+      <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_address1] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_address2].presence %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_city] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_address_state] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_zipcode] %> </dd>
+    </div>
+  </dl>
+  <div class='grid-auto'>
+    <%= link_to(
+          idv_in_person_state_id_url,
+          class: 'usa-button usa-button--unstyled padding-y-1',
+          'aria-label': t('idv.buttons.change_state_id_label'),
+        ) { t('idv.buttons.change_label') } %>
+  </div>
+</div>

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -23,140 +23,29 @@ locals:
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>
 <div class='margin-top-4 margin-bottom-2'>
-  <div class="grid-row grid-gap grid-gap-2 padding-bottom-1 border-bottom border-primary-light">
-    <dl class="grid-col-fill margin-y-0">
-      <div class="padding-y-1">
-        <h2 class="h4 margin-y-0"><%= t('headings.state_id') %></h2>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.first_name') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:first_name] %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.last_name') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:last_name] %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.dob') %>: </dt>
-        <dd class="display-inline margin-left-0">
-          <%= I18n.l(Date.parse(@pii[:dob]), format: I18n.t('time.formats.event_date')) %>
-        </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.issuing_state') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:state_id_jurisdiction] %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.id_number') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:state_id_number] %> </dd>
-      </div>
-      <div class="margin-top-105">
-        <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_address1] %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_address2].presence %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_city] %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_address_state] %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_zipcode] %> </dd>
-      </div>
-    </dl>
-    <div class='grid-auto'>
-      <%= link_to(
-            idv_in_person_state_id_url,
-            class: 'usa-button usa-button--unstyled padding-y-1',
-            'aria-label': t('idv.buttons.change_state_id_label'),
-          ) { t('idv.buttons.change_label') } %>
-    </div>
-  </div>
-  <div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-bottom border-primary-light">
-    <dl class='grid-col-fill margin-y-0'>
-      <div class="padding-y-1">
-        <h2 class="h4 margin-y-0"><%= t('headings.residential_address') %></h2>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:address1] %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:address2].presence %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:city] %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:state] %> </dd>
-      </div>
-      <div>
-        <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:zipcode] %> </dd>
-      </div>
-    </dl>
-    <div class='grid-auto'>
-      <%= link_to(
-            t('idv.buttons.change_label'),
-            idv_in_person_address_url,
-            'aria-label': t('idv.buttons.change_address_label'),
-          ) %>
-    </div>
-  </div>
-  <div class="grid-row grid-gap grid-gap-2 padding-top-1">
-    <div class='grid-col-fill'>
-      <div class="padding-y-1">
-        <h2 class="h4 margin-y-0"><%= t('headings.ssn') %></h2>
-      </div>
-      <%= t('idv.form.ssn') %>:
-      <%= render(
-            'shared/masked_text',
-            text: SsnFormatter.format(@ssn),
-            masked_text: SsnFormatter.format_masked(@ssn),
-            accessible_masked_text: t(
-              'idv.accessible_labels.masked_ssn',
-              first_number: @ssn[0],
-              last_number: @ssn[-1],
-            ),
-            toggle_label: t('forms.ssn.show'),
-          ) %>
-    </div>
-    <div class='grid-auto'>
-      <%= link_to(
-            t('idv.buttons.change_label'),
-            idv_in_person_ssn_url,
-            'aria-label': t('idv.buttons.change_ssn_label'),
-          ) %>
-    </div>
-  </div>
+  <% if !@pii[:state_id_number].nil? %>
+    <%= render 'state_id_section', pii: @pii %>
+  <% end %>
+  <%= render 'address_section', pii: @pii %>
+  <%= render 'ssn_section', ssn: @ssn %>
   <div class="margin-top-5">
-      <%= render SpinnerButtonComponent.new(
-            url: idv_in_person_verify_info_path,
-            big: true,
-            wide: true,
-            action_message: t('idv.messages.verifying'),
-            method: :put,
-            form: {
-              class: 'button_to',
-              data: {
-                form_steps_wait: '',
-                error_message: t('idv.failure.exceptions.internal_error'),
-                alert_target: '#form-steps-wait-alert',
-                wait_step_path: idv_in_person_verify_info_path,
-                poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
-              },
+    <%= render SpinnerButtonComponent.new(
+          url: idv_in_person_verify_info_path,
+          big: true,
+          wide: true,
+          action_message: t('idv.messages.verifying'),
+          method: :put,
+          form: {
+            class: 'button_to',
+            data: {
+              form_steps_wait: '',
+              error_message: t('idv.failure.exceptions.internal_error'),
+              alert_target: '#form-steps-wait-alert',
+              wait_step_path: idv_in_person_verify_info_path,
+              poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
             },
-          ).with_content(t('forms.buttons.submit.default')) %>
+          },
+        ).with_content(t('forms.buttons.submit.default')) %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -449,6 +449,8 @@ Rails.application.routes.draw do
           as: :in_person_ready_to_verify
       post '/in_person/usps_locations' => 'in_person/usps_locations#index'
       put '/in_person/usps_locations' => 'in_person/usps_locations#update'
+      get '/in_person/passport' => 'in_person/passport#show'
+      put '/in_person/passport' => 'in_person/passport#update'
       get '/in_person/state_id' => 'in_person/state_id#show'
       put '/in_person/state_id' => 'in_person/state_id#update'
       get '/in_person/address' => 'in_person/address#show'

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -136,6 +136,11 @@ module Idp
       same_address_as_id: 'true',
     }.freeze
 
+    MOCK_IPP_PASSPORT_APPLICANT = {
+      passport_number: '123456789',
+      passport_expiration_date: (DateTime.now.utc + 1.year).to_s,
+    }.freeze
+
     MOCK_IDV_APPLICANT_WITH_PASSPORT = MOCK_IDV_APPLICANT.select do |field, _value|
       %i[first_name middle_name last_name dob sex].include?(field)
     end.merge(

--- a/spec/controllers/idv/in_person/passport_controller_spec.rb
+++ b/spec/controllers/idv/in_person/passport_controller_spec.rb
@@ -97,4 +97,15 @@ RSpec.describe Idv::InPerson::PassportController do
       end
     end
   end
+
+  describe '#update' do
+    before do
+      allow(idv_session).to receive(:in_person_passports_allowed?).and_return(true)
+      put :update
+    end
+
+    it 'redirects to the address form' do
+      expect(response).to redirect_to(idv_in_person_address_path)
+    end
+  end
 end

--- a/spec/features/idv/in_person/passport_scenario_spec.rb
+++ b/spec/features/idv/in_person/passport_scenario_spec.rb
@@ -148,6 +148,24 @@ RSpec.describe 'In Person Proofing Passports', js: true do
           expect(page).to have_current_path(idv_in_person_passport_path)
           expect(page).to have_content t('in_person_proofing.headings.passport')
           expect(page).to have_content t('in_person_proofing.body.passport.info')
+
+          fill_in_passport_form
+
+          click_on t('forms.buttons.submit.default')
+
+          expect(page).to have_current_path(idv_in_person_address_path)
+
+          fill_out_address_form_ok
+
+          click_on t('forms.buttons.continue')
+
+          expect(page).to have_current_path(idv_in_person_ssn_path)
+
+          fill_out_ssn_form_ok
+
+          click_on t('forms.buttons.continue')
+
+          expect(page).to have_current_path(idv_in_person_verify_info_path)
         end
       end
 
@@ -322,5 +340,25 @@ RSpec.describe 'In Person Proofing Passports', js: true do
         expect(page).to have_current_path(idv_in_person_state_id_path)
       end
     end
+  end
+
+  def fill_in_passport_form
+    fill_in t('in_person_proofing.form.passport.surname'),
+            with: InPersonHelper::GOOD_LAST_NAME
+    fill_in t('in_person_proofing.form.passport.first_name'),
+            with: InPersonHelper::GOOD_FIRST_NAME
+
+    fill_in_memorable_date(
+      'idv_in_person_passport_form[passport_dob]',
+      InPersonHelper::GOOD_DOB,
+    )
+
+    fill_in t('in_person_proofing.form.passport.passport_number'),
+            with: InPersonHelper::GOOD_PASSPORT_NUMBER
+
+    fill_in_memorable_date(
+      'idv_in_person_passport_form[passport_expiration]',
+      InPersonHelper::GOOD_PASSPORT_EXPIRATION_DATE,
+    )
   end
 end

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -32,6 +32,10 @@ module InPersonHelper
   GOOD_IDENTITY_DOC_ZIPCODE =
     Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_zipcode].freeze
 
+  GOOD_PASSPORT_NUMBER = Idp::Constants::MOCK_IPP_PASSPORT_APPLICANT[:passport_number].freeze
+  GOOD_PASSPORT_EXPIRATION_DATE =
+    Idp::Constants::MOCK_IPP_PASSPORT_APPLICANT[:passport_expiration_date].freeze
+
   def fill_out_state_id_form_ok(same_address_as_id: false, first_name: GOOD_FIRST_NAME)
     fill_in t('in_person_proofing.form.state_id.first_name'), with: first_name
     fill_in t('in_person_proofing.form.state_id.last_name'), with: GOOD_LAST_NAME
@@ -99,6 +103,17 @@ module InPersonHelper
             with: GOOD_ZIPCODE
     click_spinner_button_and_wait(t('in_person_proofing.body.location.po_search.search_button'))
     expect(page).to have_css('.location-collection-item')
+  end
+
+  # Fills in a memorable date component input
+  #
+  # @param [String] field_name Name of the form plus the component name. e.g. `test_form[test_dob]`
+  # @param [String] date The date to enter into the input. `Format: YYYY-MM-DD`
+  def fill_in_memorable_date(field_name, date)
+    year, month, day = date.split('-')
+    fill_in "#{field_name}[month]", with: month
+    fill_in "#{field_name}[day]", with: day
+    fill_in "#{field_name}[year]", with: year
   end
 
   def complete_location_step(_user = nil)


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16086](https://cm-jira.usa.gov/browse/LG-16086)

## 🛠 Summary of changes

Add address, ssn, and verify info to IPP passport flow

## 📜 Testing Plan

Setup: Ensure the following environment variables are set for passport to work in IPP.

```text
  in_person_proofing_enabled: true
  in_person_proofing_opt_in_enabled: true
  in_person_passports_enabled: true
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100
```

**Scenario: User selects passport option and completes update verify info**
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the choose ID type page
- [x] Choose the **U.S. passport book** option
- [x] Clicks submit
- [x] Ensure user is taken to the /verify/in_person/passport
- [x] Fill out form
- [x] Clicks submit
- [x] Ensure user is taken to the /verify/in_person/address
- [x] Fill out form
- [x] Clicks submit
- [x] Ensure user is taken to the /verify/in_person/ssn
- [x] Fill out form
- [x] Clicks submit
- [x] Ensure user is taken to the /verify/in_person/verify_info

**Note: Verify info was out of scope for this story so no content needs to be verified on that page**

**Scenario: User selects ~~passport option~~ driver's license or state ID and completes update verify info**
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP flow reaching the choose ID type page
- [x] Choose the **U.S. driver’s license or state ID** option
- [x] Clicks submit
- [x] Ensure user can create a State-ID enrollment

**Note: Verify info was out of scope for this story so no content needs to be verified on that page**


