### PR TITLE
changelog: User-Facing Improvements, In-person Proofing, Add empty lo…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1284,7 +1284,7 @@ in_person_proofing.body.location.po_search.state_label: State
 in_person_proofing.body.location.po_search.usps_facilities_api_error_body_html: Please continue verifying your identity. You can use our <a target="_blank" href="%{link_url}"></a> to search for a participating location after you generate a barcode.
 in_person_proofing.body.location.po_search.usps_facilities_api_error_header: Sorry, we ran into technical difficulties and couldn’t search for a participating Post Office.
 in_person_proofing.body.location.po_search.usps_facilities_api_error_help_center_text: Help Center
-in_person_proofing.body.location.po_search.usps_facilities_api_error_icon_alt_text: empty location icon
+in_person_proofing.body.location.po_search.usps_facilities_api_error_icon_alt_text: Image of a map pin
 in_person_proofing.body.location.po_search.zipcode_label: ZIP Code
 in_person_proofing.body.location.retail_hours_heading: Retail Hours
 in_person_proofing.body.location.retail_hours_sat: 'Sat:'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1295,7 +1295,7 @@ in_person_proofing.body.location.po_search.state_label: Estado
 in_person_proofing.body.location.po_search.usps_facilities_api_error_body_html: Siga verificando su identidad. Después de generar un código de barras, puede usar nuestro <a target="_blank" href="%{link_url}"></a> para buscar un lugar participante.
 in_person_proofing.body.location.po_search.usps_facilities_api_error_header: Lo sentimos, tuvimos problemas técnicos y no pudimos buscar una oficina de correos participante.
 in_person_proofing.body.location.po_search.usps_facilities_api_error_help_center_text: Centro de ayuda
-in_person_proofing.body.location.po_search.usps_facilities_api_error_icon_alt_text: empty location icon
+in_person_proofing.body.location.po_search.usps_facilities_api_error_icon_alt_text: Imagen de un marcador de mapa
 in_person_proofing.body.location.po_search.zipcode_label: Código postal
 in_person_proofing.body.location.retail_hours_heading: Horario de atención al público
 in_person_proofing.body.location.retail_hours_sat: 'Sábado:'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1284,7 +1284,7 @@ in_person_proofing.body.location.po_search.state_label: État
 in_person_proofing.body.location.po_search.usps_facilities_api_error_body_html: Veuillez poursuivre la procédure de vérification d’identité. Vous pouvez recourir au <a target="_blank" href="%{link_url}"></a> pour rechercher un bureau participant après avoir généré un code-barres.
 in_person_proofing.body.location.po_search.usps_facilities_api_error_header: Nous n’avons pas pu rechercher de bureau de poste participant pour des raisons techniques et nous en excusons.
 in_person_proofing.body.location.po_search.usps_facilities_api_error_help_center_text: Centre d’aide
-in_person_proofing.body.location.po_search.usps_facilities_api_error_icon_alt_text: empty location icon
+in_person_proofing.body.location.po_search.usps_facilities_api_error_icon_alt_text: Image d’une épingle sur une carte
 in_person_proofing.body.location.po_search.zipcode_label: Code postal
 in_person_proofing.body.location.retail_hours_heading: Heures d’ouverture
 in_person_proofing.body.location.retail_hours_sat: 'Sam :'

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1297,7 +1297,7 @@ in_person_proofing.body.location.po_search.state_label: 州
 in_person_proofing.body.location.po_search.usps_facilities_api_error_body_html: 请继续验证你的身份。生成条形码后，你可以使用我们的<a target="_blank" href="%{link_url}"></a>搜索参与本项目的邮局。
 in_person_proofing.body.location.po_search.usps_facilities_api_error_header: 抱歉，我们遇到了技术困难，无法搜索参与本项目的邮局。
 in_person_proofing.body.location.po_search.usps_facilities_api_error_help_center_text: 帮助中心
-in_person_proofing.body.location.po_search.usps_facilities_api_error_icon_alt_text: empty location icon
+in_person_proofing.body.location.po_search.usps_facilities_api_error_icon_alt_text: 地图图钉图像
 in_person_proofing.body.location.po_search.zipcode_label: 邮编
 in_person_proofing.body.location.retail_hours_heading: 营业时间
 in_person_proofing.body.location.retail_hours_sat: 周六：

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -73,7 +73,6 @@ module I18n
         { key: 'datetime.dotiw.minutes.one' }, # "minute is minute" in French and English
         { key: 'datetime.dotiw.minutes.other' }, # "minute is minute" in French and English
         { key: 'datetime.dotiw.words_connector' }, # " , " is only punctuation and not translated
-        { key: 'in_person_proofing.body.location.po_search.usps_facilities_api_error_icon_alt_text' },
         { key: 'in_person_proofing.body.passport.info' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
         { key: 'in_person_proofing.form.passport.dob' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
         { key: 'in_person_proofing.form.passport.dob_hint' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16165](https://cm-jira.usa.gov/browse/LG-16165)

## 🛠 Summary of changes

Added in translations for usps error icon alt text.

## 📜 Testing Plan

- [ ] Confirm all four translations show for alt text on icon shown on usps locations endpoint error (can simulate outage by blocking requests to the usps_locations controller)