### PR TITLE
Bug: captcha_validation_performed is false even though reCAPTCHA was performed

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -115,9 +115,13 @@ module Users
     end
 
     def recaptcha_form
+      return @recaptcha_form if defined?(@recaptcha_form)
+      existing_device = User.find_with_confirmed_email(auth_params[:email])&.devices&.exists?(
+        cookie_uuid: cookies[:device],
+      )
+
       @recaptcha_form ||= SignInRecaptchaForm.new(
-        email: auth_params[:email],
-        device_cookie: cookies[:device],
+        existing_device: existing_device,
         ab_test_bucket: ab_test_bucket(:RECAPTCHA_SIGN_IN, user: user_from_params),
         **recaptcha_form_args,
       )

--- a/spec/forms/sign_in_recaptcha_form_spec.rb
+++ b/spec/forms/sign_in_recaptcha_form_spec.rb
@@ -5,15 +5,13 @@ RSpec.describe SignInRecaptchaForm do
   let(:user) { create(:user, :with_authenticated_device) }
   let(:score_threshold_config) { 0.2 }
   let(:analytics) { FakeAnalytics.new }
-  let(:email) { user.email }
+  let(:existing_device) { false }
   let(:ab_test_bucket) { :sign_in_recaptcha }
   let(:recaptcha_token) { 'token' }
-  let(:device_cookie) { Random.hex }
   let(:score) { 1.0 }
   subject(:form) do
     described_class.new(
-      email:,
-      device_cookie:,
+      existing_device:,
       ab_test_bucket:,
       form_class: RecaptchaMockForm,
       analytics:,
@@ -45,8 +43,7 @@ RSpec.describe SignInRecaptchaForm do
   context 'with custom recaptcha form class' do
     subject(:form) do
       described_class.new(
-        email:,
-        device_cookie:,
+        existing_device:,
         ab_test_bucket:,
         analytics:,
         form_class: RecaptchaForm,
@@ -74,8 +71,6 @@ RSpec.describe SignInRecaptchaForm do
       let(:ab_test_bucket) { nil }
 
       it { is_expected.to eq(true) }
-
-      it { expect(queries_database?).to eq(false) }
     end
 
     context 'score threshold configured at zero' do
@@ -87,11 +82,9 @@ RSpec.describe SignInRecaptchaForm do
     end
 
     context 'existing device for user' do
-      let(:device_cookie) { user.devices.first.cookie_uuid }
+      let(:existing_device) { true }
 
       it { is_expected.to eq(true) }
-
-      it { expect(queries_database?).to eq(true) }
     end
 
     def queries_database?
@@ -108,7 +101,7 @@ RSpec.describe SignInRecaptchaForm do
       let(:score) { 0.0 }
 
       context 'existing device for user' do
-        let(:device_cookie) { user.devices.first.cookie_uuid }
+        let(:existing_device) { true }
 
         it 'is successful' do
           expect(response.to_h).to eq(success: true)


### PR DESCRIPTION
## 🎫 Ticket

[LG-15936: Bug: captcha_validation_performed is false even though reCAPTCHA was performed](https://cm-jira.usa.gov/browse/LG-15936)

## 🛠 Summary of changes

This PR adds logic to check for an existing device at the point of reCAPTCHA verification

## 📜 Testing Plan

Testing is unavailable on local machines. To verify, watch the data over time in CloudWatch to see if bug has been addressed.