### PR TITLE
Adds forgot-password-email-sent event

### DIFF
--- a/app/controllers/idv/forgot_password_controller.rb
+++ b/app/controllers/idv/forgot_password_controller.rb
@@ -24,9 +24,10 @@ module Idv
     def reset_password(email, request_id)
       sign_out
       RequestPasswordReset.new(
-        email: email,
-        request_id: request_id,
-        analytics: analytics,
+        email:,
+        request_id:,
+        analytics:,
+        attempts_api_tracker:,
       ).perform
       # The user/email is always found so...
       session[:email] = email

--- a/app/controllers/users/reset_passwords_controller.rb
+++ b/app/controllers/users/reset_passwords_controller.rb
@@ -93,9 +93,10 @@ module Users
 
     def handle_valid_email
       RequestPasswordReset.new(
-        email: email,
-        request_id: request_id,
-        analytics: analytics,
+        email:,
+        request_id:,
+        analytics:,
+        attempts_api_tracker:,
       ).perform
 
       session[:email] = email

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -65,6 +65,15 @@ module AttemptsApi
       )
     end
 
+    # @param [String] email The user's email address
+    #  A user has requested a password reset.
+    def forgot_password_email_sent(email:)
+      track_event(
+        :forgot_password_email_sent,
+        email:,
+      )
+    end
+
     # @param [Boolean] success True if new password was successfully submitted
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
     # A user submits a new password have requesting a password reset

--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RequestPasswordReset = RedactedStruct.new(
-  :email, :request_id, :analytics,
+  :email, :request_id, :analytics, :attempts_api_tracker,
   keyword_init: true,
   allowed_members: [:request_id]
 ) do
@@ -26,6 +26,8 @@ RequestPasswordReset = RedactedStruct.new(
 
       event = PushNotification::RecoveryActivatedEvent.new(user: user)
       PushNotification::HttpPush.deliver(event)
+
+      attempts_api_tracker.forgot_password_email_sent(email:)
     end
   end
 

--- a/spec/controllers/idv/forgot_password_controller_spec.rb
+++ b/spec/controllers/idv/forgot_password_controller_spec.rb
@@ -25,10 +25,12 @@ RSpec.describe Idv::ForgotPasswordController do
 
     before do
       stub_sign_in(user)
+      stub_attempts_tracker
       stub_analytics
     end
 
     it 'tracks appropriate events' do
+      expect(@attempts_api_tracker).to receive(:forgot_password_email_sent).with(email: user.email)
       post :update
 
       expect(@analytics).to have_logged_event('IdV: forgot password confirmed')


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Attempts API events tracking ticket - 1820](https://gitlab.login.gov/lg-teams/FIE/moving-in/-/issues/1820)

## 🛠 Summary of changes
This change adds the `forgot-password-email-sent` event

Note: this is the first event we are adding that includes any form of PII. (email address)

A couple questions I have:
- Should this fire when it's a non-confirmed user? (in that case it's not really a forgot password event)
- Originally there was a rate limited event because it didn't seem to align with a milestone, although i now think it could align with the `Login attempt lockout` milestone. Would be pretty trivial to add it back in, should I?

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
