### PR TITLE
Allow creating AgencyIdentity if it does not exist when creating Attetempts API event

### DIFF
--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -2,6 +2,10 @@
 
 module AttemptsApi
   class Tracker
+    SKIP_AGENCY_UUID_CREATION_EVENT_TYPES = [
+      'login-email-and-password-auth',
+      'login-email-and-password-auth',
+    ].freeze
     attr_reader :session_id, :enabled_for_session, :request, :user, :sp, :cookie_device_uuid,
                 :sp_request_uri
 
@@ -31,7 +35,7 @@ module AttemptsApi
       event_metadata = {
         user_agent: request&.user_agent,
         unique_session_id: hashed_session_id,
-        user_uuid: sp && AgencyIdentityLinker.for(user: user, service_provider: sp)&.uuid,
+        user_uuid: agency_uuid(event_type: event_type),
         device_fingerprint: hashed_cookie_device_uuid,
         user_ip_address: request&.remote_ip,
         application_url: sp_request_uri,
@@ -75,6 +79,17 @@ module AttemptsApi
     end
 
     private
+
+    def agency_uuid(event_type:)
+      return nil unless sp
+      skip_create = SKIP_AGENCY_UUID_CREATION_EVENT_TYPES.include?(event_type)
+
+      if skip_create
+        AgencyIdentityLinker.for(user: user, service_provider: sp, skip_create: true)&.uuid
+      else
+        AgencyIdentityLinker.for(user: user, service_provider: sp, skip_create: false).uuid
+      end
+    end
 
     def hashed_session_id
       return nil unless user&.unique_session_id


### PR DESCRIPTION
Link to the relevant ticket:
[!90](https://gitlab.login.gov/lg-teams/FIE/partner-portal-prod-edition/-/issues/90)

## 🛠 Summary of changes

The current reliance on only using existing `AgencyIdentity` rows when logging `user_uuid` means we may have significant gaps in the `user_uuid` attribute. There is some history here described more in the ticket, but the conclusion is it should be safe to create new rows here and limit the risk by excluding certain events.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
