### PR TITLE
LG-16187 Remove Upload option from IAL1

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -60,6 +60,14 @@ module Idv
         stored_result.selfie_check_performed?
     end
 
+    def upload_enabled?
+      !resolved_authn_context_result.facial_match? || !upload_disabled_bucket
+    end
+
+    def upload_disabled_bucket
+      ab_test_bucket(:DOC_AUTH_MANUAL_UPLOAD_DISABLED) == :manual_upload_disabled
+    end
+
     def redirect_to_correct_vendor(vendor, in_hybrid_mobile:)
       return if IdentityConfig.store.doc_auth_redirect_to_correct_vendor_disabled
 

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -60,7 +60,7 @@ module Idv
         stored_result.selfie_check_performed?
     end
 
-    def upload_enabled?
+    def doc_auth_upload_enabled?
       !resolved_authn_context_result.facial_match? || !upload_disabled_bucket
     end
 

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -97,7 +97,7 @@ module Idv
         skip_doc_auth_from_socure: idv_session.skip_doc_auth_from_socure,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
         doc_auth_selfie_capture: resolved_authn_context_result.facial_match?,
-        upload_enabled: upload_enabled?,
+        doc_auth_upload_enabled: doc_auth_upload_enabled?,
         socure_errors_timeout_url: idv_socure_document_capture_errors_url(error_code: :timeout),
       }.merge(
         acuant_sdk_upgrade_a_b_testing_variables,

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -97,6 +97,7 @@ module Idv
         skip_doc_auth_from_socure: idv_session.skip_doc_auth_from_socure,
         opted_in_to_in_person_proofing: idv_session.opted_in_to_in_person_proofing,
         doc_auth_selfie_capture: resolved_authn_context_result.facial_match?,
+        upload_enabled: upload_enabled?,
         socure_errors_timeout_url: idv_socure_document_capture_errors_url(error_code: :timeout),
       }.merge(
         acuant_sdk_upgrade_a_b_testing_variables,

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -64,6 +64,7 @@ module Idv
           document_capture_session_uuid: document_capture_session_uuid,
           failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
           doc_auth_selfie_capture: resolved_authn_context_result.facial_match?,
+          upload_enabled: upload_enabled?,
           skip_doc_auth_from_socure: @skip_doc_auth_from_socure,
           socure_errors_timeout_url: idv_hybrid_mobile_socure_document_capture_errors_url(
             error_code: :timeout,

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -64,7 +64,7 @@ module Idv
           document_capture_session_uuid: document_capture_session_uuid,
           failure_to_proof_url: return_to_sp_failure_to_proof_url(step: 'document_capture'),
           doc_auth_selfie_capture: resolved_authn_context_result.facial_match?,
-          upload_enabled: upload_enabled?,
+          doc_auth_upload_enabled: doc_auth_upload_enabled?,
           skip_doc_auth_from_socure: @skip_doc_auth_from_socure,
           socure_errors_timeout_url: idv_hybrid_mobile_socure_document_capture_errors_url(
             error_code: :timeout,

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -9,6 +9,7 @@ import type {
   RegisterFieldCallback,
 } from '@18f/identity-form-steps';
 import AcuantCapture from './acuant-capture';
+import UploadContext from '../context/upload';
 import SelfieCaptureContext from '../context/selfie-capture';
 
 interface DocumentSideAcuantCaptureProps {
@@ -33,8 +34,8 @@ export class CameraAccessDeclinedError extends FormError {
   get message() {
     return this.isDetail
       ? t('doc_auth.errors.camera.blocked_detail_html', {
-          app_name: getConfigValue('appName'),
-        })
+        app_name: getConfigValue('appName'),
+      })
       : t('doc_auth.errors.camera.blocked');
   }
 }
@@ -59,8 +60,9 @@ function DocumentSideAcuantCapture({
 }: DocumentSideAcuantCaptureProps) {
   const error = errors.find(({ field }) => field === side)?.error;
   const { changeStepCanComplete } = useContext(FormStepsContext);
-  const { isSelfieCaptureEnabled, isSelfieDesktopTestMode } = useContext(SelfieCaptureContext);
-  const isUploadAllowed = isSelfieDesktopTestMode || !isSelfieCaptureEnabled;
+  const { isSelfieDesktopTestMode } = useContext(SelfieCaptureContext);
+  const { isUploadEnabled } = useContext(UploadContext);
+  const isUploadAllowed = isSelfieDesktopTestMode || isUploadEnabled;
   const stepCanComplete = !isReviewStep ? undefined : true;
   return (
     <AcuantCapture

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -9,7 +9,6 @@ import type {
   RegisterFieldCallback,
 } from '@18f/identity-form-steps';
 import AcuantCapture from './acuant-capture';
-import UploadContext from '../context/upload';
 import SelfieCaptureContext from '../context/selfie-capture';
 
 interface DocumentSideAcuantCaptureProps {
@@ -34,8 +33,8 @@ export class CameraAccessDeclinedError extends FormError {
   get message() {
     return this.isDetail
       ? t('doc_auth.errors.camera.blocked_detail_html', {
-        app_name: getConfigValue('appName'),
-      })
+          app_name: getConfigValue('appName'),
+        })
       : t('doc_auth.errors.camera.blocked');
   }
 }
@@ -60,8 +59,7 @@ function DocumentSideAcuantCapture({
 }: DocumentSideAcuantCaptureProps) {
   const error = errors.find(({ field }) => field === side)?.error;
   const { changeStepCanComplete } = useContext(FormStepsContext);
-  const { isSelfieDesktopTestMode } = useContext(SelfieCaptureContext);
-  const { isUploadEnabled } = useContext(UploadContext);
+  const { isSelfieDesktopTestMode, isUploadEnabled } = useContext(SelfieCaptureContext);
   const isUploadAllowed = isSelfieDesktopTestMode || isUploadEnabled;
   const stepCanComplete = !isReviewStep ? undefined : true;
   return (

--- a/app/javascript/packages/document-capture/context/selfie-capture.tsx
+++ b/app/javascript/packages/document-capture/context/selfie-capture.tsx
@@ -22,7 +22,7 @@ interface SelfieCaptureProps {
 
 const SelfieCaptureContext = createContext<SelfieCaptureProps>({
   isSelfieCaptureEnabled: false,
-  isUploadEnabled: false,
+  isUploadEnabled: true,
   isSelfieDesktopTestMode: false,
   showHelpInitially: true,
 });

--- a/app/javascript/packages/document-capture/context/selfie-capture.tsx
+++ b/app/javascript/packages/document-capture/context/selfie-capture.tsx
@@ -6,6 +6,10 @@ interface SelfieCaptureProps {
    */
   isSelfieCaptureEnabled: boolean;
   /**
+   * Specify whether to allow manual uploads for document capture.
+   */
+  isUploadEnabled: boolean;
+  /**
    * Specify whether to allow uploads for selfie when in test mode.
    */
   isSelfieDesktopTestMode: boolean;
@@ -18,6 +22,7 @@ interface SelfieCaptureProps {
 
 const SelfieCaptureContext = createContext<SelfieCaptureProps>({
   isSelfieCaptureEnabled: false,
+  isUploadEnabled: false,
   isSelfieDesktopTestMode: false,
   showHelpInitially: true,
 });

--- a/app/javascript/packages/document-capture/context/upload.tsx
+++ b/app/javascript/packages/document-capture/context/upload.tsx
@@ -9,7 +9,6 @@ const UploadContext = createContext({
   getStatus: () => Promise.resolve({} as UploadSuccessResponse),
   statusPollInterval: undefined as number | undefined,
   isMockClient: false,
-  isUploadEnabled: false,
   flowPath: 'standard' as FlowPath,
   idType: 'state_id',
   formData: {} as Record<string, any>,
@@ -151,11 +150,6 @@ interface UploadContextProviderProps {
   isMockClient?: boolean;
 
   /**
-   * Whether to enable manual upload.
-   */
-  isUploadEnabled?: boolean;
-
-  /**
    * Endpoint to which payload should be sent.
    */
   endpoint: string;
@@ -200,7 +194,6 @@ const DEFAULT_FORM_DATA = {};
 function UploadContextProvider({
   upload = defaultUpload,
   isMockClient = false,
-  isUploadEnabled = false,
   endpoint,
   statusEndpoint,
   statusPollInterval,
@@ -233,7 +226,6 @@ function UploadContextProvider({
     getStatus,
     statusPollInterval,
     isMockClient,
-    isUploadEnabled,
     flowPath,
     idType,
     formData,

--- a/app/javascript/packages/document-capture/context/upload.tsx
+++ b/app/javascript/packages/document-capture/context/upload.tsx
@@ -9,6 +9,7 @@ const UploadContext = createContext({
   getStatus: () => Promise.resolve({} as UploadSuccessResponse),
   statusPollInterval: undefined as number | undefined,
   isMockClient: false,
+  isUploadEnabled: false,
   flowPath: 'standard' as FlowPath,
   idType: 'state_id',
   formData: {} as Record<string, any>,
@@ -150,6 +151,11 @@ interface UploadContextProviderProps {
   isMockClient?: boolean;
 
   /**
+   * Whether to enable manual upload.
+   */
+  isUploadEnabled?: boolean;
+
+  /**
    * Endpoint to which payload should be sent.
    */
   endpoint: string;
@@ -194,6 +200,7 @@ const DEFAULT_FORM_DATA = {};
 function UploadContextProvider({
   upload = defaultUpload,
   isMockClient = false,
+  isUploadEnabled = false,
   endpoint,
   statusEndpoint,
   statusPollInterval,
@@ -226,6 +233,7 @@ function UploadContextProvider({
     getStatus,
     statusPollInterval,
     isMockClient,
+    isUploadEnabled,
     flowPath,
     idType,
     formData,

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -43,6 +43,7 @@ interface AppRootData {
   previousStepUrl: string;
   docAuthPassportsEnabled: string;
   docAuthSelfieDesktopTestMode: string;
+  docAuthUploadEnabled: string;
   accountUrl: string;
   locationsUrl: string;
   sessionsUrl: string;
@@ -62,6 +63,11 @@ function getServiceProvider() {
 function getSelfieCaptureEnabled() {
   const { docAuthSelfieCapture } = appRoot.dataset;
   return docAuthSelfieCapture === 'true';
+}
+
+function getUploadEnabled() {
+  const { docAuthUploadEnabled } = appRoot.dataset;
+  return docAuthUploadEnabled === 'true';
 }
 
 function getMetaContent(name): string | null {
@@ -171,6 +177,7 @@ render(
               statusEndpoint={String(appRoot.getAttribute('data-status-endpoint'))}
               statusPollInterval={Number(appRoot.getAttribute('data-status-poll-interval-ms'))}
               isMockClient={isMockClient}
+              isUploadEnabled={getUploadEnabled()}
               formData={formData}
               flowPath={flowPath}
               idType={idType}

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -177,7 +177,6 @@ render(
               statusEndpoint={String(appRoot.getAttribute('data-status-endpoint'))}
               statusPollInterval={Number(appRoot.getAttribute('data-status-poll-interval-ms'))}
               isMockClient={isMockClient}
-              isUploadEnabled={getUploadEnabled()}
               formData={formData}
               flowPath={flowPath}
               idType={idType}
@@ -193,6 +192,7 @@ render(
                   <SelfieCaptureContext.Provider
                     value={{
                       isSelfieCaptureEnabled: getSelfieCaptureEnabled(),
+                      isUploadEnabled: getUploadEnabled(),
                       isSelfieDesktopTestMode: String(docAuthSelfieDesktopTestMode) === 'true',
                       showHelpInitially: true,
                     }}

--- a/app/views/idv/document_capture/show.html.erb
+++ b/app/views/idv/document_capture/show.html.erb
@@ -14,5 +14,6 @@
       skip_doc_auth_from_socure: skip_doc_auth_from_socure,
       socure_errors_timeout_url: socure_errors_timeout_url,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
+      doc_auth_upload_enabled: doc_auth_upload_enabled,
       mock_client: mock_client,
     ) %>

--- a/app/views/idv/hybrid_mobile/document_capture/show.html.erb
+++ b/app/views/idv/hybrid_mobile/document_capture/show.html.erb
@@ -14,5 +14,6 @@
       skip_doc_auth_from_socure: skip_doc_auth_from_socure,
       socure_errors_timeout_url: socure_errors_timeout_url,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
+      doc_auth_upload_enabled: doc_auth_upload_enabled,
       mock_client: mock_client,
     ) %>

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -38,7 +38,7 @@
       doc_auth_passports_enabled: IdentityConfig.store.doc_auth_passports_enabled,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
       doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
-      upload_enabled: upload_enabled,
+      doc_auth_upload_enabled: doc_auth_upload_enabled,
       skip_doc_auth_from_how_to_verify: skip_doc_auth_from_how_to_verify,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       skip_doc_auth_from_socure: skip_doc_auth_from_socure,

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -38,6 +38,7 @@
       doc_auth_passports_enabled: IdentityConfig.store.doc_auth_passports_enabled,
       doc_auth_selfie_capture: doc_auth_selfie_capture,
       doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
+      upload_enabled: upload_enabled,
       skip_doc_auth_from_how_to_verify: skip_doc_auth_from_how_to_verify,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       skip_doc_auth_from_socure: skip_doc_auth_from_socure,

--- a/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/document-side-acuant-capture-spec.tsx
@@ -27,6 +27,7 @@ describe('DocumentSideAcuantCapture', () => {
               <SelfieCaptureContext.Provider
                 value={{
                   isSelfieCaptureEnabled: false,
+                  isUploadEnabled: true,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
                 }}
@@ -51,6 +52,7 @@ describe('DocumentSideAcuantCapture', () => {
               <SelfieCaptureContext.Provider
                 value={{
                   isSelfieCaptureEnabled: false,
+                  isUploadEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
                 }}
@@ -67,6 +69,31 @@ describe('DocumentSideAcuantCapture', () => {
           expect(takeOrUploadPictureText).to.have.lengthOf(2);
         });
       });
+
+      context('and doc_auth_upload_enabled is false', () => {
+        it('_does_ not display a photo upload button', () => {
+          const { queryAllByText } = render(
+            <DeviceContext.Provider value={{ isMobile: true }}>
+              <SelfieCaptureContext.Provider
+                value={{
+                  isSelfieCaptureEnabled: false,
+                  isUploadEnabled: false,
+                  isSelfieDesktopTestMode: false,
+                  showHelpInitially: false,
+                }}
+              >
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="front" />
+                <DocumentSideAcuantCapture {...DEFAULT_PROPS} side="back" />
+              </SelfieCaptureContext.Provider>
+            </DeviceContext.Provider>,
+          );
+
+          const takeOrUploadPictureText = queryAllByText(
+            'doc_auth.buttons.take_or_upload_picture_html',
+          );
+          expect(takeOrUploadPictureText).to.have.lengthOf(0);
+        });
+      });
     });
 
     context('and using desktop', () => {
@@ -79,6 +106,7 @@ describe('DocumentSideAcuantCapture', () => {
                 <SelfieCaptureContext.Provider
                   value={{
                     isSelfieCaptureEnabled: false,
+                    isUploadEnabled: true,
                     isSelfieDesktopTestMode: false,
                     showHelpInitially: false,
                   }}
@@ -100,6 +128,7 @@ describe('DocumentSideAcuantCapture', () => {
               <SelfieCaptureContext.Provider
                 value={{
                   isSelfieCaptureEnabled: false,
+                  isUploadEnabled: true,
                   isSelfieDesktopTestMode: false,
                   showHelpInitially: false,
                 }}
@@ -122,6 +151,7 @@ describe('DocumentSideAcuantCapture', () => {
               <SelfieCaptureContext.Provider
                 value={{
                   isSelfieCaptureEnabled: false,
+                  isUploadEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
                 }}
@@ -149,6 +179,7 @@ describe('DocumentSideAcuantCapture', () => {
                 value={{
                   isSelfieCaptureEnabled: true,
                   isSelfieDesktopTestMode: false,
+                  isUploadEnabled: false,
                   showHelpInitially: false,
                 }}
               >
@@ -170,12 +201,13 @@ describe('DocumentSideAcuantCapture', () => {
       });
 
       context('and doc_auth_selfie_desktop_test_mode is true', () => {
-        it('does _not_ display a photo upload button', () => {
+        it('does display a photo upload button', () => {
           const { queryAllByText } = render(
             <DeviceContext.Provider value={{ isMobile: true }}>
               <SelfieCaptureContext.Provider
                 value={{
                   isSelfieCaptureEnabled: true,
+                  isUploadEnabled: false,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
                 }}
@@ -212,6 +244,7 @@ describe('DocumentSideAcuantCapture', () => {
               <SelfieCaptureContext.Provider
                 value={{
                   isSelfieCaptureEnabled: true,
+                  isUploadEnabled: true,
                   isSelfieDesktopTestMode: true,
                   showHelpInitially: false,
                 }}

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
@@ -146,6 +146,7 @@ describe('document-capture/components/documents-step', () => {
       <SelfieCaptureContext.Provider
         value={{
           isSelfieCaptureEnabled: true,
+          isUploadEnabled: false,
           isSelfieDesktopTestMode: false,
           showHelpInitially: true,
         }}

--- a/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/selfie-step-spec.tsx
@@ -33,6 +33,7 @@ describe('document-capture/components/selfie-step', () => {
         <SelfieCaptureContext.Provider
           value={{
             isSelfieCaptureEnabled: false,
+            isUploadEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
           }}
@@ -73,6 +74,7 @@ describe('document-capture/components/selfie-step', () => {
         <SelfieCaptureContext.Provider
           value={{
             isSelfieCaptureEnabled: false,
+            isUploadEnabled: false,
             isSelfieDesktopTestMode: false,
             showHelpInitially: false,
           }}

--- a/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
+++ b/spec/javascript/packages/document-capture/context/selfie-capture-spec.jsx
@@ -9,6 +9,7 @@ describe('document-capture/context/selfie-capture', () => {
     expect(result.current).to.have.keys([
       'isSelfieCaptureEnabled',
       'isSelfieDesktopTestMode',
+      'isUploadEnabled',
       'showHelpInitially',
     ]);
     expect(result.current.isSelfieCaptureEnabled).to.be.a('boolean');

--- a/spec/views/idv/shared/_document_capture.html.erb_spec.rb
+++ b/spec/views/idv/shared/_document_capture.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
   let(:acuant_sdk_upgrade_a_b_testing_enabled) { false }
   let(:use_alternate_sdk) { false }
   let(:selfie_capture_enabled) { true }
+  let(:upload_enabled) { true }
 
   let(:acuant_version) { '1.3.3.7' }
   let(:skip_doc_auth_from_how_to_verify) { false }
@@ -55,6 +56,7 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
       use_alternate_sdk: use_alternate_sdk,
       acuant_version: acuant_version,
       doc_auth_selfie_capture: selfie_capture_enabled,
+      doc_auth_upload_enabled: upload_enabled,
       skip_doc_auth_from_how_to_verify: skip_doc_auth_from_how_to_verify,
       skip_doc_auth_from_handoff: skip_doc_auth_from_handoff,
       skip_doc_auth_from_socure: skip_doc_auth_from_socure,
@@ -145,6 +147,16 @@ RSpec.describe 'idv/shared/_document_capture.html.erb' do
         render_partial
         expect(rendered).to have_css(
           "#document-capture-form[data-doc-auth-selfie-capture='false']",
+        )
+      end
+    end
+
+    context 'when doc_auth_upload_enabled is false' do
+      let(:upload_enabled) { false }
+      it 'does not send doc_auth_upload_enabled to the FE' do
+        render_partial
+        expect(rendered).to have_css(
+          "#document-capture-form[data-doc-auth-upload-enabled='false']",
         )
       end
     end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-16187](https://cm-jira.usa.gov/browse/LG-16187)



## 🛠 Summary of changes

Connect the A/B test to have the option to remove manual upload from IAL1 IDV.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Set config variables in application.yml 
`doc_auth_selfie_desktop_test_mode: false`
`doc_auth_manual_upload_disabled_a_b_testing_enabled: true`
`doc_auth_manual_upload_disabled_a_b_testing_percent: 100`
- [ ] Go through IdV
- [ ] Confirm that there is no option to do a manual upload


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
