### PR TITLE
changelog: Upcoming Features, Attempts API, Adds idv-phone events

### DIFF
--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -101,6 +101,48 @@ module AttemptsApi
       )
     end
 
+    # @param [Boolean] success
+    # @param [String] phone_number
+    # @param [String<':sms',':voice'>] otp_delivery_method
+    # @param [Hash<Key, Array<String>>] failure_reason
+    # OTP is sent and what method chosen during idv flow.
+    def idv_phone_otp_sent(success:, phone_number:,
+                           otp_delivery_method:, failure_reason: nil)
+      track_event(
+        'idv-phone-otp-sent',
+        success:,
+        phone_number:,
+        otp_delivery_method:,
+        failure_reason:,
+      )
+    end
+
+    # @param [String] phone_number
+    # param [Boolean] success
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # User submits OTP code sent to their phone
+    def idv_phone_otp_submitted(phone_number:, success:, failure_reason: nil)
+      track_event(
+        'idv-phone-otp-submitted',
+        phone_number:,
+        success:,
+        failure_reason:,
+      )
+    end
+
+    # @param [Boolean] success
+    # @param [String] phone_number
+    # @param [Hash<Key, Array<String>>] failure_reason
+    # The user provides their phone number for identity verification
+    def idv_phone_submitted(success:, phone_number:, failure_reason: nil)
+      track_event(
+        'idv-phone-submitted',
+        success:,
+        phone_number:,
+        failure_reason:,
+      )
+    end
+
     # @param [Boolean] resend False indicates this is the initial request
     # User has requested the Address validation letter
     def idv_verify_by_mail_letter_requested(resend:)

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneOtpSent.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneOtpSent.yml
@@ -29,6 +29,7 @@ allOf:
                 - invalid_phone_number
                 - opt_out
                 - permanent_failure
+                - rate_limited
                 - sms_unsupported
                 - temporary_failure
                 - throttled

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneOtpSubmitted.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneOtpSubmitted.yml
@@ -11,19 +11,13 @@ allOf:
         description: |
           An OPTIONAL object. An associative array of attributes and errors if success is false
         properties:
-          # these are true/false bools rather than arrays of strings.
-          # can we update this to be something like:
-          # code:
-          #   type: array
-          #   items:
-          #     type: string
-          #     enum: ['code_matches', 'code_expired']
-          code_matches:
-            type: boolean
-            description: An OPTIONAL key if the code does not match
-          code_expired:
-            type: boolean
-            description: An OPTIONAL key if the code has expired
+          code:
+            type: array
+            items:
+              type: string
+              enum: 
+                - expired
+                - does_not_match
       success:
         type: boolean
         description: |

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneSubmitted.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneSubmitted.yml
@@ -18,8 +18,15 @@ allOf:
               type: string
               enum:
                 - improbable_phone
-                - We are unable to call phone numbers in {Country Name}
-                - We are unable to send text messages to phone numbers in {Country Name}
+                - voice_unsupported
+                - sms_unsupported
+          otp_delivery_preference:
+            type: array
+            description: An OPTIONAL key that describes errors with the delivery method
+            items:
+              type: string
+              enum:
+                - inclusion
       success:
         type: boolean
         description: |

--- a/spec/controllers/idv/otp_verification_controller_spec.rb
+++ b/spec/controllers/idv/otp_verification_controller_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Idv::OtpVerificationController do
 
   before do
     stub_analytics
+    stub_attempts_tracker
 
     sign_in(user)
     stub_verify_steps_one_and_two(user)
@@ -91,6 +92,11 @@ RSpec.describe Idv::OtpVerificationController do
 
     it 'invalidates future steps' do
       expect(subject).to receive(:clear_future_steps!)
+      expect(@attempts_api_tracker).to receive(:idv_phone_otp_submitted).with(
+        phone_number: PhoneFormatter.format(phone),
+        success: true,
+        failure_reason: nil,
+      )
 
       put :update, params: otp_code_param
     end
@@ -99,6 +105,12 @@ RSpec.describe Idv::OtpVerificationController do
       let(:user_phone_confirmation) { true }
 
       it 'redirects to the review step' do
+        expect(@attempts_api_tracker).to receive(:idv_phone_otp_submitted).with(
+          phone_number: PhoneFormatter.format(phone),
+          success: true,
+          failure_reason: nil,
+        )
+
         put :update, params: otp_code_param
         expect(response).to redirect_to(idv_enter_password_path)
       end
@@ -153,7 +165,42 @@ RSpec.describe Idv::OtpVerificationController do
       end
     end
 
+    context 'when the code is wrong' do
+      let(:otp_code_param) { { code: 'wrong' } }
+
+      it 'tracks the event' do
+        expect(@attempts_api_tracker).to receive(:idv_phone_otp_submitted).with(
+          phone_number: PhoneFormatter.format(phone),
+          success: false,
+          failure_reason: { code: ['does_not_match'] },
+        )
+
+        put :update, params: otp_code_param
+      end
+    end
+
+    context 'when the code is expired' do
+      let(:phone_confirmation_otp_sent_at) do
+        Time.zone.now - TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_SECONDS
+      end
+
+      it 'tracks the event' do
+        expect(@attempts_api_tracker).to receive(:idv_phone_otp_submitted).with(
+          phone_number: PhoneFormatter.format(phone),
+          success: false,
+          failure_reason: { code: ['expired'] },
+        )
+
+        put :update, params: otp_code_param
+      end
+    end
+
     it 'tracks an analytics event' do
+      expect(@attempts_api_tracker).to receive(:idv_phone_otp_submitted).with(
+        phone_number: PhoneFormatter.format(phone),
+        success: true,
+        failure_reason: nil,
+      )
       put :update, params: otp_code_param
 
       expect(@analytics).to have_logged_event(

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe Idv::PhoneController do
         :check_for_mail_only_outage,
       )
     end
-  end
 
-  describe 'before_actions' do
     it 'includes before_actions from IdvSessionConcern' do
       expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
@@ -52,6 +50,7 @@ RSpec.describe Idv::PhoneController do
     stub_sign_in(user)
     stub_up_to(:verify_info, idv_session: subject.idv_session)
     stub_analytics
+    stub_attempts_tracker
   end
 
   describe '#new' do
@@ -119,10 +118,6 @@ RSpec.describe Idv::PhoneController do
       let(:step) { 'path_where_user_asked_to_use_different_number' }
       let(:params) { { step: step } }
 
-      before do
-        stub_analytics
-      end
-
       it 'logs an event showing that the user wants to choose a different number' do
         get :new, params: params
 
@@ -134,8 +129,6 @@ RSpec.describe Idv::PhoneController do
     end
 
     it 'shows phone form if async process times out and allows successful resubmission' do
-      stub_analytics
-
       # setting the document capture session to a nonexistent uuid will trigger async
       # missing behavior
       subject.idv_session.idv_phone_step_document_capture_session_uuid = 'abc123'
@@ -193,6 +186,17 @@ RSpec.describe Idv::PhoneController do
           expect(Telephony::Test::Message.messages.length).to eq(1)
         end
 
+        it 'tracks the Attempts API event' do
+          expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+            phone_number: Phonelib.parse(phone).e164,
+            success: true,
+            otp_delivery_method: :sms,
+            failure_reason: nil,
+          )
+
+          get :new
+        end
+
         context 'the user submited their last attempt' do
           it 'redirects to the OTP confirmation and the rate limiter is maxed' do
             RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
@@ -203,6 +207,32 @@ RSpec.describe Idv::PhoneController do
             expect(Telephony::Test::Message.messages.length).to eq(1)
             expect(RateLimiter.new(user: user, rate_limit_type: :proof_address).maxed?).to eq(true)
           end
+
+          it 'tracks the event' do
+            expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+              phone_number: Phonelib.parse(phone).e164,
+              success: true,
+              otp_delivery_method: :sms,
+              failure_reason: nil,
+            )
+
+            get :new
+          end
+        end
+      end
+
+      context 'when Pinpoint throws an opt-out error' do
+        let(:phone) { Telephony::Test::ErrorSimulator::OPT_OUT_PHONE_NUMBER }
+
+        it 'tracks the Attempts API event' do
+          expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+            phone_number: Phonelib.parse(phone).e164,
+            success: false,
+            otp_delivery_method: :sms,
+            failure_reason: { telephony_error: ['opt_out'] },
+          )
+
+          get :new
         end
       end
 
@@ -217,6 +247,12 @@ RSpec.describe Idv::PhoneController do
           expect(subject.idv_session.vendor_phone_confirmation).to eq(nil)
           expect(subject.idv_session.user_phone_confirmation).to eq(nil)
           expect(Telephony::Test::Message.messages.length).to eq(0)
+        end
+
+        it 'does not track the event' do
+          expect(@attempts_api_tracker).not_to receive(:idv_phone_otp_sent)
+
+          get :new
         end
 
         context 'the user submited their last attempt' do
@@ -255,10 +291,13 @@ RSpec.describe Idv::PhoneController do
             },
         }
       end
-      before do
-      end
 
       it 'renders #new' do
+        expect(@attempts_api_tracker).to receive(:idv_phone_submitted).with(
+          phone_number: Phonelib.parse(improbable_phone_number).e164,
+          success: false,
+          failure_reason: { phone: [:improbable_phone], otp_delivery_preference: [:inclusion] },
+        )
         put :create, params: improbable_phone_form
 
         expect(flash[:error]).to eq improbable_phone_message
@@ -276,6 +315,12 @@ RSpec.describe Idv::PhoneController do
       end
 
       it 'disallows non-US numbers' do
+        expect(@attempts_api_tracker).to receive(:idv_phone_submitted).with(
+          phone_number: Phonelib.parse(international_phone).e164,
+          success: false,
+          failure_reason: { phone: [:improbable_phone] },
+        )
+
         put :create, params: { idv_phone_form: { phone: international_phone } }
 
         expect(flash[:error]).to eq improbable_phone_message
@@ -325,6 +370,12 @@ RSpec.describe Idv::PhoneController do
       end
 
       it 'tracks events with valid phone' do
+        expect(@attempts_api_tracker).to receive(:idv_phone_submitted).with(
+          phone_number: Phonelib.parse(good_phone).e164,
+          success: true,
+          failure_reason: nil,
+        )
+
         put :create, params: phone_params
 
         expect(@analytics).to have_logged_event(
@@ -350,6 +401,12 @@ RSpec.describe Idv::PhoneController do
       context 'when same as user phone' do
         it 'redirects to otp delivery page' do
           original_applicant = subject.idv_session.applicant.dup
+          expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+            phone_number: Phonelib.parse(good_phone).e164,
+            success: true,
+            otp_delivery_method: :sms,
+            failure_reason: nil,
+          )
 
           put :create, params: phone_params
 
@@ -386,6 +443,13 @@ RSpec.describe Idv::PhoneController do
 
       context 'when different phone from user phone' do
         it 'redirects to otp page and does not set phone_confirmed_at' do
+          expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+            phone_number: Phonelib.parse(good_phone).e164,
+            success: true,
+            otp_delivery_method: :sms,
+            failure_reason: nil,
+          )
+
           put :create, params: phone_params
 
           expect(response).to redirect_to idv_phone_path
@@ -447,6 +511,13 @@ RSpec.describe Idv::PhoneController do
 
     it 'tracks that the hybrid handoff phone was used' do
       subject.idv_session.phone_for_mobile_flow = good_phone
+
+      expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+        phone_number: Phonelib.parse(good_phone).e164,
+        success: true,
+        otp_delivery_method: :sms,
+        failure_reason: nil,
+      )
 
       put :create, params: { idv_phone_form: { phone: good_phone } }
       expect(response).to redirect_to idv_phone_path
@@ -526,9 +597,6 @@ RSpec.describe Idv::PhoneController do
 
       context 'when the user is rate limited by submission' do
         before do
-          stub_analytics
-          stub_attempts_tracker
-
           rate_limiter = RateLimiter.new(rate_limit_type: :proof_address, user: user)
           rate_limiter.increment_to_limited!
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Fraud Mitigation 2](https://gitlab.login.gov/lg-teams/FIE/fraud-mitigation/-/issues/2)

## 🛠 Summary of changes
This change adds: 
- idv-phone-otp-sent event  
  - with custom error parser   
-  idv-phone-otp-submitted event  
  - with custom error parser
-  idv-phone-submitted event
- and associated tests.

We have decided to format the phone numbers using `Phonelib.parse(phone).e164` to be consistent with what we use for OIDC/SAML.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
