### PR TITLE
mfa-enrolled events and some phone rate limiters

### DIFF
--- a/app/controllers/concerns/two_factor_authenticatable_methods.rb
+++ b/app/controllers/concerns/two_factor_authenticatable_methods.rb
@@ -102,8 +102,16 @@ module TwoFactorAuthenticatableMethods
     handle_max_attempts(type + '_login_attempts')
   end
 
-  def handle_too_many_otp_sends
+  def handle_too_many_otp_sends(context: nil, phone_number: nil)
     analytics.multi_factor_auth_max_sends
+    if context && phone_number
+      if UserSessionContext.authentication_context?(context)
+        attempts_api_tracker.mfa_login_phone_otp_sent_rate_limited(phone_number:)
+      elsif UserSessionContext.confirmation_context?(context)
+        attempts_api_tracker.mfa_enroll_phone_otp_sent_rate_limited(phone_number:)
+      end
+    end
+
     handle_max_attempts('otp_requests')
   end
 

--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -158,6 +158,12 @@ module TwoFactorAuthentication
     def log_confirmation_analytics(result)
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)
+      attempts_api_tracker.mfa_enrolled(
+        success: result.success?,
+        mfa_device_type: 'phone',
+        otp_delivery_method: otp_auth_method,
+        phone_number: Phonelib.parse(phone).e164,
+      )
     end
 
     def analytics_properties

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -23,7 +23,10 @@ module Users
       result = BackupCodeSetupForm.new(current_user).submit
       visit_result = result.to_h.merge(analytics_properties_for_visit)
       analytics.backup_code_setup_visit(**visit_result)
-      attempts_api_tracker.mfa_enrolled(success: result.success?, mfa_device_type: 'backup_code')
+      attempts_api_tracker.mfa_enrolled(
+        success: result.success?,
+        mfa_device_type: TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
+      )
 
       generate_codes
       track_backup_codes_created
@@ -36,7 +39,10 @@ module Users
       result = BackupCodeSetupForm.new(current_user).submit
       visit_result = result.to_h.merge(analytics_properties_for_visit)
       analytics.backup_code_setup_visit(**visit_result)
-      attempts_api_tracker.mfa_enrolled(success: result.success?, mfa_device_type: 'backup_code')
+      attempts_api_tracker.mfa_enrolled(
+        success: result.success?,
+        mfa_device_type: TwoFactorAuthenticatable::AuthMethod::BACKUP_CODE,
+      )
 
       generate_codes
       track_backup_codes_created

--- a/app/controllers/users/backup_code_setup_controller.rb
+++ b/app/controllers/users/backup_code_setup_controller.rb
@@ -23,7 +23,7 @@ module Users
       result = BackupCodeSetupForm.new(current_user).submit
       visit_result = result.to_h.merge(analytics_properties_for_visit)
       analytics.backup_code_setup_visit(**visit_result)
-      attempts_api_tracker.mfa_enroll_backup_code(success: result.success?)
+      attempts_api_tracker.mfa_enrolled(success: result.success?, mfa_device_type: 'backup_code')
 
       generate_codes
       track_backup_codes_created
@@ -36,7 +36,7 @@ module Users
       result = BackupCodeSetupForm.new(current_user).submit
       visit_result = result.to_h.merge(analytics_properties_for_visit)
       analytics.backup_code_setup_visit(**visit_result)
-      attempts_api_tracker.mfa_enroll_backup_code(success: result.success?)
+      attempts_api_tracker.mfa_enrolled(success: result.success?, mfa_device_type: 'backup_code')
 
       generate_codes
       track_backup_codes_created

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -75,6 +75,12 @@ module Users
       result = user_piv_cac_form.submit
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)
+
+      attempts_api_tracker.mfa_enrolled(
+        success: result.success?,
+        mfa_device_type: 'piv_cac',
+      )
+
       if result.success?
         process_valid_submission
         user_session.delete(:mfa_attempts)

--- a/app/controllers/users/piv_cac_authentication_setup_controller.rb
+++ b/app/controllers/users/piv_cac_authentication_setup_controller.rb
@@ -78,7 +78,7 @@ module Users
 
       attempts_api_tracker.mfa_enrolled(
         success: result.success?,
-        mfa_device_type: 'piv_cac',
+        mfa_device_type: TwoFactorAuthenticatable::AuthMethod::PIV_CAC,
       )
 
       if result.success?

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -30,7 +30,7 @@ module Users
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)
 
-      attempts_api_tracker.mfa_enroll_totp(success: result.success?)
+      attempts_api_tracker.mfa_enrolled(success: result.success?, mfa_device_type: 'totp')
 
       if result.success?
         process_valid_code

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -30,7 +30,10 @@ module Users
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)
 
-      attempts_api_tracker.mfa_enrolled(success: result.success?, mfa_device_type: 'totp')
+      attempts_api_tracker.mfa_enrolled(
+        success: result.success?,
+        mfa_device_type: TwoFactorAuthenticatable::AuthMethod::TOTP,
+      )
 
       if result.success?
         process_valid_code

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -176,11 +176,17 @@ module Users
       otp_rate_limiter.reset_count_and_otp_last_sent_at if current_user.no_longer_locked_out?
 
       if exceeded_otp_send_limit?
-        return handle_too_many_otp_sends
+        return handle_too_many_otp_sends(
+          phon_number: parsed_phone.e164,
+          context:,
+        )
       end
       otp_rate_limiter.increment
       if exceeded_otp_send_limit?
-        return handle_too_many_otp_sends
+        return handle_too_many_otp_sends(
+          phone_number: parsed_phone.e164,
+          context:,
+        )
       end
 
       if exceeded_short_term_otp_rate_limit?

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -177,7 +177,7 @@ module Users
 
       if exceeded_otp_send_limit?
         return handle_too_many_otp_sends(
-          phon_number: parsed_phone.e164,
+          phone_number: parsed_phone.e164,
           context:,
         )
       end

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -51,11 +51,11 @@ module Users
           success: false,
         )
 
-        if @platform_authenticator
-          attempts_api_tracker.mfa_enroll_webauthn_platform(success: false)
-        else
-          attempts_api_tracker.mfa_enroll_webauthn_roaming(success: false)
-        end
+        attempts_api_tracker.mfa_enrolled(
+          success: false,
+          mfa_device_type: @platform_authenticator.present? ? 'webauthn_platform' : 'webauthn',
+        )
+
       end
 
       flash_error(result.errors) unless result.success?
@@ -80,11 +80,11 @@ module Users
       )
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)
-      if @platform_authenticator
-        attempts_api_tracker.mfa_enroll_webauthn_platform(success: result.success?)
-      else
-        attempts_api_tracker.mfa_enroll_webauthn_roaming(success: result.success?)
-      end
+
+      attempts_api_tracker.mfa_enrolled(
+        success: result.success?,
+        mfa_device_type: @platform_authenticator.present? ? 'webauthn_platform' : 'webauthn',
+      )
 
       if result.success?
         process_valid_webauthn(form)

--- a/app/controllers/users/webauthn_setup_controller.rb
+++ b/app/controllers/users/webauthn_setup_controller.rb
@@ -51,9 +51,13 @@ module Users
           success: false,
         )
 
+        mfa_device_type = @platform_authenticator.present? ?
+          TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM :
+          TwoFactorAuthenticatable::AuthMethod::WEBAUTHN
+
         attempts_api_tracker.mfa_enrolled(
           success: false,
-          mfa_device_type: @platform_authenticator.present? ? 'webauthn_platform' : 'webauthn',
+          mfa_device_type:,
         )
 
       end
@@ -81,9 +85,13 @@ module Users
       properties = result.to_h.merge(analytics_properties)
       analytics.multi_factor_auth_setup(**properties)
 
+      mfa_device_type = @platform_authenticator.present? ?
+        TwoFactorAuthenticatable::AuthMethod::WEBAUTHN_PLATFORM :
+        TwoFactorAuthenticatable::AuthMethod::WEBAUTHN
+
       attempts_api_tracker.mfa_enrolled(
         success: result.success?,
-        mfa_device_type: @platform_authenticator.present? ? 'webauthn_platform' : 'webauthn',
+        mfa_device_type:,
       )
 
       if result.success?

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -64,4 +64,12 @@ class AnonymousUser
   def active_profile
     nil
   end
+
+  def unique_session_id
+    nil
+  end
+
+  def id
+    nil
+  end
 end

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -92,7 +92,8 @@ module AttemptsApi
     end
 
     def hashed_session_id
-      return nil unless user&.unique_session_id
+      return nil unless user&.unique_session_id.present?
+
       Digest::SHA1.hexdigest(user&.unique_session_id)
     end
 

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -214,11 +214,18 @@ module AttemptsApi
     end
 
     # @param [Boolean] success
-    # A user has attempted to enroll the Backup Codes MFA method to their account
-    def mfa_enroll_backup_code(success:)
+    # @param mfa_device_type [String<'backup_code', 'otp', 'personal_key', 'piv_cac',
+    # 'remember_device', 'totp', 'webauthn', 'webauthn_platform'>]
+    # @param [String<'sms','voice'>] otp_delivery_method
+    # @param [String] phone Enrolled phone number
+    # Tracks when user enrolls their MFA device.
+    def mfa_enrolled(success:, mfa_device_type:, otp_delivery_method: nil, phone: nil)
       track_event(
-        'mfa-enroll-backup-code',
+        'mfa-enrolled',
         success:,
+        mfa_device_type:,
+        otp_delivery_method:,
+        phone:,
       )
     end
 

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -240,6 +240,15 @@ module AttemptsApi
       )
     end
 
+    # @param [String] phone_number - The user's phone number used for multi-factor authentication
+    # The user has exceeded the rate limit for SMS OTP sends during mfa enrollment.
+    def mfa_enroll_phone_otp_sent_rate_limited(phone_number:)
+      track_event(
+        'mfa-enroll-phone-otp-sent-rate-limited',
+        phone_number:,
+      )
+    end
+
     # Tracks when user submits a verification attempt using their MFA.
     # @param mfa_device_type [String<'backup_code', 'otp', 'personal_key', 'piv_cac',
     # 'remember_device', 'totp', 'webauthn', 'webauthn_platform'>]
@@ -253,6 +262,15 @@ module AttemptsApi
         reauthentication:,
         success:,
         failure_reason:,
+      )
+    end
+
+    # @param [String] phone_number - The user's phone number used for multi-factor authentication
+    # The user has exceeded the rate limit for SMS OTP sends during login attempt.
+    def mfa_login_phone_otp_sent_rate_limited(phone_number:)
+      track_event(
+        'mfa-enroll-phone-otp-sent-rate-limited',
+        phone_number:,
       )
     end
 

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -213,19 +213,19 @@ module AttemptsApi
       )
     end
 
+    # Tracks when user enrolls their MFA device.
     # @param [Boolean] success
     # @param mfa_device_type [String<'backup_code', 'otp', 'personal_key', 'piv_cac',
     # 'remember_device', 'totp', 'webauthn', 'webauthn_platform'>]
     # @param [String<'sms','voice'>] otp_delivery_method
     # @param [String] phone Enrolled phone number
-    # Tracks when user enrolls their MFA device.
-    def mfa_enrolled(success:, mfa_device_type:, otp_delivery_method: nil, phone: nil)
+    def mfa_enrolled(success:, mfa_device_type:, otp_delivery_method: nil, phone_number: nil)
       track_event(
         'mfa-enrolled',
         success:,
         mfa_device_type:,
         otp_delivery_method:,
-        phone:,
+        phone_number:,
       )
     end
 
@@ -269,7 +269,7 @@ module AttemptsApi
     # The user has exceeded the rate limit for SMS OTP sends during login attempt.
     def mfa_login_phone_otp_sent_rate_limited(phone_number:)
       track_event(
-        'mfa-enroll-phone-otp-sent-rate-limited',
+        'mfa-login-phone-otp-sent-rate-limited',
         phone_number:,
       )
     end

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -229,15 +229,6 @@ module AttemptsApi
       )
     end
 
-    # @param [Boolean] success
-    # A user has attempted to enroll the TOTP MFA method to their account
-    def mfa_enroll_totp(success:)
-      track_event(
-        'mfa-enroll-totp',
-        success:,
-      )
-    end
-
     # Tracks when user submits registration password
     # @param [String<'backup_code', 'otp', 'piv_cac', 'totp'>] mfa_device_type
     # The user has exceeded the rate limit during enrollment
@@ -246,24 +237,6 @@ module AttemptsApi
       track_event(
         'mfa-enroll-code-rate-limited',
         mfa_device_type:,
-      )
-    end
-
-    # @param [Boolean] success
-    # Tracks when the user has attempted to enroll the WebAuthn-Platform MFA method to their account
-    def mfa_enroll_webauthn_platform(success:)
-      track_event(
-        'mfa-enroll-webauthn-platform',
-        success:,
-      )
-    end
-
-    # @param [Boolean] success
-    # Tracks when the user has attempted to enroll the WebAuthn MFA method to their account
-    def mfa_enroll_webauthn_roaming(success:)
-      track_event(
-        'mfa-enroll-webauthn-roaming',
-        success:,
       )
     end
 

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -215,8 +215,8 @@ module AttemptsApi
 
     # Tracks when user enrolls their MFA device.
     # @param [Boolean] success
-    # @param mfa_device_type [String<'backup_code', 'otp', 'personal_key', 'piv_cac',
-    # 'remember_device', 'totp', 'webauthn', 'webauthn_platform'>]
+    # @param mfa_device_type [String<'backup_code', 'otp', 'piv_cac',
+    # 'totp', 'webauthn', 'webauthn_platform'>]
     # @param [String<'sms','voice'>] otp_delivery_method
     # @param [String] phone_number Enrolled phone number
     def mfa_enrolled(success:, mfa_device_type:, otp_delivery_method: nil, phone_number: nil)

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -218,7 +218,7 @@ module AttemptsApi
     # @param mfa_device_type [String<'backup_code', 'otp', 'personal_key', 'piv_cac',
     # 'remember_device', 'totp', 'webauthn', 'webauthn_platform'>]
     # @param [String<'sms','voice'>] otp_delivery_method
-    # @param [String] phone Enrolled phone number
+    # @param [String] phone_number Enrolled phone number
     def mfa_enrolled(success:, mfa_device_type:, otp_delivery_method: nil, phone_number: nil)
       track_event(
         'mfa-enrolled',

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -28,7 +28,10 @@ RSpec.describe Users::BackupCodeSetupController do
       stub_analytics
       stub_attempts_tracker
       allow(controller).to receive(:in_multi_mfa_selection_flow?).and_return(true)
-      expect(@attempts_api_tracker).to receive(:mfa_enroll_backup_code).with(success: true)
+      expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
+        success: true,
+        mfa_device_type: 'backup_code',
+      )
 
       Funnel::Registration::AddMfa.call(user.id, 'phone', @analytics, threatmetrix_attrs)
       expect(PushNotification::HttpPush).to receive(:deliver)

--- a/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/piv_cac_authentication_setup_controller_spec.rb
@@ -124,6 +124,12 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
             let(:mfa_selections) { ['piv_cac'] }
             it 'redirects to suggest 2nd MFA page' do
               stub_analytics
+              stub_attempts_tracker
+
+              expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
+                success: true,
+                mfa_device_type: 'piv_cac',
+              )
 
               expect(response).to redirect_to(auth_method_confirmation_url)
 
@@ -139,6 +145,16 @@ RSpec.describe Users::PivCacAuthenticationSetupController do
 
             it 'logs mfa attempts commensurate to number of attempts' do
               stub_analytics
+              stub_attempts_tracker
+
+              expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
+                success: false,
+                mfa_device_type: 'piv_cac',
+              )
+              expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
+                success: true,
+                mfa_device_type: 'piv_cac',
+              )
 
               get :new, params: { token: bad_token }
               response

--- a/spec/controllers/users/totp_setup_controller_spec.rb
+++ b/spec/controllers/users/totp_setup_controller_spec.rb
@@ -88,7 +88,10 @@ RSpec.describe Users::TotpSetupController, devise: true do
     before do
       stub_analytics
       stub_attempts_tracker
-      expect(@attempts_api_tracker).to receive(:mfa_enroll_totp).with(success:)
+      expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
+        success:,
+        mfa_device_type: 'totp',
+      )
     end
 
     context 'user is already signed up' do
@@ -160,7 +163,10 @@ RSpec.describe Users::TotpSetupController, devise: true do
           subject.user_session[:new_totp_secret] = secret
 
           # calls the tracker again with success: true
-          expect(@attempts_api_tracker).to receive(:mfa_enroll_totp).with(success: true)
+          expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
+            success: true,
+            mfa_device_type: 'totp',
+          )
           patch :confirm, params: { name: name, code: generate_totp_code(secret) }
         end
 

--- a/spec/controllers/users/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_controller_spec.rb
@@ -378,6 +378,11 @@ RSpec.describe Users::TwoFactorAuthenticationController do
         allow(OtpRateLimiter).to receive(:exceeded_otp_send_limit?)
           .and_return(true)
 
+        stub_attempts_tracker
+        expect(@attempts_api_tracker).to receive(:mfa_login_phone_otp_sent_rate_limited).with(
+          phone_number: Phonelib.parse(MfaContext.new(@user).phone_configurations.first.phone).e164,
+        )
+
         freeze_time do
           (IdentityConfig.store.otp_delivery_blocklist_maxretry + 1).times do
             get :send_code, params: {
@@ -660,6 +665,10 @@ RSpec.describe Users::TwoFactorAuthenticationController do
 
         allow(OtpRateLimiter).to receive(:exceeded_otp_send_limit?)
           .and_return(true)
+
+        stub_attempts_tracker
+        expect(@attempts_api_tracker).to receive(:mfa_enroll_phone_otp_sent_rate_limited)
+          .with(phone_number: Phonelib.parse(subject.user_session[:unconfirmed_phone]).e164)
 
         freeze_time do
           (IdentityConfig.store.otp_delivery_blocklist_maxretry + 1).times do

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -119,8 +119,9 @@ RSpec.describe Users::WebauthnSetupController do
 
       it 'tracks the submission' do
         Funnel::Registration::AddMfa.call(user.id, 'phone', @analytics, threatmetrix_attrs)
-        expect(@attempts_api_tracker).to receive(:mfa_enroll_webauthn_roaming).with(
+        expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
           success: true,
+          mfa_device_type: 'webauthn',
         )
 
         patch :confirm, params: params
@@ -244,8 +245,9 @@ RSpec.describe Users::WebauthnSetupController do
         end
 
         it 'logs setup event with session value' do
-          expect(@attempts_api_tracker).to receive(:mfa_enroll_webauthn_roaming).with(
+          expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
             success: true,
+            mfa_device_type: 'webauthn',
           )
 
           patch :confirm, params: params
@@ -370,8 +372,9 @@ RSpec.describe Users::WebauthnSetupController do
 
         it 'should log expected events' do
           Funnel::Registration::AddMfa.call(user.id, 'phone', @analytics, threatmetrix_attrs)
-          expect(@attempts_api_tracker).to receive(:mfa_enroll_webauthn_roaming).with(
+          expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
             success: true,
+            mfa_device_type: 'webauthn',
           )
 
           patch :confirm, params: params
@@ -427,9 +430,11 @@ RSpec.describe Users::WebauthnSetupController do
         end
 
         it 'should log expected events' do
-          expect(@attempts_api_tracker).to receive(:mfa_enroll_webauthn_platform).with(
+          expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
             success: true,
+            mfa_device_type: 'webauthn_platform',
           )
+
           patch :confirm, params: params
 
           expect(@analytics).to have_logged_event(
@@ -460,8 +465,9 @@ RSpec.describe Users::WebauthnSetupController do
         end
 
         it 'should log submitted failure' do
-          expect(@attempts_api_tracker).to receive(:mfa_enroll_webauthn_platform).with(
+          expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
             success: false,
+            mfa_device_type: 'webauthn_platform',
           )
 
           get :new, params: { platform: true, error: 'NotAllowedError' }
@@ -491,8 +497,9 @@ RSpec.describe Users::WebauthnSetupController do
         it 'should log expected events' do
           allow(IdentityConfig.store).to receive(:domain_name).and_return('localhost:3000')
           allow(WebAuthn::AttestationStatement).to receive(:from).and_raise(StandardError)
-          expect(@attempts_api_tracker).to receive(:mfa_enroll_webauthn_platform).with(
+          expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
             success: false,
+            mfa_device_type: 'webauthn_platform',
           )
 
           patch :confirm, params: params
@@ -543,8 +550,9 @@ RSpec.describe Users::WebauthnSetupController do
 
       it 'tracks the submission' do
         Funnel::Registration::AddMfa.call(user.id, 'phone', @analytics, threatmetrix_attrs)
-        expect(@attempts_api_tracker).to receive(:mfa_enroll_webauthn_roaming).with(
+        expect(@attempts_api_tracker).to receive(:mfa_enrolled).with(
           success: true,
+          mfa_device_type: 'webauthn',
         )
 
         patch :confirm, params: params

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -113,6 +113,14 @@ RSpec.feature 'Sign Up' do
       click_2fa_option('backup_code')
 
       click_continue
+
+      expect(attempts_api_tracker).to receive(:mfa_enrolled).with(
+        success: true,
+        mfa_device_type: 'phone',
+        otp_delivery_method: 'sms',
+        phone_number: Phonelib.parse('703-555-1212').e164,
+      )
+
       fill_in 'new_phone_form_phone', with: '703-555-1212'
       click_send_one_time_code
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -95,11 +95,20 @@ RSpec.feature 'Sign Up' do
 
   context 'User in account creation logs in_account_creation_flow for proper analytic events' do
     let(:fake_analytics) { FakeAnalytics.new }
+    let(:attempts_api_tracker) { AttemptsApiTrackingHelper::FakeAttemptsTracker.new }
     before do
       allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
+      allow_any_instance_of(ApplicationController).to receive(:attempts_api_tracker).and_return(
+        attempts_api_tracker,
+      )
     end
+
     it 'logs analytic events for MFA selected with in account creation flow' do
       sign_up_and_set_password
+      expect(attempts_api_tracker).to receive(:mfa_enrolled).with(
+        success: true,
+        mfa_device_type: 'backup_code',
+      )
       click_2fa_option('phone')
       click_2fa_option('backup_code')
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Fraud Mitigation 2](https://gitlab.login.gov/lg-teams/FIE/fraud-mitigation/-/issues/2)

## 🛠 Summary of changes
This change continues to complete Attempts API events.


This change adds
- mfa-enrolled
- mfa-login-phone-otp-sent-rate-limited
  - includes pii
- mfa-enrolled-phone-otp-sent-rate-limited
  - includes pii

This change removes (because they are now included in the mfa-enrolled event)
- mfa-enroll-backup-code
- mfa-enroll-totp
- mfa-enroll-webauthn-platform
- mfa-enroll-webauthn-roaming

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
