### PR TITLE
Delete related DuplicateProfileConfirmations when deleting Profile

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,6 +16,7 @@ class Profile < ApplicationRecord
   # rubocop:enable Rails/InverseOf
   has_many :gpo_confirmation_codes, dependent: :destroy
   has_one :in_person_enrollment, dependent: :destroy
+  has_many :duplicate_profile_confirmations, dependent: :destroy
 
   validates :active, uniqueness: { scope: :user_id, if: :active? }
 


### PR DESCRIPTION
changelog: Bug Fixes, Profile, Delete related DuplicateProfileConfirmations when deleting Profile

This was missed when adding DuplicateProfileConfirmation.

See https://cm-jira.usa.gov/browse/LG-16224.

In my opinion, a test is not needed as the solution is just a missed declaration.
