### PR TITLE
Update tableSummaryStatsExport job to check cloudwatch on top of idp

### DIFF
--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -186,7 +186,7 @@ else
       table_summary_stats_export_job: {
         class: 'DataWarehouse::TableSummaryStatsExportJob',
         cron: gpo_cron_24h,
-        args: -> { [Time.zone.now.yesterday.end_of_day] },
+        args: -> { [Time.zone.yesterday] },
       },
       # Send Duplicate SSN report to S3
       duplicate_ssn: {


### PR DESCRIPTION
Update tableSummaryStatsExport job to check cloudwatch counts for log groups of interest.

## 🎫 Ticket
[issue-393](https://gitlab.login.gov/lg-teams/Team-Data/data-warehouse-ag/-/issues/393)

## 🛠 Summary of changes
The tableSummaryStatsExport will now query cloudwatch and get the count of records from the production.log & events.log log groups of the idp application, followed by writing them to S3.

## 📜 Testing Plan

- [ ] Step 1: Deploy to personal sandbox
- [ ] Step 2: Run job and confirm s3 file is written with expected output