### PR TITLE
Limit batch size and total size for CreateNewDeviceAlertJob

### DIFF
--- a/app/jobs/create_new_device_alert_job.rb
+++ b/app/jobs/create_new_device_alert_job.rb
@@ -8,7 +8,7 @@ class CreateNewDeviceAlertJob < ApplicationJob
     User.where(
       sql_query_for_users_with_new_device,
       tvalue: now - IdentityConfig.store.new_device_alert_delay_in_minutes.minutes,
-    ).find_each do |user|
+    ).limit(2_000).find_each(batch_size: 100) do |user|
       emails_sent += 1 if expire_sign_in_notification_timeframe_and_send_alert(user)
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

Based on investigation and discussion [here](https://gsa-tts.slack.com/archives/C16RSBG49/p1747059922558459?thread_ts=1746564508.559359&cid=C16RSBG49), we should limit the number of emails we send to reduce the chances of scheduled instances of this job running concurrently.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
