### PR TITLE
Deploy RC 478 to Production

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -504,7 +504,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.0.14)
+    rack (3.0.16)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-headers_filter (0.0.1)
@@ -512,7 +512,8 @@ GEM
       rack (>= 1.2.0)
     rack-proxy (0.7.7)
       rack
-    rack-session (2.0.0)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,7 +81,7 @@ class ApplicationController < ActionController::Base
     @attempts_api_tracker ||= AttemptsApi::Tracker.new(
       session_id: attempts_api_session_id,
       request:,
-      user: current_user,
+      user: analytics_user,
       sp: current_sp,
       cookie_device_uuid: cookies[:device],
       # this only works for oidc

--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.tsx
@@ -5,7 +5,7 @@ import { Cancel } from '@18f/identity-verify-flow';
 import { useI18n, HtmlTextWithStrongNoWrap } from '@18f/identity-react-i18n';
 import type { FormStepComponentProps } from '@18f/identity-form-steps';
 import GeneralError from './general-error';
-import { SelfieCaptureContext } from '../context';
+import { SelfieCaptureContext, UploadContext } from '../context';
 import { DocumentCaptureSubheaderOne, DocumentsCaptureStep } from './documents-step';
 import { SelfieCaptureStep } from './selfie-step';
 import type { ReviewIssuesStepValue } from './review-issues-step';
@@ -33,6 +33,12 @@ function DocumentCaptureReviewIssues({
 }: DocumentCaptureReviewIssuesProps) {
   const { t } = useI18n();
   const { isSelfieCaptureEnabled } = useContext(SelfieCaptureContext);
+  const { idType } = useContext(UploadContext);
+  const idIsPassport = idType === 'passport';
+
+  const pageHeading = idIsPassport
+    ? t('doc_auth.headings.review_issues_passport')
+    : t('doc_auth.headings.review_issues');
 
   const defaultSideProps = {
     registerField,
@@ -43,7 +49,7 @@ function DocumentCaptureReviewIssues({
 
   return (
     <>
-      <PageHeading>{t('doc_auth.headings.review_issues')}</PageHeading>
+      <PageHeading>{pageHeading}</PageHeading>
       {isSelfieCaptureEnabled && <DocumentCaptureSubheaderOne />}
       <GeneralError
         unknownFieldErrors={unknownFieldErrors}
@@ -53,6 +59,7 @@ function DocumentCaptureReviewIssues({
         altIsFailedSelfieDontIncludeAttempts
         altFailedDocTypeMsg={isFailedDocType ? t('doc_auth.errors.doc.doc_type_check') : null}
         hasDismissed={hasDismissed}
+        isPassportError={idIsPassport}
       />
       {Number.isFinite(remainingSubmitAttempts) && (
         <p>

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -51,13 +51,17 @@ function getHeading({
   return t('doc_auth.errors.rate_limited_heading');
 }
 
-function getSubheading({ nonIppOrFailedResult, t }) {
+function getSubheading({ nonIppOrFailedResult, passportError, t }) {
   const showSubheading = !nonIppOrFailedResult;
 
-  if (showSubheading) {
+  if (showSubheading && !passportError) {
     return <h2>{t('doc_auth.errors.rate_limited_subheading')}</h2>;
   }
   return undefined;
+}
+
+function isPassportError(unknownFieldErrors) {
+  return unknownFieldErrors.some((error) => error.field === 'passport');
 }
 
 function DocumentCaptureWarning({
@@ -87,10 +91,13 @@ function DocumentCaptureWarning({
   const actionText = nonIppOrFailedResult
     ? t('idv.failure.button.warning')
     : t('idv.failure.button.try_online');
+  const passportError = isPassportError(unknownFieldErrors);
   const subheading = getSubheading({
     nonIppOrFailedResult,
+    passportError,
     t,
   });
+
   const subheadingRef = useRef<HTMLDivElement>(null);
   const errorMessageDisplayedRef = useRef<HTMLDivElement>(null);
 
@@ -130,6 +137,7 @@ function DocumentCaptureWarning({
             isFailedSelfie={isFailedSelfie}
             isFailedSelfieLivenessOrQuality={isFailedSelfieLivenessOrQuality}
             hasDismissed={hasDismissed}
+            isPassportError={passportError}
           />
         </div>
         <p>

--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -62,6 +62,7 @@ function DocumentSideAcuantCapture({
   const { isSelfieCaptureEnabled, isSelfieDesktopTestMode } = useContext(SelfieCaptureContext);
   const isUploadAllowed = isSelfieDesktopTestMode || !isSelfieCaptureEnabled;
   const stepCanComplete = !isReviewStep ? undefined : true;
+
   return (
     <AcuantCapture
       ref={registerField(side, { isRequired: true })}

--- a/app/javascript/packages/document-capture/components/documents-step.tsx
+++ b/app/javascript/packages/document-capture/components/documents-step.tsx
@@ -25,8 +25,13 @@ export function DocumentsCaptureStep({
   value: Record<string, ImageValue>;
   isReviewStep: boolean;
 }) {
-  type DocumentSide = 'front' | 'back';
-  const documentsSides: DocumentSide[] = ['front', 'back'];
+  const { idType } = useContext(UploadContext);
+  const idIsPassport = idType === 'passport';
+
+  type DocumentSide = 'front' | 'back' | 'passport';
+  const documentsSides: DocumentSide[] =
+    idIsPassport && isReviewStep ? ['passport'] : ['front', 'back'];
+
   return (
     <>
       {documentsSides.map((side) => (

--- a/app/javascript/packages/document-capture/components/general-error.tsx
+++ b/app/javascript/packages/document-capture/components/general-error.tsx
@@ -11,6 +11,7 @@ interface GeneralErrorProps extends ComponentProps<'p'> {
   isFailedDocType: boolean;
   isFailedSelfie: boolean;
   isFailedSelfieLivenessOrQuality: boolean;
+  isPassportError?: boolean;
   altFailedDocTypeMsg?: string | null;
   altIsFailedSelfieDontIncludeAttempts?: boolean;
   hasDismissed: boolean;
@@ -45,6 +46,7 @@ function GeneralError({
   isFailedDocType = false,
   isFailedSelfie = false,
   isFailedSelfieLivenessOrQuality = false,
+  isPassportError = false,
   altFailedDocTypeMsg = null,
   altIsFailedSelfieDontIncludeAttempts = false,
   hasDismissed,
@@ -90,6 +92,9 @@ function GeneralError({
         )}
       </p>
     );
+  }
+  if (isPassportError) {
+    return <p>{t('doc_auth.info.review_passport')}</p>;
   }
   if (err && !hasDismissed) {
     return <p key={err.message}>{err.message}</p>;

--- a/app/jobs/create_new_device_alert_job.rb
+++ b/app/jobs/create_new_device_alert_job.rb
@@ -8,7 +8,7 @@ class CreateNewDeviceAlertJob < ApplicationJob
     User.where(
       sql_query_for_users_with_new_device,
       tvalue: now - IdentityConfig.store.new_device_alert_delay_in_minutes.minutes,
-    ).find_each do |user|
+    ).limit(2_000).find_each(batch_size: 100) do |user|
       emails_sent += 1 if expire_sign_in_notification_timeframe_and_send_alert(user)
     end
 

--- a/app/jobs/reports/irs_authentication_report.rb
+++ b/app/jobs/reports/irs_authentication_report.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'reporting/irs_authentication_report'
+
+module Reports
+  class IrsAuthenticationReport < BaseReport
+    REPORT_NAME = 'irs-authentication-report'
+
+    attr_reader :report_date
+
+    def initialize(report_date = nil, *args, **rest)
+      @report_date = report_date
+      super(*args, **rest)
+    end
+
+    def perform(date = Time.zone.yesterday.end_of_day)
+      @report_date = date
+
+      email_addresses = emails.select(&:present?)
+      if email_addresses.empty?
+        Rails.logger.warn 'No email addresses received - Authentication Report NOT SENT'
+        return false
+      end
+
+      reports.each do |report|
+        upload_to_s3(report.table, report_name: report.filename)
+      end
+
+      ReportMailer.tables_report(
+        email: email_addresses,
+        subject: "Authentication Report - #{report_date.to_date}",
+        reports: reports,
+        message: preamble,
+        attachment_format: :csv,
+      ).deliver_now
+    end
+
+    # Explanatory text to go before the report in the email
+    # @return [String]
+    def preamble(env: Identity::Hostdata.env || 'local')
+      ERB.new(<<~ERB).result(binding).html_safe # rubocop:disable Rails/OutputSafety
+        <% if env != 'prod' %>
+          <div class="usa-alert usa-alert--info usa-alert--email">
+            <div class="usa-alert__body">
+              <%#
+                NOTE: our AlertComponent doesn't support heading content like this uses,
+                so for a one-off outside the Rails pipeline it was easier to inline the HTML here.
+              %>
+              <h2 class="usa-alert__heading">
+                Non-Production Report
+              </h2>
+              <p class="usa-alert__text">
+                This was generated in the <strong><%= env %></strong> environment.
+              </p>
+            </div>
+          </div>
+        <% end %>
+      ERB
+    end
+
+    def reports
+      @reports ||= irs_authentication_report.as_emailable_reports
+    end
+
+    def irs_authentication_report
+      @irs_authentication_report ||= Reporting::IrsAuthenticationReport.new(
+        issuers: issuers,
+        time_range: report_date.all_week,
+      )
+    end
+
+    def issuers
+      [*IdentityConfig.store.irs_authentication_issuers]
+    end
+
+    def emails
+      [*IdentityConfig.store.irs_authentication_emails]
+    end
+
+    def upload_to_s3(report_body, report_name: nil)
+      _latest, path = generate_s3_paths(REPORT_NAME, 'csv', subname: report_name, now: report_date)
+
+      if bucket_name.present?
+        upload_file_to_s3_bucket(
+          path: path,
+          body: csv_file(report_body),
+          content_type: 'text/csv',
+          bucket: bucket_name,
+        )
+      end
+    end
+
+    def csv_file(report_array)
+      CSV.generate do |csv|
+        report_array.each do |row|
+          csv << row
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/reports/irs_fraud_metrics_report.rb
+++ b/app/jobs/reports/irs_fraud_metrics_report.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'reporting/irs_fraud_metrics_lg99_report'
+
+module Reports
+  class IrsFraudMetricsReport < BaseReport
+    REPORT_NAME = 'irs-fraud-metrics-report'
+
+    attr_reader :report_date
+
+    def initialize(report_date = nil, *args, **rest)
+      @report_date = report_date
+      super(*args, **rest)
+    end
+
+    def perform(date = Time.zone.yesterday.end_of_day)
+      @report_date = date
+
+      email_addresses = emails.select(&:present?)
+      if email_addresses.empty?
+        Rails.logger.warn 'No email addresses received - Fraud Metrics Report NOT SENT'
+        return false
+      end
+
+      reports.each do |report|
+        upload_to_s3(report.table, report_name: report.filename)
+      end
+
+      ReportMailer.tables_report(
+        email: email_addresses,
+        subject: "Fraud Metrics Report - #{report_date.to_date}",
+        reports: reports,
+        message: preamble,
+        attachment_format: :csv,
+      ).deliver_now
+    end
+
+    # Explanatory text to go before the report in the email
+    # @return [String]
+    def preamble(env: Identity::Hostdata.env || 'local')
+      ERB.new(<<~ERB).result(binding).html_safe # rubocop:disable Rails/OutputSafety
+        <% if env != 'prod' %>
+          <div class="usa-alert usa-alert--info usa-alert--email">
+            <div class="usa-alert__body">
+              <%#
+                NOTE: our AlertComponent doesn't support heading content like this uses,
+                so for a one-off outside the Rails pipeline it was easier to inline the HTML here.
+              %>
+              <h2 class="usa-alert__heading">
+                Non-Production Report
+              </h2>
+              <p class="usa-alert__text">
+                This was generated in the <strong><%= env %></strong> environment.
+              </p>
+            </div>
+          </div>
+        <% end %>
+      ERB
+    end
+
+    def reports
+      @reports ||= irs_fraud_metrics_lg99_report.as_emailable_reports
+    end
+
+    def irs_fraud_metrics_lg99_report
+      @irs_fraud_metrics_lg99_report ||= Reporting::IrsFraudMetricsLg99Report.new(
+        issuers: issuers,
+        time_range: report_date.all_month,
+      )
+    end
+
+    def issuers
+      [*IdentityConfig.store.irs_fraud_metrics_issuers]
+    end
+
+    def emails
+      [*IdentityConfig.store.irs_fraud_metrics_emails]
+    end
+
+    def upload_to_s3(report_body, report_name: nil)
+      _latest, path = generate_s3_paths(REPORT_NAME, 'csv', subname: report_name, now: report_date)
+
+      if bucket_name.present?
+        upload_file_to_s3_bucket(
+          path: path,
+          body: csv_file(report_body),
+          content_type: 'text/csv',
+          bucket: bucket_name,
+        )
+      end
+    end
+
+    def csv_file(report_array)
+      CSV.generate do |csv|
+        report_array.each do |row|
+          csv << row
+        end
+      end
+    end
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,6 +16,7 @@ class Profile < ApplicationRecord
   # rubocop:enable Rails/InverseOf
   has_many :gpo_confirmation_codes, dependent: :destroy
   has_one :in_person_enrollment, dependent: :destroy
+  has_many :duplicate_profile_confirmations, dependent: :destroy
 
   validates :active, uniqueness: { scope: :user_id, if: :active? }
 

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -4,7 +4,7 @@ module AttemptsApi
   class Tracker
     SKIP_AGENCY_UUID_CREATION_EVENT_TYPES = [
       'login-email-and-password-auth',
-      'login-email-and-password-auth',
+      'forgot-password-email-sent',
     ].freeze
     attr_reader :session_id, :enabled_for_session, :request, :user, :sp, :cookie_device_uuid,
                 :sp_request_uri
@@ -81,7 +81,7 @@ module AttemptsApi
     private
 
     def agency_uuid(event_type:)
-      return nil unless sp
+      return nil unless user&.id && sp
       skip_create = SKIP_AGENCY_UUID_CREATION_EVENT_TYPES.include?(event_type)
 
       if skip_create

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -2,6 +2,10 @@
 
 module AttemptsApi
   class Tracker
+    SKIP_AGENCY_UUID_CREATION_EVENT_TYPES = [
+      'login-email-and-password-auth',
+      'login-email-and-password-auth',
+    ].freeze
     attr_reader :session_id, :enabled_for_session, :request, :user, :sp, :cookie_device_uuid,
                 :sp_request_uri
 
@@ -31,7 +35,7 @@ module AttemptsApi
       event_metadata = {
         user_agent: request&.user_agent,
         unique_session_id: hashed_session_id,
-        user_uuid: sp && AgencyIdentityLinker.for(user: user, service_provider: sp)&.uuid,
+        user_uuid: agency_uuid(event_type: event_type),
         device_fingerprint: hashed_cookie_device_uuid,
         user_ip_address: request&.remote_ip,
         application_url: sp_request_uri,
@@ -75,6 +79,17 @@ module AttemptsApi
     end
 
     private
+
+    def agency_uuid(event_type:)
+      return nil unless sp
+      skip_create = SKIP_AGENCY_UUID_CREATION_EVENT_TYPES.include?(event_type)
+
+      if skip_create
+        AgencyIdentityLinker.for(user: user, service_provider: sp, skip_create: true)&.uuid
+      else
+        AgencyIdentityLinker.for(user: user, service_provider: sp, skip_create: false).uuid
+      end
+    end
 
     def hashed_session_id
       return nil unless user&.unique_session_id

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -110,6 +110,48 @@ module AttemptsApi
       )
     end
 
+    # @param [Boolean] success
+    # @param [String] phone_number
+    # @param [String<':sms',':voice'>] otp_delivery_method
+    # @param [Hash<Key, Array<String>>] failure_reason
+    # OTP is sent and what method chosen during idv flow.
+    def idv_phone_otp_sent(success:, phone_number:,
+                           otp_delivery_method:, failure_reason: nil)
+      track_event(
+        'idv-phone-otp-sent',
+        success:,
+        phone_number:,
+        otp_delivery_method:,
+        failure_reason:,
+      )
+    end
+
+    # @param [Boolean] success
+    # @param [String] phone_number
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # User submits OTP code sent to their phone
+    def idv_phone_otp_submitted(phone_number:, success:, failure_reason: nil)
+      track_event(
+        'idv-phone-otp-submitted',
+        success:,
+        phone_number:,
+        failure_reason:,
+      )
+    end
+
+    # @param [Boolean] success
+    # @param [String] phone_number
+    # @param [Hash<Key, Array<String>>] failure_reason
+    # The user provides their phone number for identity verification
+    def idv_phone_submitted(success:, phone_number:, failure_reason: nil)
+      track_event(
+        'idv-phone-submitted',
+        success:,
+        phone_number:,
+        failure_reason:,
+      )
+    end
+
     # @param [Boolean] resend False indicates this is the initial request
     # User has requested the Address validation letter
     def idv_verify_by_mail_letter_requested(resend:)

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -69,7 +69,7 @@ module AttemptsApi
     #  A user has requested a password reset.
     def forgot_password_email_sent(email:)
       track_event(
-        :forgot_password_email_sent,
+        'forgot-password-email-sent',
         email:,
       )
     end

--- a/app/services/doc_auth/dos/requests/mrz_request.rb
+++ b/app/services/doc_auth/dos/requests/mrz_request.rb
@@ -38,7 +38,7 @@ module DocAuth
           when 'NO'
             DocAuth::Response.new(
               success: false,
-              errors: { passport: 'invalid MRZ' },
+              errors: { passport: I18n.t('doc_auth.errors.general.fallback_field_level') },
               exception: nil,
               extra:,
             )

--- a/app/services/doc_auth/mock/dos_passport_api_client.rb
+++ b/app/services/doc_auth/mock/dos_passport_api_client.rb
@@ -11,7 +11,7 @@ module DocAuth
         if mock_client_response&.passport_check_result&.dig(:PassportCheckResult) == 'Fail'
           DocAuth::Response.new(
             success: false,
-            errors: { passport: 'invalid MRZ' },
+            errors: { passport: I18n.t('doc_auth.errors.general.fallback_field_level') },
           )
         else
           DocAuth::Response.new(success: true)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -220,6 +220,8 @@ in_person_results_delay_in_hours: 1
 in_person_send_proofing_notifications_enabled: false
 in_person_stop_expiring_enrollments: false
 invalid_gpo_confirmation_zipcode: '00001'
+irs_authentication_emails: '[]'
+irs_authentication_issuers: '[]'
 # LexisNexis #####################################################
 # Instant Verify and Phone Finder Integrations
 lexisnexis_account_id: test_account
@@ -584,6 +586,8 @@ test:
   hmac_fingerprinter_key: a2c813d4dca919340866ba58063e4072adc459b767a74cf2666d5c1eef3861db26708e7437abde1755eb24f4034386b0fea1850a1cb7e56bff8fae3cc6ade96c
   hmac_fingerprinter_key_queue: '["old-key-one", "old-key-two"]'
   identity_pki_disabled: true
+  irs_authentication_emails: '["g@example.com", "h@example.com"]'
+  irs_authentication_issuers: '["urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"]'
   lexisnexis_trueid_account_id: 'test_account'
   lockout_period_in_minutes: 5
   logins_per_email_and_ip_limit: 2

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -222,6 +222,8 @@ in_person_stop_expiring_enrollments: false
 invalid_gpo_confirmation_zipcode: '00001'
 irs_authentication_emails: '[]'
 irs_authentication_issuers: '[]'
+irs_fraud_metrics_emails: '[]'
+irs_fraud_metrics_issuers: '[]'
 # LexisNexis #####################################################
 # Instant Verify and Phone Finder Integrations
 lexisnexis_account_id: test_account
@@ -588,6 +590,8 @@ test:
   identity_pki_disabled: true
   irs_authentication_emails: '["g@example.com", "h@example.com"]'
   irs_authentication_issuers: '["urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"]'
+  irs_fraud_metrics_emails: '["g@example.com", "h@example.com"]'
+  irs_fraud_metrics_issuers: '["urn:gov:gsa:openidconnect.profiles:sp:sso:agency_name:app_name"]'
   lexisnexis_trueid_account_id: 'test_account'
   lockout_period_in_minutes: 5
   logins_per_email_and_ip_limit: 2

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -254,6 +254,12 @@ else
         cron: cron_24h_and_a_bit,
         args: -> { [Time.zone.yesterday.end_of_day] },
       },
+      # Send irs fraud metrics to Team Data
+      irs_fraud_metrics_report: {
+        class: 'Reports::IrsFraudMetricsReport',
+        cron: cron_24h_and_a_bit,
+        args: -> { [Time.zone.yesterday.end_of_day] },
+      },
       # Previous week's drop off report
       weekly_drop_off_report: {
         class: 'Reports::DropOffReport',

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -236,6 +236,12 @@ else
         cron: cron_every_monday,
         args: -> { [Time.zone.yesterday.end_of_day] },
       },
+      # Send previous week's authentication reports to irs
+      irs_weekly_authentication_report: {
+        class: 'Reports::IrsAuthenticationReport',
+        cron: cron_every_monday,
+        args: -> { [Time.zone.yesterday.end_of_day] },
+      },
       # Send A/B test reports
       ab_tests_report: {
         class: 'Reports::AbTestsReport',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -622,6 +622,7 @@ doc_auth.headings.passport: Your passport
 doc_auth.headings.passport_capture: Add a photo of your passport
 doc_auth.headings.passport_instructions.howto: How to take your photo
 doc_auth.headings.review_issues: Check your images and try again
+doc_auth.headings.review_issues_passport: Check your photo and try again
 doc_auth.headings.secure_account: Secure your account
 doc_auth.headings.selfie: Photo of your face
 doc_auth.headings.selfie_capture: Capture photo of yourself
@@ -678,6 +679,7 @@ doc_auth.info.passport_capture: Take a photo of the data page of your passport b
 doc_auth.info.passport_capture_help_1: Line up the data page of your passport book with the guide lines.
 doc_auth.info.passport_capture_help_2: Hold still and wait for the tool to capture a photo.
 doc_auth.info.review_examples_of_photos: Review examples of how to take clear photos of your ID.
+doc_auth.info.review_passport: We couldn’t find records matching the information from your passport. Add a new photo of your ID in case your passport information was read incorrectly.
 doc_auth.info.secure_account: We’ll encrypt your account when you re-enter your password. Encryption means your data is protected and only you will be able to change your information.
 doc_auth.info.selfie_capture_content: We’ll check that you are the person on your ID.
 doc_auth.info.selfie_capture_help_1: Line up your face with the green circle. Hold still and wait for the tool to capture a photo.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -633,6 +633,7 @@ doc_auth.headings.passport: Su pasaporte
 doc_auth.headings.passport_capture: Agregue una foto de su pasaporte
 doc_auth.headings.passport_instructions.howto: 'Cómo tomar su fotografía:'
 doc_auth.headings.review_issues: Revise sus imágenes e inténtelo de nuevo
+doc_auth.headings.review_issues_passport: Revise su foto e inténtelo de nuevo
 doc_auth.headings.secure_account: Proteja su cuenta
 doc_auth.headings.selfie: Fotografía de su cara
 doc_auth.headings.selfie_capture: Capture una foto de usted
@@ -689,6 +690,7 @@ doc_auth.info.passport_capture: Tome una fotografía de la página de datos de s
 doc_auth.info.passport_capture_help_1: Alinee la página de datos de su pasaporte con las líneas de guía.
 doc_auth.info.passport_capture_help_2: Manténgalo fijo y espere a que la cámara tome la foto.
 doc_auth.info.review_examples_of_photos: Vea ejemplos de cómo tomar fotos nítidas de su identificación.
+doc_auth.info.review_passport: No encontramos registros que coincidan con la información de su pasaporte. Agregue una nueva fotografía de su identificación en caso de que la información de su pasaporte se haya leído incorrectamente.
 doc_auth.info.secure_account: Cifraremos su cuenta cuando vuelva a ingresar su contraseña. Con el cifrado, sus datos están protegidos y solo usted puede modificar su información.
 doc_auth.info.selfie_capture_content: Revisaremos que usted sea la persona que figura en su identificación.
 doc_auth.info.selfie_capture_help_1: Alinee su cara con el círculo verde. No se mueva y espere a que la cámara capture una foto.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -622,6 +622,7 @@ doc_auth.headings.passport: Votre passeport
 doc_auth.headings.passport_capture: Ajouter une photo de votre passeport
 doc_auth.headings.passport_instructions.howto: 'Comment vous prendre en photo :'
 doc_auth.headings.review_issues: Vérifiez vos images et essayez à nouveau
+doc_auth.headings.review_issues_passport: Vérifiez votre photo et essayez à nouveau
 doc_auth.headings.secure_account: Sécuriser votre compte
 doc_auth.headings.selfie: Photo de votre visage
 doc_auth.headings.selfie_capture: Prenez-vous en photo
@@ -678,6 +679,7 @@ doc_auth.info.passport_capture: Prenez une photo de la page d’informations de 
 doc_auth.info.passport_capture_help_1: Placez la page d’informations du passeport à l’intérieur des lignes définissant le cadre.
 doc_auth.info.passport_capture_help_2: Ne bougez pas et attendez que l’appareil se déclenche.
 doc_auth.info.review_examples_of_photos: Voir des exemples qui montrent comment prendre des photos nettes de votre pièce d’identité.
+doc_auth.info.review_passport: Nous n’avons pas trouvé dans nos données enregistrées d’informations correspondant aux informations figurant sur votre passeport. Ajouter une nouvelle photo de votre pièce d’identité au cas où les informations figurant sur votre passeport auraient été lues de façon incorrecte.
 doc_auth.info.secure_account: Nous chiffrons votre compte lorsque vous ressaisissez votre mot de passe. Avec le chiffrement, vos données sont protégées et vous seul pouvez modifier vos informations.
 doc_auth.info.selfie_capture_content: Nous vérifierons que vous êtes la personne figurant sur la pièce d’identité.
 doc_auth.info.selfie_capture_help_1: Placez votre visage à l’intérieur du cercle vert. Ne bougez pas et attendez que l’appareil se déclenche.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -633,6 +633,7 @@ doc_auth.headings.passport: 你的护照
 doc_auth.headings.passport_capture: 添加一张你护照的照片
 doc_auth.headings.passport_instructions.howto: '如何拍摄你本人的照片：'
 doc_auth.headings.review_issues: 检查一下你的图片并再试一次
+doc_auth.headings.review_issues_passport: 检查一下你的照片并再试一次
 doc_auth.headings.secure_account: 保护你的账户安全
 doc_auth.headings.selfie: 照片
 doc_auth.headings.selfie_capture: 拍你本人照片
@@ -689,6 +690,7 @@ doc_auth.info.passport_capture: 拍摄一张你护照本的数据页的照片。
 doc_auth.info.passport_capture_help_1: 将护照本的数据页与各个引导线对齐。
 doc_auth.info.passport_capture_help_2: 拿稳相机，等待工具拍照。
 doc_auth.info.review_examples_of_photos: 查看如何拍出身份证件清晰照片的示例。
+doc_auth.info.review_passport: 我们找不到与你护照信息匹配的记录。添加你ID的新照片，以防你护照信息没被正确读取。
 doc_auth.info.secure_account: 你重输密码时我们会对你的账户加密。加密意味着你的数据受到保护，只有你才能更改你的信息。
 doc_auth.info.selfie_capture_content: 我们会查看你是身份证件上的人。
 doc_auth.info.selfie_capture_help_1: 把你的面部放在绿色圆圈里。请保持静止，等待工具拍照。

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneOtpSent.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneOtpSent.yml
@@ -29,6 +29,7 @@ allOf:
                 - invalid_phone_number
                 - opt_out
                 - permanent_failure
+                - rate_limited
                 - sms_unsupported
                 - temporary_failure
                 - throttled

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneOtpSubmitted.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneOtpSubmitted.yml
@@ -11,19 +11,13 @@ allOf:
         description: |
           An OPTIONAL object. An associative array of attributes and errors if success is false
         properties:
-          # these are true/false bools rather than arrays of strings.
-          # can we update this to be something like:
-          # code:
-          #   type: array
-          #   items:
-          #     type: string
-          #     enum: ['code_matches', 'code_expired']
-          code_matches:
-            type: boolean
-            description: An OPTIONAL key if the code does not match
-          code_expired:
-            type: boolean
-            description: An OPTIONAL key if the code has expired
+          code:
+            type: array
+            items:
+              type: string
+              enum: 
+                - expired
+                - does_not_match
       success:
         type: boolean
         description: |

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneSubmitted.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvPhoneSubmitted.yml
@@ -18,8 +18,15 @@ allOf:
               type: string
               enum:
                 - improbable_phone
-                - We are unable to call phone numbers in {Country Name}
-                - We are unable to send text messages to phone numbers in {Country Name}
+                - voice_unsupported
+                - sms_unsupported
+          otp_delivery_preference:
+            type: array
+            description: An OPTIONAL key that describes errors with the delivery method
+            items:
+              type: string
+              enum:
+                - inclusion
       success:
         type: boolean
         description: |

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -173,6 +173,8 @@ module IdentityConfig
     config.add(:feature_idv_hybrid_flow_enabled, type: :boolean)
     config.add(:irs_authentication_issuers, type: :json)
     config.add(:irs_authentication_emails, type: :json)
+    config.add(:irs_fraud_metrics_issuers, type: :json)
+    config.add(:irs_fraud_metrics_emails, type: :json)
     config.add(:geo_data_file_path, type: :string)
     config.add(:get_usps_proofing_results_job_cron, type: :string)
     config.add(:get_usps_proofing_results_job_reprocess_delay_minutes, type: :integer)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -171,6 +171,8 @@ module IdentityConfig
     config.add(:facial_match_general_availability_enabled, type: :boolean)
     config.add(:feature_idv_force_gpo_verification_enabled, type: :boolean)
     config.add(:feature_idv_hybrid_flow_enabled, type: :boolean)
+    config.add(:irs_authentication_issuers, type: :json)
+    config.add(:irs_authentication_emails, type: :json)
     config.add(:geo_data_file_path, type: :string)
     config.add(:get_usps_proofing_results_job_cron, type: :string)
     config.add(:get_usps_proofing_results_job_reprocess_delay_minutes, type: :integer)

--- a/lib/reporting/irs_authentication_report.rb
+++ b/lib/reporting/irs_authentication_report.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'csv'
+begin
+  require 'reporting/cloudwatch_client'
+  require 'reporting/cloudwatch_query_quoting'
+  require 'reporting/command_line_options'
+rescue LoadError => e
+  warn 'could not load paths, try running with "bundle exec rails runner"'
+  raise e
+end
+
+module Reporting
+  class IrsAuthenticationReport
+    include Reporting::CloudwatchQueryQuoting
+
+    attr_reader :issuers, :time_range
+
+    module Events
+      OIDC_AUTH_REQUEST = 'OpenID Connect: authorization request'
+      EMAIL_CONFIRMATION = 'User Registration: Email Confirmation'
+      TWO_FA_SETUP_VISITED = 'User Registration: 2FA Setup visited'
+      USER_FULLY_REGISTERED = 'User Registration: User Fully Registered'
+      SP_REDIRECT = 'SP redirect initiated'
+
+      def self.all_events
+        constants.map { |c| const_get(c) }
+      end
+    end
+
+    # @param [Array<String>] issuers
+    # @param [Range<Time>] time_range
+    def initialize(
+      issuers:,
+      time_range:,
+      verbose: false,
+      progress: false,
+      slice: 6.hours,
+      threads: 1
+    )
+      @issuers = issuers
+      @time_range = time_range
+      @verbose = verbose
+      @progress = progress
+      @slice = slice
+      @threads = threads
+    end
+
+    def verbose?
+      @verbose
+    end
+
+    def progress?
+      @progress
+    end
+
+    def as_emailable_reports
+      [
+        Reporting::EmailableReport.new(
+          title: 'Definitions',
+          table: definitions_table,
+          filename: 'definitions',
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Overview',
+          table: overview_table,
+          filename: 'overview',
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Authentication Funnel Metrics',
+          table: funnel_metrics_table,
+          filename: 'funnel_metrics',
+        ),
+      ]
+    end
+
+    def definitions_table
+      [
+        ['Metric', 'Unit', 'Definition'],
+        ['System and Application Demand', 'Count',
+         'The count of new users that started the registration process with Login.gov.'],
+        ['System and Application Errors', 'Count',
+         'The count of new users who did not complete the registration process'],
+        ['Authentication attempts', 'Count',
+         'The count of new users who completed the registration process sucessfully'],
+        ['Authentication success rate', 'Percentage',
+         'The percentage of new users who completed registration process successfully'],
+      ]
+    end
+
+    def overview_table
+      [
+        ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
+        # This needs to be Date.today so it works when run on the command line
+        ['Report Generated', Time.zone.today.to_s],
+        ['Issuer', issuers.present? ? issuers.join(', ') : 'All Issuers'],
+      ]
+    end
+
+    def funnel_metrics_table
+      [
+        ['Metric', 'Number of accounts', '% of total from start'],
+        [
+          'System and Application Demand',
+          email_confirmation,
+          format_as_percent(numerator: email_confirmation, denominator: email_confirmation),
+        ],
+        [
+          'System and Application Errors',
+          users_failed_registration,
+          format_as_percent(numerator: users_failed_registration, denominator: email_confirmation),
+        ],
+        [
+          'Authentication attempts',
+          user_fully_registered,
+          format_as_percent(numerator: user_fully_registered, denominator: email_confirmation),
+        ],
+        [
+          'Authentication success rate',
+          sp_redirect_initiated_new_users,
+          format_as_percent(
+            numerator: sp_redirect_initiated_new_users,
+            denominator: email_confirmation,
+          ),
+        ],
+      ]
+    end
+
+    def format_as_percent(numerator:, denominator:)
+      (100 * numerator.to_f / denominator.to_f).round(2).to_s + '%'
+    end
+
+    # event name => set(user ids)
+    # @return Hash<String,Set<String>>
+    def data
+      @data ||= begin
+        event_users = Hash.new do |h, uuid|
+          h[uuid] = Set.new
+        end
+
+        fetch_results.each do |row|
+          event_users[row['name']] << row['user_id']
+        end
+
+        event_users
+      end
+    end
+
+    def fetch_results
+      cloudwatch_client.fetch(query:, from: time_range.begin, to: time_range.end)
+    end
+
+    def query
+      params = {
+        issuers: quote(issuers),
+        event_names: quote(Events.all_events),
+        email_confirmation: quote(Events::EMAIL_CONFIRMATION),
+      }
+
+      format(<<~QUERY, params)
+        fields
+            name
+          , properties.user_id AS user_id
+        | filter properties.service_provider IN %{issuers}
+        | filter (name = %{email_confirmation} and properties.event_properties.success = 1)
+                 or (name != %{email_confirmation})
+        | filter name in %{event_names}
+        | limit 10000
+      QUERY
+    end
+
+    def cloudwatch_client
+      @cloudwatch_client ||= Reporting::CloudwatchClient.new(
+        num_threads: @threads,
+        ensure_complete_logs: true,
+        slice_interval: @slice,
+        progress: progress?,
+        logger: verbose? ? Logger.new(STDERR) : nil,
+      )
+    end
+
+    def email_confirmation
+      data[Events::EMAIL_CONFIRMATION].count
+    end
+
+    def two_fa_setup_visited
+      @two_fa_setup_visited ||=
+        (data[Events::TWO_FA_SETUP_VISITED] & data[Events::EMAIL_CONFIRMATION]).count
+    end
+
+    def users_failed_registration
+      @users_failed_registration ||=
+        email_confirmation - user_fully_registered
+    end
+
+    def user_fully_registered
+      @user_fully_registered ||=
+        (data[Events::USER_FULLY_REGISTERED] & data[Events::EMAIL_CONFIRMATION]).count
+    end
+
+    def sp_redirect_initiated_new_users
+      @sp_redirect_initiated_new_users ||=
+        (data[Events::SP_REDIRECT] & data[Events::EMAIL_CONFIRMATION]).count
+    end
+
+    def sp_redirect_initiated_all
+      data[Events::SP_REDIRECT].count
+    end
+
+    def oidc_auth_request
+      data[Events::OIDC_AUTH_REQUEST].count
+    end
+
+    def sp_redirect_initiated_after_oidc
+      @sp_redirect_initiated_after_oidc ||=
+        (data[Events::SP_REDIRECT] & data[Events::OIDC_AUTH_REQUEST]).count
+    end
+  end
+end

--- a/lib/reporting/irs_fraud_metrics_lg99_report.rb
+++ b/lib/reporting/irs_fraud_metrics_lg99_report.rb
@@ -11,10 +11,10 @@ rescue LoadError => e
 end
 
 module Reporting
-  class FraudMetricsLg99Report
+  class IrsFraudMetricsLg99Report
     include Reporting::CloudwatchQueryQuoting
 
-    attr_reader :time_range
+    attr_reader :issuers, :time_range
 
     module Events
       IDV_FINAL_RESOLUTION = 'IdV: Final Resolution'
@@ -26,14 +26,17 @@ module Reporting
       end
     end
 
+    # @param [Array<String>] issuers
     # @param [Range<Time>] time_range
     def initialize(
+      issuers:,
       time_range:,
       verbose: false,
       progress: false,
       slice: 6.hours,
       threads: 1
     )
+      @issuers = issuers
       @time_range = time_range
       @verbose = verbose
       @progress = progress
@@ -52,7 +55,17 @@ module Reporting
     def as_emailable_reports
       [
         Reporting::EmailableReport.new(
-          title: "Monthly LG-99 Metrics #{stats_month}",
+          title: 'Definitions',
+          table: definitions_table,
+          filename: 'definitions',
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Overview',
+          table: overview_table,
+          filename: 'overview',
+        ),
+        Reporting::EmailableReport.new(
+          title: "Monthly Fraud Metrics #{stats_month}",
           table: lg99_metrics_table,
           filename: 'lg99_metrics',
         ),
@@ -69,10 +82,33 @@ module Reporting
       ]
     end
 
+    def definitions_table
+      [
+        ['Metric', 'Unit', 'Definition'],
+        ['Fraud Rules Catch Count', 'Count',
+         'The count of unique accounts flagged for fraud review.'],
+        ['Fraudulent credentials disabled', 'Count',
+         'The count of unique accounts suspended due to ' + '
+         suspected fraudulent activity within the reporting month.'],
+        ['Fraudulent credentials reinstated', 'Count',
+         'The count of unique suspended accounts ' + '
+         that are reinstated within the reporting month.'],
+      ]
+    end
+
+    def overview_table
+      [
+        ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
+        # This needs to be Date.today so it works when run on the command line
+        ['Report Generated', Time.zone.today.to_s],
+        ['Issuer', issuers.present? ? issuers.join(', ') : 'All Issuers'],
+      ]
+    end
+
     def lg99_metrics_table
       [
         ['Metric', 'Total', 'Range Start', 'Range End'],
-        ['Unique users seeing LG-99', lg99_unique_users_count.to_s, time_range.begin.to_s,
+        ['Fraud Rules Catch Count', lg99_unique_users_count.to_s, time_range.begin.to_s,
          time_range.end.to_s],
       ]
     rescue Aws::CloudWatchLogs::Errors::ThrottlingException => err
@@ -86,7 +122,7 @@ module Reporting
       [
         ['Metric', 'Total', 'Range Start', 'Range End'],
         [
-          'Unique users suspended',
+          'Fraudulent credentials disabled',
           unique_suspended_users_count.to_s,
           time_range.begin.to_s,
           time_range.end.to_s,
@@ -110,7 +146,7 @@ module Reporting
       [
         ['Metric', 'Total', 'Range Start', 'Range End'],
         [
-          'Unique users reinstated',
+          'Fraudulent credentials reinstated',
           unique_reinstated_users_count.to_s,
           time_range.begin.to_s,
           time_range.end.to_s,
@@ -150,6 +186,7 @@ module Reporting
 
     def query
       params = {
+        issuers: quote(issuers),
         event_names: quote(Events.all_events),
         idv_final_resolution: quote(Events::IDV_FINAL_RESOLUTION),
       }
@@ -158,7 +195,8 @@ module Reporting
         fields
             name
           , properties.user_id as user_id
-         | filter (name = %{idv_final_resolution} and properties.event_properties.fraud_review_pending = 1)
+        | filter properties.service_provider IN %{issuers}
+        | filter (name = %{idv_final_resolution} and properties.event_properties.fraud_review_pending = 1)
                  or (name != %{idv_final_resolution})
         | filter name in %{event_names}
         | limit 10000

--- a/spec/controllers/idv/phone_controller_spec.rb
+++ b/spec/controllers/idv/phone_controller_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe Idv::PhoneController do
         :check_for_mail_only_outage,
       )
     end
-  end
 
-  describe 'before_actions' do
     it 'includes before_actions from IdvSessionConcern' do
       expect(subject).to have_actions(:before, :redirect_unless_sp_requested_verification)
     end
@@ -52,6 +50,7 @@ RSpec.describe Idv::PhoneController do
     stub_sign_in(user)
     stub_up_to(:verify_info, idv_session: subject.idv_session)
     stub_analytics
+    stub_attempts_tracker
   end
 
   describe '#new' do
@@ -119,10 +118,6 @@ RSpec.describe Idv::PhoneController do
       let(:step) { 'path_where_user_asked_to_use_different_number' }
       let(:params) { { step: step } }
 
-      before do
-        stub_analytics
-      end
-
       it 'logs an event showing that the user wants to choose a different number' do
         get :new, params: params
 
@@ -134,8 +129,6 @@ RSpec.describe Idv::PhoneController do
     end
 
     it 'shows phone form if async process times out and allows successful resubmission' do
-      stub_analytics
-
       # setting the document capture session to a nonexistent uuid will trigger async
       # missing behavior
       subject.idv_session.idv_phone_step_document_capture_session_uuid = 'abc123'
@@ -193,6 +186,17 @@ RSpec.describe Idv::PhoneController do
           expect(Telephony::Test::Message.messages.length).to eq(1)
         end
 
+        it 'tracks the Attempts API event' do
+          expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+            phone_number: Phonelib.parse(phone).e164,
+            success: true,
+            otp_delivery_method: :sms,
+            failure_reason: nil,
+          )
+
+          get :new
+        end
+
         context 'the user submited their last attempt' do
           it 'redirects to the OTP confirmation and the rate limiter is maxed' do
             RateLimiter.new(user: user, rate_limit_type: :proof_address).increment_to_limited!
@@ -203,6 +207,32 @@ RSpec.describe Idv::PhoneController do
             expect(Telephony::Test::Message.messages.length).to eq(1)
             expect(RateLimiter.new(user: user, rate_limit_type: :proof_address).maxed?).to eq(true)
           end
+
+          it 'tracks the event' do
+            expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+              phone_number: Phonelib.parse(phone).e164,
+              success: true,
+              otp_delivery_method: :sms,
+              failure_reason: nil,
+            )
+
+            get :new
+          end
+        end
+      end
+
+      context 'when Pinpoint throws an opt-out error' do
+        let(:phone) { Telephony::Test::ErrorSimulator::OPT_OUT_PHONE_NUMBER }
+
+        it 'tracks the Attempts API event' do
+          expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+            phone_number: Phonelib.parse(phone).e164,
+            success: false,
+            otp_delivery_method: :sms,
+            failure_reason: { telephony_error: ['opt_out'] },
+          )
+
+          get :new
         end
       end
 
@@ -217,6 +247,12 @@ RSpec.describe Idv::PhoneController do
           expect(subject.idv_session.vendor_phone_confirmation).to eq(nil)
           expect(subject.idv_session.user_phone_confirmation).to eq(nil)
           expect(Telephony::Test::Message.messages.length).to eq(0)
+        end
+
+        it 'does not track the event' do
+          expect(@attempts_api_tracker).not_to receive(:idv_phone_otp_sent)
+
+          get :new
         end
 
         context 'the user submited their last attempt' do
@@ -255,10 +291,13 @@ RSpec.describe Idv::PhoneController do
             },
         }
       end
-      before do
-      end
 
       it 'renders #new' do
+        expect(@attempts_api_tracker).to receive(:idv_phone_submitted).with(
+          phone_number: Phonelib.parse(improbable_phone_number).e164,
+          success: false,
+          failure_reason: { phone: [:improbable_phone], otp_delivery_preference: [:inclusion] },
+        )
         put :create, params: improbable_phone_form
 
         expect(flash[:error]).to eq improbable_phone_message
@@ -276,6 +315,12 @@ RSpec.describe Idv::PhoneController do
       end
 
       it 'disallows non-US numbers' do
+        expect(@attempts_api_tracker).to receive(:idv_phone_submitted).with(
+          phone_number: Phonelib.parse(international_phone).e164,
+          success: false,
+          failure_reason: { phone: [:improbable_phone] },
+        )
+
         put :create, params: { idv_phone_form: { phone: international_phone } }
 
         expect(flash[:error]).to eq improbable_phone_message
@@ -325,6 +370,12 @@ RSpec.describe Idv::PhoneController do
       end
 
       it 'tracks events with valid phone' do
+        expect(@attempts_api_tracker).to receive(:idv_phone_submitted).with(
+          phone_number: Phonelib.parse(good_phone).e164,
+          success: true,
+          failure_reason: nil,
+        )
+
         put :create, params: phone_params
 
         expect(@analytics).to have_logged_event(
@@ -350,6 +401,12 @@ RSpec.describe Idv::PhoneController do
       context 'when same as user phone' do
         it 'redirects to otp delivery page' do
           original_applicant = subject.idv_session.applicant.dup
+          expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+            phone_number: Phonelib.parse(good_phone).e164,
+            success: true,
+            otp_delivery_method: :sms,
+            failure_reason: nil,
+          )
 
           put :create, params: phone_params
 
@@ -386,6 +443,13 @@ RSpec.describe Idv::PhoneController do
 
       context 'when different phone from user phone' do
         it 'redirects to otp page and does not set phone_confirmed_at' do
+          expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+            phone_number: Phonelib.parse(good_phone).e164,
+            success: true,
+            otp_delivery_method: :sms,
+            failure_reason: nil,
+          )
+
           put :create, params: phone_params
 
           expect(response).to redirect_to idv_phone_path
@@ -447,6 +511,13 @@ RSpec.describe Idv::PhoneController do
 
     it 'tracks that the hybrid handoff phone was used' do
       subject.idv_session.phone_for_mobile_flow = good_phone
+
+      expect(@attempts_api_tracker).to receive(:idv_phone_otp_sent).with(
+        phone_number: Phonelib.parse(good_phone).e164,
+        success: true,
+        otp_delivery_method: :sms,
+        failure_reason: nil,
+      )
 
       put :create, params: { idv_phone_form: { phone: good_phone } }
       expect(response).to redirect_to idv_phone_path
@@ -526,9 +597,6 @@ RSpec.describe Idv::PhoneController do
 
       context 'when the user is rate limited by submission' do
         before do
-          stub_analytics
-          stub_attempts_tracker
-
           rate_limiter = RateLimiter.new(rate_limit_type: :proof_address, user: user)
           rate_limiter.increment_to_limited!
 

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'document capture step', :js do
   include IdvStepHelper
   include DocAuthHelper
   include DocCaptureHelper
+  include AbTestsHelper
   include ActionView::Helpers::DateHelper
 
   let(:max_attempts) { IdentityConfig.store.doc_auth_max_attempts }
@@ -269,6 +270,84 @@ RSpec.feature 'document capture step', :js do
       attach_and_submit_images
 
       expect(DocAuthLog.find_by(user_id: @user.id).state).to be_nil
+    end
+  end
+
+  context 'standard desktop passport flow', allow_browser_log: true do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_percent).and_return(100)
+      stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+        .to_return({ status: 200, body: { status: 'UP' }.to_json })
+      reload_ab_tests
+      sign_in_and_2fa_user(@user)
+      complete_doc_auth_steps_before_hybrid_handoff_step
+    end
+
+    after do
+      reload_ab_tests
+    end
+
+    it 'shows only one image on review step if passport selected' do
+      expect(page).to have_content(t('doc_auth.headings.upload_from_computer'))
+      click_on t('forms.buttons.upload_photos')
+      expect(page).to have_current_path(idv_choose_id_type_url)
+      choose(t('doc_auth.forms.id_type_preference.passport'))
+      click_on t('forms.buttons.continue')
+      expect(page).to have_current_path(idv_document_capture_url)
+      # Attach fail images and then continue to retry
+      attach_passport_image(
+        Rails.root.join(
+          'spec', 'fixtures',
+          'passport_bad_mrz_credential.yml'
+        ),
+      )
+      submit_images
+      expect(page).to have_current_path(idv_document_capture_url)
+      click_on t('idv.failure.button.warning')
+      expect(page).to have_content(t('doc_auth.headings.document_capture_passport'))
+      expect(page).not_to have_content(t('doc_auth.headings.document_capture_back'))
+      expect(page).to have_content(t('doc_auth.headings.review_issues_passport'))
+      expect(page).to have_content(t('doc_auth.info.review_passport'))
+    end
+  end
+
+  context 'standard mobile passport flow', allow_browser_log: true do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_percent).and_return(100)
+      stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+        .to_return({ status: 200, body: { status: 'UP' }.to_json })
+      reload_ab_tests
+    end
+
+    after do
+      reload_ab_tests
+    end
+
+    it 'shows only one image on review step if passport selected' do
+      perform_in_browser(:mobile) do
+        sign_in_and_2fa_user(@user)
+        complete_doc_auth_steps_before_document_capture_step
+        expect(page).to have_current_path(idv_choose_id_type_url)
+        choose(t('doc_auth.forms.id_type_preference.passport'))
+        click_on t('forms.buttons.continue')
+        expect(page).to have_current_path(idv_document_capture_url)
+        # Attach fail images and then continue to retry
+        attach_passport_image(
+          Rails.root.join(
+            'spec', 'fixtures',
+            'passport_bad_mrz_credential.yml'
+          ),
+        )
+        submit_images
+        expect(page).to have_current_path(idv_document_capture_url)
+        click_on t('idv.failure.button.warning')
+        expect(page).to have_content(t('doc_auth.headings.document_capture_passport'))
+        expect(page).not_to have_content(t('doc_auth.headings.document_capture_back'))
+        expect(page).to have_content(t('doc_auth.headings.review_issues_passport'))
+        expect(page).to have_content(t('doc_auth.info.review_passport'))
+      end
     end
   end
 

--- a/spec/jobs/reports/irs_authentication_report_spec.rb
+++ b/spec/jobs/reports/irs_authentication_report_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+RSpec.describe Reports::IrsAuthenticationReport do
+  let(:report_date) { Date.new(2021, 3, 2).in_time_zone('UTC').end_of_day }
+  let(:time_range) { report_date.all_month }
+  subject(:report) { Reports::IrsAuthenticationReport.new(report_date) }
+
+  let(:name) { 'irs-authentication-report' }
+  let(:s3_report_bucket_prefix) { 'reports-bucket' }
+  let(:report_folder) do
+    'int/irs-authentication-report/2021/2021-03-02.irs-authentication-report'
+  end
+
+  let(:expected_s3_paths) do
+    [
+      "#{report_folder}/definitions.csv",
+      "#{report_folder}/overview.csv",
+      "#{report_folder}/funnel_metrics.csv",
+    ]
+  end
+
+  let(:s3_metadata) do
+    {
+      body: anything,
+      content_type: 'text/csv',
+      bucket: 'reports-bucket.1234-us-west-1',
+    }
+  end
+
+  let(:mock_funnel_metrics_data) do
+    [
+      ['Metric', 'Number of accounts', '% of total from start'],
+      ['System and Application Demand', '100', '100%'],
+      ['System and Application Errors', '85', '85%'],
+      ['Authentication attempts', '80', '80%'],
+      ['Authentication success rate', '75', '75%'],
+    ]
+  end
+
+  let(:mock_test_auth_emails) { ['mock_feds@example.com', 'mock_contractors@example.com'] }
+  let(:mock_test_auth_issuers) { ['issuer1'] }
+
+  before do
+    allow(Identity::Hostdata).to receive(:env).and_return('int')
+    allow(Identity::Hostdata).to receive(:aws_account_id).and_return('1234')
+    allow(Identity::Hostdata).to receive(:aws_region).and_return('us-west-1')
+    allow(IdentityConfig.store).to receive(:s3_report_bucket_prefix)
+      .and_return(s3_report_bucket_prefix)
+
+    Aws.config[:s3] = {
+      stub_responses: {
+        put_object: {},
+      },
+    }
+
+    allow(IdentityConfig.store).to receive(:irs_authentication_emails)
+      .and_return(mock_test_auth_emails)
+
+    allow(report.irs_authentication_report).to receive(:funnel_metrics_table)
+      .and_return(mock_funnel_metrics_data)
+  end
+
+  it 'sends out a report to just to team data' do
+    expect(ReportMailer).to receive(:tables_report).once.with(
+      email: anything,
+      subject: 'Authentication Report - 2021-03-02',
+      reports: anything,
+      message: report.preamble,
+      attachment_format: :csv,
+    ).and_call_original
+
+    report.perform(report_date)
+  end
+
+  it 'does not send out a report with no emails' do
+    allow(IdentityConfig.store).to receive(:irs_authentication_emails).and_return('')
+
+    expect(report).to_not receive(:reports)
+
+    expect(ReportMailer).not_to receive(:tables_report)
+
+    report.perform(report_date)
+  end
+
+  it 'uploads a file to S3 based on the report date' do
+    expected_s3_paths.each do |path|
+      expect(subject).to receive(:upload_file_to_s3_bucket).with(
+        path: path,
+        **s3_metadata,
+      ).exactly(1).time.and_call_original
+    end
+
+    report.perform(report_date)
+  end
+
+  describe '#preamble' do
+    let(:env) { 'prod' }
+    subject(:preamble) { report.preamble(env:) }
+
+    it 'has a blank preamble' do
+      expect(preamble).to be_blank
+    end
+
+    context 'in a non-prod environment' do
+      let(:env) { 'staging' }
+
+      it 'has an alert with the environment name' do
+        expect(preamble).to be_html_safe
+
+        doc = Nokogiri::XML(preamble)
+
+        alert = doc.at_css('.usa-alert')
+        expect(alert.text).to include(env)
+      end
+    end
+  end
+end

--- a/spec/jobs/reports/irs_fraud_metrics_report_spec.rb
+++ b/spec/jobs/reports/irs_fraud_metrics_report_spec.rb
@@ -1,0 +1,159 @@
+require 'rails_helper'
+
+RSpec.describe Reports::IrsFraudMetricsReport do
+  let(:report_date) { Date.new(2021, 3, 2).in_time_zone('UTC').end_of_day }
+  let(:time_range) { report_date.all_month }
+  subject(:report) { Reports::IrsFraudMetricsReport.new(report_date) }
+
+  let(:name) { 'irs-fraud-metrics-report' }
+  let(:s3_report_bucket_prefix) { 'reports-bucket' }
+  let(:report_folder) do
+    'int/irs-fraud-metrics-report/2021/2021-03-02.irs-fraud-metrics-report'
+  end
+
+  let(:expected_s3_paths) do
+    [
+      "#{report_folder}/definitions.csv",
+      "#{report_folder}/overview.csv",
+      "#{report_folder}/lg99_metrics.csv",
+      "#{report_folder}/suspended_metrics.csv",
+      "#{report_folder}/reinstated_metrics.csv",
+    ]
+  end
+
+  let(:s3_metadata) do
+    {
+      body: anything,
+      content_type: 'text/csv',
+      bucket: 'reports-bucket.1234-us-west-1',
+    }
+  end
+
+  let(:mock_identity_verification_lg99_data) do
+    [
+      ['Metric', 'Total', 'Range Start', 'Range End'],
+      ['Fraud Rules Catch Count', 5, time_range.begin.to_s,
+       time_range.end.to_s],
+    ]
+  end
+  let(:mock_suspended_metrics_table) do
+    [
+      ['Metric', 'Total', 'Range Start', 'Range End'],
+      ['Fraudulent credentials disabled', 2, time_range.begin.to_s,
+       time_range.end.to_s],
+      ['Average Days Creation to Suspension', 1.5, time_range.begin.to_s,
+       time_range.end.to_s],
+      ['Average Days Proofed to Suspension', 2.0, time_range.begin.to_s,
+       time_range.end.to_s],
+    ]
+  end
+  let(:mock_reinstated_metrics_table) do
+    [
+      ['Metric', 'Total', 'Range Start', 'Range End'],
+      ['Fraudulent credentials reinstated', 1, time_range.begin.to_s,
+       time_range.end.to_s],
+      ['Average Days to Reinstatement', 3.0, time_range.begin.to_s,
+       time_range.end.to_s],
+    ]
+  end
+
+  let(:mock_test_fraud_emails) { ['mock_feds@example.com', 'mock_contractors@example.com'] }
+  let(:mock_test_fraud_issuers) { ['issuer1'] }
+
+  before do
+    allow(Identity::Hostdata).to receive(:env).and_return('int')
+    allow(Identity::Hostdata).to receive(:aws_account_id).and_return('1234')
+    allow(Identity::Hostdata).to receive(:aws_region).and_return('us-west-1')
+    allow(IdentityConfig.store).to receive(:s3_report_bucket_prefix)
+      .and_return(s3_report_bucket_prefix)
+
+    Aws.config[:s3] = {
+      stub_responses: {
+        put_object: {},
+      },
+    }
+
+    allow(IdentityConfig.store).to receive(:irs_fraud_metrics_emails)
+      .and_return(mock_test_fraud_emails)
+
+    allow(report.irs_fraud_metrics_lg99_report).to receive(:lg99_metrics_table)
+      .and_return(mock_identity_verification_lg99_data)
+
+    allow(report.irs_fraud_metrics_lg99_report).to receive(:suspended_metrics_table)
+      .and_return(mock_suspended_metrics_table)
+
+    allow(report.irs_fraud_metrics_lg99_report).to receive(:reinstated_metrics_table)
+      .and_return(mock_reinstated_metrics_table)
+  end
+
+  it 'sends out a report to just to team data' do
+    expect(ReportMailer).to receive(:tables_report).once.with(
+      email: anything,
+      subject: 'Fraud Metrics Report - 2021-03-02',
+      reports: anything,
+      message: report.preamble,
+      attachment_format: :csv,
+    ).and_call_original
+
+    report.perform(report_date)
+  end
+
+  context 'when queued from the first of the month' do
+    let(:report_date) { Date.new(2021, 3, 1).prev_day }
+
+    it 'sends out a report to everybody' do
+      expect(ReportMailer).to receive(:tables_report).once.with(
+        email: anything,
+        subject: 'Fraud Metrics Report - 2021-02-28',
+        reports: anything,
+        message: report.preamble,
+        attachment_format: :csv,
+      ).and_call_original
+
+      report.perform(report_date)
+    end
+  end
+
+  it 'does not send out a report with no emails' do
+    allow(IdentityConfig.store).to receive(:irs_fraud_metrics_emails).and_return('')
+
+    expect(report).to_not receive(:reports)
+
+    expect(ReportMailer).not_to receive(:tables_report)
+
+    report.perform(report_date)
+  end
+
+  it 'uploads a file to S3 based on the report date' do
+    expected_s3_paths.each do |path|
+      expect(subject).to receive(:upload_file_to_s3_bucket).with(
+        path: path,
+        **s3_metadata,
+      ).exactly(1).time.and_call_original
+    end
+
+    report.perform(report_date)
+  end
+
+  describe '#preamble' do
+    let(:env) { 'prod' }
+    subject(:preamble) { report.preamble(env:) }
+
+    it 'has a blank preamble' do
+      expect(preamble).to be_blank
+    end
+
+    context 'in a non-prod environment' do
+      let(:env) { 'staging' }
+
+      it 'has an alert with the environment name' do
+        expect(preamble).to be_html_safe
+
+        doc = Nokogiri::XML(preamble)
+
+        alert = doc.at_css('.usa-alert')
+        expect(alert.text).to include(env)
+      end
+    end
+  end
+end

--- a/spec/lib/reporting/irs_authentication_report_spec.rb
+++ b/spec/lib/reporting/irs_authentication_report_spec.rb
@@ -1,0 +1,197 @@
+require 'rails_helper'
+require 'reporting/irs_authentication_report'
+
+RSpec.describe Reporting::IrsAuthenticationReport do
+  let(:issuer) { 'my:example:issuer' }
+  let(:time_range) { Date.new(2022, 1, 1).in_time_zone('UTC').all_week }
+  let(:expected_definitions_table) do
+    [
+      ['Metric', 'Unit', 'Definition'],
+      ['System and Application Demand', 'Count',
+       'The count of new users that started the registration process with Login.gov.'],
+      ['System and Application Errors', 'Count',
+       'The count of new users who did not complete the registration process'],
+      ['Authentication attempts', 'Count',
+       'The count of new users who completed the registration process sucessfully'],
+      ['Authentication success rate', 'Percentage',
+       'The percentage of new users who completed registration process successfully'],
+    ]
+  end
+  let(:expected_overview_table) do
+    [
+      ['Report Timeframe', "#{time_range.begin} to #{time_range.end}"],
+      ['Report Generated', Time.zone.today.to_s],
+      ['Issuer', issuer],
+    ]
+  end
+  let(:expected_funnel_metrics_table) do
+    [
+      ['Metric', 'Number of accounts', '% of total from start'],
+      ['System and Application Demand', 4, '100.0%'],
+      ['System and Application Errors', 2, '50.0%'],
+      ['Authentication attempts', 2, '50.0%'],
+      ['Authentication success rate', 1, '25.0%'],
+    ]
+  end
+
+  subject(:report) { Reporting::IrsAuthenticationReport.new(issuers: [issuer], time_range:) }
+
+  before do
+    travel_to Time.zone.now.beginning_of_day
+    stub_cloudwatch_logs(
+      [
+        # finishes funnel
+        { 'user_id' => 'user1', 'name' => 'OpenID Connect: authorization request' },
+        { 'user_id' => 'user1', 'name' => 'User Registration: Email Confirmation' },
+        { 'user_id' => 'user1', 'name' => 'User Registration: 2FA Setup visited' },
+        { 'user_id' => 'user1', 'name' => 'User Registration: User Fully Registered' },
+        { 'user_id' => 'user1', 'name' => 'SP redirect initiated' },
+
+        # first 3 steps
+        { 'user_id' => 'user2', 'name' => 'OpenID Connect: authorization request' },
+        { 'user_id' => 'user2', 'name' => 'User Registration: Email Confirmation' },
+        { 'user_id' => 'user2', 'name' => 'User Registration: 2FA Setup visited' },
+        { 'user_id' => 'user2', 'name' => 'User Registration: User Fully Registered' },
+
+        # first 2 steps
+        { 'user_id' => 'user3', 'name' => 'OpenID Connect: authorization request' },
+        { 'user_id' => 'user3', 'name' => 'User Registration: Email Confirmation' },
+        { 'user_id' => 'user3', 'name' => 'User Registration: 2FA Setup visited' },
+
+        # first step only
+        { 'user_id' => 'user4', 'name' => 'OpenID Connect: authorization request' },
+        { 'user_id' => 'user4', 'name' => 'User Registration: Email Confirmation' },
+
+        # already existing user, just signing in
+        { 'user_id' => 'user5', 'name' => 'OpenID Connect: authorization request' },
+        { 'user_id' => 'user5', 'name' => 'SP redirect initiated' },
+      ],
+    )
+  end
+
+  describe '#definitions_table' do
+    it 'renders a definitions table' do
+      aggregate_failures do
+        report.definitions_table.zip(expected_definitions_table).each do |actual, expected|
+          expect(actual).to eq(expected)
+        end
+      end
+    end
+  end
+
+  describe '#overview_table' do
+    it 'renders an overview table' do
+      aggregate_failures do
+        report.overview_table.zip(expected_overview_table).each do |actual, expected|
+          expect(actual).to eq(expected)
+        end
+      end
+    end
+  end
+
+  describe '#funnel_metrics_table' do
+    it 'renders a funnel metrics table' do
+      aggregate_failures do
+        report.funnel_metrics_table.zip(expected_funnel_metrics_table).each do |actual, expected|
+          expect(actual).to eq(expected)
+        end
+      end
+    end
+  end
+
+  describe '#as_emailable_reports' do
+    let(:expected_reports) do
+      [
+        Reporting::EmailableReport.new(
+          title: 'Definitions',
+          filename: 'definitions',
+          table: expected_definitions_table,
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Overview',
+          filename: 'overview',
+          table: expected_overview_table,
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Authentication Funnel Metrics',
+          filename: 'funnel_metrics',
+          table: expected_funnel_metrics_table,
+        ),
+      ]
+    end
+    it 'return expected table for email' do
+      expect(report.as_emailable_reports).to eq expected_reports
+    end
+  end
+
+  describe '#cloudwatch_client' do
+    let(:opts) { {} }
+    let(:subject) { described_class.new(issuers: [issuer], time_range:, **opts) }
+    let(:default_args) do
+      {
+        num_threads: 1,
+        ensure_complete_logs: true,
+        slice_interval: 6.hours,
+        progress: false,
+        logger: nil,
+      }
+    end
+
+    describe 'when all args are default' do
+      it 'creates a client with the default options' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe 'when verbose is passed in' do
+      let(:opts) { { verbose: true } }
+      let(:logger) { double Logger }
+
+      before do
+        expect(Logger).to receive(:new).with(STDERR).and_return logger
+        default_args[:logger] = logger
+      end
+
+      it 'creates a client with the expected logger' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe 'when progress is passed in as true' do
+      let(:opts) { { progress: true } }
+      before { default_args[:progress] = true }
+
+      it 'creates a client with progress as true' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe 'when threads is passed in' do
+      let(:opts) { { threads: 17 } }
+      before { default_args[:num_threads] = 17 }
+
+      it 'creates a client with the expected thread count' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+
+    describe 'when slice is passed in' do
+      let(:opts) { { slice: 2.weeks } }
+      before { default_args[:slice_interval] = 2.weeks }
+
+      it 'creates a client with expected time slice' do
+        expect(Reporting::CloudwatchClient).to receive(:new).with(default_args)
+
+        subject.cloudwatch_client
+      end
+    end
+  end
+end

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -109,6 +109,20 @@ class ReportMailerPreview < ActionMailer::Preview
     )
   end
 
+  def irs_authentication_report
+    irs_authentication_report = Reports::IrsAuthenticationReport.new(Time.zone.yesterday)
+
+    stub_cloudwatch_client(irs_authentication_report.irs_authentication_report)
+
+    ReportMailer.tables_report(
+      email: 'test@example.com',
+      subject: "Example Authentication Report - #{Time.zone.now.to_date}",
+      message: irs_authentication_report.preamble,
+      attachment_format: :csv,
+      reports: irs_authentication_report.reports,
+    )
+  end
+
   def api_transaction_count_report
     api_transaction_count_report = Reports::ApiTransactionCountReport.new(Time.zone.yesterday)
 

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -123,6 +123,20 @@ class ReportMailerPreview < ActionMailer::Preview
     )
   end
 
+  def irs_fraud_metrics_report
+    irs_fraud_metrics_report = Reports::IrsFraudMetricsReport.new(Time.zone.yesterday)
+
+    stub_cloudwatch_client(irs_fraud_metrics_report.irs_fraud_metrics_lg99_report)
+
+    ReportMailer.tables_report(
+      email: 'test@example.com',
+      subject: "Example Fraud Key Metrics Report - #{Time.zone.now.to_date}",
+      message: irs_fraud_metrics_report.preamble,
+      attachment_format: :csv,
+      reports: irs_fraud_metrics_report.reports,
+    )
+  end
+
   def api_transaction_count_report
     api_transaction_count_report = Reports::ApiTransactionCountReport.new(Time.zone.yesterday)
 

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -83,6 +83,15 @@ RSpec.describe AttemptsApi::Tracker do
       end
     end
 
+    context 'with nil user' do
+      let(:user) { nil }
+
+      it 'logs nil user_uuid' do
+        event = subject.track_event(:test_event)
+        expect(event.event_metadata[:user]).to be_nil
+      end
+    end
+
     context 'user has existing Agency UUID' do
       context 'for event that skips UUID creation' do
         it 'returns Agency UUID in event' do


### PR DESCRIPTION
## Bug Fixes
- Profile: Delete related DuplicateProfileConfirmations when deleting Profile ([#12164](https://github.com/18F/identity-idp/pull/12164))

## Internal
- Attempts API: Allow creating AgencyIdentity if it does not exist ([#12155](https://github.com/18F/identity-idp/pull/12155))
- Attempts API: Fix incorrect event exceptions and nil users ([#12161](https://github.com/18F/identity-idp/pull/12161))
- Background Jobs: Limit batch size and total size for CreateNewDeviceAlertJob ([#12166](https://github.com/18F/identity-idp/pull/12166))
- Dependencies: Update dependencies with vulnerabilities ([#12160](https://github.com/18F/identity-idp/pull/12160))
- Reporting: IRS Monthly Fraud Metrics Report ([#12124](https://github.com/18F/identity-idp/pull/12124))
- Reporting: IRS Authentication Report ([#12136](https://github.com/18F/identity-idp/pull/12136))

## Upcoming Features
- Attempts API: Adds idv-phone events ([#12158](https://github.com/18F/identity-idp/pull/12158))
- Doc Auth: Show one image on review issues page for passport ([#12094](https://github.com/18F/identity-idp/pull/12094))