### PR TITLE
Lower Create Alert Job total size

### DIFF
--- a/app/jobs/create_new_device_alert_job.rb
+++ b/app/jobs/create_new_device_alert_job.rb
@@ -8,7 +8,7 @@ class CreateNewDeviceAlertJob < ApplicationJob
     User.where(
       sql_query_for_users_with_new_device,
       tvalue: now - IdentityConfig.store.new_device_alert_delay_in_minutes.minutes,
-    ).limit(2_000).find_each(batch_size: 100) do |user|
+    ).limit(1_000).find_each(batch_size: 100) do |user|
       emails_sent += 1 if expire_sign_in_notification_timeframe_and_send_alert(user)
     end
 


### PR DESCRIPTION
The job is still taking too long which creates a concurrency issue. 
This should hopefully reduce the size to 1k users at a time so that we don't have that issue when we decrease the time range to look for suers. 