### PR TITLE
Add enroll and login phone-otp-sent events

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -236,6 +236,24 @@ module Users
           reason: RecaptchaAnnotator::AnnotationReasons::INITIATED_TWO_FACTOR,
         ),
       )
+
+      if UserSessionContext.confirmation_context?(context)
+        attempts_api_tracker.mfa_enroll_phone_otp_sent(
+          success: @telephony_result.success?,
+          phone_number: parsed_phone.e164,
+          otp_delivery_method: otp_delivery_preference,
+          failure_reason: attempts_api_tracker.parse_failure_reason(@telephony_result),
+        )
+      elsif UserSessionContext.authentication_or_reauthentication_context?(context)
+        attempts_api_tracker.mfa_login_phone_otp_sent(
+          success: @telephony_result.success?,
+          reauthentication: UserSessionContext.reauthentication_context?(context),
+          phone_number: parsed_phone.e164,
+          otp_delivery_method: otp_delivery_preference,
+          failure_reason: attempts_api_tracker.parse_failure_reason(@telephony_result),
+        )
+
+      end
     end
 
     def exceeded_otp_send_limit?

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -284,6 +284,7 @@ module AttemptsApi
     # @param [Boolean] success
     # @param [String<'sms','voice'>] otp_delivery_method
     # @param [String] phone_number - The user's phone number used for multi-factor authentication
+    # @param [Boolean] reauthentication
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
     # During a login attempt, an OTP code has been sent to sms or voice.
     def mfa_login_phone_otp_sent(success:, otp_delivery_method:, phone_number:, reauthentication:,

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -240,6 +240,22 @@ module AttemptsApi
       )
     end
 
+    # @param [Boolean] success
+    # @param [String<'sms','voice'>] otp_delivery_method
+    # @param [String] phone_number - The user's phone number used for multi-factor authentication
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # During an MFA enrollment attempt, an OTP code has been sent to sms or voice.
+    def mfa_enroll_phone_otp_sent(success:, otp_delivery_method:, phone_number:,
+                                  failure_reason: nil)
+      track_event(
+        'mfa-enroll-phone-otp-sent',
+        success:,
+        otp_delivery_method:,
+        phone_number:,
+        failure_reason:,
+      )
+    end
+
     # @param [String] phone_number - The user's phone number used for multi-factor authentication
     # The user has exceeded the rate limit for SMS OTP sends during mfa enrollment.
     def mfa_enroll_phone_otp_sent_rate_limited(phone_number:)
@@ -261,6 +277,23 @@ module AttemptsApi
         mfa_device_type:,
         reauthentication:,
         success:,
+        failure_reason:,
+      )
+    end
+
+    # @param [Boolean] success
+    # @param [String<'sms','voice'>] otp_delivery_method
+    # @param [String] phone_number - The user's phone number used for multi-factor authentication
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # During a login attempt, an OTP code has been sent to sms or voice.
+    def mfa_login_phone_otp_sent(success:, otp_delivery_method:, phone_number:, reauthentication:,
+                                 failure_reason: nil)
+      track_event(
+        'mfa-login-phone-otp-sent',
+        success:,
+        otp_delivery_method:,
+        phone_number:,
+        reauthentication:,
         failure_reason:,
       )
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Fraud Mitigation 2](https://gitlab.login.gov/lg-teams/FIE/fraud-mitigation/-/issues/2)

## 🛠 Summary of changes
This change adds:
- mfa-enroll-phone-otp-sent
- mfa-login-phone-otp-sent
- associated tests

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
