### PR TITLE
Dmm/login rate limit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -180,6 +180,7 @@ class ApplicationController < ActionController::Base
 
     if params[:timeout] == 'session'
       analytics.session_timed_out
+      attempts_api_tracker.session_timeout
       flash[:info] = t(
         'notices.session_timedout',
         app_name: APP_NAME,

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -82,6 +82,7 @@ module Users
     end
 
     def process_rate_limited
+      attempts_api_tracker.login_rate_limited(email: auth_params[:email])
       sign_out(:user)
       warden.lock!
 

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -205,7 +205,6 @@ module AttemptsApi
     end
 
     # @param [String] email
-    # @param [Boolean] email_already_registered
     # Tracks when user is rate limited for inputting bad password
     def login_rate_limited(email:)
       track_event(
@@ -337,6 +336,11 @@ module AttemptsApi
         success:,
         failure_reason:,
       )
+    end
+
+    # Tracks when a logged in user has been inactive long enough to cause a session timeout
+    def session_timeout
+      track_event('session-timeout')
     end
 
     # @param [Boolean] success

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -204,6 +204,16 @@ module AttemptsApi
       track_event('login-completed')
     end
 
+    # @param [String] email
+    # @param [Boolean] email_already_registered
+    # Tracks when user is rate limited for inputting bad password
+    def login_rate_limited(email:)
+      track_event(
+        'login-rate-limited',
+        email:,
+      )
+    end
+
     # @param [Boolean] success
     # A user has initiated a logout event
     def logout_initiated(success:)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -402,6 +402,8 @@ RSpec.describe ApplicationController do
     context 'with session timeout parameter' do
       it 'logs an event' do
         stub_analytics
+        stub_attempts_tracker
+        expect(@attempts_api_tracker).to receive(:session_timeout)
 
         get :index, params: { timeout: 'session', request_id: '123' }
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[FIE Epic 367](https://gitlab.login.gov/groups/lg-teams/FIE/-/epics/367)

## 🛠 Summary of changes
This change adds:
- login-rate-limited event
- session-timeout event
- and associated tests

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
