### PR TITLE
LG-15980 Add passport info section to verify info form

### DIFF
--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -13,9 +13,9 @@ module Idv
       before_action :confirm_step_allowed
 
       def show
-        @step_indicator_steps = step_indicator_steps
-        @ssn = idv_session.ssn
         @pii = pii
+        @ssn = pii[:ssn]
+        @presenter = Idv::InPerson::VerifyInfoPresenter.new(enrollment: enrollment)
 
         Funnel::DocAuth::RegisterStep.new(current_user.id, sp_session[:issuer])
           .call('verify', :view, true) # specify in_person?
@@ -74,6 +74,10 @@ module Idv
           consent_given_at: idv_session.idv_consent_given_at,
           ssn: idv_session.ssn,
         )
+      end
+
+      def enrollment
+        current_user.establishing_in_person_enrollment
       end
 
       # override IdvSessionConcern

--- a/app/models/in_person_enrollment.rb
+++ b/app/models/in_person_enrollment.rb
@@ -175,6 +175,11 @@ class InPersonEnrollment < ApplicationRecord
     profile&.deactivate_due_to_in_person_verification_cancelled
   end
 
+  # @return [Boolean] Whether the enrollment is type passport book.
+  def passport_book?
+    document_type == DOCUMENT_TYPE_PASSPORT_BOOK
+  end
+
   private
 
   def days_to_expire

--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -18,7 +18,7 @@ module Idv
       end
 
       def enrolled_with_passport_book?
-        enrollment.document_type == InPersonEnrollment::DOCUMENT_TYPE_PASSPORT_BOOK
+        enrollment.passport_book?
       end
 
       # Reminder is exclusive of the day the email is sent (1 less than days_to_due_date)

--- a/app/presenters/idv/in_person/verify_info_presenter.rb
+++ b/app/presenters/idv/in_person/verify_info_presenter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Idv::InPerson::VerifyInfoPresenter
+  def initialize(enrollment:)
+    @enrollment = enrollment
+  end
+
+  def step_indicator_steps
+    Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP
+  end
+
+  def identity_info_partial
+    passport_flow? ? 'passport_section' : 'state_id_section'
+  end
+
+  def passport_flow?
+    @enrollment.passport_book?
+  end
+end

--- a/app/views/idv/in_person/verify_info/_address_section.html.erb
+++ b/app/views/idv/in_person/verify_info/_address_section.html.erb
@@ -1,27 +1,27 @@
-<div class="grid-row grid-gap grid-gap-2 padding-bottom-1 padding-top-1 border-bottom border-primary-light">
+<div class="grid-row grid-gap grid-gap-2 padding-bottom-2 padding-top-2 border-bottom border-primary-light">
   <dl class='grid-col-fill margin-y-0'>
-    <div class="padding-y-1">
+    <div class="padding-bottom-1">
       <h2 class="h4 margin-y-0"><%= t('headings.residential_address') %></h2>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:address1] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:address1] %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:address2].presence %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:address2].presence %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:city] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:city] %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:state] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:state] %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:zipcode] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:zipcode] %> </dd>
     </div>
   </dl>
   <div class='grid-auto'>

--- a/app/views/idv/in_person/verify_info/_passport_section.html.erb
+++ b/app/views/idv/in_person/verify_info/_passport_section.html.erb
@@ -1,0 +1,21 @@
+<div class="grid-row grid-gap grid-gap-2 padding-bottom-2 border-bottom border-primary-light">
+  <dl class="grid-col-fill margin-y-0">
+    <div class="padding-bottom-1">
+      <h2 class="h4 margin-y-0"><%= t('in_person_proofing.form.verify_info.passport') %></h2>
+    </div>
+    <div>
+      <dt class="display-inline"><%= t('in_person_proofing.form.passport.surname') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= pii[:passport_surname] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('in_person_proofing.form.passport.first_name') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= pii[:passport_first_name] %> </dd>
+    </div>
+    <div>
+      <dt class="display-inline"> <%= t('in_person_proofing.form.passport.dob') %>: </dt>
+      <dd class="display-inline margin-left-0">
+        <%= I18n.l(Date.parse(pii[:passport_dob]), format: I18n.t('time.formats.event_date')) %>
+      </dd>
+    </div>
+  </dl>
+</div>

--- a/app/views/idv/in_person/verify_info/_ssn_section.html.erb
+++ b/app/views/idv/in_person/verify_info/_ssn_section.html.erb
@@ -1,17 +1,16 @@
-<div class="grid-row grid-gap grid-gap-2 padding-top-1">
+<div class="grid-row grid-gap grid-gap-2 padding-top-2">
   <div class='grid-col-fill'>
-    <div class="padding-y-1">
+    <div class="padding-bottom-1">
       <h2 class="h4 margin-y-0"><%= t('headings.ssn') %></h2>
     </div>
-    <%= t('idv.form.ssn') %>:
     <%= render(
           'shared/masked_text',
-          text: SsnFormatter.format(@ssn),
-          masked_text: SsnFormatter.format_masked(@ssn),
+          text: SsnFormatter.format(ssn),
+          masked_text: SsnFormatter.format_masked(ssn),
           accessible_masked_text: t(
             'idv.accessible_labels.masked_ssn',
-            first_number: @ssn[0],
-            last_number: @ssn[-1],
+            first_number: ssn[0],
+            last_number: ssn[-1],
           ),
           toggle_label: t('forms.ssn.show'),
         ) %>

--- a/app/views/idv/in_person/verify_info/_state_id_section.html.erb
+++ b/app/views/idv/in_person/verify_info/_state_id_section.html.erb
@@ -1,55 +1,55 @@
-<div class="grid-row grid-gap grid-gap-2 padding-bottom-1 border-bottom border-primary-light">
+<div class="grid-row grid-gap grid-gap-2 padding-bottom-2 border-bottom border-primary-light">
   <dl class="grid-col-fill margin-y-0">
-    <div class="padding-y-1">
+    <div class="padding-bottom-1">
       <h2 class="h4 margin-y-0"><%= t('headings.state_id') %></h2>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.first_name') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:first_name] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:first_name] %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.last_name') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:last_name] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:last_name] %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.dob') %>: </dt>
       <dd class="display-inline margin-left-0">
-        <%= I18n.l(Date.parse(@pii[:dob]), format: I18n.t('time.formats.event_date')) %>
+        <%= I18n.l(Date.parse(pii[:dob]), format: I18n.t('time.formats.event_date')) %>
       </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.issuing_state') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:state_id_jurisdiction] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:state_id_jurisdiction] %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.id_number') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:state_id_number] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:state_id_number] %> </dd>
     </div>
     <div class="margin-top-105">
       <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_address1] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_address1] %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.address2') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_address2].presence %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_address2].presence %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.city') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_city] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_city] %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.state') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_address_state] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_address_state] %> </dd>
     </div>
     <div>
       <dt class="display-inline"> <%= t('idv.form.zipcode') %>: </dt>
-      <dd class="display-inline margin-left-0"> <%= @pii[:identity_doc_zipcode] %> </dd>
+      <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_zipcode] %> </dd>
     </div>
   </dl>
   <div class='grid-auto'>
     <%= link_to(
           idv_in_person_state_id_url,
-          class: 'usa-button usa-button--unstyled padding-y-1',
+          class: 'usa-button usa-button--unstyled',
           'aria-label': t('idv.buttons.change_state_id_label'),
         ) { t('idv.buttons.change_label') } %>
   </div>

--- a/app/views/idv/in_person/verify_info/show.html.erb
+++ b/app/views/idv/in_person/verify_info/show.html.erb
@@ -1,14 +1,13 @@
 <%#
 locals:
-  @step_indicator_steps - the correct Idv::Flows variable for this flow
   @pii - user's information
   @ssn - user's ssn
-  @had_barcode_read_failure - show warning if there's a barcode read error
+  @presenter - An instance of Idv::InPerson::VerifyInfoPresenter
 %>
 
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: @step_indicator_steps,
+        steps: @presenter.step_indicator_steps,
         current_step: :verify_info,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',
@@ -22,10 +21,13 @@ locals:
 <% self.title = t('titles.idv.verify_info') %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.verify')) %>
+<% if @presenter.passport_flow? %>
+  <p>
+    <%= t('in_person_proofing.form.verify_info.passport_intro_text') %>
+  </p>
+<% end %>
 <div class='margin-top-4 margin-bottom-2'>
-  <% if !@pii[:state_id_number].nil? %>
-    <%= render 'state_id_section', pii: @pii %>
-  <% end %>
+  <%= render @presenter.identity_info_partial, pii: @pii %>
   <%= render 'address_section', pii: @pii %>
   <%= render 'ssn_section', ssn: @ssn %>
   <div class="margin-top-5">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1359,6 +1359,8 @@ in_person_proofing.form.state_id.state_id_number_hint_forward_slashes: forward s
 in_person_proofing.form.state_id.state_id_number_hint_spaces: spaces
 in_person_proofing.form.state_id.state_id_number_texas_hint: This is the 8-digit number on your ID. Enter only numbers in this field.
 in_person_proofing.form.state_id.zipcode: ZIP Code
+in_person_proofing.form.verify_info.passport: U.S. passport book
+in_person_proofing.form.verify_info.passport_intro_text: We will check records to verify that your address and Social Security number match the information on your ID.
 in_person_proofing.headings.address: Enter your current residential address
 in_person_proofing.headings.barcode: Show this barcode and your state ID at a Post Office to finish verifying your identity
 in_person_proofing.headings.barcode_eipp: Bring this barcode and supporting documents to a Post Office to finish verifying your identity

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1370,6 +1370,8 @@ in_person_proofing.form.state_id.state_id_number_hint_forward_slashes: barras di
 in_person_proofing.form.state_id.state_id_number_hint_spaces: espacios
 in_person_proofing.form.state_id.state_id_number_texas_hint: Este es el número de 8 dígitos de su identificación. Ingrese únicamente números en este campo.
 in_person_proofing.form.state_id.zipcode: Código postal
+in_person_proofing.form.verify_info.passport: U.S. passport book
+in_person_proofing.form.verify_info.passport_intro_text: We will check records to verify that your address and Social Security number match the information on your ID.
 in_person_proofing.headings.address: Ingrese su domicilio actual
 in_person_proofing.headings.barcode: Muestre este código de barras y su identificación el estado en una oficina de correos para terminar de verificar su identidad.
 in_person_proofing.headings.barcode_eipp: Lleve este código de barras y los documentos comprobatorios a una oficina de correos para terminar de verificar su identidad

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1359,6 +1359,8 @@ in_person_proofing.form.state_id.state_id_number_hint_forward_slashes: des barre
 in_person_proofing.form.state_id.state_id_number_hint_spaces: des espaces
 in_person_proofing.form.state_id.state_id_number_texas_hint: Il s’agit du numéro à huit chiffres figurant sur votre pièce d’identité. Dans ce champ, ne saisissez que des chiffres.
 in_person_proofing.form.state_id.zipcode: Code postal
+in_person_proofing.form.verify_info.passport: U.S. passport book
+in_person_proofing.form.verify_info.passport_intro_text: We will check records to verify that your address and Social Security number match the information on your ID.
 in_person_proofing.headings.address: Saisissez votre adresse résidentielle actuelle
 in_person_proofing.headings.barcode: Présentez ce code-barres et votre pièce d’identité l’État à un bureau de poste pour terminer la vérification de votre identité
 in_person_proofing.headings.barcode_eipp: Présenter ce code-barres et les documents complémentaires à un bureau de poste pour terminer la vérification de votre identité

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1372,6 +1372,8 @@ in_person_proofing.form.state_id.state_id_number_hint_forward_slashes: 前斜杠
 in_person_proofing.form.state_id.state_id_number_hint_spaces: 空格
 in_person_proofing.form.state_id.state_id_number_texas_hint: 这是你身份证件上的8位数在这一字段中只输入数字
 in_person_proofing.form.state_id.zipcode: 邮编
+in_person_proofing.form.verify_info.passport: U.S. passport book
+in_person_proofing.form.verify_info.passport_intro_text: We will check records to verify that your address and Social Security number match the information on your ID.
 in_person_proofing.headings.address: 输入你当前住宅地址
 in_person_proofing.headings.barcode: 到邮局出示这一条形码和你政府颁发的身份证件来完成验证身份。
 in_person_proofing.headings.barcode_eipp: 携带该条形码和支持性文件到邮局去完成验证身份。

--- a/spec/features/idv/in_person/passport_scenario_spec.rb
+++ b/spec/features/idv/in_person/passport_scenario_spec.rb
@@ -166,6 +166,8 @@ RSpec.describe 'In Person Proofing Passports', js: true do
           click_on t('forms.buttons.continue')
 
           expect(page).to have_current_path(idv_in_person_verify_info_path)
+
+          check_passport_verify_info_page_content
         end
       end
 
@@ -360,5 +362,45 @@ RSpec.describe 'In Person Proofing Passports', js: true do
       'in_person_passport[passport_expiration]',
       InPersonHelper::GOOD_PASSPORT_EXPIRATION_DATE,
     )
+  end
+
+  def check_passport_verify_info_page_content
+    expect(page).to have_content t('in_person_proofing.form.verify_info.passport')
+
+    # Surname
+    expect(page).to have_content t('in_person_proofing.form.passport.surname')
+    expect(page).to have_content InPersonHelper::GOOD_LAST_NAME
+    # First name
+    expect(page).to have_content t('in_person_proofing.form.passport.first_name')
+    expect(page).to have_content InPersonHelper::GOOD_FIRST_NAME
+    # Date of Birth
+    expect(page).to have_content t('in_person_proofing.form.passport.dob')
+    expect(page).to have_content(
+      I18n.l(Date.parse(InPersonHelper::GOOD_DOB), format: t('time.formats.event_date')),
+    )
+
+    expect(page).to have_content(t('headings.residential_address'))
+    # address 1
+    expect(page).to have_content(t('idv.form.address1'))
+    expect(page).to have_content InPersonHelper::GOOD_ADDRESS1
+    # address 2
+    expect(page).to have_content(t('idv.form.address2'))
+    expect(page).to have_content InPersonHelper::GOOD_ADDRESS2
+    # address city
+    expect(page).to have_content(t('idv.form.city'))
+    expect(page).to have_content InPersonHelper::GOOD_CITY
+    # address state
+    expect(page).to have_content(t('idv.form.state'))
+    expect(page).to have_content InPersonHelper::GOOD_STATE_ABBR
+    # address zipcode
+    expect(page).to have_content(t('idv.form.zipcode'))
+    expect(page).to have_content InPersonHelper::GOOD_ZIPCODE
+
+    expect(page).to have_content(t('headings.ssn'))
+    expect(page).to have_content(t('idv.form.ssn'))
+    expect(page).to have_content SsnFormatter.format_masked(InPersonHelper::GOOD_SSN)
+
+    expect(page).to_not have_content(t('headings.state_id'))
+    expect(page).to_not have_content(t('idv.form.id_number'))
   end
 end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -85,6 +85,8 @@ module I18n
         { key: 'in_person_proofing.form.passport.passport_number' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
         { key: 'in_person_proofing.form.passport.passport_number_hint' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
         { key: 'in_person_proofing.form.passport.surname' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
+        { key: 'in_person_proofing.form.verify_info.passport' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
+        { key: 'in_person_proofing.form.verify_info.passport_intro_text' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
         { key: 'in_person_proofing.headings.barcode_passport' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
         { key: 'in_person_proofing.headings.passport' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
         { key: 'in_person_proofing.process.eipp_bring_id.image_alt_text', locales: %i[fr es zh] }, # Real ID is considered a proper noun in this context, ID translated to ID Card in Chinese

--- a/spec/models/in_person_enrollment_spec.rb
+++ b/spec/models/in_person_enrollment_spec.rb
@@ -610,4 +610,22 @@ RSpec.describe InPersonEnrollment, type: :model do
       end
     end
   end
+
+  describe '#passport_book?' do
+    context 'when the enrollment is a passport book enrollment' do
+      let(:enrollment) { create(:in_person_enrollment, :passport_book) }
+
+      it 'returns true' do
+        expect(enrollment.passport_book?).to be(true)
+      end
+    end
+
+    context 'when the enrollment is not a passport book enrollment' do
+      let(:enrollment) { create(:in_person_enrollment) }
+
+      it 'returns false' do
+        expect(enrollment.passport_book?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/presenters/idv/in_person/verify_info_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/verify_info_presenter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Idv::InPerson::VerifyInfoPresenter do
+  let(:enrollment) { create(:in_person_enrollment, :establishing) }
+
+  subject { described_class.new(enrollment: enrollment) }
+
+  describe '#step_indicator_steps' do
+    it 'returns the IPP step indicator steps' do
+      expect(subject.step_indicator_steps).to eq(
+        Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS_IPP,
+      )
+    end
+  end
+
+  describe '#identity_info_partial' do
+    context 'when enrollment is a passport enrollment' do
+      let(:enrollment) { create(:in_person_enrollment, :establishing, :passport_book) }
+
+      subject { described_class.new(enrollment: enrollment) }
+
+      it 'returns "passport_section"' do
+        expect(subject.identity_info_partial).to eq('passport_section')
+      end
+    end
+
+    context 'when enrollment is not passport enrollment' do
+      let(:enrollment) { create(:in_person_enrollment, :establishing, :state_id) }
+
+      subject { described_class.new(enrollment: enrollment) }
+
+      it 'returns "state_id_section"' do
+        expect(subject.identity_info_partial).to eq('state_id_section')
+      end
+    end
+  end
+end

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -21,6 +21,7 @@ module InPersonHelper
   GOOD_CITY = Idp::Constants::MOCK_IDV_APPLICANT[:city].freeze
   GOOD_ZIPCODE = Idp::Constants::MOCK_IDV_APPLICANT[:zipcode].freeze
   GOOD_STATE = Idp::Constants::MOCK_IDV_APPLICANT_FULL_STATE
+  GOOD_STATE_ABBR = Idp::Constants::MOCK_IDV_APPLICANT_STATE
   GOOD_IDENTITY_DOC_ADDRESS1 =
     Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS[:identity_doc_address1].freeze
   GOOD_IDENTITY_DOC_ADDRESS2 =

--- a/spec/views/idv/in_person/verify_info/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/verify_info/show.html.erb_spec.rb
@@ -1,0 +1,198 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/in_person/verify_info/show.html.erb' do
+  let(:address_pii) do
+    {
+      address1: Faker::Address.street_address,
+      address2: Faker::Address.secondary_address,
+      city: Faker::Address.city,
+      state: Faker::Address.state_abbr,
+      zipcode: Faker::Address.zip,
+    }
+  end
+
+  let(:ssn_pii) do
+    {
+      ssn: '666' + Faker::Number.number(digits: 6).to_s,
+    }
+  end
+
+  before do
+    allow(view).to receive(:user_signing_up?).and_return(false)
+    allow(view).to receive(:user_fully_authenticated?).and_return(true)
+  end
+
+  describe 'show' do
+    context 'When the user is in the state_id flow' do
+      let(:state_id_pii) do
+        {
+          first_name: Faker::Name.first_name,
+          last_name: Faker::Name.last_name,
+          dob: Faker::Date.in_date_period(year: 1985).to_s,
+          state_id_jurisdiction: Faker::Address.state_abbr,
+          state_id_number: Faker::Number.number(digits: 6).to_s,
+          identity_doc_address1: Faker::Address.street_address,
+          identity_doc_address2: Faker::Address.secondary_address,
+          identity_doc_city: Faker::Address.city,
+          identity_doc_address_state: Faker::Address.state_abbr,
+          identity_doc_zipcode: Faker::Address.zip,
+        }
+      end
+
+      let(:pii) { { **state_id_pii, **address_pii, **ssn_pii } }
+      let(:enrollment) { build(:in_person_enrollment, :state_id) }
+
+      subject(:rendered) do
+        render template: 'idv/in_person/verify_info/show'
+      end
+
+      before do
+        assign(:presenter, Idv::InPerson::VerifyInfoPresenter.new(enrollment: enrollment))
+        assign(:pii, pii)
+        assign(:ssn, pii[:ssn])
+      end
+
+      it 'renders the state_id section' do
+        # Heading
+        expect(rendered).to have_content(t('headings.state_id'))
+        # First Name
+        expect(rendered).to have_content(t('idv.form.first_name'))
+        expect(rendered).to have_content(pii[:first_name])
+        # Last Name
+        expect(rendered).to have_content(t('idv.form.last_name'))
+        expect(rendered).to have_content(pii[:last_name])
+        # Date of Birth
+        expect(rendered).to have_content(t('idv.form.dob'))
+        expect(rendered).to have_content(
+          I18n.l(Date.parse(pii[:dob]), format: I18n.t('time.formats.event_date')),
+        )
+        # Issuing State
+        expect(rendered).to have_content(t('idv.form.issuing_state'))
+        expect(rendered).to have_content(pii[:state_id_jurisdiction])
+        # State ID number
+        expect(rendered).to have_content(t('idv.form.id_number'))
+        expect(rendered).to have_content(pii[:state_id_number])
+        # State ID address 1
+        expect(rendered).to have_content(t('idv.form.address1'))
+        expect(rendered).to have_content(pii[:identity_doc_address1])
+        # State ID address 2
+        expect(rendered).to have_content(t('idv.form.address2'))
+        expect(rendered).to have_content(pii[:identity_doc_address2])
+        # State ID address city
+        expect(rendered).to have_content(t('idv.form.city'))
+        expect(rendered).to have_content(pii[:identity_doc_city])
+        # State ID address state
+        expect(rendered).to have_content(t('idv.form.state'))
+        expect(rendered).to have_content(pii[:identity_doc_address_state])
+        # State ID address zipcode
+        expect(rendered).to have_content(t('idv.form.zipcode'))
+        expect(rendered).to have_content(pii[:identity_doc_zipcode])
+      end
+
+      it 'renders the address section' do
+        # Heading
+        expect(rendered).to have_content(t('headings.residential_address'))
+        # address 1
+        expect(rendered).to have_content(t('idv.form.address1'))
+        expect(rendered).to have_content(pii[:address1])
+        # address 2
+        expect(rendered).to have_content(t('idv.form.address2'))
+        expect(rendered).to have_content(pii[:address2])
+        # address city
+        expect(rendered).to have_content(t('idv.form.city'))
+        expect(rendered).to have_content(pii[:city])
+        # address state
+        expect(rendered).to have_content(t('idv.form.state'))
+        expect(rendered).to have_content(pii[:state])
+        # address zipcode
+        expect(rendered).to have_content(t('idv.form.zipcode'))
+        expect(rendered).to have_content(pii[:zipcode])
+      end
+
+      it 'renders the ssn section' do
+        # Heading
+        expect(rendered).to have_content(t('headings.ssn'))
+        # SSN
+        expect(rendered).to have_content(t('idv.form.ssn'))
+        expect(rendered).to have_content(SsnFormatter.format_masked(pii[:ssn]))
+      end
+
+      it 'does not render the passport section' do
+        expect(rendered).to_not have_content(t('in_person_proofing.form.verify_info.passport'))
+      end
+    end
+
+    context 'When the user is in the passport flow' do
+      let(:passport_pii) do
+        {
+          passport_surname: Faker::Name.last_name,
+          passport_first_name: Faker::Name.first_name,
+          passport_dob: Faker::Date.in_date_period(year: 1985).to_s,
+          passport_number: Faker::Number.number(digits: 9).to_s,
+          passport_expiration: Faker::Date.in_date_period(year: Time.zone.now.year + 1),
+        }
+      end
+
+      let(:pii) { { **passport_pii, **address_pii, **ssn_pii } }
+      let(:enrollment) { build(:in_person_enrollment, :passport_book) }
+
+      subject(:rendered) do
+        render template: 'idv/in_person/verify_info/show'
+      end
+
+      before do
+        assign(:presenter, Idv::InPerson::VerifyInfoPresenter.new(enrollment: enrollment))
+        assign(:pii, pii)
+        assign(:ssn, pii[:ssn])
+      end
+
+      it 'renders the passport section' do
+        # Heading
+        expect(rendered).to have_content(t('in_person_proofing.form.verify_info.passport'))
+        # Surname
+        expect(rendered).to have_content(t('in_person_proofing.form.passport.surname'))
+        expect(rendered).to have_content(pii[:passport_surname])
+        # First Name
+        expect(rendered).to have_content(t('in_person_proofing.form.passport.first_name'))
+        expect(rendered).to have_content(pii[:passport_first_name])
+        # Date of Birth
+        expect(rendered).to have_content(t('in_person_proofing.form.passport.dob'))
+        expect(rendered).to have_content(
+          I18n.l(Date.parse(pii[:passport_dob]), format: I18n.t('time.formats.event_date')),
+        )
+      end
+
+      it 'renders the address section' do
+        # Heading
+        expect(rendered).to have_content(t('headings.residential_address'))
+        # address 1
+        expect(rendered).to have_content(t('idv.form.address1'))
+        expect(rendered).to have_content(pii[:address1])
+        # address 2
+        expect(rendered).to have_content(t('idv.form.address2'))
+        expect(rendered).to have_content(pii[:address2])
+        # address city
+        expect(rendered).to have_content(t('idv.form.city'))
+        expect(rendered).to have_content(pii[:city])
+        # address state
+        expect(rendered).to have_content(t('idv.form.state'))
+        expect(rendered).to have_content(pii[:state])
+        # address zipcode
+        expect(rendered).to have_content(t('idv.form.zipcode'))
+        expect(rendered).to have_content(pii[:zipcode])
+      end
+
+      it 'renders the ssn section' do
+        # Heading
+        expect(rendered).to have_content(t('headings.ssn'))
+        # SSN
+        expect(rendered).to have_content(t('idv.form.ssn'))
+        expect(rendered).to have_content(SsnFormatter.format_masked(pii[:ssn]))
+      end
+
+      it 'does not render the state-id section' do
+        expect(rendered).to_not have_content(t('headings.state_id'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15980](https://cm-jira.usa.gov/browse/LG-15980)

## 🛠 Summary of changes

Add passport info section to verify info form

## 📜 Testing Plan

**Scenario: Verify Info page in IPP Passport Flow**
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP Passport flow reaching the Verify Info page
- [x] Ensure Passport Book (Surname, First name, Date of Birth),  Address, SSN info is displayed
- [x] Ensure no update link is present in the passport section
- [x] Ensure Address info can be updated using the update link
- [x] Ensure SSN info can be updated using the update link
- [ ] Ensure Verify Info page matches Figma design

**Scenario: Verify Info page in IPP State-ID Flow**
- [x]  Login through the oidc sinatra application selecting the Identity Verified level of service.
- [x] Create a new account
- [x] Complete the ID-IPP State-ID flow reaching the Verify Info page
- [x] Ensure State-ID, Address, SSN info is displayed
- [x] Ensure State-ID info can be updated using the update link
- [x] Ensure Address info can be updated using the update link
- [x] Ensure SSN info can be updated using the update link

## 👀 Screenshots

<details>
<summary>Verify Info for Passport</summary>
<img width="675" alt="Screenshot 2025-05-19 at 10 27 13 AM" src="https://github.com/user-attachments/assets/dbfe30b0-031b-4cce-87ad-5a0bfa1419d2" />
</details>
<details>
<summary>Verify Info for State-ID</summary>
<img width="680" alt="Screenshot 2025-05-19 at 10 25 40 AM" src="https://github.com/user-attachments/assets/7b68cae0-b9d6-4407-a680-288dcf593d97" />
</details>



