### PR TITLE
Fixing datetime filter for idp tables after refactor

### DIFF
--- a/app/jobs/data_warehouse/table_summary_stats_export_job.rb
+++ b/app/jobs/data_warehouse/table_summary_stats_export_job.rb
@@ -21,7 +21,7 @@ module DataWarehouse
     def perform(timestamp)
       return if data_warehouse_disabled?
 
-      idp_data = fetch_table_max_ids_and_counts(timestamp)
+      idp_data = fetch_table_max_ids_and_counts(timestamp.end_of_day)
       cloudwatch_data = fetch_log_group_counts(timestamp)
       data = idp_data.merge(cloudwatch_data)
       upload_to_s3(data, timestamp)


### PR DESCRIPTION
Follow up to [PR-12165](https://github.com/18F/identity-idp/pull/12165), to fix the datetime filter being used for idp table count query.
## 🎫 Ticket
[issue-393](https://gitlab.login.gov/lg-teams/Team-Data/data-warehouse-ag/-/issues/393)

## 🛠 Summary of changes
The prior PR was returning a count of records that have a timestamp of before yesterday but it needs to return count of records that have a timestamp of before END of yesterday.


## 📜 Testing Plan

- [ ] Step 1: Deploy to agnes to test on an environment with more data
- [ ] Step 2: Run job and confirm s3 file is written with expected output