### PR TITLE
Dmm/idv verification submitted

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -453,18 +453,8 @@ module Idv
         stages.map { |_k, v| v[:attributes_requiring_additional_verification] }.flatten.compact
       end
 
-      def failed_vendors
-        stages.keys.select { |k| !stages[k][:success] }.map { |k| stage_to_vendor[k] }
-      end
-
-      def stage_to_vendor
-        {
-          resolution: 'InstantVerify',
-          state_id: 'AAMVA',
-          residential_address: 'InstantVerify Residential',
-          phone_precheck: 'PhoneFinder',
-          threatmetrix: 'ThreatMetrix',
-        }
+      def failed_stages
+        stages.keys.select { |k| !stages[k][:success] }
       end
 
       def resolution_adjudication_reason
@@ -488,10 +478,10 @@ module Idv
       end
 
       def formatted_failure_reasons
-        return nil if result.success? && !failed_vendors.present?
+        return nil if result.success? && !failed_stages.present?
 
         {
-          failed_vendors:,
+          failed_stages:,
           attributes_requiring_additional_verification:,
         }
           .merge(resolution_adjudication_reason)

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -180,7 +180,8 @@ module AttemptsApi
     end
 
     # @param [Boolean] success
-    # @param [String] address
+    # @param [String] address1
+    # @param [String] address2
     # @param [String] date_of_birth
     # @param [String] document_state
     # @param [String] document_number
@@ -193,7 +194,8 @@ module AttemptsApi
     # The verification was submitted during the IDV process
     def idv_verification_submitted(
       success:,
-      address: nil,
+      address1: nil,
+      address2: nil,
       date_of_birth: nil,
       document_state: nil,
       document_number: nil,
@@ -207,7 +209,8 @@ module AttemptsApi
       track_event(
         'idv-verification-submitted',
         success:,
-        address:,
+        address1:,
+        address2:,
         date_of_birth:,
         document_state:,
         document_number:,

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -179,6 +179,47 @@ module AttemptsApi
       )
     end
 
+    # @param [Boolean] success
+    # @param [String] address
+    # @param [String] date_of_birth
+    # @param [String] document_state
+    # @param [String] document_number
+    # @param [String] document_issued
+    # @param [String] document_expiration
+    # @param [String] first_name
+    # @param [String] last_name
+    # @param [String] social_security
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason
+    # The verification was submitted during the IDV process
+    def idv_verification_submitted(
+      success:,
+      address: nil,
+      date_of_birth: nil,
+      document_state: nil,
+      document_number: nil,
+      document_issued: nil,
+      document_expiration: nil,
+      first_name: nil,
+      last_name: nil,
+      social_security: nil,
+      failure_reason: nil
+    )
+      track_event(
+        'idv-verification-submitted',
+        success:,
+        address:,
+        date_of_birth:,
+        document_state:,
+        document_number:,
+        document_issued:,
+        document_expiration:,
+        first_name:,
+        last_name:,
+        social_security:,
+        failure_reason:,
+      )
+    end
+
     # @param [Boolean] success True if account successfully deleted
     # A User deletes their Login.gov account
     def logged_in_account_purged(success:)

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -96,6 +96,7 @@ module Proofing
         elsif device_profiling_result.success?
           [true, :device_profiling_result_pass]
         else
+          # a non-passing review status is handled downstream, so is considered a succcess
           [true, :device_profiling_result_review_required]
         end
       end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -287,7 +287,6 @@ RSpec.describe Idv::VerifyInfoController do
         end
 
         it 'tracks the attempts event' do
-          stub_attempts_tracker
           expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
             success: true,
             failure_reason: nil,
@@ -306,7 +305,6 @@ RSpec.describe Idv::VerifyInfoController do
         end
 
         it 'tracks a failed tmx fraud check' do
-          stub_attempts_tracker
           expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
             success: false,
             failure_reason: { tmx_summary_reason_code: ['Identity_Negative_History'] },

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe Idv::VerifyInfoController do
             address2: applicant_pii[:address2],
             social_security: applicant_pii[:ssn],
             failure_reason: {
-              failed_vendors: ['ThreatMetrix'],
+              failed_stages: [:threatmetrix],
               device_profiling_adjudication_reason: ['device_profiling_result'],
               resolution_adjudication_reason: ['pass_resolution_and_state_id'],
             },
@@ -430,7 +430,7 @@ RSpec.describe Idv::VerifyInfoController do
             address2: applicant_pii[:address2],
             social_security: applicant_pii[:ssn],
             failure_reason: {
-              failed_vendors: ['ThreatMetrix'],
+              failed_stages: [:threatmetrix],
               resolution_adjudication_reason: ['pass_resolution_and_state_id'],
               device_profiling_adjudication_reason: ['device_profiling_exception'],
             },
@@ -481,7 +481,7 @@ RSpec.describe Idv::VerifyInfoController do
             address2: applicant_pii[:address2],
             social_security: applicant_pii[:ssn],
             failure_reason: {
-              failed_vendors: ['ThreatMetrix'],
+              failed_stages: [:threatmetrix],
               device_profiling_adjudication_reason: ['device_profiling_result'],
               resolution_adjudication_reason: ['pass_resolution_and_state_id'],
             },
@@ -699,7 +699,7 @@ RSpec.describe Idv::VerifyInfoController do
             address2: applicant_pii[:address2],
             social_security: applicant_pii[:ssn],
             failure_reason: {
-              failed_vendors: ['AAMVA'],
+              failed_stages: [:state_id],
               resolution_adjudication_reason: ['fail_state_id'],
               device_profiling_adjudication_reason: ['device_profiling_result_pass'],
             },
@@ -731,7 +731,7 @@ RSpec.describe Idv::VerifyInfoController do
             address2: applicant_pii[:address2],
             social_security: applicant_pii[:ssn],
             failure_reason: {
-              failed_vendors: ['AAMVA'],
+              failed_stages: [:state_id],
               resolution_adjudication_reason: ['fail_state_id'],
               device_profiling_adjudication_reason: ['device_profiling_result_pass'],
             },
@@ -824,7 +824,7 @@ RSpec.describe Idv::VerifyInfoController do
             social_security: applicant_pii[:ssn],
             failure_reason: {
               attributes_requiring_additional_verification: ['address'],
-              failed_vendors: ['InstantVerify', 'PhoneFinder'],
+              failed_stages: [:resolution, :phone_precheck],
               resolution_adjudication_reason: ['fail_resolution_without_state_id_coverage'],
               device_profiling_adjudication_reason: ['device_profiling_result_pass'],
             },
@@ -861,7 +861,7 @@ RSpec.describe Idv::VerifyInfoController do
             social_security: applicant_pii[:ssn],
             failure_reason: {
               attributes_requiring_additional_verification: ['address', 'dob', 'ssn'],
-              failed_vendors: ['InstantVerify', 'PhoneFinder'],
+              failed_stages: [:resolution, :phone_precheck],
               resolution_adjudication_reason: ['fail_resolution_without_state_id_coverage'],
               device_profiling_adjudication_reason: ['device_profiling_result_pass'],
             },
@@ -941,7 +941,7 @@ RSpec.describe Idv::VerifyInfoController do
           address2: applicant_pii[:address2],
           social_security: applicant_pii[:ssn],
           failure_reason: {
-            failed_vendors: ['InstantVerify'],
+            failed_stages: [:resolution],
             resolution_adjudication_reason: ['fail_resolution_without_state_id_coverage'],
             device_profiling_adjudication_reason: ['device_profiling_result_pass'],
           },

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -185,12 +185,17 @@ RSpec.describe Idv::VerifyInfoController do
     context 'when proofing_device_profiling is enabled' do
       let(:threatmetrix_client_id) { 'threatmetrix_client' }
       let(:review_status) { 'pass' }
+      let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
+      let(:success) { true }
 
       let(:idv_result) do
         {
           context: {
+            device_profiling_adjudication_reason: 'device_profiling_result',
+            resolution_adjudication_reason: 'pass_resolution_and_state_id',
             stages: {
               threatmetrix: {
+                success:,
                 client: threatmetrix_client_id,
                 transaction_id: 1,
                 review_status: review_status,
@@ -286,9 +291,23 @@ RSpec.describe Idv::VerifyInfoController do
           )
         end
 
-        it 'tracks the attempts event' do
+        it 'tracks the attempts events' do
           expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
             success: true,
+            failure_reason: nil,
+          )
+          expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+            success: true,
+            document_state: applicant_pii[:state],
+            document_number: applicant_pii[:state_id_number],
+            document_issued: applicant_pii[:state_id_issued],
+            document_expiration: applicant_pii[:state_id_expiration],
+            first_name: applicant_pii[:first_name],
+            last_name: applicant_pii[:last_name],
+            date_of_birth: applicant_pii[:dob],
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            social_security: applicant_pii[:ssn],
             failure_reason: nil,
           )
 
@@ -298,6 +317,7 @@ RSpec.describe Idv::VerifyInfoController do
 
       context 'when threatmetrix response is No Result' do
         let(:review_status) { nil }
+        let(:success) { false }
 
         it 'sets the review status in the idv session' do
           get :show
@@ -308,6 +328,25 @@ RSpec.describe Idv::VerifyInfoController do
           expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
             success: false,
             failure_reason: { tmx_summary_reason_code: ['Identity_Negative_History'] },
+          )
+
+          expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+            success: true,
+            document_state: applicant_pii[:state],
+            document_number: applicant_pii[:state_id_number],
+            document_issued: applicant_pii[:state_id_issued],
+            document_expiration: applicant_pii[:state_id_expiration],
+            first_name: applicant_pii[:first_name],
+            last_name: applicant_pii[:last_name],
+            date_of_birth: applicant_pii[:dob],
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            social_security: applicant_pii[:ssn],
+            failure_reason: {
+              failed_vendors: ['ThreatMetrix'],
+              device_profiling_adjudication_reason: ['device_profiling_result'],
+              resolution_adjudication_reason: ['pass_resolution_and_state_id'],
+            },
           )
 
           get :show
@@ -321,6 +360,7 @@ RSpec.describe Idv::VerifyInfoController do
           {
             context: {
               device_profiling_adjudication_reason: 'device_profiling_exception',
+              resolution_adjudication_reason: 'pass_resolution_and_state_id',
               errors: {},
               stages: {
                 threatmetrix: {
@@ -376,6 +416,28 @@ RSpec.describe Idv::VerifyInfoController do
           )
         end
 
+        it 'tracks the event for the attempts api' do
+          expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+            success: false,
+            document_state: applicant_pii[:state],
+            document_number: applicant_pii[:state_id_number],
+            document_issued: applicant_pii[:state_id_issued],
+            document_expiration: applicant_pii[:state_id_expiration],
+            first_name: applicant_pii[:first_name],
+            last_name: applicant_pii[:last_name],
+            date_of_birth: applicant_pii[:dob],
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            social_security: applicant_pii[:ssn],
+            failure_reason: {
+              failed_vendors: ['ThreatMetrix'],
+              resolution_adjudication_reason: ['pass_resolution_and_state_id'],
+              device_profiling_adjudication_reason: ['device_profiling_exception'],
+            },
+          )
+          get :show
+        end
+
         it 'tracks a failed tmx fraud check' do
           stub_attempts_tracker
           expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
@@ -391,6 +453,7 @@ RSpec.describe Idv::VerifyInfoController do
 
       context 'when threatmetrix response is Reject' do
         let(:review_status) { 'reject' }
+        let(:success) { false }
 
         it 'sets the review status in the idv session' do
           get :show
@@ -398,11 +461,29 @@ RSpec.describe Idv::VerifyInfoController do
         end
 
         it 'tracks a failed tmx fraud check' do
-          stub_attempts_tracker
           expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
-            success: false,
+            success:,
             failure_reason: {
               tmx_summary_reason_code: ['Identity_Negative_History'],
+            },
+          )
+
+          expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+            success: true,
+            document_state: applicant_pii[:state],
+            document_number: applicant_pii[:state_id_number],
+            document_issued: applicant_pii[:state_id_issued],
+            document_expiration: applicant_pii[:state_id_expiration],
+            first_name: applicant_pii[:first_name],
+            last_name: applicant_pii[:last_name],
+            date_of_birth: applicant_pii[:dob],
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            social_security: applicant_pii[:ssn],
+            failure_reason: {
+              failed_vendors: ['ThreatMetrix'],
+              device_profiling_adjudication_reason: ['device_profiling_result'],
+              resolution_adjudication_reason: ['pass_resolution_and_state_id'],
             },
           )
 
@@ -513,6 +594,7 @@ RSpec.describe Idv::VerifyInfoController do
       let(:errors) { {} }
       let(:exception) { nil }
       let(:vendor_name) { 'aamva_placeholder' }
+      let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
 
       let(:async_state) do
         # Here we're trying to match the store to redis -> read from redis flow this data travels
@@ -537,7 +619,7 @@ RSpec.describe Idv::VerifyInfoController do
           resolution_result: Proofing::Resolution::Result.new(success: true),
           same_address_as_id: true,
           should_proof_state_id: true,
-          applicant_pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN,
+          applicant_pii:,
         ).adjudicated_result.to_h
 
         document_capture_session.create_proofing_session
@@ -580,10 +662,50 @@ RSpec.describe Idv::VerifyInfoController do
             ),
           )
         end
+
+        it 'tracks the event for the attempts api' do
+          expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+            success: true,
+            document_state: applicant_pii[:state],
+            document_number: applicant_pii[:state_id_number],
+            document_issued: applicant_pii[:state_id_issued],
+            document_expiration: applicant_pii[:state_id_expiration],
+            first_name: applicant_pii[:first_name],
+            last_name: applicant_pii[:last_name],
+            date_of_birth: applicant_pii[:dob],
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            social_security: applicant_pii[:ssn],
+            failure_reason: nil,
+          )
+          get :show
+        end
       end
 
       context 'when aamva returns success: false but no exception' do
         let(:success) { false }
+
+        it 'tracks the event for the attempts api' do
+          expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+            success: false,
+            document_state: applicant_pii[:state],
+            document_number: applicant_pii[:state_id_number],
+            document_issued: applicant_pii[:state_id_issued],
+            document_expiration: applicant_pii[:state_id_expiration],
+            first_name: applicant_pii[:first_name],
+            last_name: applicant_pii[:last_name],
+            date_of_birth: applicant_pii[:dob],
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            social_security: applicant_pii[:ssn],
+            failure_reason: {
+              failed_vendors: ['AAMVA'],
+              resolution_adjudication_reason: ['fail_state_id'],
+              device_profiling_adjudication_reason: ['device_profiling_result_pass'],
+            },
+          )
+          get :show
+        end
 
         it 'redirects to the warning URL' do
           put :show
@@ -594,6 +716,28 @@ RSpec.describe Idv::VerifyInfoController do
       context 'when aamva returns an exception' do
         let(:success) { false }
         let(:exception) { Proofing::Aamva::VerificationError.new('ExceptionId: 0001') }
+
+        it 'tracks the event for the attempts api' do
+          expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+            success: false,
+            document_state: applicant_pii[:state],
+            document_number: applicant_pii[:state_id_number],
+            document_issued: applicant_pii[:state_id_issued],
+            document_expiration: applicant_pii[:state_id_expiration],
+            first_name: applicant_pii[:first_name],
+            last_name: applicant_pii[:last_name],
+            date_of_birth: applicant_pii[:dob],
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            social_security: applicant_pii[:ssn],
+            failure_reason: {
+              failed_vendors: ['AAMVA'],
+              resolution_adjudication_reason: ['fail_state_id'],
+              device_profiling_adjudication_reason: ['device_profiling_result_pass'],
+            },
+          )
+          get :show
+        end
 
         it 'redirects user to warning' do
           put :show
@@ -621,6 +765,7 @@ RSpec.describe Idv::VerifyInfoController do
       let(:exception) { nil }
       let(:error_attributes) { nil }
       let(:vendor_name) { 'instantverify_placeholder' }
+      let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
       let(:async_state) do
         # Here we're trying to match the store to redis -> read from redis flow this data travels
         adjudicated_result = Proofing::Resolution::ResultAdjudicator.new(
@@ -643,7 +788,7 @@ RSpec.describe Idv::VerifyInfoController do
           ),
           same_address_as_id: nil,
           should_proof_state_id: true,
-          applicant_pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN,
+          applicant_pii:,
         ).adjudicated_result.to_h
 
         document_capture_session.create_proofing_session
@@ -664,6 +809,29 @@ RSpec.describe Idv::VerifyInfoController do
           expect(response).to redirect_to idv_session_errors_address_warning_url
         end
 
+        it 'tracks the event for the attempts api' do
+          expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+            success: false,
+            document_state: applicant_pii[:state],
+            document_number: applicant_pii[:state_id_number],
+            document_issued: applicant_pii[:state_id_issued],
+            document_expiration: applicant_pii[:state_id_expiration],
+            first_name: applicant_pii[:first_name],
+            last_name: applicant_pii[:last_name],
+            date_of_birth: applicant_pii[:dob],
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            social_security: applicant_pii[:ssn],
+            failure_reason: {
+              attributes_requiring_additional_verification: ['address'],
+              failed_vendors: ['InstantVerify', 'PhoneFinder'],
+              resolution_adjudication_reason: ['fail_resolution_without_state_id_coverage'],
+              device_profiling_adjudication_reason: ['device_profiling_result_pass'],
+            },
+          )
+          get :show
+        end
+
         it 'logs an event' do
           get :show
 
@@ -677,6 +845,29 @@ RSpec.describe Idv::VerifyInfoController do
 
       context 'there are more instant verify exceptions' do
         let(:error_attributes) { ['address', 'dob', 'ssn'] }
+
+        it 'tracks the event for the attempts api' do
+          expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+            success: false,
+            document_state: applicant_pii[:state],
+            document_number: applicant_pii[:state_id_number],
+            document_issued: applicant_pii[:state_id_issued],
+            document_expiration: applicant_pii[:state_id_expiration],
+            first_name: applicant_pii[:first_name],
+            last_name: applicant_pii[:last_name],
+            date_of_birth: applicant_pii[:dob],
+            address1: applicant_pii[:address1],
+            address2: applicant_pii[:address2],
+            social_security: applicant_pii[:ssn],
+            failure_reason: {
+              attributes_requiring_additional_verification: ['address', 'dob', 'ssn'],
+              failed_vendors: ['InstantVerify', 'PhoneFinder'],
+              resolution_adjudication_reason: ['fail_resolution_without_state_id_coverage'],
+              device_profiling_adjudication_reason: ['device_profiling_result_pass'],
+            },
+          )
+          get :show
+        end
 
         it 'redirects user to address warning' do
           put :show
@@ -693,6 +884,8 @@ RSpec.describe Idv::VerifyInfoController do
       let(:document_capture_session) do
         DocumentCaptureSession.create(user:)
       end
+
+      let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
 
       let(:async_state) do
         # Here we're trying to match the store to redis -> read from redis flow this data travels
@@ -724,7 +917,7 @@ RSpec.describe Idv::VerifyInfoController do
           ),
           same_address_as_id: true,
           should_proof_state_id: true,
-          applicant_pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN,
+          applicant_pii:,
         ).adjudicated_result.to_h
 
         document_capture_session.create_proofing_session
@@ -734,8 +927,31 @@ RSpec.describe Idv::VerifyInfoController do
         document_capture_session.load_proofing_result
       end
 
+      it 'tracks the attempts api event' do
+        expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
+          success: false,
+          document_state: applicant_pii[:state],
+          document_number: applicant_pii[:state_id_number],
+          document_issued: applicant_pii[:state_id_issued],
+          document_expiration: applicant_pii[:state_id_expiration],
+          first_name: applicant_pii[:first_name],
+          last_name: applicant_pii[:last_name],
+          date_of_birth: applicant_pii[:dob],
+          address1: applicant_pii[:address1],
+          address2: applicant_pii[:address2],
+          social_security: applicant_pii[:ssn],
+          failure_reason: {
+            failed_vendors: ['InstantVerify'],
+            resolution_adjudication_reason: ['fail_resolution_without_state_id_coverage'],
+            device_profiling_adjudication_reason: ['device_profiling_result_pass'],
+          },
+        )
+        get :show
+      end
+
       it 'renders the warning page' do
         get :show
+
         expect(response).to redirect_to(idv_session_errors_warning_url)
       end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
Two tickets are relevant here!
[FIE epic 367](https://gitlab.login.gov/groups/lg-teams/FIE/-/epics/367)

## 🛠 Summary of changes
This change:
- adds the idv-verification-submitted event
- it also adds a VerificationFailures struct that was necessary to work with the idv verification form response. there is a lot going on in that object, and the code that existed was all inlined. this maybe should actually be its own class at this point, but i wasn't sure where to put it and this seemed like an okay compromise for the moment 

we had to make some decisions about what granularity of error we were going to record in the attempts api. we decided for the first approach we would record:
- the vendor(s) that failed
- the attributes that still needed verification
- if the result was a success, but any of the stages failed, we return the adjudication reason
- if threatmetrix was not a success, we would return the adjudication reason (this may be of limited use, honestly)
that decision is documented in [this ticket](https://gitlab.login.gov/lg-teams/FIE/moving-in/-/issues/1826)


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
