### PR TITLE
LG-16124: Add password reset help

### DIFF
--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -11,6 +11,8 @@ class MarketingSite
     manage-your-account/delete-your-account
     manage-your-account/personal-key
     trouble-signing-in/face-or-touch-unlock
+    trouble-signing-in/forgot-your-password
+    trouble-signing-in/forgot-your-personal-key
     trouble-signing-in/security-check-failed
     verify-your-identity/accepted-identification-documents
     verify-your-identity/how-to-add-images-of-your-state-issued-id

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -20,6 +20,18 @@
   <%= f.submit t('forms.buttons.continue'), class: 'display-block margin-y-5' %>
 <% end %>
 
+<%= render TroubleshootingOptionsComponent.new do |c| %>
+  <% c.with_header { t('components.troubleshooting_options.default_heading') } %>
+      <% c.with_option(
+           url: help_center_redirect_path(category: 'trouble-signing-in', article: 'forgot-your-password'),
+           new_tab: false,
+         ).with_content(t('forms.passwords.reset.how_to_reset')) %>
+      <% c.with_option(
+           url: help_center_redirect_path(category: 'trouble-signing-in', article: 'forgot-your-personal-key', article_anchor: 'if-you-have-a-personal-key'),
+           new_tab: false,
+         ).with_content(t('forms.passwords.reset.how_to_reset_with_personal_key')) %>
+<% end %>
+
 <%= render(PageFooterComponent.new) do %>
   <%= link_to t('links.cancel'), decorated_sp_session.cancel_link_url %>
 <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -24,11 +24,11 @@
   <% c.with_header { t('components.troubleshooting_options.default_heading') } %>
       <% c.with_option(
            url: help_center_redirect_path(category: 'trouble-signing-in', article: 'forgot-your-password'),
-           new_tab: false,
+           new_tab: true,
          ).with_content(t('forms.passwords.reset.how_to_reset')) %>
       <% c.with_option(
            url: help_center_redirect_path(category: 'trouble-signing-in', article: 'forgot-your-personal-key', article_anchor: 'if-you-have-a-personal-key'),
-           new_tab: false,
+           new_tab: true,
          ).with_content(t('forms.passwords.reset.how_to_reset_with_personal_key')) %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -914,6 +914,8 @@ forms.messages.remember_device: Remember this browser
 forms.password: Password
 forms.passwords.edit.buttons.submit: Change password
 forms.passwords.edit.labels.password: New password
+forms.passwords.reset.how_to_reset: How to reset your password
+forms.passwords.reset.how_to_reset_with_personal_key: How to reset your password if you have a personal key
 forms.personal_key_partial.acknowledgement.header: You need your personal key if you forget your password. Keep it safe and don’t share it with anyone.
 forms.personal_key_partial.acknowledgement.help_link_text: Learn more about the personal key
 forms.personal_key_partial.acknowledgement.text: If you reset your password without your personal key, you’ll need to verify your identity again.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -925,6 +925,8 @@ forms.messages.remember_device: Recuerde este navegador
 forms.password: Contraseña
 forms.passwords.edit.buttons.submit: Cambiar contraseña
 forms.passwords.edit.labels.password: Nueva contraseña
+forms.passwords.reset.how_to_reset: Cómo restablecer su contraseña
+forms.passwords.reset.how_to_reset_with_personal_key: Cómo restablecer su contraseña si tiene una clave personal
 forms.personal_key_partial.acknowledgement.header: Necesitará su clave personal si olvida su contraseña. Consérvela en un lugar seguro y no la comparta con nadie.
 forms.personal_key_partial.acknowledgement.help_link_text: Obtenga más información sobre la clave personal
 forms.personal_key_partial.acknowledgement.text: Si restablece su contraseña y no tiene su clave personal, tendrá que verificar nuevamente su identidad.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -914,6 +914,8 @@ forms.messages.remember_device: Se souvenir de ce navigateur
 forms.password: Mot de passe
 forms.passwords.edit.buttons.submit: Modifier le mot de passe
 forms.passwords.edit.labels.password: Nouveau mot de passe
+forms.passwords.reset.how_to_reset: Comment réinitialiser votre mot de passe
+forms.passwords.reset.how_to_reset_with_personal_key: Comment réinitialiser votre mot de passe si vous disposez d’une clé personnelle
 forms.personal_key_partial.acknowledgement.header: En cas d’oubli de votre mot de passe, vous aurez besoin de votre clé personnelle. Gardez-la en sécurité et ne la partagez avec personne.
 forms.personal_key_partial.acknowledgement.help_link_text: En savoir plus sur la clé personnelle
 forms.personal_key_partial.acknowledgement.text: Si vous réinitialisez votre mot de passe sans votre clé personnelle, vous devrez à nouveau confirmer votre identité.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -925,6 +925,8 @@ forms.messages.remember_device: 记住这个浏览器
 forms.password: 密码
 forms.passwords.edit.buttons.submit: 变更密码
 forms.passwords.edit.labels.password: 新密码
+forms.passwords.reset.how_to_reset: 如何重置你的密码
+forms.passwords.reset.how_to_reset_with_personal_key: 如果你有个人密钥，如何重置密码
 forms.personal_key_partial.acknowledgement.header: 如果你忘记了密码，就需要你的个人密钥。请将其保管好，不要与任何人分享。
 forms.personal_key_partial.acknowledgement.help_link_text: 了解更多有关个人密钥的信息。
 forms.personal_key_partial.acknowledgement.text: 如果你在没有个人密钥情况下重设你的密码，将需要再次验证你的身份。

--- a/spec/views/devise/passwords/new.html.erb_spec.rb
+++ b/spec/views/devise/passwords/new.html.erb_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe 'devise/passwords/new.html.erb' do
     )
   end
 
+  it 'renders troubleshooting content' do
+    render
+
+    expect(rendered).to have_content(t('components.troubleshooting_options.default_heading'))
+    expect(rendered).to have_link(t('forms.passwords.reset.how_to_reset'))
+    expect(rendered).to have_link(t('forms.passwords.reset.how_to_reset_with_personal_key'))
+  end
+
   context 'service provider does not have custom help text' do
     let(:sp) do
       build_stubbed(


### PR DESCRIPTION
## 🎫 Ticket

[LG-16124](https://cm-jira.usa.gov/browse/LG-16124)

## 🛠 Summary of changes

Adds troubleshooting links (via a troubleshooting help component) to the location found at `/users/password/new`.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
