### PR TITLE
Remove unused feature_pending_in_person_password_reset_enabled configuration

### DIFF
--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -559,7 +559,6 @@ production:
   enable_usps_verification: false
   encrypted_document_storage_s3_bucket: ''
   facial_match_general_availability_enabled: false
-  feature_pending_in_person_password_reset_enabled: false
   idv_sp_required: true
   in_person_passports_enabled: false
   invalid_gpo_confirmation_zipcode: ''


### PR DESCRIPTION
## 🛠 Summary of changes

While doing some configuration maintenance, I noticed that this configuration key was removed in #11957 but perhaps mistakenly added back in #11962

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
