### PR TITLE
changelog: User-facing Improvements, In-person Proofing, Update barco…

### DIFF
--- a/app/presenters/idv/in_person/ready_to_verify_presenter.rb
+++ b/app/presenters/idv/in_person/ready_to_verify_presenter.rb
@@ -33,6 +33,10 @@ module Idv
         )
       end
 
+      def location_search_skipped?
+        enrollment.selected_location_details.nil?
+      end
+
       def selected_location_hours(prefix)
         return unless selected_location_details
         hours = selected_location_details["#{prefix}_hours"]

--- a/app/views/idv/in_person/ready_to_verify/show.html.erb
+++ b/app/views/idv/in_person/ready_to_verify/show.html.erb
@@ -19,6 +19,10 @@
   <%= t('in_person_proofing.body.barcode.email_sent') %>
 <% end %>
 
+<% if @presenter.location_search_skipped? %>
+  <%= render 'shared/location_search_skipped_notice' %>
+<% end %>
+
 <%= render PageHeadingComponent.new(class: 'text-center') do %>
   <%= @presenter.barcode_heading_text %>
 <% end %>
@@ -202,13 +206,15 @@
   <% end %>
 </section>
 
-<h2 class="margin-bottom-2"><%= t('in_person_proofing.body.location.heading') %></h2>
-<p>
-  <%= t('in_person_proofing.body.location.info') %>
-  <% if @presenter.selected_location_details.present? %>
-    <%= t('in_person_proofing.body.location.selection') %>
-  <% end %>
-</p>
+<% unless @presenter.location_search_skipped? %>
+  <h2 class="margin-bottom-2"><%= t('in_person_proofing.body.location.heading') %></h2>
+  <p>
+    <%= t('in_person_proofing.body.location.info') %>
+    <% if @presenter.selected_location_details.present? %>
+      <%= t('in_person_proofing.body.location.selection') %>
+    <% end %>
+  </p>
+<% end %>
 
 <% if @presenter.selected_location_details.present? %>
   <section aria-label="<%= t('in_person_proofing.body.barcode.location_details') %>" class="margin-bottom-4">
@@ -228,7 +234,7 @@
   </section>
 <% end %>
 
-<% if !@presenter.enhanced_ipp? %>
+<% unless @presenter.location_search_skipped? || @presenter.enhanced_ipp? %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
   <p class="margin-bottom-4">
     <%= t(

--- a/app/views/shared/_location_search_skipped_email_notice.html.erb
+++ b/app/views/shared/_location_search_skipped_email_notice.html.erb
@@ -1,0 +1,37 @@
+<div class="location_search_skipped_notice text-center">
+  <h2 class="location_search_skipped_notice__heading text-center margin-top-5 margin-bottom-4"><%= t('in_person_proofing.headings.po_search.location') %></h2>
+  <p class="location_search_skipped_notice__body text-left margin-bottom-4"><%= t('in_person_proofing.body.location.location_skipped_notice') %></p>
+  <table class="button expanded large radius">
+    <tbody>
+      <tr>
+        <td>
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  <center>
+                    <%= link_to(
+                          t('in_person_proofing.body.location.location_skipped_notice_button_text'),
+                          help_center_redirect_url(
+                            category: 'verify-your-identity',
+                            article: 'verify-your-identity-in-person/find-a-participating-post-office',
+                          ),
+                          target: '_blank',
+                          class: 'float-center',
+                          align: 'center',
+                          rel: 'noopener',
+                        )
+                    %>
+                  </center>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        <td class="expander">
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<hr class="border-0 border-bottom border-primary-light margin-y-4" />

--- a/app/views/shared/_location_search_skipped_notice.html.erb
+++ b/app/views/shared/_location_search_skipped_notice.html.erb
@@ -1,0 +1,16 @@
+<div class="location_search_skipped_notice text-center">
+  <h2 class="location_search_skipped_notice__heading text-center margin-top-5 margin-bottom-4"><%= t('in_person_proofing.headings.po_search.location') %></h2>
+  <p class="location_search_skipped_notice__body text-left margin-bottom-0"><%= t('in_person_proofing.body.location.location_skipped_notice') %></p>
+  <%= link_to(
+        t('in_person_proofing.body.location.location_skipped_notice_button_text'),
+        help_center_redirect_url(
+          category: 'verify-your-identity',
+          article: 'verify-your-identity-in-person/find-a-participating-post-office',
+        ),
+        target: '_blank',
+        class: 'location_search_skipped_notice__button usa-button usa-button--big usa-button--wide margin-top-4 margin-bottom-4',
+        rel: 'noopener',
+      )
+  %>
+</div>
+<hr class="margin-top-0 margin-bottom-4">

--- a/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
+++ b/app/views/user_mailer/shared/_in_person_ready_to_verify.html.erb
@@ -14,6 +14,10 @@
   </h1>
 <% end %>
 
+<% if @presenter.location_search_skipped? %>
+  <%= render 'shared/location_search_skipped_email_notice' %>
+<% end %>
+
 <%# Tag for GSA Enhanced Pilot Barcode %>
 <% if @presenter.enhanced_ipp? %>
   <div class="text-center margin-y-4">
@@ -251,13 +255,15 @@
   <% end %>
 </div>
 
-<h2 class="font-heading-lg text-bold margin-top-2"><%= t('in_person_proofing.body.location.heading') %></h2>
-<p class="margin-bottom-0">
-  <%= t('in_person_proofing.body.location.info') %>
-  <% if @presenter.selected_location_details.present? %>
-    <%= t('in_person_proofing.body.location.selection') %>
-  <% end %>
-</p>
+<% unless @presenter.location_search_skipped? %>
+  <h2 class="font-heading-lg text-bold margin-top-2"><%= t('in_person_proofing.body.location.heading') %></h2>
+  <p class="margin-bottom-0">
+    <%= t('in_person_proofing.body.location.info') %>
+    <% if @presenter.selected_location_details.present? %>
+      <%= t('in_person_proofing.body.location.selection') %>
+    <% end %>
+  </p>
+<% end %>
 
 <% if @presenter.selected_location_details.present? %>
   <div class="margin-y-4">
@@ -275,7 +281,7 @@
   </div>
 <% end %>
 
-<% if !@presenter.enhanced_ipp? %>
+<% unless @presenter.location_search_skipped? || @presenter.enhanced_ipp? %>
   <h3><%= t('in_person_proofing.body.location.change_location_heading') %></h3>
   <p class="margin-bottom-4">
     <%= t(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1279,6 +1279,8 @@ in_person_proofing.body.location.distance.other: '%{count} miles away'
 in_person_proofing.body.location.heading: Post Office information
 in_person_proofing.body.location.info: No appointment is needed to verify your identity.
 in_person_proofing.body.location.location_button: Select
+in_person_proofing.body.location.location_skipped_notice: No appointment is needed to verify your identity. You can visit any participating Post Office but you must search for a location before visiting to confirm it is participating.
+in_person_proofing.body.location.location_skipped_notice_button_text: Find a Post Office
 in_person_proofing.body.location.po_search.address_label: Address
 in_person_proofing.body.location.po_search.address_search_label: Enter an address to find a Post Office near you.
 in_person_proofing.body.location.po_search.city_label: City

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1290,6 +1290,8 @@ in_person_proofing.body.location.distance.other: A %{count} millas de distancia
 in_person_proofing.body.location.heading: Información de la oficina de correos
 in_person_proofing.body.location.info: No necesita hacer una cita para verificar su identidad.
 in_person_proofing.body.location.location_button: Seleccionar
+in_person_proofing.body.location.location_skipped_notice: No necesita hacer una cita para verificar su identidad. Puede visitar cualquier oficina de correos participante, pero debe buscarla antes de acudir a ella para confirmar que sea una oficina participante.
+in_person_proofing.body.location.location_skipped_notice_button_text: Buscar una oficina de correos
 in_person_proofing.body.location.po_search.address_label: Dirección
 in_person_proofing.body.location.po_search.address_search_label: Introduzca una dirección para buscar una oficina de correos cercana.
 in_person_proofing.body.location.po_search.city_label: Ciudad

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1279,6 +1279,8 @@ in_person_proofing.body.location.distance.other: à %{count} miles
 in_person_proofing.body.location.heading: Informations sur les bureaux de poste
 in_person_proofing.body.location.info: Aucun rendez-vous n’est nécessaire pour vérifier votre identité.
 in_person_proofing.body.location.location_button: Sélectionner
+in_person_proofing.body.location.location_skipped_notice: Il est inutile de prendre rendez-vous pour la vérification de votre identité. Vous pouvez vous rendre dans n’importe quel bureau de poste à condition d’avoir vérifié au préalable que c’est un bureau de poste participant.
+in_person_proofing.body.location.location_skipped_notice_button_text: Trouver un bureau de poste
 in_person_proofing.body.location.po_search.address_label: Adresse
 in_person_proofing.body.location.po_search.address_search_label: Saisissez une adresse pour trouver un bureau de poste près de chez vous.
 in_person_proofing.body.location.po_search.city_label: Ville

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1292,6 +1292,8 @@ in_person_proofing.body.location.distance.other: 距离你 %{count} 英里
 in_person_proofing.body.location.heading: 邮局信息
 in_person_proofing.body.location.info: 验证你的身份无需做预约。
 in_person_proofing.body.location.location_button: 选择
+in_person_proofing.body.location.location_skipped_notice: 无需预约即可验证你的身份。你可以前往任何参与邮局，但必须在去之前先做搜索以确认该邮局的确参与本项目。
+in_person_proofing.body.location.location_skipped_notice_button_text: 查找邮局
 in_person_proofing.body.location.po_search.address_label: 地址
 in_person_proofing.body.location.po_search.address_search_label: 输入地址来寻找你附件的邮局。
 in_person_proofing.body.location.po_search.city_label: 城市

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -188,6 +188,12 @@ class UserMailerPreview < ActionMailer::Preview
     )
   end
 
+  def in_person_ready_to_verify_skipped_location
+    UserMailer.with(user: user, email_address: email_address_record).in_person_ready_to_verify(
+      enrollment: in_person_enrollment_id_ipp_skipped_location,
+    )
+  end
+
   def in_person_ready_to_verify_passport
     UserMailer.with(user: user, email_address: email_address_record).in_person_ready_to_verify(
       enrollment: in_person_enrollment_passport,
@@ -206,6 +212,15 @@ class UserMailerPreview < ActionMailer::Preview
       email_address: email_address_record,
     ).in_person_ready_to_verify_reminder(
       enrollment: in_person_enrollment_id_ipp,
+    )
+  end
+
+  def in_person_ready_to_verify_reminder_skipped_location
+    UserMailer.with(
+      user: user,
+      email_address: email_address_record,
+    ).in_person_ready_to_verify_reminder(
+      enrollment: in_person_enrollment_id_ipp_skipped_location,
     )
   end
 
@@ -343,6 +358,27 @@ class UserMailerPreview < ActionMailer::Preview
 
   def in_person_visited_location_name
     'ACQUAINTANCESHIP'
+  end
+
+  def in_person_enrollment_id_ipp_skipped_location
+    unsaveable(
+      InPersonEnrollment.new(
+        user: user,
+        profile: unsaveable(Profile.new(user: user)),
+        enrollment_code: '2048702198804358',
+        created_at: Time.zone.now - 2.hours,
+        service_provider: ServiceProvider.new(
+          friendly_name: 'Test Service Provider',
+          issuer: SecureRandom.uuid,
+          logo: 'gsa.png',
+        ),
+        status_updated_at: Time.zone.now - 1.hour,
+        current_address_matches_id: params['current_address_matches_id'] == 'true',
+        selected_location_details: nil,
+        sponsor_id: IdentityConfig.store.usps_ipp_sponsor_id,
+        document_type: InPersonEnrollment::DOCUMENT_TYPE_STATE_ID,
+      ),
+    )
   end
 
   def in_person_enrollment_id_ipp

--- a/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/ready_to_verify_presenter_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe Idv::InPerson::ReadyToVerifyPresenter do
     end
   end
 
+  describe '#location_search_skipped?' do
+    context 'when location is not skipped' do
+      it 'returns false' do
+        expect(presenter.location_search_skipped?).to be false
+      end
+    end
+    context 'when location is skipped' do
+      let(:enrollment_selected_location_details) { nil }
+      it 'returns true' do
+        expect(presenter.location_search_skipped?).to be true
+      end
+    end
+  end
+
   describe '#selected_location_details' do
     subject(:selected_location_details) { presenter.selected_location_details }
 

--- a/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/ready_to_verify/show.html.erb_spec.rb
@@ -122,10 +122,30 @@ RSpec.describe 'idv/in_person/ready_to_verify/show.html.erb' do
     context 'when selected_location_details is not present' do
       let(:selected_location_details) { nil }
 
+      it 'renders skipped location notice' do
+        render
+
+        expect(rendered).to have_content(
+          t('in_person_proofing.headings.po_search.location'),
+        )
+        expect(rendered).to have_content(
+          t('in_person_proofing.body.location.location_skipped_notice'),
+        )
+        expect(rendered).to have_content(
+          t('in_person_proofing.body.location.location_skipped_notice_button_text'),
+        )
+
+        expect(rendered).not_to have_content(
+          t('in_person_proofing.body.location.change_location_heading'),
+        )
+      end
+
       it 'does not render a location' do
         render
 
-        expect(rendered).not_to have_content(t('in_person_proofing.body.barcode.retail_hours'))
+        expect(rendered).not_to have_content(
+          t('in_person_proofing.body.barcode.retail_hours'),
+        )
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15711](https://cm-jira.usa.gov/browse/LG-15711)

## 🛠 Summary of changes

Updates to the ready to verify page, email, and reminder email when the user skips location. A new notice is shown at the top above the barcode and other location related information below the barcode is not shown.

The flow with a selected location being present should remain the same.

Note: The email buttons will differ from comp due to being table and not proper HTML buttons/links.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ]  Verify that the new content is added to the ready to verify page when location is skipped
- [ ]  Verify that the location specific content is removed from the ready to verify page when location is skipped 
- [ ]  Verify that the new content is added to the ready to verify email when location is skipped
- [ ]  Verify that the location specific content is removed from the ready to verify email when location is skipped 
- [ ]  Verify that the new content is added to the ready to verify reminder email when location is skipped
- [ ]  Verify that the location specific content is removed from the ready to verify reminder email when location is skipped
- [ ]  Verify that when a location is selected, there are no regresssions

## Screenshots
<details><summary>Page View and Email View After</summary>
<img width="654" alt="Screenshot 2025-05-20 at 4 21 47 PM" src="https://github.com/user-attachments/assets/797a1023-f85e-4141-94cd-c2cda71eabdc" />
<img width="618" alt="Screenshot 2025-05-20 at 4 21 53 PM" src="https://github.com/user-attachments/assets/aad9ac16-bca0-4c48-bb60-c73ecd658956" />
</details>

