### PR TITLE
Use separate feature flag for logging duplicate profiles

### DIFF
--- a/app/services/duplicate_profile_checker.rb
+++ b/app/services/duplicate_profile_checker.rb
@@ -11,7 +11,7 @@ class DuplicateProfileChecker
   end
 
   def check_for_duplicate_profiles
-    return unless sp_eligible_for_one_account?
+    return unless IdentityConfig.store.feature_one_verified_account_log_duplicate_profiles
     return unless user_has_ial2_profile?
     cacher = Pii::Cacher.new(user, user_session)
 
@@ -39,10 +39,6 @@ class DuplicateProfileChecker
   end
 
   private
-
-  def sp_eligible_for_one_account?
-    sp.present? && IdentityConfig.store.eligible_one_account_providers.include?(sp.issuer)
-  end
 
   def user_has_ial2_profile?
     user.identity_verified_with_facial_match?

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -157,6 +157,7 @@ event_disavowal_expiration_hours: 240
 facial_match_general_availability_enabled: true
 feature_idv_force_gpo_verification_enabled: false
 feature_idv_hybrid_flow_enabled: true
+feature_one_verified_account_log_duplicate_profiles: true
 geo_data_file_path: 'geo_data/GeoLite2-City.mmdb'
 get_usps_proofing_results_job_cron: '0/30 * * * *'
 get_usps_proofing_results_job_reprocess_delay_minutes: 5
@@ -559,6 +560,7 @@ production:
   enable_usps_verification: false
   encrypted_document_storage_s3_bucket: ''
   facial_match_general_availability_enabled: false
+  feature_one_verified_account_log_duplicate_profiles: false
   idv_sp_required: true
   in_person_passports_enabled: false
   invalid_gpo_confirmation_zipcode: ''

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -175,6 +175,7 @@ module IdentityConfig
     config.add(:facial_match_general_availability_enabled, type: :boolean)
     config.add(:feature_idv_force_gpo_verification_enabled, type: :boolean)
     config.add(:feature_idv_hybrid_flow_enabled, type: :boolean)
+    config.add(:feature_one_verified_account_log_duplicate_profiles, type: :boolean)
     config.add(:irs_authentication_issuers, type: :json)
     config.add(:irs_authentication_emails, type: :json)
     config.add(:irs_fraud_metrics_issuers, type: :json)

--- a/spec/services/duplicate_profile_checker_spec.rb
+++ b/spec/services/duplicate_profile_checker_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe DuplicateProfileChecker do
       profile.save
     end
 
-    context 'when service provider eligible for duplicate profile check' do
+    context 'when feature flag feature_one_verified_account_log_duplicate_profiles is enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
-          .and_return([sp.issuer])
+        allow(IdentityConfig.store).to receive(:feature_one_verified_account_log_duplicate_profiles)
+          .and_return(true)
 
         session[:encrypted_profiles] = {
           profile.id.to_s => SessionEncryptor.new.kms_encrypt(active_pii.to_json),
@@ -186,9 +186,10 @@ RSpec.describe DuplicateProfileChecker do
       end
     end
 
-    context 'when service provider not eligible for duplicate profile check' do
+    context 'when feature flag feature_one_verified_account_log_duplicate_profiles is disabled' do
       before do
-        allow(IdentityConfig.store).to receive(:eligible_one_account_providers).and_return([])
+        allow(IdentityConfig.store).to receive(:feature_one_verified_account_log_duplicate_profiles)
+          .and_return(false)
       end
 
       it 'does not create a new duplicate profile confirmation' do


### PR DESCRIPTION
changelog: Internal, One Verified Account, Use separate feature flag for logging duplicate profiles

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-16260](https://cm-jira.usa.gov/browse/LG-16260)

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create account1 with an IAL2 profile
- [ ] Create account2 with an IAL2 profile and with the same SSN as account1
- [ ] Authenticate for an IAL2 request with account2
- [ ] **No entry should be created** in `duplicate_profile_confirmations`
- [ ] Set the flag `feature_one_verified_account_log_duplicate_profiles` to **disabled**
- [ ] Repeat the above steps with flag `feature_one_verified_account_log_duplicate_profiles` **enabled**
- [ ] **An entry should be created** in `duplicate_profile_confirmations`


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
