### PR TITLE
Log event for Attempts API event polling

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -308,6 +308,33 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String, nil] issuer
+  # @param [Integer, nil] requested_events_count
+  # @param [Integer, nil] requested_acknowledged_events_count
+  # @param [Integer, nil] returned_events_count
+  # @param [Integer, nil] acknowledged_events_count
+  # @param [Boolean] success
+  def attempts_api_poll_events_request(
+    issuer:,
+    requested_events_count:,
+    requested_acknowledged_events_count:,
+    returned_events_count:,
+    acknowledged_events_count:,
+    success:,
+    **extra
+  )
+    track_event(
+      :attempts_api_poll_events_request,
+      issuer:,
+      requested_events_count:,
+      requested_acknowledged_events_count:,
+      returned_events_count:,
+      acknowledged_events_count:,
+      success:,
+      **extra,
+    )
+  end
+
   # @identity.idp.previous_event_name TOTP: User Disabled
   # Tracks when a user deletes their auth app from account
   # @param [Boolean] success

--- a/app/services/attempts_api/redis_client.rb
+++ b/app/services/attempts_api/redis_client.rb
@@ -25,11 +25,14 @@ module AttemptsApi
     end
 
     def delete_events(issuer:, keys:)
+      total_deleted = 0
       hourly_keys(issuer).each do |hourly_key|
         REDIS_ATTEMPTS_API_POOL.with do |client|
-          client.hdel(hourly_key, keys)
+          total_deleted += client.hdel(hourly_key, keys)
         end
       end
+
+      total_deleted
     end
 
     private

--- a/app/services/attempts_api/request_token_validator.rb
+++ b/app/services/attempts_api/request_token_validator.rb
@@ -13,7 +13,16 @@ module AttemptsApi
     validate :valid_request_token?, if: :config_data_exists?
 
     def initialize(auth_request_header)
-      @bearer, @issuer, @token = auth_request_header&.split(' ', 3)
+      case auth_request_header&.split(' ', 3)
+      in String => bearer, String => issuer, String => token
+        @bearer = bearer
+        @issuer = issuer
+        @token = token
+      else
+        @bearer = nil
+        @issuer = nil
+        @token = nil
+      end
     end
 
     private

--- a/spec/services/attempts_api/redis_client_spec.rb
+++ b/spec/services/attempts_api/redis_client_spec.rb
@@ -120,8 +120,9 @@ RSpec.describe AttemptsApi::RedisClient do
         event_key: event2.jti, jwe: jwe2, timestamp: event2.occurred_at, issuer: issuer,
       )
 
-      subject.delete_events(issuer:, keys: [event1.jti])
+      deleted_events_count = subject.delete_events(issuer:, keys: [event1.jti])
       expect(subject.read_events(issuer:)).to eq({ event2.jti => jwe2 })
+      expect(deleted_events_count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[!19](https://gitlab.login.gov/lg-teams/FIE/fraud-mitigation/-/issues/19)

## 🛠 Summary of changes

Adds a new event for logging requests to the Attempts API polling endpoint. I've also done some slight changes to other classes to accommodate the metadata needed for logging.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
