### PR TITLE
Dmm/image object spike

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -1522,7 +1522,7 @@ module AnalyticsEvents
     flow_path:,
     liveness_checking_required:,
     submit_attempts:,
-    selfie_image_fingerprint:,
+    selfie_image_fingerprint: nil,
     front_image_fingerprint: nil,
     back_image_fingerprint: nil,
     passport_image_fingerprint: nil,

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -277,15 +277,13 @@ RSpec.describe Idv::ApiImageUploadForm do
         let(:doc_escrow_enabled) { true }
 
         before do
-          expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-          allow(writer).to receive(:write).exactly(3).times
+          expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer).exactly(2).times
+          allow(writer).to receive(:write).exactly(2).times
 
-          # testing that the storage is happening
-          expect(writer).to receive(:write).with(image: form.send(:back_image_bytes))
-            .and_return result
-          expect(writer).to receive(:write).with(image: form.send(:front_image_bytes))
-            .and_return result
-          expect(writer).to receive(:write).with(image: nil).and_call_original
+          form.send(:images).each do |image|
+            # testing that the storage is happening
+            expect(writer).to receive(:write).with(image: image.bytes).and_return result
+          end
         end
 
         it 'tracks the event' do
@@ -295,8 +293,6 @@ RSpec.describe Idv::ApiImageUploadForm do
             document_back_image_file_id: 'name',
             document_front_image_encryption_key: '12345',
             document_front_image_file_id: 'name',
-            document_selfie_image_encryption_key: nil,
-            document_selfie_image_file_id: nil,
             failure_reason: nil,
           )
           form.submit
@@ -420,16 +416,15 @@ RSpec.describe Idv::ApiImageUploadForm do
           let(:doc_escrow_enabled) { true }
 
           before do
-            expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
+            expect(EncryptedDocStorage::DocWriter).to receive(:new)
+              .and_return(writer)
+              .exactly(3).times
             allow(writer).to receive(:write).exactly(3).times
 
-            # testing that the storage is happening
-            expect(writer).to receive(:write).with(image: form.send(:back_image_bytes))
-              .and_return result
-            expect(writer).to receive(:write).with(image: form.send(:front_image_bytes))
-              .and_return result
-            expect(writer).to receive(:write).with(image: form.send(:selfie_image_bytes))
-              .and_return result
+            form.send(:images).each do |image|
+              # testing that the storage is happening
+              expect(writer).to receive(:write).with(image: image.bytes).and_return result
+            end
           end
 
           it 'tracks the event' do
@@ -555,14 +550,14 @@ RSpec.describe Idv::ApiImageUploadForm do
         let(:doc_escrow_enabled) { true }
 
         before do
-          expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-          allow(writer).to receive(:write).exactly(3).times
+          expect(EncryptedDocStorage::DocWriter).to receive(:new)
+            .and_return(writer)
+          allow(writer).to receive(:write)
 
-          # testing that the storage is happening
-          expect(writer).to receive(:write).with(image: form.send(:back_image_bytes))
-            .and_return result
-          expect(writer).to receive(:write).with(image: nil).and_call_original
-          expect(writer).to receive(:write).with(image: nil).and_call_original
+          form.send(:images).each do |image|
+            # testing that the storage is happening
+            expect(writer).to receive(:write).with(image: image.bytes).and_return result
+          end
         end
 
         it 'tracks the event' do
@@ -570,10 +565,6 @@ RSpec.describe Idv::ApiImageUploadForm do
             success: false,
             document_back_image_encryption_key: '12345',
             document_back_image_file_id: 'name',
-            document_front_image_encryption_key: nil,
-            document_front_image_file_id: nil,
-            document_selfie_image_encryption_key: nil,
-            document_selfie_image_file_id: nil,
             failure_reason: { front: [:blank] },
           )
           form.submit
@@ -617,15 +608,13 @@ RSpec.describe Idv::ApiImageUploadForm do
         let(:doc_escrow_enabled) { true }
 
         before do
-          expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-          allow(writer).to receive(:write).exactly(3).times
+          expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer).exactly(2)
+          allow(writer).to receive(:write).exactly(2).times
 
-          # testing that the storage is happening
-          expect(writer).to receive(:write).with(image: form.send(:back_image_bytes))
-            .and_return result
-          expect(writer).to receive(:write).with(image: form.send(:front_image_bytes))
-            .and_return result
-          expect(writer).to receive(:write).with(image: nil).and_call_original
+          form.send(:images).each do |image|
+            # testing that the storage is happening
+            expect(writer).to receive(:write).with(image: image.bytes).and_return result
+          end
         end
 
         it 'tracks the event (as a success as doc upload succeeded)' do
@@ -635,8 +624,6 @@ RSpec.describe Idv::ApiImageUploadForm do
             document_back_image_file_id: 'name',
             document_front_image_encryption_key: '12345',
             document_front_image_file_id: 'name',
-            document_selfie_image_encryption_key: nil,
-            document_selfie_image_file_id: nil,
             failure_reason: nil,
           )
           form.submit
@@ -808,6 +795,7 @@ RSpec.describe Idv::ApiImageUploadForm do
             user_id: document_capture_session.user.uuid,
             front_image_fingerprint: an_instance_of(String),
             back_image_fingerprint: an_instance_of(String),
+            selfie_image_fingerprint: an_instance_of(String),
             liveness_checking_required: boolean,
             side: 'both',
             document_type: document_type,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[FIE Epic 367](https://gitlab.login.gov/groups/lg-teams/FIE/-/epics/367)
(this is actually supporting work for the final event `idv-document-upload-submitted`)

## 🛠 Summary of changes
This is an attempt to refactor the image code in the `ApiImageUploadForm` and make it more flexible/usable. 

Historically, we have not had an IdvImage object. That means that when adding an image type, we have had to duplicate quite a few methods and image handling paradigms, which can be confusing to read, and makes it difficult to extend. It can also have further-reaching implications, such as: the passport image type was added to the code after I implemented the DocEscrow document storage for local image upload. Because we don't have a generic image interface, those types of images would have to be manually added, which requires awareness of work across silos.

This change allows the code to create a list of images based on the params that are passed in, and then only deals with those objects, saving us a lot of conditional code. 

I created two classes, `IdvImages`, and `IdvImage`. 

`IdvImage` is concerned with the data of the individual images.
`IdvImages` bundles all the `IdvImage` instances together in a list, and provides ways to access the individual images, as well as providing an interface to add errors and format and handle multiple images.

At the moment I just shoved these two classes at the bottom of the form. That's probably not the best place for them! Please tell me where I should put them.

This change will make my life a lot easier, and I think will make adding image types generally easier to do and reason about. 

Please share feedback and concerns about the approach! any suggestions or things I am overlooking is very welcome, as I had to heavily rely on the tests to make sure things were working as expected.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
