### PR TITLE
Add language attribute to shared event properties

### DIFF
--- a/app/services/attempts_api/attempt_event.rb
+++ b/app/services/attempts_api/attempt_event.rb
@@ -2,7 +2,7 @@
 
 module AttemptsApi
   class AttemptEvent
-    attr_reader :jti, :iat, :event_type, :session_id, :occurred_at, :event_metadata
+    attr_reader :jti, :iat, :event_type, :session_id, :occurred_at, :event_metadata, :language
 
     def initialize(
       event_type:,

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -39,6 +39,7 @@ module AttemptsApi
         device_fingerprint: hashed_cookie_device_uuid,
         user_ip_address: request&.remote_ip,
         application_url: sp_request_uri,
+        language: user&.email_language || I18n.locale.to_s,
         client_port: CloudFrontHeaderParser.new(request).client_port,
       }
 

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe AttemptsApi::Tracker do
         event = subject.track_event(:test_event)
         expect(event.event_metadata[:user]).to be_nil
       end
+
+      it 'returns the default locale as the language attribute' do
+        event = subject.track_event(:test_event)
+        expect(event.event_metadata[:language]).to eq('en')
+      end
+    end
+
+    context 'user that has a locale selected' do
+      before { user.update(email_language: :es) }
+      it 'returns that locale as a language attribute in event' do
+        event = subject.track_event(:test_event)
+
+        expect(event.event_metadata[:language]).to eq('es')
+      end
     end
 
     context 'user has existing Agency UUID' do


### PR DESCRIPTION
## 🎫 Ticket

## 🛠 Summary of changes
TIGTA requirements include the language a user has selected. 

This change
- adds the language attribute
- if a user exists, then their selected `email_language` value is used
- if not, then it falls back on the default `I18n.locale`

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
