### PR TITLE
small event fixes

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -394,7 +394,7 @@ module Idv
         date_of_birth: pii_from_doc[:dob],
         address1: pii_from_doc[:address1],
         address2: pii_from_doc[:address2],
-        social_security: idv_session.ssn,
+        ssn: idv_session.ssn,
         failure_reason:,
       )
     end

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -35,6 +35,10 @@ module Idv
         **analytics_arguments.merge(result.to_h),
       )
 
+      if current_user.has_proofed_before?
+        attempts_api_tracker.idv_reproof
+      end
+
       if result.success?
         idv_session.idv_consent_given_at = Time.zone.now
 

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -165,10 +165,6 @@ module Idv
     end
 
     def confirm_no_profile_yet
-      if current_user.has_proofed_before?
-        attempts_api_tracker.idv_reproof
-      end
-
       # When no profile has been minted yet, keep them on this page.
       return if !idv_session.profile.present?
 

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -48,7 +48,7 @@ module Idv
 
         attempts_api_tracker.idv_ssn_submitted(
           success: form_response.success?,
-          social_security: ssn_params[:ssn],
+          ssn: ssn_params[:ssn],
           failure_reason: attempts_api_tracker.parse_failure_reason(form_response),
         )
 

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -48,7 +48,7 @@ module Idv
 
       attempts_api_tracker.idv_ssn_submitted(
         success: form_response.success?,
-        social_security: ssn_params[:ssn],
+        ssn: ssn_params[:ssn],
         failure_reason: attempts_api_tracker.parse_failure_reason(form_response),
       )
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -238,7 +238,7 @@ module Users
         remember_device: remember_device_cookie.present?,
         new_device: success ? new_device? : nil,
       )
-      attempts_api_tracker.email_and_password_auth(success:)
+      attempts_api_tracker.login_email_and_password_auth(success:)
     end
 
     def user_locked_out?(user)

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -132,14 +132,14 @@ module AttemptsApi
     end
 
     # @param [Boolean] success
-    # @param [String] social_security
+    # @param [String] ssn Social Security Number
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
     # A user inputs their SSN number during Identity verification
-    def idv_ssn_submitted(success:, social_security:, failure_reason: nil)
+    def idv_ssn_submitted(success:, ssn:, failure_reason: nil)
       track_event(
         'idv-ssn-submitted',
         success:,
-        social_security:,
+        ssn:,
         failure_reason:,
       )
     end
@@ -234,7 +234,7 @@ module AttemptsApi
     # @param [String] document_expiration
     # @param [String] first_name
     # @param [String] last_name
-    # @param [String] social_security
+    # @param [String] ssn Social Security Number
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
     # The verification was submitted during the IDV process
     def idv_verification_submitted(
@@ -248,7 +248,7 @@ module AttemptsApi
       document_expiration: nil,
       first_name: nil,
       last_name: nil,
-      social_security: nil,
+      ssn: nil,
       failure_reason: nil
     )
       track_event(
@@ -263,7 +263,7 @@ module AttemptsApi
         document_expiration:,
         first_name:,
         last_name:,
-        social_security:,
+        ssn:,
         failure_reason:,
       )
     end

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -15,7 +15,7 @@ module AttemptsApi
 
     # @param [Boolean] success True if the email and password matched
     # A user has submitted an email address and password for authentication
-    def email_and_password_auth(success:)
+    def login_email_and_password_auth(success:)
       track_event(
         'login-email-and-password-auth',
         success:,

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvSsnSubmitted.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvSsnSubmitted.yml
@@ -1,9 +1,9 @@
 description: |
   When the user submits their Social Security Number during identity proofing.
 allOf:
-  - $ref: '../shared/EventProperties.yml'
+  - $ref: "../shared/EventProperties.yml"
   - type: object
     properties:
-      social_security:
+      ssn:
         type: string
         description: User-submitted Social Security Number

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -167,7 +167,9 @@ RSpec.describe Idv::AgreementController do
             resolved_authn_context_result = Vot::Parser.new(
               acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
             ).parse
-            allow(subject).to receive(:resolved_authn_context_result).and_return(resolved_authn_context_result)
+            allow(subject).to receive(:resolved_authn_context_result).and_return(
+              resolved_authn_context_result,
+            )
           end
 
           it 'tracks a reproofing event upon reproofing' do

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Idv::AgreementController do
     stub_sign_in(user)
     stub_up_to(:welcome, idv_session: subject.idv_session)
     stub_analytics
+    stub_attempts_tracker
   end
 
   describe '#step_info' do
@@ -134,6 +135,47 @@ RSpec.describe Idv::AgreementController do
       end.not_to change {
         subject.idv_session.flow_path
       }.from(nil)
+    end
+
+    context 'with a non-proofed user' do
+      it 'does not track a reproofing event during initial proofing' do
+        expect(@attempts_api_tracker).not_to receive(:idv_reproof)
+
+        put :update, params:
+      end
+    end
+
+    context 'with a previously proofed user' do
+      context 'with a deactivated profile' do
+        before { create(:profile, :deactivated, user:) }
+
+        it 'tracks a reproofing event upon reproofing' do
+          expect(@attempts_api_tracker).to receive(:idv_reproof)
+          put :update, params:
+        end
+      end
+
+      context 'with an activated legacy idv  profile' do
+        it 'does not track a reproofing event during initial proofing' do
+          expect(@attempts_api_tracker).not_to receive(:idv_reproof)
+
+          put :update, params:
+        end
+        context 'when IAL2 is needed' do
+          before do
+            create(:profile, :active, user:)
+            resolved_authn_context_result = Vot::Parser.new(
+              acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
+            ).parse
+            allow(subject).to receive(:resolved_authn_context_result).and_return(resolved_authn_context_result)
+          end
+
+          it 'tracks a reproofing event upon reproofing' do
+            expect(@attempts_api_tracker).to receive(:idv_reproof)
+            put :update, params:
+          end
+        end
+      end
     end
 
     context 'on success' do

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1075,25 +1075,7 @@ RSpec.describe Idv::EnterPasswordController do
         stub_attempts_tracker
       end
 
-      context 'with a non-proofed user' do
-        it 'does not track a reproofing event during initial proofing' do
-          # TODO: Attempts API Move the idv_reproo event to the initation of the proofing process
-          expect(@attempts_api_tracker).not_to receive(:idv_reproof)
-
-          put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-        end
-      end
-
       context 'with a previously proofed user' do
-        context 'with a deactivated profile' do
-          before { create(:profile, :deactivated, user:) }
-
-          it 'tracks a reproofing event upon reproofing' do
-            expect(@attempts_api_tracker).to receive(:idv_reproof)
-            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-          end
-        end
-
         context 'with an activated legacy idv  profile' do
           before { create(:profile, :active, user:) }
 
@@ -1108,19 +1090,7 @@ RSpec.describe Idv::EnterPasswordController do
             end
 
             it 'tracks a reproofing event upon reproofing' do
-              expect(@attempts_api_tracker).to receive(:idv_reproof)
-              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-            end
-
-            it 'tracks a reproofing event upon reproofing' do
               expect(@attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: true)
-              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-            end
-          end
-
-          context 'when not ial2' do
-            it 'redirect away, and does not track a reproofing event upon reproofing' do
-              expect(@attempts_api_tracker).not_to receive(:idv_reproof)
               put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
             end
           end

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Idv::InPerson::SsnController do
       it 'sends analytics_submitted event' do
         expect(@attempts_api_tracker).to receive(:idv_ssn_submitted).with(
           success: true,
-          social_security: ssn,
+          ssn:,
           failure_reason: nil,
         )
         put :update, params: params
@@ -220,7 +220,7 @@ RSpec.describe Idv::InPerson::SsnController do
       it 'renders the show template with an error message' do
         expect(@attempts_api_tracker).to receive(:idv_ssn_submitted).with(
           success: false,
-          social_security: ssn,
+          ssn:,
           failure_reason: { ssn: [:invalid] },
         )
         put :update, params: params

--- a/spec/controllers/idv/ssn_controller_spec.rb
+++ b/spec/controllers/idv/ssn_controller_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Idv::SsnController do
       it 'updates idv_session.ssn to the ssn' do
         expect(@attempts_api_tracker).to receive(:idv_ssn_submitted).with(
           success: true,
-          social_security: ssn,
+          ssn:,
           failure_reason: nil,
         )
         expect { put :update, params: params }.to change { subject.idv_session.ssn }
@@ -281,7 +281,7 @@ RSpec.describe Idv::SsnController do
       it 'renders the show template with an error message' do
         expect(@attempts_api_tracker).to receive(:idv_ssn_submitted).with(
           success: false,
-          social_security: ssn,
+          ssn:,
           failure_reason: { ssn: [:invalid] },
         )
         put :update, params: params

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe Idv::VerifyInfoController do
             date_of_birth: applicant_pii[:dob],
             address1: applicant_pii[:address1],
             address2: applicant_pii[:address2],
-            social_security: applicant_pii[:ssn],
+            ssn: applicant_pii[:ssn],
             failure_reason: nil,
           )
 
@@ -341,7 +341,7 @@ RSpec.describe Idv::VerifyInfoController do
             date_of_birth: applicant_pii[:dob],
             address1: applicant_pii[:address1],
             address2: applicant_pii[:address2],
-            social_security: applicant_pii[:ssn],
+            ssn: applicant_pii[:ssn],
             failure_reason: {
               failed_stages: [:threatmetrix],
               device_profiling_adjudication_reason: ['device_profiling_result'],
@@ -428,7 +428,7 @@ RSpec.describe Idv::VerifyInfoController do
             date_of_birth: applicant_pii[:dob],
             address1: applicant_pii[:address1],
             address2: applicant_pii[:address2],
-            social_security: applicant_pii[:ssn],
+            ssn: applicant_pii[:ssn],
             failure_reason: {
               failed_stages: [:threatmetrix],
               resolution_adjudication_reason: ['pass_resolution_and_state_id'],
@@ -479,7 +479,7 @@ RSpec.describe Idv::VerifyInfoController do
             date_of_birth: applicant_pii[:dob],
             address1: applicant_pii[:address1],
             address2: applicant_pii[:address2],
-            social_security: applicant_pii[:ssn],
+            ssn: applicant_pii[:ssn],
             failure_reason: {
               failed_stages: [:threatmetrix],
               device_profiling_adjudication_reason: ['device_profiling_result'],
@@ -675,7 +675,7 @@ RSpec.describe Idv::VerifyInfoController do
             date_of_birth: applicant_pii[:dob],
             address1: applicant_pii[:address1],
             address2: applicant_pii[:address2],
-            social_security: applicant_pii[:ssn],
+            ssn: applicant_pii[:ssn],
             failure_reason: nil,
           )
           get :show
@@ -697,7 +697,7 @@ RSpec.describe Idv::VerifyInfoController do
             date_of_birth: applicant_pii[:dob],
             address1: applicant_pii[:address1],
             address2: applicant_pii[:address2],
-            social_security: applicant_pii[:ssn],
+            ssn: applicant_pii[:ssn],
             failure_reason: {
               failed_stages: [:state_id],
               resolution_adjudication_reason: ['fail_state_id'],
@@ -729,7 +729,7 @@ RSpec.describe Idv::VerifyInfoController do
             date_of_birth: applicant_pii[:dob],
             address1: applicant_pii[:address1],
             address2: applicant_pii[:address2],
-            social_security: applicant_pii[:ssn],
+            ssn: applicant_pii[:ssn],
             failure_reason: {
               failed_stages: [:state_id],
               resolution_adjudication_reason: ['fail_state_id'],
@@ -821,7 +821,7 @@ RSpec.describe Idv::VerifyInfoController do
             date_of_birth: applicant_pii[:dob],
             address1: applicant_pii[:address1],
             address2: applicant_pii[:address2],
-            social_security: applicant_pii[:ssn],
+            ssn: applicant_pii[:ssn],
             failure_reason: {
               attributes_requiring_additional_verification: ['address'],
               failed_stages: [:resolution, :phone_precheck],
@@ -858,7 +858,7 @@ RSpec.describe Idv::VerifyInfoController do
             date_of_birth: applicant_pii[:dob],
             address1: applicant_pii[:address1],
             address2: applicant_pii[:address2],
-            social_security: applicant_pii[:ssn],
+            ssn: applicant_pii[:ssn],
             failure_reason: {
               attributes_requiring_additional_verification: ['address', 'dob', 'ssn'],
               failed_stages: [:resolution, :phone_precheck],
@@ -939,7 +939,7 @@ RSpec.describe Idv::VerifyInfoController do
           date_of_birth: applicant_pii[:dob],
           address1: applicant_pii[:address1],
           address2: applicant_pii[:address2],
-          social_security: applicant_pii[:ssn],
+          ssn: applicant_pii[:ssn],
           failure_reason: {
             failed_stages: [:resolution],
             resolution_adjudication_reason: ['fail_resolution_without_state_id_coverage'],

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Users::SessionsController, devise: true do
 
       it 'tracks the successful authentication for existing user' do
         stub_analytics(user:)
-        expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+        expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
           success: true,
         )
 
@@ -161,7 +161,7 @@ RSpec.describe Users::SessionsController, devise: true do
 
         it 'tracks as not being from a new device' do
           stub_analytics(user:)
-          expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+          expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
             success: true,
           )
 
@@ -240,7 +240,7 @@ RSpec.describe Users::SessionsController, devise: true do
       user = create(:user, :fully_registered)
       stub_analytics(user:)
 
-      expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+      expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
         success: false,
       ).exactly(9).times
 
@@ -291,7 +291,7 @@ RSpec.describe Users::SessionsController, devise: true do
 
       stub_analytics(user:)
       expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
-      expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+      expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
         success: false,
       )
 
@@ -314,7 +314,7 @@ RSpec.describe Users::SessionsController, devise: true do
     it 'tracks the authentication attempt for nonexistent user' do
       stub_analytics(user: kind_of(AnonymousUser))
       expect(SCrypt::Engine).to receive(:hash_secret).once.and_call_original
-      expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+      expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
         success: false,
       )
 
@@ -341,7 +341,7 @@ RSpec.describe Users::SessionsController, devise: true do
       )
 
       stub_analytics(user:)
-      expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+      expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
         success: false,
       )
 
@@ -384,7 +384,7 @@ RSpec.describe Users::SessionsController, devise: true do
         user = create(:user, :fully_registered)
 
         stub_analytics(user:)
-        expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+        expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
           success: false,
         )
 
@@ -417,7 +417,7 @@ RSpec.describe Users::SessionsController, devise: true do
         let(:sign_in_failure_window) { IdentityConfig.store.max_sign_in_failures_window_in_seconds }
         it 'prevents attempt after exceeding maximum rate limit' do
           allow(IdentityConfig.store).to receive(:max_sign_in_failures).and_return(5)
-          expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+          expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
             success: false,
           ).exactly(6).times
 
@@ -454,7 +454,7 @@ RSpec.describe Users::SessionsController, devise: true do
       )
 
       stub_analytics(user:)
-      expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+      expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
         success: false,
       ).exactly(2).times
 
@@ -476,7 +476,7 @@ RSpec.describe Users::SessionsController, devise: true do
     it 'tracks the presence of SP request_url in session' do
       subject.session[:sp] = { request_url: mock_valid_site }
       stub_analytics(user: kind_of(AnonymousUser))
-      expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+      expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
         success: false,
       )
 
@@ -650,7 +650,7 @@ RSpec.describe Users::SessionsController, devise: true do
         )
 
         stub_analytics(user:)
-        expect(@attempts_api_tracker).to receive(:email_and_password_auth).with(
+        expect(@attempts_api_tracker).to receive(:login_email_and_password_auth).with(
           success: true,
         )
 


### PR DESCRIPTION
## 🛠 Summary of changes
I'm doing some cleanup work.

This change:

- renames two `social_security` attributes to `ssn` to be clearer and more aligned with the rest of the codebase
- updates the name of an event method from `email_and_password_auth` to `login_email_and_password_auth` to be aligned with the rest of the attempts events
- moves the `idv_reproof` event from the back of the funnel to the front (it represents the initiation of identity verification for a user who has proofed previously)

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
