### PR TITLE
Dmm/idv verification event failure docs

### DIFF
--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -31,7 +31,7 @@ module AttemptsApi
     # @param [String] document_front_image_file_id Filename in S3 w/encrypted data for front image
     # @param [String] document_selfie_image_encryption_key Base64-encoded AES key used for selfie
     # @param [String] document_selfie_image_file_id Filename in S3 w/encrypted data for selfie image
-    # @param [Hash<Symbol,Array<Symbol>>] failure_reason if password was not successfully changed
+    # @param [Hash<Symbol,Array<Symbol>>] failure_reason reason the images were not uploaded
     # A user has uploaded documents locally
     def idv_document_uploaded(
         success:,

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvDocumentUploaded.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvDocumentUploaded.yml
@@ -1,16 +1,16 @@
 description: |
-   The user has uploaded documents locally 
+  The user has uploaded documents locally
 allOf:
-  - $ref: '../shared/EventProperties.yml'
+  - $ref: "../shared/EventProperties.yml"
   - type: object
     properties:
       document_front_image_file_id:
         type: string
         description: If this image exists, the ID used to retrieve it if needed
-      document_back_image_file_id: 
+      document_back_image_file_id:
         type: string
         description: If this image exists, the ID used to retrieve it if needed
-      document_selfie_image_file_id: 
+      document_selfie_image_file_id:
         type: string
         description: If this image exists, the ID used to retrieve it if needed
       document_front_image_encryption_key:
@@ -23,6 +23,45 @@ allOf:
         type: string
         description: Randomly generated Base64-encoded key used to encrypt the selfie image file if it exists.
       success:
-          type: boolean
-          description: |
-            Indicates whether the upload was successful
+        type: boolean
+        description: |
+          Indicates whether the upload was successful
+      failure_reason:
+        type: object
+        description: |
+          An OPTIONAL object. An associative array of attributes and errors if success is false
+        properties:
+          limit:
+            type: array
+            description: An OPTIONAL key if the upload is rate limited
+            items:
+              type: string
+              enum:
+                - rate_limited
+          front:
+            type: array
+            description: An OPTIONAL key if there are errors with the front image
+            items:
+              type: string
+              enum:
+                - blank
+                - duplicate_image
+                - not_a_file
+          back:
+            type: array
+            description: An OPTIONAL key if there are errors with the back image
+            items:
+              type: string
+              enum:
+                - blank
+                - duplicate_image
+                - not_a_file
+          selfie:
+            type: array
+            description: An OPTIONAL key if there are errors with the back image
+            items:
+              type: string
+              enum:
+                - blank
+                - duplicate_image
+                - not_a_file

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvVerificationSubmitted.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvVerificationSubmitted.yml
@@ -1,7 +1,7 @@
 description: |
-  When the user verifies their information when identity proofing. 
+  When the user verifies their information when identity proofing.
 allOf:
-  - $ref: '../shared/EventProperties.yml'
+  - $ref: "../shared/EventProperties.yml"
   - type: object
     properties:
       document_state:
@@ -25,15 +25,56 @@ allOf:
       address:
         type: string
       failure_reason:
-          type: object
-          description: |
-            An OPTIONAL object. An associative array of attributes and errors if success is false
-          properties:
-            pii:
-              type: array
-              # What is the best way of documenting all these errors? https://docs.google.com/document/d/1H7SAM8DSnbRJqKoSj4Qdzr-UvLCNMupt2zoqHLsIFe8/edit?tab=t.0#heading=h.26slvbezaoz5
-              # They won't be very readable in this document
-              # is there a way for us to make errors out of this more in line with other failure_reasons?
+        type: object
+        description: |
+          An OPTIONAL object. An associative array of attributes and errors if success is false
+        properties:
+          failed_stages:
+            type: array
+            description: An OPTIONAL key. A list of all the stages that failed, if any.
+            items:
+              type: string
+              enum:
+                - resolution
+                - residential_address
+                - state_id
+                - threatmetrix
+                - phone_precheck
+          attributes_requiring_additional_verification:
+            type: array
+            description: |
+              An OPTIONAL key. A list of all the attributes that require additional verification
+            items:
+              type: string
+              enum:
+                - address
+                - dob
+                - dead
+                - ssn
+                - state_id_number
+          resolution_adjudication_reason:
+            type: array
+            description: |
+              An OPTIONAL key. High-level reason for the resolution result
+            items:
+              type: string
+              enum:
+                - fail_resolution_skip_state_id
+                - pass_resolution_and_state_id
+                - fail_state_id
+                - fail_resolution_skip_state_id
+                - state_id_covers_failed_resolution
+                - fail_resolution_without_state_id_coverage
+          device_profiling_adjudication_reason:
+            type: array
+            description: |
+              An OPTIONAL key. High-level reason for the device profiling result
+            items:
+              type: string
+              enum:
+                - device_profiling_exception
+                - device_profiling_result_pass
+                - device_profiling_result_review_required
       success:
         type: boolean
         description: |


### PR DESCRIPTION

## 🛠 Summary of changes
This change updates the OpenAPI spec documentation to include the failures reasons for the idv-document-uploaded event and the idv-verification-submitted event.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
