### PR TITLE
Rename tmx references

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -344,9 +344,9 @@ module Idv
 
       success = (threatmetrix_result[:review_status] == 'pass')
 
-      attempts_api_tracker.idv_tmx_fraud_check(
+      attempts_api_tracker.idv_fraud_risk_assessment(
         success:,
-        failure_reason: threatmetrix_failure_reason(success, threatmetrix_result),
+        failure_reason: fraud_risk_failure_reason(success, threatmetrix_result),
       )
 
       return if success
@@ -375,15 +375,15 @@ module Idv
       threatmetrix_result.delete(:response_body)
     end
 
-    def threatmetrix_failure_reason(success, result)
+    def fraud_risk_failure_reason(success, result)
       return nil if success
 
-      tmx_summary_reason_code = result.dig(
+      fraud_risk_summary_reason_code = result.dig(
         :response_body,
         :tmx_summary_reason_code,
-      ) || ['ThreatMetrix review has failed for unknown reasons']
+      ) || ['Fraud risk assessment has failed for unknown reasons']
 
-      { tmx_summary_reason_code: }
+      { fraud_risk_summary_reason_code: }
     end
 
     def add_cost(token, transaction_id: nil)

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -464,7 +464,9 @@ module Idv
       end
 
       def failed_stages
-        stages.keys.select { |k| !stages[k][:success] }
+        stages.keys.select { |k| !stages[k][:success] }.map do |stage|
+          stage == :threatmetrix ? :fraud_risk_assesment : stage
+        end
       end
 
       def resolution_adjudication_reason

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -425,9 +425,9 @@ module AttemptsApi
     # @param [Boolean] success True means TMX check has a 'pass' review status
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
     # Tracks the result of the TMX fraud check during Identity Verification
-    def idv_tmx_fraud_check(success:, failure_reason: nil)
+    def idv_fraud_risk_assessment(success:, failure_reason: nil)
       track_event(
-        'idv-tmx-fraud-check',
+        'idv-fraud-risk-assessment',
         success:,
         failure_reason:,
       )

--- a/docs/attempts-api/schemas/events/IdentityProofingEvents.yml
+++ b/docs/attempts-api/schemas/events/IdentityProofingEvents.yml
@@ -1,31 +1,31 @@
 properties:
   idv-address-submitted:
-    $ref: './identity-proofing/IdvAddressSubmitted.yml'
+    $ref: "./identity-proofing/IdvAddressSubmitted.yml"
   idv-document-uploaded:
-    $ref: './identity-proofing/IdvDocumentUploaded.yml'
+    $ref: "./identity-proofing/IdvDocumentUploaded.yml"
   idv-document-upload-submitted:
-    $ref: './identity-proofing/IdvDocumentUploadSubmitted.yml'
+    $ref: "./identity-proofing/IdvDocumentUploadSubmitted.yml"
   idv-enrollment-complete:
-    $ref: './identity-proofing/IdvEnrollmentComplete.yml'
+    $ref: "./identity-proofing/IdvEnrollmentComplete.yml"
   idv-ipp-ready-to-verify-visit:
-    $ref: './identity-proofing/IdvIppReadyToVerifyVisit.yml'
+    $ref: "./identity-proofing/IdvIppReadyToVerifyVisit.yml"
   idv-phone-otp-sent:
-    $ref: './identity-proofing/IdvPhoneOtpSent.yml'
+    $ref: "./identity-proofing/IdvPhoneOtpSent.yml"
   idv-phone-otp-submitted:
-    $ref: './identity-proofing/IdvPhoneOtpSubmitted.yml'
+    $ref: "./identity-proofing/IdvPhoneOtpSubmitted.yml"
   idv-phone-submitted:
-    $ref: './identity-proofing/IdvPhoneSubmitted.yml'
+    $ref: "./identity-proofing/IdvPhoneSubmitted.yml"
   idv-rate-limited:
-    $ref: './identity-proofing/IdvRateLimited.yml'
+    $ref: "./identity-proofing/IdvRateLimited.yml"
   idv-reproof:
-    $ref: './identity-proofing/IdvReproof.yml'
+    $ref: "./identity-proofing/IdvReproof.yml"
   idv-ssn-submitted:
-    $ref: './identity-proofing/IdvSsnSubmitted.yml'
-  idv-tmx-fraud-check:
-    $ref: './identity-proofing/IdvTmxFraudCheck.yml'
+    $ref: "./identity-proofing/IdvSsnSubmitted.yml"
+  idv-fraud-risk-assessment:
+    $ref: "./identity-proofing/IdvFraudRiskAssessment.yml"
   idv-verification-submitted:
-    $ref: './identity-proofing/IdvVerificationSubmitted.yml'
+    $ref: "./identity-proofing/IdvVerificationSubmitted.yml"
   idv-verify-by-mail-letter-requested:
-    $ref: './identity-proofing/IdvVerifyByMailLetterRequested.yml'
+    $ref: "./identity-proofing/IdvVerifyByMailLetterRequested.yml"
   idv-verify-by-mail-enter-code-submitted:
-    $ref: './identity-proofing/IdvVerifyByMailEnterCodeSubmitted.yml'
+    $ref: "./identity-proofing/IdvVerifyByMailEnterCodeSubmitted.yml"

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvFraudRiskAssessment.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvFraudRiskAssessment.yml
@@ -1,14 +1,14 @@
 description: |
-  This event captures the result of the TMX fraud check during Identity Verification.
+  This event captures the result of the Fraud Risk Assessment during Identity Verification.
 allOf:
-  - $ref: '../shared/EventProperties.yml'
+  - $ref: "../shared/EventProperties.yml"
   - type: object
     properties:
       failure_reason:
         type: object
         description: |
           An OPTIONAL object. An associative array of attributes and errors if user has failed fraud review
-        properties: 
+        properties:
           tmx_summary_reason_code:
             type: array
             description: |

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvVerificationSubmitted.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvVerificationSubmitted.yml
@@ -38,7 +38,7 @@ allOf:
                 - resolution
                 - residential_address
                 - state_id
-                - threatmetrix
+                - fraud_risk_assessment
                 - phone_precheck
           attributes_requiring_additional_verification:
             type: array

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe Idv::VerifyInfoController do
         end
 
         it 'tracks the attempts events' do
-          expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
+          expect(@attempts_api_tracker).to receive(:idv_fraud_risk_assessment).with(
             success: true,
             failure_reason: nil,
           )
@@ -325,9 +325,9 @@ RSpec.describe Idv::VerifyInfoController do
         end
 
         it 'tracks a failed tmx fraud check' do
-          expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
+          expect(@attempts_api_tracker).to receive(:idv_fraud_risk_assessment).with(
             success: false,
-            failure_reason: { tmx_summary_reason_code: ['Identity_Negative_History'] },
+            failure_reason: { fraud_risk_summary_reason_code: ['Identity_Negative_History'] },
           )
 
           expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
@@ -440,10 +440,11 @@ RSpec.describe Idv::VerifyInfoController do
 
         it 'tracks a failed tmx fraud check' do
           stub_attempts_tracker
-          expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
+          expect(@attempts_api_tracker).to receive(:idv_fraud_risk_assessment).with(
             success: false,
             failure_reason: {
-              tmx_summary_reason_code: ['ThreatMetrix review has failed for unknown reasons'],
+              fraud_risk_summary_reason_code:
+                ['Fraud risk assessment has failed for unknown reasons'],
             },
           )
 
@@ -461,10 +462,10 @@ RSpec.describe Idv::VerifyInfoController do
         end
 
         it 'tracks a failed tmx fraud check' do
-          expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
+          expect(@attempts_api_tracker).to receive(:idv_fraud_risk_assessment).with(
             success:,
             failure_reason: {
-              tmx_summary_reason_code: ['Identity_Negative_History'],
+              fraud_risk_summary_reason_code: ['Identity_Negative_History'],
             },
           )
 
@@ -501,10 +502,10 @@ RSpec.describe Idv::VerifyInfoController do
 
         it 'tracks a failed tmx fraud check' do
           stub_attempts_tracker
-          expect(@attempts_api_tracker).to receive(:idv_tmx_fraud_check).with(
+          expect(@attempts_api_tracker).to receive(:idv_fraud_risk_assessment).with(
             success: false,
             failure_reason: {
-              tmx_summary_reason_code: ['Identity_Negative_History'],
+              fraud_risk_summary_reason_code: ['Identity_Negative_History'],
             },
           )
 
@@ -531,7 +532,7 @@ RSpec.describe Idv::VerifyInfoController do
         it 'does not track a threatmetrix check' do
           stub_attempts_tracker
 
-          expect(@attempts_api_tracker).not_to receive(:idv_tmx_fraud_check)
+          expect(@attempts_api_tracker).not_to receive(:idv_fraud_risk_assessment)
 
           get :show
         end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe Idv::VerifyInfoController do
             address2: applicant_pii[:address2],
             ssn: applicant_pii[:ssn],
             failure_reason: {
-              failed_stages: [:threatmetrix],
+              failed_stages: [:fraud_risk_assesment],
               device_profiling_adjudication_reason: ['device_profiling_result'],
               resolution_adjudication_reason: ['pass_resolution_and_state_id'],
             },
@@ -430,7 +430,7 @@ RSpec.describe Idv::VerifyInfoController do
             address2: applicant_pii[:address2],
             ssn: applicant_pii[:ssn],
             failure_reason: {
-              failed_stages: [:threatmetrix],
+              failed_stages: [:fraud_risk_assesment],
               resolution_adjudication_reason: ['pass_resolution_and_state_id'],
               device_profiling_adjudication_reason: ['device_profiling_exception'],
             },
@@ -482,7 +482,7 @@ RSpec.describe Idv::VerifyInfoController do
             address2: applicant_pii[:address2],
             ssn: applicant_pii[:ssn],
             failure_reason: {
-              failed_stages: [:threatmetrix],
+              failed_stages: [:fraud_risk_assesment],
               device_profiling_adjudication_reason: ['device_profiling_result'],
               resolution_adjudication_reason: ['pass_resolution_and_state_id'],
             },


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Fraud Mitigation 20](https://gitlab.login.gov/lg-teams/FIE/fraud-mitigation/-/issues/20)


## 🛠 Summary of changes
While collaborating with the data team on failure naming, the team noted that `tmx` and `threatmetrix` references were references to a specific vendor. As we do not want to return vendor-specific information, this change updates those references to be vender-neutral. 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
