### PR TITLE
Fix exception when calling email_language on AnonymousUser

### DIFF
--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -72,4 +72,8 @@ class AnonymousUser
   def id
     nil
   end
+
+  def email_language
+    nil
+  end
 end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe AttemptsApi::Tracker do
       end
     end
 
+    context 'with AnonymousUser user' do
+      let(:user) { AnonymousUser.new }
+
+      it 'logs nil user_uuid' do
+        event = subject.track_event(:test_event)
+        expect(event.event_metadata[:user]).to be_nil
+      end
+
+      it 'returns default locale as the language attribute' do
+        event = subject.track_event(:test_event)
+        expect(event.event_metadata[:language]).to eq('en')
+      end
+    end
+
     context 'user that has a locale selected' do
       before { user.update(email_language: :es) }
       it 'returns that locale as a language attribute in event' do


### PR DESCRIPTION
## 🛠 Summary of changes

There is currently a bug where an exception is raised when calling `email_language` on `AnonymousUser` within the `AttemptsApi::Tracker`.

```
     NoMethodError:
       undefined method 'email_language' for an instance of AnonymousUser
```

This PR adds a regression spec to ensure that we can call `#track_event` with an `AnonymousUser` and fixes the bug by adding the `email_language` method.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
