### PR TITLE
Remove feature flag feature_one_verified_account_log_duplicate_profiles

### DIFF
--- a/app/services/duplicate_profile_checker.rb
+++ b/app/services/duplicate_profile_checker.rb
@@ -11,7 +11,6 @@ class DuplicateProfileChecker
   end
 
   def check_for_duplicate_profiles
-    return unless IdentityConfig.store.feature_one_verified_account_log_duplicate_profiles
     return unless user_has_ial2_profile?
     cacher = Pii::Cacher.new(user, user_session)
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -157,7 +157,6 @@ event_disavowal_expiration_hours: 240
 facial_match_general_availability_enabled: true
 feature_idv_force_gpo_verification_enabled: false
 feature_idv_hybrid_flow_enabled: true
-feature_one_verified_account_log_duplicate_profiles: true
 geo_data_file_path: 'geo_data/GeoLite2-City.mmdb'
 get_usps_proofing_results_job_cron: '0/30 * * * *'
 get_usps_proofing_results_job_reprocess_delay_minutes: 5
@@ -561,7 +560,6 @@ production:
   enable_usps_verification: false
   encrypted_document_storage_s3_bucket: ''
   facial_match_general_availability_enabled: false
-  feature_one_verified_account_log_duplicate_profiles: false
   idv_sp_required: true
   in_person_passports_enabled: false
   invalid_gpo_confirmation_zipcode: ''

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -175,7 +175,6 @@ module IdentityConfig
     config.add(:facial_match_general_availability_enabled, type: :boolean)
     config.add(:feature_idv_force_gpo_verification_enabled, type: :boolean)
     config.add(:feature_idv_hybrid_flow_enabled, type: :boolean)
-    config.add(:feature_one_verified_account_log_duplicate_profiles, type: :boolean)
     config.add(:irs_authentication_issuers, type: :json)
     config.add(:irs_authentication_emails, type: :json)
     config.add(:irs_fraud_metrics_issuers, type: :json)

--- a/spec/services/duplicate_profile_checker_spec.rb
+++ b/spec/services/duplicate_profile_checker_spec.rb
@@ -24,174 +24,148 @@ RSpec.describe DuplicateProfileChecker do
     before do
       profile.encrypt_pii(active_pii, user.password)
       profile.save
+      session[:encrypted_profiles] = {
+        profile.id.to_s => SessionEncryptor.new.kms_encrypt(active_pii.to_json),
+      }
     end
 
-    context 'when feature flag feature_one_verified_account_log_duplicate_profiles is enabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:feature_one_verified_account_log_duplicate_profiles)
-          .and_return(true)
+    context 'when user has active IAL2 profile' do
+      context 'when user has already been verified for duplicate profile' do
+        let(:user2) { create(:user, :fully_registered) }
+        let!(:profile2) do
+          profile2 = create(
+            :profile, :active,
+            :facial_match_proof,
+            user: user2,
+            initiating_service_provider_issuer: sp.issuer
+          )
+          profile2.encrypt_pii(active_pii, user2.password)
+          profile2.save
+          profile2
+        end
 
-        session[:encrypted_profiles] = {
-          profile.id.to_s => SessionEncryptor.new.kms_encrypt(active_pii.to_json),
-        }
-      end
+        before do
+          DuplicateProfileConfirmation.create(
+            profile_id: profile.id,
+            confirmed_at: Time.zone.now,
+            duplicate_profile_ids: [profile2.id],
+          )
+        end
 
-      context 'when user has active IAL2 profile' do
-        context 'when user has already been verified for duplicate profile' do
-          let(:user2) { create(:user, :fully_registered) }
-          let!(:profile2) do
-            profile2 = create(
+        it 'does not create a new duplicate profile confirmation' do
+          expect(DuplicateProfileConfirmation.where(profile_id: profile.id).size).to eq(1)
+          dupe_profile_checker = DuplicateProfileChecker.new(
+            user: user, user_session: session,
+            sp: sp
+          )
+          dupe_profile_checker.check_for_duplicate_profiles
+
+          expect(DuplicateProfileConfirmation.where(profile_id: profile.id).size).to eq(1)
+        end
+
+        context 'when a new duplicate profile has been added since last login' do
+          let(:user3) { create(:user, :fully_registered) }
+          let!(:profile3) do
+            profile3 = create(
               :profile, :active,
               :facial_match_proof,
-              user: user2,
+              user: user3,
               initiating_service_provider_issuer: sp.issuer
             )
-            profile2.encrypt_pii(active_pii, user2.password)
-            profile2.save
-            profile2
+            profile3.encrypt_pii(active_pii, user3.password)
+            profile3.save
+            profile3
           end
 
-          before do
-            DuplicateProfileConfirmation.create(
-              profile_id: profile.id,
-              confirmed_at: Time.zone.now,
-              duplicate_profile_ids: [profile2.id],
+          it 'should update duplicate confirmation to include all ids' do
+            confirmation = DuplicateProfileConfirmation.where(profile_id: profile.id).first
+            expect(confirmation.duplicate_profile_ids).to eq([profile2.id])
+
+            dupe_profile_checker = DuplicateProfileChecker.new(
+              user: user, user_session: session,
+              sp: sp
             )
+            dupe_profile_checker.check_for_duplicate_profiles
+            confirmation.reload
+            expect(confirmation.duplicate_profile_ids).to eq([profile2.id, profile3.id])
           end
+        end
+      end
+
+      context 'when user has not been checked for duplicate profile' do
+        context 'when user does not have other accounts with matching profile' do
+          let(:user2) { create(:user, :proofed_with_selfie) }
 
           it 'does not create a new duplicate profile confirmation' do
-            expect(DuplicateProfileConfirmation.where(profile_id: profile.id).size).to eq(1)
             dupe_profile_checker = DuplicateProfileChecker.new(
               user: user, user_session: session,
               sp: sp
             )
             dupe_profile_checker.check_for_duplicate_profiles
 
-            expect(DuplicateProfileConfirmation.where(profile_id: profile.id).size).to eq(1)
-          end
-
-          context 'when a new duplicate profile has been added since last login' do
-            let(:user3) { create(:user, :fully_registered) }
-            let!(:profile3) do
-              profile3 = create(
-                :profile, :active,
-                :facial_match_proof,
-                user: user3,
-                initiating_service_provider_issuer: sp.issuer
-              )
-              profile3.encrypt_pii(active_pii, user3.password)
-              profile3.save
-              profile3
-            end
-
-            it 'should update duplicate confirmation to include all ids' do
-              confirmation = DuplicateProfileConfirmation.where(profile_id: profile.id).first
-              expect(confirmation.duplicate_profile_ids).to eq([profile2.id])
-
-              dupe_profile_checker = DuplicateProfileChecker.new(
-                user: user, user_session: session,
-                sp: sp
-              )
-              dupe_profile_checker.check_for_duplicate_profiles
-              confirmation.reload
-              expect(confirmation.duplicate_profile_ids).to eq([profile2.id, profile3.id])
-            end
+            expect(DuplicateProfileConfirmation.where(profile_id: profile.id)).to be_empty
           end
         end
 
-        context 'when user has not been checked for duplicate profile' do
-          context 'when user does not have other accounts with matching profile' do
-            let(:user2) { create(:user, :proofed_with_selfie) }
-
-            it 'does not create a new duplicate profile confirmation' do
-              dupe_profile_checker = DuplicateProfileChecker.new(
-                user: user, user_session: session,
-                sp: sp
-              )
-              dupe_profile_checker.check_for_duplicate_profiles
-
-              expect(DuplicateProfileConfirmation.where(profile_id: profile.id)).to be_empty
-            end
+        context 'when user has accounts with matching profile' do
+          let(:user2) { create(:user, :fully_registered) }
+          let!(:profile2) do
+            profile = create(
+              :profile,
+              :active,
+              :facial_match_proof,
+              user: user2,
+              initiating_service_provider_issuer: sp.issuer,
+            )
+            profile.encrypt_pii(active_pii, user2.password)
+            profile.save
           end
 
-          context 'when user has accounts with matching profile' do
-            let(:user2) { create(:user, :fully_registered) }
-            let!(:profile2) do
-              profile = create(
-                :profile,
-                :active,
-                :facial_match_proof,
-                user: user2,
-                initiating_service_provider_issuer: sp.issuer,
-              )
-              profile.encrypt_pii(active_pii, user2.password)
-              profile.save
-            end
-
-            before do
-              session[:encrypted_profiles] = {
-                profile.id.to_s => SessionEncryptor.new.kms_encrypt(active_pii.to_json),
-              }
-            end
-
-            it 'creates a new duplicate profile confirmation entry' do
-              expect(DuplicateProfileConfirmation.where(profile_id: profile.id).first).to eq(nil)
-
-              dupe_profile_checker = DuplicateProfileChecker.new(
-                user: user, user_session: session,
-                sp: sp
-              )
-              dupe_profile_checker.check_for_duplicate_profiles
-
-              expect(DuplicateProfileConfirmation.where(profile_id: profile.id).first).to be_present
-            end
+          before do
+            session[:encrypted_profiles] = {
+              profile.id.to_s => SessionEncryptor.new.kms_encrypt(active_pii.to_json),
+            }
           end
-        end
-      end
 
-      context 'when user does not have active IAL2 profile' do
-        let(:user) { create(:user, :fully_registered) }
-        let(:profile) do
-          create(
-            :profile,
-            :active,
-            user: user,
-            initiating_service_provider_issuer: sp.issuer,
-          )
-        end
-        it 'does not create a new duplicate profile confirmation' do
-          dupe_profile_checker = DuplicateProfileChecker.new(
-            user: user,
-            user_session: session,
-            sp: sp,
-          )
-          dupe_profile_checker.check_for_duplicate_profiles
+          it 'creates a new duplicate profile confirmation entry' do
+            expect(DuplicateProfileConfirmation.where(profile_id: profile.id).first).to eq(nil)
 
-          expect(DuplicateProfileConfirmation.where(profile_id: user.active_profile.id)).to be_empty
-        end
-      end
+            dupe_profile_checker = DuplicateProfileChecker.new(
+              user: user, user_session: session,
+              sp: sp
+            )
+            dupe_profile_checker.check_for_duplicate_profiles
 
-      context 'user does not have profile' do
-        let(:user) { create(:user) }
-        it 'does not create a new duplicate profile confirmation' do
-          dupe_profile_checker = DuplicateProfileChecker.new(
-            user: user,
-            user_session: session,
-            sp: sp,
-          )
-          dupe_profile_checker.check_for_duplicate_profiles
-
-          expect(DuplicateProfileConfirmation.where(profile_id: profile.id)).to be_empty
+            expect(DuplicateProfileConfirmation.where(profile_id: profile.id).first).to be_present
+          end
         end
       end
     end
 
-    context 'when feature flag feature_one_verified_account_log_duplicate_profiles is disabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:feature_one_verified_account_log_duplicate_profiles)
-          .and_return(false)
+    context 'when user does not have active IAL2 profile' do
+      let(:user) { create(:user, :fully_registered) }
+      let(:profile) do
+        create(
+          :profile,
+          :active,
+          user: user,
+          initiating_service_provider_issuer: sp.issuer,
+        )
       end
+      it 'does not create a new duplicate profile confirmation' do
+        dupe_profile_checker = DuplicateProfileChecker.new(
+          user: user,
+          user_session: session,
+          sp: sp,
+        )
+        dupe_profile_checker.check_for_duplicate_profiles
 
+        expect(DuplicateProfileConfirmation.where(profile_id: user.active_profile.id)).to be_empty
+      end
+    end
+
+    context 'user does not have profile' do
+      let(:user) { create(:user) }
       it 'does not create a new duplicate profile confirmation' do
         dupe_profile_checker = DuplicateProfileChecker.new(
           user: user,


### PR DESCRIPTION
The code has been deployed and found to be working correctly. There is no need to protect it with a feature flag any longer.

changelog: Internal, One Verified Account, Remove feature flag no longer needed

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-16286](https://cm-jira.usa.gov/browse/LG-16286)

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
