### PR TITLE
LG-16312: Add error icon to PIV/CAC error page on sign in failure screen

### DIFF
--- a/app/views/users/piv_cac_authentication_setup/error.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/error.html.erb
@@ -1,6 +1,7 @@
 <% self.title = @presenter.title %>
 
-<%= render PageHeadingComponent.new do %>
+<%= render StatusPageComponent.new(status: :error) do |c| %>
+  <%= render PageHeadingComponent.new do %>
   <%= @presenter.heading %>
 <% end %>
 
@@ -13,4 +14,4 @@
       wide: true,
       big: true,
     ).with_content(t('forms.piv_cac_setup.try_again')) %>
-
+<% end %>

--- a/app/views/users/piv_cac_authentication_setup/error.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/error.html.erb
@@ -2,16 +2,16 @@
 
 <%= render StatusPageComponent.new(status: :error) do |c| %>
   <%= render PageHeadingComponent.new do %>
-  <%= @presenter.heading %>
-<% end %>
+    <%= @presenter.heading %>
+  <% end %>
 
-<p class="margin-top-2 margin-bottom-5">
-  <%= @presenter.description %>
-</p>
+  <p class="margin-top-2 margin-bottom-5">
+    <%= @presenter.description %>
+  </p>
 
-<%= render ButtonComponent.new(
-      url: setup_piv_cac_url,
-      wide: true,
-      big: true,
-    ).with_content(t('forms.piv_cac_setup.try_again')) %>
+  <%= render ButtonComponent.new(
+        url: setup_piv_cac_url,
+        wide: true,
+        big: true,
+      ).with_content(t('forms.piv_cac_setup.try_again')) %>
 <% end %>

--- a/app/views/users/piv_cac_login/error.html.erb
+++ b/app/views/users/piv_cac_login/error.html.erb
@@ -1,5 +1,7 @@
 <% self.title = @presenter.title %>
 
+<%= render StatusPageComponent.new(status: :error) do |c| %>
+
 <%= render PageHeadingComponent.new do %>
   <%= @presenter.heading %>
 <% end %>
@@ -13,3 +15,5 @@
       class: 'margin-top-3',
       big: true,
     ).with_content(t('instructions.mfa.piv_cac.back_to_sign_in')) %>
+
+<% end %>

--- a/app/views/users/piv_cac_login/error.html.erb
+++ b/app/views/users/piv_cac_login/error.html.erb
@@ -1,19 +1,17 @@
 <% self.title = @presenter.title %>
 
 <%= render StatusPageComponent.new(status: :error) do |c| %>
+  <%= render PageHeadingComponent.new do %>
+    <%= @presenter.heading %>
+  <% end %>
 
-<%= render PageHeadingComponent.new do %>
-  <%= @presenter.heading %>
-<% end %>
+  <p class="margin-top-2 margin-bottom-2">
+    <%= @presenter.description %>
+  </p>
 
-<p class="margin-top-2 margin-bottom-2">
-  <%= @presenter.description %>
-</p>
-
-<%= render ButtonComponent.new(
-      url: new_user_session_url,
-      class: 'margin-top-3',
-      big: true,
-    ).with_content(t('instructions.mfa.piv_cac.back_to_sign_in')) %>
-
+  <%= render ButtonComponent.new(
+        url: new_user_session_url,
+        class: 'margin-top-3',
+        big: true,
+      ).with_content(t('instructions.mfa.piv_cac.back_to_sign_in')) %>
 <% end %>


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16312](https://cm-jira.usa.gov/browse/LG-16312)

## 🛠 Summary of changes

This pull request adds an error icon to two pages: at the point where a user does not sign in successfully using their PIV card and at unsuccessful PIV card setup

## 📜 Testing Plan

Error when signing in using PIV card
- [ ] On the home screen, click "Sign in using your government employee ID"
- [ ] Click "Insert PIV/CAC"
- [ ] Trigger an error for unsuccessful login
You will see the error icon once login is unsuccessful

Error when setting up PIV/CAC
- [ ] With an existing or new account, on the authentication methods setup screen, click "Add government employee ID"
- [ ] Click "Insert PIV/CAC"
- [ ] Trigger an error for unsuccessful setup
You will see an icon indicating an error

## 👀 Screenshots

This is a new template, so one screenshot will be provided

<details>
<summary>Before:</summary>
![screenshot of current piv/cac login/setup error screen](https://github.com/user-attachments/assets/a3325e95-ebf0-4cbd-bf1b-732003a89f88)

</details>

<details>
<summary>After:</summary>
![screenshot of desired piv/cac login/setup error screen](https://github.com/user-attachments/assets/6ce1a021-624d-4f6b-8fe7-51484eba588c)

</details>
