### PR TITLE
use find_by in active_profile

### DIFF
--- a/app/controllers/concerns/ial2_profile_concern.rb
+++ b/app/controllers/concerns/ial2_profile_concern.rb
@@ -24,6 +24,7 @@ module Ial2ProfileConcern
     rescue Encryption::EncryptionError => err
       if profile
         profile.deactivate_due_to_encryption_error
+        current_user.reload
         analytics.profile_encryption_invalid(error: err.message)
       end
     end

--- a/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
+++ b/app/forms/event_disavowal/password_reset_from_disavowal_form.rb
@@ -35,6 +35,7 @@ module EventDisavowal
       return if user.active_profile.blank?
 
       user.active_profile&.deactivate(:password_reset)
+      user.reload
       Funnel::DocAuth::ResetSteps.call(@user.id)
     end
 

--- a/app/forms/reset_password_form.rb
+++ b/app/forms/reset_password_form.rb
@@ -65,6 +65,7 @@ class ResetPasswordForm
     return if profile.blank?
 
     profile.deactivate(:password_reset)
+    user.reload
     Funnel::DocAuth::ResetSteps.call(user.id)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,8 +105,8 @@ class User < ApplicationRecord
   end
 
   def active_profile
-    return @active_profile if defined?(@active_profile) && @active_profile&.active
-    @active_profile = profiles.verified.find(&:active?)
+    return @active_profile if defined?(@active_profile)
+    @active_profile = profiles.verified.find_by(active: true)
   end
 
   def pending_profile?

--- a/app/services/idv/profile_maker.rb
+++ b/app/services/idv/profile_maker.rb
@@ -42,6 +42,8 @@ module Idv
       if fraud_pending_reason.present? && !gpo_verification_needed && !in_person_verification_needed
         profile.deactivate_for_fraud_review
       end
+
+      user.reload
       profile
     end
 


### PR DESCRIPTION
## 🛠 Summary of changes

this PR changes `active_profile` in the `user` model to use `find_by`, which should be faster. I tested my changes on my machine with a test user with four profiles and the difference was 0.449454 seconds against 0.235338 seconds. it also moves the `@active_profile` check to where profiles are deactivated by reloading the user model rather than calling `.active`, which might have been useless (if the code checks a user with a false `active_profile` and assigned `@active_profile` based on the in-memory query, `@active_profile` would become `nil` and `defined?(@active_profile)` would be true, but `.active` would be `nil`, bypassing the check)