### PR TITLE
LG-16231: display ial2 selfie error

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -33,6 +33,7 @@ module Idv
         socure: stored_result&.errors&.dig(:socure),
         pii_validation: stored_result&.errors&.dig(:pii_validation),
         unaccepted_id_type: stored_result&.errors&.dig(:unaccepted_id_type),
+        selfie_fail: stored_result&.errors&.dig(:selfie_fail),
       }
     end
 

--- a/app/controllers/concerns/idv/socure_errors_concern.rb
+++ b/app/controllers/concerns/idv/socure_errors_concern.rb
@@ -14,6 +14,8 @@ module Idv
     def error_code_for(result)
       if result.errors[:unaccepted_id_type]
         :unaccepted_id_type
+      elsif result.errors[:selfie_fail]
+        :selfie_fail
       elsif result.errors[:socure]
         result.errors.dig(:socure, :reason_codes).first
       elsif result.errors[:network]

--- a/app/controllers/idv/socure/errors_controller.rb
+++ b/app/controllers/idv/socure/errors_controller.rb
@@ -8,6 +8,7 @@ module Idv
       include IdvStepConcern
       include StepIndicatorConcern
       include AbTestAnalyticsConcern
+      include SocureErrorsConcern
 
       before_action :confirm_step_allowed
 
@@ -68,21 +69,6 @@ module Idv
         )
       end
 
-      def error_code_for(result)
-        if result.errors[:unaccepted_id_type]
-          :unaccepted_id_type
-        elsif result.errors[:socure]
-          result.errors.dig(:socure, :reason_codes).first
-        elsif result.errors[:network]
-          :network
-        elsif result.errors[:pii_validation]
-          :pii_validation
-        else
-          # No error information available (shouldn't happen). Default
-          # to :network if it does.
-          :network
-        end
-      end
     end
   end
 end

--- a/app/controllers/idv/socure/errors_controller.rb
+++ b/app/controllers/idv/socure/errors_controller.rb
@@ -68,7 +68,6 @@ module Idv
           flow_path:,
         )
       end
-
     end
   end
 end

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -146,6 +146,8 @@ class SocureErrorPresenter
       t('idv.errors.technical_difficulties')
     when :unaccepted_id_type
       t('doc_auth.headers.unaccepted_id_type')
+    when :selfie_fail
+      t('doc_auth.errors.selfie_fail_heading')
     else
       # i18n-tasks-use t('doc_auth.headers.unreadable_id')
       # i18n-tasks-use t('doc_auth.headers.unaccepted_id_type')
@@ -165,6 +167,8 @@ class SocureErrorPresenter
       t('idv.errors.try_again_later')
     when :unaccepted_id_type
       t('doc_auth.errors.unaccepted_id_type')
+    when :selfie_fail
+      t('doc_auth.errors.general.selfie_failure')
     else
       if remapped_error(error_code) == 'underage' # special handling because it says 'Login.gov'
         I18n.t('doc_auth.errors.underage', app_name: APP_NAME)

--- a/app/services/doc_auth/socure/responses/docv_result_response.rb
+++ b/app/services/doc_auth/socure/responses/docv_result_response.rb
@@ -60,7 +60,7 @@ module DocAuth
         end
 
         def doc_auth_success?
-          id_type_supported? && successful_result?
+          id_type_supported? && successful_result? && !portrait_matching_failed?
         end
 
         def selfie_status
@@ -112,6 +112,8 @@ module DocAuth
             { unaccepted_id_type: true }
           elsif !successful_result?
             { socure: { reason_codes: } }
+          elsif portrait_matching_failed?
+            { selfie_fail: true }
           else
             {}
           end
@@ -212,6 +214,10 @@ module DocAuth
 
         def reason_codes_selfie_not_processed
           IdentityConfig.store.idv_socure_reason_codes_docv_selfie_not_processed
+        end
+
+        def portrait_matching_failed?
+          selfie_status == :fail
         end
       end
     end

--- a/spec/fixtures/socure_docv/selfie_fail.json
+++ b/spec/fixtures/socure_docv/selfie_fail.json
@@ -1,0 +1,40 @@
+{
+  "referenceId": "a1234b56-e789-0123-4fga-56b7c890d123",
+  "previousReferenceId": "e9c170f2-b3e4-423b-a373-5d6e1e9b23f8",
+  "documentVerification": {
+    "reasonCodes": [
+      "R810"
+    ],
+    "documentType": {
+      "type": "Drivers License",
+      "country": "USA",
+      "state": "NY"
+    },
+    "decision": {
+      "name": "lenient",
+      "value": "accept"
+    },
+    "documentData": {
+      "firstName": "Dwayne",
+      "surName": "Denver",
+      "fullName": "Dwayne Denver",
+      "address": "123 Example Street, New York City, NY 10001",
+      "parsedAddress": {
+        "physicalAddress": "123 Example Street",
+        "physicalAddress2": "New York City NY 10001",
+        "city": "New York City",
+        "state": "NY",
+        "country": "US",
+        "zip": "10001"
+      },
+      "documentNumber": "000000000",
+      "dob": "2002-01-01",
+      "issueDate": "2024-01-01",
+      "expirationDate": "2070-01-01"
+    }
+  },
+  "customerProfile": {
+    "customerUserId": "129",
+    "userId": "u8JpWn4QsF3R7tA2"
+  }
+}

--- a/spec/presenters/socure_error_presenter_spec.rb
+++ b/spec/presenters/socure_error_presenter_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe SocureErrorPresenter do
+  let(:error_code) { :network }
+  let(:remaining_attempts) { 3 }
+  let(:sp_name) { 'Test Service Provider' }
+  let(:issuer) { 'urn:gov:gsa:openidconnect:sp:test' }
+  let(:flow_path) { 'standard' }
+
+  subject(:presenter) do
+    described_class.new(
+      error_code: error_code,
+      remaining_attempts: remaining_attempts,
+      sp_name: sp_name,
+      issuer: issuer,
+      flow_path: flow_path,
+    )
+  end
+
+  describe '#heading' do
+    context 'when error_code is :selfie_fail' do
+      let(:error_code) { :selfie_fail }
+
+      it 'returns the selfie fail heading' do
+        expect(presenter.heading).to eq(I18n.t('doc_auth.errors.selfie_fail_heading'))
+      end
+    end
+
+    context 'when error_code is :unaccepted_id_type' do
+      let(:error_code) { :unaccepted_id_type }
+
+      it 'returns the unaccepted id type heading' do
+        expect(presenter.heading).to eq(I18n.t('doc_auth.headers.unaccepted_id_type'))
+      end
+    end
+
+    context 'when error_code is :network' do
+      let(:error_code) { :network }
+
+      it 'returns the network error heading' do
+        expect(presenter.heading).to eq(I18n.t('doc_auth.headers.general.network_error'))
+      end
+    end
+
+    context 'when error_code is a socure reason code' do
+      let(:error_code) { 'R810' }
+
+      before do
+        allow(presenter).to receive(:remapped_error).with('R810').and_return('unreadable_id')
+      end
+
+      it 'returns the unreadable id heading' do
+        expect(presenter.heading).to eq(I18n.t('doc_auth.headers.unreadable_id'))
+      end
+    end
+  end
+
+  describe '#body_text' do
+    context 'when error_code is :selfie_fail' do
+      let(:error_code) { :selfie_fail }
+
+      it 'returns the selfie failure message' do
+        expect(presenter.body_text).to eq(I18n.t('doc_auth.errors.general.selfie_failure'))
+      end
+    end
+
+    context 'when error_code is :unaccepted_id_type' do
+      let(:error_code) { :unaccepted_id_type }
+
+      it 'returns the unaccepted id type message' do
+        expect(presenter.body_text).to eq(I18n.t('doc_auth.errors.unaccepted_id_type'))
+      end
+    end
+
+    context 'when error_code is :network' do
+      let(:error_code) { :network }
+
+      it 'returns the network error message' do
+        expect(presenter.body_text).to eq(I18n.t('doc_auth.errors.general.new_network_error'))
+      end
+    end
+
+    context 'when error_code is underage' do
+      let(:error_code) { 'underage' }
+
+      before do
+        allow(presenter).to receive(:remapped_error).with('underage').and_return('underage')
+      end
+
+      it 'returns the underage message with app name' do
+        expect(presenter.body_text).to eq(
+          I18n.t('doc_auth.errors.underage', app_name: APP_NAME)
+        )
+      end
+    end
+
+    context 'when error_code is another socure reason code' do
+      let(:error_code) { 'R827' }
+
+      before do
+        allow(presenter).to receive(:remapped_error).with('R827').and_return('expired_id')
+      end
+
+      it 'returns the mapped error message' do
+        expect(presenter.body_text).to eq(I18n.t('doc_auth.errors.expired_id'))
+      end
+    end
+  end
+end

--- a/spec/presenters/socure_error_presenter_spec.rb
+++ b/spec/presenters/socure_error_presenter_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe SocureErrorPresenter do
 
       it 'returns the underage message with app name' do
         expect(presenter.body_text).to eq(
-          I18n.t('doc_auth.errors.underage', app_name: APP_NAME)
+          I18n.t('doc_auth.errors.underage', app_name: APP_NAME),
         )
       end
     end

--- a/spec/views/idv/socure/errors/show.html.erb_spec.rb
+++ b/spec/views/idv/socure/errors/show.html.erb_spec.rb
@@ -131,4 +131,41 @@ RSpec.describe 'idv/socure/errors/show.html.erb' do
       )
     end
   end
+
+  context 'selfie fail error' do
+    let(:error_code) { :selfie_fail }
+
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      assign(:presenter, presenter)
+
+      render
+    end
+
+    it 'shows correct h1' do
+      expect(rendered).to have_css('h1', text: t('doc_auth.errors.selfie_fail_heading'))
+    end
+
+    it 'shows selfie failure message' do
+      expect(rendered).to have_text(t('doc_auth.errors.general.selfie_failure'))
+    end
+
+    it 'shows remaining attempts' do
+      expect(rendered).to have_text(
+        strip_tags(
+          t(
+            'doc_auth.rate_limit_warning_html',
+            count: remaining_submit_attempts,
+          ),
+        ),
+      )
+    end
+
+    it 'shows a primary action' do
+      expect(rendered).to have_link(
+        t('idv.failure.button.warning'),
+        href: idv_socure_document_capture_path,
+      )
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16231](https://cm-jira.usa.gov/browse/LG-16231)

## 🛠 Summary of changes

Added specific error messaging for selfie verification failures in the Socure IAL2 document capture flow. When users successfully upload their ID but their selfie doesn't match the ID photo, they now see a clear "We couldn't match the photo of yourself to your ID" error message instead of a generic failure.

## 📜 Testing Plan

[ ] Update `config/application.yml` with` idv_socure_reason_codes_docv_selfie_fail: '["R810"]'` and `facial_match_general_availability_enabled: true`
[ ] Trigger Socure DocV flow with portrait matching failure (reason code R810) and verify "We couldn't match the photo of yourself to your ID" error displays
[ ] Verify error message appears in all supported languages (English, Spanish, French, Chinese)

## 👀 Screenshots
![Simulator Screenshot - iPhone 16 Pro - 2025-06-11 at 15 11 33](https://github.com/user-attachments/assets/0a81bd73-c508-43f5-9988-cea43618d2b4)
![Simulator Screenshot - iPhone 16 Pro - 2025-06-11 at 15 12 23](https://github.com/user-attachments/assets/0097aa5f-cbda-4579-a53f-a04ae7308e01)
![Simulator Screenshot - iPhone 16 Pro - 2025-06-11 at 15 12 52](https://github.com/user-attachments/assets/4aba0017-edf1-44b4-be4c-dc49052a238c)
![Simulator Screenshot - iPhone 16 Pro - 2025-06-11 at 15 11 57](https://github.com/user-attachments/assets/847eca57-55bf-4b95-80d1-b3ae376f16bd)
