### PR TITLE
1042 Added column deleted_at  as timestamp with TableSummaryStatsExportJob

### DIFF
--- a/app/jobs/data_warehouse/table_summary_stats_export_job.rb
+++ b/app/jobs/data_warehouse/table_summary_stats_export_job.rb
@@ -16,6 +16,7 @@ module DataWarehouse
       'sp_return_logs' => 'returned_at',
       'registration_logs' => 'registered_at',
       'letter_requests_to_usps_ftp_logs' => 'ftp_at',
+      'deleted_users' => 'deleted_at',
     }.freeze
 
     def perform(timestamp)


### PR DESCRIPTION
changelog: Internal, Reporting,add timestamp_column to deleted_user

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-teams/Team-Data/data-warehouse-ag/-/issues/1042



## 🛠 Summary of changes

We're seeing count discrepancies between the IDP and Redshift deleted_user tables. This PR will address that by updating the job to consider the deleted_at column when getting counts for the deleted_user table.



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Unit test verified 
- [x] verified in sandbox



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
