### PR TITLE
 Pull Socure Doc Escrow into a job

### DIFF
--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -55,40 +55,73 @@ class SocureDocvResultsJob < ApplicationJob
   private
 
   def record_attempt(docv_result_response:, doc_pii_response: nil)
-    job_data = {
-      reference_id: docv_result_response.to_h[:reference_id],
-      document_capture_session_uuid:,
-      pii_from_doc: docv_result_response.pii_from_doc.to_h || {},
-      failure_reason: failure_reason(docv_result_response:, doc_pii_response:) || {},
-      success: docv_result_response.success? && doc_pii_response.success?,
-    }
+    image_errors = {}
 
-    if IdentityConfig.store.ruby_workers_idv_enabled
-      SocureImageRetrievalJob.perform_later(**job_data)
-    else
-      SocureImageRetrievalJob.perform_now(**job_data)
-    end
-  end
+    if socure_doc_escrow_enabled?
+      front = {
+        document_front_image_file_id: doc_escrow_name,
+        document_front_image_encryption_key: doc_escrow_key,
+      }
+      back = {
+        document_back_image_file_id: doc_escrow_name,
+        document_back_image_encryption_key: doc_escrow_key,
+      }
 
-  def failure_reason(docv_result_response:, doc_pii_response: nil)
-    if doc_pii_response.present?
-      parse_failure_reason(doc_pii_response)
-    else
-      failures = parse_failure_reason(docv_result_response) || {}
-      failures[:socure].presence || failures
-    end
-  end
+      image_storage_data = { front:, back: }
 
-  def parse_failure_reason(result)
-    errors = result.to_h[:error_details]
+      if docv_result_response.liveness_enabled
+        selfie = {
+          document_selfie_image_file_id: doc_escrow_name,
+          document_selfie_image_encryption_key: doc_escrow_key,
+        }
+        image_storage_data[:selfie] = selfie
+      end
 
-    if errors.present?
-      parsed_errors = errors.keys.index_with do |k|
-        errors[k].keys
+      job_data = {
+        document_capture_session_uuid:,
+        reference_id: docv_result_response.to_h[:reference_id],
+        image_storage_data:,
+      }
+
+      if IdentityConfig.store.ruby_workers_idv_enabled
+        SocureImageRetrievalJob.perform_later(**job_data)
+      else
+        SocureImageRetrievalJob.perform_now(**job_data)
       end
     end
 
-    parsed_errors || result.errors.presence
+    pii_from_doc = docv_result_response.pii_from_doc.to_h || {}
+
+    attempts_api_tracker.idv_document_upload_submitted(
+      **front,
+      **back,
+      **selfie,
+      success: docv_result_response.success? && doc_pii_response.success?,
+      document_state: pii_from_doc[:state],
+      document_number: pii_from_doc[:state_id_number],
+      document_issued: pii_from_doc[:state_id_issued],
+      document_expiration: pii_from_doc[:state_id_expiration],
+      first_name: pii_from_doc[:first_name],
+      last_name: pii_from_doc[:last_name],
+      date_of_birth: pii_from_doc[:dob],
+      address1: pii_from_doc[:address1],
+      address2: pii_from_doc[:address2],
+      city: pii_from_doc[:city],
+      state: pii_from_doc[:state],
+      zip: pii_from_doc[:zipcode],
+      failure_reason: failure_reason(docv_result_response:, doc_pii_response:, image_errors:),
+    )
+  end
+
+  def failure_reason(docv_result_response:, image_errors:, doc_pii_response: nil)
+    if doc_pii_response.present?
+      failures = attempts_api_tracker.parse_failure_reason(doc_pii_response) || {}
+    else
+      failures = attempts_api_tracker.parse_failure_reason(docv_result_response) || {}
+      failures = failures[:socure].presence || failures || {}
+    end
+
+    failures.merge(image_errors).presence
   end
 
   def analytics
@@ -97,6 +130,18 @@ class SocureDocvResultsJob < ApplicationJob
       request: nil,
       session: {},
       sp: document_capture_session.issuer,
+    )
+  end
+
+  def attempts_api_tracker
+    @attempts_api_tracker ||= AttemptsApi::Tracker.new(
+      session_id: nil,
+      request: nil,
+      user: document_capture_session.user,
+      sp:,
+      cookie_device_uuid: nil,
+      sp_request_uri: nil,
+      enabled_for_session: sp&.attempts_api_enabled?,
     )
   end
 
@@ -149,5 +194,21 @@ class SocureDocvResultsJob < ApplicationJob
       user: document_capture_session.user,
       rate_limit_type: :idv_doc_auth,
     )
+  end
+
+  def sp
+    @sp ||= ServiceProvider.find_by(issuer: document_capture_session.issuer)
+  end
+
+  def socure_doc_escrow_enabled?
+    sp&.attempts_api_enabled? && IdentityConfig.store.socure_doc_escrow_enabled
+  end
+
+  def doc_escrow_name
+    SecureRandom.uuid
+  end
+
+  def doc_escrow_key
+    SecureRandom.bytes(32)
   end
 end

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -57,7 +57,8 @@ class SocureDocvResultsJob < ApplicationJob
   def record_attempt(docv_result_response:, doc_pii_response: nil)
     image_errors = {}
 
-    if socure_doc_escrow_enabled?
+    if socure_doc_escrow_enabled? &&
+       docv_result_response.instance_of?(DocAuth::Socure::Responses::DocvResultResponse)
       front = {
         document_front_image_file_id: doc_escrow_name,
         document_front_image_encryption_key: doc_escrow_key,
@@ -209,6 +210,6 @@ class SocureDocvResultsJob < ApplicationJob
   end
 
   def doc_escrow_key
-    SecureRandom.bytes(32)
+    Base64.strict_encode64(SecureRandom.bytes(32))
   end
 end

--- a/app/jobs/socure_image_retrieval_job.rb
+++ b/app/jobs/socure_image_retrieval_job.rb
@@ -16,12 +16,17 @@ class SocureImageRetrievalJob < ApplicationJob
     if result.is_a?(Idv::IdvImages)
       result.write_with_data(image_storage_data:)
     else
-      # removing the encryption keys from the failure data
-      failure_data = image_storage_data
-        .map { |k, v| v.select { |val| val.match(/file_id$/) } }
-        .reduce({}) { |a, b| a.merge(b) }
       attempts_api_tracker.idv_image_retrieval_failed(
-        **failure_data,
+        document_back_image_file_id: image_storage_data.dig(:back, :document_back_image_file_id),
+        document_front_image_file_id: image_storage_data.dig(:front, :document_front_image_file_id),
+        document_passport_image_file_id: image_storage_data.dig(
+          :passport,
+          :document_passport_image_file_id,
+        ),
+        document_selfie_image_file_id: image_storage_data.dig(
+          :selfie,
+          :document_selfie_image_file_id,
+        ),
       )
     end
   end

--- a/app/jobs/socure_image_retrieval_job.rb
+++ b/app/jobs/socure_image_retrieval_job.rb
@@ -17,7 +17,7 @@ class SocureImageRetrievalJob < ApplicationJob
       result.write_with_data(image_storage_data:)
     else
       attempts_api_tracker.idv_image_retrieval_failed(
-        **image_storage_data,
+        **image_storage_data.values.reduce({}) { |a, b| a.merge(b) },
       )
     end
   end

--- a/app/jobs/socure_image_retrieval_job.rb
+++ b/app/jobs/socure_image_retrieval_job.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class SocureImageRetrievalJob < ApplicationJob
+  queue_as :high_socure_docv
+
+  attr_reader :document_capture_session_uuid
+
+  def perform(
+    reference_id:,
+    document_capture_session_uuid:,
+    failure_reason:,
+    success:,
+    pii_from_doc: {}
+  )
+    @document_capture_session_uuid = document_capture_session_uuid
+
+    image_errors = {}
+
+    if socure_doc_escrow_enabled?
+      result = fetch_images(reference_id)
+      if result.is_a?(Idv::IdvImages)
+        images = result.attempts_file_data
+      else
+        image_errors = { image_request: [:network_error] }
+      end
+    else
+      images = {}
+    end
+
+    attempts_api_tracker.idv_document_upload_submitted(
+      **images,
+      success:,
+      document_state: pii_from_doc[:state],
+      document_number: pii_from_doc[:state_id_number],
+      document_issued: pii_from_doc[:state_id_issued],
+      document_expiration: pii_from_doc[:state_id_expiration],
+      first_name: pii_from_doc[:first_name],
+      last_name: pii_from_doc[:last_name],
+      date_of_birth: pii_from_doc[:dob],
+      address1: pii_from_doc[:address1],
+      address2: pii_from_doc[:address2],
+      city: pii_from_doc[:city],
+      state: pii_from_doc[:state],
+      zip: pii_from_doc[:zipcode],
+      failure_reason: failure_reason.merge(image_errors).presence,
+    )
+  end
+
+  def attempts_api_tracker
+    @attempts_api_tracker ||= AttemptsApi::Tracker.new(
+      session_id: nil,
+      request: nil,
+      user: document_capture_session.user,
+      sp:,
+      cookie_device_uuid: nil,
+      sp_request_uri: nil,
+      enabled_for_session: sp&.attempts_api_enabled?,
+    )
+  end
+
+  def document_capture_session
+    @document_capture_session ||=
+      DocumentCaptureSession.find_by(uuid: document_capture_session_uuid)
+  end
+
+  def fetch_images(reference_id)
+    DocAuth::Socure::Requests::ImagesRequest.new(
+      reference_id:,
+    ).fetch
+  end
+
+  def sp
+    @sp ||= ServiceProvider.find_by(issuer: document_capture_session.issuer)
+  end
+
+  def socure_doc_escrow_enabled?
+    sp&.attempts_api_enabled? && IdentityConfig.store.socure_doc_escrow_enabled
+  end
+end

--- a/app/jobs/socure_image_retrieval_job.rb
+++ b/app/jobs/socure_image_retrieval_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SocureImageRetrievalJob < ApplicationJob
-  queue_as :high_socure_docv
+  queue_as :default
 
   attr_reader :document_capture_session_uuid
 

--- a/app/jobs/socure_image_retrieval_job.rb
+++ b/app/jobs/socure_image_retrieval_job.rb
@@ -16,8 +16,12 @@ class SocureImageRetrievalJob < ApplicationJob
     if result.is_a?(Idv::IdvImages)
       result.write_with_data(image_storage_data:)
     else
+      # removing the encryption keys from the failure data
+      failure_data = image_storage_data
+        .map { |k, v| v.select { |val| val.match(/file_id$/) } }
+        .reduce({}) { |a, b| a.merge(b) }
       attempts_api_tracker.idv_image_retrieval_failed(
-        **image_storage_data.values.reduce({}) { |a, b| a.merge(b) },
+        **failure_data,
       )
     end
   end

--- a/app/jobs/socure_image_retrieval_job.rb
+++ b/app/jobs/socure_image_retrieval_job.rb
@@ -6,44 +6,20 @@ class SocureImageRetrievalJob < ApplicationJob
   attr_reader :document_capture_session_uuid
 
   def perform(
-    reference_id:,
     document_capture_session_uuid:,
-    failure_reason:,
-    success:,
-    pii_from_doc: {}
+    reference_id:,
+    image_storage_data:
   )
     @document_capture_session_uuid = document_capture_session_uuid
 
-    image_errors = {}
-
-    if socure_doc_escrow_enabled?
-      result = fetch_images(reference_id)
-      if result.is_a?(Idv::IdvImages)
-        images = result.attempts_file_data
-      else
-        image_errors = { image_request: [:network_error] }
-      end
+    result = fetch_images(reference_id)
+    if result.is_a?(Idv::IdvImages)
+      result.write_with_data(image_storage_data:)
     else
-      images = {}
+      attempts_api_tracker.idv_image_retrieval_failed(
+        **image_storage_data,
+      )
     end
-
-    attempts_api_tracker.idv_document_upload_submitted(
-      **images,
-      success:,
-      document_state: pii_from_doc[:state],
-      document_number: pii_from_doc[:state_id_number],
-      document_issued: pii_from_doc[:state_id_issued],
-      document_expiration: pii_from_doc[:state_id_expiration],
-      first_name: pii_from_doc[:first_name],
-      last_name: pii_from_doc[:last_name],
-      date_of_birth: pii_from_doc[:dob],
-      address1: pii_from_doc[:address1],
-      address2: pii_from_doc[:address2],
-      city: pii_from_doc[:city],
-      state: pii_from_doc[:state],
-      zip: pii_from_doc[:zipcode],
-      failure_reason: failure_reason.merge(image_errors).presence,
-    )
   end
 
   def attempts_api_tracker
@@ -71,9 +47,5 @@ class SocureImageRetrievalJob < ApplicationJob
 
   def sp
     @sp ||= ServiceProvider.find_by(issuer: document_capture_session.issuer)
-  end
-
-  def socure_doc_escrow_enabled?
-    sp&.attempts_api_enabled? && IdentityConfig.store.socure_doc_escrow_enabled
   end
 end

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -134,35 +134,23 @@ module AttemptsApi
       )
     end
 
-    # @param [String] document_back_image_encryption_key Base64-encoded AES key used for back
     # @param [String] document_back_image_file_id Filename in S3 w/encrypted data for back image
-    # @param [String] document_front_image_encryption_key Base64-encoded AES key used for front
     # @param [String] document_passport_image_file_id Filename in S3 w/encry data for passport image
-    # @param [String] document_passport_image_encryption_key Base64-encoded AES key for passport
     # @param [String] document_front_image_file_id Filename in S3 w/encrypted data for front image
-    # @param [String] document_selfie_image_encryption_key Base64-encoded AES key used for selfie
     # @param [String] document_selfie_image_file_id Filename in S3 w/encrypted data for selfie image
     # We were unable to retrieve the images from the identity verification vendor.
     # This is usually due to a timeout or network error.
     def idv_image_retrieval_failed(
-      document_back_image_encryption_key: nil,
       document_back_image_file_id: nil,
-      document_front_image_encryption_key: nil,
       document_front_image_file_id: nil,
       document_passport_image_file_id: nil,
-      document_passport_image_encryption_key: nil,
-      document_selfie_image_encryption_key: nil,
       document_selfie_image_file_id: nil
     )
       track_event(
         :idv_image_retrieval_failed,
-        document_back_image_encryption_key:,
         document_back_image_file_id:,
-        document_front_image_encryption_key:,
         document_front_image_file_id:,
         document_passport_image_file_id:,
-        document_passport_image_encryption_key:,
-        document_selfie_image_encryption_key:,
         document_selfie_image_file_id:,
       )
     end

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -134,6 +134,29 @@ module AttemptsApi
       )
     end
 
+    def idv_image_retrieval_failed(
+      document_back_image_encryption_key: nil,
+      document_back_image_file_id: nil,
+      document_front_image_encryption_key: nil,
+      document_front_image_file_id: nil,
+      document_passport_image_file_id: nil,
+      document_passport_image_encryption_key: nil,
+      document_selfie_image_encryption_key: nil,
+      document_selfie_image_file_id: nil
+    )
+      track_event(
+        :idv_image_retrieval_failed,
+        document_back_image_encryption_key:,
+        document_back_image_file_id:,
+        document_front_image_encryption_key:,
+        document_front_image_file_id:,
+        document_passport_image_file_id:,
+        document_passport_image_encryption_key:,
+        document_selfie_image_encryption_key:,
+        document_selfie_image_file_id:,
+      )
+    end
+
     # @param [Boolean] success True if the link user clicked on is valid and not expired
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
     # A user clicks the email link to reset their password

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -134,6 +134,16 @@ module AttemptsApi
       )
     end
 
+    # @param [String] document_back_image_encryption_key Base64-encoded AES key used for back
+    # @param [String] document_back_image_file_id Filename in S3 w/encrypted data for back image
+    # @param [String] document_front_image_encryption_key Base64-encoded AES key used for front
+    # @param [String] document_passport_image_file_id Filename in S3 w/encry data for passport image
+    # @param [String] document_passport_image_encryption_key Base64-encoded AES key for passport
+    # @param [String] document_front_image_file_id Filename in S3 w/encrypted data for front image
+    # @param [String] document_selfie_image_encryption_key Base64-encoded AES key used for selfie
+    # @param [String] document_selfie_image_file_id Filename in S3 w/encrypted data for selfie image
+    # We were unable to retrieve the images from the identity verification vendor.
+    # This is usually due to a timeout or network error.
     def idv_image_retrieval_failed(
       document_back_image_encryption_key: nil,
       document_back_image_file_id: nil,

--- a/app/services/doc_auth/dos/request.rb
+++ b/app/services/doc_auth/dos/request.rb
@@ -6,7 +6,7 @@ module DocAuth
       attr_accessor :correlation_id
 
       def fetch
-        # return DocAuth::Respose with DocAuth:Error if workflow invalid
+        # return DocAuth::Response with DocAuth:Error if workflow invalid
         http_response = send_http_request
         # log
         return handle_invalid_response(http_response) unless http_response.success?

--- a/app/services/doc_auth/socure/responses/docv_result_response.rb
+++ b/app/services/doc_auth/socure/responses/docv_result_response.rb
@@ -74,6 +74,10 @@ module DocAuth
           :not_processed
         end
 
+        def liveness_enabled
+          selfie_status != :not_processed
+        end
+
         def extra_attributes
           {
             address_line2_present: address2.present?,
@@ -208,10 +212,6 @@ module DocAuth
 
         def reason_codes_selfie_not_processed
           IdentityConfig.store.idv_socure_reason_codes_docv_selfie_not_processed
-        end
-
-        def liveness_enabled
-          selfie_status != :not_processed
         end
       end
     end

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -29,6 +29,16 @@ module EncryptedDocStorage
       )
     end
 
+    def write_with_data(image:, data:)
+      img_key = data.find { |k, _v| k.match?(/_encryption_key$/) }.last
+      name = data.find { |k, _v| k.match?(/_file_id$/) }.last
+
+      storage.write_image(
+        encrypted_image: aes_cipher.encrypt(image, Base64.strict_decode64(img_key)),
+        name:,
+      )
+    end
+
     private
 
     def aes_cipher

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -29,12 +29,9 @@ module EncryptedDocStorage
       )
     end
 
-    def write_with_data(image:, data:)
-      img_key = data.find { |k, _v| k.match?(/_encryption_key$/) }.last
-      name = data.find { |k, _v| k.match?(/_file_id$/) }.last
-
+    def write_with_data(image:, encryption_key:, name:)
       storage.write_image(
-        encrypted_image: aes_cipher.encrypt(image, Base64.strict_decode64(img_key)),
+        encrypted_image: aes_cipher.encrypt(image, encryption_key),
         name:,
       )
     end

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -18,8 +18,9 @@ module EncryptedDocStorage
 
       name = SecureRandom.uuid
 
-      storage.write_image(
-        encrypted_image: aes_cipher.encrypt(image, key),
+      write_with_data(
+        image:,
+        encryption_key: key,
         name:,
       )
 

--- a/app/services/idv/idv_images.rb
+++ b/app/services/idv/idv_images.rb
@@ -31,7 +31,12 @@ module Idv
         image = send(key)
         next unless image.present?
 
-        write_image_with_data(image.bytes, data: image_storage_data[key])
+        encryption_key = Base64.strict_decode64(
+          image_storage_data[key][image.attempts_tracker_encryption_key],
+        )
+        name = image_storage_data[key][image.attempts_tracker_file_id_key]
+
+        write_image_with_data(image.bytes, encryption_key:, name:)
       end
     end
 
@@ -77,8 +82,8 @@ module Idv
       encrypted_document_storage_writer.write(image:)
     end
 
-    def write_image_with_data(image, data:)
-      encrypted_document_storage_writer.write_with_data(image:, data:)
+    def write_image_with_data(image, encryption_key:, name:)
+      encrypted_document_storage_writer.write_with_data(image:, encryption_key:, name:)
     end
 
     def encrypted_document_storage_writer

--- a/app/services/idv/idv_images.rb
+++ b/app/services/idv/idv_images.rb
@@ -26,6 +26,15 @@ module Idv
       end
     end
 
+    def write_with_data(image_storage_data:)
+      image_storage_data.keys.each do |key|
+        image = send(key)
+        next unless image.present?
+
+        write_image_with_data(image.bytes, data: image_storage_data[key])
+      end
+    end
+
     def submittable_images
       images.each_with_object({}) do |image, obj|
         obj[image.upload_key] = image.bytes
@@ -65,7 +74,11 @@ module Idv
     private
 
     def write_image(image)
-      encrypted_document_storage_writer.write(image: image)
+      encrypted_document_storage_writer.write(image:)
+    end
+
+    def write_image_with_data(image, data:)
+      encrypted_document_storage_writer.write_with_data(image:, data:)
     end
 
     def encrypted_document_storage_writer

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvImageRetrievalFailed.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvImageRetrievalFailed.yml
@@ -1,0 +1,26 @@
+description: |
+  There was a network error while attempting to retrieve the images for document escrow.
+  Therefore, document upload failed.
+  These image file names and encryption keys are invalid, and are not saved in the document escrow.
+allOf:
+  - $ref: "../shared/EventProperties.yml"
+  - type: object
+    properties:
+      document_front_image_file_id:
+        type: string
+        description: If this image existed, the ID  generated for storage
+      document_back_image_file_id:
+        type: string
+        description: If this image existed, the ID  generated for storage
+      document_selfie_image_file_id:
+        type: string
+        description: If this image existed, the ID  generated for storage
+      document_front_image_encryption_key:
+        type: string
+        description: Randomly generated Base64-encoded key generated to encrypt the front image file if it exists.
+      document_back_image_encryption_key:
+        type: string
+        description: Randomly generated Base64-encoded key generated to encrypt the back image file if it exists.
+      document_selfie_image_encryption_key:
+        type: string
+        description: Randomly generated Base64-encoded key generated to encrypt the selfie image file if it exists.

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -266,9 +266,7 @@ RSpec.describe SocureDocvResultsJob do
                 )
 
                 expect(attempts_api_tracker).to receive(:idv_image_retrieval_failed).with(
-                  document_back_image_encryption_key: doc_escrow_key,
                   document_back_image_file_id: doc_escrow_name,
-                  document_front_image_encryption_key: doc_escrow_key,
                   document_front_image_file_id: doc_escrow_name,
                 )
 

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -18,9 +18,6 @@ RSpec.describe SocureDocvResultsJob do
   let(:reason_codes) { %w[I831 R810] }
   let(:writer) { EncryptedDocStorage::DocWriter.new }
   let(:socure_doc_escrow_enabled) { false }
-  let(:result) do
-    EncryptedDocStorage::DocWriter::Result.new(name: 'name', encryption_key: '12345')
-  end
   let(:selfie) { false }
 
   before do
@@ -32,20 +29,21 @@ RSpec.describe SocureDocvResultsJob do
       .and_return(socure_idplus_base_url)
     allow(Analytics).to receive(:new).and_return(fake_analytics)
     allow(AttemptsApi::Tracker).to receive(:new).and_return(attempts_api_tracker)
-    allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
 
     enable_attempts_api if socure_doc_escrow_enabled
-
-    allow(writer).to receive(:write).and_return(result)
   end
 
   def enable_attempts_api
     allow(IdentityConfig.store).to receive(:socure_doc_escrow_enabled).and_return(
       socure_doc_escrow_enabled,
     )
+    allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
+    allow(writer).to receive(:write_with_data)
+
     allow(IdentityConfig.store).to receive(:attempts_api_enabled).and_return(
       socure_doc_escrow_enabled,
     )
+
     allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return(
       [{ 'issuer' => sp.issuer }],
     )
@@ -188,16 +186,16 @@ RSpec.describe SocureDocvResultsJob do
         context 'we get a 200-http response from the image endpoint' do
           before do
             expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-            expect(writer).to receive(:write).exactly(2).times
+            expect(writer).to receive(:write_with_data).exactly(2).times
           end
 
           it 'stores the images via doc escrow' do
             expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: true,
-              document_back_image_encryption_key: '12345',
-              document_back_image_file_id: 'name',
-              document_front_image_encryption_key: '12345',
-              document_front_image_file_id: 'name',
+              document_back_image_encryption_key: an_instance_of(String),
+              document_back_image_file_id: an_instance_of(String),
+              document_front_image_encryption_key: an_instance_of(String),
+              document_front_image_file_id: an_instance_of(String),
               document_state: address_data[:state],
               document_number: pii_from_doc[:documentNumber],
               document_issued: Date.parse(pii_from_doc[:issueDate]),
@@ -226,6 +224,8 @@ RSpec.describe SocureDocvResultsJob do
               let(:referenceId) { '360ae43f-123f-47ab-8e05-6af79752e76c' }
               let(:msg) { 'InternalServerException' }
               let(:socure_image_response_body) { { status:, referenceId:, msg: } }
+              let(:doc_escrow_name) { 'doc_escrow_name' }
+              let(:doc_escrow_key) { 'doc_escrow_key' }
 
               before do
                 stub_request(:get, "https://upload.socure.us/api/5.0/documents/#{socure_response_body[:referenceId]}")
@@ -238,9 +238,18 @@ RSpec.describe SocureDocvResultsJob do
                   )
               end
 
+              before do
+                allow(job).to receive(:doc_escrow_name).and_return(doc_escrow_name)
+                allow(job).to receive(:doc_escrow_key).and_return(doc_escrow_key)
+              end
+
               it 'tracks the attempt with an image-specific network error' do
                 expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                   success: true,
+                  document_back_image_encryption_key: doc_escrow_key,
+                  document_back_image_file_id: doc_escrow_name,
+                  document_front_image_encryption_key: doc_escrow_key,
+                  document_front_image_file_id: doc_escrow_name,
                   document_state: address_data[:state],
                   document_number: pii_from_doc[:documentNumber],
                   document_issued: Date.parse(pii_from_doc[:issueDate]),
@@ -253,7 +262,14 @@ RSpec.describe SocureDocvResultsJob do
                   city: address_data[:city],
                   state: address_data[:state],
                   zip: address_data[:zip],
-                  failure_reason: { image_request: [:network_error] },
+                  failure_reason: nil,
+                )
+
+                expect(attempts_api_tracker).to receive(:idv_image_retrieval_failed).with(
+                  document_back_image_encryption_key: doc_escrow_key,
+                  document_back_image_file_id: doc_escrow_name,
+                  document_front_image_encryption_key: doc_escrow_key,
+                  document_front_image_file_id: doc_escrow_name,
                 )
 
                 perform
@@ -293,18 +309,18 @@ RSpec.describe SocureDocvResultsJob do
 
             before do
               expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-              expect(writer).to receive(:write).exactly(3).times
+              expect(writer).to receive(:write_with_data).exactly(3).times
             end
 
             it 'stores the images via doc escrow' do
               expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                 success: true,
-                document_back_image_encryption_key: '12345',
-                document_back_image_file_id: 'name',
-                document_front_image_encryption_key: '12345',
-                document_front_image_file_id: 'name',
-                document_selfie_image_encryption_key: '12345',
-                document_selfie_image_file_id: 'name',
+                document_back_image_encryption_key: an_instance_of(String),
+                document_back_image_file_id: an_instance_of(String),
+                document_front_image_encryption_key: an_instance_of(String),
+                document_front_image_file_id: an_instance_of(String),
+                document_selfie_image_encryption_key: an_instance_of(String),
+                document_selfie_image_file_id: an_instance_of(String),
                 document_state: address_data[:state],
                 document_number: pii_from_doc[:documentNumber],
                 document_issued: Date.parse(pii_from_doc[:issueDate]),
@@ -343,12 +359,12 @@ RSpec.describe SocureDocvResultsJob do
               it 'stores the images via doc escrow' do
                 expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                   success: false,
-                  document_back_image_encryption_key: '12345',
-                  document_back_image_file_id: 'name',
-                  document_front_image_encryption_key: '12345',
-                  document_front_image_file_id: 'name',
-                  document_selfie_image_encryption_key: '12345',
-                  document_selfie_image_file_id: 'name',
+                  document_back_image_encryption_key: an_instance_of(String),
+                  document_back_image_file_id: an_instance_of(String),
+                  document_front_image_encryption_key: an_instance_of(String),
+                  document_front_image_file_id: an_instance_of(String),
+                  document_selfie_image_encryption_key: an_instance_of(String),
+                  document_selfie_image_file_id: an_instance_of(String),
                   document_state: address_data[:state],
                   document_number: pii_from_doc[:documentNumber],
                   document_issued: Date.parse(pii_from_doc[:issueDate]),
@@ -437,10 +453,10 @@ RSpec.describe SocureDocvResultsJob do
           it 'stores the images via doc escrow' do
             expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: false,
-              document_back_image_encryption_key: '12345',
-              document_back_image_file_id: 'name',
-              document_front_image_encryption_key: '12345',
-              document_front_image_file_id: 'name',
+              document_back_image_encryption_key: an_instance_of(String),
+              document_back_image_file_id: an_instance_of(String),
+              document_front_image_encryption_key: an_instance_of(String),
+              document_front_image_file_id: an_instance_of(String),
               document_state: address_data[:state],
               document_number: pii_from_doc[:documentNumber],
               document_issued: Date.parse(pii_from_doc[:issueDate]),
@@ -486,10 +502,10 @@ RSpec.describe SocureDocvResultsJob do
           it 'stores the images via doc escrow' do
             expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: false,
-              document_back_image_encryption_key: '12345',
-              document_back_image_file_id: 'name',
-              document_front_image_encryption_key: '12345',
-              document_front_image_file_id: 'name',
+              document_back_image_encryption_key: an_instance_of(String),
+              document_back_image_file_id: an_instance_of(String),
+              document_front_image_encryption_key: an_instance_of(String),
+              document_front_image_file_id: an_instance_of(String),
               document_state: nil,
               document_number: nil,
               document_issued: nil,
@@ -531,10 +547,10 @@ RSpec.describe SocureDocvResultsJob do
           it 'tracks the attempt and stores the images via doc escrow' do
             expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: false,
-              document_back_image_encryption_key: '12345',
-              document_back_image_file_id: 'name',
-              document_front_image_encryption_key: '12345',
-              document_front_image_file_id: 'name',
+              document_back_image_encryption_key: an_instance_of(String),
+              document_back_image_file_id: an_instance_of(String),
+              document_front_image_encryption_key: an_instance_of(String),
+              document_front_image_file_id: an_instance_of(String),
               document_state: address_data[:state],
               document_number: pii_from_doc[:documentNumber],
               document_issued: Date.parse(pii_from_doc[:issueDate]),
@@ -660,10 +676,6 @@ RSpec.describe SocureDocvResultsJob do
             it 'tracks the attempt and stores the images via doc escrow' do
               expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                 success: false,
-                document_back_image_encryption_key: '12345',
-                document_back_image_file_id: 'name',
-                document_front_image_encryption_key: '12345',
-                document_front_image_file_id: 'name',
                 document_state: nil,
                 document_number: nil,
                 document_issued: nil,

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -268,6 +268,8 @@ RSpec.describe SocureDocvResultsJob do
                 expect(attempts_api_tracker).to receive(:idv_image_retrieval_failed).with(
                   document_back_image_file_id: doc_escrow_name,
                   document_front_image_file_id: doc_escrow_name,
+                  document_passport_image_file_id: nil,
+                  document_selfie_image_file_id: nil,
                 )
 
                 perform

--- a/spec/jobs/socure_image_retrieval_job_spec.rb
+++ b/spec/jobs/socure_image_retrieval_job_spec.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SocureImageRetrievalJob do
+  let(:job) { described_class.new }
+  let(:attempts_api_tracker) { AttemptsApiTrackingHelper::FakeAttemptsTracker.new }
+  let(:sp) { create(:service_provider) }
+  let(:user) { create(:user) }
+  let(:document_capture_session) do
+    DocumentCaptureSession.create(user:).tap do |dcs|
+      dcs.socure_docv_transaction_token = '1234'
+    end
+  end
+  let(:document_capture_session_uuid) { document_capture_session.uuid }
+  let(:reference_id) { 'image-reference-id' }
+  let(:socure_image_endpoint) { "https://upload.socure.us/api/5.0/documents/#{reference_id}" }
+  let(:pii_from_doc) { Idp::Constants::MOCK_IDV_APPLICANT }
+  let(:failure_reason) { {} }
+  let(:success) { true }
+
+  let(:writer) { EncryptedDocStorage::DocWriter.new }
+  let(:socure_doc_escrow_enabled) { false }
+  let(:result) do
+    EncryptedDocStorage::DocWriter::Result.new(name: 'name', encryption_key: '12345')
+  end
+  let(:selfie) { false }
+
+  before do
+    allow(AttemptsApi::Tracker).to receive(:new).and_return(attempts_api_tracker)
+    allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
+
+    enable_attempts_api if socure_doc_escrow_enabled
+
+    allow(writer).to receive(:write).and_return(result)
+  end
+
+  def enable_attempts_api
+    document_capture_session.update(issuer: sp.issuer)
+
+    allow(IdentityConfig.store).to receive(:socure_doc_escrow_enabled).and_return(
+      socure_doc_escrow_enabled,
+    )
+    allow(IdentityConfig.store).to receive(:attempts_api_enabled).and_return(
+      socure_doc_escrow_enabled,
+    )
+    allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return(
+      [{ 'issuer' => sp.issuer }],
+    )
+  end
+
+  before do
+    stub_request(:post, socure_image_endpoint)
+      .to_return(
+        headers: {
+          'Content-Type' => 'application/zip',
+          'Content-Disposition' => 'attachment; filename=document.zip',
+        },
+        body: DocAuthImageFixtures.zipped_files(
+          reference_id:,
+          selfie:,
+        ).to_s,
+      )
+  end
+
+  describe '#perform' do
+    subject(:perform) do
+      job.perform(
+        reference_id:,
+        document_capture_session_uuid:,
+        failure_reason:,
+        success:,
+        pii_from_doc:,
+      )
+    end
+
+    context 'socure document escrow is not enabled' do
+      let(:socure_doc_escrow_enabled) { false }
+
+      before do
+        expect(EncryptedDocStorage::DocWriter).not_to receive(:new)
+      end
+
+      it 'tracks the event without the images' do
+        expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
+          success: true,
+          document_state: pii_from_doc[:state],
+          document_number: pii_from_doc[:state_id_number],
+          document_issued: pii_from_doc[:state_id_issued],
+          document_expiration: pii_from_doc[:state_id_expiration],
+          first_name: pii_from_doc[:first_name],
+          last_name: pii_from_doc[:last_name],
+          date_of_birth: pii_from_doc[:dob],
+          address1: pii_from_doc[:address1],
+          address2: pii_from_doc[:address2],
+          city: pii_from_doc[:city],
+          state: pii_from_doc[:state],
+          zip: pii_from_doc[:zipcode],
+          failure_reason: nil,
+        )
+
+        perform
+      end
+    end
+
+    context 'socure document escrow is enabled' do
+      let(:socure_doc_escrow_enabled) { true }
+
+      context 'we get a 200-http response from the image endpoint' do
+        before do
+          expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
+          expect(writer).to receive(:write).exactly(2).times
+        end
+
+        it 'stores the images via doc escrow' do
+          expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
+            success: true,
+            document_back_image_encryption_key: '12345',
+            document_back_image_file_id: 'name',
+            document_front_image_encryption_key: '12345',
+            document_front_image_file_id: 'name',
+            document_state: pii_from_doc[:state],
+            document_number: pii_from_doc[:state_id_number],
+            document_issued: pii_from_doc[:state_id_issued],
+            document_expiration: pii_from_doc[:state_id_expiration],
+            first_name: pii_from_doc[:first_name],
+            last_name: pii_from_doc[:last_name],
+            date_of_birth: pii_from_doc[:dob],
+            address1: pii_from_doc[:address1],
+            address2: pii_from_doc[:address2],
+            city: pii_from_doc[:city],
+            state: pii_from_doc[:state],
+            zip: pii_from_doc[:zipcode],
+            failure_reason: nil,
+          )
+
+          perform
+        end
+      end
+
+      context 'when we get a non-200 HTTP response back from the image endpoint' do
+        %w[400 403 404 500].each do |http_status|
+          context "Socure returns HTTP #{http_status} with an error body" do
+            let(:status) { 'Error' }
+            let(:referenceId) { '360ae43f-123f-47ab-8e05-6af79752e76c' }
+            let(:msg) { 'InternalServerException' }
+            let(:socure_image_response_body) { { status:, referenceId:, msg: } }
+
+            before do
+              stub_request(:post, socure_image_endpoint)
+                .to_return(
+                  status: http_status,
+                  headers: {
+                    'Content-Type' => 'application/json',
+                  },
+                  body: JSON.generate(socure_image_response_body),
+                )
+            end
+
+            it 'tracks the attempt with an image-specific network error' do
+              expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
+                success: true,
+                document_state: pii_from_doc[:state],
+                document_number: pii_from_doc[:state_id_number],
+                document_issued: pii_from_doc[:state_id_issued],
+                document_expiration: pii_from_doc[:state_id_expiration],
+                first_name: pii_from_doc[:first_name],
+                last_name: pii_from_doc[:last_name],
+                date_of_birth: pii_from_doc[:dob],
+                address1: pii_from_doc[:address1],
+                address2: pii_from_doc[:address2],
+                city: pii_from_doc[:city],
+                state: pii_from_doc[:state],
+                zip: pii_from_doc[:zipcode],
+                failure_reason: { image_request: [:network_error] },
+              )
+
+              perform
+            end
+          end
+        end
+      end
+    end
+
+    context 'facial match' do
+      let(:selfie) { true }
+
+      context 'when facial match successful' do
+        context 'socure document escrow is enabled' do
+          let(:socure_doc_escrow_enabled) { true }
+
+          before do
+            expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
+            expect(writer).to receive(:write).exactly(3).times
+          end
+
+          it 'stores the images via doc escrow' do
+            expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
+              success: true,
+              document_back_image_encryption_key: '12345',
+              document_back_image_file_id: 'name',
+              document_front_image_encryption_key: '12345',
+              document_front_image_file_id: 'name',
+              document_selfie_image_encryption_key: '12345',
+              document_selfie_image_file_id: 'name',
+              document_state: pii_from_doc[:state],
+              document_number: pii_from_doc[:state_id_number],
+              document_issued: pii_from_doc[:state_id_issued],
+              document_expiration: pii_from_doc[:state_id_expiration],
+              first_name: pii_from_doc[:first_name],
+              last_name: pii_from_doc[:last_name],
+              date_of_birth: pii_from_doc[:dob],
+              address1: pii_from_doc[:address1],
+              address2: pii_from_doc[:address2],
+              city: pii_from_doc[:city],
+              state: pii_from_doc[:state],
+              zip: pii_from_doc[:zipcode],
+              failure_reason: nil,
+            )
+
+            perform
+          end
+        end
+
+        context 'socure document escrow is not enabled' do
+          before do
+            expect(EncryptedDocStorage::DocWriter).not_to receive(:new)
+            expect(writer).not_to receive(:write)
+          end
+
+          it 'stores the images via doc escrow' do
+            expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
+              success: true,
+              document_state: pii_from_doc[:state],
+              document_number: pii_from_doc[:state_id_number],
+              document_issued: pii_from_doc[:state_id_issued],
+              document_expiration: pii_from_doc[:state_id_expiration],
+              first_name: pii_from_doc[:first_name],
+              last_name: pii_from_doc[:last_name],
+              date_of_birth: pii_from_doc[:dob],
+              address1: pii_from_doc[:address1],
+              address2: pii_from_doc[:address2],
+              city: pii_from_doc[:city],
+              state: pii_from_doc[:state],
+              zip: pii_from_doc[:zipcode],
+              failure_reason: nil,
+            )
+
+            perform
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/socure_image_retrieval_job_spec.rb
+++ b/spec/jobs/socure_image_retrieval_job_spec.rb
@@ -15,12 +15,8 @@ RSpec.describe SocureImageRetrievalJob do
   let(:document_capture_session_uuid) { document_capture_session.uuid }
   let(:reference_id) { 'image-reference-id' }
   let(:socure_image_endpoint) { "https://upload.socure.us/api/5.0/documents/#{reference_id}" }
-  let(:pii_from_doc) { Idp::Constants::MOCK_IDV_APPLICANT }
-  let(:failure_reason) { {} }
-  let(:success) { true }
 
   let(:writer) { EncryptedDocStorage::DocWriter.new }
-  let(:socure_doc_escrow_enabled) { false }
   let(:result) do
     EncryptedDocStorage::DocWriter::Result.new(name: 'name', encryption_key: '12345')
   end
@@ -30,23 +26,26 @@ RSpec.describe SocureImageRetrievalJob do
     allow(AttemptsApi::Tracker).to receive(:new).and_return(attempts_api_tracker)
     allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
 
-    enable_attempts_api if socure_doc_escrow_enabled
-
-    allow(writer).to receive(:write).and_return(result)
-  end
-
-  def enable_attempts_api
     document_capture_session.update(issuer: sp.issuer)
 
-    allow(IdentityConfig.store).to receive(:socure_doc_escrow_enabled).and_return(
-      socure_doc_escrow_enabled,
-    )
-    allow(IdentityConfig.store).to receive(:attempts_api_enabled).and_return(
-      socure_doc_escrow_enabled,
-    )
     allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return(
       [{ 'issuer' => sp.issuer }],
     )
+
+    allow(writer).to receive(:write_with_data).and_return(result)
+  end
+
+  let(:image_storage_data) do
+    {
+      front: {
+        document_front_image_file_id: 'name',
+        document_front_image_encryption_key: '12345',
+      },
+      back: {
+        document_back_image_file_id: 'name',
+        document_back_image_encryption_key: '12345',
+      },
+    }
   end
 
   before do
@@ -68,182 +67,48 @@ RSpec.describe SocureImageRetrievalJob do
       job.perform(
         reference_id:,
         document_capture_session_uuid:,
-        failure_reason:,
-        success:,
-        pii_from_doc:,
+        image_storage_data:,
       )
     end
 
-    context 'socure document escrow is not enabled' do
-      let(:socure_doc_escrow_enabled) { false }
-
+    context 'we get a 200-http response from the image endpoint' do
       before do
-        expect(EncryptedDocStorage::DocWriter).not_to receive(:new)
+        expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
+        expect(writer).to receive(:write_with_data).exactly(2).times
       end
 
-      it 'tracks the event without the images' do
-        expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
-          success: true,
-          document_state: pii_from_doc[:state],
-          document_number: pii_from_doc[:state_id_number],
-          document_issued: pii_from_doc[:state_id_issued],
-          document_expiration: pii_from_doc[:state_id_expiration],
-          first_name: pii_from_doc[:first_name],
-          last_name: pii_from_doc[:last_name],
-          date_of_birth: pii_from_doc[:dob],
-          address1: pii_from_doc[:address1],
-          address2: pii_from_doc[:address2],
-          city: pii_from_doc[:city],
-          state: pii_from_doc[:state],
-          zip: pii_from_doc[:zipcode],
-          failure_reason: nil,
-        )
-
+      it 'stores the images via doc escrow' do
         perform
       end
     end
 
-    context 'socure document escrow is enabled' do
-      let(:socure_doc_escrow_enabled) { true }
-
-      context 'we get a 200-http response from the image endpoint' do
-        before do
-          expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-          expect(writer).to receive(:write).exactly(2).times
-        end
-
-        it 'stores the images via doc escrow' do
-          expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
-            success: true,
-            document_back_image_encryption_key: '12345',
-            document_back_image_file_id: 'name',
-            document_front_image_encryption_key: '12345',
-            document_front_image_file_id: 'name',
-            document_state: pii_from_doc[:state],
-            document_number: pii_from_doc[:state_id_number],
-            document_issued: pii_from_doc[:state_id_issued],
-            document_expiration: pii_from_doc[:state_id_expiration],
-            first_name: pii_from_doc[:first_name],
-            last_name: pii_from_doc[:last_name],
-            date_of_birth: pii_from_doc[:dob],
-            address1: pii_from_doc[:address1],
-            address2: pii_from_doc[:address2],
-            city: pii_from_doc[:city],
-            state: pii_from_doc[:state],
-            zip: pii_from_doc[:zipcode],
-            failure_reason: nil,
-          )
-
-          perform
-        end
-      end
-
-      context 'when we get a non-200 HTTP response back from the image endpoint' do
-        %w[400 403 404 500].each do |http_status|
-          context "Socure returns HTTP #{http_status} with an error body" do
-            let(:status) { 'Error' }
-            let(:referenceId) { '360ae43f-123f-47ab-8e05-6af79752e76c' }
-            let(:msg) { 'InternalServerException' }
-            let(:socure_image_response_body) { { status:, referenceId:, msg: } }
-
-            before do
-              stub_request(:post, socure_image_endpoint)
-                .to_return(
-                  status: http_status,
-                  headers: {
-                    'Content-Type' => 'application/json',
-                  },
-                  body: JSON.generate(socure_image_response_body),
-                )
-            end
-
-            it 'tracks the attempt with an image-specific network error' do
-              expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
-                success: true,
-                document_state: pii_from_doc[:state],
-                document_number: pii_from_doc[:state_id_number],
-                document_issued: pii_from_doc[:state_id_issued],
-                document_expiration: pii_from_doc[:state_id_expiration],
-                first_name: pii_from_doc[:first_name],
-                last_name: pii_from_doc[:last_name],
-                date_of_birth: pii_from_doc[:dob],
-                address1: pii_from_doc[:address1],
-                address2: pii_from_doc[:address2],
-                city: pii_from_doc[:city],
-                state: pii_from_doc[:state],
-                zip: pii_from_doc[:zipcode],
-                failure_reason: { image_request: [:network_error] },
-              )
-
-              perform
-            end
-          end
-        end
-      end
-    end
-
-    context 'facial match' do
-      let(:selfie) { true }
-
-      context 'when facial match successful' do
-        context 'socure document escrow is enabled' do
-          let(:socure_doc_escrow_enabled) { true }
+    context 'when we get a non-200 HTTP response back from the image endpoint' do
+      %w[400 403 404 500].each do |http_status|
+        context "Socure returns HTTP #{http_status} with an error body" do
+          let(:status) { 'Error' }
+          let(:referenceId) { '360ae43f-123f-47ab-8e05-6af79752e76c' }
+          let(:msg) { 'InternalServerException' }
+          let(:socure_image_response_body) { { status:, referenceId:, msg: } }
 
           before do
-            expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-            expect(writer).to receive(:write).exactly(3).times
+            stub_request(:post, socure_image_endpoint)
+              .to_return(
+                status: http_status,
+                headers: {
+                  'Content-Type' => 'application/json',
+                },
+                body: JSON.generate(socure_image_response_body),
+              )
           end
 
-          it 'stores the images via doc escrow' do
-            expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
-              success: true,
-              document_back_image_encryption_key: '12345',
-              document_back_image_file_id: 'name',
-              document_front_image_encryption_key: '12345',
-              document_front_image_file_id: 'name',
-              document_selfie_image_encryption_key: '12345',
-              document_selfie_image_file_id: 'name',
-              document_state: pii_from_doc[:state],
-              document_number: pii_from_doc[:state_id_number],
-              document_issued: pii_from_doc[:state_id_issued],
-              document_expiration: pii_from_doc[:state_id_expiration],
-              first_name: pii_from_doc[:first_name],
-              last_name: pii_from_doc[:last_name],
-              date_of_birth: pii_from_doc[:dob],
-              address1: pii_from_doc[:address1],
-              address2: pii_from_doc[:address2],
-              city: pii_from_doc[:city],
-              state: pii_from_doc[:state],
-              zip: pii_from_doc[:zipcode],
-              failure_reason: nil,
-            )
-
-            perform
-          end
-        end
-
-        context 'socure document escrow is not enabled' do
           before do
             expect(EncryptedDocStorage::DocWriter).not_to receive(:new)
-            expect(writer).not_to receive(:write)
+            expect(writer).not_to receive(:write_with_data)
           end
 
-          it 'stores the images via doc escrow' do
-            expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
-              success: true,
-              document_state: pii_from_doc[:state],
-              document_number: pii_from_doc[:state_id_number],
-              document_issued: pii_from_doc[:state_id_issued],
-              document_expiration: pii_from_doc[:state_id_expiration],
-              first_name: pii_from_doc[:first_name],
-              last_name: pii_from_doc[:last_name],
-              date_of_birth: pii_from_doc[:dob],
-              address1: pii_from_doc[:address1],
-              address2: pii_from_doc[:address2],
-              city: pii_from_doc[:city],
-              state: pii_from_doc[:state],
-              zip: pii_from_doc[:zipcode],
-              failure_reason: nil,
+          it 'tracks the attempt with an image-specific network error' do
+            expect(attempts_api_tracker).to receive(:idv_image_retrieval_failed).with(
+              **image_storage_data,
             )
 
             perform

--- a/spec/jobs/socure_image_retrieval_job_spec.rb
+++ b/spec/jobs/socure_image_retrieval_job_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe SocureImageRetrievalJob do
   let(:front) do
     {
       document_front_image_file_id: 'name',
-      document_front_image_encryption_key: '12345',
+      document_front_image_encryption_key: Base64.strict_encode64('12345'),
     }
   end
   let(:back) do
     {
       document_back_image_file_id: 'name',
-      document_back_image_encryption_key: '12345',
+      document_back_image_encryption_key: Base64.strict_encode64('12345'),
     }
   end
 

--- a/spec/jobs/socure_image_retrieval_job_spec.rb
+++ b/spec/jobs/socure_image_retrieval_job_spec.rb
@@ -112,6 +112,8 @@ RSpec.describe SocureImageRetrievalJob do
             expect(attempts_api_tracker).to receive(:idv_image_retrieval_failed).with(
               document_front_image_file_id: 'name',
               document_back_image_file_id: 'name',
+              document_passport_image_file_id: nil,
+              document_selfie_image_file_id: nil,
             )
 
             perform

--- a/spec/jobs/socure_image_retrieval_job_spec.rb
+++ b/spec/jobs/socure_image_retrieval_job_spec.rb
@@ -35,18 +35,20 @@ RSpec.describe SocureImageRetrievalJob do
     allow(writer).to receive(:write_with_data).and_return(result)
   end
 
-  let(:image_storage_data) do
+  let(:front) do
     {
-      front: {
-        document_front_image_file_id: 'name',
-        document_front_image_encryption_key: '12345',
-      },
-      back: {
-        document_back_image_file_id: 'name',
-        document_back_image_encryption_key: '12345',
-      },
+      document_front_image_file_id: 'name',
+      document_front_image_encryption_key: '12345',
     }
   end
+  let(:back) do
+    {
+      document_back_image_file_id: 'name',
+      document_back_image_encryption_key: '12345',
+    }
+  end
+
+  let(:image_storage_data) { { front:, back: } }
 
   before do
     stub_request(:post, socure_image_endpoint)
@@ -108,7 +110,8 @@ RSpec.describe SocureImageRetrievalJob do
 
           it 'tracks the attempt with an image-specific network error' do
             expect(attempts_api_tracker).to receive(:idv_image_retrieval_failed).with(
-              **image_storage_data,
+              **front,
+              **back,
             )
 
             perform

--- a/spec/jobs/socure_image_retrieval_job_spec.rb
+++ b/spec/jobs/socure_image_retrieval_job_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SocureImageRetrievalJob do
   let(:image_storage_data) { { front:, back: } }
 
   before do
-    stub_request(:post, socure_image_endpoint)
+    stub_request(:get, socure_image_endpoint)
       .to_return(
         headers: {
           'Content-Type' => 'application/zip',
@@ -93,7 +93,7 @@ RSpec.describe SocureImageRetrievalJob do
           let(:socure_image_response_body) { { status:, referenceId:, msg: } }
 
           before do
-            stub_request(:post, socure_image_endpoint)
+            stub_request(:get, socure_image_endpoint)
               .to_return(
                 status: http_status,
                 headers: {
@@ -110,8 +110,8 @@ RSpec.describe SocureImageRetrievalJob do
 
           it 'tracks the attempt with an image-specific network error' do
             expect(attempts_api_tracker).to receive(:idv_image_retrieval_failed).with(
-              **front,
-              **back,
+              document_front_image_file_id: 'name',
+              document_back_image_file_id: 'name',
             )
 
             perform

--- a/spec/services/doc_auth/socure/requests/images_request_spec.rb
+++ b/spec/services/doc_auth/socure/requests/images_request_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe DocAuth::Socure::Requests::ImagesRequest do
 
   describe '#fetch' do
     before do
-      stub_request(:post, images_request_endpoint)
+      stub_request(:get, images_request_endpoint)
         .to_return(
           status:,
           body:,
@@ -45,7 +45,7 @@ RSpec.describe DocAuth::Socure::Requests::ImagesRequest do
     it 'fetches from the correct url' do
       subject.fetch
 
-      expect(WebMock).to have_requested(:post, images_request_endpoint)
+      expect(WebMock).to have_requested(:get, images_request_endpoint)
         .with(body: {})
     end
 
@@ -90,7 +90,7 @@ RSpec.describe DocAuth::Socure::Requests::ImagesRequest do
       let(:faraday_connection_failed_exception) { Faraday::ConnectionFailed }
 
       before do
-        stub_request(:post, images_request_endpoint).to_raise(faraday_connection_failed_exception)
+        stub_request(:get, images_request_endpoint).to_raise(faraday_connection_failed_exception)
       end
       it 'expect handle_connection_error method to be called' do
         result = subject.fetch

--- a/spec/services/doc_auth/socure/requests/images_request_spec.rb
+++ b/spec/services/doc_auth/socure/requests/images_request_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe DocAuth::Socure::Requests::ImagesRequest do
   subject(:images_request) { described_class.new(reference_id:) }
   let(:body) { DocAuthImageFixtures.zipped_files(reference_id:).to_s }
   let(:status) { 200 }
+  let(:message) do
+    [
+      subject.class.name,
+      'Unexpected HTTP response',
+      status,
+    ].join(' ')
+  end
 
   let(:connection_error_attributes) do
     {
@@ -51,13 +58,6 @@ RSpec.describe DocAuth::Socure::Requests::ImagesRequest do
 
     context 'when the response is empty' do
       let(:body) { '' }
-      let(:message) do
-        [
-          subject.class.name,
-          'Unexpected HTTP response',
-          status,
-        ].join(' ')
-      end
 
       it 'returns an error' do
         response = subject.fetch

--- a/spec/services/doc_auth/socure/requests/images_request_spec.rb
+++ b/spec/services/doc_auth/socure/requests/images_request_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe DocAuth::Socure::Requests::ImagesRequest do
+  let(:reference_id) { 'fake_reference_id' }
+  let(:images_request_endpoint) do
+    URI.join(
+      IdentityConfig.store.socure_docv_images_request_endpoint,
+      reference_id,
+    ).to_s
+  end
+
+  subject(:images_request) { described_class.new(reference_id:) }
+  let(:body) { DocAuthImageFixtures.zipped_files(reference_id:).to_s }
+  let(:status) { 200 }
+
+  let(:connection_error_attributes) do
+    {
+      success: false,
+      errors: { network: true },
+      exception: DocAuth::RequestError.new(message, status),
+      extra: {
+        vendor: 'Socure',
+        vendor_status_code: nil,
+        vendor_status_message: nil,
+      }.compact,
+    }
+  end
+
+  describe '#fetch' do
+    before do
+      stub_request(:post, images_request_endpoint)
+        .to_return(
+          status:,
+          body:,
+        )
+    end
+
+    it 'fetches from the correct url' do
+      subject.fetch
+
+      expect(WebMock).to have_requested(:post, images_request_endpoint)
+        .with(body: {})
+    end
+
+    it 'creates an IdvImages object with the binary data' do
+      response = subject.fetch
+
+      expect(response.class).to eq(Idv::IdvImages)
+      expect(response.images.first.value.class).to eq Idv::BinaryImage
+    end
+
+    context 'when the response is empty' do
+      let(:body) { '' }
+      let(:message) do
+        [
+          subject.class.name,
+          'Unexpected HTTP response',
+          status,
+        ].join(' ')
+      end
+
+      it 'returns an error' do
+        response = subject.fetch
+
+        expect(response).to eq connection_error_attributes
+      end
+    end
+
+    context 'we get a 403 back' do
+      let(:fake_socure_response) { {} }
+      let(:fake_socure_status) { 403 }
+
+      it 'does not raise an exception' do
+        expect { subject.fetch }.not_to raise_error
+      end
+    end
+
+    context 'we get a 500 back' do
+      let(:fake_socure_response) { {} }
+      let(:fake_socure_status) { 500 }
+
+      it 'does not raise an exception' do
+        expect { subject.fetch }.not_to raise_error
+      end
+    end
+
+    context 'with timeout exception' do
+      let(:response) { nil }
+      let(:response_status) { 403 }
+      let(:faraday_connection_failed_exception) { Faraday::ConnectionFailed }
+
+      before do
+        stub_request(:post, images_request_endpoint).to_raise(faraday_connection_failed_exception)
+      end
+      it 'expect handle_connection_error method to be called' do
+        result = subject.fetch
+        expect(result[:success]).to eq(connection_error_attributes[:success])
+        expect(result[:errors]).to eq(connection_error_attributes[:errors])
+        expect(result[:exception]).to be_a Faraday::ConnectionFailed
+        expect(result[:extra]).to eq(connection_error_attributes[:extra])
+      end
+    end
+  end
+end

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
         name:,
       )
 
-      subject.write_with_data(image:, data:)
+      subject.write_with_data(image:, name:, encryption_key: key)
     end
   end
 

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -1,14 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe EncryptedDocStorage::DocWriter do
+  let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg') }
+  let(:image) { File.read(img_path) }
+  subject { EncryptedDocStorage::DocWriter.new }
   describe '#write' do
-    let(:img_path) { Rails.root.join('app', 'assets', 'images', 'logo.svg') }
-    let(:image) { File.read(img_path) }
-
-    subject do
-      EncryptedDocStorage::DocWriter.new
-    end
-
     it 'encrypts the document and writes it to storage' do
       result = subject.write(image:)
 
@@ -65,9 +61,35 @@ RSpec.describe EncryptedDocStorage::DocWriter do
         end
       end
     end
+  end
 
-    def file_path(uuid)
-      Rails.root.join('tmp', 'encrypted_doc_storage', uuid)
+  describe '#write_with_data' do
+    let(:key) {  SecureRandom.bytes(32) }
+    let(:name) { 'name' }
+    let(:aes_cipher) { Encryption::AesCipherV2.new }
+    let(:data) do
+      {
+        document_front_image_file_id: name,
+        document_front_image_encryption_key: Base64.strict_encode64(key),
+      }
     end
+
+    before do
+      expect(Encryption::AesCipherV2).to receive(:new).and_return(aes_cipher)
+    end
+
+    it 'writes the image with provided data' do
+      expect(aes_cipher).to receive(:encrypt).with(image, key).and_return 'encrypted_image'
+      expect_any_instance_of(EncryptedDocStorage::LocalStorage).to receive(:write_image).with(
+        encrypted_image: 'encrypted_image',
+        name:,
+      )
+
+      subject.write_with_data(image:, data:)
+    end
+  end
+
+  def file_path(uuid)
+    Rails.root.join('tmp', 'encrypted_doc_storage', uuid)
   end
 end

--- a/spec/services/idv/idv_images_spec.rb
+++ b/spec/services/idv/idv_images_spec.rb
@@ -272,11 +272,13 @@ RSpec.describe Idv::IdvImages do
       expect(EncryptedDocStorage::DocWriter).to receive(:new).with(s3_enabled: false)
       expect(writer).to receive(:write_with_data).with(
         image: subject.front.bytes,
-        data: image_storage_data[:front],
+        encryption_key: 'front_key',
+        name: 'front_name',
       )
       expect(writer).to receive(:write_with_data).with(
         image: subject.back.bytes,
-        data: image_storage_data[:back],
+        encryption_key: 'back_key',
+        name: 'back_name',
       )
 
       subject.write_with_data(image_storage_data:)

--- a/spec/services/idv/idv_images_spec.rb
+++ b/spec/services/idv/idv_images_spec.rb
@@ -246,4 +246,40 @@ RSpec.describe Idv::IdvImages do
       end
     end
   end
+
+  describe '#write_with_data' do
+    let(:image_storage_data) do
+      {
+        front: {
+          document_front_image_file_id: 'front_name',
+          document_front_image_encryption_key: Base64.strict_encode64('front_key'),
+        },
+        back:
+        {
+          document_back_image_file_id: 'back_name',
+          document_back_image_encryption_key: Base64.strict_encode64('back_key'),
+        },
+      }
+    end
+    before do
+      allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
+      allow(IdentityConfig.store).to receive(:doc_escrow_s3_storage_enabled)
+        .and_return(doc_escrow_s3_storage_enabled)
+      allow(writer).to receive(:write_with_data)
+    end
+
+    it 'writes the image for each given image locally' do
+      expect(EncryptedDocStorage::DocWriter).to receive(:new).with(s3_enabled: false)
+      expect(writer).to receive(:write_with_data).with(
+        image: subject.front.bytes,
+        data: image_storage_data[:front],
+      )
+      expect(writer).to receive(:write_with_data).with(
+        image: subject.back.bytes,
+        data: image_storage_data[:back],
+      )
+
+      subject.write_with_data(image_storage_data:)
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Fraud mitigation 28](https://gitlab.login.gov/lg-teams/FIE/fraud-mitigation/-/issues/28)

## 🛠 Summary of changes
This change:
- Preemptively creates the encryption key and file name of the images
- Creates a `SocureImageRetrievalJob` class to handle retrieving and storing the images
- Adds a new event for indicating that the image retrieval has failed, if there is a network error of some sort
- Adds tests for `ImageRequests` as well as `SocureImageRetrievalJob`


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
