### PR TITLE
LG-16169 Skip aamva state ID check for remote passport proofing

### DIFF
--- a/app/services/proofing/resolution/plugins/aamva_plugin.rb
+++ b/app/services/proofing/resolution/plugins/aamva_plugin.rb
@@ -63,6 +63,16 @@ module Proofing
           )
         end
 
+        # @return [Proofing::StateIdResult] A result signifying that the AAMVA plugin was skipped.
+        def skipped_result
+          Proofing::StateIdResult.new(
+            errors: {},
+            exception: nil,
+            success: true,
+            vendor_name: Idp::Constants::Vendors::AAMVA_CHECK_SKIPPED,
+          )
+        end
+
         def proofer
           @proofer ||=
             if IdentityConfig.store.proofer_mock_fallback

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -78,7 +78,7 @@ module Proofing
           timer:,
         )
 
-        state_id_result = aamva_plugin.call(
+        state_id_result = process_state_id(
           applicant_pii:,
           current_sp:,
           state_id_address_resolution_result:,
@@ -169,6 +169,29 @@ module Proofing
                   "No cost token present for proofing vendor #{proofing_vendor}"
           end
         end
+      end
+
+      private
+
+      def process_state_id(
+        applicant_pii:,
+        current_sp:,
+        state_id_address_resolution_result:,
+        ipp_enrollment_in_progress:, timer:
+      )
+        return aamva_plugin.skipped_result if passport_applicant?(applicant_pii)
+
+        aamva_plugin.call(
+          applicant_pii:,
+          current_sp:,
+          state_id_address_resolution_result:,
+          ipp_enrollment_in_progress:,
+          timer:,
+        )
+      end
+
+      def passport_applicant?(applicant_pii)
+        applicant_pii[:id_doc_type] == 'passport'
       end
     end
   end

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -19,6 +19,7 @@ module Idp
       AAMVA = 'aamva'
       AAMVA_UNSUPPORTED_JURISDICTION = 'UnsupportedJurisdiction'
       STATE_ID_MOCK = 'StateIdMock'
+      AAMVA_CHECK_SKIPPED = 'AamvaCheckSkipped'
       SOURCE_CHECK = [AAMVA, AAMVA_UNSUPPORTED_JURISDICTION, STATE_ID_MOCK].freeze
     end
 
@@ -139,6 +140,29 @@ module Idp
     MOCK_IPP_PASSPORT_APPLICANT = {
       passport_number: '123456789',
       passport_expiration_date: (DateTime.now.utc + 1.year).to_s,
+    }.freeze
+
+    MOCK_IDV_PROOFING_PASSPORT_APPLICANT = {
+      first_name: 'FAKEY',
+      last_name: 'MCFAKERSON',
+      dob: '1938-10-06',
+      sex: 'Male',
+      birth_place: 'birthplace',
+      passport_expiration: '2030-03-15',
+      issuing_country_code: 'USA',
+      mrz:
+      'P<UTOSAMPLE<<COMPANY<<<<<<<<<<<<<<<<<<<<<<<<ACU1234P<5UTO0003067F4003065<<<<<<<<<<<<<<02',
+      passport_issued: '2015-03-15',
+      nationality_code: 'USA',
+      document_number: '000000',
+      id_doc_type: 'passport',
+      ssn: '666111111',
+      consent_given_at: '2025-06-12 20:16:23 UTC',
+      state: 'VA',
+      zipcode: '12345-4321',
+      city: 'Best City',
+      address1: '123 Way St',
+      address2: '2nd Address Line',
     }.freeze
 
     MOCK_IDV_APPLICANT_WITH_PASSPORT = MOCK_IDV_APPLICANT.select do |field, _value|

--- a/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
@@ -355,4 +355,13 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
       end
     end
   end
+
+  describe '#skipped_result' do
+    it 'returns a check skipped result' do
+      plugin.skipped_result.tap do |result|
+        expect(result.success?).to eql(true)
+        expect(result.vendor_name).to eql(Idp::Constants::Vendors::AAMVA_CHECK_SKIPPED)
+      end
+    end
+  end
 end


### PR DESCRIPTION
changelog: Upcoming Features, Doc Auth, Skip aamva state ID check for passport proofing

## 🎫 Ticket

Link to the relevant ticket:
[LG-16169](https://cm-jira.usa.gov/browse/LG-16169)

## 🛠 Summary of changes

Skip AAMA state ID check when the document type is passport in the progressive proofer 

## 📜 Testing Plan

Scenario: Passport flow verify info
- [ ] Login through sinatra using `Identity-verified`
- [ ] Create a new account
- [ ] Proceed through IDV using remote flow and selecting `Passport` as ID type
- [ ] On the passport upload screen use the `spec/fixtures/passport_credential.yml` file
- [ ] When on the verify info page ensure you are running to the `make watch_events` task
- [ ] Submit the verify info form
- [ ] Verify the logs report that the state_id stage has the `AamvaCheckSkipped` vendor name in the `IdV: doc auth verify proofing results` event
- [ ] Ensure you finish the flow

Scenario: State ID flow verify info
- [ ] Login through sinatra using `Identity-verified`
- [ ] Create a new account
- [ ] Proceed through IDV using remote flow and selecting `State ID` as ID type
- [ ] When on the verify info page ensure you are running to the `make watch_events` task
- [ ] Submit the verify info form
- [ ] Verify the logs report that the state_id stage ***does not*** have the `AamvaCheckSkipped` vendor name in the `IdV: doc auth verify proofing results` event
- [ ] Ensure you finish the flow
