### PR TITLE
Add passport mock if passport_submittal is true

### DIFF
--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -9,10 +9,11 @@ module DocAuth
 
       attr_reader :uploaded_file, :config
 
-      def initialize(uploaded_file, config, selfie_required = false)
+      def initialize(uploaded_file, config, selfie_required = false, passport_submittal = false)
         @uploaded_file = uploaded_file.to_s
         @config = config
         @selfie_required = selfie_required
+        @passport_submittal = passport_submittal
         super(
           success: success?,
           errors:,
@@ -93,6 +94,8 @@ module DocAuth
       def pii_from_doc
         if parsed_data_from_uploaded_file.present?
           parsed_pii_from_doc
+        elsif @passport_submittal == true
+          Pii::Passport.new(**Idp::Constants::MOCK_IDV_APPLICANT_WITH_PASSPORT)
         else
           Pii::StateId.new(**Idp::Constants::MOCK_IDV_APPLICANT)
         end

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -27,6 +27,32 @@ RSpec.describe DocAuth::Mock::ResultResponse do
     end
   end
 
+  context 'with a passport image file' do
+    let(:config) do
+      DocAuth::Mock::Config.new(
+        dpi_threshold: 290,
+        sharpness_threshold: 40,
+        glare_threshold: 40,
+        warn_notifier: warn_notifier,
+      )
+    end
+    let(:passport_submittal) { true }
+    let(:input) { DocAuthImageFixtures.document_passport_image }
+
+    subject(:response) do
+      described_class.new(input, config, false, passport_submittal)
+    end
+
+    it 'returns a successful response with the default passport PII' do
+      expect(response.success?).to eq(true)
+      expect(response.errors).to eq({})
+      expect(response.exception).to eq(nil)
+      expect(response.pii_from_doc.to_h)
+        .to eq(Idp::Constants::MOCK_IDV_APPLICANT_WITH_PASSPORT)
+      expect(response.attention_with_barcode?).to eq(false)
+    end
+  end
+
   context 'with a yaml file containing PII' do
     let(:input) do
       <<~YAML


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16196](https://cm-jira.usa.gov/browse/LG-16196)

## 🛠 Summary of changes

Doc auth mock client now return passport data in ResultResponse when passport_submittal is true.
There was also a slight refactor to allow for easier extensibility in the case of new document types.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Confirm added test in result response spec encompasses the issue sufficiently
- [ ] Confirm tests pass
