### PR TITLE
LG-16340: Make sure to not expect an empty profile. 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -541,8 +541,9 @@ class ApplicationController < ActionController::Base
   def user_duplicate_profiles_detected?
     return false unless sp_eligible_for_one_account?
     profile = current_user&.active_profile
+    return false unless profile
     DuplicateProfileConfirmation.where(
-      profile_id: profile&.id,
+      profile_id: profile.id,
       confirmed_all: nil,
     ).present?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -542,7 +542,7 @@ class ApplicationController < ActionController::Base
     return false unless sp_eligible_for_one_account?
     profile = current_user&.active_profile
     DuplicateProfileConfirmation.where(
-      profile_id: profile.id,
+      profile_id: profile&.id,
       confirmed_all: nil,
     ).present?
   end

--- a/spec/factories/duplicate_profile_confirmations.rb
+++ b/spec/factories/duplicate_profile_confirmations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :duplicate_profile_confirmation do
+    association :profile
+    confirmed_at { Time.zone.now }
+    duplicate_profile_ids { [] }
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16340](https://cm-jira.usa.gov/browse/LG-16340)


## 🛠 Summary of changes
This ensures that when a user does not have an active profile we don't return anything for that particular user. 
