### PR TITLE
LG-16176 handle mrz check passport

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -5,7 +5,7 @@ module Idv
     extend ActiveSupport::Concern
 
     def handle_stored_result(user: current_user, store_in_session: true)
-      if stored_result&.success? && selfie_requirement_met?
+      if stored_result&.success? && selfie_requirement_met? && mrz_requirement_met?
         extract_pii_from_doc(user, store_in_session: store_in_session)
         flash[:success] = t('doc_auth.headings.capture_complete')
         successful_response
@@ -59,6 +59,11 @@ module Idv
     def selfie_requirement_met?
       !resolved_authn_context_result.facial_match? ||
         stored_result.selfie_check_performed?
+    end
+
+    def mrz_requirement_met?
+      return true unless id_type == 'passport'
+      stored_result.mrz_status == :pass
     end
 
     def redirect_to_correct_vendor(vendor, in_hybrid_mobile:)

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -20,7 +20,8 @@ class DocumentCaptureSession < ApplicationRecord
   end
 
   # @param doc_auth_response [DocAuth::Response]
-  def store_result_from_response(doc_auth_response)
+  # @param mrz_status [Symbol, nil] MRZ validation status for passport documents
+  def store_result_from_response(doc_auth_response, mrz_status: nil)
     session_result = load_result || DocumentCaptureSessionResult.new(
       id: generate_result_id,
     )
@@ -31,6 +32,7 @@ class DocumentCaptureSession < ApplicationRecord
     session_result.doc_auth_success = doc_auth_response.doc_auth_success?
     session_result.selfie_status = doc_auth_response.selfie_status
     session_result.errors = doc_auth_response.errors
+    session_result.mrz_status = mrz_status if mrz_status
 
     EncryptedRedisStructStorage.store(
       session_result,

--- a/app/services/document_capture_session_result.rb
+++ b/app/services/document_capture_session_result.rb
@@ -14,11 +14,12 @@ DocumentCaptureSessionResult = RedactedStruct.new(
   :doc_auth_success,
   :selfie_status,
   :errors,
+  :mrz_status,
   keyword_init: true,
   allowed_members: [:id, :success, :attention_with_barcode, :failed_front_image_fingerprints,
                     :failed_back_image_fingerprints, :failed_passport_image_fingerprints,
                     :failed_selfie_image_fingerprints, :captured_at, :doc_auth_success,
-                    :selfie_status, :errors],
+                    :selfie_status, :errors, :mrz_status],
 ) do
   include DocAuth::SelfieConcern
 
@@ -28,6 +29,10 @@ DocumentCaptureSessionResult = RedactedStruct.new(
 
   def selfie_status
     self[:selfie_status].to_sym
+  end
+
+  def mrz_status
+    self[:mrz_status]&.to_sym
   end
 
   alias_method :success?, :success

--- a/spec/controllers/concerns/idv/document_capture_concern_spec.rb
+++ b/spec/controllers/concerns/idv/document_capture_concern_spec.rb
@@ -13,6 +13,77 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
     end
   end
 
+  describe '#handle_stored_result' do
+    controller(idv_document_capture_controller_class) do
+    end
+
+    let(:user) { build(:user) }
+    let(:document_capture_session) { instance_double(DocumentCaptureSession) }
+    let(:mrz_status) { nil }
+    let(:selfie_status) { :not_processed }
+    let(:success) { true }
+
+    before do
+      id = SecureRandom.hex
+      result = DocumentCaptureSessionResult.new(
+        id:,
+        success:,
+        doc_auth_success: true,
+        selfie_status:,
+        mrz_status:,
+        pii: { first_name: 'Test', last_name: 'User', state: 'MD' },
+        attention_with_barcode: false,
+      )
+      EncryptedRedisStructStorage.store(result)
+      stored_result = EncryptedRedisStructStorage.load(id, type: DocumentCaptureSessionResult)
+      allow(controller).to receive(:stored_result).and_return(stored_result)
+      allow(controller).to receive(:document_capture_session).and_return(document_capture_session)
+      allow(controller).to receive(:current_user).and_return(user)
+      allow(controller).to receive(:flash).and_return({})
+      allow(controller).to receive(:track_document_issuing_state)
+
+      resolution_result = Vot::Parser.new(vector_of_trust: 'P1').parse
+      allow(controller).to receive(:resolved_authn_context_result).and_return(resolution_result)
+    end
+
+    context 'when document is a passport with failed MRZ check' do
+      let(:mrz_status) { :failed }
+
+      before do
+        allow(controller).to receive(:id_type).and_return('passport')
+      end
+
+      it 'returns failure response' do
+        response = controller.handle_stored_result(user: user)
+        expect(response.success?).to eq(false)
+      end
+    end
+
+    context 'when document is a passport with passed MRZ check' do
+      let(:mrz_status) { :pass }
+
+      before do
+        allow(controller).to receive(:id_type).and_return('passport')
+      end
+
+      it 'returns success response' do
+        response = controller.handle_stored_result(user: user, store_in_session: false)
+        expect(response.success?).to eq(true)
+      end
+    end
+
+    context 'when document is a state ID' do
+      before do
+        allow(controller).to receive(:id_type).and_return('state_id')
+      end
+
+      it 'returns success response regardless of MRZ status' do
+        response = controller.handle_stored_result(user: user, store_in_session: false)
+        expect(response.success?).to eq(true)
+      end
+    end
+  end
+
   describe '#selfie_requirement_met?' do
     controller(idv_document_capture_controller_class) do
     end
@@ -88,6 +159,79 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
           it 'returns true' do
             expect(controller.selfie_requirement_met?).to eq(true)
           end
+        end
+      end
+    end
+  end
+
+  describe '#mrz_requirement_met?' do
+    controller(idv_document_capture_controller_class) do
+    end
+
+    let(:mrz_status) { nil }
+    let(:document_capture_session) { instance_double(DocumentCaptureSession) }
+
+    before do
+      id = SecureRandom.hex
+      result = DocumentCaptureSessionResult.new(
+        id:,
+        success: true,
+        doc_auth_success: true,
+        selfie_status: :not_processed,
+        mrz_status:,
+        pii: {},
+        attention_with_barcode: false,
+      )
+      EncryptedRedisStructStorage.store(result)
+      stored_result = EncryptedRedisStructStorage.load(id, type: DocumentCaptureSessionResult)
+      allow(controller).to receive(:stored_result).and_return(stored_result)
+      allow(controller).to receive(:document_capture_session).and_return(document_capture_session)
+    end
+
+    context 'when document is a state ID' do
+      before do
+        allow(controller).to receive(:id_type).and_return('state_id')
+      end
+
+      it 'returns true regardless of mrz_status' do
+        expect(controller.mrz_requirement_met?).to eq(true)
+      end
+    end
+
+    context 'when document is a passport' do
+      before do
+        allow(controller).to receive(:id_type).and_return('passport')
+      end
+
+      context 'when mrz_status is pass' do
+        let(:mrz_status) { :pass }
+
+        it 'returns true' do
+          expect(controller.mrz_requirement_met?).to eq(true)
+        end
+      end
+
+      context 'when mrz_status is failed' do
+        let(:mrz_status) { :failed }
+
+        it 'returns false' do
+          expect(controller.mrz_requirement_met?).to eq(false)
+        end
+      end
+
+      context 'when mrz_status is not_processed' do
+        let(:mrz_status) { :not_processed }
+
+        it 'returns false' do
+          expect(controller.mrz_requirement_met?).to eq(false)
+        end
+      end
+
+      context 'when mrz_status is nil' do
+        let(:mrz_status) { nil }
+
+        it 'returns false' do
+          expect(controller.mrz_requirement_met?).to eq(false)
         end
       end
     end

--- a/spec/services/document_capture_session_result_spec.rb
+++ b/spec/services/document_capture_session_result_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe DocumentCaptureSessionResult do
       expect(loaded_result.selfie_status).to eq(:success)
       expect(loaded_result.doc_auth_success).to eq(true)
     end
+
+    it 'persists mrz_status with EncryptedRedisStructStorage' do
+      result = DocumentCaptureSessionResult.new(
+        id: id,
+        success: success,
+        doc_auth_success: success,
+        selfie_status: :success,
+        mrz_status: :pass,
+        pii: pii,
+        attention_with_barcode: false,
+      )
+      EncryptedRedisStructStorage.store(result)
+      loaded_result = EncryptedRedisStructStorage.load(id, type: DocumentCaptureSessionResult)
+
+      expect(loaded_result.mrz_status).to eq(:pass)
+    end
     it 'add fingerprint with EncryptedRedisStructStorage' do
       result = DocumentCaptureSessionResult.new(
         id: id,
@@ -49,6 +65,29 @@ RSpec.describe DocumentCaptureSessionResult do
           selfie_status: 'success',
         )
         expect(result.selfie_status).to be_an_instance_of(Symbol)
+      end
+    end
+
+    describe '#mrz_status' do
+      it 'returns a symbol when present' do
+        result = DocumentCaptureSessionResult.new(
+          id: id,
+          success: success,
+          pii: pii,
+          attention_with_barcode: false,
+          mrz_status: 'pass',
+        )
+        expect(result.mrz_status).to eq(:pass)
+      end
+
+      it 'returns nil when not present' do
+        result = DocumentCaptureSessionResult.new(
+          id: id,
+          success: success,
+          pii: pii,
+          attention_with_barcode: false,
+        )
+        expect(result.mrz_status).to be_nil
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16176](https://cm-jira.usa.gov/browse/LG-16176)

## 🛠 Summary of changes

Added MRZ validation gate for passport documents. When users submit a passport, the system now verifies the MRZ data with DoS before allowing them to proceed to SSN entry. If MRZ validation fails, users remain on the document capture screen.

 - Submit a passport → MRZ validation runs and blocks/allows progression accordingly
 - Submit a state ID → Proceeds normally (no MRZ check)
 - Tests pass: `bundle exec rspec spec/controllers/concerns/idv/document_capture_concern_spec.rb`

  ## 📜 Testing Plan

  Provide a checklist of steps to confirm the changes.

 - Submit a passport → MRZ validation runs and blocks/allows progression accordingly
 - Submit a state ID → Proceeds normally (no MRZ check)
 - Tests pass: `bundle exec rspec spec/controllers/concerns/idv/document_capture_concern_spec.rb`