### PR TITLE
Send device identifier rather than device fingerprint in Attempts API metadata

### DIFF
--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -36,7 +36,7 @@ module AttemptsApi
         user_agent: request&.user_agent,
         unique_session_id: hashed_session_id,
         user_uuid: agency_uuid(event_type: event_type),
-        device_fingerprint: hashed_cookie_device_uuid,
+        device_id: cookie_device_uuid,
         user_ip_address: request&.remote_ip,
         application_url: sp_request_uri,
         language: user&.email_language || I18n.locale.to_s,
@@ -106,11 +106,6 @@ module AttemptsApi
       return nil unless user&.unique_session_id.present?
 
       Digest::SHA1.hexdigest(user&.unique_session_id)
-    end
-
-    def hashed_cookie_device_uuid
-      return nil unless cookie_device_uuid
-      Digest::SHA1.hexdigest(cookie_device_uuid)
     end
 
     def enabled?

--- a/docs/attempts-api/schemas/events/shared/EventProperties.yml
+++ b/docs/attempts-api/schemas/events/shared/EventProperties.yml
@@ -10,9 +10,9 @@ properties:
   client_port:
     type: string
     description: Known more commonly as ephemeral port numbers associated with the Client IP – This is NOT the CSP server port 443 or 80.
-  device_fingerprint:
+  device_id:
     type: string
-    description: Hashed cookie device UUID
+    description: Cookie device UUID (version 4). This value is securely randomly generated server-side as 122 bits.
   google_analytics_cookies:
     type: object
     description: |


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[!32](https://gitlab.login.gov/lg-teams/FIE/fraud-mitigation/-/issues/32)

## 🛠 Summary of changes

This updates how we send the device cookie within the Attempts API to send an unhashed version.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
