### PR TITLE
LG-16288: Guard against nil enrollment

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -69,12 +69,12 @@ module Idv
         key: :hybrid_handoff,
         controller: self,
         next_steps: [:choose_id_type, :link_sent, :document_capture, :socure_document_capture],
-        preconditions: ->(idv_session:, user:) {
-                         idv_session.idv_consent_given? &&
-                         (self.selected_remote(idv_session: idv_session) || # from opt-in screen
-                             # back from ipp doc capture screen
-                             idv_session.skip_doc_auth_from_handoff)
-                       },
+        preconditions: ->(idv_session:, user:) do
+          idv_session.idv_consent_given? &&
+          (self.selected_remote(idv_session: idv_session) || # from opt-in screen
+            # back from ipp doc capture screen
+            idv_session.skip_doc_auth_from_handoff)
+        end,
         undo_step: ->(idv_session:, user:) do
           idv_session.flow_path = nil
           idv_session.phone_for_mobile_flow = nil

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -53,7 +53,7 @@ module Idv
             # Handling passport navigation with checking in_person_passports_allowed? since passport
             # form is not setup yet. This should be updated during LG-15985 implmentation.
             (idv_session.ipp_state_id_complete? || idv_session.in_person_passports_allowed?) &&
-              user.establishing_in_person_enrollment.present?
+              user.has_establishing_in_person_enrollment?
           end,
           undo_step: ->(idv_session:, user:) do
             idv_session.invalidate_in_person_address_step!

--- a/app/controllers/idv/in_person/address_controller.rb
+++ b/app/controllers/idv/in_person/address_controller.rb
@@ -49,11 +49,12 @@ module Idv
           key: :ipp_address,
           controller: self,
           next_steps: [:ipp_ssn],
-          preconditions: ->(idv_session:, user:) {
+          preconditions: ->(idv_session:, user:) do
             # Handling passport navigation with checking in_person_passports_allowed? since passport
             # form is not setup yet. This should be updated during LG-15985 implmentation.
-            idv_session.ipp_state_id_complete? || idv_session.in_person_passports_allowed?
-          },
+            (idv_session.ipp_state_id_complete? || idv_session.in_person_passports_allowed?) &&
+              user.establishing_in_person_enrollment.present?
+          end,
           undo_step: ->(idv_session:, user:) do
             idv_session.invalidate_in_person_address_step!
           end,

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -71,9 +71,10 @@ module Idv
           key: :ipp_ssn,
           controller: self,
           next_steps: [:ipp_verify_info],
-          preconditions: ->(idv_session:, user:) {
-            idv_session.ipp_document_capture_complete?
-          },
+          preconditions: ->(idv_session:, user:) do
+            idv_session.ipp_document_capture_complete? &&
+              user.establishing_in_person_enrollment.present?
+          end,
           undo_step: ->(idv_session:, user:) {
             idv_session.invalidate_ssn_step!
           },

--- a/app/controllers/idv/in_person/ssn_controller.rb
+++ b/app/controllers/idv/in_person/ssn_controller.rb
@@ -73,7 +73,7 @@ module Idv
           next_steps: [:ipp_verify_info],
           preconditions: ->(idv_session:, user:) do
             idv_session.ipp_document_capture_complete? &&
-              user.establishing_in_person_enrollment.present?
+              user.has_establishing_in_person_enrollment?
           end,
           undo_step: ->(idv_session:, user:) {
             idv_session.invalidate_ssn_step!

--- a/app/controllers/idv/in_person/state_id_controller.rb
+++ b/app/controllers/idv/in_person/state_id_controller.rb
@@ -79,7 +79,10 @@ module Idv
           key: :ipp_state_id,
           controller: self,
           next_steps: [:ipp_address, :ipp_ssn],
-          preconditions: ->(idv_session:, user:) { user.has_establishing_in_person_enrollment? },
+          preconditions: ->(idv_session:, user:) do
+            user.has_establishing_in_person_enrollment? &&
+              !idv_session.opted_in_to_in_person_proofing.nil?
+          end,
           undo_step: ->(idv_session:, user:) do
             idv_session.invalidate_in_person_pii_from_user!
           end,

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -41,7 +41,7 @@ module Idv
           preconditions: ->(idv_session:, user:) do
             idv_session.ssn && idv_session.ipp_document_capture_complete? &&
               threatmetrix_session_id_present_or_not_required?(idv_session:) &&
-              user.establishing_in_person_enrollment.present?
+              user.has_establishing_in_person_enrollment?
           end,
           undo_step: ->(idv_session:, user:) do
             idv_session.residential_resolution_vendor = nil

--- a/app/controllers/idv/in_person/verify_info_controller.rb
+++ b/app/controllers/idv/in_person/verify_info_controller.rb
@@ -40,7 +40,8 @@ module Idv
           next_steps: [:phone],
           preconditions: ->(idv_session:, user:) do
             idv_session.ssn && idv_session.ipp_document_capture_complete? &&
-              threatmetrix_session_id_present_or_not_required?(idv_session:)
+              threatmetrix_session_id_present_or_not_required?(idv_session:) &&
+              user.establishing_in_person_enrollment.present?
           end,
           undo_step: ->(idv_session:, user:) do
             idv_session.residential_resolution_vendor = nil

--- a/app/presenters/idv/in_person/verify_info_presenter.rb
+++ b/app/presenters/idv/in_person/verify_info_presenter.rb
@@ -14,6 +14,6 @@ class Idv::InPerson::VerifyInfoPresenter
   end
 
   def passport_flow?
-    @enrollment.passport_book?
+    @enrollment&.passport_book?
   end
 end

--- a/app/presenters/idv/in_person/verify_info_presenter.rb
+++ b/app/presenters/idv/in_person/verify_info_presenter.rb
@@ -14,6 +14,6 @@ class Idv::InPerson::VerifyInfoPresenter
   end
 
   def passport_flow?
-    @enrollment&.passport_book?
+    @enrollment.passport_book?
   end
 end

--- a/spec/controllers/idv/in_person/address_controller_spec.rb
+++ b/spec/controllers/idv/in_person/address_controller_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Idv::InPerson::AddressController do
     stub_sign_in(user)
     stub_up_to(:ipp_state_id, idv_session: subject.idv_session)
     allow(user).to receive(:establishing_in_person_enrollment).and_return(enrollment)
+    subject.idv_session.opted_in_to_in_person_proofing = true
     subject.user_session['idv/in_person'] = {
       pii_from_user: pii_from_user,
     }

--- a/spec/controllers/idv/in_person/ssn_controller_spec.rb
+++ b/spec/controllers/idv/in_person/ssn_controller_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Idv::InPerson::SsnController do
     stub_analytics
     stub_attempts_tracker
     controller.idv_session.flow_path = 'standard'
+    controller.idv_session.opted_in_to_in_person_proofing = true
+    allow(user).to receive(:has_establishing_in_person_enrollment?).and_return(true)
   end
 
   describe '#step_info' do
@@ -31,7 +33,6 @@ RSpec.describe Idv::InPerson::SsnController do
     before do
       stub_up_to(:ipp_state_id, idv_session: subject.idv_session)
       subject.user_session['idv/in_person'][:pii_from_user].delete(:address1)
-      allow(user).to receive(:has_establishing_in_person_enrollment?).and_return(true)
     end
     it 'redirects if address page not completed' do
       get :show

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Idv::InPerson::StateIdController do
     allow(user).to receive(:establishing_in_person_enrollment).and_return(enrollment)
     subject.user_session['idv/in_person'] = { pii_from_user: {} }
     subject.idv_session.ssn = nil # This made specs pass. Might need more investigation.
+    subject.idv_session.opted_in_to_in_person_proofing = true
     stub_analytics
   end
 

--- a/spec/controllers/idv/in_person/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/in_person/verify_info_controller_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
     subject.user_session['idv/in_person'] = flow_session
     stub_up_to(:ipp_ssn, idv_session: subject.idv_session)
     reload_ab_tests
+    allow(user).to receive(:has_establishing_in_person_enrollment?).and_return(true)
   end
 
   describe '#step_info' do
@@ -243,8 +244,8 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
     context 'when idv/in_person data is missing' do
       before do
         stub_up_to(:ipp_verify_info, idv_session: subject.idv_session)
-        allow(user).to receive(:has_establishing_in_person_enrollment?).and_return(true)
         subject.user_session['idv/in_person'] = {}
+        subject.idv_session.opted_in_to_in_person_proofing = true
       end
 
       it 'redirects to the in person state id page' do
@@ -542,6 +543,7 @@ RSpec.describe Idv::InPerson::VerifyInfoController do
     before do
       allow(user).to receive(:establishing_in_person_enrollment).and_return(enrollment)
       allow(IdentityConfig.store).to receive(:proofing_device_profiling).and_return(:enabled)
+      subject.idv_session.opted_in_to_in_person_proofing = true
     end
 
     context 'when idv_session is missing threatmetrix_session_id' do

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -225,6 +225,7 @@ RSpec.describe 'Idv::FlowPolicy' do
       before do
         stub_up_to(:ipp_address, idv_session: idv_session)
         allow(user).to receive(:has_establishing_in_person_enrollment?).and_return(true)
+        idv_session.opted_in_to_in_person_proofing = true
         idv_session.send(:user_session)['idv/in_person'] = {
           pii_from_user: Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID.dup,
         }
@@ -263,6 +264,10 @@ RSpec.describe 'Idv::FlowPolicy' do
     end
 
     context 'preconditions for in_person verify_info are present' do
+      before do
+        idv_session.opted_in_to_in_person_proofing = true
+      end
+
       it 'returns ipp_verify_info' do
         stub_up_to(:ipp_ssn, idv_session: idv_session)
         allow(user).to receive(:has_establishing_in_person_enrollment?).and_return(true)


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16288](https://cm-jira.usa.gov/browse/LG-16288)

## 🛠 Summary of changes

We have seen some errors where the enrollment passed to the IPP verify_info_presenter is nil. 

In #11939 we started cancelling enrollments upon _visiting_ the Welcome page which is how, we believe, the user ended up with a nil enrollment. That change doesn't align with the work we did previously on Team Ada with the [FlowPolicy](https://handbook.login.gov/articles/identity-verification-flow-policy.html) which intended for controllers in the idv flow to define a StepInfo that includes preconditions and a proc to clean up (undo) the action. The FlowPolicy work was intentionally done to allow users to use the back/forward buttons at will.

This PR updates the IPP controllers preconditions to ensure that if an establishing enrollment is not present the user will be redirected back in the flow to the proper place.