### PR TITLE
Add device_fingerprint to idv-device-risk-assessment event

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -194,7 +194,6 @@ module Idv
           last_name_spaced: pii[:last_name].split(' ').many?,
           previous_ssn_edit_distance: previous_ssn_edit_distance,
           pii_like_keypaths: [
-            [:device_fingerprint],
             [:errors, :ssn],
             [:errors, :state_id_jurisdiction],
             [:proofing_results, :context, :stages, :resolution, :errors, :ssn],
@@ -346,7 +345,7 @@ module Idv
       success = (threatmetrix_result[:review_status] == 'pass')
 
       attempts_api_tracker.idv_device_risk_assessment(
-        device_fingerprint: result.dig(:device_fingerprint),
+        device_fingerprint: threatmetrix_result.dig(:device_fingerprint),
         success:,
         failure_reason: device_risk_failure_reason(success, threatmetrix_result),
       )
@@ -374,6 +373,7 @@ module Idv
       )
       return if threatmetrix_result.blank?
 
+      threatmetrix_result.delete(:device_fingerprint)
       threatmetrix_result.delete(:response_body)
     end
 

--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -194,6 +194,7 @@ module Idv
           last_name_spaced: pii[:last_name].split(' ').many?,
           previous_ssn_edit_distance: previous_ssn_edit_distance,
           pii_like_keypaths: [
+            [:device_fingerprint],
             [:errors, :ssn],
             [:errors, :state_id_jurisdiction],
             [:proofing_results, :context, :stages, :resolution, :errors, :ssn],
@@ -345,6 +346,7 @@ module Idv
       success = (threatmetrix_result[:review_status] == 'pass')
 
       attempts_api_tracker.idv_device_risk_assessment(
+        device_fingerprint: result.dig(:device_fingerprint),
         success:,
         failure_reason: device_risk_failure_reason(success, threatmetrix_result),
       )

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -527,12 +527,14 @@ module AttemptsApi
     end
 
     # @param [Boolean] success True means TMX's device risk check has a 'pass' review status
+    # @param [String] device_fingerprint 32-character string based on device attributes
     # @param [Hash<Symbol,Array<Symbol>>] failure_reason
     # Tracks the result of the Device fraud check during Identity Verification
-    def idv_device_risk_assessment(success:, failure_reason: nil)
+    def idv_device_risk_assessment(success:, device_fingerprint: nil, failure_reason: nil)
       track_event(
         'idv-device-risk-assessment',
         success:,
+        device_fingerprint:,
         failure_reason:,
       )
     end

--- a/app/services/proofing/ddp_result.rb
+++ b/app/services/proofing/ddp_result.rb
@@ -82,6 +82,10 @@ module Proofing
       }
     end
 
+    def device_fingerprint
+      response_body&.dig(:fuzzy_device_id)
+    end
+
     private
 
     def redacted_response_body

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -43,6 +43,7 @@ module Proofing
           errors: errors,
           extra: {
             exception: exception,
+            device_fingerprint: device_profiling_result.device_fingerprint,
             timed_out: timed_out?,
             threatmetrix_review_status: device_profiling_result.review_status,
             phone_finder_precheck_passed: phone_finder_result.success?,

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -43,7 +43,6 @@ module Proofing
           errors: errors,
           extra: {
             exception: exception,
-            device_fingerprint: device_profiling_result.device_fingerprint,
             timed_out: timed_out?,
             threatmetrix_review_status: device_profiling_result.review_status,
             phone_finder_precheck_passed: phone_finder_result.success?,
@@ -55,7 +54,7 @@ module Proofing
                 resolution: resolution_result.to_h,
                 residential_address: residential_resolution_result.to_h,
                 state_id: state_id_result.to_h,
-                threatmetrix: device_profiling_result.to_h,
+                threatmetrix:,
                 phone_precheck: phone_finder_result.to_h,
               },
             },
@@ -82,6 +81,12 @@ module Proofing
           residential_resolution_result.exception ||
           state_id_result.exception ||
           device_profiling_result.exception
+      end
+
+      def threatmetrix
+        device_profiling_result.to_h.merge(
+          device_fingerprint: device_profiling_result.device_fingerprint,
+        )
       end
 
       def timed_out?

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvDeviceRiskAssessment.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvDeviceRiskAssessment.yml
@@ -4,6 +4,10 @@ allOf:
   - $ref: "../shared/EventProperties.yml"
   - type: object
     properties:
+      device_fingerprint:
+        type: string
+        description: |
+          A 32-character string based exclusively on device attributes to improve detection of returning visitors, especially those trying to elude identification.
       failure_reason:
         type: object
         description: |
@@ -38,4 +42,4 @@ allOf:
       success:
         type: boolean
         description: |
-          Indicates whether the TMX response status pass.
+          Indicates whether the user has passed the device risk assessment.

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -187,6 +187,7 @@ RSpec.describe Idv::VerifyInfoController do
       let(:review_status) { 'pass' }
       let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
       let(:success) { true }
+      let(:device_fingerprint) { SecureRandom.hex(32) }
 
       let(:idv_result) do
         {
@@ -206,6 +207,7 @@ RSpec.describe Idv::VerifyInfoController do
               },
             },
           },
+          device_fingerprint:,
           errors: {},
           exception: nil,
           success: true,
@@ -284,6 +286,10 @@ RSpec.describe Idv::VerifyInfoController do
             ),
           )
           expect(@analytics).to have_logged_event(
+            'IdV: doc auth verify proofing results',
+            hash_excluding(device_fingerprint:),
+          )
+          expect(@analytics).to have_logged_event(
             :idv_threatmetrix_response_body,
             response_body: hash_including(
               client: threatmetrix_client_id,
@@ -294,6 +300,7 @@ RSpec.describe Idv::VerifyInfoController do
         it 'tracks the attempts events' do
           expect(@attempts_api_tracker).to receive(:idv_device_risk_assessment).with(
             success: true,
+            device_fingerprint:,
             failure_reason: nil,
           )
           expect(@attempts_api_tracker).to receive(:idv_verification_submitted).with(
@@ -330,6 +337,7 @@ RSpec.describe Idv::VerifyInfoController do
         it 'tracks a failed tmx fraud check' do
           expect(@attempts_api_tracker).to receive(:idv_device_risk_assessment).with(
             success: false,
+            device_fingerprint:,
             failure_reason: { fraud_risk_summary_reason_code: ['Identity_Negative_History'] },
           )
 
@@ -380,6 +388,7 @@ RSpec.describe Idv::VerifyInfoController do
                 },
               },
             },
+            device_fingerprint:,
             success: false,
           }
         end
@@ -420,6 +429,11 @@ RSpec.describe Idv::VerifyInfoController do
               ),
             ),
           )
+
+          expect(@analytics).to have_logged_event(
+            'IdV: doc auth verify proofing results',
+            hash_excluding(device_fingerprint:),
+          )
         end
 
         it 'tracks the event for the attempts api' do
@@ -451,6 +465,7 @@ RSpec.describe Idv::VerifyInfoController do
           stub_attempts_tracker
           expect(@attempts_api_tracker).to receive(:idv_device_risk_assessment).with(
             success: false,
+            device_fingerprint:,
             failure_reason: {
               fraud_risk_summary_reason_code:
                 ['Fraud risk assessment has failed for unknown reasons'],
@@ -473,6 +488,7 @@ RSpec.describe Idv::VerifyInfoController do
         it 'tracks a failed tmx fraud check' do
           expect(@attempts_api_tracker).to receive(:idv_device_risk_assessment).with(
             success:,
+            device_fingerprint:,
             failure_reason: {
               fraud_risk_summary_reason_code: ['Identity_Negative_History'],
             },
@@ -516,6 +532,7 @@ RSpec.describe Idv::VerifyInfoController do
           stub_attempts_tracker
           expect(@attempts_api_tracker).to receive(:idv_device_risk_assessment).with(
             success: false,
+            device_fingerprint:,
             failure_reason: {
               fraud_risk_summary_reason_code: ['Identity_Negative_History'],
             },

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -197,6 +197,7 @@ RSpec.describe Idv::VerifyInfoController do
             stages: {
               threatmetrix: {
                 success:,
+                device_fingerprint:,
                 client: threatmetrix_client_id,
                 transaction_id: 1,
                 review_status: review_status,
@@ -207,7 +208,6 @@ RSpec.describe Idv::VerifyInfoController do
               },
             },
           },
-          device_fingerprint:,
           errors: {},
           exception: nil,
           success: true,
@@ -287,8 +287,17 @@ RSpec.describe Idv::VerifyInfoController do
           )
           expect(@analytics).to have_logged_event(
             'IdV: doc auth verify proofing results',
-            hash_excluding(device_fingerprint:),
+            hash_including(
+              proofing_results: hash_including(
+                context: hash_including(
+                  stages: hash_including(
+                    threatmetrix: hash_excluding(device_fingerprint:),
+                  ),
+                ),
+              ),
+            ),
           )
+
           expect(@analytics).to have_logged_event(
             :idv_threatmetrix_response_body,
             response_body: hash_including(
@@ -379,6 +388,7 @@ RSpec.describe Idv::VerifyInfoController do
               stages: {
                 threatmetrix: {
                   client: nil,
+                  device_fingerprint:,
                   errors: {},
                   exception: "Unexpected ThreatMetrix review_status value: #{review_status}",
                   response_body: nil,
@@ -388,7 +398,6 @@ RSpec.describe Idv::VerifyInfoController do
                 },
               },
             },
-            device_fingerprint:,
             success: false,
           }
         end
@@ -432,7 +441,15 @@ RSpec.describe Idv::VerifyInfoController do
 
           expect(@analytics).to have_logged_event(
             'IdV: doc auth verify proofing results',
-            hash_excluding(device_fingerprint:),
+            hash_including(
+              proofing_results: hash_including(
+                context: hash_including(
+                  stages: hash_including(
+                    threatmetrix: hash_excluding(device_fingerprint:),
+                  ),
+                ),
+              ),
+            ),
           )
         end
 

--- a/spec/services/proofing/ddp_result_spec.rb
+++ b/spec/services/proofing/ddp_result_spec.rb
@@ -111,8 +111,7 @@ RSpec.describe Proofing::DdpResult do
     context 'when provided' do
       it 'is present' do
         transaction_id = 'foo'
-        result = Proofing::DdpResult.new
-        result.transaction_id = transaction_id
+        result = Proofing::DdpResult.new(transaction_id:)
         expect(result.transaction_id).to eq(transaction_id)
       end
     end
@@ -141,6 +140,31 @@ RSpec.describe Proofing::DdpResult do
         result = Proofing::DdpResult.new(response_body: '')
 
         expect(result.to_h[:response_body]).to eq('')
+      end
+    end
+  end
+
+  describe '#device_fingerprint' do
+    let(:response_body) { { fuzzy_device_id: '12345' } }
+    subject { described_class.new(response_body:) }
+
+    context 'when response_body is present' do
+      it 'returns the device fingerprint' do
+        expect(subject.device_fingerprint).to eq('12345')
+      end
+    end
+
+    context 'when response_body is nil' do
+      let(:response_body) { nil }
+      it 'returns nil' do
+        expect(subject.device_fingerprint).to be_nil
+      end
+    end
+
+    context 'when response_body does not contain fuzzy_device_id' do
+      let(:response_body) { { some_other_key: 'value' } }
+      it 'returns nil' do
+        expect(subject.device_fingerprint).to be_nil
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[FIE fraud mitigation 35](https://gitlab.login.gov/lg-teams/FIE/fraud-mitigation/-/issues/35)

## 🛠 Summary of changes
this change:
- updates the `idv-device-risk-assessment` documentation to include a `fingerprint_device` attribute
- updates the tracker event to include the `fingerprint_device` attribute that is returned from threatmetrix
- adds the attribute to `pii_like_keypaths` to ensure it's not logged

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
