### PR TITLE
changelog: Bug Fixes, Document Authentication, Fix exception when DoS…

### DIFF
--- a/app/services/doc_auth/dos/request.rb
+++ b/app/services/doc_auth/dos/request.rb
@@ -107,7 +107,7 @@ module DocAuth
             error_reason: error_reason,
             correlation_id_sent: correlation_id,
             correlation_id_received:,
-          }.compact,
+          },
         )
       end
 

--- a/spec/services/doc_auth/dos/request_spec.rb
+++ b/spec/services/doc_auth/dos/request_spec.rb
@@ -112,30 +112,10 @@ RSpec.describe DocAuth::Dos::Request do
 
     context 'with simple string error format' do
       let(:response_body) do
-        { error: 'Invalid Client' }.to_json
-      end
-
-      it 'extracts error message from string' do
-        response = subject.send(:handle_invalid_response, http_response)
-
-        expect(response.success?).to be(false)
-        expect(response.errors).to include(network: true)
-        expect(response.extra).to include(
-          vendor: 'DoS',
-          error_code: nil,
-          error_message: 'Invalid Client',
-          error_reason: nil,
-          correlation_id_received: '12345',
-        )
-      end
-    end
-
-    context 'with Authentication denied error' do
-      let(:response_body) do
         { error: 'Authentication denied.' }.to_json
       end
 
-      it 'handles the error without throwing an exception' do
+      it 'extracts error message from string' do
         response = subject.send(:handle_invalid_response, http_response)
 
         expect(response.success?).to be(false)

--- a/spec/services/doc_auth/dos/request_spec.rb
+++ b/spec/services/doc_auth/dos/request_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe DocAuth::Dos::Request do
 
       it 'extracts error details from nested hash' do
         response = subject.send(:handle_invalid_response, http_response)
-        
+
         expect(response.success?).to be(false)
         expect(response.errors).to include(network: true)
         expect(response.extra).to include(
@@ -117,7 +117,7 @@ RSpec.describe DocAuth::Dos::Request do
 
       it 'extracts error message from string' do
         response = subject.send(:handle_invalid_response, http_response)
-        
+
         expect(response.success?).to be(false)
         expect(response.errors).to include(network: true)
         expect(response.extra).to include(
@@ -137,7 +137,7 @@ RSpec.describe DocAuth::Dos::Request do
 
       it 'handles the error without throwing an exception' do
         response = subject.send(:handle_invalid_response, http_response)
-        
+
         expect(response.success?).to be(false)
         expect(response.errors).to include(network: true)
         expect(response.extra).to include(
@@ -155,7 +155,7 @@ RSpec.describe DocAuth::Dos::Request do
 
       it 'handles non-JSON response gracefully' do
         response = subject.send(:handle_invalid_response, http_response)
-        
+
         expect(response.success?).to be(false)
         expect(response.errors).to include(network: true)
         expect(response.extra).to include(
@@ -173,7 +173,7 @@ RSpec.describe DocAuth::Dos::Request do
 
       it 'handles empty response gracefully' do
         response = subject.send(:handle_invalid_response, http_response)
-        
+
         expect(response.success?).to be(false)
         expect(response.errors).to include(network: true)
         expect(response.extra).to include(

--- a/spec/services/doc_auth/dos/request_spec.rb
+++ b/spec/services/doc_auth/dos/request_spec.rb
@@ -78,4 +78,112 @@ RSpec.describe DocAuth::Dos::Request do
       end
     end
   end
+
+  describe '#handle_invalid_response' do
+    let(:http_response) do
+      instance_double(
+        Faraday::Response,
+        status: status,
+        body: response_body,
+        headers: { 'X-Correlation-ID' => '12345' },
+      )
+    end
+    let(:status) { 401 }
+
+    context 'with nested error format' do
+      let(:response_body) do
+        { error: { code: 'ERR001', message: 'Invalid request', reason: 'Bad format' } }.to_json
+      end
+
+      it 'extracts error details from nested hash' do
+        response = subject.send(:handle_invalid_response, http_response)
+        
+        expect(response.success?).to be(false)
+        expect(response.errors).to include(network: true)
+        expect(response.extra).to include(
+          vendor: 'DoS',
+          error_code: 'ERR001',
+          error_message: 'Invalid request',
+          error_reason: 'Bad format',
+          correlation_id_received: '12345',
+        )
+      end
+    end
+
+    context 'with simple string error format' do
+      let(:response_body) do
+        { error: 'Invalid Client' }.to_json
+      end
+
+      it 'extracts error message from string' do
+        response = subject.send(:handle_invalid_response, http_response)
+        
+        expect(response.success?).to be(false)
+        expect(response.errors).to include(network: true)
+        expect(response.extra).to include(
+          vendor: 'DoS',
+          error_code: nil,
+          error_message: 'Invalid Client',
+          error_reason: nil,
+          correlation_id_received: '12345',
+        )
+      end
+    end
+
+    context 'with Authentication denied error' do
+      let(:response_body) do
+        { error: 'Authentication denied.' }.to_json
+      end
+
+      it 'handles the error without throwing an exception' do
+        response = subject.send(:handle_invalid_response, http_response)
+        
+        expect(response.success?).to be(false)
+        expect(response.errors).to include(network: true)
+        expect(response.extra).to include(
+          vendor: 'DoS',
+          error_code: nil,
+          error_message: 'Authentication denied.',
+          error_reason: nil,
+          correlation_id_received: '12345',
+        )
+      end
+    end
+
+    context 'with invalid JSON' do
+      let(:response_body) { 'Not JSON' }
+
+      it 'handles non-JSON response gracefully' do
+        response = subject.send(:handle_invalid_response, http_response)
+        
+        expect(response.success?).to be(false)
+        expect(response.errors).to include(network: true)
+        expect(response.extra).to include(
+          vendor: 'DoS',
+          error_code: nil,
+          error_message: nil,
+          error_reason: nil,
+          correlation_id_received: '12345',
+        )
+      end
+    end
+
+    context 'with empty response body' do
+      let(:response_body) { '' }
+
+      it 'handles empty response gracefully' do
+        response = subject.send(:handle_invalid_response, http_response)
+        
+        expect(response.success?).to be(false)
+        expect(response.errors).to include(network: true)
+        expect(response.extra).to include(
+          vendor: 'DoS',
+          error_code: nil,
+          error_message: nil,
+          error_reason: nil,
+          correlation_id_received: '12345',
+        )
+      end
+    end
+  end
 end

--- a/spec/services/doc_auth/dos/requests/mrz_request_spec.rb
+++ b/spec/services/doc_auth/dos/requests/mrz_request_spec.rb
@@ -105,4 +105,46 @@ RSpec.describe DocAuth::Dos::Requests::MrzRequest do
       )
     end
   end
+
+  context 'when the request fails with "Invalid Client" error' do
+    let(:http_status) { 401 }
+    let(:response_body) do
+      { error: 'Invalid Client' }.to_json
+    end
+
+    it 'handles the string error without throwing an exception' do
+      response = subject.fetch
+      expect(response.success?).to be(false)
+      expect(response.errors).to include(network: true)
+      expect(response.extra).to include(
+        vendor: 'DoS',
+        error_code: nil,
+        error_message: 'Invalid Client',
+        error_reason: nil,
+        correlation_id_sent: correlation_id,
+        correlation_id_received: correlation_id,
+      )
+    end
+  end
+
+  context 'when the request fails with "Authentication denied." error' do
+    let(:http_status) { 403 }
+    let(:response_body) do
+      { error: 'Authentication denied.' }.to_json
+    end
+
+    it 'handles the string error without throwing an exception' do
+      response = subject.fetch
+      expect(response.success?).to be(false)
+      expect(response.errors).to include(network: true)
+      expect(response.extra).to include(
+        vendor: 'DoS',
+        error_code: nil,
+        error_message: 'Authentication denied.',
+        error_reason: nil,
+        correlation_id_sent: correlation_id,
+        correlation_id_received: correlation_id,
+      )
+    end
+  end
 end

--- a/spec/services/doc_auth/dos/requests/mrz_request_spec.rb
+++ b/spec/services/doc_auth/dos/requests/mrz_request_spec.rb
@@ -86,65 +86,64 @@ RSpec.describe DocAuth::Dos::Requests::MrzRequest do
   end
 
   context 'when the request fails' do
-    let(:http_status) { 500 }
-    let(:response_body) do
-      { error: { code: 'ERR', message: 'issues @ State', reason: 'just because' } }.to_json
-    end
-
-    it 'fails with a message' do
-      response = subject.fetch
-      expect(response.success?).to be(false)
-      expect(response.errors).to include(network: true)
-      expect(response.extra).to include(
-        vendor: 'DoS',
-        error_code: 'ERR',
-        error_message: 'issues @ State',
-        error_reason: 'just because',
-        correlation_id_sent: correlation_id,
-        correlation_id_received: correlation_id,
-      )
-    end
-  end
-
-  context 'when the request fails with "Invalid Client" error' do
     let(:http_status) { 401 }
-    let(:response_body) do
-      { error: 'Invalid Client' }.to_json
+
+    context 'when the response error is a hash' do
+      let(:response_body) do
+        { error: { code: 'ERR', message: 'issues @ State', reason: 'just because' } }.to_json
+      end
+
+      it 'handles the nested error without throwing an exception' do
+        response = subject.fetch
+        expect(response.success?).to be(false)
+        expect(response.errors).to include(network: true)
+        expect(response.extra).to include(
+          vendor: 'DoS',
+          error_code: 'ERR',
+          error_message: 'issues @ State',
+          error_reason: 'just because',
+          correlation_id_sent: correlation_id,
+          correlation_id_received: correlation_id,
+        )
+      end
     end
 
-    it 'handles the string error without throwing an exception' do
-      response = subject.fetch
-      expect(response.success?).to be(false)
-      expect(response.errors).to include(network: true)
-      expect(response.extra).to include(
-        vendor: 'DoS',
-        error_code: nil,
-        error_message: 'Invalid Client',
-        error_reason: nil,
-        correlation_id_sent: correlation_id,
-        correlation_id_received: correlation_id,
-      )
-    end
-  end
+    context 'when the response error is a string' do
+      let(:response_body) do
+        { error: 'Authentication denied.' }.to_json
+      end
 
-  context 'when the request fails with "Authentication denied." error' do
-    let(:http_status) { 403 }
-    let(:response_body) do
-      { error: 'Authentication denied.' }.to_json
+      it 'handles the string error without throwing an exception' do
+        response = subject.fetch
+        expect(response.success?).to be(false)
+        expect(response.errors).to include(network: true)
+        expect(response.extra).to include(
+          vendor: 'DoS',
+          error_code: nil,
+          error_message: 'Authentication denied.',
+          error_reason: nil,
+          correlation_id_sent: correlation_id,
+          correlation_id_received: correlation_id,
+        )
+      end
     end
 
-    it 'handles the string error without throwing an exception' do
-      response = subject.fetch
-      expect(response.success?).to be(false)
-      expect(response.errors).to include(network: true)
-      expect(response.extra).to include(
-        vendor: 'DoS',
-        error_code: nil,
-        error_message: 'Authentication denied.',
-        error_reason: nil,
-        correlation_id_sent: correlation_id,
-        correlation_id_received: correlation_id,
-      )
+    context 'when the response error is empty' do
+      let(:response_body) { '' }
+
+      it 'handles empty response gracefully' do
+        response = subject.fetch
+        expect(response.success?).to be(false)
+        expect(response.errors).to include(network: true)
+        expect(response.extra).to include(
+          vendor: 'DoS',
+          error_code: nil,
+          error_message: nil,
+          error_reason: nil,
+          correlation_id_sent: correlation_id,
+          correlation_id_received: correlation_id,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16143](https://cm-jira.usa.gov/browse/LG-16143)

## 🛠 Summary of changes

Fixed an issue where the DoS MRZ API client was throwing exceptions when receiving error responses in a simple string format. The client was originally built expecting errors to be nested objects like `{"error": {"code": "...", "message": "..."}}`, but we discovered the API sometimes returns errors as simple strings like ```
{"error": "Invalid Client"}``` or `{"error": "Authentication denied."}`.

Updated the error handling to support both formats, preventing crashes and ensuring error messages are properly logged for debugging


## 📜 Testing Plan

- Added test coverage for both error formats in `spec/services/doc_auth/dos/request_spec.rb`
- [ ] `bundle exec rspec spec/services/doc_auth/dos/request_spec.rb`
- Added specific test cases for the reported error strings in `spec/services/doc_auth/dos/requests/mrz_request_spec.rb`
- [ ] `bundle exec rspec spec/services/doc_auth/dos/requests/mrz_request_spec.rb`