### PR TITLE
LG-16384: passport cards are not state ids

### DIFF
--- a/app/forms/idv/doc_pii_form.rb
+++ b/app/forms/idv/doc_pii_form.rb
@@ -42,7 +42,7 @@ module Idv
 
     def self.pii_like_keypaths(document_type:)
       keypaths = [[:pii]]
-      document_attrs = document_type&.downcase == 'passport' ?
+      document_attrs = document_type&.downcase&.include?('passport') ?
         DocPiiPassport.pii_like_keypaths :
         DocPiiStateId.pii_like_keypaths
 
@@ -106,7 +106,7 @@ module Idv
       when *STATE_ID_TYPES
         state_id_validation = DocPiiStateId.new(pii: pii_from_doc)
         state_id_validation.valid? || errors.merge!(state_id_validation.errors)
-      when 'passport'
+      when 'passport', 'passport_card'
         passport_validation = DocPiiPassport.new(pii: pii_from_doc)
         passport_validation.valid? || errors.merge!(passport_validation.errors)
       else

--- a/app/forms/idv/doc_pii_passport.rb
+++ b/app/forms/idv/doc_pii_passport.rb
@@ -13,7 +13,7 @@ module Idv
               }
 
     validate :passport_not_expired?
-    validate :not_passport_card? # we don't support passport cards
+    validate :passport_book? # we don't support passport cards
 
     attr_reader :passport_expiration, :issuing_country_code, :mrz
 
@@ -43,8 +43,8 @@ module Idv
       false
     end
 
-    def not_passport_card?
-      return true if pii_from_doc[:id_doc_type] != 'passport_card'
+    def passport_book?
+      return true if pii_from_doc[:id_doc_type] == 'passport'
 
       errors.add(:id_doc_type, generic_error, type: :id_doc_type)
       false

--- a/app/forms/idv/doc_pii_passport.rb
+++ b/app/forms/idv/doc_pii_passport.rb
@@ -12,8 +12,8 @@ module Idv
                 in: 'USA', message: proc { I18n.t('doc_auth.errors.general.no_liveness') }
               }
 
-    validate :passport_expired?
-    validate :passport_book? # we don't support passport cards
+    validate :passport_not_expired?
+    validate :not_passport_card? # we don't support passport cards
 
     attr_reader :passport_expiration, :issuing_country_code, :mrz
 
@@ -36,16 +36,18 @@ module Idv
       I18n.t('doc_auth.errors.general.no_liveness')
     end
 
-    def passport_expired?
-      if passport_expiration && DateParser.parse_legacy(passport_expiration).past?
-        errors.add(:passport_expiration, generic_error, type: :passport_expiration)
-      end
+    def passport_not_expired?
+      return true unless passport_expiration && DateParser.parse_legacy(passport_expiration).past?
+
+      errors.add(:passport_expiration, generic_error, type: :passport_expiration)
+      false
     end
 
-    def passport_book?
-      if pii_from_doc[:id_doc_type] == 'passport_card'
-        errors.add(:id_doc_type, generic_error, type: :id_doc_type)
-      end
+    def not_passport_card?
+      return true if pii_from_doc[:id_doc_type] != 'passport_card'
+
+      errors.add(:id_doc_type, generic_error, type: :id_doc_type)
+      false
     end
   end
 end

--- a/app/forms/idv/doc_pii_passport.rb
+++ b/app/forms/idv/doc_pii_passport.rb
@@ -13,6 +13,7 @@ module Idv
               }
 
     validate :passport_expired?
+    validate :passport_book? # we don't support passport cards
 
     attr_reader :passport_expiration, :issuing_country_code, :mrz
 
@@ -38,6 +39,12 @@ module Idv
     def passport_expired?
       if passport_expiration && DateParser.parse_legacy(passport_expiration).past?
         errors.add(:passport_expiration, generic_error, type: :passport_expiration)
+      end
+    end
+
+    def passport_book?
+      if pii_from_doc[:id_doc_type] == 'passport_card'
+        errors.add(:id_doc_type, generic_error, type: :id_doc_type)
       end
     end
   end

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_passport_tampering_failure.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_passport_tampering_failure.json
@@ -49,7 +49,7 @@
           {
             "Group": "AUTHENTICATION_RESULT",
             "Name": "DocIssuerType",
-            "Values": [{ "Value": "StateProvince" }]
+            "Values": [{ "Value": "Country" }]
           },
           {
             "Group": "AUTHENTICATION_RESULT",

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_passport.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_passport.json
@@ -49,7 +49,7 @@
           {
             "Group": "AUTHENTICATION_RESULT",
             "Name": "DocIssuerType",
-            "Values": [{ "Value": "StateProvince" }]
+            "Values": [{ "Value": "Country" }]
           },
           {
             "Group": "AUTHENTICATION_RESULT",
@@ -1044,4 +1044,3 @@
       }
     ]
   }
-  

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_passport_card.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_passport_card.json
@@ -1,0 +1,1046 @@
+{
+  "Status": {
+    "ConversationId": "70000300394121",
+    "RequestId": "614507871",
+    "TransactionStatus": "passed",
+    "TransactionReasonCode": {
+      "Code": "trueid_pass",
+      "Description": "TRUEID PASS"
+    },
+    "Reference": "ca6e36c4-8a55-4831-aa8a-38d78b7c80e3"
+  },
+  "Products": [
+    {
+      "ProductType": "TrueID",
+      "ExecutedStepName": "True_ID_Step",
+      "ProductConfigurationName": "GSA2.V3.TrueID.CROP.PT.test",
+      "ProductStatus": "pass",
+      "ParameterDetails": [
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocumentName",
+          "Values": [{ "Value": "United States (USA) Passport Card" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocAuthResult",
+          "Values": [{ "Value": "Passed" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocAuthTamperResult",
+          "Values": [{ "Value": "Passed" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocAuthTamperSensitivity",
+          "Values": [{ "Value": "Normal" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssuerCode",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssuerName",
+          "Values": [{ "Value": "United States" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssuerType",
+          "Values": [{ "Value": "Country" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocClassCode",
+          "Values": [{ "Value": "IdentificationCard" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocClass",
+          "Values": [{ "Value": "IdentificationCard" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocClassName",
+          "Values": [{ "Value": "Identification Card" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIsGeneric",
+          "Values": [{ "Value": "false" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssue",
+          "Values": [{ "Value": "2016" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssueType",
+          "Values": [{ "Value": "Passport Card" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocSize",
+          "Values": [{ "Value": "ID1" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ClassificationMode",
+          "Values": [{ "Value": "Automatic" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "OrientationChanged",
+          "Values": [{ "Value": "true" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "PresentationChanged",
+          "Values": [{ "Value": "false" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "Side",
+          "Values": [{ "Value": "Front" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "GlareMetric",
+          "Values": [{ "Value": "100" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "SharpnessMetric",
+          "Values": [{ "Value": "65" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "IsTampered",
+          "Values": [{ "Value": "0" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "IsCropped",
+          "Values": [{ "Value": "1" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "HorizontalResolution",
+          "Values": [{ "Value": "600" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "VerticalResolution",
+          "Values": [{ "Value": "600" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "Light",
+          "Values": [{ "Value": "White" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "MimeType",
+          "Values": [
+            { "Value": "image/vnd.ms-photo" }
+          ]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "ImageMetrics_Id",
+          "Values": [
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "FullName",
+          "Values": [{ "Value": "DAVID LICENSE SAMPLE" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Sex",
+          "Values": [{ "Value": "Male" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DOB_Year",
+          "Values": [{ "Value": "1985" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DOB_Month",
+          "Values": [{ "Value": "7" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DOB_Day",
+          "Values": [{ "Value": "1" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ExpirationDate_Year",
+          "Values": [{ "Value": "2099" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ExpirationDate_Month",
+          "Values": [{ "Value": "10" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ExpirationDate_Day",
+          "Values": [{ "Value": "15" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_1_AlertName",
+          "Values": [{ "Value": "Document Expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_4_AlertName",
+          "Values": [{ "Value": "2D Barcode Content" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_5_AlertName",
+          "Values": [{ "Value": "2D Barcode Read" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_6_AlertName",
+          "Values": [{ "Value": "Barcode Encoding" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_7_AlertName",
+          "Values": [{ "Value": "Birth Date Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_8_AlertName",
+          "Values": [{ "Value": "Birth Date Valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_9_AlertName",
+          "Values": [{ "Value": "Document Classification" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_10_AlertName",
+          "Values": [{ "Value": "Document Crosscheck Aggregation" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_11_AlertName",
+          "Values": [{ "Value": "Document Number Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_15_AlertName",
+          "Values": [{ "Value": "Expiration Date Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_16_AlertName",
+          "Values": [{ "Value": "Expiration Date Valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_17_AlertName",
+          "Values": [{ "Value": "Full Name Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_18_AlertName",
+          "Values": [{ "Value": "Issue Date Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_19_AlertName",
+          "Values": [{ "Value": "Issue Date Valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_20_AlertName",
+          "Values": [{ "Value": "Series Expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_21_AlertName",
+          "Values": [{ "Value": "Sex Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Model",
+          "Values": [{ "Value": "Text Tampering Detection V1.3.1 (Beta)" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Model",
+          "Values": [{ "Value": "Photo Tampering Detection V2.4" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Model",
+          "Values": [{ "Value": "Text Tampering Detection V1.2.1" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_Model",
+          "Values": [{ "Value": "Physical Document Presence V2.5" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_1_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Checked if the document is expired."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_4_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Checked the contents of the two-dimensional barcode on the document."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_5_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Attention",
+              "Detail": "Verified that the two-dimensional barcode on the document was read successfully."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_6_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the format of the barcode."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_7_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable birth date field to the human-readable birth date field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_8_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the birth date is valid."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_9_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the type of document is supported and is able to be fully authenticated."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_10_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compared the machine-readable fields to the human-readable fields."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_11_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable document number field to the human-readable document number field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_15_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable expiration date field to the human-readable expiration date field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_16_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the expiration date is valid."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_17_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable full name field to the human-readable full name field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_18_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable issue date field to the human-readable issue date field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_19_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the issue date is valid."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_20_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified whether the document type is still in circulation."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_21_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable sex field to the human-readable sex field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_1_Disposition",
+          "Values": [{ "Value": "The document has expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_Disposition",
+          "Values": [{ "Value": "A visible pattern was not found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Disposition",
+          "Values": [
+            {
+              "Value": "Evidence suggests that the document may have been tampered with."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_4_Disposition",
+          "Values": [{ "Value": "The 2D barcode is formatted correctly" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_5_Disposition",
+          "Values": [{ "Value": "The 2D barcode was read successfully" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_6_Disposition",
+          "Values": [
+            {
+              "Value": "The barcode encoding is consistent with the expected encoding for the type"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_7_Disposition",
+          "Values": [{ "Value": "The birth dates match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_8_Disposition",
+          "Values": [{ "Value": "The birth date is valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_9_Disposition",
+          "Values": [{ "Value": "The document type is supported" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_10_Disposition",
+          "Values": [
+            {
+              "Value": "There are not a large number of differences between electronic and human-readable data sources"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_11_Disposition",
+          "Values": [{ "Value": "The document numbers match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Disposition",
+          "Values": [
+            { "Value": "No evidence of document tampering was detected." }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Disposition",
+          "Values": [
+            { "Value": "No evidence of document tampering was detected." }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_Disposition",
+          "Values": [
+            { "Value": "No evidence of document tampering was detected." }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_15_Disposition",
+          "Values": [{ "Value": "The expiration dates match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_16_Disposition",
+          "Values": [{ "Value": "The expiration date is valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_17_Disposition",
+          "Values": [{ "Value": "The full names match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_18_Disposition",
+          "Values": [{ "Value": "The issue dates match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_19_Disposition",
+          "Values": [{ "Value": "The issue date is valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_20_Disposition",
+          "Values": [{ "Value": "The series has not expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_21_Disposition",
+          "Values": [{ "Value": "The sexes match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_Disposition",
+          "Values": [{ "Value": "A visible pattern was found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_Disposition",
+          "Values": [{ "Value": "A visible pattern was found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_Disposition",
+          "Values": [{ "Value": "A visible pattern was found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_Regions",
+          "Values": [{ "Value": "Background" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Regions",
+          "Values": [
+            { "Value": "Birth Date" },
+            { "Value": "Document Number" },
+            { "Value": "Expiration Date" },
+            { "Value": "Full Name" },
+            { "Value": "Issue Date" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Regions",
+          "Values": [{ "Value": "Photo" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Regions",
+          "Values": [
+            { "Value": "Birth Date" },
+            { "Value": "Document Number" },
+            { "Value": "Expiration Date" },
+            { "Value": "Full Name" },
+            { "Value": "Issue Date" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_Regions",
+          "Values": [{ "Value": "Expires Label" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_Regions",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_Regions",
+          "Values": [{ "Value": "Background Upper" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_Regions_Reference",
+          "Values": [{ "Value": "faacfb79-d0a1-4a8e-b868-20c604988e84" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Regions_Reference",
+          "Values": [
+            { "Value": "c8be94b6-78ac-4e85-88cb-e17880371e4a" },
+            { "Value": "a8226d92-e62c-42a3-a206-ab7c3e3d9796" },
+            { "Value": "c2e18c41-e3de-46a8-abc7-3412015a6cef" },
+            { "Value": "80f8f290-daa0-47e2-828e-52106bb26f31" },
+            { "Value": "2c74b850-dd89-41bb-a21c-70ae0563ef77" },
+            { "Value": "63bf5053-f81f-493f-aff0-33c07d07a894" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Regions_Reference",
+          "Values": [{ "Value": "f29b1fe5-6482-4b39-8b4a-d91caf4ecb57" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Regions_Reference",
+          "Values": [
+            { "Value": "c8be94b6-78ac-4e85-88cb-e17880371e4a" },
+            { "Value": "a8226d92-e62c-42a3-a206-ab7c3e3d9796" },
+            { "Value": "c2e18c41-e3de-46a8-abc7-3412015a6cef" },
+            { "Value": "80f8f290-daa0-47e2-828e-52106bb26f31" },
+            { "Value": "2c74b850-dd89-41bb-a21c-70ae0563ef77" },
+            { "Value": "63bf5053-f81f-493f-aff0-33c07d07a894" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_Regions_Reference",
+          "Values": [{ "Value": "d55f2c66-f84f-4213-a660-4ff9e5d0fde5" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_Regions_Reference",
+          "Values": [{ "Value": "bbf6ba02-ee3f-4b5c-a5d0-2fdb39ac79f7" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_Regions_Reference",
+          "Values": [{ "Value": "20203cb8-f8a4-4a5b-999f-3700f73fe4fe" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_FullName",
+          "Values": [{ "Value": "DAVID PASSPORT SAMPLE" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_Surname",
+          "Values": [{ "Value": "SAMPLE" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_GivenName",
+          "Values": [{ "Value": "DAVID PASSPORT" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_FirstName",
+          "Values": [{ "Value": "DAVID" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_MiddleName",
+          "Values": [{ "Value": "PASSPORT" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DOB_Year",
+          "Values": [{ "Value": "1986" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DOB_Month",
+          "Values": [{ "Value": "7" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DOB_Day",
+          "Values": [{ "Value": "1" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DocumentClassName",
+          "Values": [{ "Value": "Identification Card" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DocumentNumber",
+          "Values": [{ "Value": "Z12345678" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_ExpirationDate_Year",
+          "Values": [{ "Value": "2099" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_ExpirationDate_Month",
+          "Values": [{ "Value": "10" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_xpirationDate_Day",
+          "Values": [{ "Value": "15" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssuingStateCode",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssuingStateName",
+          "Values": [{ "Value": "United States" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_CountryCode",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssueDate_Year",
+          "Values": [{ "Value": "2016" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssueDate_Month",
+          "Values": [{ "Value": "10" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssueDate_Day",
+          "Values": [{ "Value": "15" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_MRZ",
+          "Values": [
+            { "Value": "P<UTOSAMPLE<<COMPANY<<<<<<<<<<<<<<<<<<<<<<<<ACU1234P<5UTO0003067F4003065<<<<<<<<<<<<<<02" }
+          ]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_BirthPlace",
+          "Values": [
+            { "Value": "MY CITY. U.S.A." }
+          ]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_NationalityCode",
+          "Values": [
+            { "Value": "USA" }
+          ]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_PersonalNumber",
+          "Values": [
+            { "Value": "3067F400 3065" }
+          ]
+        },
+        {
+          "Group": "DOCUMENT_REGION",
+          "Name": "DocumentRegion_Id",
+          "Values": [
+            { "Value": "ce2cf0e2-5373-4ec2-84e8-7fe44a01642b" },
+            { "Value": "0b4f4f2b-cbd6-43e9-ac67-55bf2bdd9df5" },
+            { "Value": "c8be94b6-78ac-4e85-88cb-e17880371e4a" },
+            { "Value": "a0fdf00c-071c-4d8e-81af-8af0fc7688b8" },
+            { "Value": "faacfb79-d0a1-4a8e-b868-20c604988e84" },
+            { "Value": "3362ad4b-a36b-487e-826c-c748c7b04e8d" },
+            { "Value": "20203cb8-f8a4-4a5b-999f-3700f73fe4fe" },
+            { "Value": "a8226d92-e62c-42a3-a206-ab7c3e3d9796" },
+            { "Value": "a3e3a625-8b0e-4deb-a91e-86afc55d036b" },
+            { "Value": "cda4092d-9208-4871-bbc1-1b732c299d26" },
+            { "Value": "42770baf-3a4a-4477-9e5f-4400237273fe" },
+            { "Value": "c2e18c41-e3de-46a8-abc7-3412015a6cef" },
+            { "Value": "b36594f2-d19c-48aa-98c2-2b4f8429744f" },
+            { "Value": "80f8f290-daa0-47e2-828e-52106bb26f31" },
+            { "Value": "d55f2c66-f84f-4213-a660-4ff9e5d0fde5" },
+            { "Value": "26ca0c85-01ab-4311-bfd5-d27d2ee975eb" },
+            { "Value": "0af79f76-1542-4391-ad17-a5d6169be57f" },
+            { "Value": "2c74b850-dd89-41bb-a21c-70ae0563ef77" },
+            { "Value": "64e8ee97-2b24-452d-a5af-1627951aa737" },
+            { "Value": "63bf5053-f81f-493f-aff0-33c07d07a894" },
+            { "Value": "f29b1fe5-6482-4b39-8b4a-d91caf4ecb57" },
+            { "Value": "35442fb1-c3bb-4f2f-ad9e-537a8f0e7e0f" },
+            { "Value": "29964031-e072-4204-a9ae-b2b7122bfdc1" },
+            { "Value": "a3bbdf8b-62f5-438f-bf72-091bb2f6f0ff" },
+            { "Value": "42d0c49e-fc7a-45da-8f6d-8896c4b5267f" },
+            { "Value": "5430efcb-523b-4c62-a190-e9aa7eea4ebd" },
+            { "Value": "bbf6ba02-ee3f-4b5c-a5d0-2fdb39ac79f7" },
+            { "Value": "0686341c-0b3f-4544-840e-58822120ef06" }
+          ]
+        },
+        {
+          "Group": "DOCUMENT_REGION",
+          "Name": "DocumentRegion_Key",
+          "Values": [
+            { "Value": "1D Barcode" },
+            { "Value": "2D Barcode" },
+            { "Value": "Alaska Validator" },
+            { "Value": "Background" },
+            { "Value": "Background Lower" },
+            { "Value": "Background Upper" },
+            { "Value": "Birth Date" },
+            { "Value": "Birth Place" },
+            { "Value": "DOB Label" },
+            { "Value": "DOB Label Text" },
+            { "Value": "Document Number" },
+            { "Value": "Document Type" },
+            { "Value": "Expiration Date" },
+            { "Value": "Expires Label" },
+            { "Value": "Expires Label Position" },
+            { "Value": "Full Name" },
+            { "Value": "Issue Date" },
+            { "Value": "Photo" },
+            { "Value": "Photo Printing" },
+            { "Value": "Secondary Photo" },
+            { "Value": "Sex" },
+            { "Value": "Signature" },
+            { "Value": "USA" },
+            { "Value": "Weight" }
+          ]
+        },
+        {
+          "Group": "DOCUMENT_REGION",
+          "Name": "DocumentRegion_ImageReference",
+          "Values": [
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" }
+          ]
+        }
+      ]
+    },
+    {
+      "ProductType": "TrueID_Decision",
+      "ExecutedStepName": "Decision",
+      "ProductConfigurationName": "TRUEID_PASS",
+      "ProductStatus": "pass",
+      "ProductReason": {
+        "Code": "trueid_pass",
+        "Description": "TRUEID PASS"
+      }
+    }
+  ]
+}

--- a/spec/forms/idv/doc_pii_passport_spec.rb
+++ b/spec/forms/idv/doc_pii_passport_spec.rb
@@ -29,39 +29,6 @@ RSpec.describe Idv::DocPiiPassport do
     end
   end
 
-  context 'when birth_place is missing' do
-    let(:birth_place) { nil }
-
-    it 'is not valid' do
-      expect(subject).not_to be_valid
-      expect(subject.errors[:birth_place]).to include(
-        I18n.t('doc_auth.errors.general.no_liveness'),
-      )
-    end
-  end
-
-  context 'when passport_issued is missing' do
-    let(:passport_issued) { nil }
-
-    it 'is not valid' do
-      expect(subject).not_to be_valid
-      expect(subject.errors[:passport_issued]).to include(
-        I18n.t('doc_auth.errors.general.no_liveness'),
-      )
-    end
-  end
-
-  context 'when nationality_code is missing' do
-    let(:nationality_code) { '' }
-
-    it 'is not valid' do
-      expect(subject).not_to be_valid
-      expect(subject.errors[:nationality_code]).to include(
-        I18n.t('doc_auth.errors.general.no_liveness'),
-      )
-    end
-  end
-
   context 'when mrz is missing' do
     let(:mrz) { nil }
 
@@ -79,17 +46,6 @@ RSpec.describe Idv::DocPiiPassport do
     it 'is not valid' do
       expect(subject).not_to be_valid
       expect(subject.errors[:issuing_country_code]).to include(
-        I18n.t('doc_auth.errors.general.no_liveness'),
-      )
-    end
-  end
-
-  context 'when nationality_code is not USA' do
-    let(:nationality_code) { 'CAN' }
-
-    it 'is not valid' do
-      expect(subject).not_to be_valid
-      expect(subject.errors[:nationality_code]).to include(
         I18n.t('doc_auth.errors.general.no_liveness'),
       )
     end

--- a/spec/forms/idv/doc_pii_passport_spec.rb
+++ b/spec/forms/idv/doc_pii_passport_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Idv::DocPiiPassport do
+  let(:birth_place) { 'NY' }
+  let(:passport_expiration) { DateTime.now.advance(years: 1).strftime('%Y-%m-%d') }
+  let(:passport_issued) { '2020-01-01' }
+  let(:issuing_country_code) { 'USA' }
+  let(:nationality_code) { 'USA' }
+  let(:mrz) { 'MRZ123456789' }
+  let(:id_doc_type) { 'passport' }
+  let(:pii) do
+    {
+      birth_place:,
+      passport_expiration:,
+      passport_issued:,
+      issuing_country_code:,
+      nationality_code:,
+      mrz:,
+      id_doc_type:,
+    }
+  end
+  subject(:doc_pii_passport) { described_class.new(pii:) }
+
+  context 'when pii is valid' do
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+  end
+
+  context 'when birth_place is missing' do
+    let(:birth_place) { nil }
+
+    it 'is not valid' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:birth_place]).to include(
+        I18n.t('doc_auth.errors.general.no_liveness'),
+      )
+    end
+  end
+
+  context 'when passport_issued is missing' do
+    let(:passport_issued) { nil }
+
+    it 'is not valid' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:passport_issued]).to include(
+        I18n.t('doc_auth.errors.general.no_liveness'),
+      )
+    end
+  end
+
+  context 'when nationality_code is missing' do
+    let(:nationality_code) { '' }
+
+    it 'is not valid' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:nationality_code]).to include(
+        I18n.t('doc_auth.errors.general.no_liveness'),
+      )
+    end
+  end
+
+  context 'when mrz is missing' do
+    let(:mrz) { nil }
+
+    it 'is not valid' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:mrz]).to include(
+        I18n.t('doc_auth.errors.general.no_liveness'),
+      )
+    end
+  end
+
+  context 'when issuing_country_code is not USA' do
+    let(:issuing_country_code) { 'CAN' }
+
+    it 'is not valid' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:issuing_country_code]).to include(
+        I18n.t('doc_auth.errors.general.no_liveness'),
+      )
+    end
+  end
+
+  context 'when nationality_code is not USA' do
+    let(:nationality_code) { 'CAN' }
+
+    it 'is not valid' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:nationality_code]).to include(
+        I18n.t('doc_auth.errors.general.no_liveness'),
+      )
+    end
+  end
+
+  context 'when passport_expiration is in the past' do
+    let(:passport_expiration) { DateTime.now.advance(years: -1).strftime('%Y-%m-%d') }
+
+    it 'is not valid' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:passport_expiration]).to include(
+        I18n.t('doc_auth.errors.general.no_liveness'),
+      )
+    end
+  end
+
+  context 'when id_doc_type is passport_card' do
+    let(:id_doc_type) { 'passport_card' }
+
+    it 'is not valid' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:id_doc_type]).to include(
+        I18n.t('doc_auth.errors.general.no_liveness'),
+      )
+    end
+  end
+end

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -180,6 +180,10 @@ module LexisNexisFixtures
       read_fixture_file_at_path('true_id/true_id_response_success_passport.json')
     end
 
+    def true_id_response_passport_card
+      read_fixture_file_at_path('true_id/true_id_response_success_passport_card.json')
+    end
+
     def true_id_response_success_with_liveness
       read_fixture_file_at_path('true_id/true_id_response_success_with_liveness.json')
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16384](https://cm-jira.usa.gov/browse/LG-16384)

## 🛠 Summary of changes

Check for the DocIssueType to see if the presented id is a passport card and set the id_doc_type appropriately.
Fails doc auth when passport card and fails doc auth when passport presented but passports are not enabled.

## 📜 Testing Plan

Specs pass