### PR TITLE
changelog: Bug Fixes, Attempts API, Update key to string from symbol

### DIFF
--- a/app/services/proofing/ddp_result.rb
+++ b/app/services/proofing/ddp_result.rb
@@ -83,7 +83,7 @@ module Proofing
     end
 
     def device_fingerprint
-      response_body&.dig(:fuzzy_device_id)
+      response_body&.dig('fuzzy_device_id')
     end
 
     private

--- a/spec/fixtures/proofing/lexis_nexis/ddp/successful_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/successful_response.json
@@ -7,7 +7,10 @@
   "tmx_risk_rating": "neutral",
   "fraudpoint.score": "500",
   "first_name": "WARNING! YOU SHOULD NEVER SEE THIS PII FIELD IN THE LOGS",
-  "tmx_summary_reason_code": ["Identity_Negative_History"],
+  "tmx_summary_reason_code": [
+    "Identity_Negative_History"
+  ],
   "session_id": "super-cool-test-session-id",
-  "account_lex_id": "super-cool-test-lex-id"
+  "account_lex_id": "super-cool-test-lex-id",
+  "fuzzy_device_id": "WARNING! YOU SHOULD NEVER SEE THIS PII FIELD IN THE LOGS"
 }

--- a/spec/services/proofing/ddp_result_spec.rb
+++ b/spec/services/proofing/ddp_result_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Proofing::DdpResult do
   describe '#to_h' do
     context 'when response_body is present' do
       it 'is redacted' do
-        response_body = { first_name: 'Jonny Proofs' }
+        response_body = { 'first_name' => 'Jonny Proofs' }
         result = Proofing::DdpResult.new(response_body:)
 
         expect(result.to_h[:response_body]).to eq({})
@@ -145,7 +145,7 @@ RSpec.describe Proofing::DdpResult do
   end
 
   describe '#device_fingerprint' do
-    let(:response_body) { { fuzzy_device_id: '12345' } }
+    let(:response_body) { { 'fuzzy_device_id' => '12345' } }
     subject { described_class.new(response_body:) }
 
     context 'when response_body is present' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[FIE Fraud Mitigation 35](https://gitlab.login.gov/lg-teams/FIE/fraud-mitigation/-/issues/35)

## 🛠 Summary of changes
Small bug fix discovered in testing. The response body is in JSON, and so would be accessible via a string rather than a symbol.

This change:
- Fixes the code
- Updates the tests to reduce confusion in the future
- Adds fuzzy_device_id to mock threatmetrix response


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
