### PR TITLE
lg-16379 document_type for proofing components

### DIFF
--- a/app/services/idv/proofing_components.rb
+++ b/app/services/idv/proofing_components.rb
@@ -11,7 +11,7 @@ module Idv
     end
 
     def document_type
-      return 'state_id' if idv_session.remote_document_capture_complete?
+      return idv_session.remote_submitted_doc_type if idv_session.remote_document_capture_complete?
     end
 
     def source_check

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -299,6 +299,16 @@ module Idv
       pii_from_doc.present?
     end
 
+    def remote_submitted_doc_type
+      return nil if session[:pii_from_doc].blank?
+
+      if session[:pii_from_doc][:id_doc_type] == 'passport'
+        'passport'
+      else
+        'state_id'
+      end
+    end
+
     def ipp_document_capture_complete?
       has_pii_from_user_in_session? &&
         user_session['idv/in_person'][:pii_from_user].has_key?(:address1)

--- a/spec/services/idv/proofing_components_spec.rb
+++ b/spec/services/idv/proofing_components_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe Idv::ProofingComponents do
   end
 
   describe '#to_h' do
-    let(:pii_from_doc) { Idp::Constants::MOCK_IDV_APPLICANT }
-
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_vendor_default).and_return('test_vendor')
       idv_session.mark_verify_info_step_complete!
@@ -40,18 +38,40 @@ RSpec.describe Idv::ProofingComponents do
       idv_session.doc_auth_vendor = 'feedabee'
     end
 
-    it 'returns expected result' do
-      expect(subject.to_h).to eql(
-        {
-          document_check: 'feedabee',
-          document_type: 'state_id',
-          source_check: 'aamva',
-          resolution_check: 'lexis_nexis',
-          address_check: 'gpo_letter',
-          threatmetrix: true,
-          threatmetrix_review_status: 'pass',
-        },
-      )
+    context 'with state_id' do
+      let(:pii_from_doc) { Idp::Constants::MOCK_IDV_APPLICANT }
+
+      it 'returns expected result' do
+        expect(subject.to_h).to eql(
+          {
+            document_check: 'feedabee',
+            document_type: 'state_id',
+            source_check: 'aamva',
+            resolution_check: 'lexis_nexis',
+            address_check: 'gpo_letter',
+            threatmetrix: true,
+            threatmetrix_review_status: 'pass',
+          },
+        )
+      end
+    end
+
+    context 'with passport' do
+      let(:pii_from_doc) { Idp::Constants::MOCK_IDV_PROOFING_PASSPORT_APPLICANT }
+
+      it 'returns expected result' do
+        expect(subject.to_h).to eql(
+          {
+            document_check: 'feedabee',
+            document_type: 'passport',
+            source_check: 'aamva',
+            resolution_check: 'lexis_nexis',
+            address_check: 'gpo_letter',
+            threatmetrix: true,
+            threatmetrix_review_status: 'pass',
+          },
+        )
+      end
     end
   end
 
@@ -94,6 +114,14 @@ RSpec.describe Idv::ProofingComponents do
 
         it 'returns doc auth vendor' do
           expect(subject.document_type).to eql('state_id')
+        end
+      end
+
+      context 'after doc auth completed successfully with passport' do
+        let(:pii_from_doc) { Idp::Constants::MOCK_IDV_PROOFING_PASSPORT_APPLICANT }
+
+        it 'returns doc auth vendor' do
+          expect(subject.document_type).to eql('passport')
         end
       end
     end


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-16379](https://cm-jira.usa.gov/browse/LG-16379)

## 🛠 Summary of changes

Updating proofing component to support passport doc type

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - Confirm specs pass and test functionality

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
