### PR TITLE
LG-16389 MRZ validation only performed if passport is requested and submitted

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -290,6 +290,7 @@ module Idv
       # doc_pii validation failed
       return doc_pii_response if doc_pii_response.present? && !doc_pii_response.success?
 
+      # mrz validation failed
       return mrz_response if mrz_response.present? && !mrz_response.success?
 
       client_response
@@ -509,7 +510,7 @@ module Idv
     end
 
     def passport_requested?
-      document_capture_session&.passport_requested?
+      !!document_capture_session&.passport_requested?
     end
 
     def rate_limiter

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -47,7 +47,8 @@ module Idv
 
         if client_response.success?
           doc_pii_response = validate_pii_from_doc(client_response)
-          if doc_pii_response.success? && passport_submittal
+
+          if doc_pii_response.success? && passport_requested? && passport_submittal
             mrz_response = validate_mrz(client_response)
           end
         end
@@ -185,7 +186,7 @@ module Idv
     def document_type
       return nil if document_capture_session.nil?
 
-      @document_type ||= document_capture_session.passport_requested? \
+      @document_type ||= passport_requested? \
         ? 'Passport' : 'DriversLicense'
     end
 
@@ -505,6 +506,10 @@ module Idv
 
     def user_uuid
       document_capture_session&.user&.uuid
+    end
+
+    def passport_requested?
+      document_capture_session&.passport_requested?
     end
 
     def rate_limiter

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -1030,19 +1030,16 @@ RSpec.describe Idv::ApiImageUploadForm do
         let(:passport_image) { DocAuthImageFixtures.passport_passed_yaml }
 
         it 'does not do MRZ validation' do
-          response
           expect_any_instance_of(DocAuth::Mock::DosPassportApiClient).to_not receive(:fetch)
+
+          response
         end
 
         it 'does not call the MRZ analytics event' do
+          response
+
           expect(fake_analytics).to_not have_logged_event(
             :idv_dos_passport_verification,
-            success: true,
-            response: 'YES',
-            submit_attempts: 1,
-            remaining_submit_attempts: 3,
-            user_id: document_capture_session.user.uuid,
-            document_type: document_type,
           )
         end
       end

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Idv::ApiImageUploadForm do
   let(:front_image) { DocAuthImageFixtures.document_front_image_multipart }
   let(:back_image) { DocAuthImageFixtures.document_back_image_multipart }
   let(:passport_image) { nil }
+  let(:passport_requested) { false }
   let(:selfie_image) { nil }
   let(:liveness_checking_required) { false }
   let(:front_image_file_name) { 'front.jpg' }
@@ -89,6 +90,8 @@ RSpec.describe Idv::ApiImageUploadForm do
   before do
     allow(IdentityConfig.store).to receive(:doc_escrow_enabled).and_return doc_escrow_enabled
     allow(writer).to receive(:write).and_return result
+    allow_any_instance_of(DocumentCaptureSession).to receive(:passport_requested?)
+      .and_return(passport_requested)
   end
 
   describe '#valid?' do
@@ -899,6 +902,7 @@ RSpec.describe Idv::ApiImageUploadForm do
         )
       end
       let(:response) { form.submit }
+      let(:passport_requested) { true }
 
       before do
         allow_any_instance_of(described_class)
@@ -919,6 +923,7 @@ RSpec.describe Idv::ApiImageUploadForm do
             },
           )
         end
+        let(:document_type) { 'Passport' }
 
         before do
           allow_any_instance_of(DocAuth::Mock::DosPassportApiClient)
@@ -955,6 +960,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
       context 'Passport MRZ validation succeeds' do
         let(:passport_image) { DocAuthImageFixtures.passport_passed_yaml }
+        let(:document_type) { 'Passport' }
 
         let(:successful_passport_mrz_response) do
           DocAuth::Response.new(

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -1024,6 +1024,28 @@ RSpec.describe Idv::ApiImageUploadForm do
           expect(response.errors[:passport]).to eq(message)
         end
       end
+
+      context 'User submits passport but passport is not requested' do
+        let(:passport_requested) { false }
+        let(:passport_image) { DocAuthImageFixtures.passport_passed_yaml }
+
+        it 'does not do MRZ validation' do
+          response
+          expect_any_instance_of(DocAuth::Mock::DosPassportApiClient).to_not receive(:fetch)
+        end
+
+        it 'does not call the MRZ analytics event' do
+          expect(fake_analytics).to_not have_logged_event(
+            :idv_dos_passport_verification,
+            success: true,
+            response: 'YES',
+            submit_attempts: 1,
+            remaining_submit_attempts: 3,
+            user_id: document_capture_session.user.uuid,
+            document_type: document_type,
+          )
+        end
+      end
     end
 
     describe 'image source' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-16389](https://cm-jira.usa.gov/browse/LG-16389)



## 🛠 Summary of changes

Ensure that DOS MRZ validation is only performed if a passport is requested at the "choose your id" step and that it only occurs if the document uploaded is a passport.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Go through IdV and select Passport
- [ ] Verify that a passing passport yml succeeds and lets you go to the SSN step
- [ ] Start over and try using a driver's license and verify that it does not let you pass to the SSN step.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
