### PR TITLE
LG-16403: TMX session id

### DIFF
--- a/app/controllers/users/piv_cac_recommended_controller.rb
+++ b/app/controllers/users/piv_cac_recommended_controller.rb
@@ -30,21 +30,6 @@ module Users
       redirect_to after_sign_in_path_for(current_user)
     end
 
-    def threatmetrix_variables
-      return {} unless FeatureManagement.account_creation_device_profiling_collecting_enabled?
-      session_id = generate_threatmetrix_session_id
-
-      {
-        threatmetrix_session_id: session_id,
-        threatmetrix_javascript_urls: threatmetrix_javascript_urls(session_id),
-        threatmetrix_iframe_url: threatmetrix_iframe_url(session_id),
-      }
-    end
-
-    def generate_threatmetrix_session_id
-      user_session[:sign_up_threatmetrix_session_id] ||= SecureRandom.uuid
-    end
-
     private
 
     def redirect_unless_user_email_is_fed_or_mil

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -87,20 +87,5 @@ module Users
     rescue ActionController::ParameterMissing
       ActionController::Parameters.new(selection: [])
     end
-
-    def threatmetrix_variables
-      return {} unless FeatureManagement.account_creation_device_profiling_collecting_enabled?
-      session_id = generate_threatmetrix_session_id
-
-      {
-        threatmetrix_session_id: session_id,
-        threatmetrix_javascript_urls: threatmetrix_javascript_urls(session_id),
-        threatmetrix_iframe_url: threatmetrix_iframe_url(session_id),
-      }
-    end
-
-    def generate_threatmetrix_session_id
-      user_session[:sign_up_threatmetrix_session_id] ||= SecureRandom.uuid
-    end
   end
 end

--- a/app/services/threat_metrix_helper.rb
+++ b/app/services/threat_metrix_helper.rb
@@ -33,4 +33,19 @@ module ThreatMetrixHelper
       session_id: session_id,
     )
   end
+
+  def threatmetrix_variables
+    return {} unless FeatureManagement.account_creation_device_profiling_collecting_enabled?
+    session_id = generate_threatmetrix_session_id
+
+    {
+      threatmetrix_session_id: session_id,
+      threatmetrix_javascript_urls: threatmetrix_javascript_urls(session_id),
+      threatmetrix_iframe_url: threatmetrix_iframe_url(session_id),
+    }
+  end
+
+  def generate_threatmetrix_session_id
+    user_session[:sign_up_threatmetrix_session_id] ||= SecureRandom.uuid
+  end
 end

--- a/app/views/users/piv_cac_recommended/show.html.erb
+++ b/app/views/users/piv_cac_recommended/show.html.erb
@@ -25,3 +25,14 @@
       unstyled: true,
     ).with_content(@recommended_presenter.skip_text) %>
 
+<% if FeatureManagement.account_creation_device_profiling_collecting_enabled? %>
+  <div class="margin-bottom-2">
+    <%= render partial: 'shared/threat_metrix_profiling',
+               locals: {
+                 threatmetrix_session_id:,
+                 threatmetrix_javascript_urls:,
+                 threatmetrix_iframe_url:,
+               } %>
+  </div>
+<% end %>
+


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16403](https://cm-jira.usa.gov/browse/LG-16403)

## 🛠 Summary of changes

We need to ensure that users that dont go through MFA setup page first due to the piv cac recommended option needs to 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- Ensure u load federal domains locally with `rake federal_email_domains:load_to_db`
- Create an account with a valid .gov domain
- Ensure that can go through and add pivcac without issue. 


