### PR TITLE
Bug Fixes, Passports, Allow non-IPP flows to reach choose_id_type screen

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -42,7 +42,7 @@ module Idv
       if result.success?
         idv_session.idv_consent_given_at = Time.zone.now
 
-        if in_person_proofing_route_enabled? && params[:skip_hybrid_handoff]
+        if idv_session.passport_allowed && params[:skip_hybrid_handoff]
           redirect_to idv_choose_id_type_url
         else
           idv_session.opted_in_to_in_person_proofing = false

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -507,12 +507,6 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
           )
           allow(IdentityConfig.store).to receive(:dos_passport_mrz_endpoint)
             .and_return('https://fake-socure.test/mrz')
-
-          ### below stubs should not be required for this spec, to be removed in LG-16388
-          allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
-          allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled)
-            .and_return(true)
-          ###
         end
 
         it 'proceeds to the next page with valid info' do

--- a/spec/support/features/doc_auth_helper.rb
+++ b/spec/support/features/doc_auth_helper.rb
@@ -97,9 +97,13 @@ module DocAuthHelper
     complete_doc_auth_steps_before_welcome_step
     complete_welcome_step
     complete_agreement_step
+
     return if page.current_path == idv_hybrid_handoff_path && remote
+
     if remote
-      click_on t('forms.buttons.continue_online')
+      if page.current_path == idv_hybrid_handoff_path
+        click_on t('forms.buttons.continue_online')
+      end
     else
       click_on t('forms.buttons.continue_ipp')
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16388](https://cm-jira.usa.gov/browse/LG-16388)

## 🛠 Summary of changes

Allow non-IPP flows to reach choose_id_type screen from agreement controller an remove unnecessary tests.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Can get to choose id type from IPP and complete flow
- [ ] Can get to choose id type from Remote and complete flow
