### PR TITLE
Lg-16372 docv user must submit id requested

### DIFF
--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -241,7 +241,7 @@ class SocureDocvResultsJob < ApplicationJob
       )
     end
 
-    mrz_client = Rails.env.local? ?
+    mrz_client = Rails.env.development? ?
                     DocAuth::Mock::DosPassportApiClient.new :
                     DocAuth::Dos::Requests::MrzRequest.new(mrz: doc_pii_response.pii_from_doc[:mrz])
     response = mrz_client.fetch

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -241,7 +241,7 @@ class SocureDocvResultsJob < ApplicationJob
       )
     end
 
-    mrz_client = Rails.env.development? ?
+    mrz_client = Rails.env.local? ?
                     DocAuth::Mock::DosPassportApiClient.new :
                     DocAuth::Dos::Requests::MrzRequest.new(mrz: doc_pii_response.pii_from_doc[:mrz])
     response = mrz_client.fetch

--- a/app/services/doc_auth/socure/requests/docv_result_request.rb
+++ b/app/services/doc_auth/socure/requests/docv_result_request.rb
@@ -34,7 +34,7 @@ module DocAuth
         def handle_http_response(http_response)
           DocAuth::Socure::Responses::DocvResultResponse.new(
             http_response: http_response,
-            passport_requested: document_capture_session&.passport_requested?,
+            passport_requested: document_capture_session.passport_requested?,
           )
         end
 

--- a/app/services/doc_auth/socure/requests/docv_result_request.rb
+++ b/app/services/doc_auth/socure/requests/docv_result_request.rb
@@ -34,6 +34,7 @@ module DocAuth
         def handle_http_response(http_response)
           DocAuth::Socure::Responses::DocvResultResponse.new(
             http_response: http_response,
+            passport_requested: document_capture_session&.passport_requested?,
           )
         end
 

--- a/app/services/doc_auth/socure/responses/docv_result_response.rb
+++ b/app/services/doc_auth/socure/responses/docv_result_response.rb
@@ -119,6 +119,8 @@ module DocAuth
             { socure: { reason_codes: } }
           elsif portrait_matching_failed?
             { selfie_fail: true }
+          elsif !id_type_expected?
+            { unexpected_id_type: true }
           else
             {}
           end

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -517,6 +517,7 @@ RSpec.describe SocureDocvResultsJob do
 
             context 'when docv passports are enabled' do
               before do
+                allow(Rails.env).to receive(:development?).and_return(true)
                 allow(IdentityConfig.store).to receive(:doc_auth_passport_vendor_default)
                   .and_return(Idp::Constants::Vendors::SOCURE)
                 document_capture_session.update!(

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -519,6 +519,9 @@ RSpec.describe SocureDocvResultsJob do
               before do
                 allow(IdentityConfig.store).to receive(:doc_auth_passport_vendor_default)
                   .and_return(Idp::Constants::Vendors::SOCURE)
+                document_capture_session.update!(
+                  passport_status: 'requested',
+                )
               end
 
               it 'doc auth succeeds' do

--- a/spec/services/doc_auth/socure/requests/docv_result_request_spec.rb
+++ b/spec/services/doc_auth/socure/requests/docv_result_request_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe DocAuth::Socure::Requests::DocvResultRequest do
     )
   end
   let(:fake_analytics) { FakeAnalytics.new }
-  let(:doc_type) { '' }
-  let(:decision_value) { '' }
+  let(:doc_type) { 'Drivers License' }
+  let(:decision_value) { 'accept' }
 
   subject(:docv_result_request) do
     described_class.new(
@@ -79,8 +79,6 @@ RSpec.describe DocAuth::Socure::Requests::DocvResultRequest do
               passport_status: 'requested',
             )
           end
-          let(:doc_type) { 'Drivers License' }
-          let(:decision_value) { 'accept' }
 
           it 'returns a DocAuth::Response failure' do
             expect(response.to_h).to include(
@@ -102,7 +100,6 @@ RSpec.describe DocAuth::Socure::Requests::DocvResultRequest do
             )
           end
           let(:doc_type) { 'Passport' }
-          let(:decision_value) { 'accept' }
 
           it 'returns a DocAuth::Response failure' do
             expect(response.to_h).to include(

--- a/spec/services/doc_auth/socure/requests/docv_result_request_spec.rb
+++ b/spec/services/doc_auth/socure/requests/docv_result_request_spec.rb
@@ -51,6 +51,24 @@ RSpec.describe DocAuth::Socure::Requests::DocvResultRequest do
       it 'returns a DocvResultResponse' do
         expect(response).to be_instance_of(DocAuth::Socure::Responses::DocvResultResponse)
       end
+
+      context 'fails if doc types do not match' do
+        before do
+          document_capture_session.update!(
+            passport_status: 'requested',
+          )
+        end
+
+        it 'returns a DocAuth::Response failure' do
+          expect(response.to_h).to include(
+            success: false,
+            errors: {
+              unaccepted_id_type: true,
+            },
+            vendor: 'Socure',
+          )
+        end
+      end
     end
 
     context 'when the docv request fails' do

--- a/spec/services/doc_auth/socure/requests/docv_result_request_spec.rb
+++ b/spec/services/doc_auth/socure/requests/docv_result_request_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe DocAuth::Socure::Requests::DocvResultRequest do
   let(:user) { create(:user) }
   let(:customer_user_id) { user.uuid }
   let(:user_email) { Faker::Internet.email }
-  let(:document_capture_session_uuid) { 'fake uuid' }
+  let(:docv_transaction_token) { 'fake docv transaction token' }
+  let(:document_capture_session) do
+    create(
+      :document_capture_session,
+      user:,
+      socure_docv_transaction_token: docv_transaction_token,
+    )
+  end
   let(:fake_analytics) { FakeAnalytics.new }
   let(:doc_type) { '' }
   let(:decision_value) { '' }
@@ -12,7 +19,7 @@ RSpec.describe DocAuth::Socure::Requests::DocvResultRequest do
   subject(:docv_result_request) do
     described_class.new(
       customer_user_id:,
-      document_capture_session_uuid:,
+      document_capture_session_uuid: document_capture_session.uuid,
       user_email:,
     )
   end
@@ -20,19 +27,10 @@ RSpec.describe DocAuth::Socure::Requests::DocvResultRequest do
   describe '#fetch' do
     let(:fake_socure_endpoint) { 'https://fake-socure.test/' }
     let(:fake_socure_api_endpoint) { 'https://fake-socure.test/api/3.0/EmailAuthScore' }
-    let(:docv_transaction_token) { 'fake docv transaction token' }
-    let(:document_capture_session) do
-      create(
-        :document_capture_session,
-        user:,
-        socure_docv_transaction_token: docv_transaction_token,
-      )
-    end
 
     before do
       allow(IdentityConfig.store).to receive(:socure_idplus_base_url)
         .and_return(fake_socure_endpoint)
-      allow(DocumentCaptureSession).to receive(:find_by).and_return(document_capture_session)
     end
 
     context 'when the docv request is successful' do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-16372](https://cm-jira.usa.gov/browse/LG-16372)


## 🛠 Summary of changes

Adding passport requested attribute to docv to check if user submitted the requested document


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - Setup application.yml for mock socure testing

> doc_auth_selfie_desktop_test_mode: true
  doc_auth_vendor: mock_socure
  doc_auth_vendor_default: mock_socure
  socure_docv_enabled: true
  socure_idplus_api_key: 'nope-not-a-valid-key'
  socure_docv_webhook_secret_key: 'sekret-key'

- [ ] Step 2 - Go through Doc Auth (RAILS_MAX_THREADS=3 make run), select 'Passport Pass JSON' option once at the mock socure page
- [ ] Step 3 - Ensure you see the unexpected id type error screen.


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.
Video Demo: https://drive.google.com/file/d/1NbDci8TkY4oxLB6-X0kmnwbtd72eMNOn/view?usp=sharing

<details>
<summary>After:</summary>
<img width="681" height="651" alt="Screenshot 2025-07-11 at 10 18 04 AM" src="https://github.com/user-attachments/assets/40501822-a88b-4900-8fef-269cec13faef" />

</details>

