### PR TITLE
LG-16422 Store failure result for unsuccessful MRZ requests

### DIFF
--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -314,10 +314,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       end
 
       before do
-        user = nil
-
         perform_in_browser(:desktop) do
-          user = sign_in_and_2fa_user
+          sign_in_and_2fa_user
 
           complete_doc_auth_steps_before_hybrid_handoff_step
           clear_and_fill_in(:doc_auth_phone, phone_number)
@@ -346,6 +344,11 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
           expect(page).to have_content(t('doc_auth.info.review_passport'))
           expect_to_try_again(is_hybrid: true)
           expect(page).to have_content(t('doc_auth.info.review_passport'))
+        end
+
+        perform_in_browser(:desktop) do
+          page.refresh
+          expect(page).to have_current_path(idv_link_sent_url)
         end
       end
 
@@ -380,6 +383,11 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
             expect(page).to have_content(t('doc_auth.errors.general.network_error'))
             expect_rate_limit_warning(max_attempts - 1)
           end
+
+          perform_in_browser(:desktop) do
+            page.refresh
+            expect(page).to have_current_path(idv_link_sent_url)
+          end
         end
       end
 
@@ -406,10 +414,15 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
             expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
             expect_rate_limit_warning(max_attempts - 1)
           end
+
+          perform_in_browser(:desktop) do
+            page.refresh
+            expect(page).to have_current_path(idv_link_sent_url)
+          end
         end
       end
 
-      context 'api 400 error' do
+      context 'when MRZ request responds with 400 error' do
         let(:fake_dos_api_endpoint) { 'http://fake_dos_api_endpoint/' }
 
         before do
@@ -431,10 +444,15 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
             expect(page).not_to have_current_path(idv_hybrid_mobile_capture_complete_url)
             expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
           end
+
+          perform_in_browser(:desktop) do
+            page.refresh
+            expect(page).to have_current_path(idv_link_sent_url)
+          end
         end
       end
 
-      context 'api 500 error' do
+      context 'when MRZ request responds with 500 error' do
         let(:fake_dos_api_endpoint) { 'http://fake_dos_api_endpoint/' }
 
         before do
@@ -443,6 +461,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
           stub_request(:post, fake_dos_api_endpoint)
             .to_return(status: 500, body: '{}', headers: {})
         end
+
         it 'shows the error message' do
           expect(@sms_link).to be_present
 
@@ -456,16 +475,19 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
             expect(page).not_to have_current_path(idv_hybrid_mobile_capture_complete_url)
             expect(page).to have_current_path(idv_hybrid_mobile_document_capture_url)
           end
+
+          perform_in_browser(:desktop) do
+            page.refresh
+            expect(page).to have_current_path(idv_link_sent_url)
+          end
         end
       end
     end
   end
 
   it 'shows the waiting screen correctly after cancelling from mobile and restarting', js: true do
-    user = nil
-
     perform_in_browser(:desktop) do
-      user = sign_in_and_2fa_user
+      sign_in_and_2fa_user
       complete_doc_auth_steps_before_hybrid_handoff_step
       clear_and_fill_in(:doc_auth_phone, phone_number)
       click_send_link
@@ -507,10 +529,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
     end
 
     it 'shows capture complete on mobile and error page on desktop', js: true do
-      user = nil
-
       perform_in_browser(:desktop) do
-        user = sign_in_and_2fa_user
+        sign_in_and_2fa_user
         complete_doc_auth_steps_before_hybrid_handoff_step
         clear_and_fill_in(:doc_auth_phone, phone_number)
         click_send_link
@@ -598,11 +618,9 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
       DocAuth::Mock::DocAuthMockClient.reset!
     end
 
-    it 'succefully captures image on last attempt', js: true do
-      user = nil
-
+    it 'successfully captures image on last attempt', js: true do
       perform_in_browser(:desktop) do
-        user = sign_in_and_2fa_user
+        sign_in_and_2fa_user
         complete_doc_auth_steps_before_hybrid_handoff_step
         clear_and_fill_in(:doc_auth_phone, phone_number)
         click_send_link
@@ -631,10 +649,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
 
   context 'barcode read error on mobile (redo document capture)', allow_browser_log: true do
     it 'continues to ssn on desktop when user selects Continue', js: true do
-      user = nil
-
       perform_in_browser(:desktop) do
-        user = sign_in_and_2fa_user
+        sign_in_and_2fa_user
         complete_doc_auth_steps_before_hybrid_handoff_step
         clear_and_fill_in(:doc_auth_phone, phone_number)
         click_send_link
@@ -707,10 +723,8 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
 
   context 'barcode read error on desktop, redo document capture on mobile' do
     it 'continues to ssn on desktop when user selects Continue', js: true do
-      user = nil
-
       perform_in_browser(:desktop) do
-        user = sign_in_and_2fa_user
+        sign_in_and_2fa_user
         complete_doc_auth_steps_before_document_capture_step
         mock_doc_auth_attention_with_barcode
         attach_and_submit_images


### PR DESCRIPTION
When MRZ request failed during passport document capture the document capture result was updated to have successful status. This allowed users to proceed through document capture even when the MRZ validation failed.

changelog: Bug fixes, Passport, Store failure result in document capture session when MRZ validation fails.

## 🎫 Ticket

Link to the relevant ticket(s):
[LG-16422](https://cm-jira.usa.gov/browse/LG-16422)
[LG-16430](https://cm-jira.usa.gov/browse/LG-16430)

## 🛠 Summary of changes

When MRZ request failed during passport document capture the document capture result was updated to have successful status. This allowed users to proceed through document capture even when the MRZ validation failed.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

Scenario: Invalid mrz passport submission

- [ ] Login through oidc-sinatra using Identity-verified
- [ ] Create a new account
- [ ] Proceed through idv flow opting to send a link to your phone
- [ ] Using `/test/telephony` copy the link and open it with a private browser
- [ ] From the private browser select the passport id type
- [ ] Attempt to upload an invalid passport (`spec/fixtures/passport_bad_mrz_credential.yml`)
- [ ] Verify that the private browser displays the document capture "We couldn’t verify your ID" error page
- [ ] Verify that the non private browser remains on the `verify/link_sent` page
- [ ] Verify that the document capture session result contains `success: false` and `pii: nil` using the rails console
```
DocumentCaptureSession.last.load_result
```

Scenario: Invalid state-ID submission

- [ ] Login through oidc-sinatra using Identity-verified
- [ ] Create a new account
- [ ] Proceed through idv flow opting to send a link to your phone
- [ ] Using `/test/telephony` copy the link and open it with a private browser
- [ ] From the private browser select the state-ID id type
- [ ] Attempt to upload an invalid state-ID
- [ ] Verify that the private browser displays the document capture "We couldn’t verify your ID" error page
- [ ] Verify that the non private browser remains on the `verify/link_sent` page
- [ ] Verify that the document capture session result contains `success: false` and `pii: nil` using the rails console
```
DocumentCaptureSession.last.load_result
```


Scenario: Valid passport submission

- [ ] Login through oidc-sinatra using Identity-verified
- [ ] Create a new account
- [ ] Proceed through idv flow opting to send a link to your phone
- [ ] Using `/test/telephony` copy the link and open it with a private browser
- [ ] From the private browser select the passport id type
- [ ] Attempt to upload an valid passport (`spec/fixtures/passport_credential.yml`)
- [ ] Verify that the private browser displays the switch back view
- [ ] Verify that the non private browser proceed to the SSN form

Scenario: Valid state-ID submission

- [ ] Login through oidc-sinatra using Identity-verified
- [ ] Create a new account
- [ ] Proceed through idv flow opting to send a link to your phone
- [ ] Using `/test/telephony` copy the link and open it with a private browser
- [ ] From the private browser select the state-ID id type
- [ ] Attempt to upload an valid state-ID
- [ ] Verify that the private browser displays the switch back view
- [ ] Verify that the non private browser proceed to the SSN form
