### PR TITLE
Revert bundler to 2.6.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -890,4 +890,4 @@ RUBY VERSION
    ruby 3.4.1p0
 
 BUNDLED WITH
-   2.7.0
+   2.6.9


### PR DESCRIPTION
## 🛠 Summary of changes

We ran into some issues with 2.7.0, so this reverts it.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
