### PR TITLE
Only encrypt and write images for integrations that are on the allowlist

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -67,7 +67,7 @@ module Idv
       end
 
       # if there is no client_response, there was no submission attempt
-      if doc_escrow_enabled? && client_response
+      if client_response
         pii_from_doc = client_response.pii_from_doc.to_h || {}
 
         attempts_api_tracker.idv_document_upload_submitted(
@@ -142,8 +142,6 @@ module Idv
     end
 
     def track_upload_attempt(response)
-      return unless doc_escrow_enabled?
-
       attempts_api_tracker.idv_document_uploaded(
         **doc_escrow_images,
         success: response.success?,
@@ -152,7 +150,7 @@ module Idv
     end
 
     def doc_escrow_enabled?
-      IdentityConfig.store.doc_escrow_enabled
+      FeatureManagement.doc_escrow_enabled?(service_provider)
     end
 
     def post_images_to_client
@@ -321,7 +319,7 @@ module Idv
     end
 
     def doc_escrow_images
-      return {} unless service_provider&.attempts_api_enabled?
+      return {} unless doc_escrow_enabled?
 
       images_metadata.attempts_file_data
     end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -321,7 +321,7 @@ module Idv
     end
 
     def doc_escrow_images
-      return {} unless service_provider.attempts_api_enabled?
+      return {} unless service_provider&.attempts_api_enabled?
 
       images_metadata.attempts_file_data
     end

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -71,7 +71,7 @@ module Idv
         pii_from_doc = client_response.pii_from_doc.to_h || {}
 
         attempts_api_tracker.idv_document_upload_submitted(
-          **images_metadata.attempts_file_data,
+          **doc_escrow_images,
           success: response.success?,
           document_state: pii_from_doc[:state],
           document_number: pii_from_doc[:state_id_number],
@@ -145,7 +145,7 @@ module Idv
       return unless doc_escrow_enabled?
 
       attempts_api_tracker.idv_document_uploaded(
-        **images_metadata.attempts_file_data,
+        **doc_escrow_images,
         success: response.success?,
         failure_reason: attempts_api_tracker.parse_failure_reason(response),
       )
@@ -318,6 +318,12 @@ module Idv
 
     def images_metadata
       @images_metadata ||= IdvImages.new(params)
+    end
+
+    def doc_escrow_images
+      return {} unless service_provider.attempts_api_enabled?
+
+      images_metadata.attempts_file_data
     end
 
     def passport_submittal

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -181,4 +181,8 @@ class FeatureManagement
   def self.allow_ipp_enrollment_approval?
     IdentityConfig.store.in_person_enrollments_immediate_approval_enabled
   end
+
+  def self.doc_escrow_enabled?(service_provider)
+    IdentityConfig.store.doc_escrow_enabled && service_provider&.attempts_api_enabled?
+  end
 end

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -28,14 +28,12 @@ RSpec.describe Idv::ImageUploadsController do
   before do
     stub_attempts_tracker
     allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-    allow(IdentityConfig.store).to receive(:doc_escrow_enabled).and_return(doc_escrow_enabled)
+    # allow(IdentityConfig.store).to receive(:doc_escrow_enabled).and_return(doc_escrow_enabled)
     allow(writer).to receive(:write).and_return result
     allow(controller).to receive(:sp_session).and_return(sp_session)
-    if attempts_api_enabled_for_sp
-      allow(IdentityConfig.store).to receive(:attempts_api_enabled).and_return(true)
-      allow(IdentityConfig.store).to receive(:allowed_attempts_providers)
-        .and_return([{ 'issuer' => sp.issuer }])
-    end
+    allow(FeatureManagement).to receive(:doc_escrow_enabled?).and_return(
+      doc_escrow_enabled && attempts_api_enabled_for_sp,
+    )
     stub_sign_in(user) if user
   end
 

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -91,9 +91,10 @@ RSpec.describe Idv::ApiImageUploadForm do
 
   before do
     allow(IdentityConfig.store).to receive(:doc_escrow_enabled).and_return doc_escrow_enabled
+    allow(FeatureManagement).to receive(:doc_escrow_enabled?).and_return(
+      doc_escrow_enabled && attempts_api_enabled_for_sp,
+    )
     allow(writer).to receive(:write).and_return result
-    allow(service_provider).to receive(:attempts_api_enabled?)
-      .and_return(attempts_api_enabled_for_sp)
 
     allow_any_instance_of(DocumentCaptureSession).to receive(:passport_requested?)
       .and_return(passport_requested)


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[FIE 46](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/46)

## 🛠 Summary of changes
We had [an incident](https://gsa-tts.slack.com/archives/C5QUGUANN/p1753112196260859) with the Attempts API where all Acuant proofing images were being saved to the s3 Bucket, rather than just images for the allowed service providers.

This change checks to make sure that the service provider is on the Attempts API allowlist before encrypting and saving the images.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
