### PR TITLE
LG-16440 Fix mobile remote fail over to In-person

### DIFF
--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -41,11 +41,11 @@ module Idv
 
       if result.success?
         idv_session.idv_consent_given_at = Time.zone.now
+        idv_session.opted_in_to_in_person_proofing = false
 
         if idv_session.passport_allowed && params[:skip_hybrid_handoff]
           redirect_to idv_choose_id_type_url
         else
-          idv_session.opted_in_to_in_person_proofing = false
           idv_session.skip_doc_auth_from_how_to_verify = false
           redirect_to idv_hybrid_handoff_url
         end

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -78,11 +78,6 @@ module Idv
       }.merge(ab_test_analytics_buckets)
     end
 
-    def in_person_proofing_route_enabled?
-      IdentityConfig.store.in_person_proofing_opt_in_enabled &&
-        IdentityConfig.store.in_person_proofing_enabled
-    end
-
     def skip_to_capture
       idv_session.flow_path = 'standard'
 

--- a/app/controllers/idv/agreement_controller.rb
+++ b/app/controllers/idv/agreement_controller.rb
@@ -63,6 +63,7 @@ module Idv
         undo_step: ->(idv_session:, user:) do
           idv_session.idv_consent_given_at = nil
           idv_session.skip_hybrid_handoff = nil
+          idv_session.opted_in_to_in_person_proofing = nil
         end,
       )
     end

--- a/spec/controllers/idv/agreement_controller_spec.rb
+++ b/spec/controllers/idv/agreement_controller_spec.rb
@@ -12,12 +12,6 @@ RSpec.describe Idv::AgreementController do
     stub_attempts_tracker
   end
 
-  describe '#step_info' do
-    it 'returns a valid StepInfo object' do
-      expect(Idv::AgreementController.step_info).to be_valid
-    end
-  end
-
   describe 'before_actions' do
     it 'includes authentication before_action' do
       expect(subject).to have_actions(
@@ -315,6 +309,33 @@ RSpec.describe Idv::AgreementController do
 
         expect(subject.idv_session.idv_consent_given?).to eq(false)
         expect(subject.idv_session.idv_consent_given_at).to be_nil
+      end
+    end
+  end
+
+  describe '#step_info' do
+    it 'returns a valid StepInfo object' do
+      expect(Idv::AgreementController.step_info).to be_valid
+    end
+
+    context 'undo_step' do
+      before do
+        subject.idv_session.idv_consent_given_at = Time.zone.now
+        subject.idv_session.skip_hybrid_handoff = false
+        subject.idv_session.opted_in_to_in_person_proofing = false
+        described_class.step_info.undo_step.call(idv_session: subject.idv_session, user:)
+      end
+
+      it 'sets the idv session idv_consent_given_at to nil' do
+        expect(subject.idv_session.idv_consent_given_at).to be_nil
+      end
+
+      it 'sets the idv session skip_hybrid_handoff to nil' do
+        expect(subject.idv_session.skip_hybrid_handoff).to be_nil
+      end
+
+      it 'sets the idv session opted_in_to_in_person_proofing to nil' do
+        expect(subject.idv_session.opted_in_to_in_person_proofing).to be_nil
       end
     end
   end

--- a/spec/features/idv/in_person/mobile_remote_failover_to_ipp_spec.rb
+++ b/spec/features/idv/in_person/mobile_remote_failover_to_ipp_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe 'mobile remote failover to In-person Proofing', js: true,
+                                                               driver: :headless_chrome_mobile do
+  include IdvStepHelper
+  include SpAuthHelper
+  include InPersonHelper
+  include UspsIppHelper
+
+  let(:ipp_service_provider) { create(:service_provider, :active, :in_person_proofing_enabled) }
+  let(:user) { user_with_2fa }
+
+  context 'when passports are enabled for IdV' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_percent).and_return(100)
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
+        .and_return(true)
+      stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+        .to_return({ status: 200, body: { status: 'UP' }.to_json })
+      reload_ab_tests
+    end
+
+    context 'when In-person passports are disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(false)
+      end
+
+      context 'when the user fails remote docauth', allow_browser_log: true do
+        before do
+          visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+          complete_doc_auth_steps_before_agreement_step
+          complete_agreement_step
+          choose_id_type(:state_id)
+
+          # Fail docauth
+          complete_document_capture_step_with_yml(
+            'spec/fixtures/ial2_test_credential_multiple_doc_auth_failures_both_sides.yml',
+            expected_path: idv_document_capture_url,
+          )
+        end
+
+        context 'when the user starts IPP and selects a post office location' do
+          before do
+            # begin in-person proofing
+            find(:button, t('in_person_proofing.body.cta.button'), wait: 10).click
+            complete_prepare_step
+            complete_location_step
+          end
+
+          it 'then the user is naviaged to the state id form step' do
+            expect(page).to have_current_path(idv_in_person_state_id_path)
+          end
+        end
+      end
+    end
+
+    context 'when In-person passports are enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(true)
+      end
+
+      context 'when the user fails remote docauth', allow_browser_log: true do
+        before do
+          visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+          sign_in_via_branded_page(user)
+          click_on t('webauthn_platform_recommended.skip')
+          complete_welcome_step
+          complete_agreement_step
+          choose_id_type(:state_id)
+
+          # Fail docauth
+          complete_document_capture_step_with_yml(
+            'spec/fixtures/ial2_test_credential_multiple_doc_auth_failures_both_sides.yml',
+            expected_path: idv_document_capture_url,
+          )
+        end
+
+        context 'when the user starts IPP and finds a post office location and ID type state-ID' do
+          before do
+            # begin in-person proofing
+            find(:button, t('in_person_proofing.body.cta.button'), wait: 10).click
+            complete_prepare_step
+            complete_location_step
+            choose_id_type(:state_id)
+          end
+
+          it 'then the user is navigated to the state-id form' do
+            expect(page).to have_current_path(idv_in_person_state_id_path)
+          end
+        end
+
+        context 'when the user starts IPP and finds a post office location and ID type passport' do
+          before do
+            # begin in-person proofing
+            find(:button, t('in_person_proofing.body.cta.button'), wait: 10).click
+            complete_prepare_step
+            complete_location_step
+            choose_id_type(:passport)
+          end
+
+          it 'then the user is navigated to the passport form' do
+            expect(page).to have_current_path(idv_in_person_passport_path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/idv/in_person/mobile_remote_failover_to_ipp_spec.rb
+++ b/spec/features/idv/in_person/mobile_remote_failover_to_ipp_spec.rb
@@ -7,16 +7,12 @@ RSpec.describe 'mobile remote failover to In-person Proofing', js: true,
   include InPersonHelper
   include UspsIppHelper
 
-  let(:ipp_service_provider) { create(:service_provider, :active, :in_person_proofing_enabled) }
-  let(:user) { user_with_2fa }
-
   context 'when passports are enabled for IdV' do
     before do
       allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled).and_return(true)
       allow(IdentityConfig.store).to receive(:doc_auth_passports_percent).and_return(100)
       allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
       allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled).and_return(true)
-        .and_return(true)
       stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
         .to_return({ status: 200, body: { status: 'UP' }.to_json })
       reload_ab_tests
@@ -27,9 +23,9 @@ RSpec.describe 'mobile remote failover to In-person Proofing', js: true,
         allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(false)
       end
 
-      context 'when the user fails remote docauth', allow_browser_log: true do
+      context 'when the user fails remote docauth and switches to IPP', allow_browser_log: true do
         before do
-          visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+          sign_in_and_2fa_user
           complete_doc_auth_steps_before_agreement_step
           complete_agreement_step
           choose_id_type(:state_id)
@@ -39,17 +35,18 @@ RSpec.describe 'mobile remote failover to In-person Proofing', js: true,
             'spec/fixtures/ial2_test_credential_multiple_doc_auth_failures_both_sides.yml',
             expected_path: idv_document_capture_url,
           )
+
+          # begin in-person proofing
+          find(:button, t('in_person_proofing.body.cta.button'), wait: 10).click
         end
 
-        context 'when the user starts IPP and selects a post office location' do
+        context 'when the user selects a post office location' do
           before do
-            # begin in-person proofing
-            find(:button, t('in_person_proofing.body.cta.button'), wait: 10).click
             complete_prepare_step
             complete_location_step
           end
 
-          it 'then the user is naviaged to the state id form step' do
+          it 'then the user is navigated to the state-id form step' do
             expect(page).to have_current_path(idv_in_person_state_id_path)
           end
         end
@@ -61,12 +58,10 @@ RSpec.describe 'mobile remote failover to In-person Proofing', js: true,
         allow(IdentityConfig.store).to receive(:in_person_passports_enabled).and_return(true)
       end
 
-      context 'when the user fails remote docauth', allow_browser_log: true do
+      context 'when the user fails remote docauth and switches to IPP', allow_browser_log: true do
         before do
-          visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
-          sign_in_via_branded_page(user)
-          click_on t('webauthn_platform_recommended.skip')
-          complete_welcome_step
+          sign_in_and_2fa_user
+          complete_doc_auth_steps_before_agreement_step
           complete_agreement_step
           choose_id_type(:state_id)
 
@@ -75,12 +70,12 @@ RSpec.describe 'mobile remote failover to In-person Proofing', js: true,
             'spec/fixtures/ial2_test_credential_multiple_doc_auth_failures_both_sides.yml',
             expected_path: idv_document_capture_url,
           )
+          # begin in-person proofing
+          find(:button, t('in_person_proofing.body.cta.button'), wait: 10).click
         end
 
-        context 'when the user starts IPP and finds a post office location and ID type state-ID' do
+        context 'when the user selects a post office location and ID type state-ID' do
           before do
-            # begin in-person proofing
-            find(:button, t('in_person_proofing.body.cta.button'), wait: 10).click
             complete_prepare_step
             complete_location_step
             choose_id_type(:state_id)
@@ -91,10 +86,8 @@ RSpec.describe 'mobile remote failover to In-person Proofing', js: true,
           end
         end
 
-        context 'when the user starts IPP and finds a post office location and ID type passport' do
+        context 'when the user selects a post office location and ID type passport' do
           before do
-            # begin in-person proofing
-            find(:button, t('in_person_proofing.body.cta.button'), wait: 10).click
             complete_prepare_step
             complete_location_step
             choose_id_type(:passport)


### PR DESCRIPTION
When a user failed document capture on remote with a mobile device session the user was unable to complete ID-IPP because their session was not setup correctly.

changelog: Bug fixes, Mobile idv, Fix mobile remote failover to In-person

## 🎫 Ticket

Link to the relevant ticket:
[LG-16440](https://cm-jira.usa.gov/browse/LG-16440)

## 🛠 Summary of changes

Change the agreement_controller to default `idv_session.opted_in_to_in_person` to false on update.


## 📜 Testing Plan
<details>
<summary>Scenario: Fail over from to In-person with a mobile device in the remote State-ID flow</summary>

Setup: Ensure IDV passports are enabled and IPP is enabled

```yml
  in_person_proofing_enabled: true
  in_person_proofing_opt_in_enabled: true
  in_person_passports_enabled: false
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100
```

- [ ] Login through oidc-sinatra using Identity-verified
- [ ] Create a new account
- [ ] Ensure simulating mobile or on mobile device
- [ ] Proceed through IdV for State-ID until document upload
- [ ] Upload documents triggering failure
- [ ] Ensure failure screen
- [ ] Click-on try in-person
- [ ] Proceed through In-person proofing
- [ ] Ensure the state-ID page is can to be reached
</details>
<details>
<summary>Scenario: Fail over from to In-person with a mobile device in the remote Passport flow</summary>

Setup: Ensure IDV passports are enabled and IPP is enabled

```yml
  in_person_proofing_enabled: true
  in_person_proofing_opt_in_enabled: true
  in_person_passports_enabled: false
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100
```

- [ ] Login through oidc-sinatra using Identity-verified
- [ ] Create a new account
- [ ] Ensure simulating mobile or on mobile device
- [ ] Proceed through IdV for Passport until document upload
- [ ] Upload documents triggering failure
- [ ] Ensure failure screen
- [ ] Click-on try in-person
- [ ] Proceed through In-person proofing
- [ ] Ensure the state-ID page is can to be reached
</details>
<details>
<summary>Scenario: Fail over from to In-person with a mobile device in the remote State-ID flow w/ IPP passports enabled</summary>

Setup: Ensure IDV passports are enabled and IPP is enabled

```yml
  in_person_proofing_enabled: true
  in_person_proofing_opt_in_enabled: true
  in_person_passports_enabled: true
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100
```

- [ ] Login through oidc-sinatra using Identity-verified
- [ ] Create a new account
- [ ] Ensure simulating mobile or on mobile device
- [ ] Proceed through IdV for Passport until document upload
- [ ] Upload documents triggering failure
- [ ] Ensure failure screen
- [ ] Click-on try in-person
- [ ] Proceed through State-ID In-person proofing
- [ ] Ensure the state-ID page is can to be reached
</details>
<details>
<summary>Scenario: Fail over from to In-person with a mobile device in the remote Passport flow w/ IPP passports enabled</summary>

Setup: Ensure IDV passports are enabled and IPP is enabled

```yml
  in_person_proofing_enabled: true
  in_person_proofing_opt_in_enabled: true
  in_person_passports_enabled: true
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100
```

- [ ] Login through oidc-sinatra using Identity-verified
- [ ] Create a new account
- [ ] Ensure simulating mobile or on mobile device
- [ ] Proceed through IdV for Passport until document upload
- [ ] Upload documents triggering failure
- [ ] Ensure failure screen
- [ ] Click-on try in-person
- [ ] Proceed through passport In-person proofing
- [ ] Ensure the passport page is can to be reached
</details>
