### PR TITLE
LG-16268: Implement: Update link to help article from "I didn't receive my one time code"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1819,7 +1819,7 @@ two_factor_authentication.phone_fee_disclosure: Message and data rates may apply
 two_factor_authentication.phone_info: We’ll send you a one-time code each time you sign in.
 two_factor_authentication.phone_label: Phone number
 two_factor_authentication.phone_verification.troubleshooting.change_number: Use another phone number
-two_factor_authentication.phone_verification.troubleshooting.code_not_received: I didn’t receive my one-time code
+two_factor_authentication.phone_verification.troubleshooting.code_not_received: I'm not receiving a one-time code through SMS/Text or phone call
 two_factor_authentication.phone.delete.failure: Unable to remove your phone.
 two_factor_authentication.phone.delete.success: Your phone has been removed.
 two_factor_authentication.piv_cac_header_text: Insert your government employee ID

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1831,7 +1831,7 @@ two_factor_authentication.phone_fee_disclosure: Se pueden aplicar tarifas por me
 two_factor_authentication.phone_info: Le enviaremos un código de un solo uso cada vez que inicie sesión.
 two_factor_authentication.phone_label: Número de teléfono
 two_factor_authentication.phone_verification.troubleshooting.change_number: Use otro número de teléfono
-two_factor_authentication.phone_verification.troubleshooting.code_not_received: No recibí mi código de un solo uso
+two_factor_authentication.phone_verification.troubleshooting.code_not_received: No estoy recibiendo el código de un solo uso por mensaje de texto (SMS) ni por llamada telefónica 
 two_factor_authentication.phone.delete.failure: No se puede eliminar su teléfono.
 two_factor_authentication.phone.delete.success: Su teléfono fue eliminado.
 two_factor_authentication.piv_cac_header_text: Inserte su identificación de empleado del gobierno

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1819,7 +1819,7 @@ two_factor_authentication.phone_fee_disclosure: Des tarifs de messagerie et de d
 two_factor_authentication.phone_info: Nous vous enverrons un code à usage unique à chaque fois que vous vous connecterez.
 two_factor_authentication.phone_label: Numéro de téléphone
 two_factor_authentication.phone_verification.troubleshooting.change_number: Utiliser un autre numéro de téléphone
-two_factor_authentication.phone_verification.troubleshooting.code_not_received: Je n’ai pas reçu mon code à usage unique
+two_factor_authentication.phone_verification.troubleshooting.code_not_received: Je ne reçois pas de code à usage unique par SMS/texto ou appel téléphonique
 two_factor_authentication.phone.delete.failure: Impossible de supprimer votre téléphone.
 two_factor_authentication.phone.delete.success: Votre téléphone a été supprimé.
 two_factor_authentication.piv_cac_header_text: Insérer votre carte d’employé fédéral

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1832,7 +1832,7 @@ two_factor_authentication.phone_fee_disclosure: 可能会收短信和数据费�
 two_factor_authentication.phone_info: 你每次登录我们会给你发个一次性代码。
 two_factor_authentication.phone_label: 电话号码
 two_factor_authentication.phone_verification.troubleshooting.change_number: 使用另一个电话号码
-two_factor_authentication.phone_verification.troubleshooting.code_not_received: 我没收到一次性代码
+two_factor_authentication.phone_verification.troubleshooting.code_not_received: 我没有通过SMS/短信或电话收到一个一次性代码
 two_factor_authentication.phone.delete.failure: 无法去掉你的电话。
 two_factor_authentication.phone.delete.success: 你的电话已被去掉。
 two_factor_authentication.piv_cac_header_text: 插入您的政府雇员ID


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16268: Implement: Update link to help article from "I didn't receive my one time code"](https://cm-jira.usa.gov/browse/LG-16268)

## 🛠 Summary of changes

This pull request changes text for the link to redirect users to the help center when they have questions about not receiving their one-time code

## 📜 Testing Plan
- [ ] Follow steps to create an account
- [ ] Set up Text or voice message as your authentication method
- [ ] When prompted, enter your phone number
- [ ] On the page where you are prompted to enter your one-time code, scroll down and see the change in the second link


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
