### PR TITLE
Ensure documents are only uploaded into docment escrow once

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -322,7 +322,9 @@ module Idv
     def doc_escrow_images
       return {} unless doc_escrow_enabled?
 
-      images_metadata.attempts_file_data
+      return @doc_escrow_images if defined?(@doc_escrow_images)
+      @doc_escrow_images = images_metadata.attempts_file_data
+      @doc_escrow_images
     end
 
     def passport_submittal

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe Idv::ImageUploadsController do
           before do
             allow(writer).to receive(:write).and_return result
             expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-            expect(writer).to receive(:write).exactly(4).times
+            expect(writer).to receive(:write).exactly(2).times
           end
 
           it 'tracks the event' do

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
             form.send(:images).each do |image|
               # testing that the storage is happening
-              expect(writer).to receive(:write).with(image: image.bytes).exactly(2).times
+              expect(writer).to receive(:write).with(image: image.bytes).exactly(1).time
             end
           end
 
@@ -512,7 +512,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
               form.send(:images).each do |image|
                 # testing that the storage is happening
-                expect(writer).to receive(:write).with(image: image.bytes).exactly(2).times
+                expect(writer).to receive(:write).with(image: image.bytes).exactly(1).time
               end
             end
 


### PR DESCRIPTION
## 🎫 Ticket

## 🛠 Summary of changes

This PR does a bit of memoization to return the same image metadata in the two associated events, but only upload once.