### PR TITLE
changelog: Bug Fixes, Passports, Fix error message shown for passport…

### DIFF
--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -60,9 +60,9 @@ module DocAuth
           return {} if successful_result?
 
           if passport_detected_but_not_allowed?
-            { passport: true }
+            { passport: I18n.t('doc_auth.errors.doc.doc_type_check') }
           elsif passport_card_detected?
-            { passport_card: true }
+            { passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') }
           elsif id_type.present? && !id_doc_type_expected?
             { unexpected_id_type: I18n.t('doc_auth.errors.general.no_liveness') }
           elsif with_authentication_result?

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -373,7 +373,9 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       end
 
       it 'has error messages' do
-        expect(response.error_messages[:passport_card]).to eq(true)
+        expect(response.error_messages[:passport_card]).to eq(
+          I18n.t('doc_auth.errors.doc.doc_type_check'),
+        )
       end
     end
 
@@ -387,7 +389,9 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
       end
 
       it 'has error messages' do
-        expect(response.error_messages[:passport]).to eq(true)
+        expect(response.error_messages[:passport]).to eq(
+          I18n.t('doc_auth.errors.doc.doc_type_check'),
+        )
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16432](https://cm-jira.usa.gov/browse/LG-16432)

## 🛠 Summary of changes

Show generic ID error when passport card is used in passport book flow.

## 📜 Testing Plan

In order to properly simulate this error locally, some changes need to be made when testing.

- [ ] Step 1: Comment out the response definition in the `post_images_to_client` method inside `app/forms/idv/api_image_upload_form.rb` and add the following code above it:

```
path = File.join(
  Rails.root,
  'spec/fixtures/proofing/lexis_nexis/true_id',
  'true_id_response_success_passport_card.json',
)
      
response = DocAuth::LexisNexis::Responses::TrueIdResponse.new(
  Faraday::Response.new({response_body: File.read(path), status: 200}),
  {}
)
```

Update as of July 24 Response must be formatted as:

```
response = DocAuth::LexisNexis::Responses::TrueIdResponse.new(
  http_request: Faraday::Response.new({response_body: File.read(path), status: 200}),
  config: {}
)
```
      
- [ ] Step 2: Ensure the proper error message (instead of "true") is shown when submitting a passport card to the passport book flow in document capture.