### PR TITLE
LG-16510: Tmx session id error fix

### DIFF
--- a/app/controllers/concerns/mfa_setup_concern.rb
+++ b/app/controllers/concerns/mfa_setup_concern.rb
@@ -99,6 +99,7 @@ module MfaSetupConcern
       uuid_prefix: current_sp&.app_id,
       user_uuid: current_user.uuid,
       in_ab_test_bucket: in_tmx_ab_test_bucket?,
+      in_account_creation_flow: in_account_creation_flow?,
     }
   end
 

--- a/app/services/funnel/registration/add_mfa.rb
+++ b/app/services/funnel/registration/add_mfa.rb
@@ -17,7 +17,8 @@ module Funnel
 
       def self.process_threatmetrix_for_user(threatmetrix_attrs)
         return unless FeatureManagement.account_creation_device_profiling_collecting_enabled?
-        return unless threatmetrix_attrs.delete(:in_ab_test_bucket)
+        return unless threatmetrix_attrs.delete(:in_ab_test_bucket) &&
+                      threatmetrix_attrs.delete(:in_account_creation_flow)
         AccountCreationThreatMetrixJob.perform_now(**threatmetrix_attrs)
       end
     end

--- a/spec/controllers/users/backup_code_setup_controller_spec.rb
+++ b/spec/controllers/users/backup_code_setup_controller_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Users::BackupCodeSetupController do
         request_ip: Faker::Internet.ip_v4_address,
         threatmetrix_session_id: 'test-session',
         email: user.email,
+        in_ab_test_bucket: true,
+        in_account_creation_flow: true,
       }
     end
 

--- a/spec/controllers/users/webauthn_setup_controller_spec.rb
+++ b/spec/controllers/users/webauthn_setup_controller_spec.rb
@@ -98,6 +98,8 @@ RSpec.describe Users::WebauthnSetupController do
           request_ip: Faker::Internet.ip_v4_address,
           threatmetrix_session_id: 'test-session',
           email: user.email,
+          in_ab_test_bucket: true,
+          in_account_creation_flow: true,
         }
       end
 

--- a/spec/services/funnel/registration/add_mfa_spec.rb
+++ b/spec/services/funnel/registration/add_mfa_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Funnel::Registration::AddMfa do
       threatmetrix_session_id: SecureRandom.uuid,
       email: user.email,
       in_ab_test_bucket: true,
+      in_account_creation_flow: true,
     }
   end
 

--- a/spec/services/funnel/registration/total_registered_count_spec.rb
+++ b/spec/services/funnel/registration/total_registered_count_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Funnel::Registration::TotalRegisteredCount do
       request_ip: Faker::Internet.ip_v4_address,
       threatmetrix_session_id: 'test-session',
       email: user.email,
+      in_ab_test_bucket: true,
+      in_account_creation_flow: true,
     }
   end
   subject { described_class }


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)

## 🛠 Summary of changes

Ensure only users in account creation flow is going through and tmx 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- Go through and create user without webauthn platform
- Sign in again and be suggested webauthn platform
- successfully sign in without an issue. 
