### PR TITLE
LG-16433 fix errored passport message showing 'true'

### DIFF
--- a/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
+++ b/app/javascript/packages/document-capture/components/document-side-acuant-capture.tsx
@@ -57,7 +57,10 @@ function DocumentSideAcuantCapture({
   isReviewStep,
   showSelfieHelp,
 }: DocumentSideAcuantCaptureProps) {
-  const error = errors.find(({ field }) => field === side)?.error;
+  const isPassport = side === 'passport';
+  /* Passport errors default to 'front' see app/services/doc_auth/error_generator.rb line 28 */
+  const errorSide = isPassport ? 'front' : side;
+  const error = errors.find(({ field }) => field === errorSide)?.error;
   const { changeStepCanComplete } = useContext(FormStepsContext);
   const { isSelfieDesktopTestMode, isUploadEnabled } = useContext(SelfieCaptureContext);
   const isUploadAllowed = isSelfieDesktopTestMode || isUploadEnabled;


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket


[LG-16433](https://cm-jira.usa.gov/browse/LG-16433)



## 🛠 Summary of changes

If there is a network error that occurred when uploading a passport an unexpected error message 'true' was showing up. This eliminates it.

Essentially if we get a connection error in `app/services/doc_auth/dos/request.rb` we send back a doc auth response with 
`errors: { network: true, passport: true}`.

These two errors are used to determine what text is placed on our doc auth error page. The `passport: true` is the culprit of this true message. 

In our error generator from the backend we send passport errors as 'front' of id errors as seen in https://github.com/18F/identity-idp/blob/main/app/services/doc_auth/error_generator.rb#L28

This PR updates the error field in the front end to also treat the passport side as the front side to remove the unexpected 'true' error message.



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Set application.yml to the following
   

>      doc_auth_passports_enabled: true
>      doc_auth_passports_percent:100
>      doc_auth_mock_dos_api: false

- [ ] Set up a failing dos request connection by editing `DocAuth::Dos::Request#send_http_request`. Inside the `when :post` case replace `send_http_post_request` with `raise Faraday::ConnectionFailed.new` to mock a network failure
- [ ] Go through IdV and select Passport. Upload a passing passport (`spec/fixtures/passport_credential.yml`)
- [ ] Confirm you see an error screen and hit try again.
- [ ] Confirm that you do not see an error under "Your passport" showing `true`



## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/83ca82e4-4739-400c-8d66-aebf2bcbc327" /></details>

<details>
<summary>After:</summary>

<img width="690" height="768" alt="Screenshot 2025-07-28 at 2 58 30 PM" src="https://github.com/user-attachments/assets/95937265-4b2d-4b2e-8932-554f129da6ba" />

</details>
