### PR TITLE
Do not write file during when running seeding for Service Providers in review apps

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,9 +4,7 @@
 if ENV['KUBERNETES_REVIEW_APP'] == 'true' && ENV['DASHBOARD_URL'].present?
   dashboard_url = ENV['DASHBOARD_URL']
 
-  service_provider_seeder = ServiceProviderSeeder.new
-  service_provider_seeder.write_review_app_yaml(dashboard_url: dashboard_url)
-  service_provider_seeder.run
+  ServiceProviderSeeder.new.run_review_app(dashboard_url: dashboard_url)
 else
   ServiceProviderSeeder.new.run
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[!214](https://gitlab.login.gov/lg-teams/FIE/partner-portal-prod-edition/-/issues/214)

## 🛠 Summary of changes

Currently the seed task for review apps fails because we rely on writing to the file system. This change proposes directly creating the records in the database using the same process as we use outside of review apps. There is a small refactor to allow both cases to use the same behavior, but it should not result in any changes to non-review app database seeding.

## 📜 Testing Plan

- [ ] The review apps for this PR have a seeded database

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
