### PR TITLE
Use active service_provider in trait

### DIFF
--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -104,7 +104,7 @@ FactoryBot.define do
 
     trait :facial_match_proof do
       idv_level { :unsupervised_with_selfie }
-      initiating_service_provider_issuer { 'urn:gov:gsa:openidconnect:inactive:sp:test' }
+      initiating_service_provider_issuer { OidcAuthHelper::OIDC_FACIAL_MATCH_ISSUER }
     end
 
     after(:build) do |profile, evaluator|

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
       context 'when the SSN is not unique' do
         before do
           allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
-            .and_return(['urn:gov:gsa:openidconnect:inactive:sp:test'])
+            .and_return([OidcAuthHelper::OIDC_FACIAL_MATCH_ISSUER])
           create(:profile, :facial_match_proof, pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN)
         end
 

--- a/spec/services/idv/duplicate_ssn_finder_spec.rb
+++ b/spec/services/idv/duplicate_ssn_finder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Idv::DuplicateSsnFinder do
 
     before do
       allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
-        .and_return(['urn:gov:gsa:openidconnect:inactive:sp:test'])
+        .and_return([OidcAuthHelper::OIDC_FACIAL_MATCH_ISSUER])
     end
 
     context 'when the ssn is unique' do
@@ -76,7 +76,7 @@ RSpec.describe Idv::DuplicateSsnFinder do
 
     before do
       allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
-        .and_return(['urn:gov:gsa:openidconnect:inactive:sp:test'])
+        .and_return([OidcAuthHelper::OIDC_FACIAL_MATCH_ISSUER])
     end
 
     context 'when profile is IAL2' do
@@ -115,7 +115,7 @@ RSpec.describe Idv::DuplicateSsnFinder do
 
     before do
       allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
-        .and_return(['urn:gov:gsa:openidconnect:inactive:sp:test'])
+        .and_return([OidcAuthHelper::OIDC_FACIAL_MATCH_ISSUER])
     end
     context 'when profile is IAL2' do
       context 'when ssn is taken by different profile by and is IAL2' do

--- a/spec/support/oidc_auth_helper.rb
+++ b/spec/support/oidc_auth_helper.rb
@@ -6,6 +6,7 @@ module OidcAuthHelper
   OIDC_ISSUER = 'urn:gov:gsa:openidconnect:sp:server'.freeze
   OIDC_IAL1_ISSUER = 'urn:gov:gsa:openidconnect:sp:server_ial1'.freeze
   OIDC_AAL3_ISSUER = 'urn:gov:gsa:openidconnect:sp:server_requiring_aal3'.freeze
+  OIDC_FACIAL_MATCH_ISSUER = 'urn:gov:gsa:openidconnect:test'.freeze
 
   def sign_in_oidc_user(user)
     visit_idp_from_ial1_oidc_sp


### PR DESCRIPTION
changelog: Internal, Testing, Use active service_provider in trait

The trait `facial_match_proof` uses an inactive service provider (that is probably unintentional). This causes no harm right now. This commit should prevent any nasty surprises in the future.

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
