### PR TITLE
Include issuer in document escrow document name

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -328,7 +328,7 @@ module Idv
       return {} unless doc_escrow_enabled?
 
       return @doc_escrow_images if defined?(@doc_escrow_images)
-      @doc_escrow_images = images_metadata.attempts_file_data
+      @doc_escrow_images = images_metadata.attempts_file_data(issuer: service_provider.issuer)
       @doc_escrow_images
     end
 

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -234,7 +234,7 @@ class SocureDocvResultsJob < ApplicationJob
   end
 
   def doc_escrow_name
-    SecureRandom.uuid
+    "#{sp.issuer}/#{SecureRandom.uuid}"
   end
 
   def doc_escrow_key

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -11,12 +11,14 @@ module EncryptedDocStorage
       @s3_enabled = s3_enabled
     end
 
-    def write(image: nil)
+    def write(issuer:, image: nil)
+      raise if issuer.blank?
+
       if image.blank?
         return Result.new(name: nil, encryption_key: nil)
       end
 
-      name = SecureRandom.uuid
+      name = "#{issuer}/#{SecureRandom.uuid}"
       encryption_key = SecureRandom.bytes(32)
 
       write_with_data(
@@ -45,9 +47,7 @@ module EncryptedDocStorage
     end
 
     def storage
-      @storage ||= begin
-        @s3_enabled ? S3Storage.new : LocalStorage.new
-      end
+      @storage ||= @s3_enabled ? S3Storage.new : LocalStorage.new
     end
   end
 end

--- a/app/services/encrypted_doc_storage/local_storage.rb
+++ b/app/services/encrypted_doc_storage/local_storage.rb
@@ -3,9 +3,10 @@
 module EncryptedDocStorage
   class LocalStorage
     def write_image(encrypted_image:, name:)
-      FileUtils.mkdir_p(tmp_document_storage_dir)
+      full_path = tmp_document_storage_dir.join(name)
+      FileUtils.mkdir_p(full_path.dirname)
 
-      File.open(tmp_document_storage_dir.join(name), 'wb') do |f|
+      File.open(full_path, 'wb') do |f|
         f.write(encrypted_image)
       end
     end

--- a/app/services/idv/idv_images.rb
+++ b/app/services/idv/idv_images.rb
@@ -18,9 +18,9 @@ module Idv
       @errors = {}
     end
 
-    def attempts_file_data
+    def attempts_file_data(issuer:)
       images.each_with_object({}) do |image, obj|
-        result = write_image(image.bytes)
+        result = write_image(issuer:, image: image.bytes)
         obj[image.attempts_tracker_file_id_key] = result.name
         obj[image.attempts_tracker_encryption_key] = result.encryption_key
       end
@@ -78,8 +78,8 @@ module Idv
 
     private
 
-    def write_image(image)
-      encrypted_document_storage_writer.write(image:)
+    def write_image(issuer:, image:)
+      encrypted_document_storage_writer.write(issuer:, image:)
     end
 
     def write_image_with_data(image, encryption_key:, name:)

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Idv::ImageUploadsController do
           let(:attempts_api_enabled_for_sp) { true }
           before do
             expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-            expect(writer).to receive(:write).with(image: nil).and_call_original
+            expect(writer).to receive(:write).with(issuer: sp.issuer, image: nil).and_call_original
             allow(writer).to receive(:write).and_return result
           end
 

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -312,7 +312,10 @@ RSpec.describe Idv::ApiImageUploadForm do
 
             form.send(:images).each do |image|
               # testing that the storage is happening
-              expect(writer).to receive(:write).with(image: image.bytes).exactly(1).time
+              expect(writer).to receive(:write).with(
+                issuer: service_provider.issuer,
+                image: image.bytes,
+              ).exactly(1).time
             end
           end
 
@@ -512,7 +515,10 @@ RSpec.describe Idv::ApiImageUploadForm do
 
               form.send(:images).each do |image|
                 # testing that the storage is happening
-                expect(writer).to receive(:write).with(image: image.bytes).exactly(1).time
+                expect(writer).to receive(:write).with(
+                  issuer: service_provider.issuer,
+                  image: image.bytes,
+                ).exactly(1).time
               end
             end
 
@@ -704,7 +710,10 @@ RSpec.describe Idv::ApiImageUploadForm do
 
             form.send(:images).each do |image|
               # testing that the storage is happening
-              expect(writer).to receive(:write).with(image: image.bytes).and_return result
+              expect(writer).to receive(:write).with(
+                issuer: service_provider.issuer,
+                image: image.bytes,
+              ).exactly(1).time.and_return(result)
             end
           end
 
@@ -784,7 +793,10 @@ RSpec.describe Idv::ApiImageUploadForm do
 
             form.send(:images).each do |image|
               # testing that the storage is happening
-              expect(writer).to receive(:write).with(image: image.bytes)
+              expect(writer).to receive(:write).with(
+                issuer: service_provider.issuer,
+                image: image.bytes,
+              ).exactly(1).time
             end
           end
           it 'tracks the event (as a success as doc upload succeeded)' do

--- a/spec/services/idv/idv_images_spec.rb
+++ b/spec/services/idv/idv_images_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Idv::IdvImages do
   let(:front_image) { DocAuthImageFixtures.document_front_image_multipart }
   let(:selfie_image) { nil }
   let(:passport_image) { nil }
+  let(:issuer) { 'issuer' }
 
   let(:writer) { EncryptedDocStorage::DocWriter.new }
   let(:result) do
@@ -58,11 +59,11 @@ RSpec.describe Idv::IdvImages do
       expect(EncryptedDocStorage::DocWriter).to receive(:new).with(s3_enabled: false)
       expect(writer).to receive(:write).exactly(2).times
 
-      subject.attempts_file_data
+      subject.attempts_file_data(issuer: issuer)
     end
 
     it 'returns a hash of objects' do
-      expect(subject.attempts_file_data).to be_a_kind_of(Hash)
+      expect(subject.attempts_file_data(issuer: issuer)).to be_a_kind_of(Hash)
     end
 
     context 'when s3 storage is turned on' do
@@ -72,7 +73,7 @@ RSpec.describe Idv::IdvImages do
         expect(EncryptedDocStorage::DocWriter).to receive(:new).with(s3_enabled: true)
         expect(writer).to receive(:write).exactly(2).times
 
-        subject.attempts_file_data
+        subject.attempts_file_data(issuer: issuer)
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[!49](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/49)

## 🛠 Summary of changes

To better structure the storage, this prefixes the issuer as a "folder" to the name of the document objects.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
