### PR TITLE
Log the parsed response body for the DoS Heath Check

### DIFF
--- a/app/services/doc_auth/dos/responses/health_check_response.rb
+++ b/app/services/doc_auth/dos/responses/health_check_response.rb
@@ -36,7 +36,7 @@ module DocAuth
 
         def extra
           {
-            body:,
+            body: parsed_body,
           }
         end
 


### PR DESCRIPTION
Currently, the response body is included in the event log, but as a JSON string so we can't query against any of the fields. This PR simply changes that to a parsed hash.

[skip changelog]
