### PR TITLE
Update json gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.1.2)
       railties (>= 6.0.0)
-    json (2.13.0)
+    json (2.13.2)
     jwe (0.4.0)
     jwt (2.7.1)
     knapsack (4.0.0)


### PR DESCRIPTION
## 🛠 Summary of changes

Since updating to `2.13.0`, we've seen a few warnings with:

> warning: detected duplicate keys in JSON object. This will raise an error in json 3.0 unless enabled via allow_duplicate_key: true at line 1 column 1

The logging doesn't tell us where, but that has been added in [2.13.2](https://github.com/ruby/json/releases/tag/v2.13.2) and should help us address the warning.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
