### PR TITLE
LG-16540: A/B Framework One account 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -538,10 +538,15 @@ class ApplicationController < ActionController::Base
     ).last
   end
 
+  def user_in_one_account_verification_bucket?
+    ab_test_bucket(:ONE_ACCOUNT_USER_VERIFICATION_ENABLED) == :one_account_user_verification_enabled
+  end
+
   def user_duplicate_profiles_detected?
     return false unless sp_eligible_for_one_account?
     profile = current_user&.active_profile
     return false unless profile
+    return false unless user_in_one_account_verification_bucket?
     user_session[:duplicate_profile_ids].present?
   end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -307,6 +307,7 @@ minimum_wait_before_another_usps_letter_in_hours: 24
 mx_timeout: 3
 new_device_alert_delay_in_minutes: 5
 newrelic_license_key: ''
+one_account_user_verification_enabled_percentage: 0
 openid_connect_content_security_form_action_enabled: false
 openid_connect_redirect: client_side_js
 otp_delivery_blocklist_findtime: 5

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -137,6 +137,19 @@ module AbTests
     user&.uuid
   end.freeze
 
+  ONE_ACCOUNT_USER_VERIFICATION_ENABLED = AbTest.new(
+    experiment_name: 'One Account User Verification Enabled',
+    should_log: [
+      :account_creation_tmx_result,
+    ].to_set,
+    buckets: {
+      one_account_user_verification_enabled_percentage: IdentityConfig.store.one_account_user_verification_enabled_percentage,
+    },
+    persist: true,
+  ) do |user:, user_session:, **|
+    user&.uuid
+  end.freeze
+
   SOCURE_IDV_SHADOW_MODE_FOR_NON_DOCV_USERS = AbTest.new(
     experiment_name: 'Socure shadow mode',
     should_log: ['IdV: doc auth verify proofing results'].to_set,

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -147,9 +147,9 @@ module AbTests
       :one_account_recognize_all_profiles,
     ].to_set,
     buckets: {
-      one_account_user_verification_enabled_percentage: IdentityConfig.store.one_account_user_verification_enabled_percentage,
+      one_account_user_verification_enabled_percentage:
+        IdentityConfig.store.one_account_user_verification_enabled_percentage,
     },
-    persist: true,
   ) do |user:, user_session:, **|
     user&.uuid
   end.freeze

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -140,7 +140,11 @@ module AbTests
   ONE_ACCOUNT_USER_VERIFICATION_ENABLED = AbTest.new(
     experiment_name: 'One Account User Verification Enabled',
     should_log: [
-      :account_creation_tmx_result,
+      'Email and Password Authentication',
+      'SP redirect initiated',
+      :one_account_duplicate_profiles_detected,
+      :one_account_unknown_profile_detected,
+      :one_account_recognize_all_profiles,
     ].to_set,
     buckets: {
       one_account_user_verification_enabled_percentage: IdentityConfig.store.one_account_user_verification_enabled_percentage,

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -319,6 +319,7 @@ module IdentityConfig
     config.add(:mx_timeout, type: :integer)
     config.add(:new_device_alert_delay_in_minutes, type: :integer)
     config.add(:newrelic_license_key, type: :string)
+    config.add(:one_account_user_verification_enabled_percentage, type: :integer)
     config.add(
       :openid_connect_redirect,
       type: :string,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16540](https://cm-jira.usa.gov/browse/LG-16540)



## 🛠 Summary of changes

Adds A/B test functionality for the one verified account information


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] set `eligible_one_account_providers` to include the SP u will be coming form
- [ ] set `one_account_user_verification_enabled_percentage` to 0 for negative test and 100 for positive test
- [ ] have user with a duplicate profile on another account
- [ ] even if user has duplicate profile they move through normally when `one_account_user_verification_enabled_percentage` set to 0, and user is blocked when its set to `100` 
- [ ] test other percentages as well with different accounts
- [ ] Verify users have same experience across same device. 
