### PR TITLE
Fix LG-99 metric in Fraud Report | GL-Data-184

### DIFF
--- a/lib/reporting/fraud_metrics_lg99_report.rb
+++ b/lib/reporting/fraud_metrics_lg99_report.rb
@@ -17,7 +17,7 @@ module Reporting
     attr_reader :time_range
 
     module Events
-      IDV_FINAL_RESOLUTION = 'IdV: Final Resolution'
+      IDV_FINAL_RESOLUTION = 'IdV: final resolution'
       SUSPENDED_USERS = 'User Suspension: Suspended'
       REINSTATED_USERS = 'User Suspension: Reinstated'
 
@@ -158,9 +158,9 @@ module Reporting
         fields
             name
           , properties.user_id as user_id
+         | filter name in %{event_names}
          | filter (name = %{idv_final_resolution} and properties.event_properties.fraud_review_pending = 1)
                  or (name != %{idv_final_resolution})
-        | filter name in %{event_names}
         | limit 10000
       QUERY
     end

--- a/lib/reporting/irs_fraud_metrics_lg99_report.rb
+++ b/lib/reporting/irs_fraud_metrics_lg99_report.rb
@@ -17,7 +17,7 @@ module Reporting
     attr_reader :issuers, :time_range
 
     module Events
-      IDV_FINAL_RESOLUTION = 'IdV: Final Resolution'
+      IDV_FINAL_RESOLUTION = 'IdV: final resolution'
       SUSPENDED_USERS = 'User Suspension: Suspended'
       REINSTATED_USERS = 'User Suspension: Reinstated'
 
@@ -156,9 +156,9 @@ module Reporting
             name
           , properties.user_id as user_id
         | filter properties.service_provider IN %{issuers}
-        | filter (name = %{idv_final_resolution} and properties.event_properties.fraud_review_pending = 1)
-                 or (name != %{idv_final_resolution})
         | filter name in %{event_names}
+        | filter (name = %{idv_final_resolution} and properties.event_properties.fraud_review_pending = 1)
+                 or (name != %{idv_final_resolution})        
         | limit 10000
       QUERY
     end

--- a/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
@@ -32,16 +32,16 @@ RSpec.describe Reporting::FraudMetricsLg99Report do
     travel_to Time.zone.now.beginning_of_day
     stub_cloudwatch_logs(
       [
-        { 'user_id' => 'user1', 'name' => 'IdV: Final Resolution' },
-        { 'user_id' => 'user1', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user1', 'name' => 'IdV: final resolution' },
+        { 'user_id' => 'user1', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user2', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user2', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user3', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user3', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user4', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user4', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user5', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user5', 'name' => 'IdV: final resolution' },
 
         { 'user_id' => 'user6', 'name' => 'User Suspension: Suspended' },
         { 'user_id' => 'user6', 'name' => 'User Suspension: Reinstated' },

--- a/spec/lib/reporting/irs_fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/irs_fraud_metrics_lg99_report_spec.rb
@@ -40,16 +40,16 @@ RSpec.describe Reporting::IrsFraudMetricsLg99Report do
     travel_to Time.zone.now.beginning_of_day
     stub_cloudwatch_logs(
       [
-        { 'user_id' => 'user1', 'name' => 'IdV: Final Resolution' },
-        { 'user_id' => 'user1', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user1', 'name' => 'IdV: final resolution' },
+        { 'user_id' => 'user1', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user2', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user2', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user3', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user3', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user4', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user4', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user5', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user5', 'name' => 'IdV: final resolution' },
 
         { 'user_id' => 'user6', 'name' => 'User Suspension: Suspended' },
         { 'user_id' => 'user6', 'name' => 'User Suspension: Reinstated' },


### PR DESCRIPTION
Report has been wrong since May due to a typo/case issue.

Changes upper case to lower case for "IDV: final resolution" CloudWatch event.

See https://gitlab.login.gov/lg-teams/Team-Data/reporting/-/issues/184

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
