### PR TITLE
Lg-16481 update french chinese translations for idv

### DIFF
--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -14,7 +14,10 @@ module Idv
 
     def warning
       @remaining_submit_attempts = rate_limiter.remaining_count
-
+      @after_phone_test = nil
+      if I18n.locale == :zh
+        @after_phone_test = I18n.t('idv.failure.phone.warning.you_entered_after_phone')
+      end
       if idv_session.previous_phone_step_params
         @phone = idv_session.previous_phone_step_params[:phone]
         @country_code = idv_session.previous_phone_step_params[:international_code]

--- a/app/controllers/idv/phone_errors_controller.rb
+++ b/app/controllers/idv/phone_errors_controller.rb
@@ -7,6 +7,7 @@ module Idv
     include StepIndicatorConcern
     include Idv::AbTestAnalyticsConcern
     include Idv::VerifyByMailConcern
+    include PhoneFormatter
 
     before_action :confirm_step_allowed, except: [:failure]
     before_action :set_gpo_letter_available
@@ -14,15 +15,13 @@ module Idv
 
     def warning
       @remaining_submit_attempts = rate_limiter.remaining_count
-      @after_phone_test = nil
-      if I18n.locale == :zh
-        @after_phone_test = I18n.t('idv.failure.phone.warning.you_entered_after_phone')
-      end
+
       if idv_session.previous_phone_step_params
         @phone = idv_session.previous_phone_step_params[:phone]
         @country_code = idv_session.previous_phone_step_params[:international_code]
       end
 
+      @formatted_phone = PhoneFormatter.format(@phone, country_code: @country_code)
       track_event(type: :warning)
     end
 

--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -8,11 +8,7 @@
 
       <% if @phone %>
         <p>
-          <%= t('idv.failure.phone.warning.you_entered') %>
-          <strong class='text-no-wrap'><%= PhoneFormatter.format(@phone, country_code: @country_code) %></strong>
-          <% if @after_phone_test %>
-            <%= @after_phone_test %>
-          <% end %>
+          <%= t('idv.failure.phone.warning.you_entered_html', formatted_phone: @formatted_phone) %>
         </p>
       <% end %>
 

--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -10,6 +10,9 @@
         <p>
           <%= t('idv.failure.phone.warning.you_entered') %>
           <strong class='text-no-wrap'><%= PhoneFormatter.format(@phone, country_code: @country_code) %></strong>
+          <% if @after_phone_test %>
+            <%= @after_phone_test %>
+          <% end %>
         </p>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1124,8 +1124,7 @@ idv.failure.phone.warning.heading: We couldn’t match you to this number
 idv.failure.phone.warning.learn_more_link: Learn more about what phone number to use
 idv.failure.phone.warning.next_steps_html: Try <strong>another</strong> number that you use often and have used for a long time. This can be a work or home number.
 idv.failure.phone.warning.try_again_button: Try another number
-idv.failure.phone.warning.you_entered: 'We couldn’t find a record of you using this number:'
-idv.failure.phone.warning.you_entered_after_phone: Unused
+idv.failure.phone.warning.you_entered_html: "We couldn’t find a record of you using this number: <strong class='text-no-wrap'>%{formatted_phone}</strong>"
 idv.failure.sessions.exception: There was an internal error processing your request.
 idv.failure.sessions.fail_html: For your security, we limit the number of times you can attempt to verify personal information online. <strong>Try again in %{timeout}.</strong>
 idv.failure.sessions.heading: We couldn’t find records matching your personal information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1125,6 +1125,7 @@ idv.failure.phone.warning.learn_more_link: Learn more about what phone number to
 idv.failure.phone.warning.next_steps_html: Try <strong>another</strong> number that you use often and have used for a long time. This can be a work or home number.
 idv.failure.phone.warning.try_again_button: Try another number
 idv.failure.phone.warning.you_entered: 'We couldn’t find a record of you using this number:'
+idv.failure.phone.warning.you_entered_after_phone: Unused
 idv.failure.sessions.exception: There was an internal error processing your request.
 idv.failure.sessions.fail_html: For your security, we limit the number of times you can attempt to verify personal information online. <strong>Try again in %{timeout}.</strong>
 idv.failure.sessions.heading: We couldn’t find records matching your personal information

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1135,8 +1135,7 @@ idv.failure.phone.warning.heading: No pudimos asociarlo a este número
 idv.failure.phone.warning.learn_more_link: Obtenga más información sobre el número de teléfono que debe usar
 idv.failure.phone.warning.next_steps_html: Intente con <strong>otro</strong> número que use a menudo y haya usado por mucho tiempo. Puede ser el número del trabajo o de casa.
 idv.failure.phone.warning.try_again_button: Intentar con otro número
-idv.failure.phone.warning.you_entered: 'No pudimos encontrar su registro con este número:'
-idv.failure.phone.warning.you_entered_after_phone: Unused
+idv.failure.phone.warning.you_entered_html: "No pudimos encontrar su registro con este número: <strong class='text-no-wrap'>%{formatted_phone}</strong>"
 idv.failure.sessions.exception: Hubo un error interno al procesar su solicitud.
 idv.failure.sessions.fail_html: Por su seguridad, limitamos el número de veces que puede intentar verificar la información personal en línea. <strong>Vuelva a intentarlo en %{timeout}.</strong>
 idv.failure.sessions.heading: No encontramos registros que coincidan con sus datos personales

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1136,6 +1136,7 @@ idv.failure.phone.warning.learn_more_link: Obtenga más información sobre el n�
 idv.failure.phone.warning.next_steps_html: Intente con <strong>otro</strong> número que use a menudo y haya usado por mucho tiempo. Puede ser el número del trabajo o de casa.
 idv.failure.phone.warning.try_again_button: Intentar con otro número
 idv.failure.phone.warning.you_entered: 'No pudimos encontrar su registro con este número:'
+idv.failure.phone.warning.you_entered_after_phone: Unused
 idv.failure.sessions.exception: Hubo un error interno al procesar su solicitud.
 idv.failure.sessions.fail_html: Por su seguridad, limitamos el número de veces que puede intentar verificar la información personal en línea. <strong>Vuelva a intentarlo en %{timeout}.</strong>
 idv.failure.sessions.heading: No encontramos registros que coincidan con sus datos personales

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1138,7 +1138,7 @@ idv.failure.verify.fail_link_html: Obtenez de l’aide auprès de <strong>%{sp_n
 idv.failure.verify.fail_text: pour accéder aux services.
 idv.failure.verify.heading: Nous n’avons pas pu confirmer votre identité
 idv.failure.warning.attempts_html.one: Vous avez encore <strong>un essai.</strong> Vous devrez ensuite attendre 6 heures avant de réessayer.
-idv.failure.warning.attempts_html.other: Vous pouvez encore essayer <strong>%{count} fois de plus.</strong> Ensuite vous devrez ensuite attendre 6 heures avant de réessayer.
+idv.failure.warning.attempts_html.other: Vous pouvez encore essayer <strong>%{count} fois de plus.</strong> Ensuite, vous devrez attendre 6 heures avant de réessayer.
 idv.forgot_password.link_text: Mot de passe oublié?
 idv.forgot_password.modal_header: Êtes-vous sûr de ne pas pouvoir vous souvenir de votre mot de passe?
 idv.forgot_password.reset_password: Réinitialiser le mot de passe

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1124,8 +1124,7 @@ idv.failure.phone.warning.heading: Nous n’avons pas pu vous associer à ce num
 idv.failure.phone.warning.learn_more_link: En savoir plus sur quel numéro de téléphone utiliser
 idv.failure.phone.warning.next_steps_html: Essayez <strong>un autre</strong> numéro que vous utilisez souvent et depuis longtemps. Il peut s’agir d’un numéro professionnel ou personnel.
 idv.failure.phone.warning.try_again_button: Essayez un autre numéro
-idv.failure.phone.warning.you_entered: 'Nous n’avons pas trouvé de données vous associant au numéro suivant :'
-idv.failure.phone.warning.you_entered_after_phone: Unused
+idv.failure.phone.warning.you_entered_html: "Nous n’avons pas trouvé de données vous associant au numéro suivant: <strong class='text-no-wrap'>%{formatted_phone}</strong>"
 idv.failure.sessions.exception: Une erreur interne s’est produite lors du traitement de votre demande.
 idv.failure.sessions.fail_html: Pour votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier des renseignements personnels en ligne. <strong>Réessayez dans %{timeout}.</strong>
 idv.failure.sessions.heading: Nous n’avons pas trouvé de dossiers correspondant à vos informations personnelles

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1125,6 +1125,7 @@ idv.failure.phone.warning.learn_more_link: En savoir plus sur quel numéro de t�
 idv.failure.phone.warning.next_steps_html: Essayez <strong>un autre</strong> numéro que vous utilisez souvent et depuis longtemps. Il peut s’agir d’un numéro professionnel ou personnel.
 idv.failure.phone.warning.try_again_button: Essayez un autre numéro
 idv.failure.phone.warning.you_entered: 'Nous n’avons pas trouvé de données vous associant au numéro suivant :'
+idv.failure.phone.warning.you_entered_after_phone: Unused
 idv.failure.sessions.exception: Une erreur interne s’est produite lors du traitement de votre demande.
 idv.failure.sessions.fail_html: Pour votre sécurité, nous limitons le nombre de fois où vous pouvez tenter de vérifier des renseignements personnels en ligne. <strong>Réessayez dans %{timeout}.</strong>
 idv.failure.sessions.heading: Nous n’avons pas trouvé de dossiers correspondant à vos informations personnelles

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1137,7 +1137,8 @@ idv.failure.phone.warning.heading: 我们无法将你与该号码匹配。
 idv.failure.phone.warning.learn_more_link: 了解有关使用什么号码的更多信息。
 idv.failure.phone.warning.next_steps_html: 尝试 <strong>另一个</strong> 你经常使用并用了很久的号码。 工作或住宅号码都行。
 idv.failure.phone.warning.try_again_button: 尝试另一个号码
-idv.failure.phone.warning.you_entered: 我们找不到你使用此号码的记录：
+idv.failure.phone.warning.you_entered: 我们找不到你使用
+idv.failure.phone.warning.you_entered_after_phone: 电话号码的记录
 idv.failure.sessions.exception: 处理你的请求时内部出错。
 idv.failure.sessions.fail_html: 出于安全考虑，我们限制你在网上尝试验证个人信息的次数。<strong> %{timeout}后再试。</strong>
 idv.failure.sessions.heading: 我们找不到与你个人信息匹配的记录
@@ -1150,8 +1151,8 @@ idv.failure.verify.exit: 退出 %{app_name}
 idv.failure.verify.fail_link_html: 在<strong>%{sp_name}</strong> 得到
 idv.failure.verify.fail_text: 帮助以获得服务。
 idv.failure.verify.heading: 我们无法验证你的身份证件。
-idv.failure.warning.attempts_html.one: 您可以再试<strong>1次。</strong>然后您必须等6个小时才能再试。
-idv.failure.warning.attempts_html.other: 您可以再试<strong>%{count}次。</strong>然后您必须等6个小时才能再试。
+idv.failure.warning.attempts_html.one: 你可以再试<strong>1次。</strong>你后您必须等6个小时才能再试。
+idv.failure.warning.attempts_html.other: 你可以再试<strong>%{count}次。</strong>你后您必须等6个小时才能再试。
 idv.forgot_password.link_text: 忘了密码?
 idv.forgot_password.modal_header: 你确定不记得密码吗？
 idv.forgot_password.reset_password: 重设密码
@@ -1664,7 +1665,7 @@ step_indicator.flows.idv.go_to_the_post_office: 去邮局
 step_indicator.flows.idv.re_enter_password: 重新输入你的密码
 step_indicator.flows.idv.secure_account: 保护你账户的安全
 step_indicator.flows.idv.verify_address: 验证你的地址
-step_indicator.flows.idv.verify_id: 验证你的身份证件
+step_indicator.flows.idv.verify_id: 验证你的ID
 step_indicator.flows.idv.verify_info: 验证你的信息
 step_indicator.flows.idv.verify_phone: 验证你的电话号码
 step_indicator.status.complete: 完成了

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1137,8 +1137,7 @@ idv.failure.phone.warning.heading: 我们无法将你与该号码匹配。
 idv.failure.phone.warning.learn_more_link: 了解有关使用什么号码的更多信息。
 idv.failure.phone.warning.next_steps_html: 尝试 <strong>另一个</strong> 你经常使用并用了很久的号码。 工作或住宅号码都行。
 idv.failure.phone.warning.try_again_button: 尝试另一个号码
-idv.failure.phone.warning.you_entered: '我们找不到你使用:'
-idv.failure.phone.warning.you_entered_after_phone: 电话号码的记录
+idv.failure.phone.warning.you_entered_html: "我们找不到你使用: <strong class='text-no-wrap'>%{formatted_phone}</strong> 电话号码的记录"
 idv.failure.sessions.exception: 处理你的请求时内部出错。
 idv.failure.sessions.fail_html: 出于安全考虑，我们限制你在网上尝试验证个人信息的次数。<strong> %{timeout}后再试。</strong>
 idv.failure.sessions.heading: 我们找不到与你个人信息匹配的记录

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1137,7 +1137,7 @@ idv.failure.phone.warning.heading: 我们无法将你与该号码匹配。
 idv.failure.phone.warning.learn_more_link: 了解有关使用什么号码的更多信息。
 idv.failure.phone.warning.next_steps_html: 尝试 <strong>另一个</strong> 你经常使用并用了很久的号码。 工作或住宅号码都行。
 idv.failure.phone.warning.try_again_button: 尝试另一个号码
-idv.failure.phone.warning.you_entered: 我们找不到你使用
+idv.failure.phone.warning.you_entered: '我们找不到你使用:'
 idv.failure.phone.warning.you_entered_after_phone: 电话号码的记录
 idv.failure.sessions.exception: 处理你的请求时内部出错。
 idv.failure.sessions.fail_html: 出于安全考虑，我们限制你在网上尝试验证个人信息的次数。<strong> %{timeout}后再试。</strong>

--- a/spec/views/idv/phone_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/warning.html.erb_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'idv/phone_errors/warning.html.erb' do
     assign(:remaining_submit_attempts, remaining_submit_attempts)
     assign(:country_code, country_code)
     assign(:phone, phone)
+    assign(:formatted_phone, formatted_phone)
 
     render
   end
@@ -26,7 +27,9 @@ RSpec.describe 'idv/phone_errors/warning.html.erb' do
   end
 
   it 'shows number entered' do
-    expect(rendered).to have_text(t('idv.failure.phone.warning.you_entered'))
+    expect(rendered).to have_content(
+      strip_tags(t('idv.failure.phone.warning.you_entered_html', formatted_phone: formatted_phone)),
+    )
     expect(rendered).to have_text(formatted_phone)
   end
 
@@ -104,7 +107,11 @@ RSpec.describe 'idv/phone_errors/warning.html.erb' do
   context 'no phone' do
     let(:phone) { nil }
     it 'does not render "You entered:"' do
-      expect(rendered).not_to have_text(t('idv.failure.phone.warning.you_entered'))
+      expect(rendered).not_to have_content(
+        strip_tags(
+          t('idv.failure.phone.warning.you_entered_html', formatted_phone: formatted_phone),
+        ),
+      )
     end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-16481](https://cm-jira.usa.gov/browse/LG-16481)


## 🛠 Summary of changes

Updated French and Chinese translations for phone pages in idv.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - Go through IDV and switch to chinese once on "Enter your one-time code" screen. Ensure step indicator content has changed to "验证你的ID"
- [ ] Step 2 - Trigger phone error (I had to change logic in phone_controller to do so), and switch to french and chinese translations and verify content matches that on the ticket. 

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.


<details>
<summary>After:</summary>
<img width="750" height="734" alt="Screenshot 2025-08-06 at 9 52 43 AM" src="https://github.com/user-attachments/assets/7415ec37-7c51-4f11-bc22-e2d923cd3ef9" />
<img width="700" height="800" alt="Screenshot 2025-08-06 at 3 28 16 PM" src="https://github.com/user-attachments/assets/d3de48a0-097a-41b7-8459-b217d60d00a0" />
<img width="679" height="643" alt="Screenshot 2025-08-06 at 3 28 27 PM" src="https://github.com/user-attachments/assets/f060d86b-1073-45a0-a9b8-42d50e8933be" />

</details>

