### PR TITLE
Deploy RC 502 to Production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.7-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.9-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,10 +49,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: f76c4e093158de5f704e63bcbc09107a717a1c27
-  tag: 0.23.7-18f
+  revision: ddf27d98cde86f80680ab4148653edd1cd745efd
+  tag: 0.23.9-18f
   specs:
-    saml_idp (0.23.7.pre.18f)
+    saml_idp (0.23.9.pre.18f)
       activesupport
       builder
       faraday
@@ -646,7 +646,7 @@ GEM
     rubocop-rspec (3.2.0)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
-    ruby-saml (1.18.0)
+    ruby-saml (1.18.1)
       nokogiri (>= 1.13.10)
       rexml
     ruby-statistics (3.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.1.2)
       railties (>= 6.0.0)
-    json (2.13.0)
+    json (2.13.2)
     jwe (0.4.0)
     jwt (2.7.1)
     knapsack (4.0.0)

--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -29,17 +29,18 @@ module Idv
 
     def dos_passport_api_healthy?(
       analytics:,
+      step:,
       endpoint: IdentityConfig.store.dos_passport_composite_healthcheck_endpoint
     )
       return true if endpoint.blank?
 
       request = DocAuth::Dos::Requests::HealthCheckRequest.new(endpoint:)
-      response = request.fetch(analytics)
+      response = request.fetch(analytics, context_analytics: { step: })
       response.success?
     end
 
     def locals_attrs(analytics:, presenter:, form_submit_url: nil)
-      dos_passport_api_down = !dos_passport_api_healthy?(analytics:)
+      dos_passport_api_down = !dos_passport_api_healthy?(analytics:, step: 'choose_id_type')
       {
         presenter:,
         form_submit_url:,

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -102,7 +102,7 @@ module Idv
       end
 
       idv_session.passport_allowed ||= begin
-        if dos_passport_api_healthy?(analytics:)
+        if dos_passport_api_healthy?(analytics:, step: 'welcome')
           (ab_test_bucket(:DOC_AUTH_PASSPORT) == :passport_allowed)
         end
       end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,6 +16,7 @@ class Profile < ApplicationRecord
   # rubocop:enable Rails/InverseOf
   has_many :gpo_confirmation_codes, dependent: :destroy
   has_one :in_person_enrollment, dependent: :destroy
+  has_many :duplicate_profile_confirmations, dependent: :destroy
 
   validates :active, uniqueness: { scope: :user_id, if: :active? }
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6717,14 +6717,23 @@ module AnalyticsEvents
   # @param [Boolean] success Whether the passport api health check succeeded.
   # @param [Hash] body The health check body, if present.
   # @param [Hash] errors Any additional error information we have
+  # @param [String] step The step in the IdV flow that called the API health check
   # @param [String] exception The Faraday or other exception, if one happened
-  def passport_api_health_check(success:, body: nil, errors: nil, exception: nil, **extra)
+  def passport_api_health_check(
+    success:,
+    body: nil,
+    errors: nil,
+    exception: nil,
+    step: nil,
+    **extra
+  )
     track_event(
       :passport_api_health_check,
       success:,
       body:,
       errors:,
       exception:,
+      step:,
       **extra,
     )
   end

--- a/app/services/doc_auth/dos/requests/health_check_request.rb
+++ b/app/services/doc_auth/dos/requests/health_check_request.rb
@@ -17,7 +17,7 @@ module DocAuth
           @endpoint = endpoint
         end
 
-        def fetch(analytics)
+        def fetch(analytics, context_analytics: { step: nil })
           begin
             faraday_response = connection.get do |req|
               req.options.context = { service_name: metric_name }
@@ -30,7 +30,8 @@ module DocAuth
           analytics.passport_api_health_check(
             **response.to_h
                 .except(*UNUSED_RESPONSE_KEYS)
-                .merge(response.extra),
+                .merge(response.extra)
+                .merge(context_analytics),
           )
         end
 

--- a/app/services/duplicate_profile_checker.rb
+++ b/app/services/duplicate_profile_checker.rb
@@ -16,8 +16,10 @@ class DuplicateProfileChecker
 
     pii = cacher.fetch(profile.id)
     duplicate_ssn_finder = Idv::DuplicateSsnFinder.new(user:, ssn: pii[:ssn])
-    associated_profiles = duplicate_ssn_finder.associated_facial_match_profiles_with_ssn
-    if !duplicate_ssn_finder.ial2_profile_ssn_is_unique?
+    associated_profiles = duplicate_ssn_finder.duplicate_facial_match_profiles(
+      service_provider: sp.issuer,
+    )
+    if associated_profiles
       ids = associated_profiles.map(&:id)
       user_session[:duplicate_profile_ids] = ids
     end

--- a/app/services/idv/duplicate_ssn_finder.rb
+++ b/app/services/idv/duplicate_ssn_finder.rb
@@ -10,9 +10,7 @@ module Idv
     end
 
     def ssn_is_unique?
-      Profile.where(ssn_signature: ssn_signatures)
-        .where(initiating_service_provider_issuer: sp_eligible_for_one_account)
-        .where.not(user_id: user.id).empty?
+      Profile.where(ssn_signature: ssn_signatures).where.not(user_id: user.id).empty?
     end
 
     def associated_facial_match_profiles_with_ssn

--- a/app/services/idv/duplicate_ssn_finder.rb
+++ b/app/services/idv/duplicate_ssn_finder.rb
@@ -13,14 +13,16 @@ module Idv
       Profile.where(ssn_signature: ssn_signatures).where.not(user_id: user.id).empty?
     end
 
-    def associated_facial_match_profiles_with_ssn
-      Profile.active.facial_match.where(ssn_signature: ssn_signatures)
-        .where(initiating_service_provider_issuer: sp_eligible_for_one_account)
+    def duplicate_facial_match_profiles(service_provider:)
+      Profile
+        .active
+        .facial_match
+        .where(ssn_signature: ssn_signatures)
+        .joins('INNER JOIN identities ON identities.user_id = profiles.user_id')
+        .where(identities: { service_provider: service_provider })
+        .where(identities: { deleted_at: nil })
         .where.not(user_id: user.id)
-    end
-
-    def ial2_profile_ssn_is_unique?
-      associated_facial_match_profiles_with_ssn.empty?
+        .distinct
     end
 
     # Due to potentially inconsistent normalization of stored SSNs in the past, we must check:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2098,8 +2098,8 @@ users.delete.bullet_4: Notificaremos a las agencias a las que acceda con %{app_n
 users.delete.heading: '¿Está seguro de que desea eliminar su cuenta?'
 users.delete.instructions: Ingrese su contraseña para confirmar que desea eliminar su cuenta.
 users.delete.subheading: 'Si elimina su cuenta:'
-users.duplicate_profiles_please_call.error_details_html: <p>If you don’t recognize or can’t delete one of the duplicate accounts you saw on the multiple accounts page, call our contact center at <strong>%{contact_number}</strong> and provide them with the error code <strong>LG33</strong>.</p><p>Having questions about duplicate accounts or how to move forward? Learn more about <a href="%{help_url}">how to resolve duplicate accounts</a>.</p>
-users.duplicate_profiles_please_call.heading: Please give us a call
+users.duplicate_profiles_please_call.error_details_html: <p>Si no reconoce o no puede eliminar una de las cuentas duplicadas que vio en la página que muestra varias cuentas, llame a nuestro centro de contacto al <strong>%{contact_number}</strong> y mencione el código de error <strong>LG33</strong>.</p><p>¿Tiene preguntas acerca de las cuentas duplicadas o de lo que debe hacer? Obtenga más información acerca <a href="%{help_url}">de cómo resolver las cuentas duplicadas</a>.</p>
+users.duplicate_profiles_please_call.heading: Llámenos
 users.password_compromised.warning: Hemos encontrado su contraseña en una filtración de datos en otro sitio o aplicación. %{app_name} requiere que cambie su contraseña para proteger su cuenta.
 users.personal_key.accessible_labels.code_example: Un ejemplo de clave personal con 16 caracteres
 users.personal_key.accessible_labels.preview: Vista previa de la clave personal

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2086,8 +2086,8 @@ users.delete.bullet_4: Nous informerons les organismes auxquels vous accédez av
 users.delete.heading: Êtes-vous sûr de vouloir supprimer votre compte ?
 users.delete.instructions: Saisissez votre mot de passe pour confirmer que vous souhaitez supprimer votre compte.
 users.delete.subheading: 'Si vous supprimez votre compte :'
-users.duplicate_profiles_please_call.error_details_html: <p>If you don’t recognize or can’t delete one of the duplicate accounts you saw on the multiple accounts page, call our contact center at <strong>%{contact_number}</strong> and provide them with the error code <strong>LG33</strong>.</p><p>Having questions about duplicate accounts or how to move forward? Learn more about <a href="%{help_url}">how to resolve duplicate accounts</a>.</p>
-users.duplicate_profiles_please_call.heading: Please give us a call
+users.duplicate_profiles_please_call.error_details_html: <p>Si vous ne reconnaissez pas un compte ou ne pouvez pas accéder à l’un des comptes que vous avez identifiés sur la page détaillant vos différents comptes, veuillez appeler notre centre de contact au <strong>%{contact_number}</strong> en fournissant le code d’erreur <strong>LG33</strong>.</p><p>Vous avez des questions sur les comptes en double ou la marche à suivre ? En savoir plus sur <a href="%{help_url}">la manière de résoudre les problèmes de comptes en double</a>.</p>
+users.duplicate_profiles_please_call.heading: Nous appeler
 users.password_compromised.warning: Nous avons trouvé votre mot de passe dans le cadre d’une fuite de données sur un autre site Web ou une application. %{app_name} vous demande de modifier votre mot de passe pour protéger votre compte.
 users.personal_key.accessible_labels.code_example: Un exemple de clé personnelle à 16 caractères
 users.personal_key.accessible_labels.preview: Aperçu de clé personnelle

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -2099,8 +2099,8 @@ users.delete.bullet_4: 我们将通知你使用 %{app_name} 访问的政府机�
 users.delete.heading: 你确定要删除账户吗？
 users.delete.instructions: 输入密码来确认你要删除账户。
 users.delete.subheading: 如果你删除自己的账户：
-users.duplicate_profiles_please_call.error_details_html: <p>If you don’t recognize or can’t delete one of the duplicate accounts you saw on the multiple accounts page, call our contact center at <strong>%{contact_number}</strong> and provide them with the error code <strong>LG33</strong>.</p><p>Having questions about duplicate accounts or how to move forward? Learn more about <a href="%{help_url}">how to resolve duplicate accounts</a>.</p>
-users.duplicate_profiles_please_call.heading: Please give us a call
+users.duplicate_profiles_please_call.error_details_html: <p>如果你不认识或无法删除在列出多个帐户的那一页面上看到的某个重复帐户，请拨打 <strong>%{contact_number}</strong> 致电我们的联系中心并提供出错代码 <strong>LG33</strong>。</p><p>对重复帐户或该怎么办有疑问？了解更多关于<a href="%{help_url}">如何解决重复帐户的信息。</a></p>
+users.duplicate_profiles_please_call.heading: 请给我们打个电话
 users.password_compromised.warning: 另一个网站或应用程序的数据泄露中我们发现有你的密码。%{app_name} 要求你更改密码来保护你的账户。
 users.personal_key.accessible_labels.code_example: 有 16 个字符的个人密钥示例
 users.personal_key.accessible_labels.preview: 个人密钥预览

--- a/lib/reporting/fraud_metrics_lg99_report.rb
+++ b/lib/reporting/fraud_metrics_lg99_report.rb
@@ -17,7 +17,7 @@ module Reporting
     attr_reader :time_range
 
     module Events
-      IDV_FINAL_RESOLUTION = 'IdV: Final Resolution'
+      IDV_FINAL_RESOLUTION = 'IdV: final resolution'
       SUSPENDED_USERS = 'User Suspension: Suspended'
       REINSTATED_USERS = 'User Suspension: Reinstated'
 
@@ -158,9 +158,9 @@ module Reporting
         fields
             name
           , properties.user_id as user_id
+         | filter name in %{event_names}
          | filter (name = %{idv_final_resolution} and properties.event_properties.fraud_review_pending = 1)
                  or (name != %{idv_final_resolution})
-        | filter name in %{event_names}
         | limit 10000
       QUERY
     end

--- a/lib/reporting/irs_fraud_metrics_lg99_report.rb
+++ b/lib/reporting/irs_fraud_metrics_lg99_report.rb
@@ -17,7 +17,7 @@ module Reporting
     attr_reader :issuers, :time_range
 
     module Events
-      IDV_FINAL_RESOLUTION = 'IdV: Final Resolution'
+      IDV_FINAL_RESOLUTION = 'IdV: final resolution'
       SUSPENDED_USERS = 'User Suspension: Suspended'
       REINSTATED_USERS = 'User Suspension: Reinstated'
 
@@ -156,9 +156,9 @@ module Reporting
             name
           , properties.user_id as user_id
         | filter properties.service_provider IN %{issuers}
-        | filter (name = %{idv_final_resolution} and properties.event_properties.fraud_review_pending = 1)
-                 or (name != %{idv_final_resolution})
         | filter name in %{event_names}
+        | filter (name = %{idv_final_resolution} and properties.event_properties.fraud_review_pending = 1)
+                 or (name != %{idv_final_resolution})        
         | limit 10000
       QUERY
     end

--- a/lib/reporting/irs_fraud_metrics_lg99_report.rb
+++ b/lib/reporting/irs_fraud_metrics_lg99_report.rb
@@ -69,6 +69,11 @@ module Reporting
           table: lg99_metrics_table,
           filename: 'lg99_metrics',
         ),
+        Reporting::EmailableReport.new(
+          title: "IRS Credential Tenure Metric #{stats_month}",
+          table: credential_tenure_report_metric,
+          filename: 'Credential_Tenure_Metric',
+        ),
       ]
     end
 
@@ -83,6 +88,7 @@ module Reporting
         ['Credentials Reinstated', 'Count',
          'The count of unique suspended accounts ' + '
          that are reinstated within the reporting month.'],
+        ['Credential Tenure', 'Count', 'The average age, in months, of all accounts'],
       ]
     end
 
@@ -118,6 +124,13 @@ module Reporting
         ['Error', 'Message'],
         [err.class.name, err.message],
       ]
+    end
+
+    def credential_tenure_report_metric
+      Reporting::IrsCredentialTenureReport.new(
+        time_range.end,
+        issuers: issuers,
+      ).irs_credential_tenure_report
     end
 
     def stats_month

--- a/spec/controllers/concerns/idv/choose_id_type_concern_spec.rb
+++ b/spec/controllers/concerns/idv/choose_id_type_concern_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Idv::ChooseIdTypeConcern, :controller do
   subject { controller }
 
   let(:analytics) { FakeAnalytics.new }
+  let(:step) { 'choose_id_type' }
+  let(:context_analytics) { { step: step } }
   let(:document_capture_session) { double(DocumentCaptureSession) }
   let(:parameters) do
     ActionController::Parameters.new(
@@ -145,7 +147,8 @@ RSpec.describe Idv::ChooseIdTypeConcern, :controller do
           :dos_passport_composite_healthcheck_endpoint,
         ).and_return('http://dostest.com/status')
         allow(DocAuth::Dos::Requests::HealthCheckRequest).to receive(:new).and_return(request)
-        allow(request).to receive(:fetch).with(analytics).and_return(response)
+        allow(request).to receive(:fetch).with(analytics, context_analytics: context_analytics)
+          .and_return(response)
       end
 
       context 'when the dos response is successful' do
@@ -154,7 +157,7 @@ RSpec.describe Idv::ChooseIdTypeConcern, :controller do
         end
 
         it 'returns true' do
-          expect(subject.dos_passport_api_healthy?(analytics:)).to be(true)
+          expect(subject.dos_passport_api_healthy?(analytics:, step:)).to be(true)
         end
       end
 
@@ -164,14 +167,14 @@ RSpec.describe Idv::ChooseIdTypeConcern, :controller do
         end
 
         it 'returns false' do
-          expect(subject.dos_passport_api_healthy?(analytics:)).to be(false)
+          expect(subject.dos_passport_api_healthy?(analytics:, step:)).to be(false)
         end
       end
     end
 
     context 'when the endpoint is an empty string' do
       it 'returns true' do
-        expect(subject.dos_passport_api_healthy?(analytics:, endpoint: '')).to be(true)
+        expect(subject.dos_passport_api_healthy?(analytics:, step:, endpoint: '')).to be(true)
       end
     end
   end
@@ -187,7 +190,8 @@ RSpec.describe Idv::ChooseIdTypeConcern, :controller do
         :dos_passport_composite_healthcheck_endpoint,
       ).and_return('http://dostest.com/status')
       allow(DocAuth::Dos::Requests::HealthCheckRequest).to receive(:new).and_return(request)
-      allow(request).to receive(:fetch).with(analytics).and_return(response)
+      allow(request).to receive(:fetch).with(analytics, context_analytics: context_analytics)
+        .and_return(response)
     end
 
     context 'when the dos passport api is healthy' do

--- a/spec/features/idv/doc_auth/welcome_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.feature 'welcome step' do
   include IdvHelper
   include DocAuthHelper
+  include AbTestsHelper
 
   let(:fake_analytics) { FakeAnalytics.new }
   let(:sp_name) { 'Test SP' }
@@ -10,24 +11,53 @@ RSpec.feature 'welcome step' do
   before do
     allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
     allow_any_instance_of(ServiceProviderSession).to receive(:sp_name).and_return(sp_name)
-
-    visit_idp_from_sp_with_ial2(:oidc)
-    sign_in_and_2fa_user
-    complete_doc_auth_steps_before_welcome_step
   end
 
-  it 'logs "intro_paragraph" learn more link click' do
-    click_on t('doc_auth.info.getting_started_learn_more')
+  context 'happy path' do
+    before do
+      visit_idp_from_sp_with_ial2(:oidc)
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_welcome_step
+    end
 
-    expect(fake_analytics).to have_logged_event(
-      'External Redirect',
-      step: 'welcome',
-      location: 'intro_paragraph',
-      flow: 'idv',
-      redirect_url: MarketingSite.help_center_article_url(
-        category: 'verify-your-identity',
-        article: 'overview',
-      ),
-    )
+    it 'logs "intro_paragraph" learn more link click' do
+      click_on t('doc_auth.info.getting_started_learn_more')
+
+      expect(fake_analytics).to have_logged_event(
+        'External Redirect',
+        step: 'welcome',
+        location: 'intro_paragraph',
+        flow: 'idv',
+        redirect_url: MarketingSite.help_center_article_url(
+          category: 'verify-your-identity',
+          article: 'overview',
+        ),
+      )
+    end
+  end
+
+  context 'passport flow' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled)
+        .and_return(true)
+      allow(IdentityConfig.store).to receive(:doc_auth_passports_percent)
+        .and_return(100)
+      stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
+        .to_return({ status: 200, body: { status: 'UP' }.to_json })
+      reload_ab_tests
+      visit_idp_from_sp_with_ial2(:oidc)
+      sign_in_and_2fa_user
+      complete_doc_auth_steps_before_welcome_step
+    end
+
+    it 'logs health check with welcome step' do
+      expect(fake_analytics).to have_logged_event(
+        :passport_api_health_check,
+        step: 'welcome',
+        success: true,
+        body: '{"status":"UP"}',
+        errors: {},
+      )
+    end
   end
 end

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -107,8 +107,6 @@ module I18n
         { key: 'user_mailer.in_person_failed.verifying_step_passports_enabledb1' }, # for failed proofing emails
         { key: 'user_mailer.in_person_failed.verifying_step_passports_enabledb2' }, # for failed proofing emails
         { key: 'user_mailer.in_person_failed.verifying_step_passports_enabledb3_html' }, # for failed proofing emails
-        { key: 'users.duplicate_profiles_please_call.heading', locales: %i[es fr zh] }, # This currently doesnt have translations but under feature toggle, will be addressed after initial english only launch
-        { key: 'users.duplicate_profiles_please_call.error_details_html', locales: %i[es fr zh] }, # This currently doesnt have translations but under feature toggle, will be addressed after initial english only launch
       ].freeze
       # rubocop:enable Layout/LineLength
 

--- a/spec/jobs/reports/irs_fraud_metrics_report_spec.rb
+++ b/spec/jobs/reports/irs_fraud_metrics_report_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Reports::IrsFraudMetricsReport do
       "#{report_folder}/definitions.csv",
       "#{report_folder}/overview.csv",
       "#{report_folder}/lg99_metrics.csv",
+      "#{report_folder}/Credential_Tenure_Metric.csv",
     ]
   end
 
@@ -36,6 +37,14 @@ RSpec.describe Reports::IrsFraudMetricsReport do
        time_range.end.to_s],
       ['Credentials Reinstated', 1, time_range.begin.to_s,
        time_range.end.to_s],
+    ]
+  end
+
+  let(:mock_credential_tenure_metric) do
+    [
+      ['Metric', 'Value'],
+      ['Total Users', 5],
+      ['Credential Tenure', 2],
     ]
   end
 
@@ -60,6 +69,9 @@ RSpec.describe Reports::IrsFraudMetricsReport do
 
     allow(report.irs_fraud_metrics_lg99_report).to receive(:lg99_metrics_table)
       .and_return(mock_identity_verification_lg99_data)
+
+    allow(report.irs_fraud_metrics_lg99_report).to receive(:credential_tenure_report_metric)
+      .and_return(mock_credential_tenure_metric)
   end
 
   it 'sends out a report to just to team data' do

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -62,9 +62,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
 
       context 'when the SSN is not unique' do
         before do
-          allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
-            .and_return([OidcAuthHelper::OIDC_FACIAL_MATCH_ISSUER])
-          create(:profile, :facial_match_proof, pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN)
+          create(:profile, pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN)
         end
 
         it 'sets ssn_is_unique: false on the result' do

--- a/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
@@ -32,16 +32,16 @@ RSpec.describe Reporting::FraudMetricsLg99Report do
     travel_to Time.zone.now.beginning_of_day
     stub_cloudwatch_logs(
       [
-        { 'user_id' => 'user1', 'name' => 'IdV: Final Resolution' },
-        { 'user_id' => 'user1', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user1', 'name' => 'IdV: final resolution' },
+        { 'user_id' => 'user1', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user2', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user2', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user3', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user3', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user4', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user4', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user5', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user5', 'name' => 'IdV: final resolution' },
 
         { 'user_id' => 'user6', 'name' => 'User Suspension: Suspended' },
         { 'user_id' => 'user6', 'name' => 'User Suspension: Reinstated' },

--- a/spec/lib/reporting/irs_fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/irs_fraud_metrics_lg99_report_spec.rb
@@ -40,16 +40,16 @@ RSpec.describe Reporting::IrsFraudMetricsLg99Report do
     travel_to Time.zone.now.beginning_of_day
     stub_cloudwatch_logs(
       [
-        { 'user_id' => 'user1', 'name' => 'IdV: Final Resolution' },
-        { 'user_id' => 'user1', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user1', 'name' => 'IdV: final resolution' },
+        { 'user_id' => 'user1', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user2', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user2', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user3', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user3', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user4', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user4', 'name' => 'IdV: final resolution' },
 
-        { 'user_id' => 'user5', 'name' => 'IdV: Final Resolution' },
+        { 'user_id' => 'user5', 'name' => 'IdV: final resolution' },
 
         { 'user_id' => 'user6', 'name' => 'User Suspension: Suspended' },
         { 'user_id' => 'user6', 'name' => 'User Suspension: Reinstated' },

--- a/spec/lib/reporting/irs_fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/irs_fraud_metrics_lg99_report_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Reporting::IrsFraudMetricsLg99Report do
       ['Credentials Reinstated', 'Count',
        'The count of unique suspended accounts ' + '
          that are reinstated within the reporting month.'],
+      ['Credential Tenure', 'Count', 'The average age, in months, of all accounts'],
     ]
   end
   let(:expected_overview_table) do
@@ -31,6 +32,13 @@ RSpec.describe Reporting::IrsFraudMetricsLg99Report do
        time_range.end.to_s],
       ['Credentials Disabled', '2', time_range.begin.to_s, time_range.end.to_s],
       ['Credentials Reinstated', '1', time_range.begin.to_s, time_range.end.to_s],
+    ]
+  end
+  let(:expected_credential_tenure_metric) do
+    [
+      ['Metric', 'Values'],
+      ['Total Users', '10'],
+      ['Credential Tenure', '15'],
     ]
   end
 
@@ -154,6 +162,12 @@ RSpec.describe Reporting::IrsFraudMetricsLg99Report do
   end
 
   describe '#as_emailable_reports' do
+    before do
+      allow_any_instance_of(Reporting::IrsCredentialTenureReport)
+        .to receive(:irs_credential_tenure_report)
+        .and_return(expected_credential_tenure_metric)
+    end
+
     let(:expected_reports) do
       [
         Reporting::EmailableReport.new(
@@ -170,6 +184,11 @@ RSpec.describe Reporting::IrsFraudMetricsLg99Report do
           title: 'Monthly Fraud Metrics Jan-2022',
           filename: 'lg99_metrics',
           table: expected_lg99_metrics_table,
+        ),
+        Reporting::EmailableReport.new(
+          title: 'IRS Credential Tenure Metric Jan-2022',
+          table: expected_credential_tenure_metric,
+          filename: 'Credential_Tenure_Metric',
         ),
       ]
     end

--- a/spec/services/doc_auth/dos/requests/health_check_request_spec.rb
+++ b/spec/services/doc_auth/dos/requests/health_check_request_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe DocAuth::Dos::Requests::HealthCheckRequest do
   end
 
   let(:analytics) { FakeAnalytics.new }
+  let(:step) { 'choose_id_type' }
+  let(:context_analytics) { { step: } }
 
   before do
     stub_health_check_settings
@@ -16,7 +18,9 @@ RSpec.describe DocAuth::Dos::Requests::HealthCheckRequest do
 
   shared_examples 'a DOS healthcheck endpoint' do |endpoint, success_body|
     describe '#fetch' do
-      let(:result) { health_check_request_for(endpoint).fetch(analytics) }
+      let(:result) do
+        health_check_request_for(endpoint).fetch(analytics, context_analytics: context_analytics)
+      end
 
       describe 'happy path' do
         it 'hits the endpoint' do
@@ -30,6 +34,7 @@ RSpec.describe DocAuth::Dos::Requests::HealthCheckRequest do
             :passport_api_health_check,
             success: true,
             errors: {},
+            step: step,
             body: success_body.to_json,
           )
         end
@@ -61,6 +66,7 @@ RSpec.describe DocAuth::Dos::Requests::HealthCheckRequest do
               errors: hash_including(
                 network: 'faraday exception',
               ),
+              step: step,
               exception: a_string_matching(/Faraday::TimeoutError/),
             ),
           )

--- a/spec/services/duplicate_profile_checker_spec.rb
+++ b/spec/services/duplicate_profile_checker_spec.rb
@@ -48,6 +48,13 @@ RSpec.describe DuplicateProfileChecker do
 
         context 'when user has accounts with matching profile' do
           let(:user2) { create(:user, :fully_registered) }
+          let!(:user2_identity) do
+            create(
+              :service_provider_identity,
+              user: user2,
+              service_provider: sp.issuer,
+            )
+          end
           let!(:profile2) do
             profile = create(
               :profile,


### PR DESCRIPTION
## Bug Fixes
- Resolution Proofing: Undo unintended changes from One Account work ([#12390](https://github.com/18F/identity-idp/pull/12390))

## Internal
- Doc Auth: Adding logging for step in dos api health check ([#12387](https://github.com/18F/identity-idp/pull/12387))
- Doc Auth: Adding spec to confirm mobile flow routes from how to verify to doc capture after ipp canceled (#12393) ([#12393](https://github.com/18F/identity-idp/pull/12393))
- Maintenance: Update json gem ([#12386](https://github.com/18F/identity-idp/pull/12386))
- Reporting: Fix IRS Credential Tenure Metric query anb combine report with IRS Fraud Metric ([#12394](https://github.com/18F/identity-idp/pull/12394))
- Reporting: Fix LG-99 metric in Fraud Report ([#12396](https://github.com/18F/identity-idp/pull/12396))
- Security: Update ruby-saml gem ([#12389](https://github.com/18F/identity-idp/pull/12389))

## Upcoming Features
- One Account: Update translations for the LG33 error page ([#12388](https://github.com/18F/identity-idp/pull/12388))
- One Account: Check for duplicates only within requesting service provider ([#12391](https://github.com/18F/identity-idp/pull/12391))
