### PR TITLE
LG-16538: sms one account notifications

### DIFF
--- a/app/jobs/alert_user_duplicate_profile_discovered_job.rb
+++ b/app/jobs/alert_user_duplicate_profile_discovered_job.rb
@@ -11,7 +11,7 @@ class AlertUserDuplicateProfileDiscoveredJob < ApplicationJob
       case type
       when ACCOUNT_CREATED
         mailer.dupe_profile_created(agency_name: agency).deliver_now_or_later
-        return unless phone
+        next unless phone
         @telephony_response = Telephony.send_dupe_profile_created_notice(
           to: phone,
           country_code: Phonelib.parse(phone).country,
@@ -19,7 +19,7 @@ class AlertUserDuplicateProfileDiscoveredJob < ApplicationJob
         )
       when SIGN_IN_ATTEMPTED
         mailer.dupe_profile_sign_in_attempted(agency_name: agency).deliver_now_or_later
-        return unless phone
+        next unless phone
         @telephony_response = Telephony.send_dupe_profile_sign_in_attempted_notice(
           to: phone,
           country_code: Phonelib.parse(phone).country,

--- a/app/jobs/alert_user_duplicate_profile_discovered_job.rb
+++ b/app/jobs/alert_user_duplicate_profile_discovered_job.rb
@@ -4,14 +4,27 @@ class AlertUserDuplicateProfileDiscoveredJob < ApplicationJob
   ACCOUNT_CREATED = :account_created
   SIGN_IN_ATTEMPTED = :sign_in_attempted
   def perform(user:, agency:, type:)
+    @user = user
     user.confirmed_email_addresses.each do |email_address|
       mailer = UserMailer.with(user: user, email_address: email_address)
 
       case type
       when ACCOUNT_CREATED
         mailer.dupe_profile_created(agency_name: agency).deliver_now_or_later
+        return unless phone
+        @telephony_response = Telephony.send_dupe_profile_created_notice(
+          to: phone,
+          country_code: Phonelib.parse(phone).country,
+          agency_name: agency,
+        )
       when SIGN_IN_ATTEMPTED
         mailer.dupe_profile_sign_in_attempted(agency_name: agency).deliver_now_or_later
+        return unless phone
+        @telephony_response = Telephony.send_dupe_profile_sign_in_attempted_notice(
+          to: phone,
+          country_code: Phonelib.parse(phone).country,
+          agency_name: agency,
+        )
       else
         analytics(user: user).duplicate_profile_email_type_not_found(type: type)
       end
@@ -27,5 +40,9 @@ class AlertUserDuplicateProfileDiscoveredJob < ApplicationJob
       sp: nil,
       session: {},
     )
+  end
+
+  def phone
+    @phone ||= MfaContext.new(@user).phone_configurations.take&.phone
   end
 end

--- a/app/services/marketing_site.rb
+++ b/app/services/marketing_site.rb
@@ -10,6 +10,7 @@ class MarketingSite
     manage-your-account/add-or-change-your-authentication-method
     manage-your-account/delete-your-account
     manage-your-account/personal-key
+    manage-your-account/resolve-duplicate-accounts
     trouble-signing-in/face-or-touch-unlock
     trouble-signing-in/forgot-your-password
     trouble-signing-in/forgot-your-personal-key

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -27,6 +27,16 @@ en:
       voice: Hello! Your %{format_length}-%{format_type} %{app_name} one-time code is, %{code}. Your one-time code is, %{code}. Again, your one-time code is %{code}. This code expires in %{expiration} minutes.
     doc_auth_link: |-
       %{app_name}: %{link} You're verifying your identity to access %{sp_or_app_name}. Take a photo of your ID to continue.
+    dupe_profile_created_notice: |-
+      Someone has verified another %{app_name} account using your personal information. For your safety, we have restricted access on all accounts with matching information and access to %{sp_or_app_name}.
+
+      If this was you verifying another account, delete the duplicate account here: %{steps_link}
+      If this wasn’t you, contact the help center here: %{help_center_link}
+    dupe_profile_sign_in_attempted_notice: |-
+      Someone just signed into a %{app_name} that had previously been verified with your personal information. For your safety we have restricted access on all accounts with matching information and access to %{sp_or_app_name}.
+
+      If this was you verifying another account, delete the duplicate account here: %{steps_link}
+      If this wasn’t you, contact the help center here: %{help_center_link}
     error:
       friendly_message:
         daily_voice_limit_reached: Your one-time code failed to send because you exceeded the maximum number of phone calls in 24 hours to this phone number. You can either request a code by text message or use a different number to receive a phone call.

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -23,7 +23,7 @@ es:
       voice: 'Hola: Los %{format_length} %{format_type} de su código de un solo uso de %{app_name} son %{code}. Su código de un solo uso es %{code}. De nuevo, su código de un solo uso es %{code}. Este código vence en %{expiration} minutos.'
     doc_auth_link: '%{app_name}: %{link} Está verificando su identidad para acceder a %{sp_or_app_name}. Tome una foto de su identificación para continuar.'
     dupe_profile_created_notice: |-
-      Quelqu’un vient de se connecter sur un compte %{app_name} qui avait été confirmé à l’aide de vos renseignements personnels. Pour votre sécurité, nous avons restreint votre accès sur tous les comptes comportant des informations identiques et ayant accès à %{sp_or_app_name}.
+      Alguien verificó otra cuenta de %{app_name} usando la información personal de usted. Por su seguridad, hemos restringido su acceso a todas las cuentas con información que coincide y a %{sp_or_app_name}.
 
       Si fue usted, debe eliminar la cuenta duplicada siguiendo los pasos que se describen aquí: %{steps_link}
       Si esta no fue usted, contacte con el centro de ayuda de %{app_name} aquí: %{help_center_link}

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -22,6 +22,16 @@ es:
         @%{domain} #%{code}
       voice: 'Hola: Los %{format_length} %{format_type} de su código de un solo uso de %{app_name} son %{code}. Su código de un solo uso es %{code}. De nuevo, su código de un solo uso es %{code}. Este código vence en %{expiration} minutos.'
     doc_auth_link: '%{app_name}: %{link} Está verificando su identidad para acceder a %{sp_or_app_name}. Tome una foto de su identificación para continuar.'
+    dupe_profile_created_notice: |-
+      Quelqu’un vient de se connecter sur un compte %{app_name} qui avait été confirmé à l’aide de vos renseignements personnels. Pour votre sécurité, nous avons restreint votre accès sur tous les comptes comportant des informations identiques et ayant accès à %{sp_or_app_name}.
+
+      Si fue usted, debe eliminar la cuenta duplicada siguiendo los pasos que se describen aquí: %{steps_link}
+      Si esta no fue usted, contacte con el centro de ayuda de %{app_name} aquí: %{help_center_link}
+    dupe_profile_sign_in_attempted_notice: |-
+      Alguien acaba de iniciar sesión en una cuenta de %{app_name} que ya había sido verificada antes con la información personal de usted. Por su seguridad, hemos restringido su acceso a todas las cuentas con información que coincide y a %{sp_or_app_name}.
+
+      Si fue usted, debe eliminar la cuenta duplicada siguiendo los pasos que se describen aquí: %{steps_link}
+      Si esta no fue usted, contacte con el centro de ayuda de %{app_name} aquí: %{help_center_link}
     error:
       friendly_message:
         daily_voice_limit_reached: No se pudo enviar su código de un solo uso porque superó el número máximo de llamadas en 24 horas a este número de teléfono. Puede solicitar un código por mensaje de texto o usar un número diferente para recibir una llamada telefónica.

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -22,6 +22,16 @@ fr:
         @%{domain} #%{code}
       voice: Bonjour ! Votre code à usage unique %{app_name} à %{format_length} %{format_type} est %{code}. Votre code à usage unique est %{code}. À nouveau, votre code à usage unique est %{code}. Ce code expire dans %{expiration} minutes.
     doc_auth_link: "%{app_name} : %{link} Vous êtes en train de confirmer votre identité pour accéder à %{sp_or_app_name}. Prenez une photo de votre pièce d'identité pour continuer."
+    dupe_profile_created_notice: |-
+      Quelqu’un a utilisé vos renseignements personnels pour confirmer un autre compte %{app_name}. Pour votre sécurité, nous avons restreint votre accès sur tous les comptes comportant des informations identiques et ayant accès à %{sp_or_app_name}.
+
+      Si c’est vous qui avez confirmé un autre compte, veuillez supprimer le compte en double ici: %{steps_link}
+      Si vous n’êtes pas à l’origine de cette action, veuillez prendre contact avec le service d’assistance de %{app_name} ici: %{help_center_link}
+    dupe_profile_sign_in_attempted_notice: |-
+      Quelqu’un vient de se connecter sur un compte %{app_name} qui avait été confirmé à l’aide de vos renseignements personnels. Pour votre sécurité, nous avons restreint votre accès sur tous les comptes comportant des informations identiques et ayant accès à %{sp_or_app_name}.
+
+      Si vous êtes à l’origine de cette action, vous devez supprimer le compte en double en suivant les étapes présentées et n’en utiliser qu’un seul pour votre sécurité: %{steps_link}
+      Si vous n’êtes pas à l’origine de cette action, veuillez prendre contact avec le service d’assistance de %{app_name} ici: %{help_center_link}
     error:
       friendly_message:
         daily_voice_limit_reached: L’envoi de votre code à usage unique a échoué car vous avez dépassé le nombre maximal d’appels vers ce numéro de téléphone en 24 heures. Vous pouvez demander un code par SMS ou utiliser un autre numéro pour recevoir un appel téléphonique.

--- a/config/locales/telephony/zh.yml
+++ b/config/locales/telephony/zh.yml
@@ -24,6 +24,16 @@ zh:
       voice: 你好！你的%{format_length}%{format_type} %{app_name} 一次性代码是，%{code}。你的一次性代码是 ，%{code}。重复一下，你的一次性代码是 %{code}。此代码 %{expiration} 分钟后会作废。
     doc_auth_link: |-
       %{app_name}: %{link} 你在验证身份以访问 %{sp_or_app_name}。拍张你身份证件的照片以继续。
+    dupe_profile_created_notice: |-
+      有人使用你的个人信息验证了另一个 %{app_name} 账户。 为了你的安全，我们已限制了具有同样信息的所有账户的访问权以及对 %{sp_or_app_name} 的访问权.
+      如果另一个账户是你本人验证的，请按照这里列出的 步骤删除那个重复账户: %{steps_link}
+
+      如果不是你本人，请联系 %{app_name} 帮助中心: %{help_center_link}
+    dupe_profile_sign_in_attempted_notice: |-
+      有人使用你的个人信息验证了另一个 %{app_name} 账户。 为了你的安全，我们已限制了具有同样信息的所有账户的访问权以及对 %{sp_or_app_name} 的访问权.
+
+      如果另一个账户是你本人验证的，请按照这里列出的 步骤删除那个重复账户: %{steps_link}
+      如果不是你本人，请联系 %{app_name} 帮助中心: %{help_center_link}
     error:
       friendly_message:
         daily_voice_limit_reached: 你的一次性代码未能发出，因为已超出 24 小时内拨打这个电话号码的最多次数。你可以请求通过短信发送代码，或使用另外一个号码来接听电话。

--- a/lib/telephony.rb
+++ b/lib/telephony.rb
@@ -86,6 +86,8 @@ module Telephony
                  :send_account_deleted_notice,
                  :send_account_reset_notice,
                  :send_account_reset_cancellation_notice,
+                 :send_dupe_profile_sign_in_attempted_notice,
+                 :send_dupe_profile_created_notice,
                  :send_notification
 
   # @param [String] phone_number phone number in E.164 format

--- a/lib/telephony/alert_sender.rb
+++ b/lib/telephony/alert_sender.rb
@@ -28,6 +28,38 @@ module Telephony
       response
     end
 
+    def send_dupe_profile_created_notice(to:, country_code:, agency_name: APP_NAME)
+      message = I18n.t(
+        'telephony.dupe_profile_created_notice',
+        app_name: APP_NAME,
+        sp_or_app_name: agency_name,
+        steps_link: MarketingSite.help_center_article_url(
+          category: 'manage-your-account',
+          article: 'resolve-duplicate-accounts',
+        ),
+        help_center_link: MarketingSite.contact_url,
+      )
+      response = adapter.deliver(message: message, to: to, country_code: country_code)
+      log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
+      response
+    end
+
+    def send_dupe_profile_sign_in_attempted_notice(to:, country_code:, agency_name: APP_NAME)
+      message = I18n.t(
+        'telephony.dupe_profile_sign_in_attempted_notice',
+        app_name: APP_NAME,
+        sp_or_app_name: agency_name,
+        steps_link: MarketingSite.help_center_article_url(
+          category: 'manage-your-account',
+          article: 'resolve-duplicate-accounts',
+        ),
+        help_center_link: MarketingSite.contact_url,
+      )
+      response = adapter.deliver(message: message, to: to, country_code: country_code)
+      log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
+      response
+    end
+
     def send_doc_auth_link(to:, link:, country_code:, sp_or_app_name:)
       message = I18n.t(
         'telephony.doc_auth_link',

--- a/spec/jobs/alert_user_duplicate_profile_discovered_job_spec.rb
+++ b/spec/jobs/alert_user_duplicate_profile_discovered_job_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe AlertUserDuplicateProfileDiscoveredJob do
 
         subject.perform(user: user, agency: agency, type: :account_created)
       end
+
+      context 'when phone is present' do
+        let(:user) { create(:user, :with_phone) }
+
+        it 'sends a dupe profile created SMS' do
+          user_phone = user.phone_configurations.first.phone
+          expect(Telephony).to receive(:send_dupe_profile_created_notice)
+            .with(to: user_phone, country_code: 'US', agency_name: agency)
+
+          subject.perform(user: user, agency: agency, type: :account_created)
+        end
+      end
     end
 
     context 'when type is :sign_in_attempted' do
@@ -28,6 +40,18 @@ RSpec.describe AlertUserDuplicateProfileDiscoveredJob do
           .and_call_original
 
         subject.perform(user: user, agency: agency, type: :sign_in_attempted)
+      end
+
+      context 'when phone is present' do
+        let(:user) { create(:user, :with_phone) }
+
+        it 'sends a dupe profile sign in attempted SMS' do
+          user_phone = user.phone_configurations.first.phone
+          expect(Telephony).to receive(:send_dupe_profile_sign_in_attempted_notice)
+            .with(to: user_phone, country_code: 'US', agency_name: agency)
+
+          subject.perform(user: user, agency: agency, type: :sign_in_attempted)
+        end
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16538](https://cm-jira.usa.gov/browse/LG-16538)

## 🛠 Summary of changes

Add Sms notifications for sign in or text attempts. 

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Verify all sms messages content is working as expected
- [ ] Have a user A that has a duplicate profile on another account user B
- [ ] Sign in using relevant SP 
- [ ] Land on the Duplicate Profile page 
- [ ] Receive an sms notification letting user B know that someone has signed in with their same profile information. 
- [ ] You can see outgoing text messages related to someone signing in from other account

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
