### PR TITLE
update montlhy key metrics to have a shorter cw window

### DIFF
--- a/lib/reporting/monthly_idv_report.rb
+++ b/lib/reporting/monthly_idv_report.rb
@@ -85,11 +85,7 @@ module Reporting
     end
 
     def monthly_subreports
-      ranges = [
-        (end_date - 2.months).all_month,
-        (end_date - 1.month).all_month,
-        end_date.all_month,
-      ]
+      ranges = [end_date.all_month]
 
       ranges.map do |range|
         Reporting::IdentityVerificationReport.new(

--- a/lib/reporting/proofing_rate_report.rb
+++ b/lib/reporting/proofing_rate_report.rb
@@ -6,7 +6,7 @@ require 'reporting/unknown_progress_bar'
 
 module Reporting
   class ProofingRateReport
-    DATE_INTERVALS = [30, 60, 90].freeze
+    DATE_INTERVALS = [30].freeze
 
     attr_reader :end_date, :wait_duration
 

--- a/spec/jobs/reports/monthly_key_metrics_report_spec.rb
+++ b/spec/jobs/reports/monthly_key_metrics_report_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe Reports::MonthlyKeyMetricsReport do
 
   let(:mock_proofing_rate_data) do
     [
-      ['Metric', 'Trailing 30d', 'Trailing 60d', 'Trailing 90d'],
+      ['Metric', 'Trailing 30d'],
     ]
   end
   let(:mock_monthly_idv_data) do
     [
-      ['Metric', 'June 2024', 'July 2024', 'August 2024'],
+      ['Metric', 'Aug 2024'],
     ]
   end
 

--- a/spec/lib/reporting/monthly_idv_report_spec.rb
+++ b/spec/lib/reporting/monthly_idv_report_spec.rb
@@ -15,26 +15,6 @@ RSpec.describe Reporting::MonthlyIdvReport do
         [
           instance_double(
             'Reporting::IdentityVerificationReport',
-            time_range: Date.new(2024, 6, 1).all_month,
-            idv_started: 1111,
-            successfully_verified_users: 1111,
-            blanket_proofing_rate: 0.1111,
-            idv_final_resolution: 1111,
-            idv_final_resolution_rate: 0.1111,
-            verified_user_count: 1111,
-          ),
-          instance_double(
-            'Reporting::IdentityVerificationReport',
-            time_range: Date.new(2024, 7, 1).all_month,
-            idv_started: 2222,
-            successfully_verified_users: 2222,
-            blanket_proofing_rate: 0.2222,
-            idv_final_resolution: 2222,
-            idv_final_resolution_rate: 0.2222,
-            verified_user_count: 2222,
-          ),
-          instance_double(
-            'Reporting::IdentityVerificationReport',
             time_range: Date.new(2024, 8, 1).all_month,
             idv_started: 3333,
             successfully_verified_users: 3333,
@@ -49,19 +29,17 @@ RSpec.describe Reporting::MonthlyIdvReport do
 
     let(:expected_table) do
       [
-        ['Metric', 'Jun 2024', 'Jul 2024', 'Aug 2024'],
-        ['IDV started', 1111, 2222, 3333],
-        ['# of successfully verified users', 1111, 2222, 3333],
-        ['% IDV started to successfully verified', 0.1111, 0.2222,
-         0.3333],
-        ['# of workflow completed', 1111, 2222, 3333],
-        ['% rate of workflow completed', 0.1111, 0.2222,
-         0.3333],
-        ['# of users verified (total)', 1111, 2222, 3333],
+        ['Metric', 'Aug 2024'],
+        ['IDV started', 3333],
+        ['# of successfully verified users', 3333],
+        ['% IDV started to successfully verified', 0.3333],
+        ['# of workflow completed', 3333],
+        ['% rate of workflow completed', 0.3333],
+        ['# of users verified (total)', 3333],
       ]
     end
 
-    it 'reports 3 months of data' do
+    it 'reports 1 month of data' do
       idv_report.as_csv.zip(expected_table).each do |actual, expected|
         expect(actual).to eq(expected)
       end
@@ -96,15 +74,11 @@ RSpec.describe Reporting::MonthlyIdvReport do
   end
 
   describe '#monthly_subreports' do
-    let(:june) { Date.new(2024, 6, 1).in_time_zone('UTC').all_month }
-    let(:july) { Date.new(2024, 7, 1).in_time_zone('UTC').all_month }
     let(:august) { Date.new(2024, 8, 1).in_time_zone('UTC').all_month }
 
-    it 'returns IdV reports for the expected months' do
-      [june, july, august].each do |month|
-        expect(Reporting::IdentityVerificationReport).to receive(:new)
-          .with(issuers: nil, time_range: month, cloudwatch_client: anything)
-      end
+    it 'returns IdV report for the expected month' do
+      expect(Reporting::IdentityVerificationReport).to receive(:new)
+        .with(issuers: nil, time_range: august, cloudwatch_client: anything)
 
       subject.monthly_subreports
     end

--- a/spec/lib/reporting/proofing_rate_report_spec.rb
+++ b/spec/lib/reporting/proofing_rate_report_spec.rb
@@ -28,60 +28,27 @@ RSpec.describe Reporting::ProofingRateReport do
             idv_fraud_rejected: 0,
             time_range: (end_date - 30.days).beginning_of_day..end_date,
           ),
-          instance_double(
-            'Reporting::IdentityVerificationReport',
-            blanket_proofing_rate: 0.4,
-            intent_proofing_rate: 0.5,
-            actual_proofing_rate: 0.6666666666666666,
-            industry_proofing_rate: 0.6666666666666666,
-            idv_started: 5,
-            idv_doc_auth_welcome_submitted: 4,
-            idv_doc_auth_socure_verification_data_requested: 0,
-            idv_doc_auth_image_vendor_submitted: 3,
-            successfully_verified_users: 2,
-            idv_doc_auth_rejected: 1,
-            idv_fraud_rejected: 1,
-            time_range: (end_date - 60.days).beginning_of_day..end_date,
-          ),
-          instance_double(
-            'Reporting::IdentityVerificationReport',
-            blanket_proofing_rate: 0.5,
-            intent_proofing_rate: 0.6,
-            actual_proofing_rate: 0.75,
-            industry_proofing_rate: 0.75,
-            idv_started: 6,
-            idv_doc_auth_welcome_submitted: 5,
-            idv_doc_auth_image_vendor_submitted: 4,
-            idv_doc_auth_socure_verification_data_requested: 0,
-            successfully_verified_users: 3,
-            idv_doc_auth_rejected: 1,
-            idv_fraud_rejected: 2,
-            time_range: (end_date - 90.days).beginning_of_day..end_date,
-          ),
         ],
       )
     end
 
-    it 'renders a report with 30, 60, 90 day numbers' do
-      # rubocop:disable Layout/LineLength
+    it 'renders a report with only 30 day numbers' do
       expected_csv = [
-        ['Metric', 'Trailing 30d', 'Trailing 60d', 'Trailing 90d'],
-        ['Start Date', Date.new(2021, 12, 2), Date.new(2021, 11, 2), Date.new(2021, 10, 3)],
-        ['End Date', Date.new(2022, 1, 1), Date.new(2022, 1, 1), Date.new(2022, 1, 1)],
-        ['IDV Started', 4, 5, 6],
-        ['Welcome Submitted', 3, 4, 5],
-        ['Image Submitted', 2, 3, 4],
-        ['Socure', 0, 0, 0],
-        ['Successfully Verified', 1, 2, 3],
-        ['IDV Rejected (Non-Fraud)', 1, 1, 1],
-        ['IDV Rejected (Fraud)', 0, 1, 2],
-        ['Blanket Proofing Rate (IDV Started to Successfully Verified)', 1.0 / 4, 2.0 / 5, 3.0 / 6],
-        ['Intent Proofing Rate (Welcome Submitted to Successfully Verified)', 1.0 / 3, 2.0 / 4, 3.0 / 5],
-        ['Actual Proofing Rate (Image Submitted to Successfully Verified)', 1.0 / 2, 2.0 / 3, 3.0 / 4],
-        ['Industry Proofing Rate (Verified minus IDV Rejected)', 1.0 / 2, 2.0 / 3, 3.0 / 4],
+        ['Metric', 'Trailing 30d'],
+        ['Start Date', Date.new(2021, 12, 2)],
+        ['End Date', Date.new(2022, 1, 1)],
+        ['IDV Started', 4],
+        ['Welcome Submitted', 3],
+        ['Image Submitted', 2],
+        ['Socure', 0],
+        ['Successfully Verified', 1],
+        ['IDV Rejected (Non-Fraud)', 1],
+        ['IDV Rejected (Fraud)', 0],
+        ['Blanket Proofing Rate (IDV Started to Successfully Verified)', 1.0 / 4],
+        ['Intent Proofing Rate (Welcome Submitted to Successfully Verified)', 1.0 / 3],
+        ['Actual Proofing Rate (Image Submitted to Successfully Verified)', 1.0 / 2],
+        ['Industry Proofing Rate (Verified minus IDV Rejected)', 1.0 / 2],
       ]
-      # rubocop:enable Layout/LineLength
-
       aggregate_failures do
         report.as_csv.zip(expected_csv).each do |actual, expected|
           expect(actual).to eq(expected)
@@ -141,8 +108,6 @@ RSpec.describe Reporting::ProofingRateReport do
           expect(report.reports.map(&:time_range)).to eq(
             [
               (end_date - 30.days).beginning_of_day..end_date,
-              (end_date - 60.days).beginning_of_day..end_date,
-              (end_date - 90.days).beginning_of_day..end_date,
             ],
           )
 
@@ -152,17 +117,17 @@ RSpec.describe Reporting::ProofingRateReport do
             cloudwatch_client: report.cloudwatch_client,
           ).once
 
-          expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
+          expect(Reporting::IdentityVerificationReport).not_to have_received(:new).with(
             time_range: (end_date - 60.days).beginning_of_day..(end_date - 30.days).end_of_day,
             issuers: nil,
             cloudwatch_client: report.cloudwatch_client,
-          ).once
+          )
 
-          expect(Reporting::IdentityVerificationReport).to have_received(:new).with(
+          expect(Reporting::IdentityVerificationReport).not_to have_received(:new).with(
             time_range: (end_date - 90.days).beginning_of_day..(end_date - 60.days).end_of_day,
             issuers: nil,
             cloudwatch_client: report.cloudwatch_client,
-          ).once
+          )
         end
       end
     end


### PR DESCRIPTION
changelog: internal, reporting, monthly key metrics update

Update the Monthly Key Metrics report to prevent failures due to increasingly larger data sets causing timeouts and rate limits on cloudwatch.


Provide a checklist of steps to confirm the changes.

- [ ] Update MonthlyIdVReport for 1 month
- [ ] Update ProofingRateReport for one interval
- [ ] Update Specs


