### PR TITLE
Update jwe to patch vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,7 +385,8 @@ GEM
     jsbundling-rails (1.1.2)
       railties (>= 6.0.0)
     json (2.13.2)
-    jwe (0.4.0)
+    jwe (1.1.1)
+      base64
     jwt (2.7.1)
     knapsack (4.0.0)
       rake


### PR DESCRIPTION
## 🛠 Summary of changes

Addresses a recently published [vulnerability in jwe](https://github.com/jwt/ruby-jwe/security/advisories/GHSA-c7p4-hx26-pr73).

```
$ bundle audit
Name: jwe
Version: 0.4.0
CVE: CVE-2025-54887
GHSA: GHSA-c7p4-hx26-pr73
Criticality: Critical
URL: https://github.com/jwt/ruby-jwe/security/advisories/GHSA-c7p4-hx26-pr73
Title: JWE is missing AES-GCM authentication tag validation in encrypted JWE
Solution: update to '>= 1.1.1'

Vulnerabilities found!
```

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
