### PR TITLE
Fix flaky reporting spec

### DIFF
--- a/spec/lib/reporting/irs_verification_report_spec.rb
+++ b/spec/lib/reporting/irs_verification_report_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe Reporting::IrsVerificationReport do
 
   def previous_week_range
     one_week = 7.days
-    last_sunday = Time.current.utc.to_date.beginning_of_week(:sunday) - one_week
+    last_sunday = Time.zone.now.to_date.beginning_of_week(:sunday) - one_week
     last_saturday = last_sunday + 6.days
     last_sunday..last_saturday
   end
 
   describe '#overview_table' do
     it 'generates the overview table with the correct data' do
-      travel_to Time.zone.local(2025, 8, 4) do
-        expected_generated_date = Time.current.utc.to_date.to_s
+      freeze_time do
+        expected_generated_date = Time.zone.now.to_date.to_s
 
         table = report.overview_table
 


### PR DESCRIPTION
## 🛠 Summary of changes

#12375 introduced a spec that is sensitive to the time zone difference from UTC. This changes the spec to be time zone-insensitive.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
