### PR TITLE
Remove foreign key preparatory to dropping table

### DIFF
--- a/db/primary_migrate/20250808215829_remove_foreign_key_duplicate_profile_confirmation.rb
+++ b/db/primary_migrate/20250808215829_remove_foreign_key_duplicate_profile_confirmation.rb
@@ -1,0 +1,5 @@
+class RemoveForeignKeyDuplicateProfileConfirmation < ActiveRecord::Migration[8.0]
+  def change
+    remove_foreign_key :duplicate_profile_confirmations, :profiles, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_14_184424) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_08_215829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -705,7 +705,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_14_184424) do
 
   add_foreign_key "device_profiling_results", "users"
   add_foreign_key "document_capture_sessions", "users"
-  add_foreign_key "duplicate_profile_confirmations", "profiles"
   add_foreign_key "iaa_gtcs", "partner_accounts"
   add_foreign_key "iaa_orders", "iaa_gtcs"
   add_foreign_key "in_person_enrollments", "profiles"


### PR DESCRIPTION
We will be dropping `duplicate_profile_confirmations`. This prepares for that by dropping the foreign key constraint first.

changelog: Upcoming Features, One Account, Remove foreign key preparatory to dropping table

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
