### PR TITLE
Re-enable accessibility testing on IDV pages test

### DIFF
--- a/spec/features/accessibility/idv_pages_spec.rb
+++ b/spec/features/accessibility/idv_pages_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Accessibility on IDV pages', :js do
 
       visit idv_path
       expect_page_to_have_no_accessibility_violations(page)
-      complete_all_doc_auth_steps_before_password_step
+      complete_all_doc_auth_steps_before_password_step(expect_accessible: true)
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 
@@ -44,7 +44,7 @@ RSpec.feature 'Accessibility on IDV pages', :js do
     scenario 'doc auth steps accessibility on mobile', driver: :headless_chrome_mobile do
       sign_in_and_2fa_user
       visit idv_path
-      complete_all_doc_auth_steps_before_password_step
+      complete_all_doc_auth_steps_before_password_step(expect_accessible: true)
       fill_in t('idv.form.password'), with: Features::SessionHelper::VALID_PASSWORD
       click_continue
 


### PR DESCRIPTION
## 🛠 Summary of changes

It looks like we inadvertently removed accessibility testing in some IDV tests in #12221, this re-enables them.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
