### PR TITLE
Remove association with table to be dropped

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -16,7 +16,6 @@ class Profile < ApplicationRecord
   # rubocop:enable Rails/InverseOf
   has_many :gpo_confirmation_codes, dependent: :destroy
   has_one :in_person_enrollment, dependent: :destroy
-  has_many :duplicate_profile_confirmations, dependent: :destroy
 
   validates :active, uniqueness: { scope: :user_id, if: :active? }
 


### PR DESCRIPTION
We will be dropping `duplicate_profile_confirmations`. This prepares for that by dropping the association.

changelog: Upcoming Features, One Account, Remove association with table to be dropped

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
