### PR TITLE
Create table to hold duplicate profiles

### DIFF
--- a/app/models/duplicate_profile.rb
+++ b/app/models/duplicate_profile.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class DuplicateProfile < ApplicationRecord
+end

--- a/db/primary_migrate/20250811221924_create_duplicate_profiles.rb
+++ b/db/primary_migrate/20250811221924_create_duplicate_profiles.rb
@@ -1,0 +1,16 @@
+class CreateDuplicateProfiles < ActiveRecord::Migration[8.0]
+  def change
+    create_table :duplicate_profiles do |t|
+      t.string :service_provider, limit: 255, null: false, comment: 'sensitive=false'
+      t.bigint :profile_ids, array:true, null: false, comment: 'sensitive=false'
+      t.datetime :closed_at, null: true, comment: 'sensitive=false'
+      t.boolean :self_serviced, null: true, comment: 'sensitive=false'
+      t.boolean :fraud_investigation_conclusive, null: true, comment: 'sensitive=false'
+
+      t.timestamps comment: 'sensitive=false'
+    end
+
+    add_index(:duplicate_profiles, [:service_provider, :profile_ids], unique: true)
+    add_index(:duplicate_profiles, :profile_ids, using: 'gin')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_08_215829) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_11_221924) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -229,6 +229,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_08_215829) do
     t.datetime "created_at", null: false, comment: "sensitive=false"
     t.datetime "updated_at", null: false, comment: "sensitive=false"
     t.index ["profile_id"], name: "index_duplicate_profile_confirmations_on_profile_id"
+  end
+
+  create_table "duplicate_profiles", force: :cascade do |t|
+    t.string "service_provider", limit: 255, null: false, comment: "sensitive=false"
+    t.bigint "profile_ids", null: false, comment: "sensitive=false", array: true
+    t.datetime "closed_at", comment: "sensitive=false"
+    t.boolean "self_serviced", comment: "sensitive=false"
+    t.boolean "fraud_investigation_conclusive", comment: "sensitive=false"
+    t.datetime "created_at", null: false, comment: "sensitive=false"
+    t.datetime "updated_at", null: false, comment: "sensitive=false"
+    t.index ["profile_ids"], name: "index_duplicate_profiles_on_profile_ids", using: :gin
+    t.index ["service_provider", "profile_ids"], name: "index_duplicate_profiles_on_service_provider_and_profile_ids", unique: true
   end
 
   create_table "email_addresses", force: :cascade do |t|


### PR DESCRIPTION
This will replace duplicate_profile_confirmations.

changelog: Upcoming Features, One Account, Create table to hold duplicate profiles

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
