### PR TITLE
LG-16446: Rename gpo_letter_requested

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -234,7 +234,7 @@ module Idv
 
     def next_step_url
       return idv_request_letter_url if FeatureManagement.idv_by_mail_only? ||
-                                       idv_session.gpo_letter_requested
+                                       idv_session.gpo_request_letter_visited
       idv_phone_url
     end
 

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -4,6 +4,7 @@ module Idv
   class AddressController < ApplicationController
     include Idv::AvailabilityConcern
     include IdvStepConcern
+    include Idv::StepIndicatorConcern
 
     before_action :confirm_not_rate_limited_after_doc_auth
     before_action :confirm_step_allowed
@@ -113,6 +114,14 @@ module Idv
 
     def profile_params
       params.require(:idv_form).permit(Idv::AddressForm::ATTRIBUTES)
+    end
+
+    def step_indicator_steps
+      if idv_session.gpo_request_letter_visited
+        return StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
+      end
+
+      StepIndicatorConcern::STEP_INDICATOR_STEPS
     end
   end
 end

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -13,7 +13,7 @@ module Idv
 
       @address_form = build_address_form
       @presenter = AddressPresenter.new(
-        gpo_letter_requested: idv_session.gpo_letter_requested,
+        gpo_request_letter_visited: idv_session.gpo_request_letter_visited,
         address_update_request: address_update_request?,
       )
     end
@@ -79,7 +79,7 @@ module Idv
 
     def failure
       @presenter = AddressPresenter.new(
-        gpo_letter_requested: idv_session.gpo_letter_requested,
+        gpo_request_letter_visited: idv_session.gpo_request_letter_visited,
         address_update_request: address_update_request?,
       )
       render :new

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -39,8 +39,6 @@ module Idv
           end,
           undo_step: ->(idv_session:, user:) do
             idv_session.address_verification_mechanism = nil
-            # Can we do this?:
-            idv_session.gpo_request_letter_visited = nil
           end,
         )
       end

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -17,7 +17,7 @@ module Idv
 
         Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer)
           .call(:usps_address, :view, true)
-        idv_session.gpo_letter_requested = true
+        idv_session.gpo_request_letter_visited = true
         analytics.idv_request_letter_visited
       end
 
@@ -37,7 +37,11 @@ module Idv
           preconditions: ->(idv_session:, user:) do
             idv_session.verify_info_step_complete?
           end,
-          undo_step: ->(idv_session:, user:) { idv_session.address_verification_mechanism = nil },
+          undo_step: ->(idv_session:, user:) do
+            idv_session.address_verification_mechanism = nil
+            # Can we do this?:
+            idv_session.gpo_request_letter_visited = nil
+          end,
         )
       end
 

--- a/app/presenters/idv/address_presenter.rb
+++ b/app/presenters/idv/address_presenter.rb
@@ -2,15 +2,15 @@
 
 module Idv
   class AddressPresenter
-    attr_reader :gpo_letter_requested, :address_update_request
+    attr_reader :gpo_request_letter_visited, :address_update_request
 
-    def initialize(gpo_letter_requested:, address_update_request:)
-      @gpo_letter_requested = gpo_letter_requested
-      @address_update_request = address_update_request && !gpo_letter_requested
+    def initialize(gpo_request_letter_visited:, address_update_request:)
+      @gpo_request_letter_visited = gpo_request_letter_visited
+      @address_update_request = address_update_request && !gpo_request_letter_visited
     end
 
     def address_heading
-      if gpo_letter_requested
+      if gpo_request_letter_visited
         I18n.t('doc_auth.headings.mailing_address')
       elsif address_update_request
         I18n.t('doc_auth.headings.address_update')
@@ -28,7 +28,7 @@ module Idv
     end
 
     def address_info
-      if gpo_letter_requested
+      if gpo_request_letter_visited
         I18n.t('doc_auth.info.mailing_address')
       else
         I18n.t('doc_auth.info.address')

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -9,7 +9,7 @@ module Idv
   # @attr flow_path [String, nil]
   # @attr go_back_path [String, nil]
   # @attr gpo_code_verified [Boolean, nil]
-  # @attr gpo_letter_requested [Boolean, nil]
+  # @attr gpo_request_letter_visited [Boolean, nil]
   # @attr had_barcode_attention_error [Boolean, nil]
   # @attr had_barcode_read_failure [Boolean, nil]
   # @attr idv_consent_given [Boolean, nil]
@@ -57,7 +57,7 @@ module Idv
       flow_path
       go_back_path
       gpo_code_verified
-      gpo_letter_requested
+      gpo_request_letter_visited
       had_barcode_attention_error
       had_barcode_read_failure
       idv_consent_given

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -85,7 +85,7 @@
 
 <% if @presenter.address_update_request %>
   <%= render 'idv/shared/back', step: 'verify', fallback_path: idv_verify_info_path %>
-<% elsif @presenter.gpo_letter_requested %>
+<% elsif @presenter.gpo_request_letter_visited %>
   <%= render 'idv/shared/back', step: 'verify', fallback_path: idv_request_letter_path %>
 <% else %>
   <%= render 'idv/doc_auth/cancel', step: 'verify' %>

--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
-        steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
+        steps: step_indicator_steps,
         current_step: :verify_info,
         locale_scope: 'idv',
         class: 'margin-x-neg-2 margin-top-neg-4 tablet:margin-x-neg-6 tablet:margin-top-neg-4',

--- a/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/request_letter_controller_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe Idv::ByMail::RequestLetterController do
 
       expect(response).to redirect_to idv_enter_password_path
     end
+
+    it 'records that the gpo request letter page has been visited' do
+      expect(subject.idv_session.gpo_request_letter_visited).to be_nil
+
+      get :index
+
+      expect(subject.idv_session.gpo_request_letter_visited).to be
+    end
   end
 
   describe '#create' do
@@ -82,11 +90,14 @@ RSpec.describe Idv::ByMail::RequestLetterController do
     end
 
     it 'sets session to :gpo and redirects' do
+      expect(subject.idv_session.gpo_request_letter_visited).to be_nil
       expect(subject.idv_session.address_verification_mechanism).to be_nil
 
       put :create
 
       expect(response).to redirect_to idv_enter_password_path
+      # create action should not set the gpo_request_letter_visited flag
+      expect(subject.idv_session.gpo_request_letter_visited).to be_nil
       expect(subject.idv_session.address_verification_mechanism).to eq :gpo
     end
 

--- a/spec/features/idv/steps/request_letter_step_spec.rb
+++ b/spec/features/idv/steps/request_letter_step_spec.rb
@@ -37,15 +37,16 @@ RSpec.feature 'idv request letter step' do
     it 'sends user to address page and back to verify page if requested' do
       start_idv_from_sp
       complete_idv_steps_before_gpo_step
-      expect(page).to have_content(t('idv.titles.mail.verify'))
+      expect(page).to have_content(t('idv.messages.gpo.address_on_file'))
       click_on t('idv.messages.gpo.verify_address_again_link_text')
       expect(page).to have_content(t('doc_auth.headings.mailing_address'))
       expect(page).to have_current_path(idv_address_path)
+      expect(page).not_to have_content(t('step_indicator.flows.idv.verify_phone'))
       click_continue
       expect(page).to have_current_path(idv_verify_info_path)
       expect(page).to have_content(t('headings.verify'))
       click_submit_default
-      expect(page).to have_content(t('idv.titles.mail.verify'))
+      expect(page).to have_content(t('idv.messages.gpo.address_on_file'))
     end
   end
 

--- a/spec/presenters/idv/address_presenter_spec.rb
+++ b/spec/presenters/idv/address_presenter_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Idv::AddressPresenter do
-  let(:gpo_letter_requested) { nil }
+  let(:gpo_request_letter_visited) { nil }
   let(:address_update_request) { nil }
-  subject(:presenter) { described_class.new(gpo_letter_requested:, address_update_request:) }
+  subject(:presenter) { described_class.new(gpo_request_letter_visited:, address_update_request:) }
 
   context 'address update request is true' do
     let(:address_update_request) { true }
@@ -29,8 +29,8 @@ RSpec.describe Idv::AddressPresenter do
     end
   end
 
-  context 'gpo_letter_requested is true' do
-    let(:gpo_letter_requested) { true }
+  context 'gpo_request_letter_visited is true' do
+    let(:gpo_request_letter_visited) { true }
     let(:address_update_request) { false }
 
     it 'gives us the correct page heading' do
@@ -42,8 +42,8 @@ RSpec.describe Idv::AddressPresenter do
     end
   end
 
-  context 'gpo_letter_requested and address_update_request are true' do
-    let(:gpo_letter_requested) { true }
+  context 'gpo_request_letter_visited and address_update_request are true' do
+    let(:gpo_request_letter_visited) { true }
     let(:address_update_request) { true }
 
     it 'gives us the correct page heading' do

--- a/spec/views/idv/address/new.html.erb_spec.rb
+++ b/spec/views/idv/address/new.html.erb_spec.rb
@@ -5,10 +5,12 @@ RSpec.describe 'idv/address/new' do
   let(:parsed_page) { Nokogiri::HTML.parse(rendered) }
   let(:gpo_request_letter_visited) { nil }
   let(:address_update_request) { nil }
+  let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
 
   shared_examples 'valid address page and form' do
     before do
       allow(view).to receive(:current_user).and_return(user)
+      allow(view).to receive(:step_indicator_steps).and_return(step_indicator_steps)
       assign(
         :presenter, Idv::AddressPresenter.new(
           gpo_request_letter_visited: gpo_request_letter_visited,

--- a/spec/views/idv/address/new.html.erb_spec.rb
+++ b/spec/views/idv/address/new.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'idv/address/new' do
   let(:user) { build(:user) }
   let(:parsed_page) { Nokogiri::HTML.parse(rendered) }
-  let(:gpo_letter_requested) { nil }
+  let(:gpo_request_letter_visited) { nil }
   let(:address_update_request) { nil }
 
   shared_examples 'valid address page and form' do
@@ -11,7 +11,7 @@ RSpec.describe 'idv/address/new' do
       allow(view).to receive(:current_user).and_return(user)
       assign(
         :presenter, Idv::AddressPresenter.new(
-          gpo_letter_requested: gpo_letter_requested,
+          gpo_request_letter_visited: gpo_request_letter_visited,
           address_update_request: address_update_request,
         )
       )
@@ -20,7 +20,7 @@ RSpec.describe 'idv/address/new' do
     end
 
     it 'has correct address content' do
-      if gpo_letter_requested
+      if gpo_request_letter_visited
         expect(parsed_page).to have_content(t('doc_auth.headings.mailing_address'))
         expect(parsed_page).to have_content(t('doc_auth.info.mailing_address'))
         expect(parsed_page).to have_content(t('forms.buttons.continue'))
@@ -120,7 +120,7 @@ RSpec.describe 'idv/address/new' do
     it_behaves_like 'valid address page and form'
   end
   context 'when the user is requesting a GPO letter' do
-    let(:gpo_letter_requested) { true }
+    let(:gpo_request_letter_visited) { true }
 
     it_behaves_like 'valid address page and form'
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16446](https://cm-jira.usa.gov/browse/LG-16446)

## 🛠 Summary of changes

The idv_session flag `gpo_letter_requested` seems like, if set to true, would indicate that the user has requested a letter. This is not the case - this flag is set when the user visits the Verify by mail page, and it's purpose is to allow reuse on the address controller to modify the copy for the Mailing address entry. This PR renames the field `gpo_request_letter_visited` to avoid future confusion.

While in here I noticed/fixed two other bugs:

1. The feature specs that check that we can go back to the address page, re-verify and land back on the request_letter page were looking for the title "Verify your address" on the page. Unfortunately, the Verify your phone page (the other possibility from Verify your info) includes the link "Verify your address by mail instead" so the test passed regardless of which page the user lands on. I now check `t('idv.messages.gpo.address_on_file')` which only appears on the request_letter page.
2. I noticed that when we returned to the address page, the step indicator reverted to the standard flow. I now check `gpo_request_letter_visited` and show the GPO steps if we will be returned to the request letter page.
