### PR TITLE
Add missing elements from Attempts API Event documentation

### DIFF
--- a/docs/attempts-api/schemas/events/IdentityProofingEvents.yml
+++ b/docs/attempts-api/schemas/events/IdentityProofingEvents.yml
@@ -9,6 +9,8 @@ properties:
     $ref: './identity-proofing/IdvEnrollmentComplete.yml'
   idv-ipp-ready-to-verify-visit:
     $ref: './identity-proofing/IdvIppReadyToVerifyVisit.yml'
+  idv-image-retrieval-failed:
+    $ref: './identity-proofing/IdvImageRetrievalFailed.yml'
   idv-phone-otp-sent:
     $ref: './identity-proofing/IdvPhoneOtpSent.yml'
   idv-phone-otp-submitted:

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvDocumentUploadSubmitted.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvDocumentUploadSubmitted.yml
@@ -40,6 +40,9 @@ allOf:
       document_back_image_file_id:
         type: string
         description: The ID used to retrieve this image if needed
+      document_passport_image_file_id:
+        type: string
+        description: The ID used to retrieve this image if needed
       document_selfie_image_file_id:
         type: string
         description: The ID used to retrieve this image if needed
@@ -49,6 +52,9 @@ allOf:
       document_back_image_encryption_key:
         type: string
         description: Randomly generated Base64-encoded key used to encrypt the back image file.
+      document_passport_image_encryption_key:
+        type: string
+        description: Randomly generated Base64-encoded key used to encrypt the passport image file if it exists.
       document_selfie_image_encryption_key:
         type: string
         description: Randomly generated Base64-encoded key used to encrypt the selfie image file if it exists.

--- a/docs/attempts-api/schemas/events/identity-proofing/IdvDocumentUploaded.yml
+++ b/docs/attempts-api/schemas/events/identity-proofing/IdvDocumentUploaded.yml
@@ -10,6 +10,9 @@ allOf:
       document_back_image_file_id:
         type: string
         description: If this image exists, the ID used to retrieve it if needed
+      document_passport_image_file_id:
+        type: string
+        description: If this image exists, the ID used to retrieve it if needed
       document_selfie_image_file_id:
         type: string
         description: If this image exists, the ID used to retrieve it if needed
@@ -19,6 +22,9 @@ allOf:
       document_back_image_encryption_key:
         type: string
         description: Randomly generated Base64-encoded key used to encrypt the back image file if it exists.
+      document_passport_image_encryption_key:
+        type: string
+        description: Randomly generated Base64-encoded key used to encrypt the passport image file if it exists.
       document_selfie_image_encryption_key:
         type: string
         description: Randomly generated Base64-encoded key used to encrypt the selfie image file if it exists.


### PR DESCRIPTION
## 🛠 Summary of changes
Several field elements and an event were not added in the Attempts API. This code change:

- Associates the idv-image-retrieval-failed event to the list of IdV proofing events
- Adds passport image fields to the two events that gather image information

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
