### PR TITLE
LG-16446: Rename gpo_letter_requested (Part 2)

### DIFF
--- a/app/controllers/concerns/idv/verify_info_concern.rb
+++ b/app/controllers/concerns/idv/verify_info_concern.rb
@@ -234,8 +234,7 @@ module Idv
 
     def next_step_url
       return idv_request_letter_url if FeatureManagement.idv_by_mail_only? ||
-                                       idv_session.gpo_request_letter_visited ||
-                                       idv_session.gpo_letter_requested
+                                       idv_session.gpo_request_letter_visited
       idv_phone_url
     end
 

--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -14,8 +14,7 @@ module Idv
 
       @address_form = build_address_form
       @presenter = AddressPresenter.new(
-        gpo_request_letter_visited: idv_session.gpo_request_letter_visited ||
-          idv_session.gpo_letter_requested,
+        gpo_request_letter_visited: idv_session.gpo_request_letter_visited,
         address_update_request: address_update_request?,
       )
     end
@@ -81,8 +80,7 @@ module Idv
 
     def failure
       @presenter = AddressPresenter.new(
-        gpo_request_letter_visited: idv_session.gpo_request_letter_visited ||
-          idv_session.gpo_letter_requested,
+        gpo_request_letter_visited: idv_session.gpo_request_letter_visited,
         address_update_request: address_update_request?,
       )
       render :new
@@ -119,7 +117,7 @@ module Idv
     end
 
     def step_indicator_steps
-      if idv_session.gpo_request_letter_visited || idv_session.gpo_letter_requested
+      if idv_session.gpo_request_letter_visited
         return StepIndicatorConcern::STEP_INDICATOR_STEPS_GPO
       end
 

--- a/app/controllers/idv/by_mail/request_letter_controller.rb
+++ b/app/controllers/idv/by_mail/request_letter_controller.rb
@@ -18,7 +18,6 @@ module Idv
         Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer)
           .call(:usps_address, :view, true)
         idv_session.gpo_request_letter_visited = true
-        idv_session.gpo_letter_requested = true
         analytics.idv_request_letter_visited
       end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -9,7 +9,6 @@ module Idv
   # @attr flow_path [String, nil]
   # @attr go_back_path [String, nil]
   # @attr gpo_code_verified [Boolean, nil]
-  # @attr gpo_letter_requested [Boolean, nil]
   # @attr gpo_request_letter_visited [Boolean, nil]
   # @attr had_barcode_attention_error [Boolean, nil]
   # @attr had_barcode_read_failure [Boolean, nil]
@@ -58,7 +57,6 @@ module Idv
       flow_path
       go_back_path
       gpo_code_verified
-      gpo_letter_requested
       gpo_request_letter_visited
       had_barcode_attention_error
       had_barcode_read_failure


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16446](https://cm-jira.usa.gov/browse/LG-16446)

## 🛠 Summary of changes

This PR removes the old field, `gpo_letter_requested`, from the codebase now that the PR to add the new field,
`gpo_request_letter_visited`, has been deployed.

[skip changelog]

