### PR TITLE
Dmm/sign attempts jwe

### DIFF
--- a/app/controllers/api/attempts/certs_controller.rb
+++ b/app/controllers/api/attempts/certs_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module Attempts
     class CertsController < ApplicationController

--- a/app/controllers/api/attempts/certs_controller.rb
+++ b/app/controllers/api/attempts/certs_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module Attempts
+    class CertsController < ApplicationController
+      prepend_before_action :skip_session_load
+      prepend_before_action :skip_session_expiration
+      skip_before_action :disable_caching
+
+      JSON = AttemptsApiCertsPresenter.new.certs.freeze
+
+      def index
+        expires_in 1.week, public: true
+
+        render json: JSON
+      end
+    end
+  end
+end

--- a/app/presenters/attempts_api_certs_presenter.rb
+++ b/app/presenters/attempts_api_certs_presenter.rb
@@ -10,7 +10,7 @@ class AttemptsApiCertsPresenter
   private
 
   def key
-    if signing_key.present?
+    if IdentityConfig.store.attempts_api_signing_enabled
       cert = OpenSSL::PKey::EC.new(signing_key)
       {
         alg: 'ES256',
@@ -22,6 +22,11 @@ class AttemptsApiCertsPresenter
   end
 
   def signing_key
+    if IdentityConfig.store.attempts_api_signing_key.blank?
+      raise AttemptsApi::AttemptEvent::SigningKey::SigningKeyError,
+            'Attempts API signing key is not configured'
+    end
+
     IdentityConfig.store.attempts_api_signing_key
   end
 end

--- a/app/presenters/attempts_api_certs_presenter.rb
+++ b/app/presenters/attempts_api_certs_presenter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AttemptsApiCertsPresenter
+  def certs
+    {
+      keys: [key],
+    }
+  end
+
+  private
+
+  def key
+    if signing_key.present?
+      cert = OpenSSL::PKey::EC.new(signing_key)
+      {
+        alg: 'ES256',
+        use: 'sig',
+      }.merge(JWT::JWK::EC.new(OpenSSL::PKey::EC.new(cert.public_to_pem)).export)
+    else
+      {}
+    end
+  end
+
+  def signing_key
+    IdentityConfig.store.attempts_api_signing_key
+  end
+end

--- a/app/presenters/attempts_api_certs_presenter.rb
+++ b/app/presenters/attempts_api_certs_presenter.rb
@@ -3,7 +3,7 @@
 class AttemptsApiCertsPresenter
   def certs
     {
-      keys: [key],
+      keys: [key].compact,
     }
   end
 
@@ -16,8 +16,6 @@ class AttemptsApiCertsPresenter
         alg: 'ES256',
         use: 'sig',
       }.merge(JWT::JWK::EC.new(OpenSSL::PKey::EC.new(cert.public_to_pem)).export)
-    else
-      {}
     end
   end
 

--- a/app/presenters/attempts_configuration_presenter.rb
+++ b/app/presenters/attempts_configuration_presenter.rb
@@ -9,7 +9,7 @@ class AttemptsConfigurationPresenter
   def configuration
     {
       issuer: root_url,
-      jwks_uri: api_openid_connect_certs_url,
+      jwks_uri: api_attempts_certs_url,
       delivery_methods_supported: [
         DELIVERY_METHOD_POLL,
       ],

--- a/app/services/attempts_api/attempt_event.rb
+++ b/app/services/attempts_api/attempt_event.rb
@@ -39,11 +39,14 @@ module AttemptsApi
       signing_key = IdentityConfig.store.attempts_api_signing_private_key
 
       if signing_key.present?
+
+        public_key = OpenSSL::PKey::EC.new(signing_key).public_to_pem
+
         decrypted_event = JWT.decode(
           decrypted_event,
-          OpenSSL::PKey::RSA.new(signing_key).public_key,
+          OpenSSL::PKey::EC.new(public_key),
           true,
-          { algorithm: 'RS256' },
+          { algorithm: 'ES256' },
         ).first
       end
 
@@ -91,7 +94,7 @@ module AttemptsApi
 
     def jwe_payload(payload_json:)
       if signing_key.present?
-        JWT.encode(payload_json, signing_key, 'RS256')
+        JWT.encode(payload_json, signing_key, 'ES256')
       else
         payload_json
       end
@@ -103,7 +106,7 @@ module AttemptsApi
     end
 
     def signing_key
-      OpenSSL::PKey::RSA.new(IdentityConfig.store.attempts_api_signing_private_key) if
+      OpenSSL::PKey::EC.new(IdentityConfig.store.attempts_api_signing_private_key) if
         IdentityConfig.store.attempts_api_signing_private_key.present?
     end
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -45,6 +45,7 @@ async_stale_job_timeout_seconds: 300
 async_wait_timeout_seconds: 60
 attempts_api_enabled: false
 attempts_api_event_ttl_seconds: 3_600
+attempts_api_signing_private_key: ''
 attribute_encryption_key:
 attribute_encryption_key_queue: '[]'
 available_locales: 'en,es,fr,zh'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -45,6 +45,7 @@ async_stale_job_timeout_seconds: 300
 async_wait_timeout_seconds: 60
 attempts_api_enabled: false
 attempts_api_event_ttl_seconds: 3_600
+attempts_api_signing_enabled: false
 attempts_api_signing_key: ''
 attribute_encryption_key:
 attribute_encryption_key_queue: '[]'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -45,7 +45,7 @@ async_stale_job_timeout_seconds: 300
 async_wait_timeout_seconds: 60
 attempts_api_enabled: false
 attempts_api_event_ttl_seconds: 3_600
-attempts_api_signing_private_key: ''
+attempts_api_signing_key: ''
 attribute_encryption_key:
 attribute_encryption_key_queue: '[]'
 available_locales: 'en,es,fr,zh'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     namespace :attempts do
       post '/poll' => 'events#poll', as: :poll
       get '/status' => 'events#status', as: :status
+      get '/certs' => 'certs#index', as: :certs
     end
 
     namespace :internal do

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -63,7 +63,7 @@ module IdentityConfig
     config.add(:async_wait_timeout_seconds, type: :integer)
     config.add(:attempts_api_event_ttl_seconds, type: :integer)
     config.add(:attempts_api_enabled, type: :boolean)
-    config.add(:attempts_api_signing_private_key, type: :string)
+    config.add(:attempts_api_signing_key, type: :string)
     config.add(:attribute_encryption_key, type: :string)
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:available_locales, type: :comma_separated_string_list)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -64,6 +64,7 @@ module IdentityConfig
     config.add(:attempts_api_event_ttl_seconds, type: :integer)
     config.add(:attempts_api_enabled, type: :boolean)
     config.add(:attempts_api_signing_key, type: :string)
+    config.add(:attempts_api_signing_enabled, type: :boolean)
     config.add(:attribute_encryption_key, type: :string)
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:available_locales, type: :comma_separated_string_list)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -63,6 +63,7 @@ module IdentityConfig
     config.add(:async_wait_timeout_seconds, type: :integer)
     config.add(:attempts_api_event_ttl_seconds, type: :integer)
     config.add(:attempts_api_enabled, type: :boolean)
+    config.add(:attempts_api_signing_private_key, type: :string)
     config.add(:attribute_encryption_key, type: :string)
     config.add(:attribute_encryption_key_queue, type: :json)
     config.add(:available_locales, type: :comma_separated_string_list)

--- a/spec/presenters/attempts_api_certs_presenter_spec.rb
+++ b/spec/presenters/attempts_api_certs_presenter_spec.rb
@@ -5,22 +5,37 @@ RSpec.describe AttemptsApiCertsPresenter do
   subject(:presenter) { described_class.new }
 
   describe '#certs' do
-    describe 'when the attempts signing key is present' do
+    describe 'when attempts signing is enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:attempts_api_signing_key).and_return(
-          signing_key.to_pem,
-        )
+        allow(IdentityConfig.store).to receive(:attempts_api_signing_enabled).and_return(true)
       end
-      it 'renders the attempts api signing key as a JWK set' do
-        json = presenter.certs
 
-        expect(json[:keys].size).to eq(1)
-        expect(json[:keys].first[:alg]).to eq 'ES256'
-        expect(json[:keys].first[:use]).to eq 'sig'
+      describe 'when the attempts signing key is present' do
+        before do
+          allow(IdentityConfig.store).to receive(:attempts_api_signing_key).and_return(
+            signing_key.to_pem,
+          )
+        end
+        it 'renders the attempts api signing key as a JWK set' do
+          json = presenter.certs
+
+          expect(json[:keys].size).to eq(1)
+          expect(json[:keys].first[:alg]).to eq 'ES256'
+          expect(json[:keys].first[:use]).to eq 'sig'
+        end
+      end
+
+      describe 'when the attempts signing key is not present' do
+        it 'raises a SigningKeyError' do
+          expect { presenter.certs }.to raise_error(
+            AttemptsApi::AttemptEvent::SigningKey::SigningKeyError,
+            'Attempts API signing key is not configured',
+          )
+        end
       end
     end
 
-    describe 'when the attempts signing key is not present' do
+    describe 'when attempts signing is not enabled' do
       it 'renders an empty JWK set' do
         json = presenter.certs
 

--- a/spec/presenters/attempts_api_certs_presenter_spec.rb
+++ b/spec/presenters/attempts_api_certs_presenter_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe AttemptsApiCertsPresenter do
       it 'renders an empty JWK set' do
         json = presenter.certs
 
-        expect(json[:keys]).to eq [{}]
+        expect(json[:keys]).to eq []
       end
     end
   end

--- a/spec/presenters/attempts_api_certs_presenter_spec.rb
+++ b/spec/presenters/attempts_api_certs_presenter_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe AttemptsApiCertsPresenter do
+  let(:signing_key) { OpenSSL::PKey::EC.generate('prime256v1') }
+  subject(:presenter) { described_class.new }
+
+  describe '#certs' do
+    describe 'when the attempts signing key is present' do
+      before do
+        allow(IdentityConfig.store).to receive(:attempts_api_signing_key).and_return(
+          signing_key.to_pem,
+        )
+      end
+      it 'renders the attempts api signing key as a JWK set' do
+        json = presenter.certs
+
+        expect(json[:keys].size).to eq(1)
+        expect(json[:keys].first[:alg]).to eq 'ES256'
+        expect(json[:keys].first[:use]).to eq 'sig'
+      end
+    end
+
+    describe 'when the attempts signing key is not present' do
+      it 'renders an empty JWK set' do
+        json = presenter.certs
+
+        expect(json[:keys]).to eq [{}]
+      end
+    end
+  end
+end

--- a/spec/presenters/attempts_configuration_presenter_spec.rb
+++ b/spec/presenters/attempts_configuration_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AttemptsConfigurationPresenter do
     it 'includes information about the RISC integration' do
       aggregate_failures do
         expect(configuration[:issuer]).to eq(root_url)
-        expect(configuration[:jwks_uri]).to eq(api_openid_connect_certs_url)
+        expect(configuration[:jwks_uri]).to eq(api_attempts_certs_url)
         expect(configuration[:delivery_methods_supported])
           .to eq([AttemptsConfigurationPresenter::DELIVERY_METHOD_POLL])
 

--- a/spec/services/attempts_api/attempt_event_spec.rb
+++ b/spec/services/attempts_api/attempt_event_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe AttemptsApi::AttemptEvent do
   describe '#to_jwe' do
     describe 'when the attempts signing key is present' do
       before do
-        allow(IdentityConfig.store).to receive(:attempts_api_signing_private_key).and_return(
-          singing_private_key,
+        allow(IdentityConfig.store).to receive(:attempts_api_signing_key).and_return(
+          signing_key.to_pem,
         )
       end
       it 'returns a JWE for the event' do
@@ -121,8 +121,8 @@ RSpec.describe AttemptsApi::AttemptEvent do
 
     describe 'when the attempts signing key is present' do
       before do
-        allow(IdentityConfig.store).to receive(:attempts_api_signing_private_key).and_return(
-          singing_private_key,
+        allow(IdentityConfig.store).to receive(:attempts_api_signing_key).and_return(
+          signing_key.to_pem,
         )
       end
       it 'returns an event decrypted from the JWE' do

--- a/spec/services/attempts_api/attempt_event_spec.rb
+++ b/spec/services/attempts_api/attempt_event_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe AttemptsApi::AttemptEvent do
   let(:attempts_api_private_key) { OpenSSL::PKey::RSA.new(2048) }
   let(:attempts_api_public_key) { attempts_api_private_key.public_key }
 
+  let(:signing_key) { OpenSSL::PKey::RSA.new(2048) }
+  let(:signing_public_key) { signing_key.public_key }
+
   let(:jti) { 'test-unique-id' }
   let(:iat) { Time.zone.now.to_i }
   let(:event_type) { 'test-event' }
@@ -24,53 +27,115 @@ RSpec.describe AttemptsApi::AttemptEvent do
   end
 
   describe '#to_jwe' do
-    it 'returns a JWE for the event' do
-      jwe = subject.to_jwe(issuer: service_provider.issuer, public_key: attempts_api_public_key)
+    describe 'when the attempts signing key is present' do
+      before do
+        allow(IdentityConfig.store).to receive(:attempts_api_signing_private_key).and_return(
+          signing_key.to_s,
+        )
+      end
+      it 'returns a JWE for the event' do
+        jwe = subject.to_jwe(
+          issuer: service_provider.issuer,
+          public_key: attempts_api_public_key,
+        )
 
-      header_str, *_rest = JWE::Serialization::Compact.decode(jwe)
-      headers = JSON.parse(header_str)
+        header_str, *_rest = JWE::Serialization::Compact.decode(jwe)
+        headers = JSON.parse(header_str)
 
-      expect(headers['alg']).to eq('RSA-OAEP')
-      expect(headers['kid']).to eq(JWT::JWK.new(attempts_api_public_key).kid)
+        expect(headers['alg']).to eq('RSA-OAEP')
+        expect(headers['kid']).to eq(JWT::JWK.new(attempts_api_public_key).kid)
 
-      decrypted_jwe_payload = JWE.decrypt(jwe, attempts_api_private_key)
-      decoded_jwe_payload = JWT.decode(
-        decrypted_jwe_payload,
-        AppArtifacts.store.oidc_primary_public_key,
-        true,
-        { algorithm: 'RS256' },
-      )
+        decrypted_jwe_payload = JWE.decrypt(jwe, attempts_api_private_key)
+        decoded_jwe_payload = JWT.decode(
+          decrypted_jwe_payload,
+          signing_public_key,
+          true,
+          { algorithm: 'RS256' },
+        )
 
-      token = JSON.parse(decoded_jwe_payload.first)
+        token = JSON.parse(decoded_jwe_payload.first)
 
-      expect(token['iss']).to eq(Rails.application.routes.url_helpers.root_url)
-      expect(token['jti']).to eq(jti)
-      expect(token['iat']).to eq(iat)
-      expect(token['aud']).to eq(service_provider.issuer)
+        expect(token['iss']).to eq(Rails.application.routes.url_helpers.root_url)
+        expect(token['jti']).to eq(jti)
+        expect(token['iat']).to eq(iat)
+        expect(token['aud']).to eq(service_provider.issuer)
 
-      event_key = 'https://schemas.login.gov/secevent/attempts-api/event-type/test-event'
-      event_data = token['events'][event_key]
+        event_key = 'https://schemas.login.gov/secevent/attempts-api/event-type/test-event'
+        event_data = token['events'][event_key]
 
-      expect(event_data['subject']).to eq(
-        'subject_type' => 'session', 'session_id' => 'test-session-id',
-      )
-      expect(event_data['foo']).to eq('bar')
-      expect(event_data['occurred_at']).to eq(occurred_at.to_f)
+        expect(event_data['subject']).to eq(
+          'subject_type' => 'session', 'session_id' => 'test-session-id',
+        )
+        expect(event_data['foo']).to eq('bar')
+        expect(event_data['occurred_at']).to eq(occurred_at.to_f)
+      end
+    end
+
+    describe 'when the attempts signing key is not present' do
+      it 'returns a JWE for the event' do
+        jwe = subject.to_jwe(issuer: service_provider.issuer, public_key: attempts_api_public_key)
+
+        header_str, *_rest = JWE::Serialization::Compact.decode(jwe)
+        headers = JSON.parse(header_str)
+
+        expect(headers['alg']).to eq('RSA-OAEP')
+        expect(headers['kid']).to eq(JWT::JWK.new(attempts_api_public_key).kid)
+
+        decrypted_jwe_payload = JWE.decrypt(jwe, attempts_api_private_key)
+
+        token = JSON.parse(decrypted_jwe_payload)
+
+        expect(token['iss']).to eq(Rails.application.routes.url_helpers.root_url)
+        expect(token['jti']).to eq(jti)
+        expect(token['iat']).to eq(iat)
+        expect(token['aud']).to eq(service_provider.issuer)
+
+        event_key = 'https://schemas.login.gov/secevent/attempts-api/event-type/test-event'
+        event_data = token['events'][event_key]
+
+        expect(event_data['subject']).to eq(
+          'subject_type' => 'session', 'session_id' => 'test-session-id',
+        )
+        expect(event_data['foo']).to eq('bar')
+        expect(event_data['occurred_at']).to eq(occurred_at.to_f)
+      end
     end
   end
 
   describe '.from_jwe' do
-    it 'returns an event decrypted from the JWE' do
-      jwe = subject.to_jwe(issuer: service_provider.issuer, public_key: attempts_api_public_key)
+    describe 'when the attempts signing key is not present' do
+      it 'returns an event decrypted from the JWE' do
+        jwe = subject.to_jwe(issuer: service_provider.issuer, public_key: attempts_api_public_key)
 
-      decoded_event = described_class.from_jwe(jwe, attempts_api_private_key)
+        decoded_event = described_class.from_jwe(jwe, attempts_api_private_key)
 
-      expect(decoded_event.jti).to eq(subject.jti)
-      expect(decoded_event.iat).to eq(subject.iat)
-      expect(decoded_event.event_type).to eq(subject.event_type)
-      expect(decoded_event.session_id).to eq(subject.session_id)
-      expect(decoded_event.occurred_at).to eq(subject.occurred_at)
-      expect(decoded_event.event_metadata).to eq(subject.event_metadata.symbolize_keys)
+        expect(decoded_event.jti).to eq(subject.jti)
+        expect(decoded_event.iat).to eq(subject.iat)
+        expect(decoded_event.event_type).to eq(subject.event_type)
+        expect(decoded_event.session_id).to eq(subject.session_id)
+        expect(decoded_event.occurred_at).to eq(subject.occurred_at)
+        expect(decoded_event.event_metadata).to eq(subject.event_metadata.symbolize_keys)
+      end
+    end
+
+    describe 'when the attempts signing key is present' do
+      before do
+        allow(IdentityConfig.store).to receive(:attempts_api_signing_private_key).and_return(
+          signing_key.to_s,
+        )
+      end
+      it 'returns an event decrypted from the JWE' do
+        jwe = subject.to_jwe(issuer: service_provider.issuer, public_key: attempts_api_public_key)
+
+        decoded_event = described_class.from_jwe(jwe, attempts_api_private_key)
+
+        expect(decoded_event.jti).to eq(subject.jti)
+        expect(decoded_event.iat).to eq(subject.iat)
+        expect(decoded_event.event_type).to eq(subject.event_type)
+        expect(decoded_event.session_id).to eq(subject.session_id)
+        expect(decoded_event.occurred_at).to eq(subject.occurred_at)
+        expect(decoded_event.event_metadata).to eq(subject.event_metadata.symbolize_keys)
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 52](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/52)

## 🛠 Summary of changes
This code is addressing a request from the treasury team to sign the payload before encrypting it.

In order to make sure we don't break the API while we are putting the private key in different environments, we are conditionally allowing the signature. 

If there is an attempts API signing key in the secrets manager, it will sign the payload. 
If not, it will continue to use the plaintext event as the payload for the JWE.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
