### PR TITLE
changelog: User-Facing Improvements, Passports, Allow for hybrid flow…

### DIFF
--- a/app/javascript/packages/components/link.tsx
+++ b/app/javascript/packages/components/link.tsx
@@ -50,7 +50,7 @@ function Link({
 
   const handleClick = () => {
     // Clear the onbeforeunload event to prevent the "Leave site?" prompt
-    if (href === '/verify/choose_id_type') {
+    if (href === '/verify/choose_id_type' || href === '/verify/hybrid_mobile/choose_id_type') {
       window.onbeforeunload = null;
     }
   };

--- a/app/views/idv/hybrid_mobile/document_capture/show.html.erb
+++ b/app/views/idv/hybrid_mobile/document_capture/show.html.erb
@@ -13,8 +13,8 @@
       skip_doc_auth_from_handoff: nil,
       skip_doc_auth_from_socure:,
       socure_errors_timeout_url:,
-      choose_id_type_path:,
       doc_auth_selfie_capture:,
       doc_auth_upload_enabled:,
+      choose_id_type_path: idv_hybrid_mobile_choose_id_type_path,
       mock_client: mock_client,
     ) %>

--- a/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_mobile_spec.rb
@@ -426,6 +426,7 @@ RSpec.describe 'Hybrid Flow', :allow_net_connect_on_start do
           submit_images
           expect(page).not_to have_current_path(idv_hybrid_mobile_capture_complete_url)
           expect(page).to have_content(t('doc_auth.info.review_passport'))
+          expect(page).to have_link(href: idv_hybrid_mobile_choose_id_type_path)
           expect_to_try_again(is_hybrid: true)
           expect(page).to have_content(t('doc_auth.info.review_passport'))
         end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16586](https://cm-jira.usa.gov/browse/LG-16586)

## 🛠 Summary of changes

Allow hybrid flow user to switch id types after image upload failure

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1: Begin Hybrid flow via state ID
- [ ] Step 2: Upload failed.yml files to fail image upload for state ID
- [ ] Step 3: After reaching fail screen, scroll down and select link to change selected id type
- [ ] Step 4: Confirm you are taken to choose id screen and that you did not receive a modal alert about leaving the site

Video of working link in Jira ticket comments.
