### PR TITLE
LG-16688 Fix choose_id_type flow policy

### DIFF
--- a/app/controllers/idv/choose_id_type_controller.rb
+++ b/app/controllers/idv/choose_id_type_controller.rb
@@ -8,6 +8,7 @@ module Idv
     include Idv::ChooseIdTypeConcern
 
     before_action :redirect_if_passport_not_available
+    before_action :confirm_step_allowed
 
     def show
       analytics.idv_doc_auth_choose_id_type_visited(**analytics_arguments)
@@ -45,10 +46,10 @@ module Idv
         key: :choose_id_type,
         controller: self,
         next_steps: [:document_capture],
-        preconditions: ->(idv_session:, user:) {
+        preconditions: ->(idv_session:, user:) do
           idv_session.flow_path == 'standard' &&
-            idv_session.passport_allowed == true
-        },
+          idv_session.passport_allowed == true
+        end,
         undo_step: ->(idv_session:, user:) do
           if idv_session.document_capture_session_uuid
             DocumentCaptureSession.find_by(


### PR DESCRIPTION
Users were able to use browser back button to get to the choose_id_type step when they didn't have a document capture session.

changelog: Bug Fixes, IdV mobile flow, Fix navigation bug on choose_id_type page

## 🎫 Ticket

Link to the relevant ticket:
[LG-16688](https://cm-jira.usa.gov/browse/LG-16688)

## 🛠 Summary of changes

Users were able to use browser back button to get to the choose_id_type step when they didn't have a document capture session. I updated the choose_id_type controller to use confirm step allowed before hook to prevent users from navigating to the step without the required state set.

Also, I added more test coverage to the choose_id_type controller spec

## 📜 Testing Plan

- [ ] Navigate through IdV reaching the choose_id_type page using a mobile device
- [ ] Select an id_type and submit
- [ ] Cancel IdV
- [ ] Hit back button until reaching the choose_id_type page
- [ ] Verify that you remain on the welcome page

