### PR TITLE
Irs verification demographic report update - GL-Reporting-211

### DIFF
--- a/lib/reporting/irs_verification_demographics_report.rb
+++ b/lib/reporting/irs_verification_demographics_report.rb
@@ -33,7 +33,7 @@ module Reporting
       verbose: false,
       progress: false,
       slice: 6.hours,
-      threads: 1
+      threads: 5
     )
       @issuers = issuers
       @time_range = time_range
@@ -243,7 +243,6 @@ module Reporting
       format(<<~QUERY, params)
         fields
             properties.user_id as user_id
-          , 
         | filter properties.service_provider IN %{issuers}
         | filter (name = %{sp_redirect_initiated} and properties.event_properties.ial = 2 and properties.sp_request.facial_match = 1)
           
@@ -263,7 +262,7 @@ module Reporting
                 , properties.event_properties.proofing_results.biographical_info.state_id_jurisdiction as state,
         properties.event_properties.success as success
                 | filter properties.service_provider IN %{issuers}
-                | filter (name = %{doc_auth_verify} and 
+                | filter name = %{doc_auth_verify} 
                 | filter success = 1
                 | limit 10000
       QUERY

--- a/lib/reporting/irs_verification_demographics_report.rb
+++ b/lib/reporting/irs_verification_demographics_report.rb
@@ -98,7 +98,7 @@ module Reporting
 
     def age_metrics_table
       rows = [['Age Range', 'User Count']]
-      bins = age_bins_for_event(Events::SP_REDIRECT_INITIATED)
+      bins = age_bins
 
       bins.each do |range, count|
         rows << [range, count.to_s]
@@ -109,7 +109,7 @@ module Reporting
 
     def state_metrics_table
       rows = [['State', 'User Count']]
-      counts = state_counts_for_event(Events::SP_REDIRECT_INITIATED)
+      counts = state_counts
 
       counts.each do |state, count|
         rows << [state, count.to_s]
@@ -119,17 +119,27 @@ module Reporting
     end
 
     # TODO:-----------------------------------------------------------------------
-    # FIGURE OUT HOW TO DO THE JOIN ON MULTIPLE QUERIES
-    # TODO: END -----------------------------------------------------------------------    
-
-    # event name => set(user ids)
-    # @return Hash<String,Set<String>>
-    def data
-      @data ||= begin
+    # modify the data function and split into two related to the two new queries
+    def data_sp_redirect
+      @data_sp_redirect ||= begin
         event_users = Hash.new { |h, k| h[k] = [] }
 
-        fetch_results.each do |row|
-          event_users[row['name']] << {
+        fetch_sp_redirect_results.each do |row|
+          event_users[row['user_id']] << { # HELP HERE
+            user_id: row['user_id'],
+          }
+        end
+
+        event_users
+      end
+    end
+
+    def data_doc_auth_success_bio_info
+      @data_doc_auth_success_bio_info ||= begin
+        event_users = Hash.new { |h, k| h[k] = [] }
+
+        fetch_doc_auth_success_bio_info_results.each do |row|
+          event_users[row['user_id']] << {
             user_id: row['user_id'],
             birth_year: row['birth_year']&.to_i,
             state: row['state']&.upcase,
@@ -139,39 +149,51 @@ module Reporting
         event_users
       end
     end
-    # TODO:-----------------------------------------------------------------------
-    # modify the above data function and split into two related to the two new queries
     # TODO: END -----------------------------------------------------------------------
 
+    # TODO:-----------------------------------------------------------------------
+    # FIGURE OUT HOW TO DO THE JOIN ON MULTIPLE QUERIES
+    # JOIN: Only user_ids present in data_sp_redirect
+    def data
+      sp_redirects = data_sp_redirect
+      bio_infos = data_doc_auth_success_bio_info
+
+      result = {}
+      sp_redirects.keys.each do |user_id|
+        if bio_infos.key?(user_id)
+          result[user_id] = bio_infos[user_id]
+        end
+      end
+      result
+    end
+    # TODO: END -----------------------------------------------------------------------
+
+    # TODO need to update the metadata or do I even need it anymore??------------
     def user_metadata
       @user_metadata ||= begin
         metadata = {}
-
-        data[Events::IDV_DOC_AUTH_PROOFING_RESULTS].each do |entry|
-          user_id = entry[:user_id]
+        data.each do |user_id, bio_info|
           next unless user_id.present?
 
+          # If bio_info is an array, get the first element
+          info = bio_info.is_a?(Array) ? bio_info.first : bio_info
+          next unless info.present?
+
           metadata[user_id] = {
-            birth_year: entry[:birth_year]&.to_i,
-            state: entry[:state]&.upcase,
+            birth_year: info[:birth_year]&.to_i,
+            state: info[:state]&.upcase,
           }
         end
-
         metadata
       end
     end
+    # TODO: END ----------------------------------------------------------------
 
-    def age_bins_for_event(event_name)
+    def age_bins
       current_year = Time.zone.today.year
-
-      user_ids = data[event_name].map { |entry| entry[:user_id] }.uniq
-
       bins = Hash.new(0)
 
-      user_ids.each do |user_id|
-        metadata = user_metadata[user_id]
-        next unless metadata
-
+      user_metadata.each do |user_id, metadata|
         birth_year = metadata[:birth_year]
         next unless birth_year
 
@@ -186,53 +208,73 @@ module Reporting
       bins.sort_by { |range, _| range.split('-').first.to_i }.to_h
     end
 
-    def state_counts_for_event(event_name)
-      user_ids = data[event_name].map { |entry| entry[:user_id] }.uniq
-
+    def state_counts
       counts = Hash.new(0)
-
-      user_ids.each do |user_id|
-        state = user_metadata[user_id]&.dig(:state)
+      user_metadata.each do |user_id, metadata|
+        state = metadata[:state]
         next unless state.present?
-
         counts[state] += 1
       end
-
       counts.sort.to_h
     end
 
-    def fetch_results
-      cloudwatch_client.fetch(query:, from: time_range.begin, to: time_range.end)
-    end
     # TODO:-----------------------------------------------------------------------
     # modify and and additional fetch for the new queries
+    def fetch_sp_redirect_results
+      cloudwatch_client.fetch(query: sp_redirect_query, from: time_range.begin, to: time_range.end)
+    end
+
+    def fetch_doc_auth_success_bio_info_results
+      cloudwatch_client.fetch(
+        query: doc_auth_success_bio_info_query, from: time_range.begin,
+        to: time_range.end
+      )
+    end
     # TODO: END -----------------------------------------------------------------------
 
-
-    def query
+    # TODO: -----------------------------------------------------------------------
+    # split the original query into two
+    def sp_redirect_query
       params = {
         issuers: quote(issuers),
-        event_names: quote(Events.all_events),
         sp_redirect_initiated: quote(Events::SP_REDIRECT_INITIATED),
       }
 
       format(<<~QUERY, params)
         fields
-            name
-          , properties.user_id as user_id
-          , properties.event_properties.proofing_results.biographical_info.birth_year as birth_year
-          , properties.event_properties.proofing_results.biographical_info.state_id_jurisdiction as state
+            properties.user_id as user_id
+          , 
         | filter properties.service_provider IN %{issuers}
         | filter (name = %{sp_redirect_initiated} and properties.event_properties.ial = 2 and properties.sp_request.facial_match = 1)
-                 or (name != %{sp_redirect_initiated})
-        | filter name in %{event_names}
+          
         | limit 10000
       QUERY
     end
-    # TODO: -----------------------------------------------------------------------
-    # split the above query into two
-    # TODO: END -----------------------------------------------------------------------
 
+    def doc_auth_success_bio_info_query
+      params = {
+        issuers: quote(issuers),
+        doc_auth_verify: quote(Events::IDV_DOC_AUTH_PROOFING_RESULTS),
+      }
+
+      format(<<~QUERY, params)
+        | filter properties.service_provider IN %{issuers}
+        | filter (name = %{doc_auth_verify}
+        | fields jsonParse(@message) as message
+        | unnest message.properties.event_properties into event_properties
+        | unnest event_properties.proofing_results into proofing_results
+        | unnest proofing_results.biographical_info into biographical_info
+        | unnest biographical_info.birth_year into birth_year
+        | unnest biographical_info.state_id_jurisdiction into state
+        | unnest event_properties.success into success
+
+        | filter success = 1
+        | display properties.user_id,  birth_year, state
+        | limit 10000
+      QUERY
+    end
+
+    # TODO: END -----------------------------------------------------------------------
 
     def cloudwatch_client
       @cloudwatch_client ||= Reporting::CloudwatchClient.new(

--- a/lib/reporting/irs_verification_demographics_report.rb
+++ b/lib/reporting/irs_verification_demographics_report.rb
@@ -118,6 +118,10 @@ module Reporting
       rows
     end
 
+    # TODO:-----------------------------------------------------------------------
+    # FIGURE OUT HOW TO DO THE JOIN ON MULTIPLE QUERIES
+    # TODO: END -----------------------------------------------------------------------    
+
     # event name => set(user ids)
     # @return Hash<String,Set<String>>
     def data
@@ -135,6 +139,9 @@ module Reporting
         event_users
       end
     end
+    # TODO:-----------------------------------------------------------------------
+    # modify the above data function and split into two related to the two new queries
+    # TODO: END -----------------------------------------------------------------------
 
     def user_metadata
       @user_metadata ||= begin
@@ -197,6 +204,10 @@ module Reporting
     def fetch_results
       cloudwatch_client.fetch(query:, from: time_range.begin, to: time_range.end)
     end
+    # TODO:-----------------------------------------------------------------------
+    # modify and and additional fetch for the new queries
+    # TODO: END -----------------------------------------------------------------------
+
 
     def query
       params = {
@@ -218,6 +229,10 @@ module Reporting
         | limit 10000
       QUERY
     end
+    # TODO: -----------------------------------------------------------------------
+    # split the above query into two
+    # TODO: END -----------------------------------------------------------------------
+
 
     def cloudwatch_client
       @cloudwatch_client ||= Reporting::CloudwatchClient.new(

--- a/lib/reporting/irs_verification_demographics_report.rb
+++ b/lib/reporting/irs_verification_demographics_report.rb
@@ -193,7 +193,7 @@ module Reporting
       current_year = Time.zone.today.year
       bins = Hash.new(0)
 
-      user_metadata.each do |user_id, metadata|
+      user_metadata.each do |_user_id, metadata|
         birth_year = metadata[:birth_year]
         next unless birth_year
 
@@ -210,7 +210,7 @@ module Reporting
 
     def state_counts
       counts = Hash.new(0)
-      user_metadata.each do |user_id, metadata|
+      user_metadata.each do |_user_id, metadata|
         state = metadata[:state]
         next unless state.present?
         counts[state] += 1

--- a/lib/reporting/irs_verification_demographics_report.rb
+++ b/lib/reporting/irs_verification_demographics_report.rb
@@ -258,19 +258,14 @@ module Reporting
       }
 
       format(<<~QUERY, params)
-        | filter properties.service_provider IN %{issuers}
-        | filter (name = %{doc_auth_verify}
-        | fields jsonParse(@message) as message
-        | unnest message.properties.event_properties into event_properties
-        | unnest event_properties.proofing_results into proofing_results
-        | unnest proofing_results.biographical_info into biographical_info
-        | unnest biographical_info.birth_year into birth_year
-        | unnest biographical_info.state_id_jurisdiction into state
-        | unnest event_properties.success into success
-
-        | filter success = 1
-        | display properties.user_id,  birth_year, state
-        | limit 10000
+          fields properties.user_id as user_id
+                , properties.event_properties.proofing_results.biographical_info.birth_year as birth_year
+                , properties.event_properties.proofing_results.biographical_info.state_id_jurisdiction as state,
+        properties.event_properties.success as success
+                | filter properties.service_provider IN %{issuers}
+                | filter (name = %{doc_auth_verify} and 
+                | filter success = 1
+                | limit 10000
       QUERY
     end
 

--- a/spec/lib/reporting/irs_verification_demographics_report_spec.rb
+++ b/spec/lib/reporting/irs_verification_demographics_report_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Reporting::IrsVerificationDemographicsReport do
     let(:subject) { described_class.new(issuers: [issuer], time_range:, **opts) }
     let(:default_args) do
       {
-        num_threads: 1,
+        num_threads: 5,
         ensure_complete_logs: true,
         slice_interval: 6.hours,
         progress: false,


### PR DESCRIPTION
## 🎫 Ticket 211

Link to the relevant ticket:
[211 Bugfix: IRS demographics report](https://gitlab.login.gov/lg-teams/Team-Data/reporting/-/issues/211#top)

## 🛠 Summary of changes

Following [#163 (closed)](https://github.com/lg-teams/Team-Data/reporting/-/issues/163), we discovered that we're not calculating events where IdV doc auth verify proofing results is successful, and pulling birth year and state data only from successful events.
This work is to split the cloudwatch queries in the IRS demographics report to:
      1. Gather the list of users that were redirected to IRS at IAL2 level (sp redirect, ial=2, sp_request:facial.match=1)
      2. Gather the state ID and birth year from idv doc auth verify proofing results where the events are successful

From there, we can:
- With ruby, join the user's that were redirected to IRS at IAL2 to their birth year and state from their validated doc auth verify proofing results data (where the event property was a success)
- Return 10-year age range counts and State data into the report
- Finally, ensure that the report is configured to run on a quarterly cycle, returning three months worth of results when the report runs.

## 📜 Testing Plan

Changes: 
- [ ] Separate out the query into two queries within report.rb
- [ ] Add two fetch functions within report.rb
- [ ] Create def data specific functions (one related to each of the queries)
- [ ] Modify def data to be the join of the two queries
- [ ] Update the syntax of the user_metadata
- [ ] Update the syntax of age_bins and state_counts
- [ ] Run spec file
- [ ] Run report mailer previewer
- [ ] Run the Report in Rails Prod, and verifies it does not have 140 year+ old users and return accurate report timeframes

## 👀 Screenshots

Successful Test Runs
Spec File Successful Run Locally:
<img width="929" height="531" alt="Screenshot 2025-08-27 at 10 18 47 AM" src="https://github.com/user-attachments/assets/6ed1f83b-d417-428c-862c-44c3733a5bd6" />

Tested report:
<img width="1089" height="632" alt="Screenshot 2025-09-04 at 9 18 32 PM" src="https://github.com/user-attachments/assets/8b3f1378-e3dc-4934-856e-4321124ee35d" />
<img width="1089" height="632" alt="Screenshot 2025-09-04 at 9 18 44 PM" src="https://github.com/user-attachments/assets/0cd4e8c7-902c-4908-93d4-ff77e5712426" />
<img width="1089" height="632" alt="Screenshot 2025-09-04 at 9 18 49 PM" src="https://github.com/user-attachments/assets/fb4c806a-23d2-47a3-bf22-4bb693ca55be" />
<img width="1089" height="632" alt="Screenshot 2025-09-04 at 9 18 57 PM" src="https://github.com/user-attachments/assets/58f9f993-4243-4d4b-aed6-89f06b3f7187" />

