### PR TITLE
LG-16693 Remove DoS health check on welcome page

### DIFF
--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -84,11 +84,7 @@ module Idv
         return
       end
 
-      idv_session.passport_allowed ||= begin
-        if dos_passport_api_healthy?(analytics:, step: 'welcome')
-          (ab_test_bucket(:DOC_AUTH_PASSPORT) == :passport_allowed)
-        end
-      end
+      idv_session.passport_allowed ||= ab_test_bucket(:DOC_AUTH_PASSPORT) == :passport_allowed
     end
 
     def passport_status

--- a/spec/features/idv/doc_auth/welcome_spec.rb
+++ b/spec/features/idv/doc_auth/welcome_spec.rb
@@ -37,27 +37,36 @@ RSpec.feature 'welcome step' do
   end
 
   context 'passport flow' do
-    before do
-      allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled)
-        .and_return(true)
-      allow(IdentityConfig.store).to receive(:doc_auth_passports_percent)
-        .and_return(100)
-      stub_request(:get, IdentityConfig.store.dos_passport_composite_healthcheck_endpoint)
-        .to_return({ status: 200, body: { status: 'UP' }.to_json })
-      reload_ab_tests
-      visit_idp_from_sp_with_ial2(:oidc)
-      sign_in_and_2fa_user
-      complete_doc_auth_steps_before_welcome_step
+    context 'when passports are enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled)
+          .and_return(true)
+        allow(IdentityConfig.store).to receive(:doc_auth_passports_percent)
+          .and_return(100)
+        reload_ab_tests
+        visit_idp_from_sp_with_ial2(:oidc)
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_welcome_step
+      end
+
+      it 'displays passport and state ID instructions to the user' do
+        expect(page).to have_content t('doc_auth.instructions.bullet1b')
+      end
     end
 
-    it 'logs health check with welcome step' do
-      expect(fake_analytics).to have_logged_event(
-        :passport_api_health_check,
-        step: 'welcome',
-        success: true,
-        body: '{"status":"UP"}',
-        errors: {},
-      )
+    context 'when passports are disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_passports_enabled)
+          .and_return(false)
+        reload_ab_tests
+        visit_idp_from_sp_with_ial2(:oidc)
+        sign_in_and_2fa_user
+        complete_doc_auth_steps_before_welcome_step
+      end
+
+      it 'displays only State ID instructions to the user' do
+        expect(page).to have_content t('doc_auth.instructions.bullet1a')
+      end
     end
   end
 end

--- a/spec/features/idv/in_person/passport_scenario_spec.rb
+++ b/spec/features/idv/in_person/passport_scenario_spec.rb
@@ -168,43 +168,6 @@ RSpec.describe 'In Person Proofing Passports', js: true do
         end
       end
 
-      context 'when the first DOS health check fails on the welcome page' do
-        before do
-          stub_composite_health_check_endpoint_failure
-        end
-
-        it 'does not allow the user to access passport content' do
-          reload_ab_tests
-          visit_idp_from_sp_with_ial2(service_provider)
-          sign_in_live_with_2fa(user)
-
-          expect(page).to have_current_path(idv_welcome_path)
-          expect(page).to have_content t(
-            'doc_auth.headings.welcome',
-            sp_name: service_provider_name,
-          )
-          expect(page).to have_content t('doc_auth.instructions.bullet1a')
-
-          complete_welcome_step
-
-          expect(page).to have_current_path(idv_agreement_path)
-          complete_agreement_step
-
-          click_on t('forms.buttons.continue_ipp')
-
-          expect(page).to have_current_path(idv_document_capture_path(step: 'hybrid_handoff'))
-
-          click_on t('forms.buttons.continue')
-          complete_location_step(user)
-
-          expect(page).to have_current_path(idv_in_person_state_id_url)
-
-          expect(page).to have_content strip_nbsp(
-            t('in_person_proofing.headings.state_id_milestone_2'),
-          )
-        end
-      end
-
       context 'when the second DOS health check fails after the user selects a post office' do
         before do
           stub_health_check_settings


### PR DESCRIPTION
changelog: Internal, IdV Passports, Remove DoS health check from welcome page

## 🎫 Ticket

Link to the relevant ticket:
[LG-16693](https://cm-jira.usa.gov/browse/LG-16693)

## 🛠 Summary of changes

Remove DoS health check from welcome page

## 📜 Testing Plan

**Scenario: Passports Enabled and 100 precent enabled**
```yaml
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 100
```
- [ ] Create a new account
- [ ] Start IdV
- [ ] Ensure Passport and State ID instructions are present on the page
- [ ] Ensure no DoS check is performed
- [ ] Continue flow
- [ ] Ensure choose_id_type page can be reached

**Scenario: Passports Enabled and 0 precent enabled**
```yaml
  doc_auth_passports_enabled: true
  doc_auth_passports_percent: 0
```

- [ ] Create a new account
- [ ] Start IdV
- [ ] Ensure State ID instructions are present on the page
- [ ] Ensure no DoS check is performed
- [ ] Continue flow
- [ ] Ensure choose_id_type page cannot be reached

**Scenario: Passports Disabled**
```yaml
  doc_auth_passports_enabled: false
  doc_auth_passports_percent: 100
```
- [ ] Create a new account
- [ ] Start IdV
- [ ] Ensure State ID instructions are present on the page
- [ ] Ensure no DoS check is performed
- [ ] Continue flow
- [ ] Ensure choose_id_type page cannot be reached

