### PR TITLE
Adapt attempts for saml

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
       sp: current_sp,
       cookie_device_uuid: cookies[:device],
       # this only works for oidc
-      sp_request_uri: attempts_api_request_uri,
+      sp_redirect_uri: attempts_api_redirect_uri,
       enabled_for_session: attempts_api_enabled_for_session?,
     )
   end
@@ -148,8 +148,8 @@ class ApplicationController < ActionController::Base
     @attempts_api_session_id ||= decorated_sp_session.attempts_api_session_id
   end
 
-  def attempts_api_request_uri
-    @attempts_api_request_uri ||= decorated_sp_session.attempts_api_request_uri
+  def attempts_api_redirect_uri
+    @attempts_api_redirect_uri ||= decorated_sp_session.attempts_api_redirect_uri
   end
 
   # These attributes show up in New Relic traces for all requests.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
       sp: current_sp,
       cookie_device_uuid: cookies[:device],
       # this only works for oidc
-      sp_request_uri: decorated_sp_session.request_url_params[:redirect_uri],
+      sp_request_uri: attempts_api_request_uri,
       enabled_for_session: attempts_api_enabled_for_session?,
     )
   end
@@ -146,6 +146,10 @@ class ApplicationController < ActionController::Base
 
   def attempts_api_session_id
     @attempts_api_session_id ||= decorated_sp_session.attempts_api_session_id
+  end
+
+  def attempts_api_request_uri
+    @attempts_api_request_uri ||= decorated_sp_session.attempts_api_request_uri
   end
 
   # These attributes show up in New Relic traces for all requests.

--- a/app/decorators/null_service_provider_session.rb
+++ b/app/decorators/null_service_provider_session.rb
@@ -45,6 +45,8 @@ class NullServiceProviderSession
 
   def attempts_api_session_id; end
 
+  def attempts_api_redirect_uri; end
+
   private
 
   attr_reader :view_context

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -15,7 +15,7 @@ class ServiceProviderSession
     request_url_params['attempts_api_session_id'] || request_url_params['tid']
   end
 
-  def attempts_api_request_uri
+  def attempts_api_redirect_uri
     request_url_params[:redirect_uri] || sp&.acs_url
   end
 

--- a/app/decorators/service_provider_session.rb
+++ b/app/decorators/service_provider_session.rb
@@ -15,6 +15,10 @@ class ServiceProviderSession
     request_url_params['attempts_api_session_id'] || request_url_params['tid']
   end
 
+  def attempts_api_request_uri
+    request_url_params[:redirect_uri] || sp&.acs_url
+  end
+
   def remember_device_default
     sp_aal < 2
   end

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -516,7 +516,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       user: enrollment.user,
       sp: enrollment.service_provider,
       cookie_device_uuid: nil,
-      sp_request_uri: nil,
+      sp_redirect_uri: nil,
     )
   end
 

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -169,7 +169,7 @@ class SocureDocvResultsJob < ApplicationJob
       user: document_capture_session.user,
       sp:,
       cookie_device_uuid: nil,
-      sp_request_uri: nil,
+      sp_redirect_uri: nil,
       enabled_for_session: sp&.attempts_api_enabled?,
     )
   end

--- a/app/jobs/socure_image_retrieval_job.rb
+++ b/app/jobs/socure_image_retrieval_job.rb
@@ -38,7 +38,7 @@ class SocureImageRetrievalJob < ApplicationJob
       user: document_capture_session.user,
       sp:,
       cookie_device_uuid: nil,
-      sp_request_uri: nil,
+      sp_redirect_uri: nil,
       enabled_for_session: sp&.attempts_api_enabled?,
     )
   end

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -7,16 +7,16 @@ module AttemptsApi
       'forgot-password-email-sent',
     ].freeze
     attr_reader :session_id, :enabled_for_session, :request, :user, :sp, :cookie_device_uuid,
-                :sp_request_uri
+                :sp_redirect_uri
 
     def initialize(session_id:, request:, user:, sp:, cookie_device_uuid:,
-                   sp_request_uri:, enabled_for_session:)
+                   sp_redirect_uri:, enabled_for_session:)
       @session_id = session_id
       @request = request
       @user = user
       @sp = sp
       @cookie_device_uuid = cookie_device_uuid
-      @sp_request_uri = sp_request_uri
+      @sp_redirect_uri = sp_redirect_uri
       @enabled_for_session = enabled_for_session
     end
     include TrackerEvents
@@ -38,7 +38,7 @@ module AttemptsApi
         user_uuid: agency_uuid(event_type: event_type),
         device_id: cookie_device_uuid,
         user_ip_address: request&.remote_ip,
-        application_url: sp_request_uri,
+        application_url: sp_redirect_uri,
         language: user&.email_language || I18n.locale.to_s,
         client_port: CloudFrontHeaderParser.new(request).client_port,
         aws_region: IdentityConfig.store.aws_region,

--- a/docs/attempts-api/schemas/events/shared/EventProperties.yml
+++ b/docs/attempts-api/schemas/events/shared/EventProperties.yml
@@ -3,7 +3,7 @@ properties:
   application_url:
     type: string
     description: |
-      Indicates the SP URL (redirect_uri) from which the action was triggered.
+      Indicates the SP URL (redirect_uri) where the user will be redirected after authentication.
   aws_region:
     type: string
     description: AWS Region in which the event occurred.

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -398,7 +398,7 @@ class ActionAccount
         user: profile.user,
         sp: profile.initiating_service_provider,
         cookie_device_uuid: nil,
-        sp_request_uri: nil,
+        sp_redirect_uri: nil,
       )
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -739,7 +739,7 @@ RSpec.describe ApplicationController do
       it 'calls the AttemptsApi::Tracker class with enabled_for_session set to false' do
         expect(AttemptsApi::Tracker).to receive(:new).with(
           user:, request:, sp:, session_id: nil,
-          cookie_device_uuid: nil, sp_request_uri: nil, enabled_for_session: false
+          cookie_device_uuid: nil, sp_redirect_uri: nil, enabled_for_session: false
         )
 
         controller.attempts_api_tracker
@@ -755,7 +755,7 @@ RSpec.describe ApplicationController do
         it 'calls the AttemptsApi::Tracker class with enabled_for_session set to false' do
           expect(AttemptsApi::Tracker).to receive(:new).with(
             user:, request:, sp:, session_id: nil,
-            cookie_device_uuid: nil, sp_request_uri: nil, enabled_for_session: false
+            cookie_device_uuid: nil, sp_redirect_uri: nil, enabled_for_session: false
           )
 
           controller.attempts_api_tracker
@@ -777,7 +777,7 @@ RSpec.describe ApplicationController do
           it 'calls the AttemptsApi::Tracker class with enabled_for_session set to false' do
             expect(AttemptsApi::Tracker).to receive(:new).with(
               user:, request:, sp:, session_id: nil,
-              cookie_device_uuid: nil, sp_request_uri: nil, enabled_for_session: false
+              cookie_device_uuid: nil, sp_redirect_uri: nil, enabled_for_session: false
             )
 
             controller.attempts_api_tracker
@@ -792,7 +792,7 @@ RSpec.describe ApplicationController do
           it 'calls the AttemptsApi::Tracker class with enabled_for_session set to true' do
             expect(AttemptsApi::Tracker).to receive(:new).with(
               user:, request:, sp:, session_id: 'abc123',
-              cookie_device_uuid: nil, sp_request_uri: nil, enabled_for_session: true
+              cookie_device_uuid: nil, sp_redirect_uri: nil, enabled_for_session: true
             )
 
             controller.attempts_api_tracker

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe ServiceProviderSession do
       let(:url) { "https://example.com/auth?param0=p0&redirect_uri=#{redirect_uri}&param2=p2" }
 
       it 'returns the redirect_uri' do
-        expect(subject.attempts_api_request_uri).to eq redirect_uri
+        expect(subject.attempts_api_redirect_uri).to eq redirect_uri
       end
     end
 
@@ -265,7 +265,7 @@ RSpec.describe ServiceProviderSession do
         let(:url) { 'https://example.com/auth?param0=p0' }
 
         it 'returns the redirect_uri' do
-          expect(subject.attempts_api_request_uri).to eq redirect_uri
+          expect(subject.attempts_api_redirect_uri).to eq redirect_uri
         end
       end
     end

--- a/spec/decorators/service_provider_session_spec.rb
+++ b/spec/decorators/service_provider_session_spec.rb
@@ -245,4 +245,29 @@ RSpec.describe ServiceProviderSession do
       end
     end
   end
+
+  describe '#attempt_api_request_uri' do
+    let(:service_provider_request) { ServiceProviderRequest.new(url:) }
+    let(:redirect_uri) { 'http://example.com/redirect' }
+
+    context 'with a redirect_uri in the request_url_params' do
+      let(:url) { "https://example.com/auth?param0=p0&redirect_uri=#{redirect_uri}&param2=p2" }
+
+      it 'returns the redirect_uri' do
+        expect(subject.attempts_api_request_uri).to eq redirect_uri
+      end
+    end
+
+    context 'with no redirect uri in the request_url_params' do
+      context 'with a SAML integration' do
+        let(:sp) { build_stubbed(:service_provider, acs_url: redirect_uri) }
+
+        let(:url) { 'https://example.com/auth?param0=p0' }
+
+        it 'returns the redirect_uri' do
+          expect(subject.attempts_api_request_uri).to eq redirect_uri
+        end
+      end
+    end
+  end
 end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AttemptsApi::Tracker do
   let(:request) { instance_double(ActionDispatch::Request) }
   let(:service_provider) { create(:service_provider) }
   let(:cookie_device_uuid) { 'device_id' }
-  let(:sp_request_uri) { 'https://example.com/auth_page' }
+  let(:sp_redirect_uri) { 'https://example.com/auth_page' }
   let(:user) { create(:user) }
 
   subject do
@@ -28,7 +28,7 @@ RSpec.describe AttemptsApi::Tracker do
       user: user,
       sp: service_provider,
       cookie_device_uuid: cookie_device_uuid,
-      sp_request_uri: sp_request_uri,
+      sp_redirect_uri: sp_redirect_uri,
       enabled_for_session: enabled_for_session,
     )
   end


### PR DESCRIPTION
## 🛠 Summary of changes

We have a new partner interested in using the Attempts API that is using SAML. The `application_url` value was designed for OIDC applications, so this PR updates it to work for SAML

This change also renames an internal parameter and attribute in order to make it clearer that this field is capturing a redirect uri, so that the SP can know where a user is going after authentication (useful for integrations with multiple `redirect_uri`s)

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
