### PR TITLE
Rename DuplicateProfile to DuplicateProfileSet

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -551,7 +551,7 @@ class ApplicationController < ActionController::Base
     profile = current_user&.active_profile
     return false unless profile
     return false unless user_in_one_account_verification_bucket?
-    DuplicateProfile.involving_profile(
+    DuplicateProfileSet.involving_profile(
       profile_id: profile.id,
       service_provider: current_sp&.issuer,
     ).present?

--- a/app/models/duplicate_profile_set.rb
+++ b/app/models/duplicate_profile_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DuplicateProfile < ApplicationRecord
+class DuplicateProfileSet < ApplicationRecord
   scope :open, -> { where(closed_at: nil) }
 
   def self.involving_profiles(profile_ids:, service_provider:)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -258,7 +258,7 @@ class Profile < ApplicationRecord
 
   def deactivate_duplicate
     raise 'Profile not active' unless active
-    raise 'Profile not a duplicate' unless DuplicateProfile.open.exists?(
+    raise 'Profile not a duplicate' unless DuplicateProfileSet.open.exists?(
       ['? = ANY(profile_ids)', id],
     )
 
@@ -268,7 +268,7 @@ class Profile < ApplicationRecord
         fraud_review_pending_at: nil,
         fraud_rejection_at: Time.zone.now,
       )
-      DuplicateProfile.open.where(['? = ANY(profile_ids)', id]).find_each do |duplicate_profile|
+      DuplicateProfileSet.open.where(['? = ANY(profile_ids)', id]).find_each do |duplicate_profile|
         if duplicate_profile.profile_ids.length > 1
           duplicate_profile.profile_ids.delete(id)
           duplicate_profile.save
@@ -293,15 +293,15 @@ class Profile < ApplicationRecord
 
   def clear_duplicate
     raise 'Profile not active' unless active
-    raise 'Profile not a duplicate' unless DuplicateProfile.open.exists?(
+    raise 'Profile not a duplicate' unless DuplicateProfileSet.open.exists?(
       ['? = ANY(profile_ids)', id],
     )
-    raise 'Profile has other duplicates' if DuplicateProfile.open.exists?(
+    raise 'Profile has other duplicates' if DuplicateProfileSet.open.exists?(
       ['? = ANY(profile_ids) AND cardinality(profile_ids) > 1', id],
     )
 
     transaction do
-      DuplicateProfile.open.where(['? = ANY(profile_ids)', id]).find_each do |duplicate_profile|
+      DuplicateProfileSet.open.where(['? = ANY(profile_ids)', id]).find_each do |duplicate_profile|
         duplicate_profile.update!(
           closed_at: Time.zone.now,
           self_serviced: false,
@@ -321,12 +321,12 @@ class Profile < ApplicationRecord
 
   def close_inconclusive_duplicate
     raise 'Profile not active' unless active
-    raise 'Profile not a duplicate' unless DuplicateProfile.open.exists?(
+    raise 'Profile not a duplicate' unless DuplicateProfileSet.open.exists?(
       ['? = ANY(profile_ids)', id],
     )
 
     transaction do
-      DuplicateProfile.open.where(['? = ANY(profile_ids)', id]).find_each do |duplicate_profile|
+      DuplicateProfileSet.open.where(['? = ANY(profile_ids)', id]).find_each do |duplicate_profile|
         if duplicate_profile.profile_ids.length > 1
           duplicate_profile.profile_ids.delete(id)
           duplicate_profile.save

--- a/app/presenters/duplicate_profiles_detected_presenter.rb
+++ b/app/presenters/duplicate_profiles_detected_presenter.rb
@@ -3,11 +3,11 @@
 class DuplicateProfilesDetectedPresenter
   include ActionView::Helpers::TranslationHelper
 
-  attr_reader :user, :dupe_profile
+  attr_reader :user, :duplicate_profile_set
 
-  def initialize(user:, dupe_profile:)
+  def initialize(user:, duplicate_profile_set:)
     @user = user
-    @dupe_profile = dupe_profile
+    @duplicate_profile_set = duplicate_profile_set
   end
 
   def heading
@@ -15,7 +15,7 @@ class DuplicateProfilesDetectedPresenter
   end
 
   def associated_profiles
-    profiles = Profile.where(id: dupe_profile.profile_ids)
+    profiles = Profile.where(id: duplicate_profile_set.profile_ids)
     profiles.map do |profile|
       dupe_user = profile.user
       email = dupe_user.last_sign_in_email_address.email

--- a/app/services/duplicate_profile_checker.rb
+++ b/app/services/duplicate_profile_checker.rb
@@ -22,7 +22,7 @@ class DuplicateProfileChecker
     )
     ids = associated_profiles.map(&:id)
     dupe_profile_ids = (ids + [profile.id]).sort
-    existing_profile = DuplicateProfile.involving_profiles(
+    existing_profile = DuplicateProfileSet.involving_profiles(
       profile_ids: dupe_profile_ids,
       service_provider: sp.issuer,
     )
@@ -34,7 +34,7 @@ class DuplicateProfileChecker
           analytics.one_account_duplicate_profile_updated
         end
       else
-        DuplicateProfile.create(profile_ids: dupe_profile_ids, service_provider: sp.issuer)
+        DuplicateProfileSet.create(profile_ids: dupe_profile_ids, service_provider: sp.issuer)
         analytics.one_account_duplicate_profile_created
       end
     elsif existing_profile

--- a/db/primary_migrate/20250829182800_rename_duplicate_profile_to_duplicate_profile_set.rb
+++ b/db/primary_migrate/20250829182800_rename_duplicate_profile_to_duplicate_profile_set.rb
@@ -1,0 +1,5 @@
+class RenameDuplicateProfileToDuplicateProfileSet < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured { rename_table :duplicate_profiles, :duplicate_profile_sets }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_18_192257) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_29_182800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -221,7 +221,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_18_192257) do
     t.index ["uuid"], name: "index_document_capture_sessions_on_uuid"
   end
 
-  create_table "duplicate_profiles", force: :cascade do |t|
+  create_table "duplicate_profile_sets", force: :cascade do |t|
     t.string "service_provider", limit: 255, null: false, comment: "sensitive=false"
     t.bigint "profile_ids", null: false, comment: "sensitive=false", array: true
     t.datetime "closed_at", comment: "sensitive=false"
@@ -229,8 +229,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_18_192257) do
     t.boolean "fraud_investigation_conclusive", comment: "sensitive=false"
     t.datetime "created_at", null: false, comment: "sensitive=false"
     t.datetime "updated_at", null: false, comment: "sensitive=false"
-    t.index ["profile_ids"], name: "index_duplicate_profiles_on_profile_ids", using: :gin
-    t.index ["service_provider", "profile_ids"], name: "index_duplicate_profiles_on_service_provider_and_profile_ids", unique: true
+    t.index ["profile_ids"], name: "index_duplicate_profile_sets_on_profile_ids", using: :gin
+    t.index ["service_provider", "profile_ids"], name: "idx_on_service_provider_profile_ids_7f75d24ae3", unique: true
   end
 
   create_table "email_addresses", force: :cascade do |t|

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -630,8 +630,8 @@ RSpec.describe ApplicationController do
         expect(response.body).to eq('false')
       end
 
-      it 'returns false even with duplicate profile confirmations' do
-        create(:duplicate_profile, profile_ids: [profile.id], service_provider: 'wrong-sp')
+      it 'returns false even with duplicate profiles' do
+        create(:duplicate_profile_set, profile_ids: [profile.id], service_provider: 'wrong-sp')
 
         get :index
         expect(response.body).to eq('false')
@@ -655,11 +655,11 @@ RSpec.describe ApplicationController do
             expect(response.body).to eq('false')
           end
         end
-        context 'when duplicate profile ids found in session' do
+        context 'when duplicate profile ids found' do
           before do
             create(
-              :duplicate_profile, profile_ids: [active_profile.id],
-                                  service_provider: sp.issuer
+              :duplicate_profile_set, profile_ids: [active_profile.id],
+                                      service_provider: sp.issuer
             )
           end
 

--- a/spec/controllers/duplicate_profiles_detected_controller_spec.rb
+++ b/spec/controllers/duplicate_profiles_detected_controller_spec.rb
@@ -6,24 +6,24 @@ RSpec.describe DuplicateProfilesDetectedController, type: :controller do
   let(:current_sp) do
     create(:service_provider, issuer: 'test-sp', friendly_name: 'Test Service Provider')
   end
-  let(:dupe_profile) do
+  let(:duplicate_profile_set) do
     create(
-      :duplicate_profile, profile_ids: [user.active_profile.id, profile2.id],
-                          service_provider: current_sp.issuer
+      :duplicate_profile_set, profile_ids: [user.active_profile.id, profile2.id],
+                              service_provider: current_sp.issuer
     )
   end
 
   before do
     stub_sign_in(user)
     stub_analytics
-    dupe_profile
+    duplicate_profile_set
     allow(controller).to receive(:current_sp).and_return(current_sp)
   end
 
   describe '#show' do
     context 'when user is not authenticated with 2FA' do
       let(:user) { nil }
-      let(:dupe_profile) { nil }
+      let(:duplicate_profile_set) { nil }
 
       it 'redirects to sign in page' do
         get :show
@@ -43,7 +43,7 @@ RSpec.describe DuplicateProfilesDetectedController, type: :controller do
 
       it 'initializes the DuplicateProfilesDetectedPresenter' do
         expect(DuplicateProfilesDetectedPresenter).to receive(:new)
-          .with(user: user, dupe_profile: dupe_profile)
+          .with(user: user, duplicate_profile_set: duplicate_profile_set)
         get :show
       end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -637,9 +637,9 @@ RSpec.describe OpenidConnect::AuthorizationController do
                     :profile, :active, :verified, proofing_components: { liveness_check: true }
                   ).user
                 end
-                let(:duplicate_profile) do
+                let(:duplicate_profile_set) do
                   create(
-                    :duplicate_profile, profile_ids:
+                    :duplicate_profile_set, profile_ids:
                          [user.active_profile.id, user2.active_profile.id], service_provider: service_provider.issuer
                   )
                 end
@@ -648,7 +648,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                   allow(IdentityConfig.store).to receive(:eligible_one_account_providers).and_return([service_provider.issuer])
                   allow(controller).to receive(:user_in_one_account_verification_bucket?)
                     .and_return(true)
-                  duplicate_profile
+                  duplicate_profile_set
                   allow(controller).to receive(:user_signed_in?).and_return(true)
                   allow(controller).to receive(:current_user).and_return(user)
                 end

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -940,9 +940,9 @@ RSpec.describe SamlIdpController do
             :profile, :active, :verified, proofing_components: { liveness_check: true }
           ).user
         end
-        let(:duplicate_profile) do
+        let(:duplicate_profile_set) do
           create(
-            :duplicate_profile,
+            :duplicate_profile_set,
             profile_ids: [user.active_profile.id, user2.active_profile.id],
             service_provider: service_provider.issuer,
           )
@@ -956,7 +956,7 @@ RSpec.describe SamlIdpController do
             .and_return([service_provider.issuer])
           allow(controller).to receive(:user_in_one_account_verification_bucket?)
             .and_return(true)
-          duplicate_profile
+          duplicate_profile_set
           allow(controller).to receive(:current_user).and_return(user)
         end
 

--- a/spec/factories/duplicate_profile_sets.rb
+++ b/spec/factories/duplicate_profile_sets.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :duplicate_profile do
+  factory :duplicate_profile_set do
     profile_ids { [] }
     service_provider { OidcAuthHelper::OIDC_FACIAL_MATCH_ISSUER }
     created_at { Time.zone.now }

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -561,9 +561,9 @@ RSpec.describe ActionAccount do
           )
         end
         let(:user) { profile.user }
-        let!(:duplicate_profile) do
+        let!(:duplicate_profile_set) do
           create(
-            :duplicate_profile,
+            :duplicate_profile_set,
             profile_ids: [user.profiles.active.sole.id],
           )
         end
@@ -655,9 +655,9 @@ RSpec.describe ActionAccount do
           )
         end
         let(:user) { profile.user }
-        let!(:duplicate_profile) do
+        let!(:duplicate_profile_set) do
           create(
-            :duplicate_profile,
+            :duplicate_profile_set,
             profile_ids: [user.profiles.active.sole.id],
           )
         end
@@ -749,9 +749,9 @@ RSpec.describe ActionAccount do
           )
         end
         let(:user) { profile.user }
-        let!(:duplicate_profile) do
+        let!(:duplicate_profile_set) do
           create(
-            :duplicate_profile,
+            :duplicate_profile_set,
             profile_ids: [user.profiles.active.sole.id],
           )
         end

--- a/spec/models/duplicate_profile_set_spec.rb
+++ b/spec/models/duplicate_profile_set_spec.rb
@@ -1,23 +1,26 @@
 require 'rails_helper'
 
-RSpec.describe DuplicateProfile, type: :model do
+RSpec.describe DuplicateProfileSet, type: :model do
   let(:service_provider) { create(:service_provider, issuer: 'test-sp') }
   let(:profile_id) { 123 }
   let(:other_profile_id) { 456 }
   let!(:matching_profile) do
     create(
-      :duplicate_profile, service_provider: service_provider.issuer,
-                          profile_ids: [profile_id, other_profile_id]
+      :duplicate_profile_set, service_provider: service_provider.issuer,
+                              profile_ids: [profile_id, other_profile_id]
     )
   end
   let!(:non_matching_service) do
     create(
-      :duplicate_profile, service_provider: 'other-sp',
-                          profile_ids: [profile_id, other_profile_id]
+      :duplicate_profile_set, service_provider: 'other-sp',
+                              profile_ids: [profile_id, other_profile_id]
     )
   end
   let!(:non_matching_profile) do
-    create(:duplicate_profile, service_provider: service_provider.issuer, profile_ids: [999, 888])
+    create(
+      :duplicate_profile_set, service_provider: service_provider.issuer,
+                              profile_ids: [999, 888]
+    )
   end
 
   it 'returns record matching both service_provider and profile_id' do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1194,9 +1194,9 @@ RSpec.describe Profile do
       end
 
       context 'when the profile is identified as a duplicate' do
-        let!(:duplicate_profile) do
+        let!(:duplicate_profile_set) do
           create(
-            :duplicate_profile,
+            :duplicate_profile_set,
             profile_ids: profile_ids,
             closed_at: closed_at,
           )
@@ -1225,11 +1225,11 @@ RSpec.describe Profile do
 
             it 'closes the case as resolved by fraud', :freeze_time do
               profile.deactivate_duplicate
-              duplicate_profile.reload
-              expect(duplicate_profile.profile_ids).to include(profile.id)
-              expect(duplicate_profile.closed_at).to eq(Time.zone.now)
-              expect(duplicate_profile.self_serviced).to be(false)
-              expect(duplicate_profile.fraud_investigation_conclusive).to be(true)
+              duplicate_profile_set.reload
+              expect(duplicate_profile_set.profile_ids).to include(profile.id)
+              expect(duplicate_profile_set.closed_at).to eq(Time.zone.now)
+              expect(duplicate_profile_set.self_serviced).to be(false)
+              expect(duplicate_profile_set.fraud_investigation_conclusive).to be(true)
             end
 
             it 'notifies the user' do
@@ -1250,11 +1250,11 @@ RSpec.describe Profile do
 
             it 'does not close the case', :freeze_time do
               profile.deactivate_duplicate
-              duplicate_profile.reload
-              expect(duplicate_profile.profile_ids).not_to include(profile.id)
-              expect(duplicate_profile.closed_at).to be(nil)
-              expect(duplicate_profile.self_serviced).to be(nil)
-              expect(duplicate_profile.fraud_investigation_conclusive).to be(nil)
+              duplicate_profile_set.reload
+              expect(duplicate_profile_set.profile_ids).not_to include(profile.id)
+              expect(duplicate_profile_set.closed_at).to be(nil)
+              expect(duplicate_profile_set.self_serviced).to be(nil)
+              expect(duplicate_profile_set.fraud_investigation_conclusive).to be(nil)
             end
 
             it 'notifies the user' do
@@ -1284,9 +1284,9 @@ RSpec.describe Profile do
       end
 
       context 'when the profile is identified as a duplicate' do
-        let!(:duplicate_profile) do
+        let!(:duplicate_profile_set) do
           create(
-            :duplicate_profile,
+            :duplicate_profile_set,
             profile_ids: profile_ids,
             closed_at: closed_at,
           )
@@ -1314,11 +1314,11 @@ RSpec.describe Profile do
 
             it 'closes the case as resolved by fraud', :freeze_time do
               profile.clear_duplicate
-              duplicate_profile.reload
-              expect(duplicate_profile.profile_ids).to include(profile.id)
-              expect(duplicate_profile.closed_at).to eq(Time.zone.now)
-              expect(duplicate_profile.self_serviced).to be(false)
-              expect(duplicate_profile.fraud_investigation_conclusive).to be(true)
+              duplicate_profile_set.reload
+              expect(duplicate_profile_set.profile_ids).to include(profile.id)
+              expect(duplicate_profile_set.closed_at).to eq(Time.zone.now)
+              expect(duplicate_profile_set.self_serviced).to be(false)
+              expect(duplicate_profile_set.fraud_investigation_conclusive).to be(true)
             end
 
             it 'notifies the user' do
@@ -1358,9 +1358,9 @@ RSpec.describe Profile do
       end
 
       context 'when the profile is identified as a duplicate' do
-        let!(:duplicate_profile) do
+        let!(:duplicate_profile_set) do
           create(
-            :duplicate_profile,
+            :duplicate_profile_set,
             profile_ids: profile_ids,
             closed_at: closed_at,
           )
@@ -1389,10 +1389,10 @@ RSpec.describe Profile do
 
             it 'closes the case as inconclusive', :freeze_time do
               profile.close_inconclusive_duplicate
-              duplicate_profile.reload
-              expect(duplicate_profile.closed_at).to eq(Time.zone.now)
-              expect(duplicate_profile.self_serviced).to be(false)
-              expect(duplicate_profile.fraud_investigation_conclusive).to be(false)
+              duplicate_profile_set.reload
+              expect(duplicate_profile_set.closed_at).to eq(Time.zone.now)
+              expect(duplicate_profile_set.self_serviced).to be(false)
+              expect(duplicate_profile_set.fraud_investigation_conclusive).to be(false)
             end
           end
 
@@ -1407,11 +1407,11 @@ RSpec.describe Profile do
 
             it 'does not close the case', :freeze_time do
               profile.close_inconclusive_duplicate
-              duplicate_profile.reload
-              expect(duplicate_profile.profile_ids).not_to include(profile.id)
-              expect(duplicate_profile.closed_at).to be(nil)
-              expect(duplicate_profile.self_serviced).to be(nil)
-              expect(duplicate_profile.fraud_investigation_conclusive).to be(nil)
+              duplicate_profile_set.reload
+              expect(duplicate_profile_set.profile_ids).not_to include(profile.id)
+              expect(duplicate_profile_set.closed_at).to be(nil)
+              expect(duplicate_profile_set.self_serviced).to be(nil)
+              expect(duplicate_profile_set.fraud_investigation_conclusive).to be(nil)
             end
 
             it 'notifies the user' do

--- a/spec/presenters/duplicate_profiles_detected_presenter_spec.rb
+++ b/spec/presenters/duplicate_profiles_detected_presenter_spec.rb
@@ -2,22 +2,22 @@ require 'rails_helper'
 
 RSpec.describe DuplicateProfilesDetectedPresenter do
   let(:user) { create(:user, :proofed_with_selfie) }
-  let(:dupe_profile) do
+  let(:duplicate_profile_set) do
     create(
-      :duplicate_profile,
+      :duplicate_profile_set,
       profile_ids: [user.active_profile.id, profile2.id],
       service_provider: 'test-sp',
     )
   end
-  let(:presenter) { described_class.new(user: user, dupe_profile: dupe_profile) }
+  let(:presenter) { described_class.new(user: user, duplicate_profile_set: duplicate_profile_set) }
   let(:profile2) { create(:profile, :facial_match_proof) }
 
   describe '#associated_profiles' do
     context 'when multiple duplicate profiles were found for user' do
       let(:profile3) { create(:profile, :facial_match_proof) }
-      let(:dupe_profile) do
+      let(:duplicate_profile_set) do
         create(
-          :duplicate_profile,
+          :duplicate_profile_set,
           profile_ids: [user.active_profile.id, profile2.id, profile3.id],
           service_provider: 'test-sp',
         )

--- a/spec/services/duplicate_profile_checker_spec.rb
+++ b/spec/services/duplicate_profile_checker_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe DuplicateProfileChecker do
             analytics: @analytics,
           )
           dupe_profile_checker.check_for_duplicate_profiles
-          dupe_profile_object = DuplicateProfile.involving_profile(
+          dupe_profile_set = DuplicateProfileSet.involving_profile(
             profile_id: profile.id,
             service_provider: sp.issuer,
           )
-          expect(dupe_profile_object).to eq(nil)
+          expect(dupe_profile_set).to eq(nil)
           expect(@analytics).to_not have_logged_event(:one_account_duplicate_profile_created)
           expect(@analytics).to_not have_logged_event(:one_account_duplicate_profile_updated)
           expect(@analytics).to_not have_logged_event(:one_account_duplicate_profile_closed)
@@ -82,7 +82,7 @@ RSpec.describe DuplicateProfileChecker do
             .and_return([profile2])
         end
 
-        it 'creates a new duplicate profile object entry and tracks analysis' do
+        it 'creates a new duplicate profile set entry and tracks analysis' do
           dupe_profile_checker = DuplicateProfileChecker.new(
             user: user,
             user_session: session,
@@ -91,27 +91,27 @@ RSpec.describe DuplicateProfileChecker do
           )
           dupe_profile_checker.check_for_duplicate_profiles
 
-          dupe_profile_objects = DuplicateProfile.involving_profile(
+          dupe_profile_set = DuplicateProfileSet.involving_profile(
             profile_id: profile.id,
             service_provider: sp.issuer,
           )
-          expect(dupe_profile_objects.profile_ids).to match_array([profile2.id, profile.id])
+          expect(dupe_profile_set.profile_ids).to match_array([profile2.id, profile.id])
           expect(@analytics).to have_logged_event(
             :one_account_duplicate_profile_created,
           )
         end
 
-        context 'when duplicate profile already exists' do
-          let!(:dupe_profile) do
+        context 'when duplicate profile set already exists' do
+          let!(:dupe_profile_set) do
             create(
-              :duplicate_profile,
+              :duplicate_profile_set,
               profile_ids: [profile.id, profile2.id],
               service_provider: sp.issuer,
             )
           end
 
           context 'when the profile_ids are the same' do
-            it 'does not create a new duplicate profile objects' do
+            it 'does not create a new duplicate profile set' do
               dupe_profile_checker = DuplicateProfileChecker.new(
                 user: user,
                 user_session: session,
@@ -141,7 +141,7 @@ RSpec.describe DuplicateProfileChecker do
                 .and_return([profile2, profile3])
             end
 
-            context 'using the same profile already in dupe profile' do
+            context 'using the same profile already in the duplicate profile set' do
               it 'updates the existing duplicate profile object' do
                 dupe_profile_checker = DuplicateProfileChecker.new(
                   user: user,
@@ -151,11 +151,11 @@ RSpec.describe DuplicateProfileChecker do
                 )
                 dupe_profile_checker.check_for_duplicate_profiles
 
-                updated_dupe_profile = DuplicateProfile.involving_profile(
+                updated_dupe_profile_set = DuplicateProfileSet.involving_profile(
                   profile_id: profile.id,
                   service_provider: sp.issuer,
                 )
-                expect(updated_dupe_profile.profile_ids).to match_array(
+                expect(updated_dupe_profile_set.profile_ids).to match_array(
                   [profile2.id, profile.id,
                    profile3.id],
                 )
@@ -166,9 +166,9 @@ RSpec.describe DuplicateProfileChecker do
             end
 
             context 'using the new profile not in dupe profile' do
-              let!(:dupe_profile) do
+              let!(:dupe_profile_set) do
                 create(
-                  :duplicate_profile,
+                  :duplicate_profile_set,
                   profile_ids: [profile3.id, profile2.id],
                   service_provider: sp.issuer,
                 )
@@ -183,11 +183,11 @@ RSpec.describe DuplicateProfileChecker do
                 )
                 dupe_profile_checker.check_for_duplicate_profiles
 
-                updated_dupe_profile = DuplicateProfile.involving_profile(
+                updated_dupe_profile_set = DuplicateProfileSet.involving_profile(
                   profile_id: profile.id,
                   service_provider: sp.issuer,
                 )
-                expect(updated_dupe_profile.profile_ids).to match_array(
+                expect(updated_dupe_profile_set.profile_ids).to match_array(
                   [profile2.id, profile.id,
                    profile3.id],
                 )
@@ -215,8 +215,8 @@ RSpec.describe DuplicateProfileChecker do
                 )
                 dupe_profile_checker.check_for_duplicate_profiles
 
-                dupe_profile.reload
-                expect(dupe_profile.closed_at).to eq(Time.zone.now)
+                dupe_profile_set.reload
+                expect(dupe_profile_set.closed_at).to eq(Time.zone.now)
                 expect(@analytics).to have_logged_event(
                   :one_account_duplicate_profile_closed,
                 )
@@ -247,11 +247,11 @@ RSpec.describe DuplicateProfileChecker do
         )
         dupe_profile_checker.check_for_duplicate_profiles
 
-        dupe_profile_objects = DuplicateProfile.involving_profile(
+        dupe_profile_set = DuplicateProfileSet.involving_profile(
           profile_id: profile.id,
           service_provider: sp.issuer,
         )
-        expect(dupe_profile_objects).to eq(nil)
+        expect(dupe_profile_set).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
changelog: Upcoming Features, One Account, Rename DuplicateProfile to DuplicateProfileSet

Each instance is a `set` of profiles that are duplicates of one other.

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://cm-jira.usa.gov/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
