### PR TITLE
Modularize Attempts API Tracker - FCMS Prework

### DIFF
--- a/app/services/attempts_api/redis_client.rb
+++ b/app/services/attempts_api/redis_client.rb
@@ -12,7 +12,6 @@ module AttemptsApi
       @redis_pool.with do |client|
         client.hset(key, event_key, jwe)
         client.expire(key, event_ttl_seconds)
-        puts event_ttl_seconds
       end
     end
 

--- a/app/services/attempts_api/redis_client.rb
+++ b/app/services/attempts_api/redis_client.rb
@@ -2,9 +2,14 @@
 
 module AttemptsApi
   class RedisClient
+    attr_reader :redis_pool
+    def initialize
+      @redis_pool = REDIS_ATTEMPTS_API_POOL
+    end
+
     def write_event(event_key:, jwe:, timestamp:, issuer:)
       key = key(timestamp, issuer)
-      REDIS_ATTEMPTS_API_POOL.with do |client|
+      @redis_pool.with do |client|
         client.hset(key, event_key, jwe)
         client.expire(key, IdentityConfig.store.attempts_api_event_ttl_seconds)
       end
@@ -13,7 +18,7 @@ module AttemptsApi
     def read_events(issuer:, batch_size: 1000)
       events = {}
       hourly_keys(issuer).each do |hourly_key|
-        REDIS_ATTEMPTS_API_POOL.with do |client|
+        @redis_pool.with do |client|
           client.hscan_each(hourly_key, count: batch_size) do |k, v|
             break if events.keys.count == batch_size
 
@@ -27,7 +32,7 @@ module AttemptsApi
     def delete_events(issuer:, keys:)
       total_deleted = 0
       hourly_keys(issuer).each do |hourly_key|
-        REDIS_ATTEMPTS_API_POOL.with do |client|
+        @redis_pool.with do |client|
           total_deleted += client.hdel(hourly_key, keys)
         end
       end
@@ -38,7 +43,7 @@ module AttemptsApi
     private
 
     def hourly_keys(issuer)
-      REDIS_ATTEMPTS_API_POOL.with do |client|
+      @redis_pool.with do |client|
         client.keys("attempts-api-events:#{issuer}:*")
       end.sort
     end

--- a/app/services/attempts_api/redis_client.rb
+++ b/app/services/attempts_api/redis_client.rb
@@ -11,7 +11,8 @@ module AttemptsApi
       key = key(timestamp, issuer)
       @redis_pool.with do |client|
         client.hset(key, event_key, jwe)
-        client.expire(key, IdentityConfig.store.attempts_api_event_ttl_seconds)
+        client.expire(key, event_ttl_seconds)
+        puts event_ttl_seconds
       end
     end
 
@@ -41,6 +42,10 @@ module AttemptsApi
     end
 
     private
+
+    def event_ttl_seconds
+      IdentityConfig.store.attempts_api_event_ttl_seconds
+    end
 
     def hourly_keys(issuer)
       @redis_pool.with do |client|

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -91,7 +91,7 @@ module AttemptsApi
         client_port: CloudFrontHeaderParser.new(request).client_port,
         aws_region: IdentityConfig.store.aws_region,
         google_analytics_cookies: google_analytics_cookies(request),
-      }.merge!(extra_metadata(event_type:, metadata:))
+      }.merge!(extra_metadata(metadata:))
     end
 
     def google_analytics_cookies(request)

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -24,44 +24,16 @@ module AttemptsApi
     def track_event(event_type, metadata = {})
       return unless enabled?
 
-      extra_metadata =
-        if metadata.has_key?(:failure_reason) &&
-           (metadata[:failure_reason].blank? || metadata[:success].present?)
-          metadata.except(:failure_reason)
-        else
-          metadata
-        end
-
-      event_metadata = {
-        user_agent: request&.user_agent,
-        unique_session_id: hashed_session_id,
-        user_uuid: agency_uuid(event_type: event_type),
-        device_id: cookie_device_uuid,
-        user_ip_address: request&.remote_ip,
-        application_url: sp_redirect_uri,
-        language: user&.email_language || I18n.locale.to_s,
-        client_port: CloudFrontHeaderParser.new(request).client_port,
-        aws_region: IdentityConfig.store.aws_region,
-        google_analytics_cookies: google_analytics_cookies(request),
-      }
-
-      event_metadata.merge!(extra_metadata)
-
       event = AttemptEvent.new(
         event_type: event_type,
         session_id: session_id,
         occurred_at: Time.zone.now,
-        event_metadata: event_metadata,
-      )
-
-      jwe = event.to_jwe(
-        issuer: sp.issuer,
-        public_key: sp.attempts_public_key,
+        event_metadata: event_metadata(event_type:, metadata:),
       )
 
       redis_client.write_event(
         event_key: event.jti,
-        jwe: jwe,
+        jwe: jwe(event),
         timestamp: event.occurred_at,
         issuer: sp.issuer,
       )
@@ -82,6 +54,45 @@ module AttemptsApi
     end
 
     private
+
+    def jwe(event)
+      event.to_jwe(
+        issuer: sp.issuer,
+        public_key: sp.attempts_public_key,
+      )
+    end
+
+    def extra_attributes(event_type:)
+      {}
+    end
+
+    def extra_metadata(event_type:, metadata:)
+      failure_metadata(metadata:).merge(extra_attributes(event_type:))
+    end
+
+    def failure_metadata(metadata:)
+      if metadata.has_key?(:failure_reason) &&
+         (metadata[:failure_reason].blank? || metadata[:success].present?)
+        metadata.except(:failure_reason)
+      else
+        metadata
+      end
+    end
+
+    def event_metadata(event_type:, metadata:)
+      {
+        user_agent: request&.user_agent,
+        unique_session_id: hashed_session_id,
+        user_uuid: agency_uuid(event_type: event_type),
+        device_id: cookie_device_uuid,
+        user_ip_address: request&.remote_ip,
+        application_url: sp_redirect_uri,
+        language: user&.email_language || I18n.locale.to_s,
+        client_port: CloudFrontHeaderParser.new(request).client_port,
+        aws_region: IdentityConfig.store.aws_region,
+        google_analytics_cookies: google_analytics_cookies(request),
+      }.merge!(extra_metadata(event_type:, metadata:))
+    end
 
     def google_analytics_cookies(request)
       return nil unless request&.cookies

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -62,12 +62,12 @@ module AttemptsApi
       )
     end
 
-    def extra_attributes(event_type:)
+    def extra_attributes
       {}
     end
 
-    def extra_metadata(event_type:, metadata:)
-      failure_metadata(metadata:).merge(extra_attributes(event_type:))
+    def extra_metadata(metadata:)
+      failure_metadata(metadata:).merge(extra_attributes)
     end
 
     def failure_metadata(metadata:)


### PR DESCRIPTION
## 🎫 Ticket
🔒 [GL-Data-1105](https://gitlab.login.gov/lg-teams/Team-Data/data-warehouse-ag/-/issues/1105)

## 🛠 Summary of changes

In preparation to leverage the attempts API tracker for the Data Warehouse ingestion, we need to break up `track_event` in `tracker.rb`. Also need to break out various methods in `redis_client.rb`

In tracker, defined the following new methods
- jwe
- extra_attributes
- event_metadata
- extra_metadata
- failure_metadata

In redis_client, defined the following: 
- initialize - sets a new @redis_pool variable to wrap `REDIS_ATTEMPTS_API_POOL`
- event_ttl_seconds - wraps `IdentityConfig.store.attempts_api_event_ttl_seconds`

## 📜 Testing Plan

- [x] Make sure specs still run succesfully
- [x] Enable attempts API and use sinatra app to generate some attempts events
- [x] Check that events still work and have the expected content

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.
