### PR TITLE
Allow ServiceProviderSeeder to read a custom YAML for review apps

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,9 @@
 if ENV['KUBERNETES_REVIEW_APP'] == 'true' && ENV['DASHBOARD_URL'].present?
   dashboard_url = ENV['DASHBOARD_URL']
 
+  # This should never be invoked in production.
+  # If we change how production is deployed, we should revisit the above conditionals to ensure
+  # production never runs this.
   ServiceProviderSeeder.new.run_review_app(dashboard_url: dashboard_url)
 else
   ServiceProviderSeeder.new.run


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket: https://gitlab.login.gov/lg-teams/FIE/partner-portal-prod-edition/-/issues/229

## Problem and Goals

In our Kubernetes cluster, the IdP database seeder job is not seeding certificates properly for the Partner Portal (in the `identity-dashboard` repo) to work in the review-app environments.

### I want to get this working with the smallest possible change to IdP that is unlikely to have any downstream implications.


## 🛠 Summary of changes

Here is my proposal:

* In our EKS infrastructure we already have a configmap that allows us to override the `service_providers.yml`, and it is easy for our CI jobs to override it. Therefore we can
* tell the `ServiceProviderSeeder` to check that file and, if it contains overrides that are definitely specific to the current review environment, load that file instead of loading the review app defaults.

Note that before this change our review-app CI workflows were overriding the `service_providers.yml`, but this seeder was never reading those overridden values so the overrides had no effect.

## 📜 Testing Plan

I've created some testing branches and can confirm this approach works, and it only requires a few lines of code added to `ServiceProviderSeeder` along with an extract method refactor for ease and legibility.

To test this, you will also need a test branch in the `identity-dashboard` repo that is set up to override the `service_providers.yml` with the certificate that branch's CI workflow wants to use on the Partner Portal side. Please message me if you want to test this, and I can send you the relevant GitLab links.

## 👀 Screenshots

Demo video:

https://github.com/user-attachments/assets/c7addb0b-47dd-49d4-9773-bf2d23a53a32



