### PR TITLE
Pass hash rather than json into JWT library

### DIFF
--- a/app/services/attempts_api/attempt_event.rb
+++ b/app/services/attempts_api/attempt_event.rb
@@ -24,7 +24,7 @@ module AttemptsApi
       jwk = JWT::JWK.new(public_key)
 
       JWE.encrypt(
-        signed_payload(payload_json: payload_json(issuer:)),
+        signed_payload(issuer:),
         public_key,
         typ: 'secevent+jwe',
         zip: 'DEF',
@@ -38,15 +38,16 @@ module AttemptsApi
       decrypted_event = JWE.decrypt(jwe, private_key)
 
       if IdentityConfig.store.attempts_api_signing_enabled
-        decrypted_event = JWT.decode(
+        parsed_event = JWT.decode(
           decrypted_event,
           SigningKey.public_key,
           true,
           { algorithm: 'ES256' },
         ).first
+      else
+        parsed_event = JSON.parse(decrypted_event)
       end
 
-      parsed_event = JSON.parse(decrypted_event)
       event_type = parsed_event['events'].keys.first.split('/').last
       event_data = parsed_event['events'].values.first
       jti = parsed_event['jti'].split(':').last
@@ -72,10 +73,6 @@ module AttemptsApi
       }
     end
 
-    def payload_json(issuer:)
-      @payload_json ||= payload(issuer:)
-    end
-
     private
 
     def event_data
@@ -88,11 +85,11 @@ module AttemptsApi
       }.merge(event_metadata || {})
     end
 
-    def signed_payload(payload_json:)
+    def signed_payload(issuer:)
       if IdentityConfig.store.attempts_api_signing_enabled
-        JWT.encode(payload_json, SigningKey.private_key, 'ES256')
+        JWT.encode(payload(issuer:), SigningKey.private_key, 'ES256')
       else
-        payload_json
+        payload(issuer:).to_json
       end
     end
 

--- a/app/services/attempts_api/attempt_event.rb
+++ b/app/services/attempts_api/attempt_event.rb
@@ -24,7 +24,7 @@ module AttemptsApi
       jwk = JWT::JWK.new(public_key)
 
       JWE.encrypt(
-        jwe_payload(payload_json: payload_json(issuer:)),
+        signed_payload(payload_json: payload_json(issuer:)),
         public_key,
         typ: 'secevent+jwe',
         zip: 'DEF',
@@ -73,7 +73,7 @@ module AttemptsApi
     end
 
     def payload_json(issuer:)
-      @payload_json ||= payload(issuer:).to_json
+      @payload_json ||= payload(issuer:)
     end
 
     private
@@ -88,7 +88,7 @@ module AttemptsApi
       }.merge(event_metadata || {})
     end
 
-    def jwe_payload(payload_json:)
+    def signed_payload(payload_json:)
       if IdentityConfig.store.attempts_api_signing_enabled
         JWT.encode(payload_json, SigningKey.private_key, 'ES256')
       else

--- a/spec/services/attempts_api/attempt_event_spec.rb
+++ b/spec/services/attempts_api/attempt_event_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe AttemptsApi::AttemptEvent do
             { algorithm: 'ES256' },
           )
 
-          token = JSON.parse(decoded_jwe_payload.first)
+          token = decoded_jwe_payload.first
 
           expect(token['iss']).to eq(Rails.application.routes.url_helpers.root_url)
           expect(token['jti']).to eq(jti)


### PR DESCRIPTION
## 🛠 Summary of changes
Our partners are having trouble reading the signature correctly. They are seeing an issue with the Base64 Encoding, although they also noted that they are seeing extra backticks in their message response.

We recently moved from signing a a JWT, then encrypting it into a JWE. The ruby-JWE library [expects a payload string](https://github.com/jwt/ruby-jwe), so originally, we were passing a hash that we turned into json via `to_json` into the `JWE.encrypt` method call.

The ruby-JWT library, on the other hand, expects a [hash](https://github.com/jwt/ruby-jwt) of data to be input. When we moved to sign the JWT first, we did not update the code correspondingly, so that is why this `to_json` needs to be removed. It is unclear if this will fix the other issue the partner is seeing on their side, but needs to be updated regardless.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
