### PR TITLE
LG-16731 Remove passport enabled flag from react

### DIFF
--- a/app/javascript/packages/document-capture/components/document-capture-review-issues.spec.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-review-issues.spec.tsx
@@ -51,7 +51,6 @@ describe('DocumentCaptureReviewIssues', () => {
             locationsURL: '',
             inPersonOutageMessageEnabled: false,
             optedInToInPersonProofing: false,
-            passportEnabled: false,
             usStatesTerritories: [['Los Angeles', 'NY']],
           }}
         >
@@ -114,7 +113,6 @@ describe('DocumentCaptureReviewIssues', () => {
             locationsURL: '',
             inPersonOutageMessageEnabled: false,
             optedInToInPersonProofing: false,
-            passportEnabled: false,
             usStatesTerritories: [['Los Angeles', 'NY']],
           }}
         >

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.spec.tsx
@@ -11,6 +11,7 @@ import InPersonContext, { InPersonContextProps } from '../context/in-person';
 describe('DocumentCaptureTroubleshootingOptions', () => {
   const helpCenterRedirectURL = 'https://example.com/redirect/';
   const inPersonURL = 'https://example.com/some/idv/ipp/url';
+  const chooseIdTypePath = 'https://example.com/verify/choose_id_type';
   const serviceProviderContext: ServiceProviderContextType = {
     name: 'Example SP',
     failureToProofURL: 'http://example.test/url/to/failure-to-proof',
@@ -30,28 +31,66 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
     ),
   };
 
-  it('renders troubleshooting options', () => {
-    const { getAllByRole } = render(<DocumentCaptureTroubleshootingOptions />, {
-      wrapper: wrappers.MarketingSiteContext,
+  describe('when InPersonContext is provided with chooseIdTypePath', () => {
+    it('renders troubleshooting options with "Use another ID type" option', () => {
+      const { getAllByRole } = render(
+        <InPersonContext.Provider value={{ chooseIdTypePath } as InPersonContextProps}>
+          <DocumentCaptureTroubleshootingOptions />
+        </InPersonContext.Provider>,
+        {
+          wrapper: wrappers.MarketingSiteContext,
+        },
+      );
+
+      const links = getAllByRole('link') as HTMLAnchorElement[];
+
+      expect(links).to.have.lengthOf(3);
+
+      expect(links[0].textContent).to.equal('idv.troubleshooting.options.use_another_id_type');
+      expect(links[0].getAttribute('href')).to.equal(chooseIdTypePath);
+
+      expect(links[1].textContent).to.equal(
+        'idv.troubleshooting.options.doc_capture_tipslinks.new_tab',
+      );
+      expect(links[1].getAttribute('href')).to.equal(
+        'https://example.com/redirect/?category=verify-your-identity&article=how-to-add-images-of-your-state-issued-id&location=document_capture_troubleshooting_options',
+      );
+      expect(links[1].target).to.equal('_blank');
+
+      expect(links[2].textContent).to.equal(
+        'idv.troubleshooting.options.supported_documentslinks.new_tab',
+      );
+      expect(links[2].getAttribute('href')).to.equal(
+        'https://example.com/redirect/?category=verify-your-identity&article=accepted-identification-documents&location=document_capture_troubleshooting_options',
+      );
+      expect(links[2].target).to.equal('_blank');
     });
+  });
 
-    const links = getAllByRole('link') as HTMLAnchorElement[];
+  describe('when InPersonContext is not provided', () => {
+    it('renders troubleshooting options', () => {
+      const { getAllByRole } = render(<DocumentCaptureTroubleshootingOptions />, {
+        wrapper: wrappers.MarketingSiteContext,
+      });
 
-    expect(links).to.have.lengthOf(2);
-    expect(links[0].textContent).to.equal(
-      'idv.troubleshooting.options.doc_capture_tipslinks.new_tab',
-    );
-    expect(links[0].getAttribute('href')).to.equal(
-      'https://example.com/redirect/?category=verify-your-identity&article=how-to-add-images-of-your-state-issued-id&location=document_capture_troubleshooting_options',
-    );
-    expect(links[0].target).to.equal('_blank');
-    expect(links[1].textContent).to.equal(
-      'idv.troubleshooting.options.supported_documentslinks.new_tab',
-    );
-    expect(links[1].getAttribute('href')).to.equal(
-      'https://example.com/redirect/?category=verify-your-identity&article=accepted-identification-documents&location=document_capture_troubleshooting_options',
-    );
-    expect(links[1].target).to.equal('_blank');
+      const links = getAllByRole('link') as HTMLAnchorElement[];
+
+      expect(links).to.have.lengthOf(2);
+      expect(links[0].textContent).to.equal(
+        'idv.troubleshooting.options.doc_capture_tipslinks.new_tab',
+      );
+      expect(links[0].getAttribute('href')).to.equal(
+        'https://example.com/redirect/?category=verify-your-identity&article=how-to-add-images-of-your-state-issued-id&location=document_capture_troubleshooting_options',
+      );
+      expect(links[0].target).to.equal('_blank');
+      expect(links[1].textContent).to.equal(
+        'idv.troubleshooting.options.supported_documentslinks.new_tab',
+      );
+      expect(links[1].getAttribute('href')).to.equal(
+        'https://example.com/redirect/?category=verify-your-identity&article=accepted-identification-documents&location=document_capture_troubleshooting_options',
+      );
+      expect(links[1].target).to.equal('_blank');
+    });
   });
 
   context('with heading prop', () => {
@@ -93,12 +132,17 @@ describe('DocumentCaptureTroubleshootingOptions', () => {
   });
 
   context('with document tips hidden', () => {
-    it('renders nothing', () => {
-      const { container } = render(
-        <DocumentCaptureTroubleshootingOptions showDocumentTips={false} />,
+    it('renders only the use_another_id_type option', () => {
+      const { getAllByRole } = render(
+        <InPersonContext.Provider value={{ chooseIdTypePath } as InPersonContextProps}>
+          <DocumentCaptureTroubleshootingOptions showDocumentTips={false} />,
+        </InPersonContext.Provider>,
       );
 
-      expect(container.innerHTML).to.be.empty();
+      const links = getAllByRole('link') as HTMLAnchorElement[];
+
+      expect(links).to.have.lengthOf(1);
+      expect(links[0].textContent).to.equal('idv.troubleshooting.options.use_another_id_type');
     });
   });
 });

--- a/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-troubleshooting-options.tsx
@@ -29,7 +29,7 @@ function DocumentCaptureTroubleshootingOptions({
   showDocumentTips = true,
 }: DocumentCaptureTroubleshootingOptionsProps) {
   const { t } = useI18n();
-  const { chooseIdTypePath, inPersonURL, passportEnabled } = useContext(InPersonContext);
+  const { chooseIdTypePath, inPersonURL } = useContext(InPersonContext);
   const { getHelpCenterURL } = useContext(MarketingSiteContext);
 
   return (
@@ -39,7 +39,7 @@ function DocumentCaptureTroubleshootingOptions({
         heading={heading}
         options={
           [
-            passportEnabled && {
+            {
               url: chooseIdTypePath,
               text: t('idv.troubleshooting.options.use_another_id_type'),
               isExternal: false,

--- a/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-location-full-address-entry-post-office-search-step.spec.tsx
@@ -54,7 +54,6 @@ describe('InPersonLocationFullAddressEntryPostOfficeSearchStep', () => {
         inPersonOutageMessageEnabled: false,
         inPersonOutageExpectedUpdateDate: 'January 1, 2024',
         optedInToInPersonProofing: false,
-        passportEnabled: false,
         usStatesTerritories,
       }}
     >

--- a/app/javascript/packages/document-capture/components/in-person-outage-alert.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-outage-alert.spec.tsx
@@ -12,7 +12,6 @@ describe('InPersonOutageAlert', () => {
           inPersonOutageExpectedUpdateDate: 'January 1, 2024',
           inPersonOutageMessageEnabled: true,
           optedInToInPersonProofing: false,
-          passportEnabled: false,
           usStatesTerritories: [],
         }}
       >

--- a/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
+++ b/app/javascript/packages/document-capture/components/in-person-prepare-step.spec.tsx
@@ -41,7 +41,6 @@ describe('InPersonPrepareStep', () => {
             inPersonOutageMessageEnabled: true,
             inPersonOutageExpectedUpdateDate: 'January 1, 2024',
             optedInToInPersonProofing: false,
-            passportEnabled: false,
             usStatesTerritories: [],
           }}
         >
@@ -59,7 +58,6 @@ describe('InPersonPrepareStep', () => {
             locationsURL: 'https://localhost:3000/unused',
             inPersonOutageMessageEnabled: false,
             optedInToInPersonProofing: false,
-            passportEnabled: false,
             usStatesTerritories: [],
           }}
         >

--- a/app/javascript/packages/document-capture/context/in-person.ts
+++ b/app/javascript/packages/document-capture/context/in-person.ts
@@ -67,11 +67,6 @@ export interface InPersonContextProps {
   socureErrorsTimeoutURL?: string;
 
   /**
-   * Whether or not passports are enabled as option for user
-   */
-  passportEnabled: boolean;
-
-  /**
    * URL for going back to previous steps in Doc Auth, like handoff and howToVerify
    */
   previousStepURL?: string;
@@ -81,7 +76,6 @@ const InPersonContext = createContext<InPersonContextProps>({
   locationsURL: '',
   inPersonOutageMessageEnabled: false,
   optedInToInPersonProofing: false,
-  passportEnabled: false,
   usStatesTerritories: [],
 });
 

--- a/app/javascript/packs/document-capture.tsx
+++ b/app/javascript/packs/document-capture.tsx
@@ -42,7 +42,6 @@ interface AppRootData {
   socureErrorsTimeoutURL: string;
   previousStepUrl: string;
   chooseIdTypePath: string;
-  docAuthPassportsEnabled: string;
   docAuthSelfieDesktopTestMode: string;
   docAuthUploadEnabled: string;
   accountUrl: string;
@@ -125,7 +124,6 @@ const {
   socureErrorsTimeoutUrl,
   previousStepUrl,
   chooseIdTypePath,
-  docAuthPassportsEnabled,
   docAuthSelfieDesktopTestMode,
   locationsUrl: locationsURL,
   sessionsUrl: sessionsURL,
@@ -156,7 +154,6 @@ render(
           howToVerifyURL: howToVerifyUrl,
           chooseIdTypePath,
           socureErrorsTimeoutURL: socureErrorsTimeoutUrl,
-          passportEnabled: String(docAuthPassportsEnabled) === 'true',
           previousStepURL: previousStepUrl,
         }}
       >

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -36,7 +36,6 @@
       in_person_outage_expected_update_date: IdentityConfig.store.in_person_outage_expected_update_date,
       us_states_territories: @presenter.usps_states_territories,
       choose_id_type_path:,
-      doc_auth_passports_enabled: IdentityConfig.store.doc_auth_passports_enabled,
       doc_auth_selfie_capture:,
       doc_auth_selfie_desktop_test_mode: IdentityConfig.store.doc_auth_selfie_desktop_test_mode,
       doc_auth_upload_enabled:,

--- a/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/review-issues-step-spec.jsx
@@ -277,9 +277,7 @@ describe('document-capture/components/review-issues-step', () => {
 
   it('renders alternative error messages with not in person and doc type is not supported', async () => {
     const { getByRole, getByText, getByLabelText } = render(
-      <InPersonContext.Provider
-        value={{ chooseIdTypePath: '', inPersonURL: '', passportEnabled: true }}
-      >
+      <InPersonContext.Provider value={{ chooseIdTypePath: '', inPersonURL: '' }}>
         <I18nContext.Provider
           value={
             new I18n({


### PR DESCRIPTION
changelog: Internal, Doc Auth, Remove passport enabled flag from react document-capture


## 🎫 Ticket

Link to the relevant ticket:
[LG-16731](https://cm-jira.usa.gov/browse/LG-16731)

## 🛠 Summary of changes

Remove passport enabled flag from react document-capture

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

**Scenario:  Passports Enabled** 

- [ ] Configure passports to be enabled
```
doc_auth_passports_enabled: true
```
- [ ] Proceed through IdV using the hybrid flow (Using a private browser for the mobile piece)
- [ ] Select state_id on the choose_id_type screen
- [ ] Fail doc auth using a failing fixture
- [ ] Ensure you see `Use another type of ID` link on the error screen

**Scenario:  Passports Disabled** 

- [ ] Configure passports to be disabled
```
doc_auth_passports_enabled: false
```
- [ ] Proceed through IdV using the hybrid flow (Using a private browser for the mobile piece)
- [ ] Select state_id on the choose_id_type screen
- [ ] Fail doc auth using a failing fixture
- [ ] Ensure you see `Use another type of ID` link on the error screen