### PR TITLE
Add data-pull task for looking up duplicates

### DIFF
--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -487,7 +487,7 @@ class DataPull
         user = User.find_with_email(email)
         if user
           duplicate_profile_sets = find_duplicates(user)
-          if duplicate_profile_sets
+          if duplicate_profile_sets.present?
             uuids << user.uuid
             duplicate_profile_sets.each do |duplicate_profile_set|
               duplicate_profile_ids = duplicate_profile_set.profile_ids - [user.active_profile.id]
@@ -512,7 +512,7 @@ class DataPull
     private
 
     def find_duplicates(user)
-      if user.active_profile
+      if user.active_profile?
         DuplicateProfileSet
           .open
           .where('? = ANY(profile_ids)', user.active_profile.id)

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -583,10 +583,10 @@ RSpec.describe DataPull do
 
     let(:service_provider) { create(:service_provider) }
 
-    let(:profile1) { create(:profile, :active, user: user1) }
-    let(:profile2) { create(:profile, :active, user: user2) }
-    let(:profile3) { create(:profile, :active) }
-    let(:profile4) { create(:profile, :active) }
+    let!(:profile1) { create(:profile, :active, user: user1) }
+    let!(:profile2) { create(:profile, :active, user: user2) }
+    let!(:profile3) { create(:profile, :active) }
+    let!(:profile4) { create(:profile, :active) }
 
     let!(:duplicate_profile_set) do
       create(


### PR DESCRIPTION
Addresses https://cm-jira.usa.gov/browse/LG-16715

changelog: Upcoming Features, One Account, Add data-pull task for looking up duplicates

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-16715](https://cm-jira.usa.gov/browse/LG-16715)


<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->


## 📜 Testing Plan


- [ ] Ensure that you have duplicates detected in duplicate_profile_sets, ie, multiple active IAL2 profiles with the same SSN with a service provider in the One Account pool.

- [ ] Run `bin/data-pull duplicate-profile-lookup email1@example.com email2@example.com nonexistent@example.com` where email1@example.com is one of the accounts from Step 1, email2@example.com is a different valid account and nonexistent@example.com is not a valid user.
- [ ] You should see the correct output for each of the 3 email address arguments


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
