### PR TITLE
LG-16718 Add document attributes to USPS enrollment request

### DIFF
--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -118,7 +118,7 @@ module Idv
       if current_user.has_establishing_in_person_enrollment?
         UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
           user: current_user,
-          pii: Pii::Attributes.new_from_hash(applicant),
+          applicant_pii: Pii::UspsApplicant.from_idv_applicant(applicant),
           is_enhanced_ipp: is_enhanced_ipp,
           opt_in: opt_in_param,
         )

--- a/app/services/pii/usps_applicant.rb
+++ b/app/services/pii/usps_applicant.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Pii
+  UspsApplicant = RedactedStruct.new(
+    :first_name, :last_name, :address1, :address2, :city, :state, :zipcode,
+    :current_address_same_as_id, :id_number, :id_expiration, keyword_init: true
+  ) do
+    def self.from_idv_applicant(applicant)
+      new(
+        first_name: applicant['first_name'],
+        last_name: applicant['last_name'],
+        address1: applicant['identity_doc_address1'],
+        address2: applicant['identity_doc_address2'],
+        city: applicant['identity_doc_city'],
+        state: applicant['identity_doc_address_state'],
+        zipcode: applicant['identity_doc_zipcode'],
+        id_expiration: applicant['state_id_expiration'],
+        id_number: applicant['state_id_number'],
+        current_address_same_as_id: applicant['same_address_as_id'],
+      )
+    end
+
+    def address_line2_present?
+      address2.present?
+    end
+  end.freeze
+end

--- a/app/services/usps_in_person_proofing/applicant.rb
+++ b/app/services/usps_in_person_proofing/applicant.rb
@@ -1,12 +1,40 @@
 # frozen_string_literal: true
 
 module UspsInPersonProofing
-  Applicant = Struct.new(
+  Applicant = RedactedStruct.new(
     :unique_id, :first_name, :last_name, :address, :city, :state, :zip_code,
-    :email, keyword_init: true
+    :email, :document_type, :document_number, :document_expiration_date, keyword_init: true
   ) do
+    def self.from_usps_applicant_and_enrollment(applicant, enrollment)
+      self.new(
+        unique_id: enrollment.unique_id,
+        first_name: transliterate(applicant.first_name),
+        last_name: transliterate(applicant.last_name),
+        address: transliterate(applicant.address1),
+        city: transliterate(applicant.city),
+        state: applicant.state,
+        zip_code: applicant.zipcode,
+        email: IdentityConfig.store.usps_ipp_enrollment_status_update_email_address.presence,
+        document_number: applicant.id_number,
+        document_expiration_date: applicant.id_expiration,
+        document_type: enrollment.document_type,
+      )
+    end
+
     def has_valid_address?
       (address =~ /[^A-Za-z0-9\-' .\/#]/).nil?
     end
-  end
+
+    private
+
+    def self.transliterate(value)
+      transliterator = Transliterator.new
+      result = transliterator.transliterate(value)
+      if result.unsupported_chars.present?
+        result.original
+      else
+        result.transliterated
+      end
+    end
+  end.freeze
 end

--- a/app/services/usps_in_person_proofing/enrollment_helper.rb
+++ b/app/services/usps_in_person_proofing/enrollment_helper.rb
@@ -3,26 +3,23 @@
 module UspsInPersonProofing
   class EnrollmentHelper
     class << self
-      def schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:, opt_in: nil)
+      # Creates a USPS enrollment using the USPS API. This also updates the user's
+      # InPersonEnrollment to be pending.
+      #
+      # @param [User] user The user to create a USPS enrollment for
+      # @param [Pii::UspsApplicant] applicant_pii The data used for creating the usps applicant.
+      # @param [Boolean] is_enhanced_ipp Whether the enrollment is an EIPP enrollment.
+      # @param [Boolean] opt_in Whether the user opted in to IPP.
+      def schedule_in_person_enrollment(user:, applicant_pii:, is_enhanced_ipp:, opt_in: nil)
         enrollment = user.establishing_in_person_enrollment
         return unless enrollment
 
-        enrollment.current_address_matches_id = pii['same_address_as_id']
-
-        enrollment.save!
-
-        # Send state ID address to USPS
-        pii = pii.to_h
-        if !enrollment.current_address_matches_id?
-          pii = pii.except(*SECONDARY_ID_ADDRESS_MAP.values)
-            .transform_keys(SECONDARY_ID_ADDRESS_MAP)
-        end
-
-        enrollment_code = create_usps_enrollment(enrollment, pii, is_enhanced_ipp)
+        enrollment_code = create_usps_enrollment(enrollment, applicant_pii, is_enhanced_ipp)
         return unless enrollment_code
 
         # update the enrollment to status pending
         enrollment.enrollment_code = enrollment_code
+        enrollment.current_address_matches_id = applicant_pii.current_address_same_as_id
         enrollment.status = :pending
         enrollment.enrollment_established_at = Time.zone.now
         enrollment.save!
@@ -30,7 +27,7 @@ module UspsInPersonProofing
         analytics(user: user).usps_ippaas_enrollment_created(
           enrollment_code: enrollment.enrollment_code,
           enrollment_id: enrollment.id,
-          second_address_line_present: pii[:address2].present?,
+          second_address_line_present: applicant_pii.address_line2_present?,
           service_provider: enrollment.service_provider&.issuer,
           opted_in_to_in_person_proofing: opt_in,
           tmx_status: enrollment.profile&.tmx_status,
@@ -38,43 +35,6 @@ module UspsInPersonProofing
         )
 
         send_ready_to_verify_email(user, enrollment)
-      end
-
-      def send_ready_to_verify_email(user, enrollment)
-        user.confirmed_email_addresses.each do |email_address|
-          UserMailer.with(user: user, email_address: email_address).in_person_ready_to_verify(
-            enrollment: enrollment,
-          ).deliver_now_or_later
-        end
-      end
-
-      # Create and start tracking an in-person enrollment with USPS
-      #
-      # @param [InPersonEnrollment] enrollment The new enrollment record for tracking the enrollment
-      # @param [Pii::Attributes] pii The PII associated with the in-person enrollment
-      # @return [String] The enrollment code
-      # @raise [Exception::RequestEnrollException] Raised with a problem creating the enrollment
-      def create_usps_enrollment(enrollment, pii, is_enhanced_ipp)
-        applicant = UspsInPersonProofing::Applicant.new(
-          {
-            unique_id: enrollment.unique_id,
-            first_name: transliterate(pii[:first_name]),
-            last_name: transliterate(pii[:last_name]),
-            address: transliterate(pii[:address1]),
-            city: transliterate(pii[:city]),
-            state: pii[:state],
-            zip_code: pii[:zipcode],
-            email: IdentityConfig.store.usps_ipp_enrollment_status_update_email_address.presence,
-          },
-        )
-
-        proofer = usps_proofer
-        response = proofer.request_enroll(applicant, is_enhanced_ipp)
-        response.enrollment_code
-      rescue Faraday::BadRequestError => err
-        handle_bad_request_error(err, enrollment)
-      rescue StandardError => err
-        handle_standard_error(err, enrollment)
       end
 
       def cancel_stale_establishing_enrollments_for_user(user)
@@ -141,14 +101,6 @@ module UspsInPersonProofing
 
       private
 
-      SECONDARY_ID_ADDRESS_MAP = {
-        identity_doc_address1: :address1,
-        identity_doc_address2: :address2,
-        identity_doc_city: :city,
-        identity_doc_address_state: :state,
-        identity_doc_zipcode: :zipcode,
-      }.freeze
-
       def handle_bad_request_error(err, enrollment)
         message = err.response.dig(:body, 'responseMessage') || err.message
         raise Exception::RequestEnrollException.new(message, err, enrollment.id)
@@ -162,17 +114,28 @@ module UspsInPersonProofing
         Analytics.new(user: user, request: nil, session: {}, sp: nil)
       end
 
-      def transliterate(value)
-        result = transliterator.transliterate(value)
-        if result.unsupported_chars.present?
-          result.original
-        else
-          result.transliterated
-        end
+      def create_usps_enrollment(enrollment, applicant_pii, is_enhanced_ipp)
+        applicant = create_enrollment_applicant(applicant_pii, enrollment)
+        response = usps_proofer.request_enroll(applicant, is_enhanced_ipp)
+
+        response.enrollment_code
+      rescue Faraday::BadRequestError => err
+        handle_bad_request_error(err, enrollment)
+      rescue StandardError => err
+        handle_standard_error(err, enrollment)
       end
 
-      def transliterator
-        Transliterator.new
+      def create_enrollment_applicant(applicant, enrollment)
+        UspsInPersonProofing::Applicant.from_usps_applicant_and_enrollment(applicant, enrollment)
+      end
+
+      def send_ready_to_verify_email(user, enrollment)
+        user.confirmed_email_addresses.each do |email_address|
+          UserMailer
+            .with(user: user, email_address: email_address)
+            .in_person_ready_to_verify(enrollment:)
+            .deliver_now_or_later
+        end
       end
     end
   end

--- a/app/services/usps_in_person_proofing/proofer.rb
+++ b/app/services/usps_in_person_proofing/proofer.rb
@@ -44,8 +44,8 @@ module UspsInPersonProofing
     # USPS sends an email to the email address with instructions and the enrollment code.
     # The API response also includes the enrollment code which should be
     # stored with the unique ID to be able to request the status of proofing.
-    # @param applicant [Hash]
-    # @return [Hash] API response
+    # @param applicant [UspsInPersonProofing::Applicant]
+    # @return [UspsInPersonProofing::Response::RequestEnrollResponse] API response
     def request_enroll(applicant, is_enhanced_ipp)
       url = "#{root_url}/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant"
       request_body = {
@@ -60,6 +60,14 @@ module UspsInPersonProofing
         emailAddress: applicant.email,
         IPPAssuranceLevel: '1.5',
       }
+
+      if IdentityConfig.store.usps_opt_in_ipp_applicant_with_document_data
+        request_body.merge!(
+          documentType: applicant.document_type,
+          documentNumber: applicant.document_number,
+          documentExpirationDate: applicant.document_expiration_date,
+        )
+      end
 
       if is_enhanced_ipp
         request_body[:sponsorID] = IdentityConfig.store.usps_eipp_sponsor_id.to_i

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -492,6 +492,7 @@ usps_ipp_root_url: ''
 usps_ipp_sponsor_id: ''
 usps_ipp_username: ''
 usps_mock_fallback: true
+usps_opt_in_ipp_applicant_with_document_data: false
 usps_upload_enabled: false
 usps_upload_sftp_directory: ''
 usps_upload_sftp_host: ''

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -516,6 +516,7 @@ module IdentityConfig
     config.add(:usps_ipp_username, type: :string)
     config.add(:usps_ipp_enrollment_status_update_email_address, type: :string)
     config.add(:usps_mock_fallback, type: :boolean)
+    config.add(:usps_opt_in_ipp_applicant_with_document_data, type: :boolean)
     config.add(:usps_upload_enabled, type: :boolean)
     config.add(:usps_upload_sftp_directory, type: :string)
     config.add(:usps_upload_sftp_host, type: :string)

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -120,7 +120,7 @@ namespace :dev do
               ('a'.ord + c.to_i).chr
             end.join('')
 
-            pii = Pii::Attributes.new_from_hash(
+            applicant = {
               first_name: 'Test',
               last_name: "User #{usps_compatible_number_alternative}",
               dob: '1970-05-01',
@@ -133,7 +133,9 @@ namespace :dev do
               identity_doc_city: 'GREAT FALLS',
               identity_doc_address_state: 'VA',
               identity_doc_zipcode: '22066',
-            )
+            }
+
+            pii = Pii::Attributes.new_from_hash(applicant)
             personal_key = profile.encrypt_pii(pii, pw)
 
             if raw_enrollment_status === InPersonEnrollment::STATUS_PENDING && create_in_usps
@@ -153,7 +155,7 @@ namespace :dev do
                 begin
                   UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
                     user: user,
-                    pii: pii,
+                    applicant_pii: Pii::UspsApplicant.from_idv_applicant(applicant),
                     is_enhanced_ipp: is_enhanced_ipp,
                   )
                 rescue StandardError => e

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1061,7 +1061,7 @@ RSpec.describe Idv::EnterPasswordController do
         expect(UspsInPersonProofing::EnrollmentHelper).to receive(:schedule_in_person_enrollment)
           .with(
             user: user,
-            pii: Pii::Attributes.new_from_hash(applicant),
+            applicant_pii: Pii::UspsApplicant.from_idv_applicant(idv_session.applicant),
             is_enhanced_ipp: is_enhanced_ipp,
             opt_in: nil,
           )

--- a/spec/features/idv/in_person/usps_opt_in_ipp_applicant_expanded_payload_spec.rb
+++ b/spec/features/idv/in_person/usps_opt_in_ipp_applicant_expanded_payload_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+require 'axe-rspec'
+
+RSpec.describe 'In Person Proofing: opt in ipp applicant expanded payload', js: true do
+  include IdvStepHelper
+  include SpAuthHelper
+  include InPersonHelper
+  include UspsIppHelper
+
+  let(:ipp_service_provider) { create(:service_provider, :active, :in_person_proofing_enabled) }
+  let(:user) { user_with_2fa }
+
+  before do
+    allow(IdentityConfig.store).to receive(:usps_mock_fallback).and_return(false)
+    allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:in_person_completion_survey_delivery_enabled)
+      .and_return(true)
+    stub_request_token
+    stub_request_facilities
+    stub_request_enroll
+  end
+
+  context 'When the usps_opt_in_ipp_applicant_with_document_data is true' do
+    before do
+      allow(IdentityConfig.store).to receive(:usps_opt_in_ipp_applicant_with_document_data)
+        .and_return(true)
+    end
+
+    it 'Then the user can reach the IPP barcode page', allow_browser_log: true do
+      user = user_with_2fa
+
+      visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+
+      complete_prepare_step(user)
+      complete_location_step
+      complete_state_id_controller(user)
+      complete_ssn_step(user)
+      complete_verify_step(user)
+      fill_out_phone_form_ok(MfaContext.new(user).phone_configurations.first.phone)
+      click_idv_send_security_code
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+      complete_enter_password_step(user)
+      acknowledge_and_confirm_personal_key
+      expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
+      expect(
+        a_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant}).with do |req|
+          expect(JSON.parse(req.body)).to eq(
+            {
+              'sponsorID' => IdentityConfig.store.usps_ipp_sponsor_id.to_i,
+              'uniqueID' => InPersonEnrollment.first.unique_id,
+              'firstName' => InPersonHelper::GOOD_FIRST_NAME,
+              'lastName' => InPersonHelper::GOOD_LAST_NAME,
+              'streetAddress' => InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1,
+              'city' => InPersonHelper::GOOD_IDENTITY_DOC_CITY,
+              'state' => InPersonHelper::GOOD_STATE_ABBR,
+              'zipCode' => InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE,
+              'emailAddress' =>
+                IdentityConfig.store.usps_ipp_enrollment_status_update_email_address,
+              'documentType' => InPersonEnrollment::DOCUMENT_TYPE_STATE_ID,
+              'documentNumber' => InPersonHelper::GOOD_STATE_ID_NUMBER,
+              'documentExpirationDate' => InPersonHelper::GOOD_STATE_ID_EXPIRATION,
+              'IPPAssuranceLevel' => '1.5',
+            },
+          )
+        end,
+      ).to have_been_made
+    end
+  end
+
+  context 'When the usps_opt_in_ipp_applicant_with_document_data is false' do
+    before do
+      allow(IdentityConfig.store).to receive(
+        :usps_opt_in_ipp_applicant_with_document_data,
+      ).and_return(false)
+    end
+
+    it 'Then the user can reach the IPP barcode page', allow_browser_log: true do
+      user = user_with_2fa
+
+      visit_idp_from_sp_with_ial2(:oidc, **{ client_id: ipp_service_provider.issuer })
+      sign_in_and_2fa_user(user)
+      begin_in_person_proofing(user)
+
+      complete_prepare_step(user)
+      complete_location_step
+      complete_state_id_controller(user)
+      complete_ssn_step(user)
+      complete_verify_step(user)
+      fill_out_phone_form_ok(MfaContext.new(user).phone_configurations.first.phone)
+      click_idv_send_security_code
+      fill_in_code_with_last_phone_otp
+      click_submit_default
+      complete_enter_password_step(user)
+      acknowledge_and_confirm_personal_key
+      expect(page).to have_current_path(idv_in_person_ready_to_verify_path)
+      expect(
+        a_request(:post, %r{/ivs-ippaas-api/IPPRest/resources/rest/optInIPPApplicant}).with do |req|
+          expect(JSON.parse(req.body)).to eq(
+            {
+              'sponsorID' => IdentityConfig.store.usps_ipp_sponsor_id.to_i,
+              'uniqueID' => InPersonEnrollment.first.unique_id,
+              'firstName' => InPersonHelper::GOOD_FIRST_NAME,
+              'lastName' => InPersonHelper::GOOD_LAST_NAME,
+              'streetAddress' => InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1,
+              'city' => InPersonHelper::GOOD_IDENTITY_DOC_CITY,
+              'state' => InPersonHelper::GOOD_STATE_ABBR,
+              'zipCode' => InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE,
+              'emailAddress' =>
+                IdentityConfig.store.usps_ipp_enrollment_status_update_email_address,
+              'IPPAssuranceLevel' => '1.5',
+            },
+          )
+        end,
+      ).to have_been_made
+    end
+  end
+end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Idv::Session do
               :schedule_in_person_enrollment,
             ).with(
               user: user,
-              pii: Pii::Attributes.new_from_hash(subject.applicant),
+              applicant_pii: Pii::UspsApplicant.from_idv_applicant(subject.applicant),
               is_enhanced_ipp: is_enhanced_ipp,
               opt_in: opt_in_param,
             )

--- a/spec/services/pii/usps_applicant_spec.rb
+++ b/spec/services/pii/usps_applicant_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Pii::UspsApplicant do
+  describe '.from_idv_applicant' do
+    let(:idv_applicant) do
+      {
+        'first_name' => Faker::Name.first_name,
+        'last_name' => Faker::Name.last_name,
+        'identity_doc_address1' => Faker::Address.street_address,
+        'identity_doc_address2' => Faker::Address.secondary_address,
+        'identity_doc_city' => Faker::Address.city,
+        'identity_doc_address_state' => Faker::Address.state_abbr,
+        'identity_doc_zipcode' => Faker::Address.zip_code,
+        'state_id_number' => Faker::Number.number(digits: 9),
+        'state_id_expiration' => Faker::Date.in_date_period(year: 2030).strftime('%Y-%m-%d'),
+        'same_address_as_id' => false,
+      }
+    end
+
+    it 'returns an instance Pii::UspsApplicant' do
+      expect(described_class.from_idv_applicant(idv_applicant)).to have_attributes(
+        first_name: idv_applicant['first_name'],
+        last_name: idv_applicant['last_name'],
+        address1: idv_applicant['identity_doc_address1'],
+        address2: idv_applicant['identity_doc_address2'],
+        city: idv_applicant['identity_doc_city'],
+        state: idv_applicant['identity_doc_address_state'],
+        zipcode: idv_applicant['identity_doc_zipcode'],
+        id_number: idv_applicant['state_id_number'],
+        id_expiration: idv_applicant['state_id_expiration'],
+        current_address_same_as_id: idv_applicant['same_address_as_id'],
+      )
+    end
+  end
+
+  describe '#address_line2_present?' do
+    context 'when address2 is not an empty string' do
+      subject { described_class.new(address2: Faker::Address.secondary_address) }
+
+      it 'returns true' do
+        expect(subject.address_line2_present?).to be(true)
+      end
+    end
+
+    context 'when address2 is an empty string' do
+      subject { described_class.new(address2: '') }
+
+      it 'returns false' do
+        expect(subject.address_line2_present?).to be(false)
+      end
+    end
+
+    context 'when address2 is nil' do
+      subject { described_class.new(address2: nil) }
+
+      it 'returns false' do
+        expect(subject.address_line2_present?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/services/usps_in_person_proofing/applicant_spec.rb
+++ b/spec/services/usps_in_person_proofing/applicant_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe UspsInPersonProofing::Applicant do
+  let(:applicant_pii) do
+    {
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      address1: Faker::Address.street_name,
+      city: Faker::Address.city,
+      state: Faker::Address.state_abbr,
+      zipcode: Faker::Address.zip_code,
+      id_number: Faker::Number.number(digits: 9),
+      id_expiration: Faker::Date.in_date_period(year: 2030).strftime('%Y-%m-%d'),
+    }
+  end
+
+  describe '.from_usps_applicant_and_enrollment' do
+    context 'when values contains transliterable characters' do
+      let(:applicant) do
+        Pii::UspsApplicant.new(
+          **applicant_pii.merge(
+            first_name: 'Tèst',
+            last_name: 'Tèstington',
+            address1: 'Qüery ST',
+            city: 'Qüertyton',
+          ),
+        )
+      end
+      let(:enrollment) { build('in_person_enrollment', document_type: 'state_id') }
+      let(:email) { Faker::Internet.email(name: 'noreply') }
+
+      before do
+        allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_status_update_email_address)
+          .and_return(email)
+      end
+
+      it 'returns a UspsInPersonProofing::Applicant' do
+        expect(
+          described_class.from_usps_applicant_and_enrollment(
+            applicant,
+            enrollment,
+          ),
+        ).to have_attributes(
+          unique_id: enrollment.unique_id,
+          first_name: 'Test',
+          last_name: 'Testington',
+          address: 'Query ST',
+          city: 'Quertyton',
+          state: applicant.state,
+          zip_code: applicant.zipcode,
+          document_number: applicant.id_number,
+          document_expiration_date: applicant.id_expiration,
+          email:,
+          document_type: enrollment.document_type,
+        )
+      end
+    end
+
+    context 'when values do not contain transliterable characters' do
+      let(:applicant) { Pii::UspsApplicant.new(**applicant_pii) }
+      let(:enrollment) { build('in_person_enrollment', document_type: 'state_id') }
+      let(:email) { Faker::Internet.email(name: 'noreply') }
+
+      before do
+        allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_status_update_email_address)
+          .and_return(email)
+      end
+
+      it 'returns a UspsInPersonProofing::Applicant' do
+        expect(
+          described_class.from_usps_applicant_and_enrollment(
+            applicant,
+            enrollment,
+          ),
+        ).to have_attributes(
+          unique_id: enrollment.unique_id,
+          first_name: applicant.first_name,
+          last_name: applicant.last_name,
+          address: applicant.address1,
+          city: applicant.city,
+          state: applicant.state,
+          zip_code: applicant.zipcode,
+          document_number: applicant.id_number,
+          document_expiration_date: applicant.id_expiration,
+          email:,
+          document_type: enrollment.document_type,
+        )
+      end
+    end
+  end
+
+  describe '#has_valid_address?' do
+    let(:applicant) { described_class.new(address:) }
+
+    context 'when the address is valid' do
+      let(:address) { Faker::Address.street_address }
+
+      subject do
+        applicant.has_valid_address?
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the address invalid' do
+      let(:address) { '!@#$%' }
+
+      subject do
+        applicant.has_valid_address?
+      end
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
+++ b/spec/services/usps_in_person_proofing/enrollment_helper_spec.rb
@@ -7,53 +7,42 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
   let(:usps_mock_fallback) { false }
   let(:user) { build(:user) }
   let(:current_address_matches_id) { false }
-  let(:pii) do
-    Pii::Attributes.new_from_hash(
+  let(:applicant_pii) do
+    Pii::UspsApplicant.from_idv_applicant(
       Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID_WITH_PHONE
-        .merge(same_address_as_id: current_address_matches_id ? 'true' : 'false')
+        .merge(same_address_as_id: current_address_matches_id ? true : false)
         .transform_keys(&:to_s),
     )
   end
   subject(:subject) { described_class }
   let(:subject_analytics) { FakeAnalytics.new }
-  let(:transliterator) { UspsInPersonProofing::Transliterator.new }
   let(:service_provider) { nil }
   let(:usps_ipp_enrollment_status_update_email_address) do
     'registration@usps.local.identitysandbox.gov'
   end
-  let(:proofer) { UspsInPersonProofing::Mock::Proofer.new }
   let(:is_enhanced_ipp) { false }
   let(:usps_ipp_sponsor_id) { '2718281828' }
 
   before(:each) do
-    stub_request_token
-    stub_request_enroll
     allow(IdentityConfig.store).to receive(:usps_mock_fallback).and_return(usps_mock_fallback)
     allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_status_update_email_address)
       .and_return(usps_ipp_enrollment_status_update_email_address)
-    allow(subject).to receive(:transliterator).and_return(transliterator)
-    allow(transliterator).to receive(:transliterate)
-      .with(anything) do |val|
-        transliterated_without_change(val)
-      end
     allow(subject).to receive(:analytics).and_return(subject_analytics)
     allow(IdentityConfig.store).to receive(:usps_ipp_sponsor_id).and_return(usps_ipp_sponsor_id)
   end
 
-  describe '#schedule_in_person_enrollment' do
-    context 'when the user does not have an establishing in person enrollment' do
+  describe '.schedule_in_person_enrollment' do
+    context 'when the user does not have an establishing InPersonEnrollment' do
       let(:user) { double('user', establishing_in_person_enrollment: nil) }
 
       it 'returns without error' do
         expect do
-          subject.schedule_in_person_enrollment(
-            user:, pii:, is_enhanced_ipp: false,
-          )
+          subject.schedule_in_person_enrollment(user:, applicant_pii:, is_enhanced_ipp: false)
         end.not_to raise_error
       end
     end
 
-    context 'when the user has an establishing in person enrollment' do
+    context 'when the user has an establishing InPersonEnrollment' do
       let!(:enrollment) do
         create(
           :in_person_enrollment,
@@ -64,287 +53,119 @@ RSpec.describe UspsInPersonProofing::EnrollmentHelper do
           profile: nil,
         )
       end
+      let(:enrollment_code) { Faker::Number.number(digits: 10).to_s }
+      let(:issuer) { 'this-is-an-issuer' }
+      let(:service_provider) { build(:service_provider, issuer: issuer) }
 
       context 'when in-person mocking is enabled' do
         let(:usps_mock_fallback) { true }
+        let(:mock_proofer) { instance_double(UspsInPersonProofing::Mock::Proofer) }
+        let(:response) { double('UspsResponse') }
+
+        before do
+          allow(response).to receive(:enrollment_code).and_return(enrollment_code)
+          allow(mock_proofer).to receive(:request_enroll).and_return(response)
+          allow(UspsInPersonProofing::Mock::Proofer).to receive(:new).and_return(mock_proofer)
+
+          subject.schedule_in_person_enrollment(user:, applicant_pii:, is_enhanced_ipp:)
+        end
 
         it 'uses a mock proofer' do
-          expect(UspsInPersonProofing::Mock::Proofer).to receive(:new).and_call_original
-
-          subject.schedule_in_person_enrollment(
-            user:, pii:, is_enhanced_ipp:,
-          )
+          expect(mock_proofer).to have_received(:request_enroll)
         end
       end
 
-      context 'an establishing enrollment record exists for the user' do
+      context 'when in-person mocking is not enabled' do
+        let(:usps_mock_fallback) { false }
+        let(:opted_in) { true }
+        let(:proofer) { instance_double(UspsInPersonProofing::Proofer) }
+
         before do
-          allow(Rails).to receive(:cache).and_return(
-            ActiveSupport::Cache::RedisCacheStore.new(url: IdentityConfig.store.redis_throttle_url),
-          )
-          allow(subject).to receive(:usps_proofer).and_return(proofer)
+          allow(UspsInPersonProofing::Proofer).to receive(:new).and_return(proofer)
         end
 
-        it 'updates the existing enrollment record' do
-          expect(user.in_person_enrollments.length).to eq(1)
-
-          subject.schedule_in_person_enrollment(
-            user:, pii:, is_enhanced_ipp:,
-          )
-          enrollment.reload
-
-          # tests that the value of current_address_matches_id on the enrollment corresponds
-          # to the value of same_address_as_id in the session
-          expect(enrollment.current_address_matches_id).to eq(current_address_matches_id)
-        end
-
-        it 'creates usps enrollment while using transliteration' do
-          first_name = Idp::Constants::MOCK_IDV_APPLICANT[:first_name]
-          last_name = Idp::Constants::MOCK_IDV_APPLICANT[:last_name]
-          address = Idp::Constants::MOCK_IDV_APPLICANT[:address1]
-          city = Idp::Constants::MOCK_IDV_APPLICANT[:city]
-
-          expect(transliterator).to receive(:transliterate)
-            .with(first_name).and_return(transliterated_without_change(first_name))
-          expect(transliterator).to receive(:transliterate)
-            .with(last_name).and_return(transliterated(last_name))
-          expect(transliterator).to receive(:transliterate)
-            .with(address).and_return(transliterated_with_failure(address))
-          expect(transliterator).to receive(:transliterate)
-            .with(city).and_return(transliterated(city))
-
-          expect(proofer).to receive(:request_enroll) do |applicant|
-            expect(applicant.first_name).to eq(first_name)
-            expect(applicant.last_name).to eq("transliterated_#{last_name}")
-            expect(applicant.address).to eq(address)
-            expect(applicant.city).to eq("transliterated_#{city}")
-            expect(applicant.state).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:state])
-            expect(applicant.zip_code).to eq(Idp::Constants::MOCK_IDV_APPLICANT[:zipcode])
-            expect(applicant.email).to eq(usps_ipp_enrollment_status_update_email_address)
-            expect(applicant.unique_id).to eq(enrollment.unique_id)
-
-            UspsInPersonProofing::Mock::Proofer.new.request_enroll(applicant, is_enhanced_ipp)
-          end
-
-          subject.schedule_in_person_enrollment(
-            user:, pii:, is_enhanced_ipp:,
-          )
-        end
-
-        it <<~STR.squish do
-          sets enrollment status to pending, sponsor_id to usps_ipp_sponsor_id,
-          and sets established at date and unique id
-        STR
-          subject.schedule_in_person_enrollment(
-            user:, pii:, is_enhanced_ipp:,
-          )
-
-          expect(user.in_person_enrollments.first.status).to eq(InPersonEnrollment::STATUS_PENDING)
-          expect(user.in_person_enrollments.first.sponsor_id).to eq(usps_ipp_sponsor_id)
-          expect(user.in_person_enrollments.first.enrollment_established_at).to_not be_nil
-          expect(user.in_person_enrollments.first.unique_id).to_not be_nil
-        end
-
-        context 'event logging' do
-          context 'with no service provider' do
-            it 'logs event' do
-              subject.schedule_in_person_enrollment(
-                user:, pii:, is_enhanced_ipp:,
-              )
-
-              expect(subject_analytics).to have_logged_event(
-                'USPS IPPaaS enrollment created',
-                enrollment_code: user.in_person_enrollments.first.enrollment_code,
-                enrollment_id: user.in_person_enrollments.first.id,
-                second_address_line_present: false,
-                enhanced_ipp: false,
+        context 'when the USPS enrollment creation fails' do
+          context 'when the USPS API error is Bad Request' do
+            before do
+              allow(proofer).to receive(:request_enroll).and_raise(
+                Faraday::BadRequestError.new(
+                  {
+                    body: {
+                      responseMessage: 'Failure',
+                    },
+                  },
+                ),
               )
             end
-          end
 
-          context 'with a service provider' do
-            let(:issuer) { 'this-is-an-issuer' }
-            let(:service_provider) { build(:service_provider, issuer: issuer) }
-
-            context 'when the enrollment is enhanced_ipp' do
-              let!(:enrollment) do
-                create(
-                  :in_person_enrollment,
-                  :enhanced_ipp,
-                  user: user,
-                  service_provider: service_provider,
-                  status: :establishing,
-                  current_address_matches_id: nil,
-                  profile: nil,
-                )
-              end
-              let(:is_enhanced_ipp) { true }
-
-              it 'logs event' do
+            it 'raises a Exception::RequestEnrollException error' do
+              expect do
                 subject.schedule_in_person_enrollment(
-                  user:, pii:, is_enhanced_ipp:,
+                  user:, applicant_pii:, is_enhanced_ipp:, opt_in: opted_in,
                 )
-
-                expect(subject_analytics).to have_logged_event(
-                  'USPS IPPaaS enrollment created',
-                  enrollment_code: user.in_person_enrollments.first.enrollment_code,
-                  enrollment_id: user.in_person_enrollments.first.id,
-                  second_address_line_present: false,
-                  service_provider: issuer,
-                  enhanced_ipp: true,
-                )
-              end
-            end
-
-            context 'when the enrollment is not enhanced_ipp' do
-              it 'logs event' do
-                subject.schedule_in_person_enrollment(
-                  user:, pii:, is_enhanced_ipp:,
-                )
-
-                expect(subject_analytics).to have_logged_event(
-                  'USPS IPPaaS enrollment created',
-                  enrollment_code: user.in_person_enrollments.first.enrollment_code,
-                  enrollment_id: user.in_person_enrollments.first.id,
-                  second_address_line_present: false,
-                  service_provider: issuer,
-                  enhanced_ipp: false,
-                )
-              end
+              end.to raise_error(UspsInPersonProofing::Exception::RequestEnrollException)
             end
           end
 
-          context 'with address line 2 present' do
-            before { pii['address2'] = 'Apartment 227' }
-
-            # this is a pii bundle that adds identity_doc_* values
-            let(:pii) do
-              Pii::Attributes.new_from_hash(
-                Idp::Constants::MOCK_IDV_APPLICANT_STATE_ID_ADDRESS.transform_keys(&:to_s),
-              )
+          context 'when the USPS API errors with ServerError' do
+            before do
+              allow(proofer).to receive(:request_enroll).and_raise(Faraday::ServerError)
             end
 
-            it 'does not log the presence of address line 2 only in residential address' do
-              pii['identity_doc_address2'] = nil
-
-              subject.schedule_in_person_enrollment(
-                user:, pii:, is_enhanced_ipp:,
-              )
-
-              expect(subject_analytics).to have_logged_event(
-                'USPS IPPaaS enrollment created',
-                enrollment_code: user.in_person_enrollments.first.enrollment_code,
-                enrollment_id: user.in_person_enrollments.first.id,
-                second_address_line_present: false,
-                enhanced_ipp: false,
-              )
-            end
-
-            context 'with address line 2 present in state ID address' do
-              it 'logs the presence of address line 2' do
-                expect(pii['identity_doc_address2'].present?).to eq(true)
-
-                pii['same_address_as_id'] = false
-                pii['address2'] = nil
-
+            it 'raises a Exception::RequestEnrollException error' do
+              expect do
                 subject.schedule_in_person_enrollment(
-                  user:, pii:, is_enhanced_ipp:,
+                  user:, applicant_pii:, is_enhanced_ipp:, opt_in: opted_in,
                 )
-
-                expect(subject_analytics).to have_logged_event(
-                  'USPS IPPaaS enrollment created',
-                  enrollment_code: user.in_person_enrollments.first.enrollment_code,
-                  enrollment_id: user.in_person_enrollments.first.id,
-                  second_address_line_present: true,
-                  enhanced_ipp: false,
-                )
-              end
-            end
-          end
-
-          context 'with opt in value' do
-            let(:opt_in) { true }
-
-            it 'logs user\'s opt-in choice' do
-              subject.schedule_in_person_enrollment(
-                user:, pii:, is_enhanced_ipp:, opt_in:,
-              )
-
-              expect(subject_analytics).to have_logged_event(
-                'USPS IPPaaS enrollment created',
-                enrollment_code: user.in_person_enrollments.first.enrollment_code,
-                enrollment_id: user.in_person_enrollments.first.id,
-                opted_in_to_in_person_proofing: true,
-                second_address_line_present: false,
-                enhanced_ipp: false,
-              )
+              end.to raise_error(UspsInPersonProofing::Exception::RequestEnrollException)
             end
           end
         end
 
-        it 'sends verification emails' do
-          subject.schedule_in_person_enrollment(
-            user:, pii:, is_enhanced_ipp:,
-          )
+        context 'when the USPS enrollment creation is successful' do
+          let(:current_time) { Time.zone.now }
+          let(:response) { double('UspsResponse') }
 
-          expect_delivered_email_count(1)
-          expect_delivered_email(
-            to: [user.email_addresses.first.email],
-            subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
-          )
+          before do
+            allow(response).to receive(:enrollment_code).and_return(enrollment_code)
+            allow(proofer).to receive(:request_enroll).and_return(response)
+            freeze_time
+            travel_to(current_time) do
+              subject.schedule_in_person_enrollment(
+                user:, applicant_pii:, is_enhanced_ipp:, opt_in: opted_in,
+              )
+            end
+          end
+
+          it 'updates the enrollment' do
+            expect(enrollment.reload).to have_attributes(
+              enrollment_code: enrollment_code,
+              current_address_matches_id: applicant_pii.current_address_same_as_id,
+              status: 'pending',
+              enrollment_established_at: current_time,
+            )
+          end
+
+          it 'logs the usps_ippaas_enrollment_created event' do
+            expect(subject_analytics).to have_logged_event(
+              'USPS IPPaaS enrollment created',
+              enrollment_code: enrollment_code,
+              enrollment_id: enrollment.id,
+              second_address_line_present: false,
+              service_provider: issuer,
+              opted_in_to_in_person_proofing: opted_in,
+              enhanced_ipp: false,
+            )
+          end
+
+          it 'sends a ready to verify email' do
+            expect_delivered_email_count(1)
+            expect_delivered_email(
+              to: [user.email_addresses.first.email],
+              subject: t('user_mailer.in_person_ready_to_verify.subject', app_name: APP_NAME),
+            )
+          end
         end
-      end
-    end
-  end
-
-  describe '#create_usps_enrollment' do
-    let(:usps_mock_fallback) { true }
-    let(:usps_eipp_sponsor_id) { '314159265359' }
-    let(:pii) do
-      Pii::Attributes.new_from_hash(
-        Idp::Constants::MOCK_IDV_APPLICANT,
-      )
-    end
-    let(:applicant) do
-      UspsInPersonProofing::Applicant.new(
-        unique_id: enrollment.unique_id,
-        first_name: Idp::Constants::MOCK_IDV_APPLICANT[:first_name],
-        last_name: Idp::Constants::MOCK_IDV_APPLICANT[:last_name],
-        address: Idp::Constants::MOCK_IDV_APPLICANT[:address1],
-        city: Idp::Constants::MOCK_IDV_APPLICANT[:city],
-        state: Idp::Constants::MOCK_IDV_APPLICANT[:state],
-        zip_code: Idp::Constants::MOCK_IDV_APPLICANT[:zipcode],
-        email: usps_ipp_enrollment_status_update_email_address,
-      )
-    end
-    before do
-      allow(IdentityConfig.store).to receive(:usps_eipp_sponsor_id)
-        .and_return(usps_eipp_sponsor_id)
-      allow(UspsInPersonProofing::Mock::Proofer).to receive(:new).and_return(proofer)
-      allow(proofer).to receive(:request_enroll).and_call_original
-    end
-    context 'when the user is going through enhanced ipp' do
-      let!(:enrollment) do
-        create(
-          :in_person_enrollment,
-          :enhanced_ipp,
-          user: user,
-          service_provider: service_provider,
-          status: :establishing,
-          profile: nil,
-        )
-      end
-      let(:is_enhanced_ipp) { true }
-
-      it 'creates an enhanced ipp enrollment' do
-        expect(proofer).to receive(:request_enroll).with(applicant, is_enhanced_ipp)
-        subject.create_usps_enrollment(enrollment, pii, is_enhanced_ipp)
-      end
-
-      it 'saves sponsor_id on the enrollment to the usps_eipp_sponsor_id' do
-        subject.schedule_in_person_enrollment(user:, pii:, is_enhanced_ipp:)
-
-        expect(user.in_person_enrollments.first.sponsor_id).to eq(usps_eipp_sponsor_id)
       end
     end
   end


### PR DESCRIPTION
changelog: Internal, Upcoming Feature, Add document attributes to USPS enrollment request. Attributes are behind a feature flag to be enabled in the future.

## 🎫 Ticket

Link to the relevant ticket:
[LG-16718](https://cm-jira.usa.gov/browse/LG-16718)


## 📜 Testing Plan

Automated:
- [ ] Feature specs are passing

Manual:
- [ ] Ensure IPP enrollment creation does not fail