### PR TITLE
LG-1677: Fix dupe error issue

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6560,6 +6560,22 @@ module AnalyticsEvents
     track_event(:one_account_duplicate_profile_created)
   end
 
+  # When there's an error creating duplicate profile set
+  def one_account_duplicate_profile_creation_failed(
+    service_provider:,
+    profile_ids:,
+    error_message:,
+    **extra
+  )
+    track_event(
+      :one_account_duplicate_profile_creation_failed,
+      service_provider: service_provider,
+      profile_ids: profile_ids,
+      error_message: error_message,
+      **extra,
+    )
+  end
+
   # Tracks when a duplicate profile object is updated
   def one_account_duplicate_profile_updated
     track_event(:one_account_duplicate_profile_updated)

--- a/spec/services/duplicate_profile_checker_spec.rb
+++ b/spec/services/duplicate_profile_checker_spec.rb
@@ -224,6 +224,29 @@ RSpec.describe DuplicateProfileChecker do
               end
             end
           end
+
+          context 'when duplicate is found but existing set is closed' do
+            before do
+              dupe_profile_set.update(closed_at: Time.zone.now)
+              allow_any_instance_of(Idv::DuplicateSsnFinder)
+                .to receive(:duplicate_facial_match_profiles)
+                .and_return([profile2])
+            end
+
+            it 'logs a dupe profile set attempted' do
+              dupe_profile_checker = DuplicateProfileChecker.new(
+                user: user,
+                user_session: session,
+                sp: sp,
+                analytics: @analytics,
+              )
+              dupe_profile_checker.dupe_profile_set_for_user
+
+              expect(@analytics).to have_logged_event(
+                :one_account_duplicate_profile_creation_failed,
+              )
+            end
+          end
         end
       end
     end

--- a/spec/services/duplicate_profile_checker_spec.rb
+++ b/spec/services/duplicate_profile_checker_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe DuplicateProfileChecker do
             end
           end
 
-          context 'when a new profile is found' do
+          context 'when a new identical profile is found' do
             let!(:profile3) do
               create(
                 :profile,
@@ -135,6 +135,7 @@ RSpec.describe DuplicateProfileChecker do
                 user: create(:user, :fully_registered),
               )
             end
+
             before do
               allow_any_instance_of(Idv::DuplicateSsnFinder)
                 .to receive(:duplicate_facial_match_profiles)


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-16777](https://cm-jira.usa.gov/browse/LG-16777)

## 🛠 Summary of changes
 Prevents a rails error showing up for an attempt at making dupe accounts. 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Setup: 1 Fully authenticated IDV facial match user.
- [ ] User1 has been fully authorized without issue.
- [ ] User2 goes through IDV facial match with same SSN as User1 for SP
- [ ] User2 is shown duplicate profile screen.
- [ ] User 2 signs out
- [ ] User 1 signs in using SP and properly redirected to SP
- [ ] User 2 signs in using SP and should not throw an error
