### PR TITLE
LG-16690: Remove unused FraudPoint logic from IDV flow

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/response_redacter.rb
+++ b/app/services/proofing/lexis_nexis/ddp/response_redacter.rb
@@ -114,19 +114,6 @@ module Proofing
           enabled_services
           event_datetime
           event_type
-          fraudpoint.conversation_id
-          fraudpoint.friendly_fraud_index
-          fraudpoint.manipulated_identity_index
-          fraudpoint.product_status
-          fraudpoint.transaction_reason_code
-          fraudpoint.risk_indicators_codes
-          fraudpoint.risk_indicators_descriptions
-          fraudpoint.score
-          fraudpoint.stolen_identity_index
-          fraudpoint.suspicious_activity_index
-          fraudpoint.synthetic_identity_index
-          fraudpoint.transaction_status
-          fraudpoint.vulnerable_victim_index
           fuzzy_device_first_seen
           fuzzy_device_id_confidence
           fuzzy_device_last_event

--- a/lib/reporting/api_transaction_count_report.rb
+++ b/lib/reporting/api_transaction_count_report.rb
@@ -312,16 +312,9 @@ module Reporting
       <<~QUERY
         filter name = "idv_threatmetrix_response_body"
         | fields 
-          properties.event_properties.response_body.fraudpoint.conversation_id as conversation_id,
-          properties.event_properties.response_body.fraudpoint.score as score,
-          properties.event_properties.response_body.fraudpoint.friendly_fraud_index as friendly_fraud_index,
-          properties.event_properties.response_body.fraudpoint.manipulated_identity_index as manipulated_identity_index,
-          properties.event_properties.response_body.fraudpoint.stolen_identity_index as stolen_identity_index,
-          properties.event_properties.response_body.fraudpoint.suspicious_activity_index as suspicious_activity_index,
-          properties.event_properties.response_body.fraudpoint.synthetic_identity_index as synthetic_identity_index,
-          properties.event_properties.response_body.fraudpoint.vulnerable_victim_index as vulnerable_victim_index,
-          properties.event_properties.response_body.fraudpoint.risk_indicators_codes as risk_indicators_codes,
-          properties.event_properties.response_body.fraudpoint.risk_indicators_descriptions as risk_indicators_descriptions
+          properties.event_properties.response_body.review_status as review_status,
+          properties.event_properties.response_body.risk_rating as risk_rating,
+          properties.event_properties.response_body.summary_risk_score as summary_risk_score
         | limit 10000
       QUERY
     end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'Analytics Regression', :js do
   let(:threatmetrix_response_body) do
     {
       account_lex_id: 'super-cool-test-lex-id',
-      'fraudpoint.score': '500',
       request_id: '1234',
       request_result: 'success',
       review_status: 'pass',

--- a/spec/fixtures/proofing/lexis_nexis/ddp/successful_redacted_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/successful_redacted_response.json
@@ -5,7 +5,6 @@
   "risk_rating": "trusted",
   "summary_risk_score": "-6",
   "tmx_risk_rating": "neutral",
-  "fraudpoint.score": "500",
   "tmx_summary_reason_code": ["Identity_Negative_History"],
   "session_id": "super-cool-test-session-id",
   "account_lex_id": "super-cool-test-lex-id"

--- a/spec/fixtures/proofing/lexis_nexis/ddp/successful_response.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/successful_response.json
@@ -5,7 +5,6 @@
   "risk_rating": "trusted",
   "summary_risk_score": "-6",
   "tmx_risk_rating": "neutral",
-  "fraudpoint.score": "500",
   "first_name": "WARNING! YOU SHOULD NEVER SEE THIS PII FIELD IN THE LOGS",
   "tmx_summary_reason_code": [
     "Identity_Negative_History"

--- a/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
+++ b/spec/jobs/socure_shadow_mode_proofing_job_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe SocureShadowModeProofingJob do
               transaction_id: 'ddp-mock-transaction-id-123',
               review_status: 'pass',
               response_body: {
-                "fraudpoint.score": '500',
                 request_id: '1234',
                 request_result: 'success',
                 review_status: 'pass',

--- a/spec/services/proofing/lexis_nexis/ddp/response_redacter_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/response_redacter_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Proofing::LexisNexis::Ddp::ResponseRedacter do
         'ssn_hash' => 'unsafe ssn hash',
         'review_status' => 'safe value',
         'summary_risk_score' => 'safe value',
-        'fraudpoint.score' => 'safe value',
       }
     end
     context 'hash with mixed known and unknown keys' do
@@ -22,7 +21,6 @@ RSpec.describe Proofing::LexisNexis::Ddp::ResponseRedacter do
         expect(json).to eq(
           'review_status' => 'safe value',
           'summary_risk_score' => 'safe value',
-          'fraudpoint.score' => 'safe value',
         )
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16690](https://cm-jira.usa.gov/browse/LG-16690)

## 🛠 Summary of changes

Removed FraudPoint data collection from IDV flow. FraudPoint was collected from ThreatMetrix DDP but was unused in fraud decisions - only `review_status` matters for fraud detection.

## 📜 Testing Plan

- [ ] No FraudPoint references remain in IDV code
- [ ] All DDP tests passing
- [ ] ThreatMetrix functionality intact

commands to run
- DDP tests: `bundle exec rspec spec/services/proofing/lexis_nexis/ddp/ spec/services/proofing/ddp_result_spec.rb`
- IDV tests: `bundle exec rspec spec/services/idv/profile_maker_spec.rb spec/services/fraud_review_check_spec.rb`
- LexisNexis tests: `bundle exec rspec spec/services/proofing/lexis_nexis/instant_verify/ spec/services/proofing/lexis_nexis/phone_finder/`