### PR TITLE
LG-16739: Implement - Add LG22 Code - ThreatMetrix Failure Screen in Account Creation Workflow

### DIFF
--- a/app/views/device_profiling_failed/show.html.erb
+++ b/app/views/device_profiling_failed/show.html.erb
@@ -3,7 +3,7 @@
 <%= render AlertIconComponent.new(icon_name: :error, class: 'display-block margin-bottom-4') %>
 <%= render PageHeadingComponent.new.with_content(t('profiling_failed.title')) %>
 <p>
-  <%= t('profiling_failed.details') %>
+  <%= t('profiling_failed.details_html') %>
 </p>
 
 <%= link_to(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1589,7 +1589,7 @@ openid_connect.user_info.errors.no_authorization: No Authorization header provid
 openid_connect.user_info.errors.not_found: Could not find authorization for the contents of the provided access_token or it may have expired
 pages.page_took_too_long.body: You might want to wait a few minutes and try again. (503)
 pages.page_took_too_long.header: The server took too long to process your request.
-profiling_failed.details: We are unable to authenticate or sign you in. Reach out to your agency to access services.
+profiling_failed.details_html: 'Call our contact center at <strong>(844) 875-6446</strong> and provide them with the error code <strong>LG22</strong>.'
 profiling_failed.title: We couldn’t sign you into your account
 report_mailer.deleted_accounts_report.issuers: Issuers
 report_mailer.deleted_accounts_report.name: Name

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1601,7 +1601,7 @@ openid_connect.user_info.errors.no_authorization: No se proporcionó ningún enc
 openid_connect.user_info.errors.not_found: No se pudo encontrar la autorización para el contenido del access_token proporcionado o puede ser que este haya vencido
 pages.page_took_too_long.body: Es conveniente que espere unos minutos y vuelva a intentarlo. (503)
 pages.page_took_too_long.header: El servidor tardó demasiado en procesar su solicitud.
-profiling_failed.details: No podemos autenticarle ni iniciar sesión. Contacte con su agencia para acceder a los servicios.
+profiling_failed.details_html: 'Llame a nuestro centro de contacto al <strong>(844) 875-6446</strong> y mencione el código de error <strong>LG22</strong>.'
 profiling_failed.title: No pudimos iniciar sesión en su cuenta
 report_mailer.deleted_accounts_report.issuers: Emisores
 report_mailer.deleted_accounts_report.name: Nombre
@@ -1635,7 +1635,7 @@ service_providers.errors.inactive.heading: '%{sp_name} ya no utiliza %{app_name}
 service_providers.errors.inactive.instructions: '%{sp_name} ya no utiliza %{app_name} como servicio para iniciar sesión en su sitio web. Si ya creó una cuenta de %{app_name}, todavía está activa y se puede usar para acceder a otros sitios web participantes del gobierno.'
 service_providers.errors.inactive.instructions2: Visite la agencia para contactarlos y obtener más información.
 shared.banner.fake_site: Un sitio web de demostración del Gobierno de los Estados Unidos
-shared.banner.gov_description_html: Un sitio web <strong>.gov</strong> pertenece a una organización oficial del Gobierno de los Estados Unidos.
+shared.banner.gov_description_html: 'Un sitio web <strong>.gov</strong> pertenece a una organización oficial del Gobierno de los Estados Unidos.'
 shared.banner.gov_heading: Los sitios web oficiales usan .gov
 shared.banner.how: Así es como usted puede saberlo
 shared.banner.landmark_label: Sitio web oficial del Gobierno

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1589,7 +1589,7 @@ openid_connect.user_info.errors.no_authorization: Aucune en-tête d’autorisati
 openid_connect.user_info.errors.not_found: L’autorisation pour le contenu du access_token fourni introuvable ou il peut être expiré
 pages.page_took_too_long.body: Nous vous recommandons de patienter quelques minutes, puis de réessayer. (503)
 pages.page_took_too_long.header: Le serveur a mis trop de temps à traiter votre demande.
-profiling_failed.details: Nous ne sommes pas en mesure de vous authentifier pour vous connecter. Veuillez contacter votre organisme pour accéder à ses services.
+profiling_failed.details_html: 'Appelez notre centre de contact au <strong>(844) 875-6446</strong> en fournissant le code d’erreur <strong>LG22</strong>.'
 profiling_failed.title: Nous n’avons pas pu vous connecter à votre compte
 report_mailer.deleted_accounts_report.issuers: Émetteurs
 report_mailer.deleted_accounts_report.name: Nom

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1602,7 +1602,7 @@ openid_connect.user_info.errors.no_authorization: 未提供授权标头
 openid_connect.user_info.errors.not_found: 就提供的 access_token 内容找不到授权或者授权已过期。
 pages.page_took_too_long.body: 你也许想等几分钟后再试。（503）
 pages.page_took_too_long.header: 服务器处理你请求的时间过长。
-profiling_failed.details: 我们无法证实你的身份并让你登录。请联系你的机构以获取服务。
+profiling_failed.details_html: '请拨打 <strong>(844) 875-6446</strong> 致电我们的联系中心并提供出错代码 <strong>LG22</strong>'
 profiling_failed.title: 我们无法把你登入你的帐户。
 report_mailer.deleted_accounts_report.issuers: 发放方
 report_mailer.deleted_accounts_report.name: 姓名


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16739: Implement - Add LG22 Code - ThreatMetrix Failure Screen in Account Creation Workflow](https://cm-jira.usa.gov/browse/LG-16739)

## 🛠 Summary of changes

This ticket edits content for the LG22 error to direct users to call the contact center


## 📜 Testing Plan
Before testing: set `account_creation_device_profiling config` to `enabled` and `lexisnexis_threatmetrix_mock_enabled` to true

- [ ] Create new user,
- [ ] At authentication setup change the mock profiling to reject
- [ ] Finish Account setup 
- [ ] Be redirected page letting them know that they couldn't be signed in.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
| Header | Header | Header | Header |
|--------|--------|--------|--------|
| <img width="656" height="533" alt="image" src="https://github.com/user-attachments/assets/7bf2de20-ec1d-4596-822d-43160f1d14a5" /> | <img width="634" height="535" alt="image" src="https://github.com/user-attachments/assets/c029f345-237f-416b-95f5-fdcfc7aa252f" /> | <img width="649" height="566" alt="image" src="https://github.com/user-attachments/assets/a21d92d1-67d4-4cea-9d83-895e0e573cdc" /> | <img width="670" height="530" alt="image" src="https://github.com/user-attachments/assets/350147b2-bda3-4990-80a4-4cf6441a8636" /> | 

</details>

<details>
<summary>After:</summary>

| English | Spanish | French | Chinese |
|--------|--------|--------|--------|
| <img width="788" height="574" alt="image" src="https://github.com/user-attachments/assets/2106edbc-9d72-480b-80ff-162af3ab5662" /> | <img width="740" height="565" alt="image" src="https://github.com/user-attachments/assets/3b1e098a-de58-4474-baa6-610c2e79809a" /> | <img width="690" height="554" alt="image" src="https://github.com/user-attachments/assets/a3193348-1851-43cb-ba84-0b2cdb3dc0ad" /> | <img width="686" height="529" alt="image" src="https://github.com/user-attachments/assets/fdf35c09-ef83-457b-b573-f59618f2ffdb" /> | 
</details>
