### PR TITLE
feat(ci): add SECURE_ANALYZERS_PREFIX variable to GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ variables:
   FF_SCRIPT_SECTIONS: 'true'
   JUNIT_OUTPUT: 'true'
   ECR_REGISTRY: '${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com'
+  SECURE_ANALYZERS_PREFIX: "$ECR_REGISTRY/gitlab/security-products"
   IDP_CI_SHA: 'sha256:787f58c3d7e0899d7a622202aa21a9ead24a3fc160d1b158160429bdcc33e4fe'
   PKI_IMAGE_TAG: 'main'
   DASHBOARD_IMAGE_TAG: 'main'


### PR DESCRIPTION

## 🛠 Summary of changes

This merge request introduces a new environment variable, `SECURE_ANALYZERS_PREFIX`, to the GitLab CI/CD configuration file (`.gitlab-ci.yml`). The variable is dynamically set using the `ECR_REGISTRY` value, enabling better integration with GitLab's security products.

## Why?

Using our ECR_REGISTRY instead of pulling containers images from Gitlab directly reduces latency, container provisioning time, and timeout errors related to fetching images.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Code changes are minimal and do not introduce breaking changes.
- [x] CI/CD pipeline runs successfully with the updated configuration.
