### PR TITLE
[LG-16629] - Adding warning content below instances of "remember this device" button

### DIFF
--- a/app/views/two_factor_authentication/backup_code_verification/show.html.erb
+++ b/app/views/two_factor_authentication/backup_code_verification/show.html.erb
@@ -35,6 +35,7 @@
           checked: @presenter.remember_device_box_checked?,
         },
       ) %>
+  <p class='margin-top-1 font-body-2xs'><%= t('forms.messages.public_shared_device_html') %></p>
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
 <% end %>
 

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -52,6 +52,7 @@
           checked: @presenter.remember_device_box_checked?,
         },
       ) %>
+  <p class='margin-top-1 font-body-2xs'><%= t('forms.messages.public_shared_device_html') %></p>
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-top-5 margin-bottom-2' %>
   <%= hidden_field_tag 'otp_make_default_number',
                        @presenter.otp_make_default_number %>

--- a/app/views/two_factor_authentication/totp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/totp_verification/show.html.erb
@@ -23,6 +23,7 @@
           checked: @presenter.remember_device_box_checked?,
         },
       ) %>
+  <p class='margin-top-1 font-body-2xs'><%= t('forms.messages.public_shared_device_html') %></p>
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-top-5' %>
 <% end %>
 

--- a/app/views/two_factor_authentication/webauthn_verification/show.html.erb
+++ b/app/views/two_factor_authentication/webauthn_verification/show.html.erb
@@ -32,6 +32,7 @@
           checked: @presenter.remember_device_box_checked?,
         },
       ) %>
+  <p class='margin-top-1 font-body-2xs'><%= t('forms.messages.public_shared_device_html') %></p>
 
   <%= render 'two_factor_authentication/troubleshooting_options', presenter: @presenter %>
 <% end %>

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -71,6 +71,7 @@
           checked: @presenter.remember_device_box_checked?,
         },
       ) %>
+  <p class='margin-top-1 font-body-2xs'><%= t('forms.messages.public_shared_device_html') %></p>
   <%= f.submit t('forms.buttons.submit.default'), class: 'display-block margin-y-5' %>
 <% end %>
 

--- a/app/views/users/webauthn_setup/new.html.erb
+++ b/app/views/users/webauthn_setup/new.html.erb
@@ -87,6 +87,7 @@
           checked: @presenter.remember_device_box_checked?,
         },
       ) %>
+  <p class='margin-top-1 font-body-2xs'><%= t('forms.messages.public_shared_device_html') %></p>
   <%= render SubmitButtonComponent.new(class: 'display-block margin-y-5').with_content(@presenter.button_text) %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -917,6 +917,7 @@ forms.confirmation.show_hdr: Create a strong password
 forms.email.buttons.delete: Delete email address
 forms.example: 'Example:'
 forms.messages.remember_device: Remember this browser
+forms.messages.public_shared_device_html: Select this to skip authentication on supported sites. DO NOT select “Remember this browser” if you are on a public or shared device.
 forms.password: Password
 forms.passwords.edit.buttons.submit: Change password
 forms.passwords.edit.labels.password: New password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -917,7 +917,7 @@ forms.confirmation.show_hdr: Create a strong password
 forms.email.buttons.delete: Delete email address
 forms.example: 'Example:'
 forms.messages.remember_device: Remember this browser
-forms.messages.public_shared_device_html: Select this to skip authentication on supported sites. DO NOT select “Remember this browser” if you are on a public or shared device.
+forms.messages.public_shared_device_html: Select this to skip authentication on supported sites. <strong>DO NOT</strong> select “Remember this browser” if you are on a public or shared device.
 forms.password: Password
 forms.passwords.edit.buttons.submit: Change password
 forms.passwords.edit.labels.password: New password

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -928,7 +928,7 @@ forms.confirmation.show_hdr: Crear una contraseña segura
 forms.email.buttons.delete: Eliminar dirección de correo electrónico
 forms.example: 'Ejemplo:'
 forms.messages.remember_device: Recuerde este navegador
-forms.messages.public_shared_device_html: Marque esta casilla para omitir la autenticación en los sitios compatibles. Si está usando un dispositivo público o compartido, NO seleccione “Recordar este navegador”.
+forms.messages.public_shared_device_html: Marque esta casilla para omitir la autenticación en los sitios compatibles. Si está usando un dispositivo público o compartido, <strong>NO</strong> seleccione “Recordar este navegador”.
 forms.password: Contraseña
 forms.passwords.edit.buttons.submit: Cambiar contraseña
 forms.passwords.edit.labels.password: Nueva contraseña

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -928,6 +928,7 @@ forms.confirmation.show_hdr: Crear una contraseña segura
 forms.email.buttons.delete: Eliminar dirección de correo electrónico
 forms.example: 'Ejemplo:'
 forms.messages.remember_device: Recuerde este navegador
+forms.messages.public_shared_device_html: Marque esta casilla para omitir la autenticación en los sitios compatibles. Si está usando un dispositivo público o compartido, NO seleccione “Recordar este navegador”.
 forms.password: Contraseña
 forms.passwords.edit.buttons.submit: Cambiar contraseña
 forms.passwords.edit.labels.password: Nueva contraseña

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -917,7 +917,7 @@ forms.confirmation.show_hdr: Créer un mot de passe fort
 forms.email.buttons.delete: Supprimer l’adresse e-mail
 forms.example: 'Exemple :'
 forms.messages.remember_device: Se souvenir de ce navigateur
-forms.messages.public_shared_device_html: Sélectionnez cette option pour ignorer l’authentification sur les sites pris en charge. NE SÉLECTIONNEZ PAS l’option « Se souvenir de ce navigateur » si vous êtes sur un ordinateur public ou partagé.
+forms.messages.public_shared_device_html: Sélectionnez cette option pour ignorer l’authentification sur les sites pris en charge. <strong>NE SÉLECTIONNEZ PAS</strong> l’option « Se souvenir de ce navigateur » si vous êtes sur un ordinateur public ou partagé.
 forms.password: Mot de passe
 forms.passwords.edit.buttons.submit: Modifier le mot de passe
 forms.passwords.edit.labels.password: Nouveau mot de passe

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -917,6 +917,7 @@ forms.confirmation.show_hdr: Créer un mot de passe fort
 forms.email.buttons.delete: Supprimer l’adresse e-mail
 forms.example: 'Exemple :'
 forms.messages.remember_device: Se souvenir de ce navigateur
+forms.messages.public_shared_device_html: Sélectionnez cette option pour ignorer l’authentification sur les sites pris en charge. NE SÉLECTIONNEZ PAS l’option « Se souvenir de ce navigateur » si vous êtes sur un ordinateur public ou partagé.
 forms.password: Mot de passe
 forms.passwords.edit.buttons.submit: Modifier le mot de passe
 forms.passwords.edit.labels.password: Nouveau mot de passe

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -928,7 +928,7 @@ forms.confirmation.show_hdr: 设一个强密码
 forms.email.buttons.delete: 删除电邮地址
 forms.example: 举例：
 forms.messages.remember_device: 记住这个浏览器
-forms.messages.public_shared_device_html: 选择这个可在得到支持的网站上跳过身份证实。如果你使用的是公共或共享设备，请勿选择“记住此浏览器”。
+forms.messages.public_shared_device_html: 选择这个可在得到支持的网站上跳过身份证实。如果你使用的是公共或共享设备，<strong>请勿</strong>选择“记住此浏览器”。
 forms.password: 密码
 forms.passwords.edit.buttons.submit: 变更密码
 forms.passwords.edit.labels.password: 新密码

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -928,6 +928,7 @@ forms.confirmation.show_hdr: 设一个强密码
 forms.email.buttons.delete: 删除电邮地址
 forms.example: 举例：
 forms.messages.remember_device: 记住这个浏览器
+forms.messages.public_shared_device_html: 选择这个可在得到支持的网站上跳过身份证实。如果你使用的是公共或共享设备，请勿选择“记住此浏览器”。
 forms.password: 密码
 forms.passwords.edit.buttons.submit: 变更密码
 forms.passwords.edit.labels.password: 新密码


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-16629](https://cm-jira.usa.gov/browse/LG-16629)

## 🛠 Summary of changes

Adding content below "Remember this Device" checkboxes warning users to not use the feature if they are on a public device.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1: Create new account
- [ ] Step 2: Visit each MFA option (OTP, backup codes, TOTP, etc) and ensure that text is present
- [ ] Step 3: Follow up in all translations and confirm that they match [content spreadsheet](https://docs.google.com/spreadsheets/d/1ZVfYo20FCyBB-z1hXsBXmL9-u0Brng9cTwiGPQEBFLk/edit?gid=801742071#gid=801742071)

## 👀 Screenshots
<img width="791" height="715" alt="Screenshot 2025-09-19 at 1 57 43 PM" src="https://github.com/user-attachments/assets/275f087c-103c-4da4-8f67-035a043758bb" />
