### PR TITLE
LG16689: Metrics: Track Self-Service Success in Duplicate Account Resolution - Iteration 2

### DIFF
--- a/app/controllers/concerns/one_account_concern.rb
+++ b/app/controllers/concerns/one_account_concern.rb
@@ -32,6 +32,7 @@ module OneAccountConcern
       sp: sp_from_sp_session,
       analytics: analytics,
     ).dupe_profile_set_for_user
+    login_success_after_dupe_deletion?(profile_set: dupe_profile_set)
     dupe_profile_set.present? && dupe_profile_set.closed_at.nil?
   end
 
@@ -59,5 +60,11 @@ module OneAccountConcern
       profile_id: current_user.active_profile.id,
       service_provider: sp_from_sp_session&.issuer,
     ).present?
+  end
+
+  def login_success_after_dupe_deletion?(profile_set: dupe_profile_set)
+    if profile_set.present? && profile_set.closed_at.present?
+      analytics.one_account_login_success_after_dupe_deletion
+    end
   end
 end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6596,6 +6596,11 @@ module AnalyticsEvents
     track_event(:one_account_duplicate_profiles_warning_page_visited, source: source, **extra)
   end
 
+  # Tracks when a user logs in after deleting a duplicate profile
+  def one_account_login_success_after_dupe_deletion
+    track_event(:one_account_login_success_after_dupe_deletion)
+  end
+
   # Tracks when a user self services their duplicate account issue
   # @param [Symbol] source where the self service occurs (account_management, account_reset, etc...)
   # @param [String] service_provider The service provider  of the duplicate profile set serviced

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -693,8 +693,18 @@ RSpec.describe ApplicationController do
           context 'when duplicate profile set is already closed' do
             it 'returns false' do
               duplicate_profile_set.update!(closed_at: Time.zone.now)
+
               get :index
               expect(response.body).to eq('false')
+            end
+
+            it 'logs an event when users are able to log in again after self-resolving duplicate profiles' do
+              stub_analytics
+              duplicate_profile_set.update!(closed_at: Time.zone.now)
+
+              get :index
+              
+              expect(@analytics).to have_logged_event(:one_account_login_success_after_dupe_deletion)
             end
           end
         end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16689: Metrics: Track Self-Service Success in Duplicate Account Resolution - Iteration 2](https://cm-jira.usa.gov/browse/LG-16689)
-->

## 🛠 Summary of changes

This PR adds a logging event for when a user successfully logs in again after having duplicate profiles deleted.