### PR TITLE
Handle SAML request errors from saml_idp gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem 'rqrcode'
 gem 'ruby-progressbar'
 gem 'ruby-saml'
 gem 'safe_target_blank', '>= 1.0.2'
-gem 'saml_idp', github: '18F/saml_idp', tag: '0.23.9-18f'
+gem 'saml_idp', github: '18F/saml_idp', tag: 'v0.23.10-18f'
 gem 'scrypt'
 gem 'simple_form', '>= 5.0.2'
 gem 'stringex', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,10 +49,10 @@ GIT
 
 GIT
   remote: https://github.com/18F/saml_idp.git
-  revision: ddf27d98cde86f80680ab4148653edd1cd745efd
-  tag: 0.23.9-18f
+  revision: c67a251a0cf959fe700751bd24f084b4b038038b
+  tag: v0.23.10-18f
   specs:
-    saml_idp (0.23.9.pre.18f)
+    saml_idp (0.23.10.pre.18f)
       activesupport
       builder
       faraday

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -77,7 +77,8 @@ module SamlIdpAuthConcern
   def validate_and_create_saml_request_object
     # this saml_idp method creates the saml_request object used for validations
     validate_saml_request
-    @saml_request_validator = SamlRequestValidator.new
+    saml_errors = saml_request.errors
+    @saml_request_validator = SamlRequestValidator.new(saml_errors:)
   rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
     @saml_request_validator = SamlRequestValidator.new(blank_cert: true)
   end

--- a/app/models/federated_protocols/saml.rb
+++ b/app/models/federated_protocols/saml.rb
@@ -9,7 +9,7 @@ module FederatedProtocols
     end
 
     def issuer
-      request.service_provider.identifier
+      request.service_provider&.identifier
     end
 
     def ial

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -786,6 +786,7 @@ errors.messages.already_confirmed: was already confirmed, please try signing in
 errors.messages.backup_code_limited: You tried too many times, please try again in %{timeout}.
 errors.messages.blank: Please fill in this field.
 errors.messages.blank_cert_element_req: We cannot detect a certificate in your request.
+errors.messages.both_auth_and_logout_request: SAML request contains both an authnrequest and logout request. Only one can be specified.
 errors.messages.confirmation_code_incorrect: Incorrect verification code
 errors.messages.confirmation_invalid_token: Invalid confirmation link. Either the link expired or you already confirmed your account.
 errors.messages.confirmation_period_expired: Expired confirmation link. You can click “Resend confirmation instructions” to get another one.
@@ -799,11 +800,15 @@ errors.messages.invalid_calling_area: Calls to that phone number are not support
 errors.messages.invalid_phone_number.international: Enter a phone number with the correct number of digits.
 errors.messages.invalid_phone_number.us: Enter a 10 digit phone number.
 errors.messages.invalid_recaptcha_token: We’re sorry, but your computer or network may be sending automated queries. To protect our users, we can’t process your request right now.
+errors.messages.invalid_signature: SAML request contains an invalid signature
 errors.messages.invalid_sms_number: The phone number entered doesn’t support text messaging. Try the Phone call option.
 errors.messages.invalid_voice_number: Invalid phone number. Check that you’ve entered the correct country code or area code.
+errors.messages.issuer_missing_or_invalid: Issuer missing from SAML request
 errors.messages.missing_field: Please fill in this field.
+errors.messages.no_auth_or_logout_request: SAML request is missing either an authnrequest or logout request. One of the two is required.
 errors.messages.no_cert_registered: Your service provider does not have a certificate registered.
 errors.messages.no_pending_profile: No profile is waiting for verification
+errors.messages.no_response_url: SAML request is missing Assertion Consumer Service URL or Assertion Consumer Logout Service URL
 errors.messages.not_a_number: is not a number
 errors.messages.otp_format: Enter your entire one-time code without spaces or special characters
 errors.messages.password_incorrect: Incorrect password

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -797,6 +797,7 @@ errors.messages.already_confirmed: ya estaba confirmado, intente iniciar una ses
 errors.messages.backup_code_limited: Lo intentó demasiadas veces; vuelva a intentarlo en %{timeout}.
 errors.messages.blank: Llene este campo.
 errors.messages.blank_cert_element_req: No podemos detectar un certificado en su solicitud.
+errors.messages.both_auth_and_logout_request: SAML request contains both an authnrequest and logout request. Only one can be specified.
 errors.messages.confirmation_code_incorrect: Código de verificación incorrecto
 errors.messages.confirmation_invalid_token: El vínculo de confirmación no es válido. El vínculo venció o usted ya confirmó su cuenta.
 errors.messages.confirmation_period_expired: El vínculo de confirmación venció. Puede hacer clic en “Volver a enviar instrucciones de confirmación” para obtener otro.
@@ -810,11 +811,15 @@ errors.messages.invalid_calling_area: No se admiten llamadas a ese número de te
 errors.messages.invalid_phone_number.international: Ingrese un número de teléfono con el número correcto de dígitos.
 errors.messages.invalid_phone_number.us: Ingrese un número de teléfono de 10 dígitos.
 errors.messages.invalid_recaptcha_token: Lo sentimos, pero es posible que tu computadora o red te estén enviando consultas automáticas. Para proteger a nuestros usuarios, no podemos procesar tu solicitud en este momento.
+errors.messages.invalid_signature: SAML request contains an invalid signature
 errors.messages.invalid_sms_number: El número de teléfono ingresado no admite mensajes de texto. Intente la opción de llamada telefónica.
 errors.messages.invalid_voice_number: Número de teléfono no válido. Verifique haber ingresado el código de país o de área correcto.
+errors.messages.issuer_missing_or_invalid: Issuer missing from SAML request
 errors.messages.missing_field: Llene este campo.
+errors.messages.no_auth_or_logout_request: SAML request is missing either an authnrequest or logout request. One of the two is required.
 errors.messages.no_cert_registered: No podemos detectar un certificado en su solicitud.
 errors.messages.no_pending_profile: No hay ningún perfil en espera de verificación
+errors.messages.no_response_url: SAML request is missing Assertion Consumer Service URL or Assertion Consumer Logout Service URL
 errors.messages.not_a_number: no es un número
 errors.messages.otp_format: Ingrese su código de un solo uso completo, sin espacios ni caracteres especiales.
 errors.messages.password_incorrect: Contraseña incorrecta

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -786,6 +786,7 @@ errors.messages.already_confirmed: a déjà été confirmé, veuillez essayer de
 errors.messages.backup_code_limited: Vous avez essayé trop de fois, veuillez réessayer dans %{timeout}.
 errors.messages.blank: Veuillez remplir ce champ.
 errors.messages.blank_cert_element_req: Nous ne pouvons pas détecter un certificat sur votre demande.
+errors.messages.both_auth_and_logout_request: SAML request contains both an authnrequest and logout request. Only one can be specified.
 errors.messages.confirmation_code_incorrect: Code de vérification incorrect
 errors.messages.confirmation_invalid_token: Lien de confirmation non valide. Le lien est expiré ou vous avez déjà confirmé votre compte.
 errors.messages.confirmation_period_expired: Lien de confirmation expiré. Vous pouvez cliquer sur « Renvoyer les instructions de confirmation » pour en obtenir un autre.
@@ -799,11 +800,15 @@ errors.messages.invalid_calling_area: Les appels vers ce numéro de téléphone 
 errors.messages.invalid_phone_number.international: Saisissez un numéro de téléphone avec le nombre correct de chiffres.
 errors.messages.invalid_phone_number.us: Saisissez un numéro de téléphone à 10 chiffres.
 errors.messages.invalid_recaptcha_token: Désolé, il est possible que votre ordinateur ou votre réseau envoie des requêtes automatiques. Pour protéger nos utilisateurs, nous ne pouvons pas traiter votre demande pour le moment.
+errors.messages.invalid_signature: SAML request contains an invalid signature
 errors.messages.invalid_sms_number: Le numéro de téléphone saisi ne prend pas en charge les messages texte. Veuillez essayer l’option d’appel téléphonique.
 errors.messages.invalid_voice_number: Numéro de téléphone non valide. Vérifiez que vous avez entré le bon indicatif international ou régional.
+errors.messages.issuer_missing_or_invalid: Issuer missing from SAML request
 errors.messages.missing_field: Veuillez remplir ce champ.
+errors.messages.no_auth_or_logout_request: SAML request is missing either an authnrequest or logout request. One of the two is required.
 errors.messages.no_cert_registered: Nous ne pouvons pas détecter un certificat sur votre demande.
 errors.messages.no_pending_profile: Aucun profil en attente de vérification
+errors.messages.no_response_url: SAML request is missing Assertion Consumer Service URL or Assertion Consumer Logout Service URL
 errors.messages.not_a_number: n’est pas un chiffre
 errors.messages.otp_format: Saisissez l’intégralité de votre code à usage unique sans espaces ni caractères spéciaux
 errors.messages.password_incorrect: Mot de passe incorrect

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -797,6 +797,7 @@ errors.messages.already_confirmed: 已确认，请尝试登录
 errors.messages.backup_code_limited: 你尝试了太多次。请在 %{timeout}后再试。
 errors.messages.blank: 请填写这一字段。
 errors.messages.blank_cert_element_req: 我们在你的请求中探查不到证书。
+errors.messages.both_auth_and_logout_request: SAML request contains both an authnrequest and logout request. Only one can be specified.
 errors.messages.confirmation_code_incorrect: 验证码不对。你打字打对了吗？
 errors.messages.confirmation_invalid_token: 确认链接有误。链接已过期，或者你已确认了你的账户。
 errors.messages.confirmation_period_expired: 过期的确认链接。你可以点击“重新发送确认说明”来得到另一个。
@@ -810,11 +811,15 @@ errors.messages.invalid_calling_area: 不支持给那个号码打的电话。如
 errors.messages.invalid_phone_number.international: 输入一个位数正确的电话号码。
 errors.messages.invalid_phone_number.us: 输入 10 位的电话号码。
 errors.messages.invalid_recaptcha_token: 你必须完成预防滥发邮件测验。
+errors.messages.invalid_signature: SAML request contains an invalid signature
 errors.messages.invalid_sms_number: 输入的电话号码不支持短信。尝试接听电话选项。
 errors.messages.invalid_voice_number: 电话号码有误。检查一下你是否输入了正确的国家代码或区域代码。
+errors.messages.issuer_missing_or_invalid: Issuer missing from SAML request
 errors.messages.missing_field: 请填写这一字段。
+errors.messages.no_auth_or_logout_request: SAML request is missing either an authnrequest or logout request. One of the two is required.
 errors.messages.no_cert_registered: 我们在你的请求中探查不到证书。
 errors.messages.no_pending_profile: 没有等待验证的用户资料
+errors.messages.no_response_url: SAML request is missing Assertion Consumer Service URL or Assertion Consumer Logout Service URL
 errors.messages.not_a_number: 不是数字
 errors.messages.otp_format: 输入你完整的一次性代码（没有空白或特殊字符）
 errors.messages.password_incorrect: 密码不对。

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe SamlIdpController do
       )
       expect(@analytics).to have_logged_event(
         :sp_integration_errors_present,
-        error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
+        error_details: [:issuer_missing_or_invalid, :no_auth_or_logout_request],
         error_types: { saml_request_errors: true },
         event: :saml_logout_request,
         integration_exists: false,
@@ -342,7 +342,7 @@ RSpec.describe SamlIdpController do
       expect(@analytics).to have_logged_event('Remote Logout initiated', saml_request_valid: false)
       expect(@analytics).to have_logged_event(
         :sp_integration_errors_present,
-        error_details: [:issuer_missing_or_invald, :no_auth_or_logout_request, :invalid_signature],
+        error_details: [:issuer_missing_or_invalid, :no_auth_or_logout_request],
         error_types: { saml_request_errors: true },
         event: :saml_remote_logout_request,
         integration_exists: false,
@@ -2047,6 +2047,115 @@ RSpec.describe SamlIdpController do
       end
     end
 
+    context 'issuer in SAML request is blank' do
+      let(:user) { create(:user, :fully_registered) }
+      let(:service_provider) { build(:service_provider, issuer: 'http://localhost:3000') }
+
+      before do
+        stub_analytics
+      end
+
+      # the RubySAML library won't let us pass an empty string in as the certificate
+      # element, so this test substitutes a SAMLRequest that has that element blank
+      let(:blank_issuer_req) do
+        <<-XML.gsub(/^[\s]+|[\s]+\n/, '')
+          <?xml version="1.0"?>
+          <samlp:AuthnRequest xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" AssertionConsumerServiceURL="http://localhost:3000/test/saml/decode_assertion" Destination="http://www.example.com/api/saml/auth2025" ID="_6b15011e-abfe-4c55-925f-6a5b3872a64c" IssueInstant="2024-01-11T18:03:38Z" Version="2.0">
+            <samlp:NameIDPolicy AllowCreate="true" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"/>
+          </samlp:AuthnRequest>
+        XML
+      end
+      let(:deflated_encoded_req) do
+        Base64.encode64(Zlib::Deflate.deflate(blank_issuer_req, 9)[2..-5])
+      end
+
+      before do
+        IdentityLinker.new(user, service_provider).link_identity
+        user.identities.last.update!(verified_attributes: ['email'])
+        expect(CGI).to receive(:unescape).and_return deflated_encoded_req
+      end
+
+      it 'notes it in the analytics event' do
+        generate_saml_response(user, saml_settings)
+
+        expect(@analytics).to have_logged_event(
+          'SAML Auth',
+          success: false,
+          error_details: { service_provider: { issuer_missing_or_invalid: true,
+                                               unauthorized_service_provider: true } },
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+          requested_nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+          authn_context: [],
+          authn_context_comparison: 'exact',
+          request_signed: false,
+          requested_ial: 'none',
+          endpoint: "/api/saml/auth#{path_year}",
+          idv: false,
+          finish_profile: false,
+        )
+      end
+
+      it 'returns a 400' do
+        generate_saml_response(user, saml_settings)
+        expect(controller).to render_template('saml_idp/auth/error')
+        expect(response.status).to eq(400)
+        expect(response.body).to include(t('errors.messages.issuer_missing_or_invalid'))
+      end
+    end
+
+    context 'AuthnRequest in SAML request is blank' do
+      let(:user) { create(:user, :fully_registered) }
+      let(:service_provider) { build(:service_provider, issuer: 'http://localhost:3000') }
+
+      before do
+        stub_analytics
+      end
+
+      # the RubySAML library won't let us pass an empty string in as the certificate
+      # element, so this test substitutes a SAMLRequest that has that element blank
+      let(:blank_authn_req) do
+        <<-XML.gsub(/^[\s]+|[\s]+\n/, '')
+          <?xml version="1.0"?>
+        XML
+      end
+      let(:deflated_encoded_req) do
+        Base64.encode64(Zlib::Deflate.deflate(blank_authn_req, 9)[2..-5])
+      end
+
+      before do
+        IdentityLinker.new(user, service_provider).link_identity
+        user.identities.last.update!(verified_attributes: ['email'])
+        expect(CGI).to receive(:unescape).and_return deflated_encoded_req
+      end
+
+      it 'notes it in the analytics event' do
+        generate_saml_response(user, saml_settings)
+
+        expect(@analytics).to have_logged_event(
+          'SAML Auth',
+          success: false,
+          error_details: { service_provider: { issuer_missing_or_invalid: true,
+                                               unauthorized_service_provider: true,
+                                               no_auth_or_logout_request: true } },
+          nameid_format: Saml::Idp::Constants::NAME_ID_FORMAT_PERSISTENT,
+          authn_context: [],
+          authn_context_comparison: 'exact',
+          request_signed: false,
+          requested_ial: 'none',
+          endpoint: "/api/saml/auth#{path_year}",
+          idv: false,
+          finish_profile: false,
+        )
+      end
+
+      it 'returns a 400' do
+        generate_saml_response(user, saml_settings)
+        expect(controller).to render_template('saml_idp/auth/error')
+        expect(response.status).to eq(400)
+        expect(response.body).to include(t('errors.messages.no_auth_or_logout_request'))
+      end
+    end
+
     context 'no IAL explicitly requested' do
       let(:user) { create(:user, :fully_registered) }
 
@@ -2267,10 +2376,10 @@ RSpec.describe SamlIdpController do
     end
 
     describe 'HEAD /api/saml/auth', type: :request do
-      it 'responds with "403 Forbidden"' do
+      it 'responds with "400 Bad Request"' do
         head '/api/saml/auth2025?SAMLRequest=bang!'
 
-        expect(response.status).to eq(403)
+        expect(response.status).to eq(400)
       end
     end
 
@@ -2278,15 +2387,12 @@ RSpec.describe SamlIdpController do
       it 'responds with "403 Forbidden"' do
         get :auth, params: { path_year: path_year }
 
-        expect(response.status).to eq(403)
-      end
-    end
-
-    context 'with invalid SAMLRequest param' do
-      it 'responds with "403 Forbidden"' do
-        get :auth, params: { path_year: path_year }
-
-        expect(response.status).to eq(403)
+        expect(response.status).to eq(400)
+        expect(response.body).to include('Service provider Issuer missing from SAML request')
+        error = 'Service provider SAML request is missing either an authnrequest or logout ' \
+                'request. One of the two is required.'
+        expect(response.body).to include(error)
+        expect(response.body).to include('Service provider Unauthorized Service Provider')
       end
     end
 

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -34,11 +34,11 @@ RSpec.feature 'saml api' do
       sp.save
     end
 
-    it 'returns a 403' do
+    it 'returns a 400' do
       sign_in_via_branded_page(user)
       click_submit_default
 
-      expect(page.status_code).to eq 403
+      expect(page.status_code).to eq 400
     end
   end
 

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -68,6 +68,11 @@ module I18n
         { key: 'account.email_language.name.zh', locales: %i[es fr zh] },
         { key: 'account.navigation.menu', locales: %i[fr] }, # "Menu" is "Menu" in French
         { key: /^countries/ }, # Some countries have the same name across languages
+        { key: 'errors.messages.both_auth_and_logout_request', locales: %i[es fr zh] }, # This error will only be seen by partners during integration testing
+        { key: 'errors.messages.invalid_signature', locales: %i[es fr zh] }, # This error will only be seen by partners during integration testing
+        { key: 'errors.messages.issuer_missing_or_invalid', locales: %i[es fr zh] }, # This error will only be seen by partners during integration testing
+        { key: 'errors.messages.no_auth_or_logout_request', locales: %i[es fr zh] }, # This error will only be seen by partners during integration testing
+        { key: 'errors.messages.no_response_url', locales: %i[es fr zh] }, # This error will only be seen by partners during integration testing
         { key: 'date.formats.long', locales: %i[es zh] },
         { key: 'date.formats.short', locales: %i[es zh] },
         { key: 'datetime.dotiw.minutes.one' }, # "minute is minute" in French and English

--- a/spec/support/fake_saml_request.rb
+++ b/spec/support/fake_saml_request.rb
@@ -85,4 +85,8 @@ class FakeSamlRequest
       },
     }
   end
+
+  def errors
+    []
+  end
 end


### PR DESCRIPTION
Before, the saml_idp gem would return a 403 response if it found
specific errors with the SAML request, such as a missing issuer, or a
missing AuthnRequest. The problem is that this did not provide any
helpful information to partners while testing their integration.

To improve this, we updated the `saml_idp` gem to populate the
`saml_request` object with errors and not do anything else. This allows
the IdP to consume those errors and handle them appropriately, by
rendering them in the existing `/saml_idp/auth/error` template.

This allows partners to quickly understand what part of their SAML
Request is  invalid, and makes it easier for them to fix the problem.
If they don't  know how to fix it themselves, they can let us know the
error message they see, which makes it easier and faster for us to help
our partners.

The corresponding PR in the saml_idp repo is here: https://github.com/18F/saml_idp/pull/156

changelog: User-Facing Improvements, SAML Request Handling, Display SAML request errors so partners can understand what they did wrong

Here is what partners see now if there is an error caught by the saml_idp gem:
<img width="781" height="366" alt="Screenshot 2025-09-22 at 14 00 28" src="https://github.com/user-attachments/assets/e33a2b14-760a-449b-b0d4-a15911be7640" />

Before, they saw this:

<img width="1385" height="879" alt="Screenshot 2025-09-19 at 15 44 40" src="https://github.com/user-attachments/assets/fdae4db0-a0fc-4789-8f4c-4d50f70d62f1" />



