### PR TITLE
Fix flaky SP handoff feature tests

### DIFF
--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -135,6 +135,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
   end
 
   def expect_successful_oidc_handoff
+    validate_return_to_sp
     token_response = oidc_decoded_token
     decoded_id_token = oidc_decoded_id_token
 


### PR DESCRIPTION
## 🛠 Summary of changes

The tests that call `expect_successful_oidc_handoff ` rely on the `code` parameter returned in the OIDC redirect, but there is a rarer race condition that can happen where the redirect does not complete and the test fails ([example](https://gitlab.login.gov/lg/identity-idp/-/jobs/1990486)). The fix is to assert that the browser is currently at the SP return path with the `validate_return_to_sp` helper (which makes use of Capybara's built-in wait functionality).

Example test failure:

```
Failures:
  1) IdV SP handoff with oidc behaves like sp handoff after identity verification unverified user sign in requires idv and hands off successfully
     Failure/Error:
       @oidc_decoded_id_token ||= JWT.decode(
         oidc_decoded_token[:id_token],
         Rails.application.config.oidc_public_key,
         true,
         algorithm: 'RS256',
       ).first.with_indifferent_access
     JWT::DecodeError:
       Nil JSON web token
     Shared Example Group: "sp handoff after identity verification" called from ./spec/features/idv/sp_handoff_spec.rb:8
     # ./spec/support/oidc_auth_helper.rb:196:in 'OidcAuthHelper#oidc_decoded_id_token'
     # ./spec/support/idv_examples/sp_handoff.rb:139:in 'RSpec::ExampleGroups::IdVSPHandoff::WithOidc::BehavesLikeSpHandoffAfterIdentityVerification#expect_successful_oidc_handoff'
     # ./spec/support/idv_examples/sp_handoff.rb:62:in 'block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:134:in 'block (2 levels) in <top (required)>'
```