### PR TITLE
LG-16724 Add methods to pii passport and state_id structs

### DIFF
--- a/app/controllers/idv/address_controller.rb
+++ b/app/controllers/idv/address_controller.rb
@@ -46,31 +46,12 @@ module Idv
 
     def build_address_form
       Idv::AddressForm.new(
-        idv_session.updated_user_address || address_from_document || null_address,
+        idv_session.updated_user_address || address_from_document,
       )
     end
 
     def address_from_document
-      return if idv_session.pii_from_doc.document_type_received == 'passport'
-      return if idv_session.pii_from_doc.id_doc_type == 'passport'
-
-      Pii::Address.new(
-        address1: idv_session.pii_from_doc.address1,
-        address2: idv_session.pii_from_doc.address2,
-        city: idv_session.pii_from_doc.city,
-        state: idv_session.pii_from_doc.state,
-        zipcode: idv_session.pii_from_doc.zipcode,
-      )
-    end
-
-    def null_address
-      Pii::Address.new(
-        address1: nil,
-        address2: nil,
-        city: nil,
-        state: nil,
-        zipcode: nil,
-      )
+      idv_session.pii_from_doc.to_pii_address
     end
 
     def success

--- a/app/controllers/idv/ssn_controller.rb
+++ b/app/controllers/idv/ssn_controller.rb
@@ -87,11 +87,7 @@ module Idv
     private
 
     def next_url
-      if (
-           idv_session.pii_from_doc&.document_type_received == 'passport' ||
-             idv_session.pii_from_doc&.id_doc_type == 'passport' ||
-             idv_session.pii_from_doc&.state == 'PR'
-         ) && !ssn_presenter.updating_ssn?
+      if idv_session.pii_from_doc.residential_address_required? && !ssn_presenter.updating_ssn?
         idv_address_url
       else
         idv_verify_info_url

--- a/app/services/pii/passport.rb
+++ b/app/services/pii/passport.rb
@@ -20,6 +20,22 @@ module Pii
     def id_doc_type
       document_type_received
     end
+
+    # @returns [Boolean] Whether the document requires a residential address.
+    def residential_address_required?
+      true
+    end
+
+    # @returns [Pii::Address] The address created from the document.
+    def to_pii_address
+      Pii::Address.new(
+        address1: nil,
+        address2: nil,
+        city: nil,
+        state: nil,
+        zipcode: nil,
+      )
+    end
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/app/services/pii/state_id.rb
+++ b/app/services/pii/state_id.rb
@@ -27,6 +27,22 @@ module Pii
     def id_doc_type
       document_type_received
     end
+
+    # @returns [Boolean] Whether the document requires a residential address.
+    def residential_address_required?
+      state == 'PR'
+    end
+
+    # @returns [Pii::Address] The address created from the document.
+    def to_pii_address
+      Pii::Address.new(
+        address1: address1,
+        address2: address2,
+        city: city,
+        state: state,
+        zipcode: zipcode,
+      )
+    end
   end
 end
 # rubocop:enable Style/MutableConstant

--- a/spec/services/pii/passport_spec.rb
+++ b/spec/services/pii/passport_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Pii::Passport do
+  let(:passport) do
+    {
+      first_name: Faker::Name.first_name,
+      middle_name: Faker::Name.middle_name,
+      last_name: Faker::Name.last_name,
+      dob: Faker::Date.between(from: 90.years.ago, to: 13.years.ago).strftime('%Y-%m-%d'),
+      sex: Faker::Gender.short_binary_type,
+      birth_place: Faker::Address.city,
+      passport_expiration: Faker::Date.between(from: 1.day.after, to: 2.years.after)
+        .strftime('%Y-%m-%d'),
+      issuing_country_code: 'USA',
+      mrz: Idp::Constants::MOCK_IDV_APPLICANT_WITH_PASSPORT[:mrz],
+      passport_issued: Faker::Date.between(from: 3.years.ago, to: 1.year.ago).strftime('%Y-%m-%d'),
+      nationality_code: 'USA',
+      document_number: Faker::Number.number(digits: 9),
+      document_type_received: 'passport',
+    }
+  end
+
+  subject { described_class.new(**passport) }
+
+  describe '#id_doc_type' do
+    it 'returns the value of document_type_received' do
+      expect(subject.id_doc_type).to eq(passport[:document_type_received])
+    end
+  end
+
+  describe '#residential_address_required?' do
+    it 'returns true' do
+      expect(subject.residential_address_required?).to be(true)
+    end
+  end
+
+  describe '#to_pii_address' do
+    it 'returns an empty Pii::Address' do
+      expect(subject.to_pii_address).to have_attributes(
+        address1: nil,
+        address2: nil,
+        city: nil,
+        state: nil,
+        zipcode: nil,
+      )
+    end
+  end
+end

--- a/spec/services/pii/state_id_spec.rb
+++ b/spec/services/pii/state_id_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe Pii::StateId do
+  let(:state_id) do
+    {
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name,
+      middle_name: Faker::Name.middle_name,
+      name_suffix: Faker::Name.suffix,
+      address1: Faker::Address.street_name,
+      address2: Faker::Address.secondary_address,
+      city: Faker::Address.city,
+      state: Faker::Address.state_abbr,
+      zipcode: Faker::Address.zip_code,
+      dob: Faker::Date.between(from: 90.years.ago, to: 13.years.ago).strftime('%Y-%m-%d'),
+      sex: Faker::Gender.short_binary_type,
+      height: 72,
+      weight: nil,
+      eye_color: Faker::Color.name,
+      state_id_expiration: Faker::Date.between(from: 1.day.after, to: 2.years.after)
+        .strftime('%Y-%m-%d'),
+      state_id_issued: Faker::Date.between(from: 3.years.ago, to: 1.year.ago).strftime('%Y-%m-%d'),
+      state_id_jurisdiction: Faker::Address.state_abbr,
+      state_id_number: Faker::Number.number(digits: 9),
+      document_type_received: 'state_id',
+      issuing_country_code: 'USA',
+    }
+  end
+
+  subject { described_class.new(**state_id) }
+
+  describe '#id_doc_type' do
+    it 'returns the value of document_type_received' do
+      expect(subject.id_doc_type).to eq(state_id[:document_type_received])
+    end
+  end
+
+  describe '#residential_address_required?' do
+    context 'when the state is Puerto Rico' do
+      subject { described_class.new(**state_id, state: 'PR') }
+
+      it 'returns true' do
+        expect(subject.residential_address_required?).to be(true)
+      end
+    end
+
+    context 'when the state is not Puerto Rico' do
+      subject { described_class.new(**state_id, state: 'MD') }
+
+      it 'returns false' do
+        expect(subject.residential_address_required?).to be(false)
+      end
+    end
+  end
+
+  describe '#to_pii_address' do
+    it 'returns an Pii::Address using document address info' do
+      expect(subject.to_pii_address).to have_attributes(
+        address1: state_id[:address1],
+        address2: state_id[:address2],
+        city: state_id[:city],
+        state: state_id[:state],
+        zipcode: state_id[:zipcode],
+      )
+    end
+  end
+end


### PR DESCRIPTION
Added methods to Pii passport and state_id structs for determining if residential address is needed and constructing Pii address from internal object data.

changelog: Internal, Remote IdV, Add helper methods to Pii passport and state_id structs

## 🎫 Ticket

Link to the relevant ticket:
[LG-16724](https://cm-jira.usa.gov/browse/LG-16724)

## 🛠 Summary of changes

Added methods to Pii passport and state_id structs for determining if residential address is needed and constructing Pii address from internal object data.

## 📜 Testing Plan

- [ ] Automation tests pass

