### PR TITLE
Enable freezing string literals when running tests in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -254,6 +254,7 @@ specs:
     AWS_REGION: us-west-2
     AWS_SECRET_ACCESS_KEY: test
     CAPYBARA_WAIT_TIME_SECONDS: 5
+    RUBYOPT: '--enable=frozen-string-literal'
     COVERAGE: 'true'
     DOCKER_DB_HOST: db-postgres
     POSTGRES_DB: identity_idp_test

--- a/spec/bin/aamva-test-cert_spec.rb
+++ b/spec/bin/aamva-test-cert_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AamvaTestCert do
 
   describe '#run' do
     subject(:run) { instance.run(out: out, argv: argv) }
-    let(:out) { StringIO.new('') }
+    let(:out) { StringIO.new(+'') }
     let(:argv) { [] }
 
     context 'missing arguments' do

--- a/spec/requests/headers_spec.rb
+++ b/spec/requests/headers_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Headers' do
   end
 
   it 'does not raise an error when HTTP_HOST Header is encoded with ASCII-8BIT' do
-    get root_path, headers: { 'Host' => '¿’¿”'.force_encoding(Encoding::ASCII_8BIT) }
+    get root_path, headers: { 'Host' => (+'¿’¿”').force_encoding(Encoding::ASCII_8BIT) }
 
     expect(response.status).to eq 200
   end

--- a/spec/services/barcode_outputter_spec.rb
+++ b/spec/services/barcode_outputter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BarcodeOutputter do
 
     it 'returns image data' do
       # See: https://en.wikipedia.org/wiki/List_of_file_signatures
-      png_signature = "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a".force_encoding(Encoding::ASCII_8BIT)
+      png_signature = (+"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a").force_encoding(Encoding::ASCII_8BIT)
       expect(image_data).to start_with(png_signature)
     end
   end

--- a/spec/services/encrypted_redis_struct_storage_spec.rb
+++ b/spec/services/encrypted_redis_struct_storage_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe EncryptedRedisStructStorage do
 
       context 'with funky ASCII data inside the struct' do
         let(:data) do
-          "HTTP Status 401 \xE2\x80\x93 Unauthorized".force_encoding('ASCII-8BIT').freeze
+          (+"HTTP Status 401 \xE2\x80\x93 Unauthorized").force_encoding('ASCII-8BIT').freeze
         end
 
         it 'converts the data and stores it' do


### PR DESCRIPTION
## 🛠 Summary of changes

There is potential for string literals to be [frozen by default](https://bugs.ruby-lang.org/issues/20205) in future Rubies, so this enables the flag in CI during test runs.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
