### PR TITLE
LG-16651 New Wrong ID Type screens

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -34,6 +34,7 @@ module Idv
         pii_validation: stored_result&.errors&.dig(:pii_validation),
         unaccepted_id_type: stored_result&.errors&.dig(:unaccepted_id_type),
         selfie_fail: stored_result&.errors&.dig(:selfie_fail),
+        unexpected_id_type: stored_result&.errors&.dig(:unexpected_id_type),
       }
     end
 

--- a/app/controllers/concerns/idv/socure_errors_concern.rb
+++ b/app/controllers/concerns/idv/socure_errors_concern.rb
@@ -16,6 +16,8 @@ module Idv
         :unaccepted_id_type
       elsif result.errors[:selfie_fail]
         :selfie_fail
+      elsif result.errors[:unexpected_id_type]
+        :unexpected_id_type
       elsif result.errors[:socure]
         result.errors.dig(:socure, :reason_codes).first
       elsif result.errors[:network]

--- a/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
@@ -68,6 +68,7 @@ module Idv
             remaining_attempts: remaining_submit_attempts,
             sp_name: service_provider&.friendly_name || APP_NAME,
             issuer: service_provider&.issuer,
+            passport_requested: document_capture_session&.passport_requested?,
             flow_path: :hybrid,
           )
         end

--- a/app/controllers/idv/socure/errors_controller.rb
+++ b/app/controllers/idv/socure/errors_controller.rb
@@ -65,7 +65,7 @@ module Idv
           remaining_attempts: remaining_submit_attempts,
           sp_name: decorated_sp_session&.sp_name || APP_NAME,
           issuer: decorated_sp_session&.sp_issuer,
-          passport_requested: document_capture_session.passport_requested?,
+          passport_requested: document_capture_session&.passport_requested?,
           flow_path:,
         )
       end

--- a/app/controllers/idv/socure/errors_controller.rb
+++ b/app/controllers/idv/socure/errors_controller.rb
@@ -65,6 +65,7 @@ module Idv
           remaining_attempts: remaining_submit_attempts,
           sp_name: decorated_sp_session&.sp_name || APP_NAME,
           issuer: decorated_sp_session&.sp_issuer,
+          passport_requested: document_capture_session.passport_requested?,
           flow_path:,
         )
       end

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -27,6 +27,7 @@ type GetHeadingArguments = {
   isFailedDocType: boolean;
   isFailedSelfie: boolean;
   isFailedSelfieLivenessOrQuality: boolean;
+  unexpectedIdTypeError: boolean;
   t: typeof I18n.prototype.t;
 };
 function getHeading({
@@ -34,8 +35,12 @@ function getHeading({
   isFailedDocType,
   isFailedSelfie,
   isFailedSelfieLivenessOrQuality,
+  unexpectedIdTypeError,
   t,
 }: GetHeadingArguments) {
+  if (unexpectedIdTypeError) {
+    return t('doc_auth.errors.verify_passport_heading');
+  }
   if (isFailedDocType) {
     return t('doc_auth.errors.rate_limited_heading');
   }
@@ -64,6 +69,10 @@ function isPassportError(unknownFieldErrors) {
   return unknownFieldErrors.some((error) => error.field === 'passport');
 }
 
+function isUnexpectedIdTypeError(unknownFieldErrors) {
+  return unknownFieldErrors.some((error) => error.field === 'unexpected_id_type');
+}
+
 function DocumentCaptureWarning({
   isResultCodeInvalid,
   isFailedDocType,
@@ -81,11 +90,13 @@ function DocumentCaptureWarning({
   const { trackEvent } = useContext(AnalyticsContext);
 
   const nonIppOrFailedResult = !inPersonURL || isFailedResult;
+  const unexpectedIdTypeError = isUnexpectedIdTypeError(unknownFieldErrors);
   const heading = getHeading({
     isResultCodeInvalid,
     isFailedDocType,
     isFailedSelfie,
     isFailedSelfieLivenessOrQuality,
+    unexpectedIdTypeError,
     t,
   });
   const actionText = nonIppOrFailedResult
@@ -138,6 +149,7 @@ function DocumentCaptureWarning({
             isFailedSelfieLivenessOrQuality={isFailedSelfieLivenessOrQuality}
             hasDismissed={hasDismissed}
             isPassportError={passportError}
+            isUnexpectedIdTypeError={unexpectedIdTypeError}
           />
         </div>
         <p>

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -22,6 +22,11 @@ interface DocumentCaptureWarningProps {
   hasDismissed: boolean;
 }
 
+function getIdType(unknownFieldErrors) {
+  const idType = unknownFieldErrors.find((error) => error.field === 'unexpected_id_type');
+  return idType ? idType.error : null;
+}
+
 type GetHeadingArguments = {
   isResultCodeInvalid: boolean;
   isFailedDocType: boolean;
@@ -45,7 +50,7 @@ function getHeading({
     const isPassport = idType?.message === 'passport';
     const heading = isPassport
       ? t('doc_auth.errors.verify_drivers_license_heading')
-      : t('doc_auth.errors.verify_passport_heading')
+      : t('doc_auth.errors.verify_passport_heading');
     return heading;
   }
   if (isFailedDocType) {
@@ -78,11 +83,6 @@ function isPassportError(unknownFieldErrors) {
 
 function isUnexpectedIdTypeError(unknownFieldErrors) {
   return unknownFieldErrors.some((error) => error.field === 'unexpected_id_type');
-}
-
-function getIdType(unknownFieldErrors) {
-  const idType = unknownFieldErrors.find((error) => error.field === 'unexpected_id_type')
-  return idType ? idType.error : null;
 }
 
 function DocumentCaptureWarning({

--- a/app/javascript/packages/document-capture/components/document-capture-warning.tsx
+++ b/app/javascript/packages/document-capture/components/document-capture-warning.tsx
@@ -28,6 +28,7 @@ type GetHeadingArguments = {
   isFailedSelfie: boolean;
   isFailedSelfieLivenessOrQuality: boolean;
   unexpectedIdTypeError: boolean;
+  unknownFieldErrors: FormStepError<{ front: string; back: string }>[];
   t: typeof I18n.prototype.t;
 };
 function getHeading({
@@ -36,10 +37,16 @@ function getHeading({
   isFailedSelfie,
   isFailedSelfieLivenessOrQuality,
   unexpectedIdTypeError,
+  unknownFieldErrors,
   t,
 }: GetHeadingArguments) {
   if (unexpectedIdTypeError) {
-    return t('doc_auth.errors.verify_passport_heading');
+    const idType = getIdType(unknownFieldErrors);
+    const isPassport = idType?.message === 'passport';
+    const heading = isPassport
+      ? t('doc_auth.errors.verify_drivers_license_heading')
+      : t('doc_auth.errors.verify_passport_heading')
+    return heading;
   }
   if (isFailedDocType) {
     return t('doc_auth.errors.rate_limited_heading');
@@ -73,6 +80,11 @@ function isUnexpectedIdTypeError(unknownFieldErrors) {
   return unknownFieldErrors.some((error) => error.field === 'unexpected_id_type');
 }
 
+function getIdType(unknownFieldErrors) {
+  const idType = unknownFieldErrors.find((error) => error.field === 'unexpected_id_type')
+  return idType ? idType.error : null;
+}
+
 function DocumentCaptureWarning({
   isResultCodeInvalid,
   isFailedDocType,
@@ -97,6 +109,7 @@ function DocumentCaptureWarning({
     isFailedSelfie,
     isFailedSelfieLivenessOrQuality,
     unexpectedIdTypeError,
+    unknownFieldErrors,
     t,
   });
   const actionText = nonIppOrFailedResult

--- a/app/javascript/packages/document-capture/components/general-error.tsx
+++ b/app/javascript/packages/document-capture/components/general-error.tsx
@@ -103,9 +103,13 @@ function GeneralError({
     );
   }
   if (isUnexpectedIdTypeError) {
+    const isPassport = err?.message === 'passport';
+    const message = isPassport
+      ? t('doc_auth.errors.verify_drivers_license_text_html')
+      : t('doc_auth.errors.verify_passport_text_html');
     return (
       <p>
-        {t('doc_auth.errors.verify_passport_text_html' )}{' '}
+        {t(message)}{' '}
         <Link href={chooseIdTypePath || ''} isExternal={false}>
           {t('doc_auth.errors.verify.use_another_type_of_id')}
         </Link>

--- a/app/javascript/packages/document-capture/components/general-error.tsx
+++ b/app/javascript/packages/document-capture/components/general-error.tsx
@@ -13,6 +13,7 @@ interface GeneralErrorProps extends ComponentProps<'p'> {
   isFailedSelfie: boolean;
   isFailedSelfieLivenessOrQuality: boolean;
   isPassportError?: boolean;
+  isUnexpectedIdTypeError?: boolean;
   altFailedDocTypeMsg?: string | null;
   altIsFailedSelfieDontIncludeAttempts?: boolean;
   hasDismissed: boolean;
@@ -52,6 +53,7 @@ function GeneralError({
   isFailedSelfie = false,
   isFailedSelfieLivenessOrQuality = false,
   isPassportError = false,
+  isUnexpectedIdTypeError = false,
   altFailedDocTypeMsg = null,
   altIsFailedSelfieDontIncludeAttempts = false,
   hasDismissed,
@@ -99,6 +101,16 @@ function GeneralError({
         )}
       </p>
     );
+  }
+  if (isUnexpectedIdTypeError) {
+    return (
+      <p>
+        {t('doc_auth.errors.verify_passport_text_html' )}{' '}
+        <Link href={chooseIdTypePath || ''} isExternal={false}>
+          {t('doc_auth.errors.verify.use_another_type_of_id')}
+        </Link>
+      </p>
+    )
   }
   if (isPassportError) {
     if (!isNetwork) {

--- a/app/javascript/packages/document-capture/components/general-error.tsx
+++ b/app/javascript/packages/document-capture/components/general-error.tsx
@@ -105,8 +105,8 @@ function GeneralError({
   if (isUnexpectedIdTypeError) {
     const isPassport = err?.message === 'passport';
     const message = isPassport
-      ? t('doc_auth.errors.verify_drivers_license_text_html')
-      : t('doc_auth.errors.verify_passport_text_html');
+      ? t('doc_auth.errors.verify_drivers_license_text')
+      : t('doc_auth.errors.verify_passport_text');
     return (
       <p>
         {t(message)}{' '}
@@ -114,7 +114,7 @@ function GeneralError({
           {t('doc_auth.errors.verify.use_another_type_of_id')}
         </Link>
       </p>
-    )
+    );
   }
   if (isPassportError) {
     if (!isNetwork) {

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -6,13 +6,14 @@ class SocureErrorPresenter
   include ActionView::Helpers::TranslationHelper
   include LinkHelper
 
-  attr_reader :url_options
+  attr_reader :url_options, :passport_requested
 
-  def initialize(error_code:, remaining_attempts:, sp_name:, issuer:, flow_path:)
+  def initialize(error_code:, remaining_attempts:, sp_name:, issuer:, passport_requested:, flow_path:)
     @error_code = error_code
     @remaining_attempts = remaining_attempts
     @sp_name = sp_name
     @issuer = issuer
+    @passport_requested = passport_requested
     @flow_path = flow_path
     @url_options = {}
   end
@@ -120,6 +121,8 @@ class SocureErrorPresenter
       t('idv.errors.technical_difficulties')
     when :unaccepted_id_type
       t('doc_auth.headers.unaccepted_id_type')
+    when :unexpected_id_type
+      unexpected_id_type_heading
     when :selfie_fail
       t('doc_auth.errors.selfie_fail_heading')
     else
@@ -141,6 +144,8 @@ class SocureErrorPresenter
       t('idv.errors.try_again_later')
     when :unaccepted_id_type
       t('doc_auth.errors.unaccepted_id_type')
+    when :unexpected_id_type
+      unexpected_id_type_text
     when :selfie_fail
       t('doc_auth.errors.general.selfie_failure')
     else
@@ -155,6 +160,31 @@ class SocureErrorPresenter
         I18n.t("doc_auth.errors.#{remapped_error(error_code)}")
       end
     end
+  end
+
+  def unexpected_id_type_heading
+    if passport_requested
+      t('doc_auth.errors.verify_passport_heading')
+    else
+      t('doc_auth.errors.verify_drivers_license_heading')
+    end
+  end
+
+  def unexpected_id_type_text
+    verify_id_text = passport_requested ?
+      t('doc_auth.errors.verify_passport_text_html') :
+      t('doc_auth.errors.verify_drivers_license_text_html')
+
+    safe_join(
+      [
+        verify_id_text,
+        link_to(
+          t('doc_auth.errors.verify.use_another_type_of_id'),
+          idv_choose_id_type_path,
+        ),
+      ],
+      ' ',
+    )
   end
 
   def in_person_enabled?

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -8,7 +8,8 @@ class SocureErrorPresenter
 
   attr_reader :url_options, :passport_requested
 
-  def initialize(error_code:, remaining_attempts:, sp_name:, issuer:, passport_requested:, flow_path:)
+  def initialize(error_code:, remaining_attempts:, sp_name:, issuer:, passport_requested:,
+                 flow_path:)
     @error_code = error_code
     @remaining_attempts = remaining_attempts
     @sp_name = sp_name
@@ -172,8 +173,8 @@ class SocureErrorPresenter
 
   def unexpected_id_type_text
     verify_id_text = passport_requested ?
-      t('doc_auth.errors.verify_passport_text_html') :
-      t('doc_auth.errors.verify_drivers_license_text_html')
+      t('doc_auth.errors.verify_passport_text') :
+      t('doc_auth.errors.verify_drivers_license_text')
 
     safe_join(
       [

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -64,7 +64,7 @@ module DocAuth
           elsif passport_card_detected?
             { passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') }
           elsif id_type.present? && !expected_document_type_received?
-            { unexpected_id_type: I18n.t('doc_auth.errors.general.no_liveness') }
+            { unexpected_id_type: id_type }
           elsif with_authentication_result?
             ErrorGenerator.new(config).generate_doc_auth_errors(response_info)
           elsif true_id_product.present?

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -92,7 +92,8 @@ module DocAuth
         )
       end
 
-      def get_results(instance_id:, selfie_required: false, passport_submittal: false, passport_requested: false)
+      def get_results(instance_id:, selfie_required: false, passport_submittal: false,
+                      passport_requested: false)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
         last_image = passport_submittal ?
                        self.class.last_uploaded_passport_image : self.class.last_uploaded_back_image

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -88,10 +88,11 @@ module DocAuth
           instance_id: instance_id,
           selfie_required: liveness_checking_required,
           passport_submittal: passport_image.present?,
+          passport_requested:,
         )
       end
 
-      def get_results(instance_id:, selfie_required: false, passport_submittal: false)
+      def get_results(instance_id:, selfie_required: false, passport_submittal: false, passport_requested: false)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
         last_image = passport_submittal ?
                        self.class.last_uploaded_passport_image : self.class.last_uploaded_back_image
@@ -108,6 +109,7 @@ module DocAuth
           overriden_config,
           selfie_required:,
           passport_submittal:,
+          passport_requested:,
         )
       end
       # rubocop:enable Lint/UnusedMethodArgument

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -65,7 +65,7 @@ module DocAuth
             ].any?(&:present?)
 
             if id_type.present?
-              return { unexpected_id_type: true } unless expected_document_type_received?
+              return { unexpected_id_type: id_type } unless expected_document_type_received?
             end
 
             if has_fields
@@ -74,7 +74,6 @@ module DocAuth
               return {} if all_doc_capture_values_passing?(
                 transaction_status, id_type_supported?
               )
-
 
               mock_args = {}
               mock_args[:transaction_status] = transaction_status if transaction_status.present?

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -7,9 +7,11 @@ module DocAuth
       include DocAuth::SelfieConcern
       include DocAuth::Mock::YmlLoaderConcern
 
-      attr_reader :uploaded_file, :config, :selfie_required, :passport_submittal, :passport_requested
+      attr_reader :uploaded_file, :config, :selfie_required, :passport_submittal,
+                  :passport_requested
 
-      def initialize(uploaded_file, config, selfie_required: false, passport_submittal: false, passport_requested: false)
+      def initialize(uploaded_file, config, selfie_required: false, passport_submittal: false,
+                     passport_requested: false)
         @uploaded_file = uploaded_file.to_s
         @config = config
         @selfie_required = selfie_required

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -7,13 +7,14 @@ module DocAuth
       include DocAuth::SelfieConcern
       include DocAuth::Mock::YmlLoaderConcern
 
-      attr_reader :uploaded_file, :config, :selfie_required, :passport_submittal
+      attr_reader :uploaded_file, :config, :selfie_required, :passport_submittal, :passport_requested
 
-      def initialize(uploaded_file, config, selfie_required: false, passport_submittal: false)
+      def initialize(uploaded_file, config, selfie_required: false, passport_submittal: false, passport_requested: false)
         @uploaded_file = uploaded_file.to_s
         @config = config
         @selfie_required = selfie_required
         @passport_submittal = passport_submittal
+        @passport_requested = passport_requested
         super(
           success: success?,
           errors:,
@@ -63,12 +64,17 @@ module DocAuth
               passport_check_result,
             ].any?(&:present?)
 
+            if id_type.present?
+              return { unexpected_id_type: true } unless expected_document_type_received?
+            end
+
             if has_fields
               # Error generator is not to be called when it's not failure
               # allows us to test successful results
               return {} if all_doc_capture_values_passing?(
                 transaction_status, id_type_supported?
               )
+
 
               mock_args = {}
               mock_args[:transaction_status] = transaction_status if transaction_status.present?
@@ -122,6 +128,7 @@ module DocAuth
 
       def doc_auth_success?
         return false unless id_type_supported?
+        return false unless expected_document_type_received?
         return false if transaction_status_from_uploaded_file ==
                         LexisNexis::TransactionCodes::FAILED.name
         return true if transaction_status_from_uploaded_file ==
@@ -231,6 +238,20 @@ module DocAuth
         transaction_status == LexisNexis::TransactionCodes::PASSED.name &&
           id_type_supported &&
           (selfie_check_performed? ? selfie_passed? : true)
+      end
+
+      def expected_document_type_received?
+        return true if id_type.blank?
+
+        expected_id_types = passport_requested ?
+          Idp::Constants::DocumentTypes::SUPPORTED_PASSPORT_TYPES :
+          Idp::Constants::DocumentTypes::SUPPORTED_STATE_ID_TYPES
+
+        expected_id_types.include?(id_type)
+      end
+
+      def id_type
+        parsed_data_from_uploaded_file&.dig('document', 'document_type_received')
       end
 
       def selfie_passed?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -588,9 +588,10 @@ doc_auth.errors.underage: You must be at least 13 years old to use %{app_name}. 
 doc_auth.errors.unreadable_id: Take your photos in a well-lit area without shadows or glare. Make sure that everything on your ID is in focus and that the card fills the frame.
 doc_auth.errors.upload_error: Sorry, something went wrong on our end.
 doc_auth.errors.verify_drivers_license_heading: We couldn’t verify your driver’s license or state ID
-doc_auth.errors.verify_drivers_license_text_html: Make sure you are taking photos of a driver’s license or state ID. Try again, <a href="%{choose_id_url}">or use another type of ID.</a>
+doc_auth.errors.verify_drivers_license_text_html: Make sure you are taking photos of a driver’s license or state ID. Try again,
 doc_auth.errors.verify_passport_heading: We couldn’t verify your passport
-doc_auth.errors.verify_passport_text_html: Make sure you are taking photos of a passport. Try again, <a href="%{choose_id_url}">or use another type of ID.</a>
+doc_auth.errors.verify_passport_text_html: Make sure you are taking photos of a passport. Try again, 
+doc_auth.errors.verify.use_another_type_of_id: or use another type of ID.
 doc_auth.forms.change_file: Change file
 doc_auth.forms.choose_file_html: Drag file here or <lg-underline>choose from folder</lg-underline>
 doc_auth.forms.doc_success: We verified your information

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -588,9 +588,9 @@ doc_auth.errors.underage: You must be at least 13 years old to use %{app_name}. 
 doc_auth.errors.unreadable_id: Take your photos in a well-lit area without shadows or glare. Make sure that everything on your ID is in focus and that the card fills the frame.
 doc_auth.errors.upload_error: Sorry, something went wrong on our end.
 doc_auth.errors.verify_drivers_license_heading: We couldn’t verify your driver’s license or state ID
-doc_auth.errors.verify_drivers_license_text_html: Make sure you are taking photos of a driver’s license or state ID. Try again,
+doc_auth.errors.verify_drivers_license_text: Make sure you are taking photos of a driver’s license or state ID. Try again,
 doc_auth.errors.verify_passport_heading: We couldn’t verify your passport
-doc_auth.errors.verify_passport_text_html: Make sure you are taking photos of a passport. Try again, 
+doc_auth.errors.verify_passport_text: Make sure you are taking photos of a passport. Try again,
 doc_auth.errors.verify.use_another_type_of_id: or use another type of ID.
 doc_auth.forms.change_file: Change file
 doc_auth.forms.choose_file_html: Drag file here or <lg-underline>choose from folder</lg-underline>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -587,6 +587,10 @@ doc_auth.errors.unaccepted_id_type: We do not accept passports, military IDs, pa
 doc_auth.errors.underage: You must be at least 13 years old to use %{app_name}. If you are 13 or older, try again and make sure your date of birth is in focus.
 doc_auth.errors.unreadable_id: Take your photos in a well-lit area without shadows or glare. Make sure that everything on your ID is in focus and that the card fills the frame.
 doc_auth.errors.upload_error: Sorry, something went wrong on our end.
+doc_auth.errors.verify_drivers_license_heading: We couldn’t verify your driver’s license or state ID
+doc_auth.errors.verify_drivers_license_text_html: Make sure you are taking photos of a driver’s license or state ID. Try again, <a href="%{choose_id_url}">or use another type of ID.</a>
+doc_auth.errors.verify_passport_heading: We couldn’t verify your passport
+doc_auth.errors.verify_passport_text_html: Make sure you are taking photos of a passport. Try again, <a href="%{choose_id_url}">or use another type of ID.</a>
 doc_auth.forms.change_file: Change file
 doc_auth.forms.choose_file_html: Drag file here or <lg-underline>choose from folder</lg-underline>
 doc_auth.forms.doc_success: We verified your information

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -599,9 +599,9 @@ doc_auth.errors.underage: Debe tener al menos 13 años para usar %{app_name}. Si
 doc_auth.errors.unreadable_id: Tome sus fotografías en un lugar bien iluminado sin sombras ni reflejos. Revise que la información en su identificación se vea nítida y que la tarjeta llene el marco.
 doc_auth.errors.upload_error: Lo sentimos, algo no funcionó bien.
 doc_auth.errors.verify_drivers_license_heading: No pudimos verificar su licencia de conducir o su identificación estatal
-doc_auth.errors.verify_drivers_license_text_html: Revise que las fotos que está tomando sean de una licencia de conducir o identificación estatal. Vuelva a intentarlo,
+doc_auth.errors.verify_drivers_license_text: Revise que las fotos que está tomando sean de una licencia de conducir o identificación estatal. Vuelva a intentarlo,
 doc_auth.errors.verify_passport_heading: No pudimos verificar su pasaporte
-doc_auth.errors.verify_passport_text_html: Revise que las fotos que está tomando sean de un pasaporte. Vuelva a intentarlo,
+doc_auth.errors.verify_passport_text: Revise que las fotos que está tomando sean de un pasaporte. Vuelva a intentarlo,
 doc_auth.errors.verify.use_another_type_of_id: o use otro tipo de identificación
 doc_auth.forms.change_file: Cambiar archivo
 doc_auth.forms.choose_file_html: Arrastrar el archivo aquí o <lg-underline>seleccionarlo de la carpeta</lg-underline>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -599,9 +599,10 @@ doc_auth.errors.underage: Debe tener al menos 13 años para usar %{app_name}. Si
 doc_auth.errors.unreadable_id: Tome sus fotografías en un lugar bien iluminado sin sombras ni reflejos. Revise que la información en su identificación se vea nítida y que la tarjeta llene el marco.
 doc_auth.errors.upload_error: Lo sentimos, algo no funcionó bien.
 doc_auth.errors.verify_drivers_license_heading: No pudimos verificar su licencia de conducir o su identificación estatal
-doc_auth.errors.verify_drivers_license_text_html: Revise que las fotos que está tomando sean de una licencia de conducir o identificación estatal. Vuelva a intentarlo, <a href="%{choose_id_url}">o use otro tipo de identificación</a>
+doc_auth.errors.verify_drivers_license_text_html: Revise que las fotos que está tomando sean de una licencia de conducir o identificación estatal. Vuelva a intentarlo,
 doc_auth.errors.verify_passport_heading: No pudimos verificar su pasaporte
-doc_auth.errors.verify_passport_text_html: Revise que las fotos que está tomando sean de un pasaporte. Vuelva a intentarlo, <a href="%{choose_id_url}">o use otro tipo de identificación</a>
+doc_auth.errors.verify_passport_text_html: Revise que las fotos que está tomando sean de un pasaporte. Vuelva a intentarlo,
+doc_auth.errors.verify.use_another_type_of_id: o use otro tipo de identificación
 doc_auth.forms.change_file: Cambiar archivo
 doc_auth.forms.choose_file_html: Arrastrar el archivo aquí o <lg-underline>seleccionarlo de la carpeta</lg-underline>
 doc_auth.forms.doc_success: Verificamos su información

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -598,6 +598,10 @@ doc_auth.errors.unaccepted_id_type: No aceptamos pasaportes, identificaciones mi
 doc_auth.errors.underage: Debe tener al menos 13 años para usar %{app_name}. Si tiene 13 años o más, vuelva a intentarlo y verifique que su fecha de nacimiento se vea nítida.
 doc_auth.errors.unreadable_id: Tome sus fotografías en un lugar bien iluminado sin sombras ni reflejos. Revise que la información en su identificación se vea nítida y que la tarjeta llene el marco.
 doc_auth.errors.upload_error: Lo sentimos, algo no funcionó bien.
+doc_auth.errors.verify_drivers_license_heading: No pudimos verificar su licencia de conducir o su identificación estatal
+doc_auth.errors.verify_drivers_license_text_html: Revise que las fotos que está tomando sean de una licencia de conducir o identificación estatal. Vuelva a intentarlo, <a href="%{choose_id_url}">o use otro tipo de identificación</a>
+doc_auth.errors.verify_passport_heading: No pudimos verificar su pasaporte
+doc_auth.errors.verify_passport_text_html: Revise que las fotos que está tomando sean de un pasaporte. Vuelva a intentarlo, <a href="%{choose_id_url}">o use otro tipo de identificación</a>
 doc_auth.forms.change_file: Cambiar archivo
 doc_auth.forms.choose_file_html: Arrastrar el archivo aquí o <lg-underline>seleccionarlo de la carpeta</lg-underline>
 doc_auth.forms.doc_success: Verificamos su información

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -588,9 +588,10 @@ doc_auth.errors.underage: Vous devez être âgé de 13 ans au moins pour utilise
 doc_auth.errors.unreadable_id: Prenez vos photos dans un endroit bien éclairé sans ombre ou reflet. Veillez à ce que tous les renseignements figurant sur votre pièce d’identité soient nets et que l’ensemble de la pièce soit visible à l’intérieur du cadre.
 doc_auth.errors.upload_error: Désolé, il y a eu un problème de notre côté.
 doc_auth.errors.verify_drivers_license_heading: Nous n’avons pas pu vérifier votre permis de conduire ou carte d’identité d’un État
-doc_auth.errors.verify_drivers_license_text_html: Assurez-vous que vous prenez des photos d'un permis de conduire ou d’une carte d’identité d’un État. Veuillez réessayer <a href="%{choose_id_url}">ou utiliser un autre type de pièce d’identité</a>
+doc_auth.errors.verify_drivers_license_text_html: Assurez-vous que vous prenez des photos d'un permis de conduire ou d’une carte d’identité d’un État. Veuillez réessayer
 doc_auth.errors.verify_passport_heading: Nous n’avons pas pu vérifier votre passeport
-doc_auth.errors.verify_passport_text_html: Assurez-vous que vous prenez des photos d'un passeport. Veuillez réessayer <a href="%{choose_id_url}">ou utiliser un autre type de pièce d’identité</a>
+doc_auth.errors.verify_passport_text_html: Assurez-vous que vous prenez des photos d'un passeport. Veuillez réessayer
+doc_auth.errors.verify.use_another_type_of_id: ou utiliser un autre type de pièce d’identité
 doc_auth.forms.change_file: Changer de fichier
 doc_auth.forms.choose_file_html: Faites glisser le fichier ici ou <lg-underline>choisissez dans un dossier</lg-underline>
 doc_auth.forms.doc_success: Nous avons vérifié vos informations

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -587,6 +587,10 @@ doc_auth.errors.unaccepted_id_type: Nous n’acceptons pas de passeports, de car
 doc_auth.errors.underage: Vous devez être âgé de 13 ans au moins pour utiliser %{app_name}. Si vous avez 13 ans ou plus, réessayez et assurez-vous que votre date de naissance est bien visible.
 doc_auth.errors.unreadable_id: Prenez vos photos dans un endroit bien éclairé sans ombre ou reflet. Veillez à ce que tous les renseignements figurant sur votre pièce d’identité soient nets et que l’ensemble de la pièce soit visible à l’intérieur du cadre.
 doc_auth.errors.upload_error: Désolé, il y a eu un problème de notre côté.
+doc_auth.errors.verify_drivers_license_heading: Nous n’avons pas pu vérifier votre permis de conduire ou carte d’identité d’un État
+doc_auth.errors.verify_drivers_license_text_html: Assurez-vous que vous prenez des photos d'un permis de conduire ou d’une carte d’identité d’un État. Veuillez réessayer <a href="%{choose_id_url}">ou utiliser un autre type de pièce d’identité</a>
+doc_auth.errors.verify_passport_heading: Nous n’avons pas pu vérifier votre passeport
+doc_auth.errors.verify_passport_text_html: Assurez-vous que vous prenez des photos d'un passeport. Veuillez réessayer <a href="%{choose_id_url}">ou utiliser un autre type de pièce d’identité</a>
 doc_auth.forms.change_file: Changer de fichier
 doc_auth.forms.choose_file_html: Faites glisser le fichier ici ou <lg-underline>choisissez dans un dossier</lg-underline>
 doc_auth.forms.doc_success: Nous avons vérifié vos informations

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -588,9 +588,9 @@ doc_auth.errors.underage: Vous devez être âgé de 13 ans au moins pour utilise
 doc_auth.errors.unreadable_id: Prenez vos photos dans un endroit bien éclairé sans ombre ou reflet. Veillez à ce que tous les renseignements figurant sur votre pièce d’identité soient nets et que l’ensemble de la pièce soit visible à l’intérieur du cadre.
 doc_auth.errors.upload_error: Désolé, il y a eu un problème de notre côté.
 doc_auth.errors.verify_drivers_license_heading: Nous n’avons pas pu vérifier votre permis de conduire ou carte d’identité d’un État
-doc_auth.errors.verify_drivers_license_text_html: Assurez-vous que vous prenez des photos d'un permis de conduire ou d’une carte d’identité d’un État. Veuillez réessayer
+doc_auth.errors.verify_drivers_license_text: Assurez-vous que vous prenez des photos d'un permis de conduire ou d’une carte d’identité d’un État. Veuillez réessayer
 doc_auth.errors.verify_passport_heading: Nous n’avons pas pu vérifier votre passeport
-doc_auth.errors.verify_passport_text_html: Assurez-vous que vous prenez des photos d'un passeport. Veuillez réessayer
+doc_auth.errors.verify_passport_text: Assurez-vous que vous prenez des photos d'un passeport. Veuillez réessayer
 doc_auth.errors.verify.use_another_type_of_id: ou utiliser un autre type de pièce d’identité
 doc_auth.forms.change_file: Changer de fichier
 doc_auth.forms.choose_file_html: Faites glisser le fichier ici ou <lg-underline>choisissez dans un dossier</lg-underline>

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -599,9 +599,9 @@ doc_auth.errors.underage: 你必须年满 13 岁才能使用 %{app_name}。如�
 doc_auth.errors.unreadable_id: 请在光线充足而且没有阴影或眩光的地方拍照。确保你身份证件上的所有内容都清晰对焦，并且身份卡填满画面。
 doc_auth.errors.upload_error: 抱歉，我们这边出错了。
 doc_auth.errors.verify_drivers_license_heading: 我们无法验证你的驾照或州 ID。
-doc_auth.errors.verify_drivers_license_text_html: 请确保你正在拍摄的是驾照或州 ID。再试一次，
+doc_auth.errors.verify_drivers_license_text: 请确保你正在拍摄的是驾照或州 ID。再试一次，
 doc_auth.errors.verify_passport_heading: 我们无法验证你的护照
-doc_auth.errors.verify_passport_text_html: 请确保你正在拍摄的是护照。再试一次，
+doc_auth.errors.verify_passport_text: 请确保你正在拍摄的是护照。再试一次，
 doc_auth.errors.verify.use_another_type_of_id: 或使用另一种类型的 ID。
 doc_auth.forms.change_file: 更改文件
 doc_auth.forms.choose_file_html: 将文件拖到此处或者<lg-underline>从文件夹中选择</lg-underline>。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -598,6 +598,10 @@ doc_auth.errors.unaccepted_id_type: 我们不接受护照、军人身份证件�
 doc_auth.errors.underage: 你必须年满 13 岁才能使用 %{app_name}。如果你年满 13 岁，请重试并确保你的出生日期对焦。
 doc_auth.errors.unreadable_id: 请在光线充足而且没有阴影或眩光的地方拍照。确保你身份证件上的所有内容都清晰对焦，并且身份卡填满画面。
 doc_auth.errors.upload_error: 抱歉，我们这边出错了。
+doc_auth.errors.verify_drivers_license_heading: 我们无法验证你的驾照或州 ID。
+doc_auth.errors.verify_drivers_license_text_html: 请确保你正在拍摄的是驾照或州 ID。再试一次，<a href="%{choose_id_url}>或使用另一种类型的 ID。</a>
+doc_auth.errors.verify_passport_heading: 我们无法验证你的护照
+doc_auth.errors.verify_passport_text_html: 请确保你正在拍摄的是护照。再试一次，<a href="%{choose_id_url}">或使用另一种类型的 ID。</a>
 doc_auth.forms.change_file: 更改文件
 doc_auth.forms.choose_file_html: 将文件拖到此处或者<lg-underline>从文件夹中选择</lg-underline>。
 doc_auth.forms.doc_success: 我们验证了你的信息

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -599,9 +599,10 @@ doc_auth.errors.underage: 你必须年满 13 岁才能使用 %{app_name}。如�
 doc_auth.errors.unreadable_id: 请在光线充足而且没有阴影或眩光的地方拍照。确保你身份证件上的所有内容都清晰对焦，并且身份卡填满画面。
 doc_auth.errors.upload_error: 抱歉，我们这边出错了。
 doc_auth.errors.verify_drivers_license_heading: 我们无法验证你的驾照或州 ID。
-doc_auth.errors.verify_drivers_license_text_html: 请确保你正在拍摄的是驾照或州 ID。再试一次，<a href="%{choose_id_url}>或使用另一种类型的 ID。</a>
+doc_auth.errors.verify_drivers_license_text_html: 请确保你正在拍摄的是驾照或州 ID。再试一次，
 doc_auth.errors.verify_passport_heading: 我们无法验证你的护照
-doc_auth.errors.verify_passport_text_html: 请确保你正在拍摄的是护照。再试一次，<a href="%{choose_id_url}">或使用另一种类型的 ID。</a>
+doc_auth.errors.verify_passport_text_html: 请确保你正在拍摄的是护照。再试一次，
+doc_auth.errors.verify.use_another_type_of_id: 或使用另一种类型的 ID。
 doc_auth.forms.change_file: 更改文件
 doc_auth.forms.choose_file_html: 将文件拖到此处或者<lg-underline>从文件夹中选择</lg-underline>。
 doc_auth.forms.doc_success: 我们验证了你的信息

--- a/spec/fixtures/ial2_test_credential.yml
+++ b/spec/fixtures/ial2_test_credential.yml
@@ -11,3 +11,4 @@ document:
   phone: +1 314-555-1212
   state_id_jurisdiction: 'ND'
   state_id_number: 'S59397998'
+  document_type_received: 'drivers_license'

--- a/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
+++ b/spec/javascript/packages/document-capture/components/document-capture-warning-spec.jsx
@@ -288,7 +288,7 @@ describe('DocumentCaptureWarning', () => {
         validateTroubleShootingSection();
       });
     });
-    
+
     context('unexpected id type', () => {
       const isFailedResult = false;
       const isFailedDocType = false;
@@ -312,7 +312,7 @@ describe('DocumentCaptureWarning', () => {
           // error message section
           validateHeader('doc_auth.errors.verify_passport_heading', 1, true);
           validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
-          expect(getByText('doc_auth.errors.verify_passport_text_html')).to.be.ok();
+          expect(getByText('doc_auth.errors.verify_passport_text')).to.be.ok();
           expect(getByText('idv.failure.attempts_html')).to.be.ok();
           expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
           // the ipp section isn't displayed with isFailedResult=true
@@ -320,7 +320,7 @@ describe('DocumentCaptureWarning', () => {
           // troubleshooting section
           validateTroubleShootingSection();
         });
-      }); 
+      });
 
       context('expected id type is drivers_license', () => {
         it('renders a unable to verify drivers_license screen', () => {
@@ -341,7 +341,7 @@ describe('DocumentCaptureWarning', () => {
           // error message section
           validateHeader('doc_auth.errors.verify_drivers_license_heading', 1, true);
           validateHeader('doc_auth.errors.rate_limited_subheading', 2, false);
-          expect(getByText('doc_auth.errors.verify_drivers_license_text_html')).to.be.ok();
+          expect(getByText('doc_auth.errors.verify_drivers_license_text')).to.be.ok();
           expect(getByText('idv.failure.attempts_html')).to.be.ok();
           expect(getByRole('button', { name: 'idv.failure.button.warning' })).to.be.ok();
           // the ipp section isn't displayed with isFailedResult=true
@@ -349,7 +349,7 @@ describe('DocumentCaptureWarning', () => {
           // troubleshooting section
           validateTroubleShootingSection();
         });
-      }); 
+      });
     });
 
     context('failed result', () => {

--- a/spec/presenters/socure_error_presenter_spec.rb
+++ b/spec/presenters/socure_error_presenter_spec.rb
@@ -1,19 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe SocureErrorPresenter do
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::UrlHelper
+  include ActionView::Helpers::OutputSafetyHelper
+
   let(:error_code) { :network }
   let(:remaining_attempts) { 3 }
   let(:sp_name) { 'Test Service Provider' }
   let(:issuer) { 'urn:gov:gsa:openidconnect:sp:test' }
+  let(:passport_requested) { false }
   let(:flow_path) { 'standard' }
 
   subject(:presenter) do
     described_class.new(
-      error_code: error_code,
-      remaining_attempts: remaining_attempts,
-      sp_name: sp_name,
-      issuer: issuer,
-      flow_path: flow_path,
+      error_code:,
+      remaining_attempts:,
+      sp_name:,
+      issuer:,
+      passport_requested:,
+      flow_path:,
     )
   end
 
@@ -31,6 +37,24 @@ RSpec.describe SocureErrorPresenter do
 
       it 'returns the unaccepted id type heading' do
         expect(presenter.heading).to eq(I18n.t('doc_auth.headers.unaccepted_id_type'))
+      end
+    end
+
+    context 'when error_code is :unexpected_id_type' do
+      let(:error_code) { :unexpected_id_type }
+
+      context 'when the passport is requested' do
+        let(:passport_requested) { true }
+        it 'returns the passport unexpected id type heading' do
+          expect(presenter.heading).to eq(I18n.t('doc_auth.errors.verify_passport_heading'))
+        end
+      end
+
+      context 'when the passport not requested' do
+        let(:passport_requested) { false }
+        it 'returns the passport unexpected id type heading' do
+          expect(presenter.heading).to eq(I18n.t('doc_auth.errors.verify_drivers_license_heading'))
+        end
       end
     end
 
@@ -69,6 +93,46 @@ RSpec.describe SocureErrorPresenter do
 
       it 'returns the unaccepted id type message' do
         expect(presenter.body_text).to eq(I18n.t('doc_auth.errors.unaccepted_id_type'))
+      end
+    end
+
+    context 'when error_code is :unexpected_id_type' do
+      let(:error_code) { :unexpected_id_type }
+
+      context 'when the passport is requested' do
+        let(:passport_requested) { true }
+        it 'returns the passport unexpected id type heading' do
+          expect(presenter.body_text).to eq(
+            safe_join(
+              [
+                I18n.t('doc_auth.errors.verify_passport_text_html'),
+                link_to(
+                  I18n.t('doc_auth.errors.verify.use_another_type_of_id'),
+                  idv_choose_id_type_path,
+                ),
+              ],
+              ' ',
+            ),
+          )
+        end
+      end
+
+      context 'when the passport not requested' do
+        let(:passport_requested) { false }
+        it 'returns the passport unexpected id type heading' do
+          expect(presenter.body_text).to eq(
+            safe_join(
+              [
+                I18n.t('doc_auth.errors.verify_drivers_license_text_html'),
+                link_to(
+                  I18n.t('doc_auth.errors.verify.use_another_type_of_id'),
+                  idv_choose_id_type_path,
+                ),
+              ],
+              ' ',
+            ),
+          )
+        end
       end
     end
 

--- a/spec/presenters/socure_error_presenter_spec.rb
+++ b/spec/presenters/socure_error_presenter_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe SocureErrorPresenter do
           expect(presenter.body_text).to eq(
             safe_join(
               [
-                I18n.t('doc_auth.errors.verify_passport_text_html'),
+                I18n.t('doc_auth.errors.verify_passport_text'),
                 link_to(
                   I18n.t('doc_auth.errors.verify.use_another_type_of_id'),
                   idv_choose_id_type_path,
@@ -123,7 +123,7 @@ RSpec.describe SocureErrorPresenter do
           expect(presenter.body_text).to eq(
             safe_join(
               [
-                I18n.t('doc_auth.errors.verify_drivers_license_text_html'),
+                I18n.t('doc_auth.errors.verify_drivers_license_text'),
                 link_to(
                   I18n.t('doc_auth.errors.verify.use_another_type_of_id'),
                   idv_choose_id_type_path,

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
 
       it 'has error messages' do
         expect(response.error_messages[:unexpected_id_type])
-          .to eq(I18n.t('doc_auth.errors.general.no_liveness'))
+          .to eq('drivers_license')
       end
     end
 
@@ -365,7 +365,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
 
       it 'has error messages' do
         expect(response.error_messages[:unexpected_id_type])
-          .to eq(I18n.t('doc_auth.errors.general.no_liveness'))
+          .to eq('passport')
       end
     end
   end

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -64,6 +64,56 @@ RSpec.describe DocAuth::Mock::ResultResponse do
     end
   end
 
+  context 'document_type_received does not match requested doc type' do
+    subject(:response) do
+      described_class.new(input, config, selfie_required:, passport_submittal:, passport_requested:)
+    end
+
+    context 'doc type requested is passport but document_type_received is drivers_license' do
+      let(:passport_submittal) { false }
+      let(:passport_requested) { true }
+      let(:input) do
+        <<~YAML
+          document:
+            first_name: Susan
+            last_name: Smith
+            middle_name: Q
+            document_type_received: drivers_license
+        YAML
+      end
+
+      it 'returns an error about the doc type mismatch' do
+        expect(response.success?).to eq(false)
+        expect(response.errors).to eq({ unexpected_id_type: true })
+      end
+    end
+
+    context 'doc type requested is drivers_license but document_type_received is passport' do
+      let(:passport_submittal) { true }
+      let(:passport_requested) { false }
+      let(:input) do
+        <<~YAML
+          document:
+            first_name: Susan
+            last_name: Smith
+            middle_name: Q
+            birth_place: 'Springfield, IL'
+            passport_expiration: '2030-01-01'
+            mrz: 'P<USASMITH<<SUSAN<<<<<<<<<<<<<<<<<<<<<<<<<1234567890USA8001019F2301012<<<<<<<<<<<<<<04'
+            passport_issued: '2020-01-01'
+            nationality_code: USA
+            document_number: '1234567890'
+            document_type_received: passport
+        YAML
+      end
+
+      it 'returns an error about the doc type mismatch' do
+        expect(response.success?).to eq(false)
+        expect(response.errors).to eq({ unexpected_id_type: true })
+      end
+    end
+  end
+
   context 'with a yaml file containing PII' do
     let(:input) do
       <<~YAML

--- a/spec/views/idv/socure/errors/show.html.erb_spec.rb
+++ b/spec/views/idv/socure/errors/show.html.erb_spec.rb
@@ -146,11 +146,14 @@ RSpec.describe 'idv/socure/errors/show.html.erb' do
 
     context 'when passport is not requested' do
       it 'shows correct h1' do
-        expect(rendered).to have_css('h1', text: t('doc_auth.errors.verify_drivers_license_heading'))
+        expect(rendered).to have_css(
+          'h1',
+          text: t('doc_auth.errors.verify_drivers_license_heading'),
+        )
       end
 
       it 'shows unexpected_id_type message' do
-        expect(rendered).to have_text(t('doc_auth.errors.verify_drivers_license_text_html'))
+        expect(rendered).to have_text(t('doc_auth.errors.verify_drivers_license_text'))
       end
     end
 
@@ -161,7 +164,7 @@ RSpec.describe 'idv/socure/errors/show.html.erb' do
       end
 
       it 'shows unexpected_id_type message' do
-        expect(rendered).to have_text(t('doc_auth.errors.verify_passport_text_html'))
+        expect(rendered).to have_text(t('doc_auth.errors.verify_passport_text'))
       end
     end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-16651](https://cm-jira.usa.gov/browse/LG-16651)



## 🛠 Summary of changes

Created new driver's license and passport flow error screens for the wrong ID type in the Lexis Nexis and Socure flows.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

For Mock/LexisNexis
- [ ] Go through the mock IdV flow and for choose your ID flow choose driver's license
- [ ] Upload `spec/fixtures/passport_credential.yml` in both front and back fields
- [ ] Verify that you are taken to an error screen that says "We couldn't verify your driver's license or State ID
- [ ] Restart IDV
- [ ] choose passport at the choose your ID page
- [ ] Upload `spec/fixturesial2_test_credential.yml` in the passport field
- [ ] Verify that you are taken to an error screen that says "We couldn't verify your passport'

For Socure
- [ ]  Setup application.yml for mock socure testing

> doc_auth_selfie_desktop_test_mode: true
  doc_auth_vendor: mock_socure
  doc_auth_vendor_default: mock_socure
  doc_auth_passport_vendor_default: socure
  socure_docv_enabled: true
  socure_idplus_api_key: 'nope-not-a-valid-key'
  socure_docv_webhook_secret_key: 'sekret-key'
- [ ] Go through Doc Auth (`RAILS_MAX_THREADS=3 make run`), at the choose your ID page select Driver's License
- [ ] Select 'Passport Pass JSON' option once at the mock socure page
- [ ] Verify that you are taken to an error screen that says "We couldn't verify your driver's license or State ID
- [ ] Restart IDV and choose Passport at the choose your ID page
- [ ]  Select 'License Pass JSON' option once at the mock socure page
- [ ] Verify that you are taken to an error screen that says "We couldn't verify your passport'



## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

Drivers License
<img width="624" height="965" alt="Screenshot 2025-10-01 at 7 28 32 PM" src="https://github.com/user-attachments/assets/1957a7e2-d76b-4c4c-9713-85f5743882c0" />

Passport
<img width="626" height="933" alt="Screenshot 2025-10-01 at 7 29 39 PM" src="https://github.com/user-attachments/assets/896f8373-5a7f-44fe-aa6a-4e13cde16b91" />



