### PR TITLE
LG-16803 Add issuing country code to pii bundle

### DIFF
--- a/app/services/pii/attributes.rb
+++ b/app/services/pii/attributes.rb
@@ -18,6 +18,8 @@ module Pii
     # the state in the state id address, which may not be the state that issued the ID
     :identity_doc_address_state,
     :ssn, :dob, :phone,
+    # The country the passport was issued in.
+    :issuing_country_code,
     *DEPRECATED_PII_ATTRIBUTES,
     keyword_init: true
   ) do

--- a/spec/controllers/idv/personal_key_controller_spec.rb
+++ b/spec/controllers/idv/personal_key_controller_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Idv::PersonalKeyController do
       state_id_issued
       state_id_number
       document_type_received
-      issuing_country_code
     ]
 
     profile_pii_pairs.each do |profile, pii|

--- a/spec/features/idv/doc_auth/idv_flow_spec.rb
+++ b/spec/features/idv/doc_auth/idv_flow_spec.rb
@@ -1,0 +1,276 @@
+require 'rails_helper'
+
+RSpec.describe 'Completing all IDV steps', :js, :allow_browser_log do
+  include IdvStepHelper
+  include InPersonHelper
+  include PassportApiHelpers
+
+  let(:user) { user_with_2fa }
+  let(:phone_number) { '2028675309' }
+  let(:fake_dos_api_endpoint) { 'http://fake_dos_api_endpoint/' }
+
+  before do
+    allow(IdentityConfig.store).to receive(:doc_auth_vendor).and_return(doc_auth_vendor)
+    allow(IdentityConfig.store).to receive(:doc_auth_vendor_default).and_return(doc_auth_vendor)
+    allow(IdentityConfig.store).to receive(:doc_auth_passport_vendor).and_return(doc_auth_vendor)
+    allow(IdentityConfig.store).to receive(:doc_auth_passport_vendor_default).and_return(
+      doc_auth_vendor,
+    )
+    allow(IdentityConfig.store).to receive(:doc_auth_vendor_switching_enabled).and_return(true)
+    allow(IdentityConfig.store).to receive(:dos_passport_mrz_endpoint)
+      .and_return(fake_dos_api_endpoint)
+    stub_health_check_settings
+    stub_health_check_endpoints_success
+    stub_request(:post, fake_dos_api_endpoint)
+      .to_return_json({ status: 200, body: { response: 'YES' } })
+  end
+
+  describe 'when doc auth vendor is "lexis_nexis"' do
+    let(:doc_auth_vendor) { 'lexis_nexis' }
+
+    before do
+      stub_request(:post, /.*\/restws\/identity\/v3\/accounts\/.*\/workflows\/.*\/conversations/)
+        .and_return(status: 200, body: doc_auth_response)
+    end
+
+    describe 'IDV State ID flow' do
+      let(:doc_auth_response) { LexisNexisFixtures.true_id_response_success }
+
+      scenario 'When the user completes all IDV steps' do
+        visit_idp_from_oidc_sp_with_ial2
+        sign_in_and_2fa_user(user)
+        visit idv_welcome_path
+        complete_welcome_step
+        complete_agreement_step
+        complete_hybrid_handoff_step
+        complete_choose_id_type_step
+        attach_images(Rails.root.join('spec', 'fixtures', 'doc_auth_images', 'id-front.jpg'))
+        submit_images
+        complete_ssn_step
+        complete_verify_step
+        fill_out_phone_form_ok(phone_number)
+        verify_phone_otp
+        complete_enter_password_step(user)
+
+        expect(page).to have_current_path(idv_personal_key_path)
+
+        profile = user.profiles.last
+
+        expect(profile.active).to be(true)
+        expect(profile.decrypt_pii(user.password)).to have_attributes(
+          first_name: 'LICENSE',
+          middle_name: nil,
+          last_name: 'SAMPLE',
+          dob: '1966-05-05',
+          ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
+          phone: phone_number,
+          address1: '123 ABC AVE',
+          address2: 'APT 3E',
+          city: 'ANYTOWN',
+          state: 'NY',
+          zipcode: '12345',
+          same_address_as_id: nil,
+          identity_doc_address1: nil,
+          identity_doc_address2: nil,
+          identity_doc_city: nil,
+          identity_doc_zipcode: nil,
+          identity_doc_address_state: nil,
+          state_id_jurisdiction: 'NY',
+          issuing_country_code: nil,
+        )
+      end
+    end
+
+    describe 'IDV Passport Flow' do
+      let(:address1) { '123 Main St' }
+      let(:city) { 'Anywhere' }
+      let(:state_abbr) { 'VA' }
+      let(:state) { 'Virginia' }
+      let(:zipcode) { '66044' }
+      let(:fake_dos_api_endpoint) { 'http://fake_dos_api_endpoint/' }
+      let(:doc_auth_response) { LexisNexisFixtures.true_id_response_passport_without_tamper }
+
+      before do
+      end
+
+      scenario 'When the user completes all IDV steps' do
+        visit_idp_from_oidc_sp_with_ial2
+        sign_in_and_2fa_user(user)
+        visit idv_welcome_path
+        complete_welcome_step
+        complete_agreement_step
+        complete_hybrid_handoff_step
+        complete_choose_id_type_step(choose_id_type: 'passport')
+        attach_passport_image(
+          Rails.root.join('spec', 'fixtures', 'doc_auth_images', 'passport.jpg'),
+        )
+        submit_images
+        complete_ssn_step
+        fill_in 'idv_form_address1', with: address1
+        fill_in 'idv_form_city', with: city
+        select state, from: 'idv_form_state'
+        fill_in 'idv_form_zipcode', with: zipcode
+        click_idv_continue
+        complete_verify_step
+        fill_out_phone_form_ok(phone_number)
+        verify_phone_otp
+        complete_enter_password_step(user)
+
+        expect(page).to have_current_path(idv_personal_key_path)
+
+        profile = user.profiles.last
+
+        expect(profile.active).to be(true)
+        expect(profile.decrypt_pii(user.password)).to have_attributes(
+          first_name: 'DAVID',
+          middle_name: 'PASSPORT',
+          last_name: 'SAMPLE',
+          dob: '1986-07-01',
+          ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
+          phone: phone_number,
+          address1:,
+          address2: '',
+          city:,
+          state: state_abbr,
+          zipcode:,
+          same_address_as_id: nil,
+          identity_doc_address1: nil,
+          identity_doc_address2: nil,
+          identity_doc_city: nil,
+          identity_doc_zipcode: nil,
+          identity_doc_address_state: nil,
+          state_id_jurisdiction: nil,
+          issuing_country_code: 'USA',
+        )
+      end
+    end
+  end
+
+  describe 'when doc auth vendor is "socure"' do
+    let(:doc_auth_vendor) { 'socure' }
+    let(:socure_docv_webhook_secret_key) { 'socure_docv_webhook_secret_key' }
+    let(:fake_socure_docv_document_request_endpoint) { 'https://fake-socure.test/document-request' }
+
+    before do
+      allow(IdentityConfig.store).to receive(:socure_docv_enabled).and_return(true)
+      allow(IdentityConfig.store).to receive(:socure_docv_webhook_secret_key)
+        .and_return(socure_docv_webhook_secret_key)
+      allow(IdentityConfig.store).to receive(:socure_docv_document_request_endpoint)
+        .and_return(fake_socure_docv_document_request_endpoint)
+      allow(IdentityConfig.store).to receive(:ruby_workers_idv_enabled).and_return(false)
+      @docv_transaction_token = stub_docv_document_request(user:)
+      stub_request(:post, /.*\/api\/3.0\/EmailAuthScore/)
+        .and_return(status: 200, body: doc_auth_response)
+    end
+
+    describe 'IDV State ID flow' do
+      let(:doc_auth_response) { SocureDocvFixtures.pass_json }
+
+      scenario 'When the user completes all IDV steps' do
+        visit_idp_from_oidc_sp_with_ial2
+        sign_in_and_2fa_user(user)
+        visit idv_welcome_path
+        complete_welcome_step
+        complete_agreement_step
+        complete_hybrid_handoff_step
+        complete_choose_id_type_step
+        visit idv_socure_document_capture_path
+        expect(page).to have_current_path(idv_socure_document_capture_path)
+        socure_docv_upload_documents(docv_transaction_token: @docv_transaction_token)
+        visit idv_socure_document_capture_update_path
+        complete_ssn_step
+        complete_verify_step
+        fill_out_phone_form_ok(phone_number)
+        verify_phone_otp
+        complete_enter_password_step(user)
+
+        expect(page).to have_current_path(idv_personal_key_path)
+
+        profile = user.profiles.last
+
+        expect(profile.active).to be(true)
+        expect(profile.decrypt_pii(user.password)).to have_attributes(
+          first_name: 'Dwayne',
+          middle_name: nil,
+          last_name: 'Denver',
+          dob: '2002-01-01',
+          ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
+          phone: phone_number,
+          address1: '123 Example Street',
+          address2: 'New York City NY 10001',
+          city: 'New York City',
+          state: 'NY',
+          zipcode: '10001',
+          same_address_as_id: nil,
+          identity_doc_address1: nil,
+          identity_doc_address2: nil,
+          identity_doc_city: nil,
+          identity_doc_zipcode: nil,
+          identity_doc_address_state: nil,
+          state_id_jurisdiction: 'NY',
+          issuing_country_code: 'USA',
+        )
+      end
+    end
+
+    describe 'IDV Passport flow' do
+      let(:address1) { '123 Main St' }
+      let(:city) { 'Anywhere' }
+      let(:state_abbr) { 'VA' }
+      let(:state) { 'Virginia' }
+      let(:zipcode) { '66044' }
+      let(:doc_auth_response) { SocureDocvFixtures.pass_json(document_type: :passport) }
+
+      scenario 'When the user completes all IDV steps' do
+        visit_idp_from_oidc_sp_with_ial2
+        sign_in_and_2fa_user(user)
+        visit idv_welcome_path
+        complete_welcome_step
+        complete_agreement_step
+        complete_hybrid_handoff_step
+        complete_choose_id_type_step(choose_id_type: 'passport')
+        visit idv_socure_document_capture_path
+        expect(page).to have_current_path(idv_socure_document_capture_path)
+        socure_docv_upload_documents(docv_transaction_token: @docv_transaction_token)
+        visit idv_socure_document_capture_update_path
+        complete_ssn_step
+        fill_in 'idv_form_address1', with: address1
+        fill_in 'idv_form_city', with: city
+        select state, from: 'idv_form_state'
+        fill_in 'idv_form_zipcode', with: zipcode
+        click_idv_continue
+        complete_verify_step
+        fill_out_phone_form_ok(phone_number)
+        verify_phone_otp
+        complete_enter_password_step(user)
+
+        expect(page).to have_current_path(idv_personal_key_path)
+
+        profile = user.profiles.last
+
+        expect(profile.active).to be(true)
+        expect(profile.decrypt_pii(user.password)).to have_attributes(
+          first_name: 'DWAYNE',
+          middle_name: nil,
+          last_name: 'DENVER',
+          dob: '1965-02-05',
+          ssn: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN[:ssn],
+          phone: phone_number,
+          address1:,
+          address2: '',
+          city:,
+          state: state_abbr,
+          zipcode:,
+          same_address_as_id: nil,
+          identity_doc_address1: nil,
+          identity_doc_address2: nil,
+          identity_doc_city: nil,
+          identity_doc_zipcode: nil,
+          identity_doc_address_state: nil,
+          state_id_jurisdiction: nil,
+          issuing_country_code: 'USA',
+        )
+      end
+    end
+  end
+end

--- a/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_passport_without_tamper.json
+++ b/spec/fixtures/proofing/lexis_nexis/true_id/true_id_response_success_passport_without_tamper.json
@@ -1,0 +1,1022 @@
+{
+  "Status": {
+    "ConversationId": "70000300394121",
+    "RequestId": "614507871",
+    "TransactionStatus": "passed",
+    "TransactionReasonCode": {
+      "Code": "trueid_pass",
+      "Description": "TRUEID PASS"
+    },
+    "Reference": "ca6e36c4-8a55-4831-aa8a-38d78b7c80e3"
+  },
+  "Products": [
+    {
+      "ProductType": "TrueID",
+      "ExecutedStepName": "True_ID_Step",
+      "ProductConfigurationName": "GSA2.V3.TrueID.CROP.PT.test",
+      "ProductStatus": "pass",
+      "ParameterDetails": [
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocumentName",
+          "Values": [{ "Value": "United States (USA) Passport - STAR" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocAuthResult",
+          "Values": [{ "Value": "Passed" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssuerCode",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssuerName",
+          "Values": [{ "Value": "United States" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssuerType",
+          "Values": [{ "Value": "Country" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocClassCode",
+          "Values": [{ "Value": "Passport" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocClass",
+          "Values": [{ "Value": "Passport" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocClassName",
+          "Values": [{ "Value": "Passport" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIsGeneric",
+          "Values": [{ "Value": "false" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssue",
+          "Values": [{ "Value": "2016" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocIssueType",
+          "Values": [{ "Value": "Passport - STAR" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DocSize",
+          "Values": [{ "Value": "ID1" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ClassificationMode",
+          "Values": [{ "Value": "Automatic" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "OrientationChanged",
+          "Values": [{ "Value": "true" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "PresentationChanged",
+          "Values": [{ "Value": "false" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "Side",
+          "Values": [{ "Value": "Front" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "GlareMetric",
+          "Values": [{ "Value": "100" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "SharpnessMetric",
+          "Values": [{ "Value": "65" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "IsTampered",
+          "Values": [{ "Value": "0" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "IsCropped",
+          "Values": [{ "Value": "1" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "HorizontalResolution",
+          "Values": [{ "Value": "600" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "VerticalResolution",
+          "Values": [{ "Value": "600" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "Light",
+          "Values": [{ "Value": "White" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "MimeType",
+          "Values": [{ "Value": "image/vnd.ms-photo" }]
+        },
+        {
+          "Group": "IMAGE_METRICS_RESULT",
+          "Name": "ImageMetrics_Id",
+          "Values": [{ "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "FullName",
+          "Values": [{ "Value": "DAVID LICENSE SAMPLE" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Sex",
+          "Values": [{ "Value": "Male" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DOB_Year",
+          "Values": [{ "Value": "1985" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DOB_Month",
+          "Values": [{ "Value": "7" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "DOB_Day",
+          "Values": [{ "Value": "1" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ExpirationDate_Year",
+          "Values": [{ "Value": "2099" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ExpirationDate_Month",
+          "Values": [{ "Value": "10" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "ExpirationDate_Day",
+          "Values": [{ "Value": "15" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_1_AlertName",
+          "Values": [{ "Value": "Document Expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_4_AlertName",
+          "Values": [{ "Value": "2D Barcode Content" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_5_AlertName",
+          "Values": [{ "Value": "2D Barcode Read" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_6_AlertName",
+          "Values": [{ "Value": "Barcode Encoding" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_7_AlertName",
+          "Values": [{ "Value": "Birth Date Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_8_AlertName",
+          "Values": [{ "Value": "Birth Date Valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_9_AlertName",
+          "Values": [{ "Value": "Document Classification" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_10_AlertName",
+          "Values": [{ "Value": "Document Crosscheck Aggregation" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_11_AlertName",
+          "Values": [{ "Value": "Document Number Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_AlertName",
+          "Values": [{ "Value": "Document Tampering Detection" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_15_AlertName",
+          "Values": [{ "Value": "Expiration Date Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_16_AlertName",
+          "Values": [{ "Value": "Expiration Date Valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_17_AlertName",
+          "Values": [{ "Value": "Full Name Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_18_AlertName",
+          "Values": [{ "Value": "Issue Date Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_19_AlertName",
+          "Values": [{ "Value": "Issue Date Valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_20_AlertName",
+          "Values": [{ "Value": "Series Expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_21_AlertName",
+          "Values": [{ "Value": "Sex Crosscheck" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_AlertName",
+          "Values": [{ "Value": "Visible Pattern" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Model",
+          "Values": [{ "Value": "Text Tampering Detection V1.3.1 (Beta)" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Model",
+          "Values": [{ "Value": "Photo Tampering Detection V2.4" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Model",
+          "Values": [{ "Value": "Text Tampering Detection V1.2.1" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_Model",
+          "Values": [{ "Value": "Physical Document Presence V2.5" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_1_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Checked if the document is expired."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_4_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Checked the contents of the two-dimensional barcode on the document."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_5_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Attention",
+              "Detail": "Verified that the two-dimensional barcode on the document was read successfully."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_6_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the format of the barcode."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_7_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable birth date field to the human-readable birth date field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_8_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the birth date is valid."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_9_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the type of document is supported and is able to be fully authenticated."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_10_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compared the machine-readable fields to the human-readable fields."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_11_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable document number field to the human-readable document number field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Examines a document for evidence of tampering"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_15_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable expiration date field to the human-readable expiration date field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_16_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the expiration date is valid."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_17_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable full name field to the human-readable full name field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_18_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable issue date field to the human-readable issue date field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_19_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified that the issue date is valid."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_20_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified whether the document type is still in circulation."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_21_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Compare the machine-readable sex field to the human-readable sex field."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_AuthenticationResult",
+          "Values": [
+            {
+              "Value": "Passed",
+              "Detail": "Verified the presence of a pattern on the visible image."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_1_Disposition",
+          "Values": [{ "Value": "The document has expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_Disposition",
+          "Values": [{ "Value": "A visible pattern was not found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Disposition",
+          "Values": [
+            {
+              "Value": "Evidence suggests that the document may have been tampered with."
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_4_Disposition",
+          "Values": [{ "Value": "The 2D barcode is formatted correctly" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_5_Disposition",
+          "Values": [{ "Value": "The 2D barcode was read successfully" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_6_Disposition",
+          "Values": [
+            {
+              "Value": "The barcode encoding is consistent with the expected encoding for the type"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_7_Disposition",
+          "Values": [{ "Value": "The birth dates match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_8_Disposition",
+          "Values": [{ "Value": "The birth date is valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_9_Disposition",
+          "Values": [{ "Value": "The document type is supported" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_10_Disposition",
+          "Values": [
+            {
+              "Value": "There are not a large number of differences between electronic and human-readable data sources"
+            }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_11_Disposition",
+          "Values": [{ "Value": "The document numbers match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Disposition",
+          "Values": [{ "Value": "No evidence of document tampering was detected." }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Disposition",
+          "Values": [{ "Value": "No evidence of document tampering was detected." }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_14_Disposition",
+          "Values": [{ "Value": "No evidence of document tampering was detected." }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_15_Disposition",
+          "Values": [{ "Value": "The expiration dates match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_16_Disposition",
+          "Values": [{ "Value": "The expiration date is valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_17_Disposition",
+          "Values": [{ "Value": "The full names match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_18_Disposition",
+          "Values": [{ "Value": "The issue dates match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_19_Disposition",
+          "Values": [{ "Value": "The issue date is valid" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_20_Disposition",
+          "Values": [{ "Value": "The series has not expired" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_21_Disposition",
+          "Values": [{ "Value": "The sexes match" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_Disposition",
+          "Values": [{ "Value": "A visible pattern was found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_Disposition",
+          "Values": [{ "Value": "A visible pattern was found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_Disposition",
+          "Values": [{ "Value": "A visible pattern was found" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_Regions",
+          "Values": [{ "Value": "Background" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Regions",
+          "Values": [
+            { "Value": "Birth Date" },
+            { "Value": "Document Number" },
+            { "Value": "Expiration Date" },
+            { "Value": "Full Name" },
+            { "Value": "Issue Date" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Regions",
+          "Values": [{ "Value": "Photo" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Regions",
+          "Values": [
+            { "Value": "Birth Date" },
+            { "Value": "Document Number" },
+            { "Value": "Expiration Date" },
+            { "Value": "Full Name" },
+            { "Value": "Issue Date" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_Regions",
+          "Values": [{ "Value": "Expires Label" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_Regions",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_Regions",
+          "Values": [{ "Value": "Background Upper" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_2_Regions_Reference",
+          "Values": [{ "Value": "faacfb79-d0a1-4a8e-b868-20c604988e84" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_3_Regions_Reference",
+          "Values": [
+            { "Value": "c8be94b6-78ac-4e85-88cb-e17880371e4a" },
+            { "Value": "a8226d92-e62c-42a3-a206-ab7c3e3d9796" },
+            { "Value": "c2e18c41-e3de-46a8-abc7-3412015a6cef" },
+            { "Value": "80f8f290-daa0-47e2-828e-52106bb26f31" },
+            { "Value": "2c74b850-dd89-41bb-a21c-70ae0563ef77" },
+            { "Value": "63bf5053-f81f-493f-aff0-33c07d07a894" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_12_Regions_Reference",
+          "Values": [{ "Value": "f29b1fe5-6482-4b39-8b4a-d91caf4ecb57" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_13_Regions_Reference",
+          "Values": [
+            { "Value": "c8be94b6-78ac-4e85-88cb-e17880371e4a" },
+            { "Value": "a8226d92-e62c-42a3-a206-ab7c3e3d9796" },
+            { "Value": "c2e18c41-e3de-46a8-abc7-3412015a6cef" },
+            { "Value": "80f8f290-daa0-47e2-828e-52106bb26f31" },
+            { "Value": "2c74b850-dd89-41bb-a21c-70ae0563ef77" },
+            { "Value": "63bf5053-f81f-493f-aff0-33c07d07a894" }
+          ]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_22_Regions_Reference",
+          "Values": [{ "Value": "d55f2c66-f84f-4213-a660-4ff9e5d0fde5" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_23_Regions_Reference",
+          "Values": [{ "Value": "bbf6ba02-ee3f-4b5c-a5d0-2fdb39ac79f7" }]
+        },
+        {
+          "Group": "AUTHENTICATION_RESULT",
+          "Name": "Alert_24_Regions_Reference",
+          "Values": [{ "Value": "20203cb8-f8a4-4a5b-999f-3700f73fe4fe" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_FullName",
+          "Values": [{ "Value": "DAVID PASSPORT SAMPLE" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_Surname",
+          "Values": [{ "Value": "SAMPLE" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_GivenName",
+          "Values": [{ "Value": "DAVID PASSPORT" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_FirstName",
+          "Values": [{ "Value": "DAVID" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_MiddleName",
+          "Values": [{ "Value": "PASSPORT" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DOB_Year",
+          "Values": [{ "Value": "1986" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DOB_Month",
+          "Values": [{ "Value": "7" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DOB_Day",
+          "Values": [{ "Value": "1" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DocumentClassName",
+          "Values": [{ "Value": "Passport" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_DocumentNumber",
+          "Values": [{ "Value": "Z12345678" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_ExpirationDate_Year",
+          "Values": [{ "Value": "2099" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_ExpirationDate_Month",
+          "Values": [{ "Value": "10" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_xpirationDate_Day",
+          "Values": [{ "Value": "15" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssuingStateCode",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssuingStateName",
+          "Values": [{ "Value": "United States" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_CountryCode",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssueDate_Year",
+          "Values": [{ "Value": "2016" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssueDate_Month",
+          "Values": [{ "Value": "10" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_IssueDate_Day",
+          "Values": [{ "Value": "15" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_MRZ",
+          "Values": [
+            {
+              "Value": "P<UTOSAMPLE<<COMPANY<<<<<<<<<<<<<<<<<<<<<<<<ACU1234P<5UTO0003067F4003065<<<<<<<<<<<<<<02"
+            }
+          ]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_BirthPlace",
+          "Values": [{ "Value": "MY CITY. U.S.A." }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_NationalityCode",
+          "Values": [{ "Value": "USA" }]
+        },
+        {
+          "Group": "IDAUTH_FIELD_DATA",
+          "Name": "Fields_PersonalNumber",
+          "Values": [{ "Value": "3067F400 3065" }]
+        },
+        {
+          "Group": "DOCUMENT_REGION",
+          "Name": "DocumentRegion_Id",
+          "Values": [
+            { "Value": "ce2cf0e2-5373-4ec2-84e8-7fe44a01642b" },
+            { "Value": "0b4f4f2b-cbd6-43e9-ac67-55bf2bdd9df5" },
+            { "Value": "c8be94b6-78ac-4e85-88cb-e17880371e4a" },
+            { "Value": "a0fdf00c-071c-4d8e-81af-8af0fc7688b8" },
+            { "Value": "faacfb79-d0a1-4a8e-b868-20c604988e84" },
+            { "Value": "3362ad4b-a36b-487e-826c-c748c7b04e8d" },
+            { "Value": "20203cb8-f8a4-4a5b-999f-3700f73fe4fe" },
+            { "Value": "a8226d92-e62c-42a3-a206-ab7c3e3d9796" },
+            { "Value": "a3e3a625-8b0e-4deb-a91e-86afc55d036b" },
+            { "Value": "cda4092d-9208-4871-bbc1-1b732c299d26" },
+            { "Value": "42770baf-3a4a-4477-9e5f-4400237273fe" },
+            { "Value": "c2e18c41-e3de-46a8-abc7-3412015a6cef" },
+            { "Value": "b36594f2-d19c-48aa-98c2-2b4f8429744f" },
+            { "Value": "80f8f290-daa0-47e2-828e-52106bb26f31" },
+            { "Value": "d55f2c66-f84f-4213-a660-4ff9e5d0fde5" },
+            { "Value": "26ca0c85-01ab-4311-bfd5-d27d2ee975eb" },
+            { "Value": "0af79f76-1542-4391-ad17-a5d6169be57f" },
+            { "Value": "2c74b850-dd89-41bb-a21c-70ae0563ef77" },
+            { "Value": "64e8ee97-2b24-452d-a5af-1627951aa737" },
+            { "Value": "63bf5053-f81f-493f-aff0-33c07d07a894" },
+            { "Value": "f29b1fe5-6482-4b39-8b4a-d91caf4ecb57" },
+            { "Value": "35442fb1-c3bb-4f2f-ad9e-537a8f0e7e0f" },
+            { "Value": "29964031-e072-4204-a9ae-b2b7122bfdc1" },
+            { "Value": "a3bbdf8b-62f5-438f-bf72-091bb2f6f0ff" },
+            { "Value": "42d0c49e-fc7a-45da-8f6d-8896c4b5267f" },
+            { "Value": "5430efcb-523b-4c62-a190-e9aa7eea4ebd" },
+            { "Value": "bbf6ba02-ee3f-4b5c-a5d0-2fdb39ac79f7" },
+            { "Value": "0686341c-0b3f-4544-840e-58822120ef06" }
+          ]
+        },
+        {
+          "Group": "DOCUMENT_REGION",
+          "Name": "DocumentRegion_Key",
+          "Values": [
+            { "Value": "1D Barcode" },
+            { "Value": "2D Barcode" },
+            { "Value": "Alaska Validator" },
+            { "Value": "Background" },
+            { "Value": "Background Lower" },
+            { "Value": "Background Upper" },
+            { "Value": "Birth Date" },
+            { "Value": "Birth Place" },
+            { "Value": "DOB Label" },
+            { "Value": "DOB Label Text" },
+            { "Value": "Document Number" },
+            { "Value": "Document Type" },
+            { "Value": "Expiration Date" },
+            { "Value": "Expires Label" },
+            { "Value": "Expires Label Position" },
+            { "Value": "Full Name" },
+            { "Value": "Issue Date" },
+            { "Value": "Photo" },
+            { "Value": "Photo Printing" },
+            { "Value": "Secondary Photo" },
+            { "Value": "Sex" },
+            { "Value": "Signature" },
+            { "Value": "USA" },
+            { "Value": "Weight" }
+          ]
+        },
+        {
+          "Group": "DOCUMENT_REGION",
+          "Name": "DocumentRegion_ImageReference",
+          "Values": [
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "637aa4c6-eeb3-453f-899e-a56effcf3747" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" },
+            { "Value": "8a19313b-5dc6-4113-85f5-42c9829d903e" }
+          ]
+        }
+      ]
+    },
+    {
+      "ProductType": "TrueID_Decision",
+      "ExecutedStepName": "Decision",
+      "ProductConfigurationName": "TRUEID_PASS",
+      "ProductStatus": "pass",
+      "ProductReason": {
+        "Code": "trueid_pass",
+        "Description": "TRUEID PASS"
+      }
+    }
+  ]
+}

--- a/spec/support/lexis_nexis_fixtures.rb
+++ b/spec/support/lexis_nexis_fixtures.rb
@@ -188,6 +188,10 @@ module LexisNexisFixtures
       read_fixture_file_at_path('true_id/true_id_response_success_passport_card.json')
     end
 
+    def true_id_response_passport_without_tamper
+      read_fixture_file_at_path('true_id/true_id_response_success_passport_without_tamper.json')
+    end
+
     def true_id_response_success_with_liveness
       read_fixture_file_at_path('true_id/true_id_response_success_with_liveness.json')
     end


### PR DESCRIPTION
changelog: Internal, IDV, Add issuing country code to pii bundle

## 🎫 Ticket

Link to the relevant ticket:
[LG-16803](https://cm-jira.usa.gov/browse/LG-16803)

## 🛠 Summary of changes

Add issuing country code to pii bundle.


## 📜 Testing Plan

- [ ] Feature specs passing

Manual Testing:

Scenario: Passport
- [ ] Create an account go through remote IdV flow
- [ ] Complete up to enter password for Passport Flow
- [ ] Set a break point on before app/services/idv/profile_maker.rb:30
- [ ] Ensure issuing_country_code is set in the `pii_attributes` variable
- [ ] Continue and ensure IdV can be completed
