### PR TITLE
LG-16675: Prevent suspended user attempts to go through SP 

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -26,6 +26,7 @@ module OpenidConnect
     before_action :confirm_two_factor_authenticated, only: :index
     before_action :redirect_to_reauthenticate, only: :index, if: :remember_device_expired_for_sp?
     before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: [:index]
+    before_action :confirm_user_is_not_suspended, only: :index
 
     def index
       if resolved_authn_context_result.identity_proofing?
@@ -275,6 +276,10 @@ module OpenidConnect
 
       (params[:acr_values].split - Saml::Idp::Constants::VALID_AUTHN_CONTEXTS)
         .join(' ').presence
+    end
+
+    def confirm_user_is_not_suspended
+      redirect_to user_please_call_url if current_user.suspended?
     end
   end
 end

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -31,6 +31,7 @@ class SamlIdpController < ApplicationController
   before_action :confirm_two_factor_authenticated, only: :auth
   before_action :redirect_to_reauthenticate, only: :auth, if: :remember_device_expired_for_sp?
   before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: :auth
+  before_action :confirm_user_is_not_suspended, only: :auth
 
   def auth
     capture_analytics
@@ -269,5 +270,9 @@ class SamlIdpController < ApplicationController
 
   def req_attrs_regexp
     Regexp.escape(Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF)
+  end
+
+  def confirm_user_is_not_suspended
+    redirect_to user_please_call_url if current_user.suspended?
   end
 end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -2269,6 +2269,34 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
       end
     end
+
+    context 'user is suspended' do
+      let(:user) { create(:user, :fully_registered, :suspended) }
+      let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
+      let(:vtr) { nil }
+      let(:sign_in_flow) { :sign_in }
+
+      context 'user is signed in' do
+        before do
+          stub_sign_in user
+          session[:sign_in_flow] = sign_in_flow
+          session[:sign_in_page_visited_at] = Time.zone.now.to_s
+        end
+
+        it 'redirects to the please call page if the user is signed in and suspended' do
+          sign_in_as_user(user)
+          action
+          expect(response).to redirect_to(user_please_call_url)
+        end
+      end
+
+      context 'user not signed in' do
+        it 'redirects to sign in page' do
+          action
+          expect(response).to redirect_to(new_user_session_url)
+        end
+      end
+    end
   end
 end
 # rubocop:enable Layout/LineLength

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2195,6 +2195,25 @@ RSpec.describe SamlIdpController do
       end
     end
 
+    context 'User is suspended' do
+      let(:user) { create(:user, :fully_registered, :suspended) }
+      let(:acr_values) do
+        Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF +
+          ' ' +
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+      end
+
+      before do
+        sign_in(user)
+        stub_analytics
+      end
+
+      it 'renders the please call for suspended user page' do
+        saml_get_auth(saml_settings)
+        expect(response).to redirect_to(user_please_call_url)
+      end
+    end
+
     describe 'NameID format' do
       let(:user) { create(:user, :fully_registered) }
       let(:subject_element) { xmldoc.subject_nodeset[0] }


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-16675](https://cm-jira.usa.gov/browse/LG-16675)

## 🛠 Summary of changes

Makes it so users cannot bypass suspension by trying to request SP sign in a secodn time. 


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- Sign in with suspended user
- See please call page
- Go back to sp 
- Click sign in from SP
- expect to be redirected to please call url instead of success login. 

