### PR TITLE
[LG-16741] Fix last logged in on duplicate profile page

### DIFF
--- a/app/presenters/duplicate_profiles_detected_presenter.rb
+++ b/app/presenters/duplicate_profiles_detected_presenter.rb
@@ -20,7 +20,7 @@ class DuplicateProfilesDetectedPresenter
       dupe_user = profile.user
       sp_identity = ServiceProviderIdentity.find_by(
         user_id: dupe_user.id,
-        service_provider: profile.initiating_service_provider_issuer,
+        service_provider: duplicate_profile_set.service_provider,
       )
       email = dupe_user.last_sign_in_email_address.email
       {

--- a/app/presenters/duplicate_profiles_detected_presenter.rb
+++ b/app/presenters/duplicate_profiles_detected_presenter.rb
@@ -18,11 +18,15 @@ class DuplicateProfilesDetectedPresenter
     profiles = Profile.where(id: duplicate_profile_set.profile_ids)
     profiles.map do |profile|
       dupe_user = profile.user
+      sp_identity = ServiceProviderIdentity.find_by(
+        user_id: dupe_user.id,
+        service_provider: profile.initiating_service_provider_issuer,
+      )
       email = dupe_user.last_sign_in_email_address.email
       {
         email: email,
         masked_email: EmailMasker.mask(email),
-        last_sign_in: dupe_user.last_sign_in_email_address.last_sign_in_at,
+        last_sign_in: sp_identity&.last_authenticated_at,
         created_at: dupe_user.created_at,
         connected_accts: user.connected_apps.count,
         current_account: dupe_user.id == user.id,

--- a/spec/presenters/duplicate_profiles_detected_presenter_spec.rb
+++ b/spec/presenters/duplicate_profiles_detected_presenter_spec.rb
@@ -2,12 +2,11 @@ require 'rails_helper'
 
 RSpec.describe DuplicateProfilesDetectedPresenter do
   let(:user) { create(:user, :proofed_with_selfie) }
-  let(:sp) { create(:service_provider) }
   let(:duplicate_profile_set) do
     create(
       :duplicate_profile_set,
       profile_ids: [user.active_profile.id, profile2.id],
-      service_provider: sp,
+      service_provider: 'test-sp',
     )
   end
   let(:presenter) { described_class.new(user: user, duplicate_profile_set: duplicate_profile_set) }

--- a/spec/presenters/duplicate_profiles_detected_presenter_spec.rb
+++ b/spec/presenters/duplicate_profiles_detected_presenter_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 RSpec.describe DuplicateProfilesDetectedPresenter do
   let(:user) { create(:user, :proofed_with_selfie) }
+  let(:sp) { create(:service_provider) }
   let(:duplicate_profile_set) do
     create(
       :duplicate_profile_set,
       profile_ids: [user.active_profile.id, profile2.id],
-      service_provider: 'test-sp',
+      service_provider: sp,
     )
   end
   let(:presenter) { described_class.new(user: user, duplicate_profile_set: duplicate_profile_set) }


### PR DESCRIPTION


<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-16741](https://cm-jira.usa.gov/browse/LG-16741)

## 🛠 Summary of changes

We were previously populating the 'last logged in' field, displayed on the duplicate profile page, with the `last_signed_in` on from the `EmailAddress` model.  It is inaccurate for a few reasons so we updated it to be populated with `last_authenticated_at` from the `ServiceProviderIdentity`.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1: Recreate duplicate account scenario by creating two accounts and signing into a SP requiring Facial Match
- [ ] Step 2: You will be redirected to a duplicate accounts page as shown in the image below
- [ ] Step 3: You should see the last login date populated


## 👀 Screenshots

<img width="509" height="418" alt="Screenshot 2025-10-03 at 12 58 59 PM" src="https://github.com/user-attachments/assets/089ffdfd-9dcd-4d35-a8cb-3794561c87f1" />


