### PR TITLE
Add guard for if a sp does not exist in a SAML request

### DIFF
--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -157,6 +157,8 @@ class SamlIdpController < ApplicationController
   end
 
   def matching_cert_serial
+    return if saml_request_service_provider.blank?
+
     saml_request.matching_cert&.serial&.to_s
   rescue SamlIdp::XMLSecurity::SignedDocument::ValidationError
     nil

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2070,6 +2070,7 @@ RSpec.describe SamlIdpController do
       end
 
       before do
+        allow_any_instance_of(Saml::XML::Document).to receive(:signed?).and_return true
         IdentityLinker.new(user, service_provider).link_identity
         user.identities.last.update!(verified_attributes: ['email'])
         expect(CGI).to receive(:unescape).and_return deflated_encoded_req
@@ -2087,7 +2088,7 @@ RSpec.describe SamlIdpController do
           requested_nameid_format: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
           authn_context: [],
           authn_context_comparison: 'exact',
-          request_signed: false,
+          request_signed: true,
           requested_ial: 'none',
           endpoint: "/api/saml/auth#{path_year}",
           idv: false,


### PR DESCRIPTION
A [new error](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&duration=43200000&filters=selectedInstance%20IN%20%28%29&state=ca64c275-bb91-0db2-fcba-c983e389d5ee) has sprouted up since [this PR adding user-facing errors to the SAML flow](https://github.com/18F/identity-idp/commit/2da2b127cc24759d65d834b17148c6d17ee903e7) was deployed.

The specs did not catch it because it's fairly difficult to fake a bad SAML request; in order to get it to trigger, we need to mock out the `signed?` method to return `true`, even though our fake SAML request is not actually signed.

## 🛠 Summary of changes
- Updates spec to reproduce error
- Fixes error

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
