### PR TITLE
LG-16699 Fix inconsistent passport error messages in IAL2 flow

### DIFF
--- a/app/javascript/packages/document-capture/components/documents-step.tsx
+++ b/app/javascript/packages/document-capture/components/documents-step.tsx
@@ -50,7 +50,14 @@ export function DocumentsCaptureStep({
 
 export function DocumentCaptureSubheaderOne() {
   const { t } = useI18n();
-  return <h1>{t('doc_auth.headings.document_capture')}</h1>;
+  const { idType } = useContext(UploadContext);
+  const idIsPassport = idType === 'passport';
+
+  const heading = idIsPassport
+    ? t('doc_auth.headings.passport_capture')
+    : t('doc_auth.headings.document_capture');
+
+  return <h1>{heading}</h1>;
 }
 
 export default function DocumentsStep({

--- a/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
+++ b/spec/javascript/packages/document-capture/components/documents-step-spec.tsx
@@ -174,4 +174,27 @@ describe('document-capture/components/documents-step', () => {
     expect(back).to.be.ok();
     expect(pageHeader).to.be.ok();
   });
+
+  it('renders passport heading when idType is passport', () => {
+    const { getByRole } = render(
+      <UploadContextProvider flowPath="standard" endpoint="unused" idType="passport">
+        <DocumentsStep
+          value={{}}
+          onChange={() => undefined}
+          errors={[]}
+          onError={() => undefined}
+          registerField={() => undefined}
+          unknownFieldErrors={[]}
+          toPreviousStep={() => undefined}
+        />
+      </UploadContextProvider>,
+    );
+
+    const pageHeader = getByRole('heading', {
+      name: 'doc_auth.headings.passport_capture',
+      level: 1,
+    });
+
+    expect(pageHeader).to.be.ok();
+  });
 });


### PR DESCRIPTION
changelog: User-Facing Improvements, LN IAL2 Passport Flow, Fix inconsistent error messaging to show correct ID type in headings

Link to the relevant ticket:
[LG-16699](https://cm-jira.usa.gov/browse/LG-16699)

## 🛠 Summary of changes

Fixed the passport error page to show the correct heading. Before, it said **"Add photos of your driver's license or state ID card"** even when the user was uploading a passport. Now it correctly says **"Add a photo of your passport"** for passport flows.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
- [ ] Start IAL2 passport flow with selfie enabled
- [ ] Upload a bad passport fixture to trigger an error (spec/fixtures/passport_bad_mrz_credential.yml)
- [ ] Confirm the H1 heading says "Add a photo of your passport" instead of referencing driver's license
- [ ] Run the test

## 👀 Screenshots

<img width="435" height="720" alt="Check your photo and try again" src="https://github.com/user-attachments/assets/5b04b555-8214-4705-a874-49813792c5bd" />

<img width="538" height="829" alt="Revise su foto e inténtelo de nuevo" src="https://github.com/user-attachments/assets/01735880-237a-4999-aec7-d93bcffe6376" />

<img width="531" height="664" alt="O LOGIN GOV" src="https://github.com/user-attachments/assets/0701b22a-9c34-4dcb-bba7-7f31ff24c206" />
<img width="536" height="880" alt="Screenshot 2025-10-06 at 4 25 25 PM" src="https://github.com/user-attachments/assets/ddd92a3a-b3c7-4149-ba9e-dbf2696babf2" />
