### PR TITLE
LG-16853: Autocapture no longer crops images

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -186,7 +186,8 @@ module Idv
         doc_auth_client.post_images(
           **images_metadata.submittable_images,
           image_source: image_source,
-          images_cropped: acuant_sdk_autocaptured_id?,
+          # autocapture no longer crops the images
+          images_cropped: false, # acuant_sdk_autocaptured_id?,
           user_uuid: user_uuid,
           uuid_prefix: uuid_prefix,
           liveness_checking_required: liveness_checking_required,

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -1439,7 +1439,7 @@ RSpec.describe Idv::ApiImageUploadForm do
         let(:image_source) { DocAuth::ImageSources::ACUANT_SDK }
 
         context 'when both images are captured via autocapture' do
-          let(:images_cropped) { true }
+          # let(:images_cropped) { true } # Autocapture does not crop images anymore
           before do
             front_image_metadata[:acuantCaptureMode] = 'AUTO'
             back_image_metadata[:acuantCaptureMode] = 'AUTO'


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-16853](https://cm-jira.usa.gov/browse/LG-16853)

## 🛠 Summary of changes

In a recent change, we modified the Acuant SDK to not crop images. These un-cropped images need to go through a different TrueID flow.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
