### PR TITLE
Guard against deleted account and profile

### DIFF
--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -492,7 +492,11 @@ class DataPull
             duplicate_profile_sets.each do |duplicate_profile_set|
               duplicate_profile_ids = duplicate_profile_set.profile_ids - [user.active_profile.id]
               duplicate_uuids = user_uuids(duplicate_profile_ids)
-              table << [email, user.uuid, duplicate_profile_set.service_provider, duplicate_uuids]
+              if duplicate_uuids.present?
+                table << [email, user.uuid, duplicate_profile_set.service_provider, duplicate_uuids]
+              else
+                table << [email, '[DUPLICATES NOT FOUND]', nil, nil]
+              end
             end
           else
             table << [email, '[DUPLICATES NOT FOUND]', nil, nil]
@@ -520,7 +524,9 @@ class DataPull
     end
 
     def user_uuids(profile_ids)
-      profile_ids.map { |profile_id| Profile.find(profile_id).user.uuid }
+      profile_ids.map do |profile_id|
+        Profile.exists?(profile_id) ? Profile.find(profile_id).user.uuid : nil
+      end.compact
     end
   end
 end

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -578,48 +578,83 @@ RSpec.describe DataPull do
   describe DataPull::UuidExport do
     subject(:subtask) { DataPull::DuplicateProfileLookup.new }
 
-    let(:user1) { create(:user, :fully_registered) }
-    let(:user2) { create(:user, :fully_registered) }
-
-    let(:service_provider) { create(:service_provider) }
-
-    let!(:profile1) { create(:profile, :active, user: user1) }
-    let!(:profile2) { create(:profile, :active, user: user2) }
-    let!(:profile3) { create(:profile, :active) }
-    let!(:profile4) { create(:profile, :active) }
-
-    let!(:duplicate_profile_set) do
-      create(
-        :duplicate_profile_set,
-        service_provider: service_provider.issuer,
-        profile_ids: [profile1.id, profile3.id, profile4.id],
-      )
-    end
-
-    let(:args) do
-      [user1.email_addresses.sole.email,
-       user2.email_addresses.sole.email,
-       'does-not-exist']
-    end
-
     let(:include_missing) { true }
 
     subject(:result) { subtask.run(args: args, config: config) }
 
     describe '#run' do
       let(:config) { ScriptBase::Config.new(include_missing: include_missing) }
+      let(:service_provider) { create(:service_provider) }
 
-      it 'returns duplicates if they exist', aggregate_failures: true do
-        expected_table = [
-          ['email', 'uuid', 'service_provider', 'duplicate_uuids'],
-          [user1.email_addresses.sole.email, user1.uuid, service_provider.issuer,
-           [profile3.user.uuid, profile4.user.uuid]],
-          [user2.email_addresses.sole.email, '[DUPLICATES NOT FOUND]', nil, nil],
-          ['does-not-exist', '[EMAIL NOT FOUND]', nil, nil],
-        ]
-        expect(result.table).to match_array(expected_table)
-        expect(result.subtask).to eq('duplicate-profile-lookup')
-        expect(result.uuids).to match_array([user1.uuid])
+      context 'when a normal duplicate exists', aggregate_failures: true do
+        let(:user1) { create(:user, :fully_registered) }
+        let(:user2) { create(:user, :fully_registered) }
+
+        let!(:profile1) { create(:profile, :active, user: user1) }
+        let!(:profile2) { create(:profile, :active, user: user2) }
+        let!(:profile3) { create(:profile, :active) }
+        let!(:profile4) { create(:profile, :active) }
+
+        let(:args) do
+          [user1.email_addresses.sole.email,
+           user2.email_addresses.sole.email,
+           'does-not-exist']
+        end
+
+        let!(:duplicate_profile_set) do
+          create(
+            :duplicate_profile_set,
+            service_provider: service_provider.issuer,
+            profile_ids: [profile1.id, profile3.id, profile4.id],
+          )
+        end
+
+        it 'returns duplicates if they exist', aggregate_failures: true do
+          expected_table = [
+            ['email', 'uuid', 'service_provider', 'duplicate_uuids'],
+            [user1.email_addresses.sole.email, user1.uuid, service_provider.issuer,
+             [profile3.user.uuid, profile4.user.uuid]],
+            [user2.email_addresses.sole.email, '[DUPLICATES NOT FOUND]', nil, nil],
+            ['does-not-exist', '[EMAIL NOT FOUND]', nil, nil],
+          ]
+          expect(result.table).to match_array(expected_table)
+          expect(result.subtask).to eq('duplicate-profile-lookup')
+          expect(result.uuids).to match_array([user1.uuid])
+        end
+      end
+
+      context 'when the 2nd profile is no longer around' do
+        let(:user1) { create(:user, :fully_registered) }
+        let(:user2) { create(:user, :fully_registered) }
+
+        let(:service_provider) { create(:service_provider) }
+
+        let!(:profile1) { create(:profile, :active, user: user1) }
+        let!(:profile2) { create(:profile, :active, user: user2) }
+
+        let!(:duplicate_profile_set) do
+          create(
+            :duplicate_profile_set,
+            service_provider: service_provider.issuer,
+            profile_ids: [profile1.id, profile2.id],
+          )
+        end
+
+        let(:args) { [user1.email_addresses.sole.email] }
+
+        before do
+          user2.destroy
+        end
+
+        it 'returns DUPLICATES_NOT_FOUND', aggregate_failures: true do
+          expected_table = [
+            ['email', 'uuid', 'service_provider', 'duplicate_uuids'],
+            [user1.email_addresses.sole.email, '[DUPLICATES NOT FOUND]', nil, nil],
+          ]
+          expect(result.table).to match_array(expected_table)
+          expect(result.subtask).to eq('duplicate-profile-lookup')
+          expect(result.uuids).to match_array([user1.uuid])
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes https://cm-jira.usa.gov/browse/LG-16854

The user may self serve by deleting an account and profile, but may not "close" the duplicate profile set, as they did not sign in subsequently.

changelog: Bug Fixes, One Account, Guard against deleted account and profile

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-16854](https://cm-jira.usa.gov/browse/LG-16854)



## 🛠 Summary of changes

If the "duplicate" profile cannot be found (as it may have been deleted), return "DUPLICATES NOT FOUND".



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create 2 accounts + profiles with the same SSN with a service provider enforcing OneAccount
- [ ] Sign in with one of the accounts, say Account1, so that you encounter the Duplicates screen
- [ ] Self serve by deleting the other account - Account 2
- [ ] **DON'T sign in with Account 1**
- [ ] Execute the `duplicate-profile-lookup` script
- [ ] There should be no error. It should return with "DUPLICATES NOT FOUND".



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
