### PR TITLE
Add seeders for review-app env for portal user creation

### DIFF
--- a/app/services/review_app_user_seeder.rb
+++ b/app/services/review_app_user_seeder.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class ReviewAppUserSeeder
+  REVIEW_APP_USERS = %w[
+    logingov-admin@gsa.gov
+    logingov-readonly@gsa.gov
+    partner-admin@gsa.gov
+    partner-developer@gsa.gov
+    partner-readonly@gsa.gov
+  ].freeze
+
+  DEFAULT_PASSWORD = 'salty pickles'
+
+  def run
+    return unless ENV['KUBERNETES_REVIEW_APP'] == 'true'
+
+    REVIEW_APP_USERS.each_with_index do |email, index|
+      next if user_exists?(email)
+
+      create_user(email: email, index: index)
+      Rails.logger.info("ReviewAppUserSeeder: Created user #{email}")
+    end
+  end
+
+  private
+
+  def user_exists?(email)
+    User.find_with_email(email).present?
+  end
+
+  def create_user(email:, index:)
+    user = User.create!
+
+    EmailAddress.create!(
+      email: email,
+      user: user,
+      confirmed_at: Time.zone.now,
+    )
+
+    user.reset_password(DEFAULT_PASSWORD, DEFAULT_PASSWORD)
+
+    MfaContext.new(user).phone_configurations.create(
+      delivery_preference: user.otp_delivery_preference,
+      phone: format('+1 (202) 555-%04d', index),
+      confirmed_at: Time.zone.now,
+    )
+
+    Event.create(user_id: user.id, event_type: :account_created)
+  end
+end

--- a/app/services/review_app_user_seeder.rb
+++ b/app/services/review_app_user_seeder.rb
@@ -12,7 +12,7 @@ class ReviewAppUserSeeder
   DEFAULT_PASSWORD = 'salty pickles'
 
   def run
-    return unless ENV['KUBERNETES_REVIEW_APP'] == 'true'
+    return unless ENV['POSTGRES_HOST']&.include?('.review-app')
 
     REVIEW_APP_USERS.each_with_index do |email, index|
       next if user_exists?(email)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,7 @@ if ENV['KUBERNETES_REVIEW_APP'] == 'true' && ENV['DASHBOARD_URL'].present?
   # If we change how production is deployed, we should revisit the above conditionals to ensure
   # production never runs this.
   ServiceProviderSeeder.new.run_review_app(dashboard_url: dashboard_url)
+  ReviewAppUserSeeder.new.run
 else
   ServiceProviderSeeder.new.run
 end

--- a/spec/services/review_app_user_seeder_spec.rb
+++ b/spec/services/review_app_user_seeder_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReviewAppUserSeeder do
+  describe '#run' do
+    subject(:run) { described_class.new.run }
+
+    context 'when KUBERNETES_REVIEW_APP is not set' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('KUBERNETES_REVIEW_APP').and_return(nil)
+      end
+
+      it 'does not create any users' do
+        expect { run }.to_not change(User, :count)
+      end
+    end
+
+    context 'when KUBERNETES_REVIEW_APP is set to true' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('KUBERNETES_REVIEW_APP').and_return('true')
+      end
+
+      it 'creates users for each role' do
+        expect { run }.to change(User, :count).by(5)
+      end
+
+      it 'creates users with correct emails' do
+        run
+
+        ReviewAppUserSeeder::REVIEW_APP_USERS.each do |email|
+          expect(User.find_with_email(email)).to be_present
+        end
+      end
+
+      it 'sets up password for each user' do
+        run
+
+        ReviewAppUserSeeder::REVIEW_APP_USERS.each do |email|
+          user = User.find_with_email(email)
+          expect(user.valid_password?(ReviewAppUserSeeder::DEFAULT_PASSWORD)).to be(true)
+        end
+      end
+
+      it 'sets up phone MFA for each user' do
+        run
+
+        ReviewAppUserSeeder::REVIEW_APP_USERS.each do |email|
+          user = User.find_with_email(email)
+          expect(MfaContext.new(user).phone_configurations.count).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/review_app_user_seeder_spec.rb
+++ b/spec/services/review_app_user_seeder_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe ReviewAppUserSeeder do
   describe '#run' do
     subject(:run) { described_class.new.run }
 
-    context 'when KUBERNETES_REVIEW_APP is not set' do
+    context 'when POSTGRES_HOST does not include .review-app' do
       before do
         allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with('KUBERNETES_REVIEW_APP').and_return(nil)
+        allow(ENV).to receive(:[]).with('POSTGRES_HOST').and_return('localhost')
       end
 
       it 'does not create any users' do
@@ -17,10 +17,10 @@ RSpec.describe ReviewAppUserSeeder do
       end
     end
 
-    context 'when KUBERNETES_REVIEW_APP is set to true' do
+    context 'when POSTGRES_HOST includes .review-app' do
       before do
         allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with('KUBERNETES_REVIEW_APP').and_return('true')
+        allow(ENV).to receive(:[]).with('POSTGRES_HOST').and_return('db.review-app.example.com')
       end
 
       it 'creates users for each role' do


### PR DESCRIPTION
changelog: Internal, Review Apps, Add user seeding for portal review app authentication

## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-teams/FIE/team-fie-daily/-/issues/62

## 🛠 Summary of changes

Adds to seeders to add users for testing the Partner Portal in the Review Apps requirement.
