### PR TITLE
Add "Not Auth Certificate" to PIV card error list

### DIFF
--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -23,6 +23,8 @@
           ['Unverified certificate', 'certificate.unverified'],
           ['Missing token', 'token.missing'],
           ['Invalid token', 'token.invalid'],
+          # This error is only applicable when a user is attempting to sign in with their PIV card
+          ['Not auth cert', 'certificate.not_auth_cert']
         ],
       ) %>
   <%= f.submit('Proceed', class: 'display-block margin-y-5 usa-button usa-button--big usa-button--wide') %>

--- a/app/views/test/piv_cac_authentication_test_subject/new.html.erb
+++ b/app/views/test/piv_cac_authentication_test_subject/new.html.erb
@@ -24,7 +24,8 @@
           ['Missing token', 'token.missing'],
           ['Invalid token', 'token.invalid'],
           # This error is only applicable when a user is attempting to sign in with their PIV card
-          ['Not auth cert', 'certificate.not_auth_cert']
+          # At the HSPD12 authentication assurance level
+          ['Incorrect certificate type', 'certificate.not_auth_cert'],
         ],
       ) %>
   <%= f.submit('Proceed', class: 'display-block margin-y-5 usa-button usa-button--big usa-button--wide') %>


### PR DESCRIPTION
This PR adds an option to view the "Not auth cert" error to the PIV testing list
