### PR TITLE
Reports: remove partner_strings configuration parameter

### DIFF
--- a/app/jobs/reports/sp_cred_metrics_report.rb
+++ b/app/jobs/reports/sp_cred_metrics_report.rb
@@ -56,7 +56,7 @@ module Reports
 
       if report_receiver == :both && partner_emails.empty?
         Rails.logger.warn(
-          "#{agency_abbreviation} Credential Report: recipient is :both " \
+          "#{@agency_abbreviation} Credential Report: recipient is :both " \
           "but no external email specified",
         )
       end
@@ -117,7 +117,7 @@ module Reports
       bcc_emails = emails[:bcc].select(&:present?)
       
       if to_emails.empty? && bcc_emails.empty?
-        Rails.logger.warn "No email addresses received - #{@partner_strings.first} Credential Report NOT SENT"
+        Rails.logger.warn "No email addresses received - #{partner_strings.first} Credential Report NOT SENT"
         return false
       end
 
@@ -140,7 +140,7 @@ module Reports
           )
         end
       else
-        Rails.logger.warn "No report available - #{@partner_strings.first} Credential Metrics Report NOT SENT"
+        Rails.logger.warn "No report available - #{partner_strings.first} Credential Metrics Report NOT SENT"
         return false
       end
       # rubocop:enable Layout/LineLength
@@ -148,7 +148,7 @@ module Reports
       ReportMailer.tables_report(
         to: to_emails,
         bcc: bcc_emails,
-        subject: "#{@partner_strings.first} Credential Metrics - #{@report_date.to_date}",
+        subject: "#{partner_strings.first} Credential Metrics - #{@report_date.to_date}",
         message: preamble,
         reports: reports,
         attachment_format: :csv,

--- a/app/jobs/reports/sp_cred_metrics_report.rb
+++ b/app/jobs/reports/sp_cred_metrics_report.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 module Reports
   class SpCredMetricsReport < BaseReport
     attr_reader :report_date, :report_receiver, :report_name
@@ -15,6 +14,29 @@ module Reports
     def issuers
       @issuers || []
     end
+
+    def partner_strings
+      @partner_strings ||= begin
+        matching_partners = partner_accounts.map(&:partner).uniq
+        
+        if matching_partners.any?
+          if matching_partners.size > 1
+            Rails.logger.warn(
+              "Multiple partners found for issuers #{issuers}: #{matching_partners}. " \
+              "Using first: #{matching_partners.first}"
+            )
+          end
+          matching_partners
+        else
+          Rails.logger.warn(
+            "No partner accounts found for issuers #{issuers}. " \
+            "Falling back to agency_abbreviation: #{@agency_abbreviation}"
+          )
+          [@agency_abbreviation || 'Unknown Partner']
+        end
+      end
+    end
+
 
     def iaas
       IaaReportingHelper.iaas.filter do |iaa|
@@ -89,11 +111,11 @@ module Reports
       @internal_emails = report_config['internal_emails']
       @agency_abbreviation = report_config['agency_abbreviation']
       @report_name = "#{@agency_abbreviation.downcase}_monthly_cred_metrics"
-
+      
       emails = email_addresses
       to_emails = emails[:to].select(&:present?)
       bcc_emails = emails[:bcc].select(&:present?)
-
+      
       if to_emails.empty? && bcc_emails.empty?
         Rails.logger.warn "No email addresses received - #{@partner_strings.first} Credential Report NOT SENT"
         return false
@@ -102,6 +124,7 @@ module Reports
       reports = as_emailable_partner_report(
         date: @report_date,
       )
+
       if reports.present?
         reports.each do |report|
           _latest_path, path = generate_s3_paths(
@@ -134,42 +157,44 @@ module Reports
     end
 
     def as_emailable_partner_report(date:)
-      emailable_report_array =
-        [
-          Reporting::EmailableReport.new(
-            title: 'Definitions',
-            table: definitions_table,
-            filename: 'partner_monthly_cred_definitions',
-          ),
-          Reporting::EmailableReport.new(
-            title: 'Overview',
-            table: overview_table,
-            filename: 'partner_monthly_cred_overview',
-          ),
-        ]
-
-      if issuer_report_data.present?
-        emailable_report_array <<
-          Reporting::EmailableReport.new(
-            title: "#{partner_strings.first} Credential Metrics #{date.strftime('%B %Y')}",
-            table: issuer_report_data,
-            filename: 'multi_issuer_monthly_cred_metrics',
-          )
+      
+      emailable_report_array = [
+        Reporting::EmailableReport.new(
+          title: 'Definitions',
+          table: definitions_table,
+          filename: 'partner_monthly_cred_definitions',
+        ),
+        Reporting::EmailableReport.new(
+          title: 'Overview',
+          table: overview_table,
+          filename: 'partner_monthly_cred_overview',
+        ),
+      ]
+      
+      issuer_data = issuer_report_data
+      
+      if issuer_data.present?
+        emailable_report_array << Reporting::EmailableReport.new(
+          title: "#{partner_strings.first} Monthly Credential Metrics #{date.strftime('%B %Y')}",
+          table: issuer_data,
+          filename: 'multi_issuer_monthly_cred_metrics',
+        )
       else
         return nil
       end
-
-      if partner_report_data.present?
-        emailable_report_array <<
-          Reporting::EmailableReport.new(
-            title: "Partner Credential Metrics #{date.strftime('%B %Y')}",
-            table: partner_report_data,
-            filename: 'partner_monthly_cred_metrics',
-          )
+      
+      partner_data = partner_report_data
+      
+      if partner_data.present?
+        emailable_report_array << Reporting::EmailableReport.new(
+          title: "Partner Monthly Credential Metrics #{date.strftime('%B %Y')}",
+          table: partner_data,
+          filename: 'partner_monthly_cred_metrics',
+        )
       else
         return nil
       end
-
+      
       emailable_report_array
     end
 

--- a/app/jobs/reports/sp_cred_metrics_report.rb
+++ b/app/jobs/reports/sp_cred_metrics_report.rb
@@ -15,29 +15,6 @@ module Reports
       @issuers || []
     end
 
-    def partner_strings
-      @partner_strings ||= begin
-        matching_partners = partner_accounts.map(&:partner).uniq
-        
-        if matching_partners.any?
-          if matching_partners.size > 1
-            Rails.logger.warn(
-              "Multiple partners found for issuers #{issuers}: #{matching_partners}. " \
-              "Using first: #{matching_partners.first}"
-            )
-          end
-          matching_partners
-        else
-          Rails.logger.warn(
-            "No partner accounts found for issuers #{issuers}. " \
-            "Falling back to agency_abbreviation: #{@agency_abbreviation}"
-          )
-          [@agency_abbreviation || 'Unknown Partner']
-        end
-      end
-    end
-
-
     def iaas
       IaaReportingHelper.iaas.filter do |iaa|
         iaa.end_date > 90.days.ago && (iaa.issuers & issuers).any?

--- a/app/jobs/reports/sp_cred_metrics_report.rb
+++ b/app/jobs/reports/sp_cred_metrics_report.rb
@@ -117,7 +117,7 @@ module Reports
       bcc_emails = emails[:bcc].select(&:present?)
       
       if to_emails.empty? && bcc_emails.empty?
-        Rails.logger.warn "No email addresses received - #{partner_strings.first} Credential Report NOT SENT"
+        Rails.logger.warn "No email addresses received - #{@agency_abbreviation} Credential Report NOT SENT"
         return false
       end
 
@@ -140,7 +140,7 @@ module Reports
           )
         end
       else
-        Rails.logger.warn "No report available - #{partner_strings.first} Credential Metrics Report NOT SENT"
+        Rails.logger.warn "No report available - #{@agency_abbreviation} Credential Metrics Report NOT SENT"
         return false
       end
       # rubocop:enable Layout/LineLength
@@ -148,7 +148,7 @@ module Reports
       ReportMailer.tables_report(
         to: to_emails,
         bcc: bcc_emails,
-        subject: "#{partner_strings.first} Credential Metrics - #{@report_date.to_date}",
+        subject: "#{@agency_abbreviation} Credential Metrics - #{@report_date.to_date}",
         message: preamble,
         reports: reports,
         attachment_format: :csv,
@@ -175,7 +175,7 @@ module Reports
       
       if issuer_data.present?
         emailable_report_array << Reporting::EmailableReport.new(
-          title: "#{partner_strings.first} Monthly Credential Metrics #{date.strftime('%B %Y')}",
+          title: "#{@agency_abbreviation} Monthly Credential Metrics #{date.strftime('%B %Y')}",
           table: issuer_data,
           filename: 'multi_issuer_monthly_cred_metrics',
         )
@@ -291,21 +291,15 @@ module Reports
 
     def build_partner_data
       invoice_data_csv = CSV.parse(invoice_report_data, headers: true)
-
+      
+      # Filter by issuers (previously was filtering by partner_strings, which we've removed)
       partner_invoice_data = invoice_data_csv.select do |r|
-        partner_strings.include?(r['partner'])
+        issuers.include?(r['issuer']) 
       end
-
+      
       if partner_invoice_data.empty?
-        Rails.logger.warn "No data for any partners in #{partner_strings}"
+        Rails.logger.warn "No data for any issuers in #{issuers}" 
         return nil
-      else
-        # Check if all expected partners have data
-        found_partners = partner_invoice_data.map { |row| row['partner'] }.uniq
-        missing_partners = partner_strings - found_partners
-        if missing_partners.any?
-          Rails.logger.warn "Missing data for partners: #{missing_partners.join(', ')}"
-        end
       end
 
       parsed_invoice_data = CSV::Table.new(

--- a/app/jobs/reports/sp_cred_metrics_report.rb
+++ b/app/jobs/reports/sp_cred_metrics_report.rb
@@ -12,14 +12,8 @@ module Reports
       super(init_date, init_receiver, report_config, *args, **rest)
     end
 
-    def partner_strings
-      @partner_strings || []
-    end
-
-    def partner_accounts
-      IaaReportingHelper.partner_accounts.filter do |account|
-        partner_strings.include?(account.partner)
-      end
+    def issuers
+      @issuers || []
     end
 
     def iaas
@@ -28,8 +22,10 @@ module Reports
       end
     end
 
-    def issuers
-      @issuers || []
+    def partner_accounts
+      IaaReportingHelper.partner_accounts.filter do |account|
+        (account.issuers & issuers).any?
+      end
     end
 
     def email_addresses
@@ -38,7 +34,7 @@ module Reports
 
       if report_receiver == :both && partner_emails.empty?
         Rails.logger.warn(
-          "#{partner_strings.first} Monthly Credential Report: recipient is :both " \
+          "#{agency_abbreviation} Monthly Credential Report: recipient is :both " \
           "but no external email specified",
         )
       end
@@ -89,11 +85,10 @@ module Reports
       @report_config = report_config
 
       @issuers = report_config['issuers']
-      @partner_strings = report_config['partner_strings']
       @partner_emails = report_config['partner_emails']
       @internal_emails = report_config['internal_emails']
-
-      @report_name = "#{@partner_strings.first.downcase}_monthly_cred_metrics"
+      @agency_abbreviation = report_config['agency_abbreviation']
+      @report_name = "#{@agency_abbreviation.downcase}_monthly_cred_metrics"
 
       emails = email_addresses
       to_emails = emails[:to].select(&:present?)

--- a/app/jobs/reports/sp_cred_metrics_report.rb
+++ b/app/jobs/reports/sp_cred_metrics_report.rb
@@ -269,7 +269,6 @@ module Reports
     def build_partner_data
       invoice_data_csv = CSV.parse(invoice_report_data, headers: true)
 
-      # Filter by issuers (previously was filtering by partner_strings, which we've removed)
       partner_invoice_data = invoice_data_csv.select do |r|
         issuers.include?(r['issuer'])
       end

--- a/app/jobs/reports/sp_cred_metrics_report.rb
+++ b/app/jobs/reports/sp_cred_metrics_report.rb
@@ -95,7 +95,7 @@ module Reports
       bcc_emails = emails[:bcc].select(&:present?)
 
       if to_emails.empty? && bcc_emails.empty?
-        Rails.logger.warn "No email addresses received - #{@partner_strings.first} Monthly Credential Report NOT SENT"
+        Rails.logger.warn "No email addresses received - #{@partner_strings.first} Credential Report NOT SENT"
         return false
       end
 
@@ -117,7 +117,7 @@ module Reports
           )
         end
       else
-        Rails.logger.warn "No report available - #{@partner_strings.first} Monthly Credential Report NOT SENT"
+        Rails.logger.warn "No report available - #{@partner_strings.first} Credential Metrics Report NOT SENT"
         return false
       end
       # rubocop:enable Layout/LineLength
@@ -125,7 +125,7 @@ module Reports
       ReportMailer.tables_report(
         to: to_emails,
         bcc: bcc_emails,
-        subject: "#{@partner_strings.first} Monthly Credential Metrics - #{@report_date.to_date}",
+        subject: "#{@partner_strings.first} Credential Metrics - #{@report_date.to_date}",
         message: preamble,
         reports: reports,
         attachment_format: :csv,
@@ -151,7 +151,7 @@ module Reports
       if issuer_report_data.present?
         emailable_report_array <<
           Reporting::EmailableReport.new(
-            title: "#{partner_strings.first} Monthly Credential Metrics #{date.strftime('%B %Y')}",
+            title: "#{partner_strings.first} Credential Metrics #{date.strftime('%B %Y')}",
             table: issuer_report_data,
             filename: 'multi_issuer_monthly_cred_metrics',
           )
@@ -162,7 +162,7 @@ module Reports
       if partner_report_data.present?
         emailable_report_array <<
           Reporting::EmailableReport.new(
-            title: "Partner Monthly Credential Metrics #{date.strftime('%B %Y')}",
+            title: "Partner Credential Metrics #{date.strftime('%B %Y')}",
             table: partner_report_data,
             filename: 'partner_monthly_cred_metrics',
           )

--- a/app/jobs/reports/sp_cred_metrics_report.rb
+++ b/app/jobs/reports/sp_cred_metrics_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reports
   class SpCredMetricsReport < BaseReport
     attr_reader :report_date, :report_receiver, :report_name
@@ -88,11 +89,11 @@ module Reports
       @internal_emails = report_config['internal_emails']
       @agency_abbreviation = report_config['agency_abbreviation']
       @report_name = "#{@agency_abbreviation.downcase}_monthly_cred_metrics"
-      
+
       emails = email_addresses
       to_emails = emails[:to].select(&:present?)
       bcc_emails = emails[:bcc].select(&:present?)
-      
+
       if to_emails.empty? && bcc_emails.empty?
         Rails.logger.warn "No email addresses received - #{@agency_abbreviation} Credential Report NOT SENT"
         return false
@@ -134,7 +135,6 @@ module Reports
     end
 
     def as_emailable_partner_report(date:)
-      
       emailable_report_array = [
         Reporting::EmailableReport.new(
           title: 'Definitions',
@@ -147,9 +147,9 @@ module Reports
           filename: 'partner_monthly_cred_overview',
         ),
       ]
-      
+
       issuer_data = issuer_report_data
-      
+
       if issuer_data.present?
         emailable_report_array << Reporting::EmailableReport.new(
           title: "#{@agency_abbreviation} Monthly Credential Metrics #{date.strftime('%B %Y')}",
@@ -159,9 +159,9 @@ module Reports
       else
         return nil
       end
-      
+
       partner_data = partner_report_data
-      
+
       if partner_data.present?
         emailable_report_array << Reporting::EmailableReport.new(
           title: "Partner Monthly Credential Metrics #{date.strftime('%B %Y')}",
@@ -171,7 +171,7 @@ module Reports
       else
         return nil
       end
-      
+
       emailable_report_array
     end
 
@@ -268,14 +268,14 @@ module Reports
 
     def build_partner_data
       invoice_data_csv = CSV.parse(invoice_report_data, headers: true)
-      
+
       # Filter by issuers (previously was filtering by partner_strings, which we've removed)
       partner_invoice_data = invoice_data_csv.select do |r|
-        issuers.include?(r['issuer']) 
+        issuers.include?(r['issuer'])
       end
-      
+
       if partner_invoice_data.empty?
-        Rails.logger.warn "No data for any issuers in #{issuers}" 
+        Rails.logger.warn "No data for any issuers in #{issuers}"
         return nil
       end
 

--- a/app/jobs/reports/sp_cred_metrics_report.rb
+++ b/app/jobs/reports/sp_cred_metrics_report.rb
@@ -34,7 +34,7 @@ module Reports
 
       if report_receiver == :both && partner_emails.empty?
         Rails.logger.warn(
-          "#{agency_abbreviation} Monthly Credential Report: recipient is :both " \
+          "#{agency_abbreviation} Credential Report: recipient is :both " \
           "but no external email specified",
         )
       end

--- a/spec/jobs/reports/sp_cred_metrics_report_orchestrator_spec.rb
+++ b/spec/jobs/reports/sp_cred_metrics_report_orchestrator_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Reports::SpCredMetricsReportOrchestrator do
   let(:config_1) do
     {
       'issuers' => ['issuer1'],
-      #'partner_strings' => ['Partner_1'],
       'agency_abbreviation' => ['PRTNR1'],
       'partner_emails' => ['partner1@example.com'],
       'internal_emails' => ['internal1@example.com'],
@@ -21,7 +20,6 @@ RSpec.describe Reports::SpCredMetricsReportOrchestrator do
   let(:config_2) do
     {
       'issuers' => ['issuer2'],
-      #'partner_strings' => ['Partner_2'],
       'agency_abbreviation' => ['PRTNR2'],
       'partner_emails' => ['partner2@example.com'],
       'internal_emails' => ['internal2@example.com'],

--- a/spec/jobs/reports/sp_cred_metrics_report_orchestrator_spec.rb
+++ b/spec/jobs/reports/sp_cred_metrics_report_orchestrator_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Reports::SpCredMetricsReportOrchestrator do
   let(:config_1) do
     {
       'issuers' => ['issuer1'],
-      'partner_strings' => ['Partner_1'],
+      #'partner_strings' => ['Partner_1'],
+      'agency_abbreviation' => ['PRTNR1'],
       'partner_emails' => ['partner1@example.com'],
       'internal_emails' => ['internal1@example.com'],
     }
@@ -20,7 +21,8 @@ RSpec.describe Reports::SpCredMetricsReportOrchestrator do
   let(:config_2) do
     {
       'issuers' => ['issuer2'],
-      'partner_strings' => ['Partner_2'],
+      #'partner_strings' => ['Partner_2'],
+      'agency_abbreviation' => ['PRTNR2'],
       'partner_emails' => ['partner2@example.com'],
       'internal_emails' => ['internal2@example.com'],
     }

--- a/spec/jobs/reports/sp_cred_metrics_report_spec.rb
+++ b/spec/jobs/reports/sp_cred_metrics_report_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Reports::SpCredMetricsReport do
         to: mock_reports_partner_emails,
         bcc: mock_reports_internal_emails,
         subject:
-          "#{MOCK_PARTNER_NAME} Monthly Credential Metrics - " \
+          "#{MOCK_PARTNER_NAME} Credential Metrics - " \
           "#{report_date.to_date}",
         reports: anything,
         message: report.preamble,
@@ -148,7 +148,7 @@ RSpec.describe Reports::SpCredMetricsReport do
         to: mock_reports_internal_emails,
         bcc: [],
         subject:
-          "#{MOCK_PARTNER_NAME} Monthly Credential Metrics - " \
+          "#{MOCK_PARTNER_NAME} Credential Metrics - " \
           "#{report_date.to_date}",
         reports: anything,
         message: report.preamble,
@@ -175,7 +175,7 @@ RSpec.describe Reports::SpCredMetricsReport do
 
     it 'logs a warning and sends the report only to internal emails' do
       expect(Rails.logger).to receive(:warn).with(
-        "#{MOCK_AGENCY_ABBR} Monthly Credential Report: recipient is :both " \
+        "#{MOCK_AGENCY_ABBR} Credential Report: recipient is :both " \
         "but no external email specified",
       )
 
@@ -183,7 +183,7 @@ RSpec.describe Reports::SpCredMetricsReport do
         to: mock_reports_internal_emails,
         bcc: [],
         subject:
-          "#{MOCK_PARTNER_NAME} Monthly Credential Metrics - " \
+          "#{MOCK_PARTNER_NAME} Credential Metrics - " \
           "#{report_date.to_date}",
         reports: anything,
         message: report.preamble,
@@ -211,7 +211,7 @@ RSpec.describe Reports::SpCredMetricsReport do
     it 'logs a warning and does not send the report' do
       expect(Rails.logger).to receive(:warn).with(
         "No email addresses received - #{MOCK_PARTNER_NAME} " \
-        "Monthly Credential Report NOT SENT",
+        "Credential Report NOT SENT",
       )
 
       expect(ReportMailer).not_to receive(:tables_report)

--- a/spec/jobs/reports/sp_cred_metrics_report_spec.rb
+++ b/spec/jobs/reports/sp_cred_metrics_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-MOCK_PARTNER_NAME = 'Partner_1' # Matches spec/fixtures/partner_cred_metrics_input.csv
 MOCK_AGENCY_ABBR = 'PRTNR1'
+REPORT_NAME = "#{MOCK_AGENCY_ABBR.downcase}_monthly_cred_metrics"
 
 RSpec.describe Reports::SpCredMetricsReport do
   let(:report_date) { Date.new(2021, 3, 2).in_time_zone('UTC').end_of_day }
@@ -13,13 +13,11 @@ RSpec.describe Reports::SpCredMetricsReport do
   let(:mock_reports_partner_emails)  { ['mock_partner@example.com'] }
   let(:mock_reports_internal_emails) { ['mock_internal@example.com'] }
   let(:mock_issuers) { ['Issuer_4'] }
-  #let(:mock_partner_strings) { ['Partner_1'] }
   let(:mock_agency_abbreviation) { MOCK_AGENCY_ABBR }
 
   let(:report_config) do
     {
       'issuers' => mock_issuers,
-      #'partner_strings' => mock_partner_strings, # Now derived via IAAHelper
       'agency_abbreviation' => mock_agency_abbreviation,
       'partner_emails' => mock_reports_partner_emails,
       'internal_emails' => mock_reports_internal_emails,
@@ -28,7 +26,7 @@ RSpec.describe Reports::SpCredMetricsReport do
 
   # Derived by job: "#{partner_strings.first.downcase}_monthly_cred_metrics"
   #let(:report_name) { "#{mock_partner_strings.first.downcase}_monthly_cred_metrics" }
-  let(:report_name) { "#{MOCK_AGENCY_ABBR.downcase}_monthly_cred_metrics"}
+  let(:report_name) { REPORT_NAME }
   let(:report_folder) do
     "int/#{report_name}/2021/2021-03-02.#{report_name}"
   end
@@ -70,7 +68,6 @@ RSpec.describe Reports::SpCredMetricsReport do
 
 
     mock_partner_config = IaaReportingHelper::PartnerConfig.new(
-        partner: MOCK_PARTNER_NAME,
         issuers: ['Issuer_4'],
         start_date: 1.year.ago,
         end_date: 1.year.from_now
@@ -125,7 +122,7 @@ RSpec.describe Reports::SpCredMetricsReport do
         to: mock_reports_partner_emails,
         bcc: mock_reports_internal_emails,
         subject:
-          "#{MOCK_PARTNER_NAME} Credential Metrics - " \
+          "#{MOCK_AGENCY_ABBR} Credential Metrics - " \
           "#{report_date.to_date}",
         reports: anything,
         message: report.preamble,
@@ -148,7 +145,7 @@ RSpec.describe Reports::SpCredMetricsReport do
         to: mock_reports_internal_emails,
         bcc: [],
         subject:
-          "#{MOCK_PARTNER_NAME} Credential Metrics - " \
+          "#{MOCK_AGENCY_ABBR} Credential Metrics - " \
           "#{report_date.to_date}",
         reports: anything,
         message: report.preamble,
@@ -183,7 +180,7 @@ RSpec.describe Reports::SpCredMetricsReport do
         to: mock_reports_internal_emails,
         bcc: [],
         subject:
-          "#{MOCK_PARTNER_NAME} Credential Metrics - " \
+          "#{MOCK_AGENCY_ABBR} Credential Metrics - " \
           "#{report_date.to_date}",
         reports: anything,
         message: report.preamble,
@@ -210,7 +207,7 @@ RSpec.describe Reports::SpCredMetricsReport do
 
     it 'logs a warning and does not send the report' do
       expect(Rails.logger).to receive(:warn).with(
-        "No email addresses received - #{MOCK_PARTNER_NAME} " \
+        "No email addresses received - #{MOCK_AGENCY_ABBR} " \
         "Credential Report NOT SENT",
       )
 
@@ -272,7 +269,6 @@ RSpec.describe Reports::SpCredMetricsReport do
     let(:report_config) do
       super().merge(
         'issuers' => ['Issuer_2', 'Issuer_3', 'Issuer_4'],
-        #'partner_strings' => mock_partner_strings,
       )
     end
 
@@ -329,96 +325,6 @@ RSpec.describe Reports::SpCredMetricsReport do
       expect(hashed['Existing identity verification credentials authorized'])
         .to eq(expected_existing)
       expect(hashed['Total authentications']).to eq(expected_total)
-    end
-  end
-  describe '#partner_strings' do
-    let(:report_config) do
-      {
-        'issuers' => ['Issuer_4'],
-        'agency_abbreviation' => MOCK_AGENCY_ABBR,
-        'partner_emails' => mock_reports_partner_emails,
-        'internal_emails' => mock_reports_internal_emails,
-      }
-    end
-    
-    context 'when partner accounts exist for issuers' do
-      before do
-        mock_partner_config = IaaReportingHelper::PartnerConfig.new(
-          partner: MOCK_PARTNER_NAME,
-          issuers: ['Issuer_4'],
-          start_date: 1.year.ago,
-          end_date: 1.year.from_now
-        )
-        
-        allow_any_instance_of(Reports::SpCredMetricsReport)
-          .to receive(:partner_accounts)
-          .and_return([mock_partner_config])
-      end
-      
-      it 'returns partner name from partner accounts' do
-        report = Reports::SpCredMetricsReport.new(report_date, report_receiver, report_config)
-        report.instance_variable_set(:@issuers, ['Issuer_4'])
-        report.instance_variable_set(:@agency_abbreviation, MOCK_AGENCY_ABBR)
-        
-        expect(report.partner_strings).to eq([MOCK_PARTNER_NAME])
-      end
-    end
-    
-    context 'when no partner accounts exist' do
-      before do
-        allow_any_instance_of(Reports::SpCredMetricsReport)
-          .to receive(:partner_accounts)
-          .and_return([])
-      end
-      
-      it 'falls back to agency abbreviation' do
-        report = Reports::SpCredMetricsReport.new(report_date, report_receiver, report_config)
-        report.instance_variable_set(:@issuers, ['nonexistent.gov'])
-        report.instance_variable_set(:@agency_abbreviation, MOCK_AGENCY_ABBR)
-        
-        expect(Rails.logger).to receive(:warn).with(
-          "No partner accounts found for issuers [\"nonexistent.gov\"]. " \
-          "Falling back to agency_abbreviation: #{MOCK_AGENCY_ABBR}"
-        )
-        
-        expect(report.partner_strings).to eq([MOCK_AGENCY_ABBR])
-      end
-    end
-    
-    context 'when multiple partner accounts exist' do
-      before do
-        mock_configs = [
-          IaaReportingHelper::PartnerConfig.new(
-            partner: 'Partner A',
-            issuers: ['issuer1.gov'],
-            start_date: 1.year.ago,
-            end_date: 1.year.from_now
-          ),
-          IaaReportingHelper::PartnerConfig.new(
-            partner: 'Partner B',
-            issuers: ['issuer2.gov'],
-            start_date: 1.year.ago,
-            end_date: 1.year.from_now
-          )
-        ]
-        
-        allow_any_instance_of(Reports::SpCredMetricsReport)
-          .to receive(:partner_accounts)
-          .and_return(mock_configs)
-      end
-      
-      it 'returns all partner names and logs warning' do
-        report = Reports::SpCredMetricsReport.new(report_date, report_receiver, report_config)
-        report.instance_variable_set(:@issuers, ['issuer1.gov', 'issuer2.gov'])
-        report.instance_variable_set(:@agency_abbreviation, MOCK_AGENCY_ABBR)
-        
-        expect(Rails.logger).to receive(:warn).with(
-          "Multiple partners found for issuers [\"issuer1.gov\", \"issuer2.gov\"]: " \
-          "[\"Partner A\", \"Partner B\"]. Using first: Partner A"
-        )
-        
-        expect(report.partner_strings).to eq(['Partner A', 'Partner B'])
-      end
     end
   end
 end

--- a/spec/jobs/reports/sp_cred_metrics_report_spec.rb
+++ b/spec/jobs/reports/sp_cred_metrics_report_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
+MOCK_PARTNER_NAME = 'Partner_1' # Matches spec/fixtures/partner_cred_metrics_input.csv
+MOCK_AGENCY_ABBR = 'PRTNR1'
+
 RSpec.describe Reports::SpCredMetricsReport do
   let(:report_date) { Date.new(2021, 3, 2).in_time_zone('UTC').end_of_day }
   let(:report_receiver) { :internal }
@@ -10,20 +13,22 @@ RSpec.describe Reports::SpCredMetricsReport do
   let(:mock_reports_partner_emails)  { ['mock_partner@example.com'] }
   let(:mock_reports_internal_emails) { ['mock_internal@example.com'] }
   let(:mock_issuers) { ['Issuer_4'] }
-  let(:mock_partner_strings) { ['Partner_1'] }
+  #let(:mock_partner_strings) { ['Partner_1'] }
+  let(:mock_agency_abbreviation) { MOCK_AGENCY_ABBR }
 
   let(:report_config) do
     {
       'issuers' => mock_issuers,
-      'partner_strings' => mock_partner_strings,
+      #'partner_strings' => mock_partner_strings, # Now derived via IAAHelper
+      'agency_abbreviation' => mock_agency_abbreviation,
       'partner_emails' => mock_reports_partner_emails,
       'internal_emails' => mock_reports_internal_emails,
     }
   end
 
   # Derived by job: "#{partner_strings.first.downcase}_monthly_cred_metrics"
-  let(:report_name) { "#{mock_partner_strings.first.downcase}_monthly_cred_metrics" }
-
+  #let(:report_name) { "#{mock_partner_strings.first.downcase}_monthly_cred_metrics" }
+  let(:report_name) { "#{MOCK_AGENCY_ABBR.downcase}_monthly_cred_metrics"}
   let(:report_folder) do
     "int/#{report_name}/2021/2021-03-02.#{report_name}"
   end
@@ -62,6 +67,19 @@ RSpec.describe Reports::SpCredMetricsReport do
         put_object: {},
       },
     }
+
+
+    mock_partner_config = IaaReportingHelper::PartnerConfig.new(
+        partner: MOCK_PARTNER_NAME,
+        issuers: ['Issuer_4'],
+        start_date: 1.year.ago,
+        end_date: 1.year.from_now
+      )
+      
+    allow_any_instance_of(Reports::SpCredMetricsReport)
+      .to receive(:partner_accounts)
+      .and_return([mock_partner_config])
+      
 
     # Mock the report data methods
     allow_any_instance_of(Reports::SpCredMetricsReport)
@@ -107,7 +125,7 @@ RSpec.describe Reports::SpCredMetricsReport do
         to: mock_reports_partner_emails,
         bcc: mock_reports_internal_emails,
         subject:
-          "#{mock_partner_strings.first} Monthly Credential Metrics - " \
+          "#{MOCK_PARTNER_NAME} Monthly Credential Metrics - " \
           "#{report_date.to_date}",
         reports: anything,
         message: report.preamble,
@@ -130,7 +148,7 @@ RSpec.describe Reports::SpCredMetricsReport do
         to: mock_reports_internal_emails,
         bcc: [],
         subject:
-          "#{mock_partner_strings.first} Monthly Credential Metrics - " \
+          "#{MOCK_PARTNER_NAME} Monthly Credential Metrics - " \
           "#{report_date.to_date}",
         reports: anything,
         message: report.preamble,
@@ -157,7 +175,7 @@ RSpec.describe Reports::SpCredMetricsReport do
 
     it 'logs a warning and sends the report only to internal emails' do
       expect(Rails.logger).to receive(:warn).with(
-        "#{mock_partner_strings.first} Monthly Credential Report: recipient is :both " \
+        "#{MOCK_AGENCY_ABBR} Monthly Credential Report: recipient is :both " \
         "but no external email specified",
       )
 
@@ -165,7 +183,7 @@ RSpec.describe Reports::SpCredMetricsReport do
         to: mock_reports_internal_emails,
         bcc: [],
         subject:
-          "#{mock_partner_strings.first} Monthly Credential Metrics - " \
+          "#{MOCK_PARTNER_NAME} Monthly Credential Metrics - " \
           "#{report_date.to_date}",
         reports: anything,
         message: report.preamble,
@@ -192,7 +210,7 @@ RSpec.describe Reports::SpCredMetricsReport do
 
     it 'logs a warning and does not send the report' do
       expect(Rails.logger).to receive(:warn).with(
-        "No email addresses received - #{mock_partner_strings.first} " \
+        "No email addresses received - #{MOCK_PARTNER_NAME} " \
         "Monthly Credential Report NOT SENT",
       )
 
@@ -254,7 +272,7 @@ RSpec.describe Reports::SpCredMetricsReport do
     let(:report_config) do
       super().merge(
         'issuers' => ['Issuer_2', 'Issuer_3', 'Issuer_4'],
-        'partner_strings' => mock_partner_strings,
+        #'partner_strings' => mock_partner_strings,
       )
     end
 
@@ -268,15 +286,21 @@ RSpec.describe Reports::SpCredMetricsReport do
 
     it 'returns issuer and partner tables with expected shapes and values' do
       result = report.perform(report_date, :internal, report_config)
+      
+      expect(result).not_to eq(false), "Report.perform returned false, indicating an error condition"
+      expect(result).to be_an(Array), "Expected result to be an Array, got #{result.class}: #{result.inspect}"
+      expect(result.length).to eq(2), "Expected 2 elements [issuer_table, partner_table], got #{result.length}: #{result.inspect}"
+      
       issuer_table, partner_table = result
-
-      expect(result.length).to eq(2)
-
+      
+      expect(issuer_table).to be_present, "Issuer table should not be nil or empty"
+      expect(partner_table).to be_present, "Partner table should not be nil or empty"
+      
       expect(issuer_table.first.length).to eq(6)
       expect(issuer_table.length).to eq(1 + 3)
-
       expect(partner_table.length).to eq(4)
       partner_table.each { |row| expect(row.length).to eq(2) }
+      
 
       fixture_row = parsed_invoice_data.find do |r|
         r['issuer'] == 'Issuer_4' && r['year_month'] == report_year_month
@@ -305,6 +329,96 @@ RSpec.describe Reports::SpCredMetricsReport do
       expect(hashed['Existing identity verification credentials authorized'])
         .to eq(expected_existing)
       expect(hashed['Total authentications']).to eq(expected_total)
+    end
+  end
+  describe '#partner_strings' do
+    let(:report_config) do
+      {
+        'issuers' => ['Issuer_4'],
+        'agency_abbreviation' => MOCK_AGENCY_ABBR,
+        'partner_emails' => mock_reports_partner_emails,
+        'internal_emails' => mock_reports_internal_emails,
+      }
+    end
+    
+    context 'when partner accounts exist for issuers' do
+      before do
+        mock_partner_config = IaaReportingHelper::PartnerConfig.new(
+          partner: MOCK_PARTNER_NAME,
+          issuers: ['Issuer_4'],
+          start_date: 1.year.ago,
+          end_date: 1.year.from_now
+        )
+        
+        allow_any_instance_of(Reports::SpCredMetricsReport)
+          .to receive(:partner_accounts)
+          .and_return([mock_partner_config])
+      end
+      
+      it 'returns partner name from partner accounts' do
+        report = Reports::SpCredMetricsReport.new(report_date, report_receiver, report_config)
+        report.instance_variable_set(:@issuers, ['Issuer_4'])
+        report.instance_variable_set(:@agency_abbreviation, MOCK_AGENCY_ABBR)
+        
+        expect(report.partner_strings).to eq([MOCK_PARTNER_NAME])
+      end
+    end
+    
+    context 'when no partner accounts exist' do
+      before do
+        allow_any_instance_of(Reports::SpCredMetricsReport)
+          .to receive(:partner_accounts)
+          .and_return([])
+      end
+      
+      it 'falls back to agency abbreviation' do
+        report = Reports::SpCredMetricsReport.new(report_date, report_receiver, report_config)
+        report.instance_variable_set(:@issuers, ['nonexistent.gov'])
+        report.instance_variable_set(:@agency_abbreviation, MOCK_AGENCY_ABBR)
+        
+        expect(Rails.logger).to receive(:warn).with(
+          "No partner accounts found for issuers [\"nonexistent.gov\"]. " \
+          "Falling back to agency_abbreviation: #{MOCK_AGENCY_ABBR}"
+        )
+        
+        expect(report.partner_strings).to eq([MOCK_AGENCY_ABBR])
+      end
+    end
+    
+    context 'when multiple partner accounts exist' do
+      before do
+        mock_configs = [
+          IaaReportingHelper::PartnerConfig.new(
+            partner: 'Partner A',
+            issuers: ['issuer1.gov'],
+            start_date: 1.year.ago,
+            end_date: 1.year.from_now
+          ),
+          IaaReportingHelper::PartnerConfig.new(
+            partner: 'Partner B',
+            issuers: ['issuer2.gov'],
+            start_date: 1.year.ago,
+            end_date: 1.year.from_now
+          )
+        ]
+        
+        allow_any_instance_of(Reports::SpCredMetricsReport)
+          .to receive(:partner_accounts)
+          .and_return(mock_configs)
+      end
+      
+      it 'returns all partner names and logs warning' do
+        report = Reports::SpCredMetricsReport.new(report_date, report_receiver, report_config)
+        report.instance_variable_set(:@issuers, ['issuer1.gov', 'issuer2.gov'])
+        report.instance_variable_set(:@agency_abbreviation, MOCK_AGENCY_ABBR)
+        
+        expect(Rails.logger).to receive(:warn).with(
+          "Multiple partners found for issuers [\"issuer1.gov\", \"issuer2.gov\"]: " \
+          "[\"Partner A\", \"Partner B\"]. Using first: Partner A"
+        )
+        
+        expect(report.partner_strings).to eq(['Partner A', 'Partner B'])
+      end
     end
   end
 end

--- a/spec/jobs/reports/sp_cred_metrics_report_spec.rb
+++ b/spec/jobs/reports/sp_cred_metrics_report_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe Reports::SpCredMetricsReport do
     }
   end
 
-  # Derived by job: "#{partner_strings.first.downcase}_monthly_cred_metrics"
-  # let(:report_name) { "#{mock_partner_strings.first.downcase}_monthly_cred_metrics" }
   let(:report_name) { REPORT_NAME }
   let(:report_folder) do
     "int/#{report_name}/2021/2021-03-02.#{report_name}"

--- a/spec/jobs/reports/sp_cred_metrics_report_spec.rb
+++ b/spec/jobs/reports/sp_cred_metrics_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-MOCK_AGENCY_ABBR = 'PRTNR1'
-REPORT_NAME = "#{MOCK_AGENCY_ABBR.downcase}_monthly_cred_metrics"
+MOCK_AGENCY_ABBR = 'PRTNR1'.freeze
+REPORT_NAME = "#{MOCK_AGENCY_ABBR.downcase}_monthly_cred_metrics".freeze
 
 RSpec.describe Reports::SpCredMetricsReport do
   let(:report_date) { Date.new(2021, 3, 2).in_time_zone('UTC').end_of_day }
@@ -25,7 +25,7 @@ RSpec.describe Reports::SpCredMetricsReport do
   end
 
   # Derived by job: "#{partner_strings.first.downcase}_monthly_cred_metrics"
-  #let(:report_name) { "#{mock_partner_strings.first.downcase}_monthly_cred_metrics" }
+  # let(:report_name) { "#{mock_partner_strings.first.downcase}_monthly_cred_metrics" }
   let(:report_name) { REPORT_NAME }
   let(:report_folder) do
     "int/#{report_name}/2021/2021-03-02.#{report_name}"
@@ -66,17 +66,15 @@ RSpec.describe Reports::SpCredMetricsReport do
       },
     }
 
-
     mock_partner_config = IaaReportingHelper::PartnerConfig.new(
-        issuers: ['Issuer_4'],
-        start_date: 1.year.ago,
-        end_date: 1.year.from_now
-      )
-      
+      issuers: ['Issuer_4'],
+      start_date: 1.year.ago,
+      end_date: 1.year.from_now,
+    )
+
     allow_any_instance_of(Reports::SpCredMetricsReport)
       .to receive(:partner_accounts)
       .and_return([mock_partner_config])
-      
 
     # Mock the report data methods
     allow_any_instance_of(Reports::SpCredMetricsReport)
@@ -282,21 +280,24 @@ RSpec.describe Reports::SpCredMetricsReport do
 
     it 'returns issuer and partner tables with expected shapes and values' do
       result = report.perform(report_date, :internal, report_config)
-      
-      expect(result).not_to eq(false), "Report.perform returned false, indicating an error condition"
-      expect(result).to be_an(Array), "Expected result to be an Array, got #{result.class}: #{result.inspect}"
-      expect(result.length).to eq(2), "Expected 2 elements [issuer_table, partner_table], got #{result.length}: #{result.inspect}"
-      
+
+      expect(result).not_to eq(false),
+                            'Report.perform returned false, indicating an error condition'
+      expect(result).to be_an(Array),
+                        "Expected result to be an Array, got #{result.class}: #{result.inspect}"
+      expect(result.length).to eq(2),
+                               "Expected 2 elements [issuer_table, partner_table], " \
+                               "got #{result.length}: #{result.inspect}"
+
       issuer_table, partner_table = result
-      
-      expect(issuer_table).to be_present, "Issuer table should not be nil or empty"
-      expect(partner_table).to be_present, "Partner table should not be nil or empty"
-      
+
+      expect(issuer_table).to be_present, 'Issuer table should not be nil or empty'
+      expect(partner_table).to be_present, 'Partner table should not be nil or empty'
+
       expect(issuer_table.first.length).to eq(6)
       expect(issuer_table.length).to eq(1 + 3)
       expect(partner_table.length).to eq(4)
       partner_table.each { |row| expect(row.length).to eq(2) }
-      
 
       fixture_row = parsed_invoice_data.find do |r|
         r['issuer'] == 'Issuer_4' && r['year_month'] == report_year_month

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -393,7 +393,6 @@ class ReportMailerPreview < ActionMailer::Preview
     report_date = Time.zone.parse('2025-11-30').end_of_day
     config = {
       'issuers' => ['Issuer_2', 'Issuer_3', 'Issuer_4'],
-      # 'partner_strings' => ['Partner_1'],
       'agency_abbreviation' => 'PRTNR1',
       'partner_emails' => ['partner1@example.com'],
       'internal_emails' => ['internal1@example.com'],
@@ -405,18 +404,16 @@ class ReportMailerPreview < ActionMailer::Preview
       [
         IaaReportingHelper::PartnerConfig.new(
           partner: 'Partner_1',
-          issuers: ['Issuer_2', 'Issuer_3', 'Issuer_4'], # ← Match your config issuers
+          issuers: ['Issuer_2', 'Issuer_3', 'Issuer_4'],
           start_date: 1.year.ago,
           end_date: 1.year.from_now,
         ),
       ]
     end
 
-    # Apply config the same way send_report does
     report.instance_variable_set(:@report_date, report_date)
     report.instance_variable_set(:@report_receiver, :internal)
     report.instance_variable_set(:@issuers, config['issuers'])
-    # report.instance_variable_set(:@partner_strings, config['partner_strings'])
     report.instance_variable_set(:@agency_abbreviation, config['agency_abbreviation'])
     report.instance_variable_set(:@partner_emails, config['partner_emails'])
     report.instance_variable_set(:@internal_emails, config['internal_emails'])

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -393,23 +393,36 @@ class ReportMailerPreview < ActionMailer::Preview
     report_date = Time.zone.parse('2025-11-30').end_of_day
     config = {
       'issuers' => ['Issuer_2', 'Issuer_3', 'Issuer_4'],
-      'partner_strings' => ['Partner_1'],
+      #'partner_strings' => ['Partner_1'],
+      'agency_abbreviation' => 'PRTNR1',
       'partner_emails' => ['partner1@example.com'],
       'internal_emails' => ['internal1@example.com'],
     }
-
     report = Reports::SpCredMetricsReport.new(report_date, :internal)
 
+    # Mock the partner lookup 
+    def report.partner_accounts
+      [
+        IaaReportingHelper::PartnerConfig.new(
+          partner: 'Partner_1',
+          issuers: ['Issuer_2', 'Issuer_3', 'Issuer_4'],  # ← Match your config issuers
+          start_date: 1.year.ago,
+          end_date: 1.year.from_now
+        )
+      ]
+    end
+    
     # Apply config the same way send_report does
     report.instance_variable_set(:@report_date, report_date)
     report.instance_variable_set(:@report_receiver, :internal)
     report.instance_variable_set(:@issuers, config['issuers'])
-    report.instance_variable_set(:@partner_strings, config['partner_strings'])
+    #report.instance_variable_set(:@partner_strings, config['partner_strings'])
+    report.instance_variable_set(:@agency_abbreviation, config['agency_abbreviation'])
     report.instance_variable_set(:@partner_emails, config['partner_emails'])
     report.instance_variable_set(:@internal_emails, config['internal_emails'])
     report.instance_variable_set(
       :@report_name,
-      "#{config['partner_strings'].first.downcase}_monthly_cred_metrics",
+      "#{config['agency_abbreviation'].downcase}_monthly_cred_metrics",
     )
 
     fixture_csv_data = File.read(

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -246,7 +246,7 @@ class ReportMailerPreview < ActionMailer::Preview
 
     date    = Time.zone.yesterday.end_of_day
     issuers = ['issuer1']
-    agency_abbreviation  = 'TSTAGNCY'
+    agency_abbreviation = 'TSTAGNCY'
 
     builder = Reporting::SpVerificationReport.new(
       time_range: date.beginning_of_week(:sunday).prev_occurring(:sunday).all_week(:sunday),
@@ -393,30 +393,30 @@ class ReportMailerPreview < ActionMailer::Preview
     report_date = Time.zone.parse('2025-11-30').end_of_day
     config = {
       'issuers' => ['Issuer_2', 'Issuer_3', 'Issuer_4'],
-      #'partner_strings' => ['Partner_1'],
+      # 'partner_strings' => ['Partner_1'],
       'agency_abbreviation' => 'PRTNR1',
       'partner_emails' => ['partner1@example.com'],
       'internal_emails' => ['internal1@example.com'],
     }
     report = Reports::SpCredMetricsReport.new(report_date, :internal)
 
-    # Mock the partner lookup 
+    # Mock the partner lookup
     def report.partner_accounts
       [
         IaaReportingHelper::PartnerConfig.new(
           partner: 'Partner_1',
-          issuers: ['Issuer_2', 'Issuer_3', 'Issuer_4'],  # ← Match your config issuers
+          issuers: ['Issuer_2', 'Issuer_3', 'Issuer_4'], # ← Match your config issuers
           start_date: 1.year.ago,
-          end_date: 1.year.from_now
-        )
+          end_date: 1.year.from_now,
+        ),
       ]
     end
-    
+
     # Apply config the same way send_report does
     report.instance_variable_set(:@report_date, report_date)
     report.instance_variable_set(:@report_receiver, :internal)
     report.instance_variable_set(:@issuers, config['issuers'])
-    #report.instance_variable_set(:@partner_strings, config['partner_strings'])
+    # report.instance_variable_set(:@partner_strings, config['partner_strings'])
     report.instance_variable_set(:@agency_abbreviation, config['agency_abbreviation'])
     report.instance_variable_set(:@partner_emails, config['partner_emails'])
     report.instance_variable_set(:@internal_emails, config['internal_emails'])

--- a/spec/mailers/previews/report_mailer_preview.rb
+++ b/spec/mailers/previews/report_mailer_preview.rb
@@ -246,20 +246,20 @@ class ReportMailerPreview < ActionMailer::Preview
 
     date    = Time.zone.yesterday.end_of_day
     issuers = ['issuer1']
-    agency  = 'Test_Agency'
+    agency_abbreviation  = 'TSTAGNCY'
 
     builder = Reporting::SpVerificationReport.new(
       time_range: date.beginning_of_week(:sunday).prev_occurring(:sunday).all_week(:sunday),
       issuers: issuers,
-      agency_abbreviation: agency,
+      agency_abbreviation: agency_abbreviation,
     )
     stub_cloudwatch_client(builder)
 
     ReportMailer.tables_report(
       to: 'test@example.com',
       bcc: 'bcc@example.com',
-      subject: "#{agency} Verification Report - #{date.to_date}",
-      message: "Report: #{agency} Verification Report - #{date.to_date}",
+      subject: "#{agency_abbreviation} Verification Report - #{date.to_date}",
+      message: "Report: #{agency_abbreviation} Verification Report - #{date.to_date}",
       attachment_format: :csv,
       reports: builder.as_emailable_reports,
     )


### PR DESCRIPTION
The `sp_cred_metrics_report.rb` previously utilized a config parameter `partner_strings` for logging and emailing purposes (purely cosmetic). This PR replaces all cosmetic uses of the `partner_strings` with the `agency_abbreviation` config parameter instead. This simplifies the credential metrics report and makes it more in line with other `sp_*` reports.

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-teams/Team-Data/reporting/-/issues/533


## 🛠 Summary of changes

- Removed the use of `partner_strings` in `sp_cred_metrics_report.rb`
- Updated the corresponding specs (`sp_cred_metrics_report_spec.rb`, `sp_cred_metrics_report_orchestrator_spec.rb`)
- Updated `spec/mailers/previews/report_mailer_preview.rb` as well to use new config for cred_metrics preview
- Updated the sp_config google doc

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

