### PR TITLE
Add customer event type to DDP requests

### DIFF
--- a/app/services/doc_auth/lexis_nexis/requests/ddp/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/ddp/true_id_request.rb
@@ -37,6 +37,7 @@ module DocAuth
           def body
             {
               account_email: applicant[:email],
+              customer_event_type: 'true_id',
               policy:,
               'Trueid.image_data.white_front': encode(id_front_image),
               'Trueid.image_data.white_back': back_image_value,

--- a/app/services/proofing/lexis_nexis/ddp/requests/instant_verify_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/requests/instant_verify_request.rb
@@ -26,6 +26,7 @@ module Proofing
               account_drivers_license_type: applicant[:state_id_number] ? 'us_dl' : '',
               account_drivers_license_issuer: applicant[:state_id_jurisdiction].to_s.strip || '',
               event_type: 'ACCOUNT_CREATION',
+              customer_event_type: 'instant_verify',
               policy: config.ddp_policy,
               service_type: 'all',
               national_id_number: applicant[:ssn]&.gsub(/\D/, '') || '',

--- a/app/services/proofing/lexis_nexis/ddp/requests/phone_finder_request.rb
+++ b/app/services/proofing/lexis_nexis/ddp/requests/phone_finder_request.rb
@@ -17,6 +17,7 @@ module Proofing
               account_last_name: applicant[:last_name] || '',
               account_telephone: applicant[:phone],
               event_type: 'ACCOUNT_CREATION',
+              customer_event_type: 'phone_finder',
               policy: config.ddp_policy,
               service_type: 'all',
               national_id_number: applicant[:ssn].to_s.gsub(/\D/, ''),

--- a/spec/fixtures/proofing/lexis_nexis/ddp/instant_verify/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/instant_verify/request.json
@@ -15,6 +15,7 @@
   "account_drivers_license_type": "us_dl",
   "account_drivers_license_issuer": "LA",
   "event_type": "ACCOUNT_CREATION",
+  "customer_event_type": "instant_verify",
   "policy": "test-policy",
   "service_type": "all",
   "national_id_number": "123456789",

--- a/spec/fixtures/proofing/lexis_nexis/ddp/phone_finder/request.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/phone_finder/request.json
@@ -6,6 +6,7 @@
   "account_last_name": "McTesterson",
   "account_telephone": "5551231234",
   "event_type": "ACCOUNT_CREATION",
+  "customer_event_type": "phone_finder",
   "policy": "test-policy",
   "service_type": "all",
   "national_id_number": "123456789",

--- a/spec/services/doc_auth/lexis_nexis/requests/ddp/true_id_request_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/requests/ddp/true_id_request_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe DocAuth::LexisNexis::Requests::Ddp::TrueIdRequest do
         .with { |req|
           body = JSON.parse(req.body)
           body['account_email'] == 'person.name@email.test' &&
+            body['customer_event_type'] == 'true_id' &&
             body['service_type'] == 'basic' &&
             body['local_attrib_1'] == 'test_prefix' &&
             body['local_attrib_3'] == 'test_uuid_12345'


### PR DESCRIPTION
changelog: Internal, IdV, Add customer event type to LexisNexis DDP requests

## 🎫 Ticket

Link to the relevant ticket:

[joan-23](https://gitlab.login.gov/lg-teams/joan/-/issues/23)

## 🛠 Summary of changes

Add customer event type to LexisNexis DDP requests.