### PR TITLE
Fix flaky tests when CI runner is in Adelaide timezone (30 minute offset)

### DIFF
--- a/app/jobs/reports/sp_proofing_events_by_uuid.rb
+++ b/app/jobs/reports/sp_proofing_events_by_uuid.rb
@@ -21,7 +21,7 @@ module Reports
       issuers = report_config['issuers']
       agency_abbreviation = report_config['agency_abbreviation']
       emails = report_config['emails']
-      report_hour = report_date.in_time_zone.beginning_of_hour
+      report_hour = report_date.utc.beginning_of_hour
       previous_hour_range = (report_hour - 1.hour)...report_hour
 
       agency_report_name = "#{agency_abbreviation.downcase}_proofing_events_by_uuid"


### PR DESCRIPTION
[skip changelog]

Our CI runner apparently uses the Adelaide timezone, which is a 30 minute offset. When the test was run between 30 and 59 in a given hour, the specs would fail:

```
#<Reports::SpProofingEventsByUuid:0x00007fd9e4e9a320 @arguments=[], @job_id="a9dcc859-f3a1-41ca-b7b8-628614968237", @queue_name="long_running", @scheduled_at=nil, @priority=nil, @executions=0, @exception_executions={}, @timezone="Adelaide", @report_date=2024-12-09 15:42:10 UTC> received :build_report_maker with unexpected arguments
         expected: ({agency_abbreviation: "ABC", issuers: ["super:cool:test:issuer"], time_range: 2024-12-09 14:00:00 UTC...2024-12-09 15:00:00 UTC})
              got: ({agency_abbreviation: "ABC", issuers: ["super:cool:test:issuer"], time_range: 2024-12-10 01:00:00.000000000 ACDT +10:30...2024-12-10 02:00:00.000000000 ACDT +10:30})
```