### PR TITLE
LG-17457: passport no match network error

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -36,6 +36,7 @@ module Idv
         selfie_fail: stored_result&.errors&.dig(:selfie_fail),
         unexpected_id_type: stored_result&.errors&.dig(:unexpected_id_type),
         state_id_verification: stored_result&.errors&.dig(:state_id_verification),
+        passport: stored_result&.errors&.dig(:passport),
       }
     end
 

--- a/app/controllers/concerns/idv/socure_errors_concern.rb
+++ b/app/controllers/concerns/idv/socure_errors_concern.rb
@@ -26,6 +26,8 @@ module Idv
         :pii_validation
       elsif result.errors[:state_id_verification]
         :state_id_verification
+      elsif result.errors[:passport]
+        :passport
       else
         # No error information available (shouldn't happen). Default
         # to :network if it does.

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -128,6 +128,8 @@ class SocureErrorPresenter
       t('doc_auth.errors.selfie_fail_heading')
     when :state_id_verification
       t('doc_auth.headers.state_id_verification')
+    when :passport
+      t('doc_auth.errors.rate_limited_heading')
     else
       # i18n-tasks-use t('doc_auth.headers.unreadable_id')
       # i18n-tasks-use t('doc_auth.headers.unaccepted_id_type')
@@ -155,6 +157,8 @@ class SocureErrorPresenter
       t('doc_auth.errors.general.selfie_failure')
     when :state_id_verification
       t('doc_auth.errors.state_id_verification')
+    when :passport
+      t('doc_auth.info.review_passport')
     else
       if remapped_error(error_code) == 'underage' # special handling because it says 'Login.gov'
         I18n.t('doc_auth.errors.underage', app_name: APP_NAME)

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -552,6 +552,7 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
                 transaction_token: @docv_transaction_token,
               ),
             )
+            byebug
             expect(page).to have_content(t('idv.errors.try_again_later'))
 
             click_on t('idv.failure.button.warning')

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -552,7 +552,7 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
                 transaction_token: @docv_transaction_token,
               ),
             )
-            byebug
+            # byebug
             expect(page).to have_content(t('idv.errors.try_again_later'))
 
             click_on t('idv.failure.button.warning')

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -552,8 +552,9 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
                 transaction_token: @docv_transaction_token,
               ),
             )
-            # byebug
-            expect(page).to have_content(t('idv.errors.try_again_later'))
+
+            expect(page).to have_content(t('doc_auth.errors.rate_limited_heading'))
+            expect(page).to have_content(t('doc_auth.info.review_passport'))
 
             click_on t('idv.failure.button.warning')
 

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -207,6 +207,7 @@ RSpec.describe 'Hybrid Flow' do
               transaction_token: @docv_transaction_token,
             ),
           )
+          byebug
           expect(page).to have_content(t('idv.errors.try_again_later'))
           expect(page).to have_content(
             I18n.t('idv.troubleshooting.options.use_another_id_type'),

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe 'Hybrid Flow' do
               transaction_token: @docv_transaction_token,
             ),
           )
-          byebug
+          # byebug
           expect(page).to have_content(t('idv.errors.try_again_later'))
           expect(page).to have_content(
             I18n.t('idv.troubleshooting.options.use_another_id_type'),

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -208,7 +208,8 @@ RSpec.describe 'Hybrid Flow' do
             ),
           )
           # byebug
-          expect(page).to have_content(t('idv.errors.try_again_later'))
+          expect(page).to have_content(t('doc_auth.errors.rate_limited_heading'))
+          expect(page).to have_content(t('doc_auth.info.review_passport'))
           expect(page).to have_content(
             I18n.t('idv.troubleshooting.options.use_another_id_type'),
           )

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe 'Hybrid Flow' do
               transaction_token: @docv_transaction_token,
             ),
           )
-          # byebug
+
           expect(page).to have_content(t('doc_auth.errors.rate_limited_heading'))
           expect(page).to have_content(t('doc_auth.info.review_passport'))
           expect(page).to have_content(


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-17457](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17457)

## 🛠 Summary of changes
Errors presenter to handle passport errors, previously defaulting to network errors.

## 📜 Testing Plan
Automated feature specs.

## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.


<summary>Before:</summary>
<img width="308" height="621" alt="passport_network_error" src="https://github.com/user-attachments/assets/11cb6707-a560-477f-a8d2-9bb8190410a5" />

<summary>After:</summary>
<img width="623" height="476" alt="Screenshot 2026-04-10 at 4 45 19 PM" src="https://github.com/user-attachments/assets/563da29b-0cba-44ce-a2f5-c74afb6c93d1" />


[LG-17457]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17457