### PR TITLE
Add socure phone risk to event summarizer

### DIFF
--- a/lib/event_summarizer/idv_matcher.rb
+++ b/lib/event_summarizer/idv_matcher.rb
@@ -10,6 +10,7 @@ require 'event_summarizer/vendor_result_evaluators/phone_finder'
 require 'event_summarizer/vendor_result_evaluators/true_id'
 require 'event_summarizer/vendor_result_evaluators/socure_doc_v'
 require 'event_summarizer/vendor_result_evaluators/socure_kyc'
+require 'event_summarizer/vendor_result_evaluators/socure_phone_risk'
 
 module EventSummarizer
   class IdvMatcher
@@ -41,6 +42,11 @@ module EventSummarizer
         id: :socure_kyc,
         name: 'Socure KYC',
         evaluator_module: EventSummarizer::VendorResultEvaluators::SocureKyc,
+      },
+      'socure_phonerisk' => {
+        id: :socure_phonerisk,
+        name: 'Socure Phone Risk',
+        evaluator_module: EventSummarizer::VendorResultEvaluators::SocurePhoneRisk,
       },
       'lexisnexis:instant_verify' => {
         id: :instant_verify,
@@ -508,12 +514,14 @@ module EventSummarizer
     def handle_phone_confirmation_vendor_event(event:)
       timestamp = event['@timestamp']
       success = event.dig(*EVENT_PROPERTIES, 'success')
+      vendor = event.dig(*EVENT_PROPERTIES, 'vendor', 'vendor_name')
+      vendor_name = VENDORS.dig(vendor, :name) || UNKNOWN_VENDOR.dig(:name)
 
       if success
         add_significant_event(
           timestamp:,
-          type: :passed_phone_finder,
-          description: 'Phone Finder check succeeded',
+          type: :passed_phone_confirmation,
+          description: "Phone confirmation check succeeded via #{vendor_name}",
         )
 
         return

--- a/lib/event_summarizer/vendor_result_evaluators/socure.rb
+++ b/lib/event_summarizer/vendor_result_evaluators/socure.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module EventSummarizer
+  module VendorResultEvaluators
+    # Base class for socure vendor result evaluators. Child classes should implement the
+    # module_name, type, and reason_code template methods.
+    class Socure
+      class << self
+        # @param result [Hash{String => Object}] The result structure logged to Cloudwatch
+        # @return [Hash{Symbol => String}] A Hash with a type and description keys.
+        def evaluate_result(result)
+          return successful_response if result['success'] == true
+          return timeout_response if result['timeout'] == true
+
+          return failure_response(result)
+        end
+
+        private
+
+        BULLET = "#{' ' * 17}- ".freeze
+
+        def successful_response
+          response(
+            type: :"socure_#{type}_success",
+            description: "Socure #{module_name} call succeeded",
+          )
+        end
+
+        def timeout_response
+          response(
+            type: :"socure_#{type}_timeout",
+            description: "Socure #{module_name} call timed out",
+          )
+        end
+
+        def failure_response(result)
+          response(type: :"socure_#{type}_failures", description: failure_description(result))
+        end
+
+        def failure_description(result)
+          failures = failure_reason_codes(reason_codes(result))
+
+          failures.empty? ?
+          "#{failure_message(result)}: Without reason codes" :
+          "#{failure_message(result)}:#{failures}"
+        end
+
+        def failure_reason_codes(reason_codes)
+          return [] if !reason_codes
+
+          reason_codes.map do |code, reason|
+            "\n#{BULLET}#{code}: #{reason}" if code.match?(/^R\d+/)
+          end.join
+        end
+
+        def failure_message(_result)
+          "Socure #{module_name} request failed"
+        end
+
+        def response(type:, description:)
+          { type:, description: }
+        end
+      end
+    end
+  end
+end

--- a/lib/event_summarizer/vendor_result_evaluators/socure_doc_v.rb
+++ b/lib/event_summarizer/vendor_result_evaluators/socure_doc_v.rb
@@ -1,78 +1,67 @@
 # frozen_string_literal: true
 
-require 'byebug'
+require_relative 'socure'
 
 module EventSummarizer
   module VendorResultEvaluators
-    class SocureDocV
-      # @param result {Hash} The array of processed_alerts.failed logged to Cloudwatch
-      # @option result [Boolean] :success Whether the Socure DocV check was successful
-      # @option result [String] :document_type The type of document processed
-      # @option result [Array<String>] :reason_codes The array of reason codes returned by Socure
-      #
-      # @return [Hash] A Hash with a type and description keys.
-      def self.evaluate_result(result)
-        return if result[:success] == true
+    class SocureDocV < Socure
+      class << self
+        private
 
-        alerts = []
-        result[:reason_codes]&.each do |code|
-          if code[0] == 'R'
-            alerts << {
-              type: code,
-              description: "#{code}: #{reason_code_description(code)}",
-            }
+        def type
+          'docv'
+        end
+
+        def module_name
+          'DocV'
+        end
+
+        def failure_message(result)
+          "Socure #{module_name} request failed (document_type: #{result[:document_type]})"
+        end
+
+        def reason_codes(result)
+          # rubocop:disable Rails/IndexWith
+          result[:reason_codes].to_h do |code|
+            [code, REASON_CODES[code] || '']
           end
+          # rubocop:enable Rails/IndexWith
         end
 
-        alerts.uniq! { |a| a[:description] }
-        bullet = "#{' ' * 17}- "
-        description = "Socure DocV request failed (document_type: #{result[:document_type]}):"
-        if !alerts.empty?
-          description += "\n#{bullet}#{alerts.map { |a| a[:description] }.join("\n#{bullet}")}"
-        end
-        return {
-          type: :socure_docv_failures,
-          description:,
-        }
+        # This list includes all the R8xx reason codes as of 10/3/2025
+        # Easier to maintain here than in the DB
+        REASON_CODES = {
+          'R810' =>	'Document pattern and layout integrity check failed',
+          'R819' =>	'Document fails liveness check',
+          'R820' =>	'Document headshot has been modified',
+          'R822' =>	'First name extracted from document does not match input first name',
+          'R823' =>	'Last name extracted from document does not match input last name',
+          'R824' =>	'Address extracted from document does not match input address',
+          'R825' =>	'DOB extracted from document does not match input DOB',
+          'R826' =>	'Document Number extracted from document does not match input number',
+          'R827' =>	'Document is expired',
+          'R831' =>	'Cannot extract the minimum information from barcode',
+          'R833' =>	'Cannot extract the minimum required information from MRZ',
+          'R834' =>	'Selfie fails the liveness check',
+          'R836' =>	'Document image does not correlate with self-portrait',
+          'R838' =>	'Minimum amount of information cannot be extracted from document',
+          'R845' =>	'Minimum age criteria not met',
+          'R850' =>	'Self-portrait or the headshot is not usable for Facial Match',
+          'R853' =>	'Unable to classify the ID or this is an unsupported ID type',
+          'R856' =>	'Obstructions on the face affecting the liveness',
+          'R857' =>	'No face found in the selfie frame',
+          'R858' =>	'The age on the document doesn\'t correlate with the selfie predicted age',
+          'R859' =>	'ID image correlates to another ID image',
+          'R861' =>	'Data extracted from document does not match with barcode or MRZ',
+          'R862' =>	'The document could not be classified',
+          'R863' =>	'Incorrect side of document uploaded',
+          'R864' =>	'Image upload from file detected',
+          'R865' =>	'Disallowed ID Type',
+          'R895' =>	'First Name extracted from document was fuzzy matched with input First Name',
+          'R896' =>	'Last Name extracted from document was fuzzy matched with input Last Name',
+          'R897' =>	'DOB extracted from document was fuzzy matched with input DOB',
+        }.freeze
       end
-
-      def self.reason_code_description(code)
-        REASON_CODES[code]
-      end
-
-      # This list includes all the R8xx reason codes as of 10/3/2025
-      # Easier to maintain here than in the DB
-      REASON_CODES = {
-        'R810' =>	'Document pattern and layout integrity check failed',
-        'R819' =>	'Document fails liveness check',
-        'R820' =>	'Document headshot has been modified',
-        'R822' =>	'First name extracted from document does not match input first name',
-        'R823' =>	'Last name extracted from document does not match input last name',
-        'R824' =>	'Address extracted from document does not match input address',
-        'R825' =>	'DOB extracted from document does not match input DOB',
-        'R826' =>	'Document Number extracted from document does not match input number',
-        'R827' =>	'Document is expired',
-        'R831' =>	'Cannot extract the minimum information from barcode',
-        'R833' =>	'Cannot extract the minimum required information from MRZ',
-        'R834' =>	'Selfie fails the liveness check',
-        'R836' =>	'Document image does not correlate with self-portrait',
-        'R838' =>	'Minimum amount of information cannot be extracted from document',
-        'R845' =>	'Minimum age criteria not met',
-        'R850' =>	'Self-portrait or the headshot is not usable for Facial Match',
-        'R853' =>	'Unable to classify the ID or this is an unsupported ID type',
-        'R856' =>	'Obstructions on the face affecting the liveness',
-        'R857' =>	'No face found in the selfie frame',
-        'R858' =>	'The age on the document doesn\'t correlate with the selfie predicted age',
-        'R859' =>	'ID image correlates to another ID image',
-        'R861' =>	'Data extracted from document does not match with barcode or MRZ',
-        'R862' =>	'The document could not be classified',
-        'R863' =>	'Incorrect side of document uploaded',
-        'R864' =>	'Image upload from file detected',
-        'R865' =>	'Disallowed ID Type',
-        'R895' =>	'First Name extracted from document was fuzzy matched with input First Name',
-        'R896' =>	'Last Name extracted from document was fuzzy matched with input Last Name',
-        'R897' =>	'DOB extracted from document was fuzzy matched with input DOB',
-      }.freeze
     end
   end
 end

--- a/lib/event_summarizer/vendor_result_evaluators/socure_phone_risk.rb
+++ b/lib/event_summarizer/vendor_result_evaluators/socure_phone_risk.rb
@@ -4,20 +4,20 @@ require_relative 'socure'
 
 module EventSummarizer
   module VendorResultEvaluators
-    class SocureKyc < Socure
+    class SocurePhoneRisk < Socure
       class << self
         private
 
         def reason_codes(result)
-          result['reason_codes']
+          result['vendor']['result']['phonerisk']['reason_codes']
         end
 
         def type
-          'kyc'
+          'phonerisk'
         end
 
         def module_name
-          'KYC'
+          'Phone Risk'
         end
       end
     end

--- a/spec/lib/event_summarizer/idv_matcher_spec.rb
+++ b/spec/lib/event_summarizer/idv_matcher_spec.rb
@@ -53,38 +53,119 @@ RSpec.describe EventSummarizer::IdvMatcher do
       end
     end
 
-    context "On 'IdV: phone confirmation vendor' (PhoneFinder) event" do
-      let(:event) do
-        {
-          '@timestamp' => Time.zone.now,
-          'name' => 'IdV: phone confirmation vendor',
-          '@message' => {
-            'properties' => {
-              'event_properties' => {
-                'success' => true,
+    context "On 'IdV: phone confirmation vendor' event" do
+      context 'When the vendor is Phone Finder' do
+        let(:event) do
+          {
+            '@timestamp' => Time.zone.now,
+            'name' => 'IdV: phone confirmation vendor',
+            '@message' => {
+              'properties' => {
+                'event_properties' => {
+                  'success' => true,
+                  'vendor' => {
+                    'vendor_name' => 'lexisnexis:phone_finder',
+                  },
+                },
               },
             },
-          },
-        }
+          }
+        end
+
+        before do
+          allow(matcher).to receive(:current_idv_attempt).and_return(
+            EventSummarizer::IdvMatcher::IdvAttempt.new(
+              started_at: Time.zone.now,
+            ),
+          )
+        end
+
+        it 'adds a passed_phone_finder significant event when successful' do
+          matcher.handle_cloudwatch_event(event)
+
+          expect(matcher.current_idv_attempt.significant_events).to include(
+            have_attributes(
+              type: :passed_phone_confirmation,
+              description: 'Phone confirmation check succeeded via Phone Finder',
+            ),
+          )
+        end
       end
 
-      before do
-        allow(matcher).to receive(:current_idv_attempt).and_return(
-          EventSummarizer::IdvMatcher::IdvAttempt.new(
-            started_at: Time.zone.now,
-          ),
-        )
+      context 'When the vendor is Phone Risk' do
+        let(:event) do
+          {
+            '@timestamp' => Time.zone.now,
+            'name' => 'IdV: phone confirmation vendor',
+            '@message' => {
+              'properties' => {
+                'event_properties' => {
+                  'success' => true,
+                  'vendor' => {
+                    'vendor_name' => 'socure_phonerisk',
+                  },
+                },
+              },
+            },
+          }
+        end
+
+        before do
+          allow(matcher).to receive(:current_idv_attempt).and_return(
+            EventSummarizer::IdvMatcher::IdvAttempt.new(
+              started_at: Time.zone.now,
+            ),
+          )
+        end
+
+        it 'adds a passed_phone_confirmation significant event when successful' do
+          matcher.handle_cloudwatch_event(event)
+
+          expect(matcher.current_idv_attempt.significant_events).to include(
+            have_attributes(
+              type: :passed_phone_confirmation,
+              description: 'Phone confirmation check succeeded via Socure Phone Risk',
+            ),
+          )
+        end
       end
 
-      it 'adds a passed_phone_finder significant event when successful' do
-        matcher.handle_cloudwatch_event(event)
+      context 'When the vendor is Unknown' do
+        let(:event) do
+          {
+            '@timestamp' => Time.zone.now,
+            'name' => 'IdV: phone confirmation vendor',
+            '@message' => {
+              'properties' => {
+                'event_properties' => {
+                  'success' => true,
+                  'vendor' => {
+                    'vendor_name' => 'an unknown vendor',
+                  },
+                },
+              },
+            },
+          }
+        end
 
-        expect(matcher.current_idv_attempt.significant_events).to include(
-          have_attributes(
-            type: :passed_phone_finder,
-            description: 'Phone Finder check succeeded',
-          ),
-        )
+        before do
+          allow(matcher).to receive(:current_idv_attempt).and_return(
+            EventSummarizer::IdvMatcher::IdvAttempt.new(
+              started_at: Time.zone.now,
+            ),
+          )
+        end
+
+        it 'adds a passed_phone_confirmation significant event when successful' do
+          matcher.handle_cloudwatch_event(event)
+
+          expect(matcher.current_idv_attempt.significant_events).to include(
+            have_attributes(
+              type: :passed_phone_confirmation,
+              description: 'Phone confirmation check succeeded via Unknown vendor',
+            ),
+          )
+        end
       end
     end
   end

--- a/spec/lib/event_summarizer/vendor_result_evaluators/socure_doc_v_spec.rb
+++ b/spec/lib/event_summarizer/vendor_result_evaluators/socure_doc_v_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe EventSummarizer::VendorResultEvaluators::SocureDocV do
         expect(evaluation).to eql(
           {
             type: :socure_docv_failures,
-            description: "Socure DocV request failed (document_type: #{document_type}):",
+            description: "Socure DocV request failed (document_type: #{document_type}): " \
+            "Without reason codes",
           },
         )
       end

--- a/spec/lib/event_summarizer/vendor_result_evaluators/socure_phone_risk_spec.rb
+++ b/spec/lib/event_summarizer/vendor_result_evaluators/socure_phone_risk_spec.rb
@@ -1,0 +1,88 @@
+require 'event_summarizer/vendor_result_evaluators/socure_phone_risk'
+
+RSpec.describe EventSummarizer::VendorResultEvaluators::SocurePhoneRisk do
+  describe '.evaluate_result' do
+    subject { described_class }
+
+    let(:description_bullet) { "#{' ' * 17}- " }
+    let(:reason_codes) { nil }
+    let(:timeout) { false }
+    let(:result) do
+      {
+        'success' => success,
+        'timeout' => timeout,
+        'vendor' => {
+          'result' => {
+            'phonerisk' => {
+              'reason_codes' => reason_codes,
+            },
+          },
+        },
+      }
+    end
+
+    context 'when the result is successful' do
+      let(:success) { true }
+
+      it 'returns a success hash' do
+        expect(subject.evaluate_result(result)).to eq(
+          {
+            type: :socure_phonerisk_success,
+            description: 'Socure Phone Risk call succeeded',
+          },
+        )
+      end
+    end
+
+    context 'when the result is not successful' do
+      let(:success) { false }
+
+      context 'when the result is a timeout' do
+        let(:timeout) { true }
+
+        it 'returns a timeout response' do
+          expect(subject.evaluate_result(result)).to eq(
+            {
+              type: :socure_phonerisk_timeout,
+              description: 'Socure Phone Risk call timed out',
+            },
+          )
+        end
+      end
+
+      context 'when the result is not a timeout' do
+        let(:timeout) { false }
+
+        context 'when reason codes are present' do
+          let(:reason_codes) do
+            {
+              'I600' => 'Some numbers match',
+              'R800' => 'I am error',
+              'R801' => 'Identity not associated',
+            }
+          end
+
+          it 'returns a failure hash' do
+            expect(subject.evaluate_result(result)).to eq(
+              type: :socure_phonerisk_failures,
+              description: "Socure Phone Risk request failed:" \
+              "\n#{description_bullet}R800: I am error" \
+              "\n#{description_bullet}R801: Identity not associated",
+            )
+          end
+        end
+      end
+
+      context 'when reason codes are not present' do
+        let(:reason_codes) { nil }
+
+        it 'returns a failure hash' do
+          expect(subject.evaluate_result(result)).to eq(
+            type: :socure_phonerisk_failures,
+            description: 'Socure Phone Risk request failed: Without reason codes',
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[JOAN-22](https://gitlab.login.gov/lg-teams/joan/-/issues/22)

## 🛠 Summary of changes

Add socure phone risk to the event summarizer. Refactored socure result evaluators to use a template class. Helping to reduce duplication between the different socure result evaluators.