### PR TITLE
LG-17462: update messaging when mrz match raises

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -37,7 +37,8 @@ module Idv
         unexpected_id_type: stored_result&.errors&.dig(:unexpected_id_type),
         state_id_verification: stored_result&.errors&.dig(:state_id_verification),
         passport: stored_result&.errors&.dig(:passport),
-        passport_network: stored_result&.errors&.dig(:network) && stored_result&.errors&.dig(:passport),
+        passport_network: stored_result&.errors&.dig(:network) &&
+          stored_result.errors.dig(:passport),
       }
     end
 

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -37,6 +37,7 @@ module Idv
         unexpected_id_type: stored_result&.errors&.dig(:unexpected_id_type),
         state_id_verification: stored_result&.errors&.dig(:state_id_verification),
         passport: stored_result&.errors&.dig(:passport),
+        passport_network: stored_result&.errors&.dig(:network) && stored_result&.errors&.dig(:passport),
       }
     end
 

--- a/app/controllers/concerns/idv/socure_errors_concern.rb
+++ b/app/controllers/concerns/idv/socure_errors_concern.rb
@@ -26,6 +26,8 @@ module Idv
         :pii_validation
       elsif result.errors[:state_id_verification]
         :state_id_verification
+      elsif result.errors[:passport_network]
+        :passport_network
       elsif result.errors[:passport]
         :passport
       else

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -142,7 +142,6 @@ class SocureErrorPresenter
   end
 
   def error_string_for(error_code)
-    puts "\n\nerror code: #{error_code}\n\n"
     case error_code.to_sym
     when :network
       t('doc_auth.errors.general.new_network_error')
@@ -158,19 +157,20 @@ class SocureErrorPresenter
       t('doc_auth.errors.general.selfie_failure')
     when :state_id_verification
       t('doc_auth.errors.state_id_verification')
-    when :passport
-      t('doc_auth.info.review_passport')
     when :passport_network
       safe_join(
-      [
-        t('doc_auth.errors.general.network_error_passport'),
-        link_to(
-          t('doc_auth.errors.general.network_error_passport_link_text'),
-          idv_choose_id_type_path,
-        ),
-      ],
-      ' ',
-    )
+        [
+          t('doc_auth.errors.general.network_error_passport'),
+          link_to(
+            t('doc_auth.errors.general.network_error_passport_link_text'),
+            idv_choose_id_type_path,
+          ),
+          t('doc_auth.errors.general.network_error_passport_ending'),
+        ],
+        ' ',
+      )
+    when :passport
+      t('doc_auth.info.review_passport')
     else
       if remapped_error(error_code) == 'underage' # special handling because it says 'Login.gov'
         I18n.t('doc_auth.errors.underage', app_name: APP_NAME)

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -128,7 +128,7 @@ class SocureErrorPresenter
       t('doc_auth.errors.selfie_fail_heading')
     when :state_id_verification
       t('doc_auth.headers.state_id_verification')
-    when :passport
+    when :passport, :passport_network
       t('doc_auth.errors.rate_limited_heading')
     else
       # i18n-tasks-use t('doc_auth.headers.unreadable_id')

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -142,6 +142,7 @@ class SocureErrorPresenter
   end
 
   def error_string_for(error_code)
+    puts "\n\nerror code: #{error_code}\n\n"
     case error_code.to_sym
     when :network
       t('doc_auth.errors.general.new_network_error')
@@ -159,6 +160,17 @@ class SocureErrorPresenter
       t('doc_auth.errors.state_id_verification')
     when :passport
       t('doc_auth.info.review_passport')
+    when :passport_network
+      safe_join(
+      [
+        t('doc_auth.errors.general.network_error_passport'),
+        link_to(
+          t('doc_auth.errors.general.network_error_passport_link_text'),
+          idv_choose_id_type_path,
+        ),
+      ],
+      ' ',
+    )
     else
       if remapped_error(error_code) == 'underage' # special handling because it says 'Login.gov'
         I18n.t('doc_auth.errors.underage', app_name: APP_NAME)

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -163,7 +163,7 @@ class SocureErrorPresenter
           t('doc_auth.errors.general.network_error_passport'),
           link_to(
             t('doc_auth.errors.general.network_error_passport_link_text'),
-            idv_choose_id_type_path,
+            choose_id_type_path,
           ),
           t('doc_auth.errors.general.network_error_passport_ending'),
         ],
@@ -203,7 +203,7 @@ class SocureErrorPresenter
         verify_id_text,
         link_to(
           t('doc_auth.errors.verify.use_another_type_of_id'),
-          idv_choose_id_type_path,
+          choose_id_type_path,
         ),
       ],
       ' ',
@@ -222,7 +222,7 @@ class SocureErrorPresenter
   def default_options
     [
       {
-        url: hybrid_flow? ? idv_hybrid_mobile_choose_id_type_path : idv_choose_id_type_path,
+        url: choose_id_type_path,
         text: I18n.t('idv.troubleshooting.options.use_another_id_type'),
         isExternal: false,
       },
@@ -251,5 +251,9 @@ class SocureErrorPresenter
         isExternal: true,
       },
     ]
+  end
+
+  def choose_id_type_path
+    hybrid_flow? ? idv_hybrid_mobile_choose_id_type_path : idv_choose_id_type_path
   end
 end

--- a/app/services/doc_auth/dos/requests/health_check_request.rb
+++ b/app/services/doc_auth/dos/requests/health_check_request.rb
@@ -30,7 +30,7 @@ module DocAuth
           analytics.passport_api_health_check(
             **response.to_h
                 .except(*UNUSED_RESPONSE_KEYS)
-                .merge(response.extra)
+                .merge(response ? response.extra : {})
                 .merge(context_analytics),
           )
         end

--- a/app/services/doc_auth/dos/requests/health_check_request.rb
+++ b/app/services/doc_auth/dos/requests/health_check_request.rb
@@ -30,7 +30,7 @@ module DocAuth
           analytics.passport_api_health_check(
             **response.to_h
                 .except(*UNUSED_RESPONSE_KEYS)
-                .merge(response ? response.extra : {})
+                .merge(response.extra)
                 .merge(context_analytics),
           )
         end

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -631,7 +631,6 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
               @docv_stub = stub_docv_verification_data_pass(
                 docv_transaction_token: @docv_transaction_token,
                 reason_codes: ['not_processed'],
-                # document_type: :passport,
                 user:,
               )
               expect(page).to have_current_path(idv_choose_id_type_url)

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -588,6 +588,78 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
           end
         end
 
+        context 'retries w/ state ID after network error on the MRZ check' do
+          it 'proceeds to the next page with valid info' do
+            perform_in_browser(:mobile) do
+              visit_idp_from_oidc_sp_with_ial2
+              sign_in_and_2fa_user(user)
+
+              complete_doc_auth_steps_before_hybrid_handoff_step
+              click_continue
+              expect(page).to have_current_path(idv_choose_id_type_url)
+              choose(t('doc_auth.forms.id_type_preference.passport'))
+              click_on t('forms.buttons.continue')
+
+              expect(page).to have_current_path(idv_socure_document_capture_url)
+              expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+              @mrz_stub = stub_request(:post, IdentityConfig.store.dos_passport_mrz_endpoint)
+                .to_return_json({ status: 500, body: { error: 'Gone fishin' } })
+              click_idv_continue
+              socure_docv_upload_documents(
+                docv_transaction_token: @docv_transaction_token,
+              )
+              visit idv_socure_document_capture_update_path
+
+              expect(page).to have_current_path(
+                idv_socure_document_capture_errors_url(
+                  transaction_token: @docv_transaction_token,
+                ),
+              )
+
+              expect(page).to have_content(t('doc_auth.errors.general.network_error_passport'))
+              click_on t('doc_auth.errors.general.network_error_passport_link_text')
+
+              remove_request_stub(@docv_stub)
+              @docv_stub = stub_docv_verification_data_pass(
+                docv_transaction_token: @docv_transaction_token,
+                reason_codes: ['not_processed'],
+                # document_type: :passport,
+                user:,
+              )
+              expect(page).to have_current_path(idv_choose_id_type_url)
+              choose(t('doc_auth.forms.id_type_preference.drivers_license'))
+
+              click_on t('forms.buttons.continue')
+              click_idv_continue # open capture app
+
+              expect(page).to have_current_path(fake_socure_document_capture_app_url)
+              visit idv_socure_document_capture_path
+              expect(page).to have_current_path(idv_socure_document_capture_path)
+              socure_docv_upload_documents(
+                docv_transaction_token: @docv_transaction_token,
+              )
+
+              visit idv_socure_document_capture_update_path
+
+              expect(page).to have_current_path(idv_ssn_url)
+
+              expect(fake_analytics).to have_logged_event(
+                :idv_socure_document_request_submitted,
+              )
+              expect(fake_analytics).to have_logged_event(
+                :idv_socure_verification_data_requested,
+              )
+              expect(fake_analytics).to have_logged_event(
+                'IdV: doc auth image upload vendor pii validation',
+              )
+
+              fill_out_ssn_form_ok
+              click_idv_continue
+            end
+          end
+        end
+
         context 'when a selfie is required' do
           let(:socure_docv_webhook_repeat_endpoints) { [] }
           let(:max_attempts) { 4 }

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -617,6 +617,7 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
                 ),
               )
 
+              expect(page).to have_content(t('doc_auth.errors.rate_limited_heading'))
               expect(page).to have_content(
                 [
                   t('doc_auth.errors.general.network_error_passport'),

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -617,7 +617,13 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
                 ),
               )
 
-              expect(page).to have_content(t('doc_auth.errors.general.network_error_passport'))
+              expect(page).to have_content(
+                [
+                  t('doc_auth.errors.general.network_error_passport'),
+                  t('doc_auth.errors.general.network_error_passport_link_text'),
+                  t('doc_auth.errors.general.network_error_passport_ending'),
+                ].join(' '),
+              )
               click_on t('doc_auth.errors.general.network_error_passport_link_text')
 
               remove_request_stub(@docv_stub)

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -391,6 +391,99 @@ RSpec.describe 'Hybrid Flow' do
             click_idv_continue
           end
         end
+
+        context 'retries w/ state ID after network error on the MRZ check' do
+          it 'proceeds to the next page with valid info' do
+            expect(SocureDocvRepeatWebhookJob).not_to receive(:perform_later)
+
+            perform_in_browser(:desktop) do
+              visit_idp_from_oidc_sp_with_ial2(facial_match_required: true)
+              sign_in_and_2fa_user(user)
+
+              complete_doc_auth_steps_before_hybrid_handoff_step
+              clear_and_fill_in(:doc_auth_phone, phone_number)
+              click_send_link
+            end
+
+            expect(@sms_link).to be_present
+
+            perform_in_browser(:mobile) do
+              visit @sms_link
+
+              expect(page).to have_current_path(idv_hybrid_mobile_choose_id_type_url)
+              choose(t('doc_auth.forms.id_type_preference.passport'))
+              click_on t('forms.buttons.continue')
+
+              expect(page).to have_current_path(idv_hybrid_mobile_socure_document_capture_url)
+              expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+
+              @docv_stub = stub_docv_verification_data_pass(
+                docv_transaction_token: @docv_transaction_token,
+                reason_codes: ['not_processed'],
+                user:,
+                document_type: :passport,
+              )
+              @mrz_stub = stub_request(:post, IdentityConfig.store.dos_passport_mrz_endpoint)
+                .to_return_json({ status: 500, body: { error: 'Gone fishin' } })
+              click_idv_continue
+              socure_docv_upload_documents(
+                docv_transaction_token: @docv_transaction_token,
+              )
+              visit idv_hybrid_mobile_socure_document_capture_update_path
+
+              expect(page).to have_current_path(
+                idv_hybrid_mobile_socure_document_capture_errors_url(
+                  transaction_token: @docv_transaction_token,
+                ),
+              )
+
+              expect(page).to have_content(
+                [
+                  t('doc_auth.errors.general.network_error_passport'),
+                  t('doc_auth.errors.general.network_error_passport_link_text'),
+                  t('doc_auth.errors.general.network_error_passport_ending'),
+                ].join(' '),
+              )
+
+              click_on t('doc_auth.errors.general.network_error_passport_link_text')
+
+              remove_request_stub(@docv_stub)
+              @docv_stub = stub_docv_verification_data_pass(
+                docv_transaction_token: @docv_transaction_token,
+                reason_codes: ['pass'],
+                user:,
+              )
+              expect(page).to have_current_path(idv_hybrid_mobile_choose_id_type_path)
+              choose(t('doc_auth.forms.id_type_preference.drivers_license'))
+
+              click_on t('forms.buttons.continue')
+              click_idv_continue # open capture app
+
+              socure_docv_upload_documents(
+                docv_transaction_token: @docv_transaction_token,
+              )
+
+              visit idv_hybrid_mobile_socure_document_capture_update_url
+
+              expect(page).to have_current_path(idv_hybrid_mobile_capture_complete_url)
+              expect(page).to have_content(strip_nbsp(t('doc_auth.headings.capture_complete')))
+              expect(page).to have_text(t('doc_auth.instructions.switch_back'))
+              expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+            end
+
+            perform_in_browser(:desktop) do
+              expect(page).to_not have_content(t('doc_auth.headings.text_message'), wait: 10)
+              expect(page).to have_current_path(idv_ssn_path)
+              expect(@analytics).to have_logged_event(:idv_socure_document_request_submitted)
+              expect(@analytics).to have_logged_event(:idv_socure_verification_data_requested)
+              expect(@analytics).to have_logged_event(
+                'IdV: doc auth image upload vendor pii validation',
+              )
+              fill_out_ssn_form_ok
+              click_idv_continue
+            end
+          end
+        end
       end
     end
 

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -437,6 +437,7 @@ RSpec.describe 'Hybrid Flow' do
                 ),
               )
 
+              expect(page).to have_content(t('doc_auth.errors.rate_limited_heading'))
               expect(page).to have_content(
                 [
                   t('doc_auth.errors.general.network_error_passport'),


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-17462](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17462)

## 🛠 Summary of changes
Furthering the resolution for https://github.com/18F/identity-idp/pull/13032:
When MRZ match fails due to network error after passing DocV, display message on errors page advising user they can try another document type.  This brings behavior parity with mock/LN implementation.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="650" height="600" alt="dl_ppt_net_docv_old" src="https://github.com/user-attachments/assets/3deb12f4-6229-47f5-a48d-e62bef1c1d34" />
</details>

<details>
<summary>After:</summary>
<img width="662" height="709" alt="dl_ppt_net_docv" src="https://github.com/user-attachments/assets/488765e3-932e-44a3-a614-df8ccd567f7b" />
</details>


[LG-17462]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17462