### PR TITLE
LG-17295: store agent proofed user in Redis

### DIFF
--- a/app/controllers/api/proofing_agent/proofing_agent_controller.rb
+++ b/app/controllers/api/proofing_agent/proofing_agent_controller.rb
@@ -230,7 +230,7 @@ module Api
 
         required_keys = %i[suspected_fraud email first_name last_name dob phone ssn id_type]
         required_keys.each do |key|
-          result[key] = params.expect(key)
+          result[key] = params.permit(key).send(:[], key)
         end
 
         optional_keys = %i[residential_address state_id passport]
@@ -243,7 +243,7 @@ module Api
         optional_keys.each do |key|
           if params[key].present?
             result[key] =
-              params.expect(key => optional_parameters[key]).to_h.with_indifferent_access
+              params.permit(key => optional_parameters[key]).send(:[], key).to_h
           end
         end
 

--- a/app/forms/idv/proofing_agent/agent_pii_form.rb
+++ b/app/forms/idv/proofing_agent/agent_pii_form.rb
@@ -11,7 +11,6 @@ module Idv
 
       validates_presence_of(*REQUIRED_ATTRIBUTES, message: 'cannot be blank')
 
-      validate :name_valid?
       validate :dob_valid?
       validate :id_type_valid?
 
@@ -73,13 +72,9 @@ module Idv
 
       attr_reader(*ATTRIBUTES)
 
-      def name_valid?
-        return if first_name.present? && last_name.present?
-
-        errors.add(:name, name_error, type: :name)
-      end
-
       def dob_valid?
+        return unless dob
+
         dob_date = DateParser.parse_legacy(dob)
         today = Time.zone.today
         age = today.year - dob_date.year - ((today.month > dob_date.month ||

--- a/app/jobs/proofing_agent_job.rb
+++ b/app/jobs/proofing_agent_job.rb
@@ -107,7 +107,7 @@ class ProofingAgentJob < ApplicationJob
 
     resolution_result = call_resolution_proofing_job(
       timer:,
-      result_id:,
+      result_id: SecureRandom.uuid,
       encrypted_arguments: re_encrypted_arguments,
       trace_id:,
       user_id: user.id,

--- a/app/jobs/proofing_agent_job.rb
+++ b/app/jobs/proofing_agent_job.rb
@@ -23,8 +23,6 @@ class ProofingAgentJob < ApplicationJob
     @document_capture_session = DocumentCaptureSession.find_by(uuid: transaction_id)
     raise ArgumentError, 'DocumentCaptureSession not found' if @document_capture_session.nil?
 
-    document_capture_session.create_proofing_session
-
     raise_stale_job! if stale_job?(enqueued_at)
 
     decrypted_args = JSON.parse(

--- a/app/jobs/proofing_agent_job.rb
+++ b/app/jobs/proofing_agent_job.rb
@@ -50,7 +50,7 @@ class ProofingAgentJob < ApplicationJob
 
     combined_result = proofing_result.combined_result.to_h
 
-    document_capture_session.store_proofing_result(proofing_result.combined_result)
+    document_capture_session.store_agent_proofed_user(proofing_result.combined_result)
 
     success = combined_result[:success]
     reason = combined_result[:reason]

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -135,7 +135,10 @@ class DocumentCaptureSession < ApplicationRecord
     if aamva_response&.success?
       session_result.aamva_verified_attributes = aamva_response.extra[:verified_attributes]
     end
-    session_result.state_id_vendor = aamva_response&.extra&.[](:vendor_name)
+    session_result.source_check_vendor = determine_source_check_vendor(
+      aamva: aamva_response,
+      mrz: agent_proofing_result[:mrz],
+    )
     session_result.captured_at = Time.zone.now
 
     EncryptedRedisStructStorage.store(
@@ -148,6 +151,13 @@ class DocumentCaptureSession < ApplicationRecord
   def agent_proofing_success(agent_proofing_result)
     !!agent_proofing_result[:success] &&
       (agent_proofing_result[:aamva]&.success? || agent_proofing_result[:mrz]&.success?)
+  end
+
+  def determine_source_check_vendor(aamva:, mrz:)
+    raise ArgumentError.new('received both aamva and mrz args') if aamva.present? && mrz.present?
+
+    return aamva.extra[:vendor_name] if aamva.present?
+    'dos' if mrz.present?
   end
 
   def expired?

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -120,20 +120,20 @@ class DocumentCaptureSession < ApplicationRecord
     session_result = load_agent_proofed_user ||
                      Idv::ProofingAgent::AgentProofedUser.new(id: generate_result_id)
 
-    session_result.success = agent_proofing_success(agent_proofing_result)
+    session_result.doc_auth_success = agent_proofing_success(agent_proofing_result)
     session_result.reason = agent_proofing_result[:reason]
     session_result.pii = agent_proofing_result[:pii]
     # session_result.proofing_components = agent_proofing_result.proofing_components
-    session_result.location_id = agent_proofing_result[:proofing_location_id]
-    session_result.agent_id = agent_proofing_result[:proofing_agent_id]
+    session_result.proofing_location_id = agent_proofing_result[:proofing_location_id]
+    session_result.proofing_agent_id = agent_proofing_result[:proofing_agent_id]
     session_result.correlation_id = agent_proofing_result[:correlation_id]
     session_result.issuer = agent_proofing_result[:service_provider_issuer]
     session_result.resolution = agent_proofing_result[:resolution]
     session_result.mrz_status = determine_mrz_status(agent_proofing_result[:mrz])
     aamva_response = agent_proofing_result[:aamva]
     session_result.aamva_status = determine_aamva_status(aamva_response)
-    if aamva_response&.success?
-      session_result.aamva_verified_attributes = aamva_response.extra[:verified_attributes]
+    if aamva_response&.dig(:success)
+      session_result.aamva_verified_attributes = aamva_response.dig(:extra, :verified_attributes)
     end
     session_result.source_check_vendor = determine_source_check_vendor(
       aamva: aamva_response,
@@ -150,13 +150,13 @@ class DocumentCaptureSession < ApplicationRecord
 
   def agent_proofing_success(agent_proofing_result)
     !!agent_proofing_result[:success] &&
-      (agent_proofing_result[:aamva]&.success? || agent_proofing_result[:mrz]&.success?)
+      (agent_proofing_result.dig(:aamva, :success) || agent_proofing_result.dig(:mrz, :success))
   end
 
   def determine_source_check_vendor(aamva:, mrz:)
     raise ArgumentError.new('received both aamva and mrz args') if aamva.present? && mrz.present?
 
-    return aamva.extra[:vendor_name] if aamva.present?
+    return aamva.dig(:extra, :vendor_name) if aamva.present?
     'dos' if mrz.present?
   end
 
@@ -201,13 +201,29 @@ class DocumentCaptureSession < ApplicationRecord
   def determine_mrz_status(mrz_response)
     return :not_processed unless mrz_response
 
-    mrz_response.success? ? :pass : :failed
+    mrz_success = false
+    if mrz_response.respond_to?(:success?)
+      mrz_success = mrz_response.success?
+    end
+    if mrz_response.is_a? Hash
+      mrz_success = mrz_response[:success]
+    end
+
+    mrz_success ? :pass : :failed
   end
 
   def determine_aamva_status(aamva_response)
     return :not_processed unless aamva_response
 
-    aamva_response.success? ? :passed : :failed
+    aamva_success = false
+    if aamva_response.respond_to?(:success?)
+      aamva_success = aamva_response.success?
+    end
+    if aamva_response.is_a? Hash
+      aamva_success = aamva_response[:success]
+    end
+
+    aamva_success ? :passed : :failed
   end
 
   def passport_not_requested_attributes

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -117,10 +117,9 @@ class DocumentCaptureSession < ApplicationRecord
   end
 
   def store_agent_proofed_user(agent_proofing_result)
-    session_result = load_agent_proofed_user ||
-                     Idv::ProofingAgent::AgentProofedUser.new(id: generate_result_id)
+    session_result = Idv::ProofingAgent::AgentProofedUser.new(id: generate_result_id)
 
-    session_result.doc_auth_success = agent_proofing_success(agent_proofing_result)
+    session_result.success = agent_proofing_result[:success]
     session_result.reason = agent_proofing_result[:reason]
     session_result.pii = agent_proofing_result[:pii]
     session_result.proofing_location_id = agent_proofing_result[:proofing_location_id]
@@ -146,11 +145,6 @@ class DocumentCaptureSession < ApplicationRecord
       expires_in: IdentityConfig.store.agent_proofed_user_time_validity_hours.hours.in_seconds,
     )
     save!
-  end
-
-  def agent_proofing_success(agent_proofing_result)
-    !!agent_proofing_result[:success] &&
-      (agent_proofing_result.dig(:aamva, :success) || agent_proofing_result.dig(:mrz, :success))
   end
 
   def determine_source_check_vendor(aamva:, mrz:)

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -130,11 +130,11 @@ class DocumentCaptureSession < ApplicationRecord
     session_result.issuer = agent_proofing_result[:service_provider_issuer]
     session_result.resolution = agent_proofing_result[:resolution]
     session_result.mrz_status = determine_mrz_status(agent_proofing_result[:mrz])
-    aamva_result = agent_proofing_result[:aamva]
-    session_result.aamva_status = determine_aamva_status(aamva_result)
-    if aamva_result
-      session_result.aamva_verified_attributes = aamva_result.extra[:verified_attributes]
-      session_result.state_id_vendor = aamva_result.extra[:vendor_name]
+    aamva_response = agent_proofing_result[:aamva]
+    session_result.aamva_status = determine_aamva_status(aamva_response)
+    if aamva_response
+      session_result.aamva_verified_attributes = aamva_response.extra[:verified_attributes]
+      session_result.state_id_vendor = aamva_response.extra[:vendor_name]
     end
     session_result.captured_at = Time.zone.now
 
@@ -146,8 +146,8 @@ class DocumentCaptureSession < ApplicationRecord
   end
 
   def agent_proofing_success(agent_proofing_result)
-    agent_proofing_result[:success] &&
-      (agent_proofing_result[:aamva].success? || agent_proofing_result[:mrz].success?)
+    !!agent_proofing_result[:success] &&
+      (agent_proofing_result[:aamva]&.success? || agent_proofing_result[:mrz]&.success?)
   end
 
   def expired?

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -116,27 +116,26 @@ class DocumentCaptureSession < ApplicationRecord
     EncryptedRedisStructStorage.load(result_id, type: Idv::ProofingAgent::AgentProofedUser)
   end
 
-  def store_agent_proofed_user(agent_proofing_result:, attempt:, mrz_response: nil,
-                               aamva_response: nil)
+  def store_agent_proofed_user(agent_proofing_result)
     session_result = load_agent_proofed_user ||
                      Idv::ProofingAgent::AgentProofedUser.new(id: generate_result_id)
 
-    session_result.success = agent_proofing_result.success
-    session_result.pii = agent_proofing_result.pii_from_doc.to_h
-    session_result.proofing_components = agent_proofing_result.proofing_components
-    session_result.location_id = agent_proofing_result.location_id
-    session_result.agent_id = agent_proofing_result.agent_id
-    session_result.issuer = agent_proofing_result.issuer
-    session_result.success = agent_proofing_result.success
-    session_result.errors = agent_proofing_result.errors
-    session_result.doc_auth_success = agent_proofing_result.doc_auth_success
-    session_result.mrz_status = determine_mrz_status(mrz_response)
-    session_result.aamva_status = determine_aamva_status(aamva_response)
-    if aamva_response
-      session_result.aamva_verified_attributes = aamva_response.extra[:verified_attributes]
-      session_result.state_id_vendor = aamva_response.extra[:vendor_name]
+    session_result.success = agent_proofing_result[:success]
+    session_result.reason = agent_proofing_result[:reason]
+    session_result.pii = agent_proofing_result[:pii]
+    # session_result.proofing_components = agent_proofing_result.proofing_components
+    session_result.location_id = agent_proofing_result[:proofing_location_id]
+    session_result.agent_id = agent_proofing_result[:proofing_agent_id]
+    session_result.correlation_id = agent_proofing_result[:correlation_id]
+    session_result.issuer = agent_proofing_result[:service_provider_issuer]
+    session_result.resolution = agent_proofing_result[:resolution]
+    session_result.mrz_status = determine_mrz_status(agent_proofing_result[:mrz])
+    aamva_result = agent_proofing_result[:aamva]
+    session_result.aamva_status = determine_aamva_status(aamva_result)
+    if aamva_result
+      session_result.aamva_verified_attributes = aamva_result.extra[:verified_attributes]
+      session_result.state_id_vendor = aamva_result.extra[:vendor_name]
     end
-    session_result.attempt = attempt
     session_result.captured_at = Time.zone.now
 
     EncryptedRedisStructStorage.store(
@@ -144,6 +143,11 @@ class DocumentCaptureSession < ApplicationRecord
       expires_in: IdentityConfig.store.agent_proofed_user_time_validity_hours.hours.in_seconds,
     )
     save!
+  end
+
+  def agent_proofing_success(agent_proofing_result:, mrz_response: nil, aamva_response: nil)
+    agent_proofing_result.success? &&
+      (aamva_response.success? || mrz_response.success?)
   end
 
   def expired?

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -132,10 +132,10 @@ class DocumentCaptureSession < ApplicationRecord
     session_result.mrz_status = determine_mrz_status(agent_proofing_result[:mrz])
     aamva_response = agent_proofing_result[:aamva]
     session_result.aamva_status = determine_aamva_status(aamva_response)
-    if aamva_response
+    if aamva_response&.success?
       session_result.aamva_verified_attributes = aamva_response.extra[:verified_attributes]
-      session_result.state_id_vendor = aamva_response.extra[:vendor_name]
     end
+    session_result.state_id_vendor = aamva_response&.extra&.[](:vendor_name)
     session_result.captured_at = Time.zone.now
 
     EncryptedRedisStructStorage.store(

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -120,7 +120,7 @@ class DocumentCaptureSession < ApplicationRecord
     session_result = load_agent_proofed_user ||
                      Idv::ProofingAgent::AgentProofedUser.new(id: generate_result_id)
 
-    session_result.success = agent_proofing_result[:success]
+    session_result.success = agent_proofing_success(agent_proofing_result)
     session_result.reason = agent_proofing_result[:reason]
     session_result.pii = agent_proofing_result[:pii]
     # session_result.proofing_components = agent_proofing_result.proofing_components
@@ -145,9 +145,9 @@ class DocumentCaptureSession < ApplicationRecord
     save!
   end
 
-  def agent_proofing_success(agent_proofing_result:, mrz_response: nil, aamva_response: nil)
-    agent_proofing_result.success? &&
-      (aamva_response.success? || mrz_response.success?)
+  def agent_proofing_success(agent_proofing_result)
+    agent_proofing_result[:success] &&
+      (agent_proofing_result[:aamva].success? || agent_proofing_result[:mrz].success?)
   end
 
   def expired?

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -123,10 +123,10 @@ class DocumentCaptureSession < ApplicationRecord
     session_result.doc_auth_success = agent_proofing_success(agent_proofing_result)
     session_result.reason = agent_proofing_result[:reason]
     session_result.pii = agent_proofing_result[:pii]
-    # session_result.proofing_components = agent_proofing_result.proofing_components
     session_result.proofing_location_id = agent_proofing_result[:proofing_location_id]
     session_result.proofing_agent_id = agent_proofing_result[:proofing_agent_id]
     session_result.correlation_id = agent_proofing_result[:correlation_id]
+    session_result.transaction_id = agent_proofing_result[:transaction_id]
     session_result.issuer = agent_proofing_result[:service_provider_issuer]
     session_result.resolution = agent_proofing_result[:resolution]
     session_result.mrz_status = determine_mrz_status(agent_proofing_result[:mrz])
@@ -156,8 +156,8 @@ class DocumentCaptureSession < ApplicationRecord
   def determine_source_check_vendor(aamva:, mrz:)
     raise ArgumentError.new('received both aamva and mrz args') if aamva.present? && mrz.present?
 
-    return aamva.dig(:extra, :vendor_name) if aamva.present?
-    'dos' if mrz.present?
+    return aamva.dig(:vendor_name) if aamva.present?
+    mrz.presence&.dig(:vendor_name)
   end
 
   def expired?
@@ -204,8 +204,7 @@ class DocumentCaptureSession < ApplicationRecord
     mrz_success = false
     if mrz_response.respond_to?(:success?)
       mrz_success = mrz_response.success?
-    end
-    if mrz_response.is_a? Hash
+    elsif mrz_response.is_a? Hash
       mrz_success = mrz_response[:success]
     end
 
@@ -218,8 +217,7 @@ class DocumentCaptureSession < ApplicationRecord
     aamva_success = false
     if aamva_response.respond_to?(:success?)
       aamva_success = aamva_response.success?
-    end
-    if aamva_response.is_a? Hash
+    elsif aamva_response.is_a? Hash
       aamva_success = aamva_response[:success]
     end
 

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -110,6 +110,42 @@ class DocumentCaptureSession < ApplicationRecord
     )
   end
 
+  def load_agent_proofed_user
+    return nil unless result_id.present?
+
+    EncryptedRedisStructStorage.load(result_id, type: Idv::ProofingAgent::AgentProofedUser)
+  end
+
+  def store_agent_proofed_user(agent_proofing_result:, attempt:, mrz_response: nil,
+                               aamva_response: nil)
+    session_result = load_agent_proofed_user ||
+                     Idv::ProofingAgent::AgentProofedUser.new(id: generate_result_id)
+
+    session_result.success = agent_proofing_result.success
+    session_result.pii = agent_proofing_result.pii_from_doc.to_h
+    session_result.proofing_components = agent_proofing_result.proofing_components
+    session_result.location_id = agent_proofing_result.location_id
+    session_result.agent_id = agent_proofing_result.agent_id
+    session_result.issuer = agent_proofing_result.issuer
+    session_result.success = agent_proofing_result.success
+    session_result.errors = agent_proofing_result.errors
+    session_result.doc_auth_success = agent_proofing_result.doc_auth_success
+    session_result.mrz_status = determine_mrz_status(mrz_response)
+    session_result.aamva_status = determine_aamva_status(aamva_response)
+    if aamva_response
+      session_result.aamva_verified_attributes = aamva_response.extra[:verified_attributes]
+      session_result.state_id_vendor = aamva_response.extra[:vendor_name]
+    end
+    session_result.attempt = attempt
+    session_result.captured_at = Time.zone.now
+
+    EncryptedRedisStructStorage.store(
+      session_result,
+      expires_in: IdentityConfig.store.agent_proofed_user_time_validity_hours.hours.in_seconds,
+    )
+    save!
+  end
+
   def expired?
     return true unless requested_at
     (requested_at + IdentityConfig.store.doc_capture_request_valid_for_minutes.minutes) <

--- a/app/services/doc_auth/mock/dos_passport_api_client.rb
+++ b/app/services/doc_auth/mock/dos_passport_api_client.rb
@@ -21,7 +21,7 @@ module DocAuth
             extra:,
           )
         else
-          DocAuth::Response.new(success: true)
+          DocAuth::Response.new(success: true, extra:)
         end
       end
 

--- a/app/services/idv/proofing_agent/agent_proofed_user.rb
+++ b/app/services/idv/proofing_agent/agent_proofed_user.rb
@@ -8,31 +8,31 @@ module Idv
       :proofing_components,
       :location_id,
       :agent_id,
+      :correlation_id,
       :issuer,
       :success,
-      :errors,
-      :doc_auth_success,          # trueid/socure
+      :reason,
+      :resolution,                # instant_verify/socure_kyc
       :mrz_status,                # DoS
       :aamva_status,              # aamva
       :aamva_verified_attributes,
-      :address_resolution_status, # phone_finder/kyc
       :state_id_vendor,
-      :attempt,
+      :address_resolution_status, # phone_finder
       :captured_at,
       allowed_members: [
         :proofing_components,
         :location_id,
         :agent_id,
+        :correlation_id,
         :issuer,
         :success,
-        :errors,
-        :doc_auth_success,
+        :reason,
+        :resolution,
         :mrz_status,
         :aamva_status,
         :aamva_verified_attributes,
         :address_resolution_status,
         :state_id_vendor,
-        :attempt,
         :captured_at,
       ],
     ) do

--- a/app/services/idv/proofing_agent/agent_proofed_user.rb
+++ b/app/services/idv/proofing_agent/agent_proofed_user.rb
@@ -6,11 +6,11 @@ module Idv
       :id,
       :pii,
       :proofing_components,
-      :location_id,
-      :agent_id,
+      :proofing_location_id,
+      :proofing_agent_id,
       :correlation_id,
       :issuer,
-      :success,
+      :doc_auth_success,
       :reason,
       :resolution,                # instant_verify/socure_kyc
       :mrz_status,                # DoS
@@ -21,11 +21,11 @@ module Idv
       :captured_at,
       allowed_members: [
         :proofing_components,
-        :location_id,
-        :agent_id,
+        :proofing_location_id,
+        :proofing_agent_id,
         :correlation_id,
         :issuer,
-        :success,
+        :doc_auth_success,
         :reason,
         :resolution,
         :mrz_status,
@@ -60,7 +60,30 @@ module Idv
         self[:address_resolution_status]&.to_sym
       end
 
-      alias_method :success?, :success
+      # This hash should be merged into the idv_session in order to populate proofing components in
+      # the event logs.
+      def proofing_components
+        {
+          doc_auth_vendor:,
+          document_type_received: pii[:document_type_received],
+          source_check_vendor:,
+          residential_resolution_vendor: resolution&.dig(
+            :context, :stages, :residential_address, :vendor_name
+          ),
+          verify_info_step_complete: resolution&.dig(:success),
+          phone_precheck_vendor: resolution&.dig(
+            :context, :stages, :phone_precheck, :vendor_name
+          ),
+          address_verification_vendor: resolution&.dig(
+            :context, :stages, :residential_address, :vendor_name
+          ),
+          threat_metrix_review_status: resolution&.dig(
+            :context, :stages, :threatmetrix, :review_status
+          ),
+        }
+      end
+
+      alias_method :success?, :doc_auth_success
       alias_method :pii_from_doc, :pii
     end.freeze
   end

--- a/app/services/idv/proofing_agent/agent_proofed_user.rb
+++ b/app/services/idv/proofing_agent/agent_proofed_user.rb
@@ -9,6 +9,7 @@ module Idv
       :proofing_location_id,
       :proofing_agent_id,
       :correlation_id,
+      :transaction_id,
       :issuer,
       :doc_auth_success,
       :reason,
@@ -24,6 +25,7 @@ module Idv
         :proofing_location_id,
         :proofing_agent_id,
         :correlation_id,
+        :transaction_id,
         :issuer,
         :doc_auth_success,
         :reason,
@@ -38,6 +40,11 @@ module Idv
     ) do
       def self.redis_key_prefix
         'proofing_agent:result'
+      end
+
+      def success?
+        doc_auth_success &&
+          (aamva_status == :passed || mrz_status == :pass)
       end
 
       def mrz_status
@@ -63,27 +70,28 @@ module Idv
       # This hash should be merged into the idv_session in order to populate proofing components in
       # the event logs.
       def proofing_components
-        {
-          doc_auth_vendor:,
-          document_type_received: pii[:document_type_received],
-          source_check_vendor:,
-          residential_resolution_vendor: resolution&.dig(
-            :context, :stages, :residential_address, :vendor_name
-          ),
-          verify_info_step_complete: resolution&.dig(:success),
-          phone_precheck_vendor: resolution&.dig(
-            :context, :stages, :phone_precheck, :vendor_name
-          ),
-          address_verification_vendor: resolution&.dig(
-            :context, :stages, :residential_address, :vendor_name
-          ),
-          threat_metrix_review_status: resolution&.dig(
-            :context, :stages, :threatmetrix, :review_status
-          ),
-        }
+        if success?
+          {
+            doc_auth_vendor:,
+            document_type_received: pii[:document_type_received],
+            source_check_vendor:,
+            residential_resolution_vendor: resolution&.dig(
+              :context, :stages, :residential_address, :vendor_name
+            ),
+            verify_info_step_complete: resolution&.dig(:success),
+            phone_precheck_vendor: resolution&.dig(
+              :context, :stages, :phone_precheck, :vendor_name
+            ),
+            address_verification_vendor: resolution&.dig(
+              :context, :stages, :residential_address, :vendor_name
+            ),
+            threat_metrix_review_status: resolution&.dig(
+              :context, :stages, :threatmetrix, :review_status
+            ),
+          }
+        end
       end
 
-      alias_method :success?, :doc_auth_success
       alias_method :pii_from_doc, :pii
     end.freeze
   end

--- a/app/services/idv/proofing_agent/agent_proofed_user.rb
+++ b/app/services/idv/proofing_agent/agent_proofed_user.rb
@@ -16,7 +16,7 @@ module Idv
       :mrz_status,                # DoS
       :aamva_status,              # aamva
       :aamva_verified_attributes,
-      :state_id_vendor,
+      :source_check_vendor,
       :address_resolution_status, # phone_finder
       :captured_at,
       allowed_members: [
@@ -31,8 +31,8 @@ module Idv
         :mrz_status,
         :aamva_status,
         :aamva_verified_attributes,
+        :source_check_vendor,
         :address_resolution_status,
-        :state_id_vendor,
         :captured_at,
       ],
     ) do
@@ -48,8 +48,8 @@ module Idv
         self[:aamva_status]&.to_sym
       end
 
-      def state_id_vendor
-        self[:state_id_vendor]&.to_sym
+      def source_check_vendor
+        self[:source_check_vendor]&.to_sym
       end
 
       def aamva_verified_attributes

--- a/app/services/idv/proofing_agent/agent_proofed_user.rb
+++ b/app/services/idv/proofing_agent/agent_proofed_user.rb
@@ -5,13 +5,12 @@ module Idv
     AgentProofedUser = RedactedStruct.new(
       :id,
       :pii,
-      :proofing_components,
       :proofing_location_id,
       :proofing_agent_id,
       :correlation_id,
       :transaction_id,
       :issuer,
-      :doc_auth_success,
+      :success,
       :reason,
       :resolution,                # instant_verify/socure_kyc
       :mrz_status,                # DoS
@@ -21,13 +20,12 @@ module Idv
       :address_resolution_status, # phone_finder
       :captured_at,
       allowed_members: [
-        :proofing_components,
         :proofing_location_id,
         :proofing_agent_id,
         :correlation_id,
         :transaction_id,
         :issuer,
-        :doc_auth_success,
+        :success,
         :reason,
         :resolution,
         :mrz_status,
@@ -40,11 +38,6 @@ module Idv
     ) do
       def self.redis_key_prefix
         'proofing_agent:result'
-      end
-
-      def success?
-        doc_auth_success &&
-          (aamva_status == :passed || mrz_status == :pass)
       end
 
       def mrz_status
@@ -67,30 +60,34 @@ module Idv
         self[:address_resolution_status]&.to_sym
       end
 
-      # This hash should be merged into the idv_session in order to populate proofing components in
-      # the event logs.
-      def proofing_components
-        if success?
-          {
-            doc_auth_vendor:,
-            document_type_received: pii[:document_type_received],
-            source_check_vendor:,
-            resolution_vendor: resolution&.dig(
-              :context, :stages, :resolution, :vendor_name
-            ),
-            residential_resolution_vendor: resolution&.dig(
-              :context, :stages, :residential_address, :vendor_name
-            ),
-            verify_info_step_complete: resolution&.dig(:success),
-            phone_precheck_vendor: resolution&.dig(
-              :context, :stages, :phone_precheck, :vendor_name
-            ),
-            threat_metrix_review_status: resolution&.dig(
-              :context, :stages, :threatmetrix, :review_status
-            ),
-          }
-        end
-      end
+      # This hash includes the values that should be merged into the idv_session in order to
+      # populate proofing components in the event logs.
+      #
+      # This is NOT the hash to be logged as proofing_components.
+      # See app/services/idv/proofing_components.rb
+      #
+      # This is left in to guide development of analytics logging in LG-17507 if useful.
+      #
+      # def proofing_components
+      #   {
+      #     doc_auth_vendor:,
+      #     document_type_received: pii[:document_type_received],
+      #     source_check_vendor:,
+      #     resolution_vendor: resolution&.dig(
+      #       :context, :stages, :resolution, :vendor_name
+      #     ),
+      #     residential_resolution_vendor: resolution&.dig(
+      #       :context, :stages, :residential_address, :vendor_name
+      #     ),
+      #     verify_info_step_complete: resolution&.dig(:success),
+      #     phone_precheck_vendor: resolution&.dig(
+      #       :context, :stages, :phone_precheck, :vendor_name
+      #     ),
+      #     threat_metrix_review_status: resolution&.dig(
+      #       :context, :stages, :threatmetrix, :review_status
+      #     ),
+      #   }
+      # end
 
       alias_method :pii_from_doc, :pii
     end.freeze

--- a/app/services/idv/proofing_agent/agent_proofed_user.rb
+++ b/app/services/idv/proofing_agent/agent_proofed_user.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Idv
+  module ProofingAgent
+    AgentProofedUser = RedactedStruct.new(
+      :id,
+      :pii,
+      :proofing_components,
+      :location_id,
+      :agent_id,
+      :issuer,
+      :success,
+      :errors,
+      :doc_auth_success,          # trueid/socure
+      :mrz_status,                # DoS
+      :aamva_status,              # aamva
+      :aamva_verified_attributes,
+      :address_resolution_status, # phone_finder/kyc
+      :state_id_vendor,
+      :attempt,
+      :captured_at,
+      allowed_members: [
+        :proofing_components,
+        :location_id,
+        :agent_id,
+        :issuer,
+        :success,
+        :errors,
+        :doc_auth_success,
+        :mrz_status,
+        :aamva_status,
+        :aamva_verified_attributes,
+        :address_resolution_status,
+        :state_id_vendor,
+        :attempt,
+        :captured_at,
+      ],
+    ) do
+      def self.redis_key_prefix
+        'proofing_agent:result'
+      end
+
+      def mrz_status
+        self[:mrz_status]&.to_sym
+      end
+
+      def aamva_status
+        self[:aamva_status]&.to_sym
+      end
+
+      def state_id_vendor
+        self[:state_id_vendor]&.to_sym
+      end
+
+      def aamva_verified_attributes
+        self[:aamva_verified_attributes] || []
+      end
+
+      def address_resolution_status
+        self[:address_resolution_status]&.to_sym
+      end
+
+      alias_method :success?, :success
+      alias_method :pii_from_doc, :pii
+    end.freeze
+  end
+end

--- a/app/services/idv/proofing_agent/agent_proofed_user.rb
+++ b/app/services/idv/proofing_agent/agent_proofed_user.rb
@@ -75,15 +75,15 @@ module Idv
             doc_auth_vendor:,
             document_type_received: pii[:document_type_received],
             source_check_vendor:,
+            resolution_vendor: resolution&.dig(
+              :context, :stages, :resolution, :vendor_name
+            ),
             residential_resolution_vendor: resolution&.dig(
               :context, :stages, :residential_address, :vendor_name
             ),
             verify_info_step_complete: resolution&.dig(:success),
             phone_precheck_vendor: resolution&.dig(
               :context, :stages, :phone_precheck, :vendor_name
-            ),
-            address_verification_vendor: resolution&.dig(
-              :context, :stages, :residential_address, :vendor_name
             ),
             threat_metrix_review_status: resolution&.dig(
               :context, :stages, :threatmetrix, :review_status

--- a/app/services/proofing_agent/proofing_result.rb
+++ b/app/services/proofing_agent/proofing_result.rb
@@ -35,16 +35,19 @@ module ProofingAgent
       reason = determine_failure_reason
       success = reason.nil?
 
-      result = { success:, reason: }
+      result = {
+        success:,
+        reason:,
+        service_provider_issuer:,
+        proofing_agent_id:,
+        proofing_location_id:,
+        correlation_id:,
+      }
 
       result[:pii] = pii if pii.present?
       result[:resolution] = resolution_result if resolution_result.present?
       result[:aamva] = aamva_result if aamva_result.present?
       result[:mrz] = mrz_result if mrz_result.present?
-      result[:service_provider_issuer] = service_provider_issuer
-      result[:proofing_agent_id] = proofing_agent_id
-      result[:proofing_location_id] = proofing_location_id
-      result[:correlation_id] = correlation_id
 
       result
     end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -35,6 +35,7 @@ account_suspended_support_code: EFGHI
 # These are publicly available credentials used to initialize the client-side Acuant SDK
 acuant_sdk_initialization_creds: 'a2V5bGVzc0dTQV9wcm9kQGxleGlzbmV4aXNyaXNrLmNvbTouPkQ3VTRgMj1ae2E='
 acuant_sdk_initialization_endpoint: 'https://us.acas.acuant.net'
+agent_proofed_user_time_validity_hours: 1
 add_email_link_valid_for_hours: 24
 address_identity_proofing_supported_country_codes: '["AS", "GU", "MP", "PR", "US", "VI"]'
 all_redirect_uris_cache_duration_minutes: 2

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -35,9 +35,9 @@ account_suspended_support_code: EFGHI
 # These are publicly available credentials used to initialize the client-side Acuant SDK
 acuant_sdk_initialization_creds: 'a2V5bGVzc0dTQV9wcm9kQGxleGlzbmV4aXNyaXNrLmNvbTouPkQ3VTRgMj1ae2E='
 acuant_sdk_initialization_endpoint: 'https://us.acas.acuant.net'
-agent_proofed_user_time_validity_hours: 1
 add_email_link_valid_for_hours: 24
 address_identity_proofing_supported_country_codes: '["AS", "GU", "MP", "PR", "US", "VI"]'
+agent_proofed_user_time_validity_hours: 1
 all_redirect_uris_cache_duration_minutes: 2
 allowed_attempts_providers: '[]'
 allowed_client_id_in_risc_service_providers: '[]'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -54,6 +54,7 @@ module IdentityConfig
     config.add(:acuant_sdk_initialization_endpoint)
     config.add(:add_email_link_valid_for_hours, type: :integer)
     config.add(:address_identity_proofing_supported_country_codes, type: :json)
+    config.add(:agent_proofed_user_time_validity_hours, type: :integer)
     config.add(:all_redirect_uris_cache_duration_minutes, type: :integer)
     config.add(:allowed_attempts_providers, type: :json)
     config.add(:allowed_client_id_in_risc_service_providers, type: :json)

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -88,6 +88,7 @@ RSpec.feature 'Analytics Regression', :js do
       state: 'MT',
       state_id_jurisdiction: 'ND',
       state_id_number: '#############',
+      state_id_verified_attributes: ['address', 'dob', 'state_id_number'],
     }
 
     if idv_phone_precheck_enabled
@@ -185,6 +186,7 @@ RSpec.feature 'Analytics Regression', :js do
         state: 'MT',
         state_id_jurisdiction: 'ND',
         state_id_number: '#############',
+        state_id_verified_attributes: ['address', 'dob', 'state_id_number'],
       },
     }
   end

--- a/spec/jobs/proofing_agent_job_spec.rb
+++ b/spec/jobs/proofing_agent_job_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe ProofingAgentJob, type: :job do
         expect(result[:doc_auth_success]).to be true
         expect(result[:reason]).to be_nil
         expect(result[:mrz_status]).to eq 'pass'
-        expect(result[:source_check_vendor]).to eq('dos')
+        expect(result[:source_check_vendor]).to eq('PassportMock')
       end
     end
 

--- a/spec/jobs/proofing_agent_job_spec.rb
+++ b/spec/jobs/proofing_agent_job_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe ProofingAgentJob, type: :job do
       it 'stores a successful result' do
         perform
 
-        result = document_capture_session.reload.load_proofing_result[:result]
-        expect(result[:success]).to be true
+        result = document_capture_session.reload.load_agent_proofed_user
+        expect(result[:doc_auth_success]).to be true
         expect(result[:reason]).to be_nil
         expect(result[:resolution][:success]).to be true
         expect(result[:resolution][:exception]).to be_nil
@@ -67,8 +67,8 @@ RSpec.describe ProofingAgentJob, type: :job do
       it 'stores a failed result' do
         perform
 
-        result = document_capture_session.reload.load_proofing_result[:result]
-        expect(result[:success]).to be false
+        result = document_capture_session.reload.load_agent_proofed_user
+        expect(result[:doc_auth_success]).to be false
         expect(result[:reason]).to eq('profile_resolution_fail')
         expect(result[:resolution][:success]).to be false
       end
@@ -91,17 +91,17 @@ RSpec.describe ProofingAgentJob, type: :job do
       it 'stores a successful result with aamva data' do
         perform
 
-        result = document_capture_session.reload.load_proofing_result[:result]
-        expect(result[:success]).to be true
+        result = document_capture_session.reload.load_agent_proofed_user
+        expect(result[:doc_auth_success]).to be true
         expect(result[:reason]).to be_nil
-        expect(result[:aamva][:success]).to be true
-        expect(result[:aamva][:vendor_name]).to eq('StateIdMock')
+        expect(result[:aamva_status]).to eq 'passed'
+        expect(result[:source_check_vendor]).to eq('StateIdMock')
       end
 
       it 'passes aamva_verified_attributes into resolution_result' do
         perform
 
-        result = document_capture_session.reload.load_proofing_result[:result]
+        result = document_capture_session.reload.load_agent_proofed_user
         expect(result[:pii][:aamva_verified_attributes]).to be_present
       end
     end
@@ -114,10 +114,10 @@ RSpec.describe ProofingAgentJob, type: :job do
       it 'stores a failed result' do
         perform
 
-        result = document_capture_session.reload.load_proofing_result[:result]
-        expect(result[:success]).to be false
+        result = document_capture_session.reload.load_agent_proofed_user
+        expect(result[:doc_auth_success]).to be false
         expect(result[:reason]).to eq('id_fail')
-        expect(result[:aamva][:success]).to be false
+        expect(result[:aamva_status]).to eq 'failed'
       end
 
       it 'enqueues a ProofingAgentWebhookJob with success: false' do
@@ -136,10 +136,11 @@ RSpec.describe ProofingAgentJob, type: :job do
       it 'stores a successful result with mrz data' do
         perform
 
-        result = document_capture_session.reload.load_proofing_result[:result]
-        expect(result[:success]).to be true
+        result = document_capture_session.reload.load_agent_proofed_user
+        expect(result[:doc_auth_success]).to be true
         expect(result[:reason]).to be_nil
-        expect(result[:mrz][:success]).to be true
+        expect(result[:mrz_status]).to eq 'pass'
+        expect(result[:source_check_vendor]).to eq('dos')
       end
     end
 
@@ -158,10 +159,10 @@ RSpec.describe ProofingAgentJob, type: :job do
       it 'stores a failed result' do
         perform
 
-        result = document_capture_session.reload.load_proofing_result[:result]
-        expect(result[:success]).to be false
+        result = document_capture_session.reload.load_agent_proofed_user
+        expect(result[:doc_auth_success]).to be false
         expect(result[:reason]).to eq('passport_fail')
-        expect(result[:mrz][:success]).to be false
+        expect(result[:mrz_status]).to eq 'failed'
       end
 
       it 'enqueues a ProofingAgentWebhookJob with success: false' do

--- a/spec/jobs/proofing_agent_job_spec.rb
+++ b/spec/jobs/proofing_agent_job_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ProofingAgentJob, type: :job do
         perform
 
         result = document_capture_session.reload.load_agent_proofed_user
-        expect(result[:doc_auth_success]).to be true
+        expect(result[:success]).to be true
         expect(result[:reason]).to be_nil
         expect(result[:resolution][:success]).to be true
         expect(result[:resolution][:exception]).to be_nil
@@ -68,7 +68,7 @@ RSpec.describe ProofingAgentJob, type: :job do
         perform
 
         result = document_capture_session.reload.load_agent_proofed_user
-        expect(result[:doc_auth_success]).to be false
+        expect(result[:success]).to be false
         expect(result[:reason]).to eq('profile_resolution_fail')
         expect(result[:resolution][:success]).to be false
       end
@@ -92,7 +92,7 @@ RSpec.describe ProofingAgentJob, type: :job do
         perform
 
         result = document_capture_session.reload.load_agent_proofed_user
-        expect(result[:doc_auth_success]).to be true
+        expect(result[:success]).to be true
         expect(result[:reason]).to be_nil
         expect(result[:aamva_status]).to eq 'passed'
         expect(result[:source_check_vendor]).to eq('StateIdMock')
@@ -115,7 +115,7 @@ RSpec.describe ProofingAgentJob, type: :job do
         perform
 
         result = document_capture_session.reload.load_agent_proofed_user
-        expect(result[:doc_auth_success]).to be false
+        expect(result[:success]).to be false
         expect(result[:reason]).to eq('id_fail')
         expect(result[:aamva_status]).to eq 'failed'
       end
@@ -137,7 +137,7 @@ RSpec.describe ProofingAgentJob, type: :job do
         perform
 
         result = document_capture_session.reload.load_agent_proofed_user
-        expect(result[:doc_auth_success]).to be true
+        expect(result[:success]).to be true
         expect(result[:reason]).to be_nil
         expect(result[:mrz_status]).to eq 'pass'
         expect(result[:source_check_vendor]).to eq('PassportMock')
@@ -160,7 +160,7 @@ RSpec.describe ProofingAgentJob, type: :job do
         perform
 
         result = document_capture_session.reload.load_agent_proofed_user
-        expect(result[:doc_auth_success]).to be false
+        expect(result[:success]).to be false
         expect(result[:reason]).to eq('passport_fail')
         expect(result[:mrz_status]).to eq 'failed'
       end

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe DocumentCaptureSession do
         record.store_agent_proofed_user(agent_proofing_result)
         result = record.load_agent_proofed_user
 
-        expect(result.success?).to eq(agent_proofing_result[:success])
+        expect(result.success).to eq(agent_proofing_result[:success])
         expect(result.pii).to eq(agent_proofing_result[:pii])
       end
 
@@ -266,7 +266,7 @@ RSpec.describe DocumentCaptureSession do
 
         it 'stores the results' do
           expect(document_capture_session.load_agent_proofed_user).to have_attributes(
-            doc_auth_success: true,
+            success: true,
             reason: nil,
             pii: agent_proofing_result[:pii],
             proofing_location_id: '123',

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -322,6 +322,41 @@ RSpec.describe DocumentCaptureSession do
           end
         end
       end
+
+      context 'when mrz response is passed in' do
+        before do
+          document_capture_session.store_agent_proofed_user(agent_proofing_result)
+        end
+
+        context 'when the mrz response is successful' do
+          let(:mrz) { DocAuth::Response.new(success: true) }
+
+          it 'stores mrz_status as :passed' do
+            expect(document_capture_session.load_agent_proofed_user).to have_attributes(
+              mrz_status: :pass,
+            )
+          end
+        end
+
+        context 'when the mrz response is unsuccessful' do
+          let(:mrz) { DocAuth::Response.new(success: false) }
+
+          it 'stores mrz_status as :failed' do
+            expect(document_capture_session.load_agent_proofed_user).to have_attributes(
+              mrz_status: :failed,
+            )
+          end
+        end
+        context 'when the mrz response is nil' do
+          let(:mrz_response) { nil }
+
+          it 'stores mrz_status as :not_processed' do
+            expect(document_capture_session.load_agent_proofed_user).to have_attributes(
+              mrz_status: :not_processed,
+            )
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe DocumentCaptureSession do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
               aamva_status: :passed,
               aamva_verified_attributes: aamva_attrs,
-              state_id_vendor: aamva_vendor,
+              source_check_vendor: aamva_vendor,
             )
           end
         end
@@ -305,7 +305,7 @@ RSpec.describe DocumentCaptureSession do
           it 'stores aamva_status as :failed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
               aamva_status: :failed,
-              state_id_vendor: aamva_vendor,
+              source_check_vendor: aamva_vendor,
             )
           end
         end
@@ -321,7 +321,19 @@ RSpec.describe DocumentCaptureSession do
         end
       end
 
+      context 'when both aamva and mrz response is passed in' do
+        let(:aamva) { DocAuth::Response.new(success: true) }
+        let(:mrz) { DocAuth::Response.new(success: true) }
+
+        it 'raises an exception' do
+          expect do
+            document_capture_session.store_agent_proofed_user(agent_proofing_result)
+          end.to raise_error(ArgumentError, 'received both aamva and mrz arguments')
+        end
+      end
+
       context 'when mrz response is passed in' do
+        let(:aamva) { nil }
         before do
           document_capture_session.store_agent_proofed_user(agent_proofing_result)
         end
@@ -332,6 +344,7 @@ RSpec.describe DocumentCaptureSession do
           it 'stores mrz_status as :passed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
               mrz_status: :pass,
+              source_check_vendor: :dos,
             )
           end
         end
@@ -342,6 +355,7 @@ RSpec.describe DocumentCaptureSession do
           it 'stores mrz_status as :failed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
               mrz_status: :failed,
+              source_check_vendor: :dos,
             )
           end
         end

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -188,8 +188,8 @@ RSpec.describe DocumentCaptureSession do
     let(:aamva) do
       {
         success: aamva_success,
+        vendor_name: aamva_vendor,
         extra: {
-          vendor_name: aamva_vendor,
           verified_attributes: aamva_attrs,
         }.compact,
       }
@@ -337,7 +337,7 @@ RSpec.describe DocumentCaptureSession do
         end
 
         context 'when the mrz response is successful' do
-          let(:mrz) { { success: true, extra: { vendor_name: 'test_dos' } } }
+          let(:mrz) { { success: true, vendor_name: 'test_dos' } }
 
           it 'stores mrz_status as :passed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
@@ -348,7 +348,7 @@ RSpec.describe DocumentCaptureSession do
         end
 
         context 'when the mrz response is unsuccessful' do
-          let(:mrz) { { success: false, extra: { vendor_name: 'test_dos' } } }
+          let(:mrz) { { success: false, vendor_name: 'test_dos' } }
 
           it 'stores mrz_status as :failed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -179,30 +179,35 @@ RSpec.describe DocumentCaptureSession do
 
   context 'proofing agent' do
     let(:success) { true }
-    let(:attempt) { 1 }
+    let(:reason) { nil }
+    let(:resolution) { { success: true } }
+    let(:mrz) { nil }
+    let(:aamva) { nil }
+    # let(:attempt) { 1 }
     let(:agent_proofing_result) do
-      # This should be re-written to use whatever response object is created via
-      # the proofing process being developed in LG-17293
-      # rubocop:disable Style/OpenStructUse
-      OpenStruct.new(
-        pii_from_doc: { first_name: 'Testy', last_name: 'Testerson' },
-        proofing_components: { foo: 'bar' },
+      {
+        pii: { first_name: 'Testy', last_name: 'Testerson' },
+        # proofing_components: { foo: 'bar' },
         location_id: '123',
         agent_id: '456',
+        correlation_id: '789',
         issuer: 'test_issuer',
         success:,
-      )
-      # rubocop:enable Style/OpenStructUse
+        reason:,
+        resolution:,
+        mrz:,
+        aamva:,
+      }
     end
 
     describe '#load_agent_proofed_user' do
       it 'loads the previously stored result' do
         record = DocumentCaptureSession.new
-        record.store_agent_proofed_user(agent_proofing_result:, attempt:)
+        record.store_agent_proofed_user(agent_proofing_result)
         result = record.load_agent_proofed_user
 
-        expect(result.success?).to eq(agent_proofing_result.success)
-        expect(result.pii).to eq(agent_proofing_result.pii_from_doc.to_h.deep_symbolize_keys)
+        expect(result.success?).to eq(agent_proofing_result[:success])
+        expect(result.pii).to eq(agent_proofing_result[:pii])
       end
 
       it 'returns nil if the previously stored result does not exist' do
@@ -214,7 +219,7 @@ RSpec.describe DocumentCaptureSession do
 
       xit 'returns nil if the previously stored result is expired' do
         record = DocumentCaptureSession.new
-        record.store_agent_proofed_user(agent_proofing_result:, attempt: 1)
+        record.store_agent_proofed_user(agent_proofing_result)
         past_exp = IdentityConfig.store.agent_proofed_user_time_validity_hours.hours.in_seconds
         travel_to((2 * past_exp).seconds.from_now) do
           result = record.load_agent_proofed_user
@@ -229,7 +234,7 @@ RSpec.describe DocumentCaptureSession do
 
       it 'generates a result ID stores the result encrypted in redis' do
         record = document_capture_session
-        record.store_agent_proofed_user(agent_proofing_result:, attempt:)
+        record.store_agent_proofed_user(agent_proofing_result)
 
         result_id = record.result_id
         key = EncryptedRedisStructStorage.key(result_id, type: Idv::ProofingAgent::AgentProofedUser)
@@ -246,39 +251,38 @@ RSpec.describe DocumentCaptureSession do
         before do
           freeze_time
           travel_to(current_time) do
-            document_capture_session.store_agent_proofed_user(
-              agent_proofing_result:,
-              mrz_response:, aamva_response:, attempt: 3
-            )
+            document_capture_session.store_agent_proofed_user(agent_proofing_result)
           end
         end
 
         it 'stores the results' do
           expect(document_capture_session.load_agent_proofed_user).to have_attributes(
             success: true,
-            pii: agent_proofing_result.pii_from_doc.to_h,
+            reason: nil,
+            pii: agent_proofing_result[:pii],
             captured_at: current_time,
-            doc_auth_success: nil,
-            errors: nil,
-            mrz_status: :pass,
-            aamva_status: :passed,
-            attempt: 3,
+            resolution: { success: true },
+            mrz_status: :not_processed,
+            aamva_status: :not_processed,
           )
         end
       end
 
       context 'when aamva response is passed in' do
         before do
-          document_capture_session.store_agent_proofed_user(
-            agent_proofing_result:,
-            mrz_response:,
-            aamva_response:,
-            attempt:,
-          )
+          document_capture_session.store_agent_proofed_user(agent_proofing_result)
         end
 
         context 'when the aamva response is successful' do
-          let(:aamva_response) { DocAuth::Response.new(success: true) }
+          let(:aamva) do
+            DocAuth::Response.new(
+              success: true,
+              extra: {
+                vendor_name: 'aamva',
+                verified_attributes: [:all, :of, :them],
+              },
+            )
+          end
 
           it 'stores aamva_status as :passed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
@@ -288,7 +292,14 @@ RSpec.describe DocumentCaptureSession do
         end
 
         context 'when the aamva response is unsuccessful' do
-          let(:aamva_response) { DocAuth::Response.new(success: false) }
+          let(:aamva) do
+            DocAuth::Response.new(
+              success: false,
+              extra: {
+                vendor_name: 'aamva',
+              },
+            )
+          end
 
           it 'stores aamva_status as :failed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
@@ -298,7 +309,7 @@ RSpec.describe DocumentCaptureSession do
         end
 
         context 'when the aamva response is nil' do
-          let(:aamva_response) { nil }
+          let(:aamva) { nil }
 
           it 'stores aamva_status as :not_processed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -182,7 +182,18 @@ RSpec.describe DocumentCaptureSession do
     let(:reason) { nil }
     let(:resolution) { { success: true } }
     let(:mrz) { nil }
-    let(:aamva) { DocAuth::Response.new(success: true) }
+    let(:aamva_success) { true }
+    let(:aamva_vendor) { :document_check_vendor }
+    let(:aamva_attrs) { %w[all of them] }
+    let(:aamva) do
+      DocAuth::Response.new(
+        success: aamva_success,
+        extra: {
+          vendor_name: aamva_vendor,
+          verified_attributes: aamva_attrs,
+        }.compact,
+      )
+    end
     # let(:attempt) { 1 }
     let(:agent_proofing_result) do
       {
@@ -278,36 +289,23 @@ RSpec.describe DocumentCaptureSession do
         end
 
         context 'when the aamva response is successful' do
-          let(:aamva) do
-            DocAuth::Response.new(
-              success: true,
-              extra: {
-                vendor_name: 'aamva',
-                verified_attributes: [:all, :of, :them],
-              },
-            )
-          end
-
           it 'stores aamva_status as :passed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
               aamva_status: :passed,
+              aamva_verified_attributes: aamva_attrs,
+              state_id_vendor: aamva_vendor,
             )
           end
         end
 
         context 'when the aamva response is unsuccessful' do
-          let(:aamva) do
-            DocAuth::Response.new(
-              success: false,
-              extra: {
-                vendor_name: 'aamva',
-              },
-            )
-          end
+          let(:aamva_success) { false }
+          let(:aamva_attrs) { nil }
 
           it 'stores aamva_status as :failed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
               aamva_status: :failed,
+              state_id_vendor: aamva_vendor,
             )
           end
         end

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -186,19 +186,18 @@ RSpec.describe DocumentCaptureSession do
     let(:aamva_vendor) { :document_check_vendor }
     let(:aamva_attrs) { %w[all of them] }
     let(:aamva) do
-      DocAuth::Response.new(
+      {
         success: aamva_success,
         extra: {
           vendor_name: aamva_vendor,
           verified_attributes: aamva_attrs,
         }.compact,
-      )
+      }
     end
     # let(:attempt) { 1 }
     let(:agent_proofing_result) do
       {
         pii: { first_name: 'Testy', last_name: 'Testerson' },
-        # proofing_components: { foo: 'bar' },
         proofing_location_id: '123',
         proofing_agent_id: '456',
         correlation_id: '789',
@@ -268,11 +267,11 @@ RSpec.describe DocumentCaptureSession do
 
         it 'stores the results' do
           expect(document_capture_session.load_agent_proofed_user).to have_attributes(
-            success: true,
+            doc_auth_success: true,
             reason: nil,
             pii: agent_proofing_result[:pii],
-            location_id: '123',
-            agent_id: '456',
+            proofing_location_id: '123',
+            proofing_agent_id: '456',
             correlation_id: '789',
             issuer: 'test_issuer',
             captured_at: current_time,
@@ -322,8 +321,8 @@ RSpec.describe DocumentCaptureSession do
       end
 
       context 'when both aamva and mrz response is passed in' do
-        let(:aamva) { DocAuth::Response.new(success: true) }
-        let(:mrz) { DocAuth::Response.new(success: true) }
+        let(:aamva) { { success: true } }
+        let(:mrz) { { success: true } }
 
         it 'raises an exception' do
           expect do
@@ -339,7 +338,7 @@ RSpec.describe DocumentCaptureSession do
         end
 
         context 'when the mrz response is successful' do
-          let(:mrz) { DocAuth::Response.new(success: true) }
+          let(:mrz) { { success: true } }
 
           it 'stores mrz_status as :passed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
@@ -350,7 +349,7 @@ RSpec.describe DocumentCaptureSession do
         end
 
         context 'when the mrz response is unsuccessful' do
-          let(:mrz) { DocAuth::Response.new(success: false) }
+          let(:mrz) { { success: false } }
 
           it 'stores mrz_status as :failed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe DocumentCaptureSession do
         it 'raises an exception' do
           expect do
             document_capture_session.store_agent_proofed_user(agent_proofing_result)
-          end.to raise_error(ArgumentError, 'received both aamva and mrz arguments')
+          end.to raise_error(ArgumentError, 'received both aamva and mrz args')
         end
       end
 

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -194,7 +194,6 @@ RSpec.describe DocumentCaptureSession do
         }.compact,
       }
     end
-    # let(:attempt) { 1 }
     let(:agent_proofing_result) do
       {
         pii: { first_name: 'Testy', last_name: 'Testerson' },
@@ -338,23 +337,23 @@ RSpec.describe DocumentCaptureSession do
         end
 
         context 'when the mrz response is successful' do
-          let(:mrz) { { success: true } }
+          let(:mrz) { { success: true, extra: { vendor_name: 'test_dos' } } }
 
           it 'stores mrz_status as :passed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
               mrz_status: :pass,
-              source_check_vendor: :dos,
+              source_check_vendor: :test_dos,
             )
           end
         end
 
         context 'when the mrz response is unsuccessful' do
-          let(:mrz) { { success: false } }
+          let(:mrz) { { success: false, extra: { vendor_name: 'test_dos' } } }
 
           it 'stores mrz_status as :failed' do
             expect(document_capture_session.load_agent_proofed_user).to have_attributes(
               mrz_status: :failed,
-              source_check_vendor: :dos,
+              source_check_vendor: :test_dos,
             )
           end
         end

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -182,16 +182,16 @@ RSpec.describe DocumentCaptureSession do
     let(:reason) { nil }
     let(:resolution) { { success: true } }
     let(:mrz) { nil }
-    let(:aamva) { nil }
+    let(:aamva) { DocAuth::Response.new(success: true) }
     # let(:attempt) { 1 }
     let(:agent_proofing_result) do
       {
         pii: { first_name: 'Testy', last_name: 'Testerson' },
         # proofing_components: { foo: 'bar' },
-        location_id: '123',
-        agent_id: '456',
+        proofing_location_id: '123',
+        proofing_agent_id: '456',
         correlation_id: '789',
-        issuer: 'test_issuer',
+        service_provider_issuer: 'test_issuer',
         success:,
         reason:,
         resolution:,
@@ -260,10 +260,14 @@ RSpec.describe DocumentCaptureSession do
             success: true,
             reason: nil,
             pii: agent_proofing_result[:pii],
+            location_id: '123',
+            agent_id: '456',
+            correlation_id: '789',
+            issuer: 'test_issuer',
             captured_at: current_time,
             resolution: { success: true },
             mrz_status: :not_processed,
-            aamva_status: :not_processed,
+            aamva_status: :passed,
           )
         end
       end

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -177,6 +177,139 @@ RSpec.describe DocumentCaptureSession do
     end
   end
 
+  context 'proofing agent' do
+    let(:success) { true }
+    let(:attempt) { 1 }
+    let(:agent_proofing_result) do
+      # This should be re-written to use whatever response object is created via
+      # the proofing process being developed in LG-17293
+      # rubocop:disable Style/OpenStructUse
+      OpenStruct.new(
+        pii_from_doc: { first_name: 'Testy', last_name: 'Testerson' },
+        proofing_components: { foo: 'bar' },
+        location_id: '123',
+        agent_id: '456',
+        issuer: 'test_issuer',
+        success:,
+      )
+      # rubocop:enable Style/OpenStructUse
+    end
+
+    describe '#load_agent_proofed_user' do
+      it 'loads the previously stored result' do
+        record = DocumentCaptureSession.new
+        record.store_agent_proofed_user(agent_proofing_result:, attempt:)
+        result = record.load_agent_proofed_user
+
+        expect(result.success?).to eq(agent_proofing_result.success)
+        expect(result.pii).to eq(agent_proofing_result.pii_from_doc.to_h.deep_symbolize_keys)
+      end
+
+      it 'returns nil if the previously stored result does not exist' do
+        record = DocumentCaptureSession.new
+        result = record.load_agent_proofed_user
+
+        expect(result).to eq(nil)
+      end
+
+      xit 'returns nil if the previously stored result is expired' do
+        record = DocumentCaptureSession.new
+        record.store_agent_proofed_user(agent_proofing_result:, attempt: 1)
+        past_exp = IdentityConfig.store.agent_proofed_user_time_validity_hours.hours.in_seconds
+        travel_to((2 * past_exp).seconds.from_now) do
+          result = record.load_agent_proofed_user
+
+          expect(result).to eq(nil)
+        end
+      end
+    end
+
+    describe '#store_agent_proofed_user' do
+      let(:document_capture_session) { DocumentCaptureSession.new(result_id: SecureRandom.uuid) }
+
+      it 'generates a result ID stores the result encrypted in redis' do
+        record = document_capture_session
+        record.store_agent_proofed_user(agent_proofing_result:, attempt:)
+
+        result_id = record.result_id
+        key = EncryptedRedisStructStorage.key(result_id, type: Idv::ProofingAgent::AgentProofedUser)
+        data = REDIS_POOL.with { |client| client.get(key) }
+        expect(data).to be_a(String)
+        expect(data).to_not be_blank
+        expect(data).to_not include('Testy')
+        expect(data).to_not include('Testerson')
+      end
+
+      context 'when all fields are passed in' do
+        let(:current_time) { Time.zone.now }
+
+        before do
+          freeze_time
+          travel_to(current_time) do
+            document_capture_session.store_agent_proofed_user(
+              agent_proofing_result:,
+              mrz_response:, aamva_response:, attempt: 3
+            )
+          end
+        end
+
+        it 'stores the results' do
+          expect(document_capture_session.load_agent_proofed_user).to have_attributes(
+            success: true,
+            pii: agent_proofing_result.pii_from_doc.to_h,
+            captured_at: current_time,
+            doc_auth_success: nil,
+            errors: nil,
+            mrz_status: :pass,
+            aamva_status: :passed,
+            attempt: 3,
+          )
+        end
+      end
+
+      context 'when aamva response is passed in' do
+        before do
+          document_capture_session.store_agent_proofed_user(
+            agent_proofing_result:,
+            mrz_response:,
+            aamva_response:,
+            attempt:,
+          )
+        end
+
+        context 'when the aamva response is successful' do
+          let(:aamva_response) { DocAuth::Response.new(success: true) }
+
+          it 'stores aamva_status as :passed' do
+            expect(document_capture_session.load_agent_proofed_user).to have_attributes(
+              aamva_status: :passed,
+            )
+          end
+        end
+
+        context 'when the aamva response is unsuccessful' do
+          let(:aamva_response) { DocAuth::Response.new(success: false) }
+
+          it 'stores aamva_status as :failed' do
+            expect(document_capture_session.load_agent_proofed_user).to have_attributes(
+              aamva_status: :failed,
+            )
+          end
+        end
+
+        context 'when the aamva response is nil' do
+          let(:aamva_response) { nil }
+
+          it 'stores aamva_status as :not_processed' do
+            expect(document_capture_session.load_agent_proofed_user).to have_attributes(
+              aamva_status: :not_processed,
+            )
+          end
+        end
+      end
+    end
+  end
+
   describe '#expired?' do
     before do
       allow(IdentityConfig.store).to receive(:doc_capture_request_valid_for_minutes).and_return(15)

--- a/spec/services/idv/proofing_agent/agent_proofed_user_spec.rb
+++ b/spec/services/idv/proofing_agent/agent_proofed_user_spec.rb
@@ -4,14 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Idv::ProofingAgent::AgentProofedUser do
   let(:id) { SecureRandom.uuid }
-  let(:doc_auth_success) { true }
+  let(:success) { true }
   let(:pii) { { 'first_name' => 'Testy', 'last_name' => 'Testerson' } }
 
   context 'EncryptedRedisStructStorage' do
     it 'works with EncryptedRedisStructStorage' do
       result = Idv::ProofingAgent::AgentProofedUser.new(
         id:,
-        doc_auth_success:,
+        success:,
         pii:,
       )
       EncryptedRedisStructStorage.store(result)
@@ -22,7 +22,7 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
 
       expect(loaded_result).to have_attributes(
         id:,
-        doc_auth_success:,
+        success:,
         pii: pii.deep_symbolize_keys,
         aamva_status: nil,
       )
@@ -31,7 +31,7 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
     it 'persists mrz_status with EncryptedRedisStructStorage' do
       result = Idv::ProofingAgent::AgentProofedUser.new(
         id:,
-        doc_auth_success:,
+        success:,
         mrz_status: :pass,
         pii:,
       )
@@ -48,7 +48,7 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
       it 'returns a symbol when present' do
         result = Idv::ProofingAgent::AgentProofedUser.new(
           id:,
-          doc_auth_success:,
+          success:,
           pii:,
           mrz_status: 'pass',
         )
@@ -58,7 +58,7 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
       it 'returns nil when not present' do
         result = Idv::ProofingAgent::AgentProofedUser.new(
           id:,
-          doc_auth_success:,
+          success:,
           pii:,
         )
         expect(result.mrz_status).to be_nil
@@ -82,52 +82,6 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
 
         it 'returns nil' do
           is_expected.to be_nil
-        end
-      end
-    end
-
-    describe '#success?' do
-      let(:aamva_status) { nil }
-      let(:mrz_status) { nil }
-      let(:result) do
-        Idv::ProofingAgent::AgentProofedUser.new(
-          id: id,
-          doc_auth_success: true,
-          pii: nil,
-          aamva_status:,
-          mrz_status:,
-        )
-      end
-
-      context 'doc_auth_success is true, and aamva passed' do
-        let(:aamva_status) { 'passed' }
-
-        it 'returns true' do
-          expect(result.success?).to eq(true)
-        end
-      end
-
-      context 'doc_auth_success is true, and mrz passed' do
-        let(:mrz_status) { 'pass' }
-
-        it 'returns true' do
-          expect(result.success?).to eq(true)
-        end
-      end
-
-      context 'doc_auth_success is true, but aamva failed' do
-        let(:aamva_status) { 'failed' }
-
-        it 'returns false' do
-          expect(result.success?).to eq(false)
-        end
-      end
-
-      context 'doc_auth_success is true, but mrz failed' do
-        let(:mrz_status) { 'failed' }
-
-        it 'returns false' do
-          expect(result.success?).to eq(false)
         end
       end
     end

--- a/spec/services/idv/proofing_agent/agent_proofed_user_spec.rb
+++ b/spec/services/idv/proofing_agent/agent_proofed_user_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Idv::ProofingAgent::AgentProofedUser do
+  let(:id) { SecureRandom.uuid }
+  let(:success) { true }
+  let(:pii) { { 'first_name' => 'Testy', 'last_name' => 'Testerson' } }
+
+  context 'EncryptedRedisStructStorage' do
+    it 'works with EncryptedRedisStructStorage' do
+      result = Idv::ProofingAgent::AgentProofedUser.new(
+        id:,
+        success:,
+        pii:,
+        attempt: 3,
+      )
+      EncryptedRedisStructStorage.store(result)
+      loaded_result = EncryptedRedisStructStorage.load(
+        id,
+        type: Idv::ProofingAgent::AgentProofedUser,
+      )
+
+      expect(loaded_result).to have_attributes(
+        id:,
+        success:,
+        pii: pii.deep_symbolize_keys,
+        doc_auth_success: nil,
+        aamva_status: nil,
+        attempt: 3,
+      )
+    end
+
+    it 'persists mrz_status with EncryptedRedisStructStorage' do
+      result = Idv::ProofingAgent::AgentProofedUser.new(
+        id:,
+        success:,
+        doc_auth_success: success,
+        mrz_status: :pass,
+        pii:,
+      )
+      EncryptedRedisStructStorage.store(result)
+      loaded_result = EncryptedRedisStructStorage.load(
+        id,
+        type: Idv::ProofingAgent::AgentProofedUser,
+      )
+
+      expect(loaded_result.mrz_status).to eq(:pass)
+    end
+
+    describe '#mrz_status' do
+      it 'returns a symbol when present' do
+        result = Idv::ProofingAgent::AgentProofedUser.new(
+          id:,
+          success:,
+          pii:,
+          mrz_status: 'pass',
+        )
+        expect(result.mrz_status).to eq(:pass)
+      end
+
+      it 'returns nil when not present' do
+        result = Idv::ProofingAgent::AgentProofedUser.new(
+          id:,
+          success:,
+          pii:,
+        )
+        expect(result.mrz_status).to be_nil
+      end
+    end
+
+    describe '#aamva_status' do
+      let(:agent_proofed_user) { Idv::ProofingAgent::AgentProofedUser.new(aamva_status: status) }
+      subject { agent_proofed_user.aamva_status }
+
+      context 'when aamva status is present' do
+        let(:status) { :passed }
+
+        it 'returns a symbol' do
+          is_expected.to be(status)
+        end
+      end
+
+      context 'when aamva status is nil' do
+        let(:status) { nil }
+
+        it 'returns nil' do
+          is_expected.to be_nil
+        end
+      end
+    end
+
+    describe '#success?' do
+      it 'returns the value in the success attribute' do
+        result = Idv::ProofingAgent::AgentProofedUser.new(
+          id: id,
+          success: true,
+          pii: nil,
+          doc_auth_success: false,
+        )
+        expect(result.success?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/services/idv/proofing_agent/agent_proofed_user_spec.rb
+++ b/spec/services/idv/proofing_agent/agent_proofed_user_spec.rb
@@ -4,14 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Idv::ProofingAgent::AgentProofedUser do
   let(:id) { SecureRandom.uuid }
-  let(:success) { true }
+  let(:doc_auth_success) { true }
   let(:pii) { { 'first_name' => 'Testy', 'last_name' => 'Testerson' } }
 
   context 'EncryptedRedisStructStorage' do
     it 'works with EncryptedRedisStructStorage' do
       result = Idv::ProofingAgent::AgentProofedUser.new(
         id:,
-        success:,
+        doc_auth_success:,
         pii:,
       )
       EncryptedRedisStructStorage.store(result)
@@ -22,7 +22,7 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
 
       expect(loaded_result).to have_attributes(
         id:,
-        success:,
+        doc_auth_success:,
         pii: pii.deep_symbolize_keys,
         aamva_status: nil,
       )
@@ -31,7 +31,7 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
     it 'persists mrz_status with EncryptedRedisStructStorage' do
       result = Idv::ProofingAgent::AgentProofedUser.new(
         id:,
-        success:,
+        doc_auth_success:,
         mrz_status: :pass,
         pii:,
       )
@@ -48,7 +48,7 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
       it 'returns a symbol when present' do
         result = Idv::ProofingAgent::AgentProofedUser.new(
           id:,
-          success:,
+          doc_auth_success:,
           pii:,
           mrz_status: 'pass',
         )
@@ -58,7 +58,7 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
       it 'returns nil when not present' do
         result = Idv::ProofingAgent::AgentProofedUser.new(
           id:,
-          success:,
+          doc_auth_success:,
           pii:,
         )
         expect(result.mrz_status).to be_nil
@@ -87,13 +87,48 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
     end
 
     describe '#success?' do
-      it 'returns the value in the success attribute' do
-        result = Idv::ProofingAgent::AgentProofedUser.new(
+      let(:aamva_status) { nil }
+      let(:mrz_status) { nil }
+      let(:result) do
+        Idv::ProofingAgent::AgentProofedUser.new(
           id: id,
-          success: true,
+          doc_auth_success: true,
           pii: nil,
+          aamva_status:,
+          mrz_status:,
         )
-        expect(result.success?).to eq(true)
+      end
+
+      context 'doc_auth_success is true, and aamva passed' do
+        let(:aamva_status) { 'passed' }
+
+        it 'returns true' do
+          expect(result.success?).to eq(true)
+        end
+      end
+
+      context 'doc_auth_success is true, and mrz passed' do
+        let(:mrz_status) { 'pass' }
+
+        it 'returns true' do
+          expect(result.success?).to eq(true)
+        end
+      end
+
+      context 'doc_auth_success is true, but aamva failed' do
+        let(:aamva_status) { 'failed' }
+
+        it 'returns false' do
+          expect(result.success?).to eq(false)
+        end
+      end
+
+      context 'doc_auth_success is true, but mrz failed' do
+        let(:mrz_status) { 'failed' }
+
+        it 'returns false' do
+          expect(result.success?).to eq(false)
+        end
       end
     end
   end

--- a/spec/services/idv/proofing_agent/agent_proofed_user_spec.rb
+++ b/spec/services/idv/proofing_agent/agent_proofed_user_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
         id:,
         success:,
         pii:,
-        attempt: 3,
       )
       EncryptedRedisStructStorage.store(result)
       loaded_result = EncryptedRedisStructStorage.load(
@@ -25,9 +24,7 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
         id:,
         success:,
         pii: pii.deep_symbolize_keys,
-        doc_auth_success: nil,
         aamva_status: nil,
-        attempt: 3,
       )
     end
 
@@ -35,7 +32,6 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
       result = Idv::ProofingAgent::AgentProofedUser.new(
         id:,
         success:,
-        doc_auth_success: success,
         mrz_status: :pass,
         pii:,
       )
@@ -96,7 +92,6 @@ RSpec.describe Idv::ProofingAgent::AgentProofedUser do
           id: id,
           success: true,
           pii: nil,
-          doc_auth_success: false,
         )
         expect(result.success?).to eq(true)
       end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17295](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17295)

## 🛠 Summary of changes

Adds methods to the DocumentCaptureSession to store/load the data, encrypted, for an agent-proofed user.

Note: The exact structure of the data stored will be determined in future PRs.

changelog: Upcoming Features, Proofing Agent, Store received data encrypted.

## 📜 Testing Plan

- [ ] Specs pass


[LG-17295]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17295