### PR TITLE
Add different phone number event matcher to event summarizer

### DIFF
--- a/lib/event_summarizer/idv_matcher.rb
+++ b/lib/event_summarizer/idv_matcher.rb
@@ -21,6 +21,7 @@ module EventSummarizer
     IDV_SOCURE_VERIFICATION_DATA_REQUESTED = 'idv_socure_verification_data_requested'
     IDV_PHONE_CONFIRMATION_VENDOR_EVENT = 'IdV: phone confirmation vendor'
     IDV_VERIFY_PROOFING_RESULTS_EVENT = 'IdV: doc auth verify proofing results'
+    IDV_DIFFERENT_PHONE_NUMBER = 'IdV: use different phone number'
     IPP_ENROLLMENT_STATUS_UPDATED_EVENT = 'GetUspsProofingResultsJob: Enrollment status updated'
     PROFILE_ENCRYPTION_INVALID_EVENT = 'Profile Encryption: Invalid'
     RATE_LIMIT_REACHED_EVENT = 'Rate Limit Reached'
@@ -159,6 +160,11 @@ module EventSummarizer
         when IDV_PHONE_CONFIRMATION_VENDOR_EVENT
           for_current_idv_attempt(event:) do
             handle_phone_confirmation_vendor_event(event:)
+          end
+
+        when IDV_DIFFERENT_PHONE_NUMBER
+          for_current_idv_attempt(event:) do
+            handle_different_phone_number(event:)
           end
 
         when IDV_VERIFY_PROOFING_RESULTS_EVENT
@@ -417,6 +423,14 @@ module EventSummarizer
           description: "Rate limited for #{limit_name}",
         )
       end
+    end
+
+    def handle_different_phone_number(event:)
+      add_significant_event(
+        timestamp: event['@timestamp'],
+        type: :different_phone_number,
+        description: 'User attempted to use a different phone number',
+      )
     end
 
     def handle_image_upload_vendor_submitted(event:)

--- a/spec/lib/event_summarizer/idv_matcher_spec.rb
+++ b/spec/lib/event_summarizer/idv_matcher_spec.rb
@@ -168,5 +168,39 @@ RSpec.describe EventSummarizer::IdvMatcher do
         end
       end
     end
+
+    context "On 'IdV: use different phone number' (Phone Verification Step) event" do
+      let(:event) do
+        {
+          '@timestamp' => Time.zone.now,
+          'name' => 'IdV: use different phone number',
+          '@message' => {
+            'properties' => {
+              'event_properties' => {
+                'step' => 'phone_otp_verification',
+              },
+            },
+          },
+        }
+      end
+
+      before do
+        allow(matcher).to receive(:current_idv_attempt).and_return(
+          EventSummarizer::IdvMatcher::IdvAttempt.new(
+            started_at: Time.zone.now,
+          ),
+        )
+        matcher.handle_cloudwatch_event(event)
+      end
+
+      it 'adds a different_phone_number significant event when present' do
+        expect(matcher.current_idv_attempt.significant_events).to include(
+          have_attributes(
+            type: :different_phone_number,
+            description: 'User attempted to use a different phone number',
+          ),
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[JOAN-21](https://gitlab.login.gov/lg-teams/joan/-/issues/21)

## 🛠 Summary of changes

Add different phone number event matcher to event summarizer