### PR TITLE
LG-17477: remove store_in_session when handling stored result

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -4,9 +4,9 @@ module Idv
   module DocumentCaptureConcern
     extend ActiveSupport::Concern
 
-    def handle_stored_result(user: current_user, store_in_session: true)
+    def handle_stored_result(user: current_user)
       if stored_result&.success? && validation_requirements_met?
-        extract_pii_from_doc(user, store_in_session: store_in_session)
+        extract_pii_from_doc(user)
         flash[:success] = t('doc_auth.headings.capture_complete')
         successful_response
       else
@@ -40,17 +40,14 @@ module Idv
       }
     end
 
-    def extract_pii_from_doc(user, store_in_session: false)
+    def extract_pii_from_doc(user)
       if defined?(idv_session) # hybrid mobile does not have idv_session
         idv_session.had_barcode_read_failure = stored_result.attention_with_barcode?
         # See also Idv::InPerson::StateIdController#update
         idv_session.doc_auth_vendor = document_capture_session.doc_auth_vendor
-        if store_in_session
-          idv_session.pii_from_doc = stored_result.pii_from_doc
-          idv_session.aamva_verified_attributes = stored_result.aamva_verified_attributes
-          idv_session.selfie_check_performed = stored_result.selfie_check_performed?
-        end
-
+        idv_session.pii_from_doc = stored_result.pii_from_doc
+        idv_session.aamva_verified_attributes = stored_result.aamva_verified_attributes
+        idv_session.selfie_check_performed = stored_result.selfie_check_performed?
         idv_session.source_check_vendor = stored_result.source_check_vendor
       end
 

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -32,8 +32,7 @@ module Idv
       def update
         document_capture_session.confirm_ocr
         result = handle_stored_result(
-          user: document_capture_user,
-          store_in_session: false,
+          user: document_capture_user
         )
 
         analytics.idv_doc_auth_document_capture_submitted(**result.to_h.merge(analytics_arguments))

--- a/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/document_capture_controller.rb
@@ -32,7 +32,7 @@ module Idv
       def update
         document_capture_session.confirm_ocr
         result = handle_stored_result(
-          user: document_capture_user
+          user: document_capture_user,
         )
 
         analytics.idv_doc_auth_document_capture_submitted(**result.to_h.merge(analytics_arguments))

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -84,7 +84,6 @@ module Idv
 
           result = handle_stored_result(
             user: document_capture_session.user,
-            store_in_session: false,
           )
           # TODO: new analytics event?
           analytics.idv_doc_auth_document_capture_submitted(
@@ -103,7 +102,6 @@ module Idv
         def errors
           result = handle_stored_result(
             user: document_capture_user,
-            store_in_session: false,
           )
           @presenter = socure_errors_presenter(result)
         end

--- a/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
@@ -17,7 +17,6 @@ module Idv
           if error_code.nil?
             result = handle_stored_result(
               user: document_capture_session.user,
-              store_in_session: false,
             )
             error_code = error_code_for(result)
           end

--- a/app/controllers/idv/link_sent_controller.rb
+++ b/app/controllers/idv/link_sent_controller.rb
@@ -80,7 +80,7 @@ module Idv
     end
 
     def handle_document_verification_success
-      extract_pii_from_doc(current_user, store_in_session: true)
+      extract_pii_from_doc(current_user)
       idv_session.flow_path = 'hybrid'
     end
 

--- a/spec/controllers/concerns/idv/document_capture_concern_spec.rb
+++ b/spec/controllers/concerns/idv/document_capture_concern_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
       end
 
       it 'returns success response' do
-        response = controller.handle_stored_result(user: user, store_in_session: false)
+        response = controller.handle_stored_result(user: user)
         expect(response.success?).to eq(true)
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
       end
 
       it 'returns success response regardless of MRZ status' do
-        response = controller.handle_stored_result(user: user, store_in_session: false)
+        response = controller.handle_stored_result(user: user)
         expect(response.success?).to eq(true)
       end
 
@@ -144,7 +144,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
           let(:aamva_status) { :passed }
 
           it 'returns success response' do
-            response = controller.handle_stored_result(user: user, store_in_session: false)
+            response = controller.handle_stored_result(user: user)
             expect(response.success?).to eq(true)
           end
         end
@@ -153,7 +153,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
           let(:aamva_status) { :failed }
 
           it 'returns failure response' do
-            response = controller.handle_stored_result(user: user, store_in_session: false)
+            response = controller.handle_stored_result(user: user)
             expect(response.success?).to eq(false)
           end
         end
@@ -162,7 +162,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
           let(:aamva_status) { :not_processed }
 
           it 'returns failure response' do
-            response = controller.handle_stored_result(user: user, store_in_session: false)
+            response = controller.handle_stored_result(user: user)
             expect(response.success?).to eq(false)
           end
         end
@@ -173,7 +173,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
         let(:aamva_status) { :failed }
 
         it 'returns success response even with failed AAMVA' do
-          response = controller.handle_stored_result(user: user, store_in_session: false)
+          response = controller.handle_stored_result(user: user)
           expect(response.success?).to eq(true)
         end
       end

--- a/spec/controllers/concerns/idv/document_capture_concern_spec.rb
+++ b/spec/controllers/concerns/idv/document_capture_concern_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
       let(:passport_requested) { true }
 
       it 'returns failure response' do
-        response = controller.handle_stored_result(user: user)
+        response = controller.handle_stored_result(user:)
         expect(response.success?).to eq(false)
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
       end
 
       it 'returns success response' do
-        response = controller.handle_stored_result(user: user)
+        response = controller.handle_stored_result(user:)
         expect(response.success?).to eq(true)
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
       end
 
       it 'returns success response regardless of MRZ status' do
-        response = controller.handle_stored_result(user: user)
+        response = controller.handle_stored_result(user:)
         expect(response.success?).to eq(true)
       end
 
@@ -144,7 +144,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
           let(:aamva_status) { :passed }
 
           it 'returns success response' do
-            response = controller.handle_stored_result(user: user)
+            response = controller.handle_stored_result(user:)
             expect(response.success?).to eq(true)
           end
         end
@@ -153,7 +153,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
           let(:aamva_status) { :failed }
 
           it 'returns failure response' do
-            response = controller.handle_stored_result(user: user)
+            response = controller.handle_stored_result(user:)
             expect(response.success?).to eq(false)
           end
         end
@@ -162,7 +162,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
           let(:aamva_status) { :not_processed }
 
           it 'returns failure response' do
-            response = controller.handle_stored_result(user: user)
+            response = controller.handle_stored_result(user:)
             expect(response.success?).to eq(false)
           end
         end
@@ -173,7 +173,7 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
         let(:aamva_status) { :failed }
 
         it 'returns success response even with failed AAMVA' do
-          response = controller.handle_stored_result(user: user)
+          response = controller.handle_stored_result(user:)
           expect(response.success?).to eq(true)
         end
       end


### PR DESCRIPTION
changelog: Internal, Document Authentication, Remove store_in_session handling successful stored result

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-17477](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17477)

## 🛠 Summary of changes
Remove store_in_session argument since idv_session existence is checked.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17477]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17477