### PR TITLE
Deploy RC 569 to Production

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -577,7 +577,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.2.5)
+    rack (3.2.6)
     rack-cors (3.0.0)
       logger
       rack (>= 3.0.14)
@@ -586,7 +586,7 @@ GEM
       rack (>= 1.2.0)
     rack-proxy (0.7.7)
       rack
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -9,28 +9,25 @@ module Idv
       return unless historical_events_enabled?
       @password = password
 
-      if !existing_user_proofing_event
-        encrypted_events = encrypt_attempt_events_bundle(user_session['idv/attempts'])
-        encrypted_events_json = JSON.parse(encrypted_events)
-        new_user_proofing_event = UserProofingEvent.new(
-          encrypted_events:,
-          profile_id: current_user.active_profile.id,
-          service_providers_sent: [],
-          cost: encrypted_events_json['cost'],
-          salt: encrypted_events_json['salt'],
-        )
-        new_user_proofing_event.save
-      else
-        existing_events = JSON.parse(decrypt_user_proofing_events)
-        combined_events = existing_events.merge(user_session['idv/attempts'])
-        encrypted_events = encrypt_attempt_events_bundle(combined_events)
+      new_events = user_session['idv/attempts'] || []
 
-        existing_user_proofing_event.update_encrypted_events(encrypted_events)
-      end
+      encrypted_events = encrypt_attempt_events_bundle(new_events)
+      encrypted_events_json = JSON.parse(encrypted_events)
+      new_user_proofing_event = UserProofingEvent.new(
+        encrypted_events:,
+        profile_id: current_user.active_profile.id,
+        service_providers_sent: [],
+        cost: encrypted_events_json['cost'],
+        salt: encrypted_events_json['salt'],
+      )
+      new_user_proofing_event.save
+
+      # Now that proofing events are saved, remove the plaintext events from user_session
+      user_session.delete('idv/attempts')
     end
 
     def cache_user_proofing_events(password)
-      return unless historical_events_permitted? && existing_user_proofing_event
+      return unless historical_events_need_be_sent? && existing_user_proofing_event
       @password = password
 
       existing_events = decrypt_user_proofing_events
@@ -44,7 +41,7 @@ module Idv
       resolved_authn_context_result.identity_proofing_or_ialmax? && current_user.identity_verified?
     end
 
-    def historical_events_permitted?
+    def historical_events_need_be_sent?
       return false unless historical_events_enabled?
 
       sent_to_aaca = existing_user_proofing_event&.service_providers_sent&.include?(

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -24,7 +24,7 @@ module SignUp
       update_verified_attributes
       send_in_person_completion_survey
       notify_user_of_connected_sp
-      send_historical_events if historical_events_permitted?
+      send_historical_events if historical_events_need_be_sent?
       if user_session[:selected_email_id_for_linked_identity].nil?
         user_session[:selected_email_id_for_linked_identity] = current_user
           .last_sign_in_email_address.id
@@ -148,7 +148,7 @@ module SignUp
       user_proofing_event.add_sp_sent(current_sp.issuer)
     end
 
-    def historical_events_permitted?
+    def historical_events_need_be_sent?
       globally_enabled = IdentityConfig.store.historical_attempts_api_enabled
       aaca = current_sp.attempts_api_enabled?
       idv = ial2_requested?

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -24,6 +24,7 @@ class Profile < ApplicationRecord
   # rubocop:enable Rails/InverseOf
   has_many :gpo_confirmation_codes, dependent: :destroy
   has_one :in_person_enrollment, dependent: :destroy
+  has_one :user_proofing_event, dependent: :destroy
 
   validates :active, uniqueness: { scope: :user_id, if: :active? }
 

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -1,21 +1,13 @@
 # frozen_string_literal: true
 
 class UserProofingEvent < ApplicationRecord
+  belongs_to :profile
+
   # @param [String] issuer Client ID of service provider to add to "sent" list
   def add_sp_sent(issuer)
     return if self.service_providers_sent.include? issuer
 
     self.service_providers_sent.push(issuer)
-    self.save!
-  end
-
-  # @param [String] new_events Stringified encrypted_events from a UserProofingEvent
-  def update_encrypted_events(new_events)
-    new_events_json = JSON.parse(new_events)
-
-    self.encrypted_events = new_events
-    self.cost = new_events_json['cost']
-    self.salt = new_events_json['salt']
     self.save!
   end
 end

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -71,11 +71,11 @@ module AttemptsApi
     private
 
     def log_history(event)
+      return unless session && session['warden.user.user.session']
+
       session['warden.user.user.session']['idv/attempts'] ||= []
       session['warden.user.user.session']['idv/attempts'].push(
-        {
-          event.event_type => { 'user_uuid' => user.uuid },
-        },
+        { event.event_type => JSON.parse(event.to_json) },
       )
     end
 
@@ -159,7 +159,6 @@ module AttemptsApi
 
     def will_log_history?(event_type)
       return false unless IdentityConfig.store.historical_attempts_api_enabled
-      return false unless session && session['warden.user.user.session']
 
       event_type.start_with?(*LOG_HISTORY_PREFIXES)
     end

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -23,9 +23,16 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       'cost' => '000$0$0$',
     }
   end
-  let(:idv_attempts) { { 'test_attempt' => 'some_data' } }
+  let(:test_data) { { test_data: 'data' } }
+  let(:old_data) { { old_data: 'data' } }
+  let(:idv_attempts) do
+    [
+      { 'idv-ssn-submitted' => test_data },
+      { 'idv-enrollment-complete' => test_data },
+    ]
+  end
   let(:pii_encryptor) { Encryption::Encryptors::PiiEncryptor.new(registered_user.password) }
-  let(:existing_events) { { 'old_attempt' => 'old_data' } }
+  let(:existing_events) { [{ 'old_attempt' => old_data }] }
   let(:encrypted_existing_events) do
     pii_encryptor.encrypt(existing_events.to_json, user_uuid: registered_user.uuid)
   end
@@ -97,7 +104,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       end
     end
 
-    context 'when the user does not have an existing UserProofingEvent' do
+    context 'when historical events need to be sent' do
       before do
         allow(Encryption::Encryptors::PiiEncryptor).to receive(:new).and_return(encryptor_mock)
         allow(encryptor_mock).to receive(:encrypt).and_return(encrypted_events.to_json)
@@ -117,41 +124,6 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
           cost: encrypted_events['cost'],
           salt: encrypted_events['salt'],
         )
-      end
-    end
-
-    context 'when the user already has an existing UserProofingEvent' do
-      let(:concatenated_events) { existing_events.merge(idv_attempts) }
-      let(:user_proofing_event) do
-        create(
-          :user_proofing_event,
-          encrypted_events: encrypted_existing_events,
-          service_providers_sent: [sp.issuer],
-          cost: JSON.parse(encrypted_existing_events)['cost'],
-          salt: JSON.parse(encrypted_existing_events)['salt'],
-          profile_id: registered_user.active_profile.id,
-        )
-      end
-
-      before do
-        allow(UserProofingEvent).to receive(:new).and_call_original
-        allow(UserProofingEvent).to receive(:find_by).and_return(user_proofing_event)
-        allow(user_proofing_event).to receive(:update_encrypted_events).and_return(true)
-        record_user_proofing_events
-      end
-
-      it 'decrypts existing UserProofingEvent' do
-        expect(pii_encryptor).to have_received(:decrypt).once
-      end
-
-      it 'encrypts concatenated data' do
-        expect(pii_encryptor).to have_received(:encrypt).with(
-          concatenated_events.to_json, user_uuid: registered_user.uuid
-        )
-      end
-
-      it 'updates the UserProofingEvent with concatenated data' do
-        expect(user_proofing_event).to have_received(:update_encrypted_events).once
       end
     end
   end
@@ -256,7 +228,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
         )
       end
 
-      it 'updates the user_session with the UserProofingEvent' do
+      it 'updates the session with the UserProofingEvent' do
         expect(controller.user_session[:encrypted_proofing_events]).to eq(kms_encrypted_events)
       end
     end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1124,13 +1124,15 @@ RSpec.describe Idv::EnterPasswordController do
     end
 
     describe 'historical events tracking' do
-      let(:mock_user_session) do
-        {
-          'idv/attempts' => ['idv-enrollment-complete' => {
-            user_uuid: user.uuid,
-          }],
-        }
+      let(:idv_attempt) do
+        AttemptsApi::AttemptEvent.new(
+          event_type: 'idv-enrollment-complete',
+          session_id: 0,
+          occurred_at: Time.zone.now,
+          event_metadata: { event_type: 'idv-enrollment-complete', data: 'event data' },
+        )
       end
+      let(:mock_user_session) { { 'idv/attempts' => [idv_attempt] } }
       let(:mock) { double }
 
       before do
@@ -1141,7 +1143,7 @@ RSpec.describe Idv::EnterPasswordController do
           historical_attempts_api_enabled: true,
           allowed_attempts_providers: [{ 'issuer' => sp.issuer }],
         )
-        allow(subject).to receive(:user_session).and_return(mock_user_session)
+        session['warden.user.user.session'] = mock_user_session
         # at this point in the flow, the applicant should have a UUID
         subject.idv_session.applicant['uuid'] = 'aabbccdd-0000-00000-0000-aabbccddeeff'
       end

--- a/spec/models/user_proofing_event_spec.rb
+++ b/spec/models/user_proofing_event_spec.rb
@@ -30,33 +30,4 @@ RSpec.describe UserProofingEvent, type: :model do
       expect(user_proofing_event.service_providers_sent).to eq([issuer])
     end
   end
-
-  describe '#update_encrypted_events' do
-    let(:encrypted_events) { 'new_encrypted_events' }
-    let(:cost) { '1$cost$' }
-    let(:salt) { 'salt1' }
-    let(:new_events) do
-      {
-        encrypted_events:,
-        cost:,
-        salt:,
-      }.to_json
-    end
-
-    before do
-      user_proofing_event.update_encrypted_events(new_events)
-    end
-
-    it 'updates encrypted events' do
-      expect(user_proofing_event.encrypted_events).to eq(new_events)
-    end
-
-    it 'updates cost' do
-      expect(user_proofing_event.cost).to eq(cost)
-    end
-
-    it 'updates salt' do
-      expect(user_proofing_event.salt).to eq(salt)
-    end
-  end
 end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -242,6 +242,7 @@ RSpec.describe AttemptsApi::Tracker do
 
       context 'with Devise session' do
         let(:mock_session) { { 'warden.user.user.session' => {} } }
+        let(:user_session) { mock_session['warden.user.user.session'] }
 
         before do
           allow(request).to receive(:session).and_return(mock_session)
@@ -249,10 +250,8 @@ RSpec.describe AttemptsApi::Tracker do
 
         it 'populates the session info' do
           subject.idv_enrollment_complete(reproof: false)
-          expect(mock_session['warden.user.user.session']).to eq(
-            'idv/attempts' => ['idv-enrollment-complete' => {
-              'user_uuid' => user.uuid,
-            }],
+          expect(user_session['idv/attempts']).to include(
+            hash_including('idv-enrollment-complete'),
           )
         end
 
@@ -285,10 +284,8 @@ RSpec.describe AttemptsApi::Tracker do
 
           it 'still populates the session info' do
             subject.idv_enrollment_complete(reproof: false)
-            expect(mock_session['warden.user.user.session']).to eq(
-              'idv/attempts' => ['idv-enrollment-complete' => {
-                'user_uuid' => user.uuid,
-              }],
+            expect(user_session['idv/attempts']).to include(
+              hash_including('idv-enrollment-complete'),
             )
           end
         end


### PR DESCRIPTION
## Internal
- Security: Upgrade rack-session to 2.1.2 ([#13043](https://github.com/18F/identity-idp/pull/13043))

## Upcoming Features
- Historical Attempts API: Save appropriate attempts data ([#13026](https://github.com/18F/identity-idp/pull/13026))
