### PR TITLE
Only save idv events

### DIFF
--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -75,7 +75,7 @@ module AttemptsApi
 
       session['warden.user.user.session']['idv/attempts'] ||= []
       session['warden.user.user.session']['idv/attempts'].push(
-        { event.event_type => JSON.parse(event.to_json) },
+        event.event_type => { 'user_uuid' => user.uuid },
       )
     end
 

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -8,7 +8,7 @@ module AttemptsApi
     ].freeze
 
     # These are events that should be encrypted and then persisted as historical information
-    LOG_HISTORY_PREFIXES = ['forgot-password-', 'user-registration-', 'idv-'].freeze
+    LOG_HISTORY_PREFIXES = ['idv-'].freeze
 
     attr_reader :session_id, :enabled_for_session, :request, :user, :sp, :cookie_device_uuid,
                 :sp_redirect_uri

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -248,22 +248,70 @@ RSpec.describe AttemptsApi::Tracker do
           allow(request).to receive(:session).and_return(mock_session)
         end
 
-        it 'populates the session info' do
-          subject.idv_enrollment_complete(reproof: false)
-          expect(user_session['idv/attempts']).to include(
-            hash_including('idv-enrollment-complete'),
-          )
+        context 'it is an event prefixed with "idv"' do
+          it 'populates the session info' do
+            subject.idv_enrollment_complete(reproof: false)
+            expect(user_session['idv/attempts']).to include(
+              hash_including('idv-enrollment-complete'),
+            )
+          end
+
+          it 'records to redis' do
+            freeze_time do
+              subject.idv_enrollment_complete(reproof: false)
+
+              events = AttemptsApi::RedisClient.new.read_events(
+                issuer: service_provider.issuer,
+              )
+
+              expect(events.values.length).to eq(1)
+            end
+          end
         end
 
-        it 'records to redis' do
-          freeze_time do
+        context 'it is an event not prefixed with "idv"' do
+          it 'does not populate the session info' do
+            subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
+            expect(user_session).to eq({})
+          end
+
+          it 'records to redis' do
+            freeze_time do
+              subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
+
+              events = AttemptsApi::RedisClient.new.read_events(
+                issuer: service_provider.issuer,
+              )
+
+              expect(events.values.length).to eq(1)
+            end
+          end
+        end
+
+        context 'both prefixed and not prefixed events are recorded' do
+          it 'does not populate the event is not prefixed with idv-' do
             subject.idv_enrollment_complete(reproof: false)
-
-            events = AttemptsApi::RedisClient.new.read_events(
-              issuer: service_provider.issuer,
+            subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
+            expect(user_session['idv/attempts']).to include(
+              hash_including('idv-enrollment-complete'),
             )
+          end
 
-            expect(events.values.length).to eq(1)
+          it 'records both to redis' do
+            freeze_time do
+              subject.idv_enrollment_complete(reproof: false)
+
+              subject.user_registration_email_confirmed(
+                success: true,
+                email: 'email@example.com',
+              )
+
+              events = AttemptsApi::RedisClient.new.read_events(
+                issuer: service_provider.issuer,
+              )
+
+              expect(events.values.length).to eq(2)
+            end
           end
         end
 

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -251,8 +251,8 @@ RSpec.describe AttemptsApi::Tracker do
         context 'it is an event prefixed with "idv"' do
           it 'populates the session info' do
             subject.idv_enrollment_complete(reproof: false)
-            expect(user_session['idv/attempts']).to include(
-              hash_including('idv-enrollment-complete'),
+            expect(user_session['idv/attempts']).to eq(
+              [{ 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } }],
             )
           end
 
@@ -292,8 +292,8 @@ RSpec.describe AttemptsApi::Tracker do
           it 'does not populate the event is not prefixed with idv-' do
             subject.idv_enrollment_complete(reproof: false)
             subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
-            expect(user_session['idv/attempts']).to include(
-              hash_including('idv-enrollment-complete'),
+            expect(user_session['idv/attempts']).to eq(
+              [{ 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } }],
             )
           end
 
@@ -332,8 +332,8 @@ RSpec.describe AttemptsApi::Tracker do
 
           it 'still populates the session info' do
             subject.idv_enrollment_complete(reproof: false)
-            expect(user_session['idv/attempts']).to include(
-              hash_including('idv-enrollment-complete'),
+            expect(user_session['idv/attempts']).to eq(
+              [{ 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } }],
             )
           end
         end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 89](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/89)
-->

## 🛠 Summary of changes
This change

- Updates `LOG_HISTORY_PREFIXES` to only be `idv-`
- Reverts saved data to just be the uuid, and not the whole event data
- Adds tests

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
