### PR TITLE
LG-17492: rename the tmx cert env variable

### DIFF
--- a/app/jobs/threat_metrix_js_verification_job.rb
+++ b/app/jobs/threat_metrix_js_verification_job.rb
@@ -14,7 +14,7 @@ class ThreatMetrixJsVerificationJob < ApplicationJob
     signature = nil
 
     # Certificate is stored ASCII-armored in config
-    raw_cert = IdentityConfig.store.lexisnexis_threatmetrix_js_signing_cert
+    raw_cert = IdentityConfig.store.lexisnexis_threatmetrix_js_public_cert
     cert = OpenSSL::X509::Certificate.new(raw_cert) if raw_cert.present?
     raise ConfigurationError, 'JS signing certificate is missing' if !cert
     raise 'JS signing certificate is expired' if cert.not_after < Time.zone.now

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -306,7 +306,7 @@ lexisnexis_threatmetrix_api_key:
 lexisnexis_threatmetrix_authentication_policy: '1234'
 lexisnexis_threatmetrix_base_url:
 lexisnexis_threatmetrix_hybrid_handoff_policy:
-lexisnexis_threatmetrix_js_signing_cert: ''
+lexisnexis_threatmetrix_js_public_cert: ''
 lexisnexis_threatmetrix_mock_enabled: true
 lexisnexis_threatmetrix_org_id:
 lexisnexis_threatmetrix_policy:

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -318,7 +318,7 @@ module IdentityConfig
     config.add(:lexisnexis_threatmetrix_api_key, type: :string, allow_nil: true)
     config.add(:lexisnexis_threatmetrix_base_url, type: :string, allow_nil: true)
     config.add(:lexisnexis_threatmetrix_hybrid_handoff_policy, :string, allow_nil: true)
-    config.add(:lexisnexis_threatmetrix_js_signing_cert, type: :string)
+    config.add(:lexisnexis_threatmetrix_js_public_cert, type: :string)
     config.add(:lexisnexis_threatmetrix_mock_enabled, type: :boolean)
     config.add(:lexisnexis_threatmetrix_org_id, type: :string, allow_nil: true)
     config.add(:lexisnexis_threatmetrix_policy, type: :string, allow_nil: true)

--- a/spec/jobs/threat_metrix_js_verification_job_spec.rb
+++ b/spec/jobs/threat_metrix_js_verification_job_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ThreatMetrixJsVerificationJob, type: :job do
     before do
       allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_org_id)
         .and_return(threatmetrix_org_id)
-      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_js_signing_cert)
+      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_js_public_cert)
         .and_return(threatmetrix_signing_certificate)
       allow(IdentityConfig.store).to receive(:proofing_device_profiling)
         .and_return(threatmetrix_enabled ? :collect_only : :disabled)


### PR DESCRIPTION
changelog: Internal, Identity Verification, Rename tmx cert env var

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-17492](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17492)


## 🛠 Summary of changes
lexisnexis_threatmetrix_js_signing_cert has been renamed lexisnexis_threatmetrix_js_public_cert

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17492]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17492