### PR TITLE
Deploy RC 571 to Production

### DIFF
--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -66,7 +66,11 @@ module Idv
 
     def passports_enabled?
       IdentityConfig.store.doc_auth_passports_enabled ||
-        IdentityConfig.store.doc_auth_passport_cards_enabled
+        (FeatureManagement.doc_auth_passport_cards_enabled? && in_passport_cards_allowed_bucket?)
+    end
+
+    def in_passport_cards_allowed_bucket?
+      ab_test_bucket(:DOC_AUTH_PASSPORT_CARDS_ALLOWED) == :doc_auth_passport_cards_allowed
     end
   end
 end

--- a/app/jobs/threat_metrix_js_verification_job.rb
+++ b/app/jobs/threat_metrix_js_verification_job.rb
@@ -14,7 +14,7 @@ class ThreatMetrixJsVerificationJob < ApplicationJob
     signature = nil
 
     # Certificate is stored ASCII-armored in config
-    raw_cert = IdentityConfig.store.lexisnexis_threatmetrix_js_signing_cert
+    raw_cert = IdentityConfig.store.lexisnexis_threatmetrix_js_public_cert
     cert = OpenSSL::X509::Certificate.new(raw_cert) if raw_cert.present?
     raise ConfigurationError, 'JS signing certificate is missing' if !cert
     raise 'JS signing certificate is expired' if cert.not_after < Time.zone.now

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -118,6 +118,7 @@ doc_auth_max_capture_attempts_before_native_camera: 3
 doc_auth_max_submission_attempts_before_native_camera: 3
 doc_auth_mock_dos_api: false
 doc_auth_passport_cards_enabled: false
+doc_auth_passport_cards_enabled_percent: 0
 doc_auth_passport_selfie_vendor_default: 'mock'
 doc_auth_passport_selfie_vendor_lexis_nexis_ddp_percent: 0
 doc_auth_passport_selfie_vendor_lexis_nexis_percent: 100

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -306,7 +306,7 @@ lexisnexis_threatmetrix_api_key:
 lexisnexis_threatmetrix_authentication_policy: '1234'
 lexisnexis_threatmetrix_base_url:
 lexisnexis_threatmetrix_hybrid_handoff_policy:
-lexisnexis_threatmetrix_js_signing_cert: ''
+lexisnexis_threatmetrix_js_public_cert: ''
 lexisnexis_threatmetrix_mock_enabled: true
 lexisnexis_threatmetrix_org_id:
 lexisnexis_threatmetrix_policy:

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -212,4 +212,14 @@ module AbTests
   ) do |service_provider:, session:, user:, user_session:, **|
     document_capture_session_uuid_discriminator(service_provider:, session:, user:, user_session:)
   end.freeze
+
+  DOC_AUTH_PASSPORT_CARDS_ALLOWED = AbTest.new(
+    experiment_name: 'Doc Auth Passport Cards Allowed',
+    should_log: /^idv/i,
+    buckets: {
+      doc_auth_passport_cards_allowed: IdentityConfig.store.doc_auth_passport_cards_enabled_percent,
+    },
+  ) do |user:, user_session:, **|
+    user&.uuid
+  end.freeze
 end

--- a/db/primary_migrate/20260331000000_allow_null_service_provider_on_duplicate_profile_sets.rb
+++ b/db/primary_migrate/20260331000000_allow_null_service_provider_on_duplicate_profile_sets.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AllowNullServiceProviderOnDuplicateProfileSets < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    change_column_null :duplicate_profile_sets, :service_provider, true
+
+    # Add index where SP is null
+    # This allows for multiple open duplicate profile sets for different SPs
+    # But only one open duplicate profile set without an SP
+    # Will modify after change is permanent
+    add_index :duplicate_profile_sets, :profile_ids,
+              unique: true,
+              where: 'service_provider IS NULL',
+              name: 'index_duplicate_profile_sets_on_profile_ids_sp_null',
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :duplicate_profile_sets,
+                 name: 'index_duplicate_profile_sets_on_profile_ids_sp_null',
+                 algorithm: :concurrently
+
+    # Backfill any null service_provider rows before re-adding the constraint
+    DuplicateProfileSet.where(service_provider: nil).update_all(service_provider: 'unknown')
+    change_column_null :duplicate_profile_sets, :service_provider, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_06_213343) do
+ActiveRecord::Schema[8.0].define(version: 2026_03_31_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -224,7 +224,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_06_213343) do
   end
 
   create_table "duplicate_profile_sets", force: :cascade do |t|
-    t.string "service_provider", limit: 255, null: false, comment: "sensitive=false"
+    t.string "service_provider", limit: 255, comment: "sensitive=false"
     t.bigint "profile_ids", null: false, comment: "sensitive=false", array: true
     t.datetime "closed_at", comment: "sensitive=false"
     t.boolean "self_serviced", comment: "sensitive=false"
@@ -232,6 +232,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_06_213343) do
     t.datetime "created_at", null: false, comment: "sensitive=false"
     t.datetime "updated_at", null: false, comment: "sensitive=false"
     t.index ["profile_ids"], name: "index_duplicate_profile_sets_on_profile_ids", using: :gin
+    t.index ["profile_ids"], name: "index_duplicate_profile_sets_on_profile_ids_sp_null", unique: true, where: "(service_provider IS NULL)"
     t.index ["service_provider", "profile_ids"], name: "idx_on_service_provider_profile_ids_7f75d24ae3", unique: true
   end
 

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -98,6 +98,10 @@ class FeatureManagement
     IdentityConfig.store.check_user_password_compromised_enabled
   end
 
+  def self.doc_auth_passport_cards_enabled?
+    IdentityConfig.store.doc_auth_passport_cards_enabled
+  end
+
   def self.doc_capture_polling_enabled?
     IdentityConfig.store.doc_capture_polling_enabled
   end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -141,6 +141,7 @@ module IdentityConfig
     config.add(:doc_auth_passport_vendor_switching_enabled, type: :boolean)
     config.add(:doc_auth_desktop_test_mode, type: :boolean)
     config.add(:doc_auth_passport_cards_enabled, type: :boolean)
+    config.add(:doc_auth_passport_cards_enabled_percent, type: :integer)
     config.add(:doc_auth_passport_selfie_vendor_default, type: :string)
     config.add(:doc_auth_passport_selfie_vendor_lexis_nexis_ddp_percent, type: :integer)
     config.add(:doc_auth_passport_selfie_vendor_lexis_nexis_percent, type: :integer)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -318,7 +318,7 @@ module IdentityConfig
     config.add(:lexisnexis_threatmetrix_api_key, type: :string, allow_nil: true)
     config.add(:lexisnexis_threatmetrix_base_url, type: :string, allow_nil: true)
     config.add(:lexisnexis_threatmetrix_hybrid_handoff_policy, :string, allow_nil: true)
-    config.add(:lexisnexis_threatmetrix_js_signing_cert, type: :string)
+    config.add(:lexisnexis_threatmetrix_js_public_cert, type: :string)
     config.add(:lexisnexis_threatmetrix_mock_enabled, type: :boolean)
     config.add(:lexisnexis_threatmetrix_org_id, type: :string, allow_nil: true)
     config.add(:lexisnexis_threatmetrix_policy, type: :string, allow_nil: true)

--- a/spec/config/initializers/ab_tests_spec.rb
+++ b/spec/config/initializers/ab_tests_spec.rb
@@ -637,4 +637,24 @@ RSpec.describe AbTests do
 
     it_behaves_like 'an A/B test that uses document_capture_session_uuid as a discriminator'
   end
+
+  describe 'DOC_AUTH_PASSPORT_CARDS_ALLOWED' do
+    let(:ab_test) { :DOC_AUTH_PASSPORT_CARDS_ALLOWED }
+
+    let(:disable_ab_test) do
+      -> {
+        allow(IdentityConfig.store).to receive(:doc_auth_passport_cards_enabled_percent)
+          .and_return(0)
+      }
+    end
+
+    let(:enable_ab_test) do
+      -> {
+        allow(IdentityConfig.store).to receive(:doc_auth_passport_cards_enabled_percent)
+          .and_return(50)
+      }
+    end
+
+    it_behaves_like 'an A/B test that uses user_uuid as a discriminator'
+  end
 end

--- a/spec/controllers/concerns/idv/choose_id_type_concern_spec.rb
+++ b/spec/controllers/concerns/idv/choose_id_type_concern_spec.rb
@@ -299,6 +299,12 @@ RSpec.describe Idv::ChooseIdTypeConcern, :controller do
           .and_return(false)
         allow(IdentityConfig.store).to receive(:doc_auth_passport_cards_enabled)
           .and_return(true)
+        ab_test = AbTests::DOC_AUTH_PASSPORT_CARDS_ALLOWED.dup
+        allow(ab_test).to receive(:bucket).and_return(:doc_auth_passport_cards_allowed)
+        stub_const(
+          'AbTests::DOC_AUTH_PASSPORT_CARDS_ALLOWED',
+          ab_test,
+        )
         allow(response).to receive(:success?).and_return(true)
       end
 

--- a/spec/jobs/threat_metrix_js_verification_job_spec.rb
+++ b/spec/jobs/threat_metrix_js_verification_job_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ThreatMetrixJsVerificationJob, type: :job do
     before do
       allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_org_id)
         .and_return(threatmetrix_org_id)
-      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_js_signing_cert)
+      allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_js_public_cert)
         .and_return(threatmetrix_signing_certificate)
       allow(IdentityConfig.store).to receive(:proofing_device_profiling)
         .and_return(threatmetrix_enabled ? :collect_only : :disabled)


### PR DESCRIPTION
## Internal
-  One Account: User adds sp on duplicate profile sets ([#13007](https://github.com/18F/identity-idp/pull/13007))
- Identity Verification: Rename tmx cert env var ([#13056](https://github.com/18F/identity-idp/pull/13056))

## Upcoming Features
- Doc Auth: Passport card bucket ([#13059](https://github.com/18F/identity-idp/pull/13059))
