### PR TITLE
update user proofing events

### DIFF
--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -7,19 +7,23 @@ module Idv
 
     def record_user_proofing_events(password)
       return unless historical_events_enabled?
+      # TODO: move UserProofingEvent creation to the Profile object
       @password = password
 
       new_events = user_session['idv/attempts'] || []
 
-      encrypted_events = encrypt_attempt_events_bundle(new_events)
-      encrypted_events_json = JSON.parse(encrypted_events)
-      new_user_proofing_event = UserProofingEvent.new(
-        encrypted_events:,
-        profile_id: current_user.active_profile.id,
-        service_providers_sent: [],
-        cost: encrypted_events_json['cost'],
-        salt: encrypted_events_json['salt'],
-      )
+      encrypted_events_json = encrypt_attempt_events_bundle(new_events)
+      encrypted_events = JSON.parse(encrypted_events_json)
+
+      # TODO: Write encrypted_events['encrypted_data'] to S3
+
+      new_user_proofing_event = current_user
+        .active_profile
+        .build_user_proofing_event(
+          cost: encrypted_events['cost'],
+          salt: encrypted_events['salt'],
+        )
+
       new_user_proofing_event.save
 
       # Now that proofing events are saved, remove the plaintext events from user_session
@@ -37,6 +41,12 @@ module Idv
 
     private
 
+    def data_sent_to_sp?
+      existing_user_proofing_event&.service_providers_sent&.include?(
+        current_sp.issuer,
+      )
+    end
+
     def ial2_requested?
       resolved_authn_context_result.identity_proofing_or_ialmax? && current_user.identity_verified?
     end
@@ -44,8 +54,10 @@ module Idv
     def historical_events_need_be_sent?
       return false unless historical_events_enabled?
 
-      sent_to_aaca = existing_user_proofing_event&.service_providers_sent&.include?(
-        current_sp.issuer,
+      # TODO: This will return true if existing_user_proofing_event does not exist.
+      # That seems wrong?
+      sent_to_aaca = existing_user_proofing_event&.service_provider_ids_sent&.include?(
+        current_sp.id,
       )
 
       return !sent_to_aaca
@@ -58,9 +70,7 @@ module Idv
     end
 
     def existing_user_proofing_event
-      @existing_user_proofing_event ||= UserProofingEvent.find_by(
-        profile_id: current_user.active_profile.id,
-      )
+      @existing_user_proofing_event ||= current_user.active_profile.user_proofing_event
     end
 
     def encrypt_attempt_events_bundle(bundle)
@@ -68,7 +78,15 @@ module Idv
     end
 
     def decrypt_user_proofing_events
-      pii_encryptor.decrypt(existing_user_proofing_event['encrypted_events'], user_uuid:)
+      # TODO: Retrieve encrypted_events from S3 or locally
+      # Currently this is not in use, so passing in dummy data
+      data = pii_encryptor.encrypt(
+        [
+          { 'idv-ssn-submitted' => { 'user_uuid' => user_uuid } },
+        ].to_json,
+        user_uuid:,
+      )
+      pii_encryptor.decrypt(data, user_uuid:)
     end
 
     def pii_encryptor

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -16,6 +16,7 @@ module Idv
       encrypted_events = JSON.parse(encrypted_events_json)
 
       # TODO: Write encrypted_events['encrypted_data'] to S3
+      # TODO: Save reference to S3 object in current_user.active_profile
 
       new_user_proofing_event = current_user
         .active_profile
@@ -55,7 +56,6 @@ module Idv
       return false unless historical_events_enabled?
 
       # TODO: This will return true if existing_user_proofing_event does not exist.
-      # That seems wrong?
       sent_to_aaca = existing_user_proofing_event&.service_provider_ids_sent&.include?(
         current_sp.id,
       )

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -32,7 +32,7 @@ module Idv
     end
 
     def cache_user_proofing_events(password)
-      return unless historical_events_need_be_sent? && existing_user_proofing_event
+      return unless historical_events_need_be_sent?
       @password = password
 
       existing_events = decrypt_user_proofing_events
@@ -54,13 +54,9 @@ module Idv
 
     def historical_events_need_be_sent?
       return false unless historical_events_enabled?
+      return false if existing_user_proofing_event.blank?
 
-      # TODO: This will return true if existing_user_proofing_event does not exist.
-      sent_to_aaca = existing_user_proofing_event&.service_provider_ids_sent&.include?(
-        current_sp.id,
-      )
-
-      return !sent_to_aaca
+      return !existing_user_proofing_event.already_sent_to_sp?(current_sp.id)
     end
 
     def historical_events_enabled?

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -42,12 +42,6 @@ module Idv
 
     private
 
-    def data_sent_to_sp?
-      existing_user_proofing_event&.service_providers_sent&.include?(
-        current_sp.issuer,
-      )
-    end
-
     def ial2_requested?
       resolved_authn_context_result.identity_proofing_or_ialmax? && current_user.identity_verified?
     end

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -141,28 +141,26 @@ module SignUp
     end
 
     def send_historical_events
-      return unless user_proofing_event && current_sp.issuer
+      # TODO: send to redis queue
 
-      # send to redis queue and update sp_sent
-
-      user_proofing_event.add_sp_sent(current_sp.issuer)
+      user_proofing_event.add_sp_sent(current_sp.id)
     end
 
     def historical_events_need_be_sent?
-      globally_enabled = IdentityConfig.store.historical_attempts_api_enabled
-      aaca = current_sp.attempts_api_enabled?
-      idv = ial2_requested?
+      return false unless IdentityConfig.store.historical_attempts_api_enabled
+      return false unless current_sp.attempts_api_enabled?
+      return false unless ial2_requested?
+      return false unless user_proofing_event.present?
 
-      return false unless globally_enabled && aaca && idv
+      return !sent_to_aaca?
+    end
 
-      sent_to_aaca = user_proofing_event&.service_providers_sent&.include?(current_sp.issuer)
-
-      return !sent_to_aaca
+    def sent_to_aaca?
+      user_proofing_event&.already_sent_to_sp?(current_sp.id)
     end
 
     def user_proofing_event
-      @user_proofing_event ||=
-        UserProofingEvent.find_by(profile_id: current_user&.active_profile&.id)
+      @user_proofing_event ||= current_user&.active_profile&.user_proofing_event
     end
 
     def pii

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -2,12 +2,13 @@
 
 class UserProofingEvent < ApplicationRecord
   belongs_to :profile
+  self.ignored_columns = %w[encrypted_events service_providers_sent]
 
-  # @param [String] issuer Client ID of service provider to add to "sent" list
-  def add_sp_sent(issuer)
-    return if self.service_providers_sent.include? issuer
+  # @param [String] id ID of service provider to add to "sent" list
+  def add_sp_sent(id)
+    return if self.service_provider_ids_sent.include?(id)
 
-    self.service_providers_sent.push(issuer)
+    self.service_provider_ids_sent.push(id)
     self.save!
   end
 end

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -11,4 +11,8 @@ class UserProofingEvent < ApplicationRecord
     self.service_provider_ids_sent.push(id)
     self.save!
   end
+
+  def already_sent_to_sp?(id)
+    service_provider_ids_sent.include?(id)
+  end
 end

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -4,7 +4,7 @@ class UserProofingEvent < ApplicationRecord
   belongs_to :profile
   self.ignored_columns = %w[encrypted_events service_providers_sent]
 
-  # @param [String] id ID of service provider to add to "sent" list
+  # @param [Integer] id ID of service provider to add to "sent" list
   def add_sp_sent(id)
     return if self.service_provider_ids_sent.include?(id)
 

--- a/db/primary_migrate/20260429160306_update_user_proofing_events.rb
+++ b/db/primary_migrate/20260429160306_update_user_proofing_events.rb
@@ -1,0 +1,13 @@
+class UpdateUserProofingEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :user_proofing_events,
+               :service_provider_ids_sent,
+               :bigint,
+               null: false,
+               default: [],
+               array: true,
+               comment: 'sensitive=false'
+
+    change_column_null(:user_proofing_events, :encrypted_events, true)
+  end
+end

--- a/db/primary_migrate/20260430204118_add_encrypted_attempts_file_reference_to_profiles.rb
+++ b/db/primary_migrate/20260430204118_add_encrypted_attempts_file_reference_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddEncryptedAttemptsFileReferenceToProfiles < ActiveRecord::Migration[8.0]
+  def change
+    add_column :profiles, :encrypted_attempts_file_reference, :string, comment: 'sensitive=false'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_31_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_29_160306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -644,13 +644,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_31_000000) do
   end
 
   create_table "user_proofing_events", id: :serial, force: :cascade do |t|
-    t.string "encrypted_events", null: false, comment: "sensitive=true"
+    t.string "encrypted_events", comment: "sensitive=true"
     t.bigint "profile_id", null: false, comment: "sensitive=false"
     t.jsonb "service_providers_sent", default: [], null: false, comment: "sensitive=false"
     t.string "cost", null: false, comment: "sensitive=true"
     t.string "salt", null: false, comment: "sensitive=true"
     t.datetime "created_at", null: false, comment: "sensitive=false"
     t.datetime "updated_at", null: false, comment: "sensitive=false"
+    t.bigint "service_provider_ids_sent", default: [], null: false, comment: "sensitive=false", array: true
     t.index ["profile_id"], name: "index_user_proofing_events_on_profile_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_04_29_160306) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_30_204118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -497,6 +497,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_04_29_160306) do
     t.text "encrypted_pii_recovery_multi_region", comment: "sensitive=true"
     t.datetime "gpo_verification_expired_at", comment: "sensitive=false"
     t.integer "idv_level", comment: "sensitive=false"
+    t.string "encrypted_attempts_file_reference", comment: "sensitive=false"
     t.index ["fraud_pending_reason"], name: "index_profiles_on_fraud_pending_reason"
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -83,26 +83,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       end
     end
 
-    context 'service_provider is not an allowed_attempts_providers' do
-      # TODO: This spec is not correct.
-      # We are recording on all IAL2 requests.
-      # We are only sending the data to SPs that are allowed_attempts_providers and have not already
-      # received the data.
-      before do
-        allow(IdentityConfig.store).to receive(
-          :allowed_attempts_providers,
-        ).and_return([])
-      end
-
-      it 'does not modify or create a UserProofingEvent' do
-        record_user_proofing_events
-
-        expect(UserProofingEvent).to_not have_received(:new)
-        expect(UserProofingEvent).to_not have_received(:save)
-      end
-    end
-
-    context 'when historical events need to be sent' do
+    context 'historical_attempts_api_enabled feature flag is true' do
       before do
         allow(Encryption::Encryptors::PiiEncryptor).to receive(:new).and_return(encryptor_mock)
         allow(encryptor_mock).to receive(:encrypt).and_return(encrypted_events.to_json)
@@ -119,6 +100,25 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
         expect(user_proofing_event.salt).to eq(encrypted_events['salt'])
         expect(user_proofing_event.profile).to eq(profile)
       end
+
+      context 'service_provider is not an allowed_attempts_providers' do
+        # TODO: This spec is not correct.
+        # We are recording on all IAL2 requests.
+        # We are only sending the data to SPs that are allowed_attempts_providers and have not already
+        # received the data.
+        before do
+          allow(IdentityConfig.store).to receive(
+            :allowed_attempts_providers,
+          ).and_return([])
+        end
+
+        it 'does not modify or create a UserProofingEvent' do
+          record_user_proofing_events
+
+          expect(UserProofingEvent).to_not have_received(:new)
+          expect(UserProofingEvent).to_not have_received(:save)
+        end
+      end
     end
   end
 
@@ -134,18 +134,41 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       )
     end
 
-    context 'historical events are disallowed' do
-      context 'historical_attempts_api_enabled feature flag is false' do
-        before do
-          allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
-        end
+    context 'historical_attempts_api_enabled feature flag is false' do
+      before do
+        allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
+      end
 
-        it 'does not decrypt or encrypt events' do
-          expect(pii_encryptor).to_not receive(:decrypt)
-          expect(pii_encryptor).to_not receive(:encrypt)
+      it 'does not decrypt or encrypt events' do
+        expect(pii_encryptor).to_not receive(:decrypt)
+        expect(pii_encryptor).to_not receive(:encrypt)
 
-          cache_user_proofing_events
-        end
+        cache_user_proofing_events
+      end
+    end
+
+    context 'historical_attempts_api_enabled feature flag is true' do
+      let(:mock_session_encryptor) { double }
+      let(:kms_encrypted_events) { 'kms_encrypted_events' }
+
+      before do
+        allow(SessionEncryptor).to receive(:new).and_return(mock_session_encryptor)
+        allow(mock_session_encryptor).to receive(:kms_encrypt).and_return(kms_encrypted_events)
+        cache_user_proofing_events
+      end
+
+      it 'decrypts the appropriate UserProofingEvent' do
+        expect(pii_encryptor).to have_received(:decrypt).once
+      end
+
+      it 'encrypts with the kms session key' do
+        expect(mock_session_encryptor).to have_received(:kms_encrypt).once.with(
+          idv_attempts.to_json,
+        )
+      end
+
+      it 'updates the session with the UserProofingEvent' do
+        expect(controller.user_session[:encrypted_proofing_events]).to eq(kms_encrypted_events)
       end
 
       context 'service_provider is not an allowed_attempts_providers' do
@@ -176,31 +199,6 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
           cache_user_proofing_events
         end
-      end
-    end
-
-    context 'historical events are permitted' do
-      let(:mock_session_encryptor) { double }
-      let(:kms_encrypted_events) { 'kms_encrypted_events' }
-
-      before do
-        allow(SessionEncryptor).to receive(:new).and_return(mock_session_encryptor)
-        allow(mock_session_encryptor).to receive(:kms_encrypt).and_return(kms_encrypted_events)
-        cache_user_proofing_events
-      end
-
-      it 'decrypts the appropriate UserProofingEvent' do
-        expect(pii_encryptor).to have_received(:decrypt).once
-      end
-
-      it 'encrypts with the kms session key' do
-        expect(mock_session_encryptor).to have_received(:kms_encrypt).once.with(
-          idv_attempts.to_json,
-        )
-      end
-
-      it 'updates the session with the UserProofingEvent' do
-        expect(controller.user_session[:encrypted_proofing_events]).to eq(kms_encrypted_events)
       end
     end
   end

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
   let(:sp) { create(:service_provider, ial: 2, issuer: issuer) }
   let(:profile) { create(:profile, :active, :verified) }
   let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
-  let(:user_proofing_event_new) { build(:user_proofing_event) }
   let(:encryptor_mock) { double }
   let(:encrypted_events) do
     {
@@ -23,18 +22,14 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       'cost' => '000$0$0$',
     }
   end
-  let(:test_data) { { test_data: 'data' } }
-  let(:old_data) { { old_data: 'data' } }
   let(:idv_attempts) do
     [
-      { 'idv-ssn-submitted' => test_data },
-      { 'idv-enrollment-complete' => test_data },
+      { 'idv-ssn-submitted' => { 'user_uuid' => registered_user.uuid } },
     ]
   end
   let(:pii_encryptor) { Encryption::Encryptors::PiiEncryptor.new(registered_user.password) }
-  let(:existing_events) { [{ 'old_attempt' => old_data }] }
   let(:encrypted_existing_events) do
-    pii_encryptor.encrypt(existing_events.to_json, user_uuid: registered_user.uuid)
+    pii_encryptor.encrypt(idv_attempts.to_json, user_uuid: registered_user.uuid)
   end
 
   controller ApplicationController do
@@ -61,9 +56,8 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       historical_attempts_api_enabled: true,
     )
 
-    allow(UserProofingEvent).to receive(:new).and_return(user_proofing_event_new)
-    allow(user_proofing_event_new).to receive(:save).and_return(true)
-    allow(UserProofingEvent).to receive(:save).and_return(true)
+    allow(UserProofingEvent).to receive(:new).and_call_original
+    allow(UserProofingEvent).to receive(:save).and_call_original
     allow(Encryption::Encryptors::PiiEncryptor).to receive(:new).and_return(pii_encryptor)
     allow(pii_encryptor).to receive(:decrypt).and_call_original
     allow(pii_encryptor).to receive(:encrypt).and_call_original
@@ -74,7 +68,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       controller.record_user_proofing_events(password)
     end
 
-    context 'historical_attempts_api_enabled is false at the secrets level' do
+    context 'historical_attempts_api_enabled feature flag is false' do
       before do
         allow(IdentityConfig.store).to receive(
           :historical_attempts_api_enabled,
@@ -90,6 +84,10 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
     end
 
     context 'service_provider is not an allowed_attempts_providers' do
+      # TODO: This spec is not correct.
+      # We are recording on all IAL2 requests.
+      # We are only sending the data to SPs that are allowed_attempts_providers and have not already
+      # received the data.
       before do
         allow(IdentityConfig.store).to receive(
           :allowed_attempts_providers,
@@ -113,17 +111,13 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
       it 'creates and saves a UserProofingEvent' do
         expect(UserProofingEvent).to have_received(:new)
-        expect(user_proofing_event_new).to have_received(:save)
       end
 
-      it 'includes the encrypted_events' do
-        expect(UserProofingEvent).to have_received(:new).with(
-          encrypted_events: encrypted_events.to_json,
-          profile_id: registered_user.active_profile.id,
-          service_providers_sent: [],
-          cost: encrypted_events['cost'],
-          salt: encrypted_events['salt'],
-        )
+      it 'includes the encrypted event metadata' do
+        user_proofing_event = UserProofingEvent.last
+        expect(user_proofing_event.cost).to eq(encrypted_events['cost'])
+        expect(user_proofing_event.salt).to eq(encrypted_events['salt'])
+        expect(user_proofing_event.profile).to eq(profile)
       end
     end
   end
@@ -133,28 +127,17 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       controller.cache_user_proofing_events(password)
     end
 
-    let(:user_proofing_event) do
-      create(
-        :user_proofing_event,
-        encrypted_events: encrypted_existing_events,
-        service_providers_sent: [],
+    let!(:user_proofing_event) do
+      registered_user.active_profile.build_user_proofing_event(
         cost: JSON.parse(encrypted_existing_events)['cost'],
         salt: JSON.parse(encrypted_existing_events)['salt'],
-        profile_id: registered_user.active_profile.id,
       )
     end
 
-    before do
-      allow(UserProofingEvent).to receive(:find_by).and_return(user_proofing_event)
-      allow(user_proofing_event).to receive(:update_encrypted_events).and_return(true)
-    end
-
     context 'historical events are disallowed' do
-      context 'historical_attempts_api_enabled is false at the secrets level' do
+      context 'historical_attempts_api_enabled feature flag is false' do
         before do
-          allow(IdentityConfig.store).to receive(
-            :historical_attempts_api_enabled,
-          ).and_return(false)
+          allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
         end
 
         it 'does not decrypt or encrypt events' do
@@ -167,9 +150,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
       context 'service_provider is not an allowed_attempts_providers' do
         before do
-          allow(IdentityConfig.store).to receive(
-            :allowed_attempts_providers,
-          ).and_return([])
+          allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return([])
         end
 
         it 'does not decrypt or encrypt events' do
@@ -182,18 +163,11 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
       context 'events already sent to SP' do
         let(:user_proofing_event) do
-          create(
-            :user_proofing_event,
-            encrypted_events: encrypted_existing_events,
-            service_providers_sent: [sp.issuer],
+          registered_user.active_profile.build_user_proofing_event(
             cost: JSON.parse(encrypted_existing_events)['cost'],
             salt: JSON.parse(encrypted_existing_events)['salt'],
-            profile_id: registered_user.active_profile.id,
+            service_provider_ids_sent: [sp.id],
           )
-        end
-
-        before do
-          allow(UserProofingEvent).to receive(:find_by).and_return(user_proofing_event)
         end
 
         it 'does not decrypt or encrypt events' do
@@ -216,15 +190,12 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       end
 
       it 'decrypts the appropriate UserProofingEvent' do
-        expect(pii_encryptor).to have_received(:decrypt).once.with(
-          user_proofing_event.encrypted_events,
-          user_uuid: registered_user.uuid,
-        )
+        expect(pii_encryptor).to have_received(:decrypt).once
       end
 
       it 'encrypts with the kms session key' do
         expect(mock_session_encryptor).to have_received(:kms_encrypt).once.with(
-          existing_events.to_json,
+          idv_attempts.to_json,
         )
       end
 

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -100,25 +100,6 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
         expect(user_proofing_event.salt).to eq(encrypted_events['salt'])
         expect(user_proofing_event.profile).to eq(profile)
       end
-
-      context 'service_provider is not an allowed_attempts_providers' do
-        # TODO: This spec is not correct.
-        # We are recording on all IAL2 requests.
-        # We are only sending the data to SPs that are allowed_attempts_providers and have not already
-        # received the data.
-        before do
-          allow(IdentityConfig.store).to receive(
-            :allowed_attempts_providers,
-          ).and_return([])
-        end
-
-        it 'does not modify or create a UserProofingEvent' do
-          record_user_proofing_events
-
-          expect(UserProofingEvent).to_not have_received(:new)
-          expect(UserProofingEvent).to_not have_received(:save)
-        end
-      end
     end
   end
 
@@ -198,6 +179,14 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
           expect(pii_encryptor).to_not receive(:encrypt)
 
           cache_user_proofing_events
+        end
+      end
+
+      context 'when no UserProofingEvent exists for the profile' do
+        let(:user_proofing_event) { nil }
+
+        it 'does not raise an error' do
+          expect { cache_user_proofing_events }.to_not raise_error
         end
       end
     end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1125,27 +1125,21 @@ RSpec.describe Idv::EnterPasswordController do
 
     describe 'historical events tracking' do
       let(:idv_attempt) do
-        AttemptsApi::AttemptEvent.new(
-          event_type: 'idv-enrollment-complete',
-          session_id: 0,
-          occurred_at: Time.zone.now,
-          event_metadata: { event_type: 'idv-enrollment-complete', data: 'event data' },
-        )
+        {
+          'idv/attempts' => [
+            { 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } },
+          ],
+        }
       end
+
       let(:mock_user_session) { { 'idv/attempts' => [idv_attempt] } }
-      let(:mock) { double }
 
       before do
-        allow(UserProofingEvent).to receive(:new).and_return(mock)
-        allow(mock).to receive(:save).and_return(true)
         allow(IdentityConfig.store).to receive_messages(
           attempts_api_enabled: true,
           historical_attempts_api_enabled: true,
           allowed_attempts_providers: [{ 'issuer' => sp.issuer }],
         )
-        session['warden.user.user.session'] = mock_user_session
-        # at this point in the flow, the applicant should have a UUID
-        subject.idv_session.applicant['uuid'] = 'aabbccdd-0000-00000-0000-aabbccddeeff'
       end
 
       after do
@@ -1163,22 +1157,11 @@ RSpec.describe Idv::EnterPasswordController do
         end
 
         context 'with a newly proofed user' do
-          it 'creates a new UserProofingEvent' do
-            expect(UserProofingEvent).to receive(:new)
-            expect(mock).to receive(:save)
+          it 'creates a UserProofingEvent for the profile' do
             put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-          end
-        end
+            event = UserProofingEvent.last
 
-        context 'with a proofed user who has already sent attempts to this SP' do
-          before do
-            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-          end
-
-          it 'does not create a new UserProofingEvent' do
-            expect(UserProofingEvent).to_not receive(:new)
-            expect(mock).to_not receive(:save)
-            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+            expect(event.profile_id).to eq(user.profiles.last.id)
           end
         end
       end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe SignUp::CompletionsController do
           )
         end
 
-        context 'issuer is an allowed attempts provider' do
+        context 'service_provider is an allowed attempts provider' do
           before do
             allow(IdentityConfig.store).to receive(:allowed_attempts_providers)
               .and_return([{ 'issuer' => sp.issuer }])
@@ -403,7 +403,7 @@ RSpec.describe SignUp::CompletionsController do
               )
             end
 
-            it 'should update the appropriate user proofing event' do
+            it 'updates the associated user proofing event' do
               stub_sign_in(user)
 
               subject.session[:sp] = {
@@ -413,11 +413,11 @@ RSpec.describe SignUp::CompletionsController do
                 requested_attributes: %w[email first_name verified_at],
               }
 
-              expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-                .to_not include(sp.issuer)
+              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
+                .to_not include(sp.id)
               patch :update
-              expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-                .to include(sp.issuer)
+              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
+                .to include(sp.id)
             end
           end
 
@@ -427,11 +427,11 @@ RSpec.describe SignUp::CompletionsController do
                 :user_proofing_event,
                 :existing,
                 profile_id: profile.id,
-                service_providers_sent: [sp.issuer],
+                service_provider_ids_sent: [sp.id],
               )
             end
 
-            it 'should not update the user proofing event' do
+            it 'does not update the user proofing event' do
               stub_sign_in(user)
 
               subject.session[:sp] = {
@@ -441,11 +441,9 @@ RSpec.describe SignUp::CompletionsController do
                 requested_attributes: %w[email first_name verified_at],
               }
 
-              expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-                .to include(sp.issuer).once
               patch :update
-              expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-                .to include(sp.issuer).once
+              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
+                .to include(sp.id).once
             end
           end
         end
@@ -464,7 +462,7 @@ RSpec.describe SignUp::CompletionsController do
               .and_return([])
           end
 
-          it 'should not update the user proofing event' do
+          it 'does not update the user proofing event' do
             stub_sign_in(user)
 
             subject.session[:sp] = {
@@ -474,10 +472,9 @@ RSpec.describe SignUp::CompletionsController do
               requested_attributes: %w[email first_name verified_at],
             }
 
-            expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-              .to_not include(sp.issuer)
             patch :update
-            expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
+
+            expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
               .to_not include(sp.issuer)
           end
         end

--- a/spec/factories/user_proofing_events.rb
+++ b/spec/factories/user_proofing_events.rb
@@ -1,14 +1,12 @@
 FactoryBot.define do
   factory :user_proofing_event do
-    encrypted_events { nil }
-    service_providers_sent { [] }
+    service_provider_ids_sent { [] }
     cost { nil }
     salt { nil }
     profile_id { nil }
 
     trait :existing do
-      encrypted_events { '6d79206576656e74732061726520656e63727970746564' }
-      service_providers_sent { [] }
+      service_provider_ids_sent { [] }
       cost { '0$0$0$' }
       salt { '73616c74' }
       association :profile

--- a/spec/models/user_proofing_event_spec.rb
+++ b/spec/models/user_proofing_event_spec.rb
@@ -3,31 +3,30 @@ require 'rails_helper'
 RSpec.describe UserProofingEvent, type: :model do
   let(:user_proofing_event) do
     UserProofingEvent.new(
-      encrypted_events: 'these_events_are_encrypted',
       profile_id: 1,
-      service_providers_sent: [],
+      service_provider_ids_sent: [],
       cost: '0$cost$',
       salt: 'salt0',
     )
   end
 
   describe '#add_sp_sent' do
-    let(:issuer) { 'a:test:issuer' }
+    let(:sp) { create(:service_provider) }
 
     before do
-      user_proofing_event.add_sp_sent(issuer)
+      user_proofing_event.add_sp_sent(sp.id)
     end
 
-    it 'should add a given issuer to the list of service_providers_sent' do
-      expect(user_proofing_event.service_providers_sent).to eq([issuer])
+    it 'should add a given id to the list of service_provider_ids_sent' do
+      expect(user_proofing_event.service_provider_ids_sent).to eq([sp.id])
     end
 
     it 'should be idempotent' do
-      expect(user_proofing_event.service_providers_sent.length).to eq(1)
+      expect(user_proofing_event.service_provider_ids_sent.length).to eq(1)
 
-      user_proofing_event.add_sp_sent(issuer)
+      user_proofing_event.add_sp_sent(sp.id)
 
-      expect(user_proofing_event.service_providers_sent).to eq([issuer])
+      expect(user_proofing_event.service_provider_ids_sent).to eq([sp.id])
     end
   end
 end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe AttemptsApi::Tracker do
       end
     end
 
-    context 'with historical_attempts_api_enabled' do
+    context 'when historical_attempts_api_enabled is true' do
       before do
         allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(true)
       end
@@ -355,6 +355,33 @@ RSpec.describe AttemptsApi::Tracker do
       end
     end
 
+    context 'when historical_attempts_api_enabled is false' do
+      before do
+        allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
+      end
+
+      context 'with Devise session' do
+        let(:mock_session) { { 'warden.user.user.session' => {} } }
+
+        it 'records to redis' do
+          freeze_time do
+            subject.idv_enrollment_complete(reproof: false)
+
+            events = AttemptsApi::RedisClient.new.read_events(
+              issuer: service_provider.issuer,
+            )
+
+            expect(events.values.length).to eq(1)
+          end
+        end
+
+        it 'does not populate the historical session info' do
+          subject.idv_enrollment_complete(reproof: false)
+          expect(mock_session).to eq({ 'warden.user.user.session' => {} })
+        end
+      end
+    end
+
     context 'the attempts API is not enabled' do
       let(:attempts_api_enabled) { false }
 
@@ -369,31 +396,6 @@ RSpec.describe AttemptsApi::Tracker do
           expect(events.values.length).to eq(0)
         end
       end
-    end
-  end
-
-  context 'with a Devise session and historical_attempts_api_disabled' do
-    let(:mock_session) { { 'warden.user.user.session' => {} } }
-
-    before do
-      allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
-    end
-
-    it 'records to redis' do
-      freeze_time do
-        subject.idv_enrollment_complete(reproof: false)
-
-        events = AttemptsApi::RedisClient.new.read_events(
-          issuer: service_provider.issuer,
-        )
-
-        expect(events.values.length).to eq(1)
-      end
-    end
-
-    it 'does not populate the historical session info' do
-      subject.idv_enrollment_complete(reproof: false)
-      expect(mock_session).to eq({ 'warden.user.user.session' => {} })
     end
   end
 

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -337,6 +337,19 @@ RSpec.describe AttemptsApi::Tracker do
             )
           end
         end
+
+        context 'there is already an event in the session' do
+          it 'appends to the existing events' do
+            user_session['idv/attempts'] = [{ 'idv-something' => { 'user_uuid' => user.uuid } }]
+            subject.idv_enrollment_complete(reproof: false)
+            expect(user_session['idv/attempts']).to eq(
+              [
+                { 'idv-something' => { 'user_uuid' => user.uuid } },
+                { 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } },
+              ],
+            )
+          end
+        end
       end
 
       it 'does not fail if the request is missing' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 106](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/106)

## 🛠 Summary of changes
Team Data had a number of recommendations for the data design for the Historical Attempts Data feature. This code is the first step in implementing those changes. [See updated SBAR for more details.](https://docs.google.com/document/d/1ohHcpiLa_jLOwM3_ll3ukH32FkW-roEWrG4pgDph_40/edit?tab=t.2hx7yqlzjlq)

This change:
- Ignores the existing `encrypted_events` and `service_providers_sent` columns on the UserProofingEvents table
- Adds a `service_provider_ids_sent` column to the UserProofingEvents table that is an array of bigints (to improve lookups)
- Adds an `encrypted_attempts_file_reference` column to the Profiles table that is a string
- Updates the code so that it still works (this includes temporarily passing some dummy data into the `decrypt_user_proofing_events` method because we are not yet writing/retrieving the data)
- Cleans up/updates code and specs generally



<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
