### PR TITLE
lg-17432 allow bypass aamva exception ids

### DIFF
--- a/app/services/proofing/resolution/plugins/aamva_plugin.rb
+++ b/app/services/proofing/resolution/plugins/aamva_plugin.rb
@@ -61,6 +61,14 @@ module Proofing
               )
             end
 
+            if contains_bypass_exception_id?(result.exception)
+              log_state_id_validation(
+                analytics:, result: result.to_h, applicant_pii:, ipp_enrollment_in_progress:,
+                aamva_checked: result.exception.blank?
+              )
+              return skipped_result(exception: result.exception)
+            end
+
             if doc_auth_flow
               log_state_id_validation(
                 analytics:, result: result.to_h, applicant_pii:, ipp_enrollment_in_progress:,
@@ -68,6 +76,15 @@ module Proofing
               )
             end
           end
+        end
+
+        def contains_bypass_exception_id?(result_exception)
+          return false if result_exception.blank?
+
+          IdentityConfig.store.idv_aamva_bypass_exception_ids.each do |exception_id|
+            return true if result_exception.to_s.include?("ExceptionId: #{exception_id}")
+          end
+          false
         end
 
         def aamva_supports_state_id_jurisdiction?(applicant_pii)
@@ -85,10 +102,10 @@ module Proofing
         end
 
         # @return [Proofing::StateIdResult] A result signifying that the AAMVA plugin was skipped.
-        def skipped_result
+        def skipped_result(exception: nil)
           Proofing::StateIdResult.new(
             errors: {},
-            exception: nil,
+            exception: exception,
             success: true,
             vendor_name: Idp::Constants::Vendors::AAMVA_CHECK_SKIPPED,
           )

--- a/app/services/proofing/resolution/plugins/aamva_plugin.rb
+++ b/app/services/proofing/resolution/plugins/aamva_plugin.rb
@@ -50,32 +50,27 @@ module Proofing
               applicant_pii
             end
 
-          timer.time('state_id') do
+          result = timer.time('state_id') do
             proofer.proof(applicant_pii_with_state_id_address)
-          end.tap do |result|
-            if result.exception.blank?
-              Db::SpCost::AddSpCost.call(
-                current_sp,
-                :aamva,
-                transaction_id: result.transaction_id,
-              )
-            end
-
-            if contains_bypass_exception_id?(result.exception)
-              log_state_id_validation(
-                analytics:, result: result.to_h, applicant_pii:, ipp_enrollment_in_progress:,
-                aamva_checked: result.exception.blank?
-              )
-              return skipped_result(exception: result.exception)
-            end
-
-            if doc_auth_flow
-              log_state_id_validation(
-                analytics:, result: result.to_h, applicant_pii:, ipp_enrollment_in_progress:,
-                aamva_checked: result.exception.blank?
-              )
-            end
           end
+
+          if result.exception.blank?
+            Db::SpCost::AddSpCost.call(
+              current_sp,
+              :aamva,
+              transaction_id: result.transaction_id,
+            )
+          end
+
+          log_state_id_validation(
+            analytics:, result: result.to_h, applicant_pii:, ipp_enrollment_in_progress:,
+            aamva_checked: result.exception.blank?
+          )
+          if contains_bypass_exception_id?(result.exception)
+            return skipped_result(exception: result.exception)
+          end
+
+          result
         end
 
         def contains_bypass_exception_id?(result_exception)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -204,6 +204,7 @@ identity_verification_outcomes_report_emails: '[]'
 identity_verification_outcomes_report_issuers: '[]'
 idv_aamva_at_doc_auth_enabled: false
 idv_aamva_at_doc_auth_ipp_enabled: false
+idv_aamva_bypass_exception_ids: '[]'
 idv_aamva_split_last_name_states: '[]'
 idv_account_verified_email_campaign_id: '20241028'
 idv_acuant_sdk_upgrade_a_b_testing_enabled: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -265,6 +265,7 @@ module IdentityConfig
     config.add(:idv_socure_reason_codes_docv_selfie_not_processed, type: :json)
     config.add(:idv_socure_reason_codes_docv_selfie_pass, type: :json)
     config.add(:idv_sp_required, type: :boolean)
+    config.add(:idv_aamva_bypass_exception_ids, type: :json)
     config.add(:idv_aamva_split_last_name_states, type: :json)
     config.add(:in_person_completion_survey_delivery_enabled, type: :boolean)
     config.add(:in_person_completion_survey_url, type: :string)

--- a/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
@@ -846,6 +846,28 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
               )
             end
           end
+
+          context 'when aamva returns a bypassed exception' do
+            let(:proofer_result) do
+              Proofing::StateIdResult.new(
+                success: false,
+                vendor_name: 'state_id:aamva',
+                transaction_id: proofer_transaction_id,
+                exception: RuntimeError.new('ExceptionId: bypass_id'),
+              )
+            end
+            let(:proofer_result_hash) { proofer_result.to_h }
+
+            it 'returns a skipped result' do
+              allow(IdentityConfig.store).to receive(:idv_aamva_bypass_exception_ids).and_return(
+                ['test_id', 'bypass_id'],
+              )
+              call.tap do |result|
+                expect(result.success?).to eq(true)
+                expect(result.vendor_name).to eq(Idp::Constants::Vendors::AAMVA_CHECK_SKIPPED)
+              end
+            end
+          end
         end
       end
 


### PR DESCRIPTION


<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-17432](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17432)


## 🛠 Summary of changes

Added bypass aamva exception ids to application.yml and identity config and checks for them in aamva proofer. returns a skipped result if found

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - Ensure specs pass


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17432]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17432