### PR TITLE
Update code expiration to be 5 minutes, decouple from session expiration

### DIFF
--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -34,7 +34,7 @@ class OpenidConnectTokenForm
     ATTRS.each do |key|
       instance_variable_set(:"@#{key}", params[key])
     end
-    @session_expiration = IdentityConfig.store.session_timeout_in_seconds.seconds.ago
+    @code_expiration = IdentityConfig.store.openid_connect_authorization_code_expiration_seconds.seconds.ago
     @identity = find_identity_with_code
   end
 
@@ -68,7 +68,7 @@ class OpenidConnectTokenForm
 
   private
 
-  attr_reader :identity, :session_expiration
+  attr_reader :identity, :code_expiration
 
   def find_identity_with_code
     return if code.blank? || code.include?("\x00")
@@ -103,7 +103,7 @@ class OpenidConnectTokenForm
   end
 
   def validate_expired
-    if identity&.updated_at && identity.updated_at < session_expiration
+    if identity&.updated_at && identity.updated_at < code_expiration
       errors.add :code, t('openid_connect.token.errors.expired_code'), type: :expired_code
     end
   end

--- a/app/forms/openid_connect_token_form.rb
+++ b/app/forms/openid_connect_token_form.rb
@@ -34,7 +34,8 @@ class OpenidConnectTokenForm
     ATTRS.each do |key|
       instance_variable_set(:"@#{key}", params[key])
     end
-    @code_expiration = IdentityConfig.store.openid_connect_authorization_code_expiration_seconds.seconds.ago
+    code_expiration_secs = IdentityConfig.store.openid_connect_authorization_code_expiration_seconds
+    @code_expiration = code_expiration_secs.seconds.ago
     @identity = find_identity_with_code
   end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -356,6 +356,7 @@ mx_timeout: 3
 new_device_alert_delay_in_minutes: 5
 new_device_alert_window_start_in_minutes: 15
 newrelic_license_key: ''
+openid_connect_authorization_code_expiration_seconds: 300
 openid_connect_content_security_form_action_enabled: false
 openid_connect_redirect: client_side_js
 otp_delivery_blocklist_findtime: 5

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -371,6 +371,7 @@ module IdentityConfig
       type: :string,
       enum: ['server_side', 'client_side_js'],
     )
+    config.add(:openid_connect_authorization_code_expiration_seconds, type: :integer)
     config.add(:openid_connect_content_security_form_action_enabled, type: :boolean)
     config.add(:otp_delivery_blocklist_findtime, type: :integer)
     config.add(:otp_delivery_blocklist_maxretry, type: :integer)

--- a/spec/forms/openid_connect_token_form_spec.rb
+++ b/spec/forms/openid_connect_token_form_spec.rb
@@ -107,6 +107,23 @@ RSpec.describe OpenidConnectTokenForm do
         end
       end
 
+      context 'code expiration is independent of session timeout' do
+        before do
+          allow(IdentityConfig.store).to receive(
+            :openid_connect_authorization_code_expiration_seconds,
+          ).and_return(60)
+          allow(IdentityConfig.store).to receive(
+            :session_timeout_in_seconds,
+          ).and_return(900)
+          identity.update(updated_at: 2.minutes.ago)
+        end
+
+        it 'expires based on code expiration, not session timeout' do
+          expect(valid?).to eq(false)
+          expect(form.errors[:code]).to eq([t('openid_connect.token.errors.expired_code')])
+        end
+      end
+
       context 'code is nil' do
         before do
           # Create a service provider identity with a nil session uuid to make sure the form is not


### PR DESCRIPTION
changelog: Internal, OpenID Connect, Decouple authorization code expiration from session timeout and code expiration be 300 seconds (5 minutes)

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/100


## 🛠 Summary of changes

Decouples the code validity timer and the session expiration timer. Reduces the code validity timer to 300 seconds (5 minutes) in accordance with NIST 800-63C, rev 4, control# 366C, section 4.11.1.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
