### PR TITLE
Write encrypted events to storage (s3 or ./tmp)

### DIFF
--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -48,6 +48,7 @@ module Idv
 
     def historical_events_need_be_sent?
       return false unless historical_events_enabled?
+      return false unless current_sp&.attempts_api_enabled?
       return false if existing_user_proofing_event.blank?
 
       return !existing_user_proofing_event.already_sent_to_sp?(current_sp.id)
@@ -56,7 +57,7 @@ module Idv
     def historical_events_enabled?
       return false unless IdentityConfig.store.historical_attempts_api_enabled
 
-      current_sp&.attempts_api_enabled? && ial2_requested?
+      ial2_requested?
     end
 
     def existing_user_proofing_event

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -5,37 +5,13 @@ module Idv
   module HistoricalAttemptsConcern
     extend ActiveSupport::Concern
 
-    def record_user_proofing_events(password)
-      return unless historical_events_enabled?
-      # TODO: move UserProofingEvent creation to the Profile object
-      @password = password
-
-      new_events = user_session['idv/attempts'] || []
-
-      encrypted_events_json = encrypt_attempt_events_bundle(new_events)
-      encrypted_events = JSON.parse(encrypted_events_json)
-
-      # TODO: Write encrypted_events['encrypted_data'] to S3
-      # TODO: Save reference to S3 object in current_user.active_profile
-
-      new_user_proofing_event = current_user
-        .active_profile
-        .build_user_proofing_event(
-          cost: encrypted_events['cost'],
-          salt: encrypted_events['salt'],
-        )
-
-      new_user_proofing_event.save
-
-      # Now that proofing events are saved, remove the plaintext events from user_session
-      user_session.delete('idv/attempts')
-    end
-
     def cache_user_proofing_events(password)
       return unless historical_events_need_be_sent?
-      @password = password
 
-      existing_events = decrypt_user_proofing_events
+      existing_events = current_user
+        .active_profile
+        .decrypt_user_proofing_events(password:)
+
       kms_encrypted_events = SessionEncryptor.new.kms_encrypt(existing_events)
       user_session[:encrypted_proofing_events] = kms_encrypted_events
     end
@@ -62,26 +38,6 @@ module Idv
 
     def existing_user_proofing_event
       @existing_user_proofing_event ||= current_user.active_profile.user_proofing_event
-    end
-
-    def encrypt_attempt_events_bundle(bundle)
-      pii_encryptor.encrypt(bundle.to_json, user_uuid:)
-    end
-
-    def decrypt_user_proofing_events
-      # TODO: Retrieve encrypted_events from S3 or locally
-      # Currently this is not in use, so passing in dummy data
-      data = pii_encryptor.encrypt(
-        [
-          { 'idv-ssn-submitted' => { 'user_uuid' => user_uuid } },
-        ].to_json,
-        user_uuid:,
-      )
-      pii_encryptor.decrypt(data, user_uuid:)
-    end
-
-    def pii_encryptor
-      @pii_encryptor ||= Encryption::Encryptors::PiiEncryptor.new(@password)
     end
 
     def user_uuid

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -37,7 +37,7 @@ module Idv
 
       init_profile
 
-      record_user_proofing_events(password)
+      record_user_proofing_events
 
       flash[:success] =
         if idv_session.verify_by_mail?
@@ -206,6 +206,21 @@ module Idv
       flash[:error] = t('idv.failure.exceptions.internal_error')
       idv_session.invalidate_personal_key!
       redirect_to idv_enter_password_url
+    end
+
+    def record_user_proofing_events
+      return unless historical_events_enabled?
+      # TODO: move UserProofingEvent creation to the Profile object
+
+      current_user.active_profile.create_user_proofing_event(password:, attempt_events:)
+
+      # Now that proofing events are saved, remove the plaintext events from user_session
+
+      user_session.delete('idv/attempts')
+    end
+
+    def attempt_events
+      user_session['idv/attempts'] || []
     end
   end
 end

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -210,11 +210,8 @@ module Idv
 
     def record_user_proofing_events
       return unless historical_events_enabled?
-      # TODO: move UserProofingEvent creation to the Profile object
 
       current_user.active_profile.create_user_proofing_event(password:, attempt_events:)
-
-      # Now that proofing events are saved, remove the plaintext events from user_session
 
       user_session.delete('idv/attempts')
     end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -425,7 +425,7 @@ class Profile < ApplicationRecord
 
     result = encrypted_doc_writer.write_encrypted_attempt_events(
       file_path: attempt_events_file_path,
-      encrypted_attempt_events: encrypted_events,
+      encrypted_attempt_events: encrypted_events_json,
     )
 
     update!(encrypted_attempts_file_reference: result.name)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -423,8 +423,12 @@ class Profile < ApplicationRecord
     encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
     encrypted_events = JSON.parse(encrypted_events_json)
 
-    # TODO: Write encrypted_events['encrypted_data'] to S3
-    # TODO: Save reference to S3 object in current_user.active_profile
+    result = encrypted_doc_writer.write_encrypted_attempt_events(
+      file_path: attempt_events_file_path,
+      encrypted_attempt_events: encrypted_events,
+    )
+
+    update!(encrypted_attempts_file_reference: result.name)
 
     new_user_proofing_event = build_user_proofing_event(
       cost: encrypted_events['cost'],
@@ -436,14 +440,12 @@ class Profile < ApplicationRecord
 
   def decrypt_user_proofing_events(password:)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-    #  TODO: Retrieve encrypted_events from S3 or locally
-    #   # Currently this is not in use, so passing in dummy data
-    data = encryptor.encrypt(
-      [
-        { 'idv-ssn-submitted' => { 'user_uuid' => user.uuid } },
-      ].to_json,
-      user_uuid: user.uuid,
+
+    data = attempt_data_retriever.retrieve_user_proofing_events(
+      file_path: attempt_events_file_path,
+      file_name: encrypted_attempts_file_reference,
     )
+
     encryptor.decrypt(data, user_uuid: user.uuid)
   end
 
@@ -451,6 +453,26 @@ class Profile < ApplicationRecord
 
   def confirm_that_profile_can_be_activated!
     raise reason_not_to_activate if reason_not_to_activate
+  end
+
+  def encrypted_doc_writer
+    @encrypted_doc_writer ||= EncryptedDocStorage::DocWriter.new(
+      s3_enabled: historical_attempts_s3_storage_enabled?,
+    )
+  end
+
+  def attempt_data_retriever
+    @attempt_data_retriever ||= EncryptedDocStorage::AttemptDataRetriever.new(
+      s3_enabled: historical_attempts_s3_storage_enabled?,
+    )
+  end
+
+  def attempt_events_file_path
+    "attempt_events/#{user.uuid}/#{self.id}"
+  end
+
+  def historical_attempts_s3_storage_enabled?
+    IdentityConfig.store.historical_attempts_s3_storage_enabled
   end
 
   def personal_key_generator

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -418,6 +418,35 @@ class Profile < ApplicationRecord
     FACIAL_MATCH_IDV_LEVELS.include?(idv_level)
   end
 
+  def create_user_proofing_event(password:, attempt_events:)
+    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
+    encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
+    encrypted_events = JSON.parse(encrypted_events_json)
+
+    # TODO: Write encrypted_events['encrypted_data'] to S3
+    # TODO: Save reference to S3 object in current_user.active_profile
+
+    new_user_proofing_event = build_user_proofing_event(
+      cost: encrypted_events['cost'],
+      salt: encrypted_events['salt'],
+    )
+
+    new_user_proofing_event.save
+  end
+
+  def decrypt_user_proofing_events(password:)
+    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
+    #  TODO: Retrieve encrypted_events from S3 or locally
+    #   # Currently this is not in use, so passing in dummy data
+    data = encryptor.encrypt(
+      [
+        { 'idv-ssn-submitted' => { 'user_uuid' => user.uuid } },
+      ].to_json,
+      user_uuid: user.uuid,
+    )
+    encryptor.decrypt(data, user_uuid: user.uuid)
+  end
+
   private
 
   def confirm_that_profile_can_be_activated!

--- a/app/services/encrypted_doc_storage/attempt_data_retriever.rb
+++ b/app/services/encrypted_doc_storage/attempt_data_retriever.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module EncryptedDocStorage
+  class AttemptDataRetriever
+    def initialize(s3_enabled: false)
+      @s3_enabled = s3_enabled
+    end
+
+    def retrieve_user_proofing_events(file_path:, file_name:)
+      storage.retrieve(file_path:, file_name:)
+    end
+
+    private
+
+    def storage
+      @storage ||= @s3_enabled ? S3Storage.new : LocalStorage.new
+    end
+  end
+end

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -42,9 +42,12 @@ module EncryptedDocStorage
 
     def write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
       name = SecureRandom.uuid
-      path = "attempt_events/#{file_path}/#{name}"
+      path = "#{file_path}/#{name}"
 
-      storage.write_attempt_events(path:, encrypted_attempt_events:)
+      storage.write_attempt_events(
+        path:,
+        encrypted_attempt_events: encrypted_attempt_events.to_json,
+      )
       Result.new(name:, encryption_key: nil)
     end
 

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -46,7 +46,7 @@ module EncryptedDocStorage
 
       storage.write_attempt_events(
         path:,
-        encrypted_attempt_events: encrypted_attempt_events.to_json,
+        encrypted_attempt_events:,
       )
       Result.new(name:, encryption_key: nil)
     end

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -40,6 +40,14 @@ module EncryptedDocStorage
       )
     end
 
+    def write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
+      name = SecureRandom.uuid
+      path = "attempt_events/#{file_path}/#{name}"
+
+      storage.write_attempt_events(path:, encrypted_attempt_events:)
+      Result.new(name:, encryption_key: nil)
+    end
+
     private
 
     def aes_cipher

--- a/app/services/encrypted_doc_storage/local_storage.rb
+++ b/app/services/encrypted_doc_storage/local_storage.rb
@@ -20,6 +20,12 @@ module EncryptedDocStorage
       end
     end
 
+    def retrieve(file_path:, file_name:)
+      full_path = tmp_attempt_events_dir.join(file_path, file_name)
+
+      File.read(full_path) if File.exist?(full_path)
+    end
+
     private
 
     def tmp_document_storage_dir

--- a/app/services/encrypted_doc_storage/local_storage.rb
+++ b/app/services/encrypted_doc_storage/local_storage.rb
@@ -11,10 +11,23 @@ module EncryptedDocStorage
       end
     end
 
+    def write_attempt_events(path:, encrypted_attempt_events:)
+      full_path = tmp_attempt_events_dir.join(path)
+      FileUtils.mkdir_p(full_path.dirname)
+
+      File.open(full_path, 'wb') do |f|
+        f.write(encrypted_attempt_events)
+      end
+    end
+
     private
 
     def tmp_document_storage_dir
       Rails.root.join('tmp', 'encrypted_doc_storage')
+    end
+
+    def tmp_attempt_events_dir
+      Rails.root.join('tmp', 'encrypted_attempt_events')
     end
   end
 end

--- a/app/services/encrypted_doc_storage/s3_storage.rb
+++ b/app/services/encrypted_doc_storage/s3_storage.rb
@@ -11,9 +11,18 @@ module EncryptedDocStorage
     end
 
     def write_attempt_events(path:, encrypted_attempt_events:)
+      # TODO: Make attempt_events/ directory in s3 escrow bucket
+      # TODO: Make directory readable from application
       s3_client.put_object(
         bucket:,
         body: encrypted_attempt_events,
+        key: path,
+      )
+    end
+
+    def retrieve_attempt_object(path:)
+      s3_client.get_object(
+        bucket:,
         key: path,
       )
     end

--- a/app/services/encrypted_doc_storage/s3_storage.rb
+++ b/app/services/encrypted_doc_storage/s3_storage.rb
@@ -10,6 +10,14 @@ module EncryptedDocStorage
       )
     end
 
+    def write_attempt_events(path:, encrypted_attempt_events:)
+      s3_client.put_object(
+        bucket:,
+        body: encrypted_attempt_events,
+        key: path,
+      )
+    end
+
     private
 
     def s3_client

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -196,6 +196,7 @@ gpo_designated_receiver_pii: '{}'
 gpo_max_profile_age_to_send_letter_in_days: 30
 hide_phone_mfa_signup: false
 historical_attempts_api_enabled: false
+historical_attempts_s3_storage_enabled: false
 hmac_fingerprinter_key:
 hmac_fingerprinter_key_queue: '[]'
 hybrid_mobile_tmx_processed_percent: 0

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -212,6 +212,7 @@ module IdentityConfig
     config.add(:gpo_max_profile_age_to_send_letter_in_days, type: :integer)
     config.add(:hide_phone_mfa_signup, type: :boolean)
     config.add(:historical_attempts_api_enabled, type: :boolean)
+    config.add(:historical_attempts_s3_storage_enabled, type: :boolean)
     config.add(:hmac_fingerprinter_key, type: :string)
     config.add(:hmac_fingerprinter_key_queue, type: :json)
     config.add(:hybrid_mobile_tmx_processed_percent, type: :integer)

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       { 'idv-ssn-submitted' => { 'user_uuid' => registered_user.uuid } },
     ]
   end
+  let(:allowed_attempts_providers) { [{ 'issuer' => sp.issuer }] }
   let(:pii_encryptor) { Encryption::Encryptors::PiiEncryptor.new(registered_user.password) }
   let(:encrypted_existing_events) do
     pii_encryptor.encrypt(idv_attempts.to_json, user_uuid: registered_user.uuid)
@@ -51,7 +52,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       active_profile: profile,
     )
     allow(IdentityConfig.store).to receive_messages(
-      allowed_attempts_providers: [{ 'issuer' => sp.issuer }],
+      allowed_attempts_providers:,
       attempts_api_enabled: true,
       historical_attempts_api_enabled: true,
     )
@@ -99,6 +100,17 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
         expect(user_proofing_event.cost).to eq(encrypted_events['cost'])
         expect(user_proofing_event.salt).to eq(encrypted_events['salt'])
         expect(user_proofing_event.profile).to eq(profile)
+      end
+
+      context 'when the service provider is not enabled for attempts API' do
+        let(:allowed_attempts_providers) { [] }
+
+        it 'creates a UserProofingEvent' do
+          user_proofing_event = UserProofingEvent.last
+          expect(user_proofing_event.cost).to eq(encrypted_events['cost'])
+          expect(user_proofing_event.salt).to eq(encrypted_events['salt'])
+          expect(user_proofing_event.profile).to eq(profile)
+        end
       end
     end
   end

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -6,22 +6,13 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
     create(
       :user,
       :fully_registered,
-      password: password,
+      password:,
       email: 'email@example.com',
     )
   end
   let(:issuer) { 'this:is:a:test' }
-  let(:sp) { create(:service_provider, ial: 2, issuer: issuer) }
+  let(:sp) { create(:service_provider, ial: 2, issuer:) }
   let(:profile) { create(:profile, :active, :verified) }
-  let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
-  let(:encryptor_mock) { double }
-  let(:encrypted_events) do
-    {
-      'encrypted_data' => 'encrypted_test_data',
-      'salt' => 'abcdef0123456789',
-      'cost' => '000$0$0$',
-    }
-  end
   let(:idv_attempts) do
     [
       { 'idv-ssn-submitted' => { 'user_uuid' => registered_user.uuid } },
@@ -44,8 +35,9 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       current_sp: sp,
       current_user: registered_user,
       sp_from_sp_session: sp,
-      sp_session: { vtr: nil,
-                    acr_values: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF },
+      sp_session: {
+        acr_values: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+      },
       user_session: { 'idv/attempts' => idv_attempts },
     )
     allow(registered_user).to receive_messages(
@@ -56,63 +48,6 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       attempts_api_enabled: true,
       historical_attempts_api_enabled: true,
     )
-
-    allow(UserProofingEvent).to receive(:new).and_call_original
-    allow(UserProofingEvent).to receive(:save).and_call_original
-    allow(Encryption::Encryptors::PiiEncryptor).to receive(:new).and_return(pii_encryptor)
-    allow(pii_encryptor).to receive(:decrypt).and_call_original
-    allow(pii_encryptor).to receive(:encrypt).and_call_original
-  end
-
-  describe '#record_user_proofing_events' do
-    subject(:record_user_proofing_events) do
-      controller.record_user_proofing_events(password)
-    end
-
-    context 'historical_attempts_api_enabled feature flag is false' do
-      before do
-        allow(IdentityConfig.store).to receive(
-          :historical_attempts_api_enabled,
-        ).and_return(false)
-      end
-
-      it 'does not modify or create a UserProofingEvent' do
-        record_user_proofing_events
-
-        expect(UserProofingEvent).to_not have_received(:new)
-        expect(UserProofingEvent).to_not have_received(:save)
-      end
-    end
-
-    context 'historical_attempts_api_enabled feature flag is true' do
-      before do
-        allow(Encryption::Encryptors::PiiEncryptor).to receive(:new).and_return(encryptor_mock)
-        allow(encryptor_mock).to receive(:encrypt).and_return(encrypted_events.to_json)
-        record_user_proofing_events
-      end
-
-      it 'creates and saves a UserProofingEvent' do
-        expect(UserProofingEvent).to have_received(:new)
-      end
-
-      it 'includes the encrypted event metadata' do
-        user_proofing_event = UserProofingEvent.last
-        expect(user_proofing_event.cost).to eq(encrypted_events['cost'])
-        expect(user_proofing_event.salt).to eq(encrypted_events['salt'])
-        expect(user_proofing_event.profile).to eq(profile)
-      end
-
-      context 'when the service provider is not enabled for attempts API' do
-        let(:allowed_attempts_providers) { [] }
-
-        it 'creates a UserProofingEvent' do
-          user_proofing_event = UserProofingEvent.last
-          expect(user_proofing_event.cost).to eq(encrypted_events['cost'])
-          expect(user_proofing_event.salt).to eq(encrypted_events['salt'])
-          expect(user_proofing_event.profile).to eq(profile)
-        end
-      end
-    end
   end
 
   describe '#cache_user_proofing_events' do
@@ -130,11 +65,11 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
     context 'historical_attempts_api_enabled feature flag is false' do
       before do
         allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
+        allow(profile).to receive(:decrypt_user_proofing_events)
       end
 
-      it 'does not decrypt or encrypt events' do
-        expect(pii_encryptor).to_not receive(:decrypt)
-        expect(pii_encryptor).to_not receive(:encrypt)
+      it 'does not decrypt events' do
+        expect(profile).to_not receive(:decrypt_user_proofing_events)
 
         cache_user_proofing_events
       end
@@ -147,11 +82,12 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       before do
         allow(SessionEncryptor).to receive(:new).and_return(mock_session_encryptor)
         allow(mock_session_encryptor).to receive(:kms_encrypt).and_return(kms_encrypted_events)
+        allow(profile).to receive(:decrypt_user_proofing_events).and_return(idv_attempts.to_json)
         cache_user_proofing_events
       end
 
       it 'decrypts the appropriate UserProofingEvent' do
-        expect(pii_encryptor).to have_received(:decrypt).once
+        expect(profile).to have_received(:decrypt_user_proofing_events).once
       end
 
       it 'encrypts with the kms session key' do
@@ -169,9 +105,8 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
           allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return([])
         end
 
-        it 'does not decrypt or encrypt events' do
-          expect(pii_encryptor).to_not receive(:decrypt)
-          expect(pii_encryptor).to_not receive(:encrypt)
+        it 'does not decrypt events' do
+          expect(profile).to_not receive(:decrypt_user_proofing_events)
 
           cache_user_proofing_events
         end
@@ -186,9 +121,8 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
           )
         end
 
-        it 'does not decrypt or encrypt events' do
-          expect(pii_encryptor).to_not receive(:decrypt)
-          expect(pii_encryptor).to_not receive(:encrypt)
+        it 'does not decrypt events' do
+          expect(profile).to_not receive(:decrypt_user_proofing_events)
 
           cache_user_proofing_events
         end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1133,11 +1133,11 @@ RSpec.describe Idv::EnterPasswordController do
       end
 
       let(:mock_user_session) { { 'idv/attempts' => [idv_attempt] } }
+      let(:historical_attempts_api_enabled) { true }
 
       before do
         allow(IdentityConfig.store).to receive_messages(
-          attempts_api_enabled: true,
-          historical_attempts_api_enabled: true,
+          historical_attempts_api_enabled:,
           allowed_attempts_providers: [{ 'issuer' => sp.issuer }],
         )
       end
@@ -1146,23 +1146,50 @@ RSpec.describe Idv::EnterPasswordController do
         subject.idv_session.applicant['uuid'] = nil
       end
 
-      context 'when requesting ial2' do
-        before do
-          resolved_authn_context_result = Component::Parser.new(
-            acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
-          ).parse
+      context 'when historical attempts api is enabled' do
+        context 'when the request requires identity verification' do
+          before do
+            resolved_authn_context_result = Component::Parser.new(
+              acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
+            ).parse
 
-          allow(controller).to receive(:resolved_authn_context_result)
-            .and_return(resolved_authn_context_result)
+            allow(controller).to receive(:resolved_authn_context_result)
+              .and_return(resolved_authn_context_result)
+          end
+
+          context 'with a newly proofed user' do
+            it 'creates a UserProofingEvent for the profile' do
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+              event = UserProofingEvent.last
+
+              expect(event.profile_id).to eq(user.profiles.last.id)
+            end
+          end
         end
 
-        context 'with a newly proofed user' do
-          it 'creates a UserProofingEvent for the profile' do
-            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-            event = UserProofingEvent.last
+        context 'when request does not include identity verification' do
+          before do
+            resolved_authn_context_result = Component::Parser.new(
+              acr_values: Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
+            ).parse
 
-            expect(event.profile_id).to eq(user.profiles.last.id)
+            allow(controller).to receive(:resolved_authn_context_result)
+              .and_return(resolved_authn_context_result)
           end
+
+          it 'does not create a UserProofingEvent for the profile' do
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+            expect(UserProofingEvent.count).to eq(0)
+          end
+        end
+      end
+
+      context 'when historical attempts api is disabled' do
+        let(:historical_attempts_api_enabled) { false }
+
+        it 'does not create a UserProofingEvent for the profile' do
+          put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+          expect(UserProofingEvent.count).to eq(0)
         end
       end
     end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1431,6 +1431,14 @@ RSpec.describe Profile do
   end
 
   describe 'create_user_proofing_event' do
+    let(:doc_writer) do
+      double('DocWriter', write_encrypted_attempt_events: double('Result', name: 'test'))
+    end
+
+    before do
+      allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(doc_writer)
+    end
+
     it 'creates a user proofing events object' do
       expect do
         profile.create_user_proofing_event(
@@ -1440,6 +1448,15 @@ RSpec.describe Profile do
       end.to change { UserProofingEvent.count }.by(1)
 
       expect(UserProofingEvent.last.profile).to eq(profile)
+    end
+
+    it 'updates the profile with the encrypted attempt events reference' do
+      profile.create_user_proofing_event(
+        password: 'password',
+        attempt_events: [{ 'event' => 'test' }],
+      )
+
+      expect(profile.encrypted_attempts_file_reference).to eq('test')
     end
   end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1431,12 +1431,15 @@ RSpec.describe Profile do
   end
 
   describe 'create_user_proofing_event' do
-    let(:doc_writer) do
-      double('DocWriter', write_encrypted_attempt_events: double('Result', name: 'test'))
-    end
+    after do
+      dir_path = Rails.root.join(
+        'tmp',
+        'encrypted_attempt_events',
+        'attempt_events',
+        profile.user.uuid,
+      )
 
-    before do
-      allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(doc_writer)
+      FileUtils.rm_rf(dir_path) if Dir.exist?(dir_path)
     end
 
     it 'creates a user proofing events object' do
@@ -1449,18 +1452,20 @@ RSpec.describe Profile do
 
       expect(UserProofingEvent.last.profile).to eq(profile)
     end
-
-    it 'updates the profile with the encrypted attempt events reference' do
-      profile.create_user_proofing_event(
-        password: 'password',
-        attempt_events: [{ 'event' => 'test' }],
-      )
-
-      expect(profile.encrypted_attempts_file_reference).to eq('test')
-    end
   end
 
   describe 'decrypt_user_proofing_events' do
+    after do
+      dir_path = Rails.root.join(
+        'tmp',
+        'encrypted_attempt_events',
+        'attempt_events',
+        profile.user.uuid,
+      )
+
+      FileUtils.rm_rf(dir_path) if Dir.exist?(dir_path)
+    end
+
     let(:attempt_events) { [{ 'idv-ssn-submitted' => { 'user_uuid' => user.uuid } }] }
     it 'decrypts user proofing events' do
       profile.create_user_proofing_event(

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1429,4 +1429,31 @@ RSpec.describe Profile do
       end
     end
   end
+
+  describe 'create_user_proofing_event' do
+    it 'creates a user proofing events object' do
+      expect do
+        profile.create_user_proofing_event(
+          password: 'password',
+          attempt_events: [{ 'event' => 'test' }],
+        )
+      end.to change { UserProofingEvent.count }.by(1)
+
+      expect(UserProofingEvent.last.profile).to eq(profile)
+    end
+  end
+
+  describe 'decrypt_user_proofing_events' do
+    let(:attempt_events) { [{ 'idv-ssn-submitted' => { 'user_uuid' => user.uuid } }] }
+    it 'decrypts user proofing events' do
+      profile.create_user_proofing_event(
+        password: 'password',
+        attempt_events:,
+      )
+
+      expect(
+        profile.decrypt_user_proofing_events(password: 'password'),
+      ).to eq(attempt_events.to_json)
+    end
+  end
 end

--- a/spec/services/encrypted_doc_storage/attempt_data_retriever_spec.rb
+++ b/spec/services/encrypted_doc_storage/attempt_data_retriever_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+RSpec.describe EncryptedDocStorage::AttemptDataRetriever do
+  subject { EncryptedDocStorage::AttemptDataRetriever.new }
+  let(:file_path) { 'attempts_events/file/path' }
+  let(:file_name) { 'file_name' }
+
+  describe '#retrieve_user_proofing_events' do
+    let(:local_storage) { double('LocalStorage') }
+    before do
+      allow(EncryptedDocStorage::LocalStorage).to receive(:new).and_return(local_storage)
+    end
+
+    it 'defaults to retrieving events from local storage' do
+      expect(local_storage).to receive(:retrieve).with(file_path:, file_name:)
+      subject.retrieve_user_proofing_events(file_path:, file_name:)
+    end
+
+    context 'when S3 is enabled' do
+      subject { EncryptedDocStorage::AttemptDataRetriever.new(s3_enabled: true) }
+      let(:s3_storage) { double('S3Storage') }
+
+      before do
+        allow(EncryptedDocStorage::S3Storage).to receive(:new).and_return(s3_storage)
+      end
+
+      it 'retrieves events from S3 storage' do
+        expect(s3_storage).to receive(:retrieve).with(file_path:, file_name:)
+        subject.retrieve_user_proofing_events(file_path:, file_name:)
+      end
+    end
+  end
+end

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
 
   describe '#write_encrypted_attempt_events' do
     let(:file_path) { 'file_path' }
-    let(:encrypted_attempt_events) { { events: 'encrypted_attempt_events' } }
+    let(:encrypted_attempt_events) { { events: 'encrypted_attempt_events' }.to_json }
     let(:uuid) { 'test-uuid' }
     let(:path) { "#{file_path}/#{uuid}" }
     before do
@@ -117,7 +117,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
         :write_attempt_events,
       ).with(
         path:,
-        encrypted_attempt_events: encrypted_attempt_events.to_json,
+        encrypted_attempt_events:,
       )
 
       result = subject.write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
@@ -134,7 +134,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
           :write_attempt_events,
         ).with(
           path:,
-          encrypted_attempt_events: encrypted_attempt_events.to_json,
+          encrypted_attempt_events:,
         )
         expect_any_instance_of(EncryptedDocStorage::LocalStorage).not_to receive(
           :write_attempt_events,

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -103,6 +103,46 @@ RSpec.describe EncryptedDocStorage::DocWriter do
     end
   end
 
+  describe '#write_encrypted_attempt_events' do
+    let(:file_path) { 'file_path' }
+    let(:encrypted_attempt_events) { 'encrypted_attempt_events' }
+    let(:uuid) { 'test-uuid' }
+    let(:path) { "attempt_events/#{file_path}/#{uuid}" }
+    before do
+      allow(SecureRandom).to receive(:uuid).and_return(uuid)
+    end
+
+    it 'writes the encrypted attempt events to storage' do
+      expect_any_instance_of(EncryptedDocStorage::LocalStorage).to receive(
+        :write_attempt_events,
+      ).with(
+        path:,
+        encrypted_attempt_events:,
+      )
+
+      result = subject.write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
+      expect(result.name).to eq(uuid)
+    end
+
+    context 'when S3Storage is initalized' do
+      subject do
+        EncryptedDocStorage::DocWriter.new(s3_enabled: true)
+      end
+
+      it 'uses S3' do
+        expect_any_instance_of(EncryptedDocStorage::S3Storage).to receive(
+          :write_attempt_events,
+        ).with(path:, encrypted_attempt_events:)
+        expect_any_instance_of(EncryptedDocStorage::LocalStorage).not_to receive(
+          :write_attempt_events,
+        )
+
+        result = subject.write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
+        expect(result.name).to eq(uuid)
+      end
+    end
+  end
+
   def file_path(uuid)
     Rails.root.join('tmp', 'encrypted_doc_storage', uuid)
   end

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -105,9 +105,9 @@ RSpec.describe EncryptedDocStorage::DocWriter do
 
   describe '#write_encrypted_attempt_events' do
     let(:file_path) { 'file_path' }
-    let(:encrypted_attempt_events) { 'encrypted_attempt_events' }
+    let(:encrypted_attempt_events) { { events: 'encrypted_attempt_events' } }
     let(:uuid) { 'test-uuid' }
-    let(:path) { "attempt_events/#{file_path}/#{uuid}" }
+    let(:path) { "#{file_path}/#{uuid}" }
     before do
       allow(SecureRandom).to receive(:uuid).and_return(uuid)
     end
@@ -117,7 +117,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
         :write_attempt_events,
       ).with(
         path:,
-        encrypted_attempt_events:,
+        encrypted_attempt_events: encrypted_attempt_events.to_json,
       )
 
       result = subject.write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
@@ -132,7 +132,10 @@ RSpec.describe EncryptedDocStorage::DocWriter do
       it 'uses S3' do
         expect_any_instance_of(EncryptedDocStorage::S3Storage).to receive(
           :write_attempt_events,
-        ).with(path:, encrypted_attempt_events:)
+        ).with(
+          path:,
+          encrypted_attempt_events: encrypted_attempt_events.to_json,
+        )
         expect_any_instance_of(EncryptedDocStorage::LocalStorage).not_to receive(
           :write_attempt_events,
         )

--- a/spec/services/encrypted_doc_storage/local_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/local_storage_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe EncryptedDocStorage::LocalStorage do
   describe '#retrieve' do
     let(:name) { SecureRandom.uuid }
     let(:path) { 'attempts' }
-    let(:encrypted_attempt_events) { 'abcdefg' }
+    let(:encrypted_attempt_events) { 'abcd1245' }
     it 'retrieves the attempt events from the disk' do
       # Write the file first
       EncryptedDocStorage::LocalStorage.new.write_attempt_events(

--- a/spec/services/encrypted_doc_storage/local_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/local_storage_spec.rb
@@ -49,4 +49,24 @@ RSpec.describe EncryptedDocStorage::LocalStorage do
       expect(result).to eq(encrypted_attempt_events)
     end
   end
+
+  describe '#retrieve' do
+    let(:name) { SecureRandom.uuid }
+    let(:path) { 'attempts' }
+    let(:encrypted_attempt_events) { 'abcdefg' }
+    it 'retrieves the attempt events from the disk' do
+      # Write the file first
+      EncryptedDocStorage::LocalStorage.new.write_attempt_events(
+        path: path + '/' + name,
+        encrypted_attempt_events:,
+      )
+
+      result = EncryptedDocStorage::LocalStorage.new.retrieve(file_path: path, file_name: name)
+
+      # cleanup
+      File.delete(Rails.root.join('tmp', 'encrypted_attempt_events', path, name))
+
+      expect(result).to eq(encrypted_attempt_events)
+    end
+  end
 end

--- a/spec/services/encrypted_doc_storage/local_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/local_storage_spec.rb
@@ -27,4 +27,26 @@ RSpec.describe EncryptedDocStorage::LocalStorage do
       expect(result).to eq(encrypted_image)
     end
   end
+
+  describe '#write_attempt_events' do
+    it 'writes the attempt events to the disk' do
+      path = SecureRandom.uuid
+      encrypted_attempt_events = SecureRandom.bytes(32)
+
+      EncryptedDocStorage::LocalStorage.new.write_attempt_events(
+        path:,
+        encrypted_attempt_events:,
+      )
+      full_path = Rails.root.join('tmp', 'encrypted_attempt_events', path)
+
+      f = File.new(full_path, 'rb')
+      result = f.read
+      f.close
+
+      # cleanup
+      File.delete(full_path)
+
+      expect(result).to eq(encrypted_attempt_events)
+    end
+  end
 end

--- a/spec/services/encrypted_doc_storage/s3_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/s3_storage_spec.rb
@@ -28,4 +28,26 @@ RSpec.describe EncryptedDocStorage::S3Storage do
       )
     end
   end
+
+  describe '#write_attempt_events' do
+    let(:stubbed_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+
+    before do
+      allow(subject).to receive(:s3_client).and_return(stubbed_s3_client)
+      allow(stubbed_s3_client).to receive(:put_object)
+    end
+
+    it 'writes the attempt events to S3' do
+      path = 'attempt_events/123abc'
+      encrypted_attempt_events = SecureRandom.bytes(32)
+
+      subject.write_attempt_events(path:, encrypted_attempt_events:)
+
+      expect(stubbed_s3_client).to have_received(:put_object).with(
+        bucket: IdentityConfig.store.encrypted_document_storage_s3_bucket,
+        key: path,
+        body: encrypted_attempt_events,
+      )
+    end
+  end
 end

--- a/spec/services/encrypted_doc_storage/s3_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/s3_storage_spec.rb
@@ -49,5 +49,26 @@ RSpec.describe EncryptedDocStorage::S3Storage do
         body: encrypted_attempt_events,
       )
     end
+
+    describe '#retrieve_attempt_object' do
+      let(:stubbed_s3_client) { Aws::S3::Client.new(stub_responses: true) }
+      let(:name) { SecureRandom.uuid }
+      let(:path) { 'attempt_events/123abc' }
+      let(:encrypted_attempt_events) { 'abcdefg' }
+
+      before do
+        allow(subject).to receive(:s3_client).and_return(stubbed_s3_client)
+        allow(stubbed_s3_client).to receive(:get_object)
+      end
+
+      it 'retrieves the attempt events from S3' do
+        subject.retrieve_attempt_object(path:)
+
+        expect(stubbed_s3_client).to have_received(:get_object).with(
+          bucket: IdentityConfig.store.encrypted_document_storage_s3_bucket,
+          key: path,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 107](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/107)

## 🛠 Summary of changes
This change:

- Adds a historical_attempts_s3_storage_enabled flag that is defaulted to `false`
-  Extends the EncrypedDocStorage module to write encrypted attempts events to either local storage or the doc escrow s3 bucket.
- Refactors the UserProofingEvent creation to the Profile model (since the UserProofingEvent belongs to the Profile model)
- Updates decryption code so that it can decrypt the events for insertion into the redis queue.
- Fixes a bug so that the events are recorded for ALL service providers if the `historical_attempts_api_enabled` flag is true
- Adds tests

## 📜 Testing Plan

Since we are not yet adding the decrypted events, there are no user-facing changes. This must be tested locally for the moment.

- [ ] Add `historical_attempts_api_enabled` to application.yml locally
- [ ] Start IdP and OIDC Sample app locally
- [ ] Navigate to http://localhost:9292/
- [ ] Select "Identity Verified" from the Level of Service drop-down
- [ ] Create a new account, and go through the verification process
    - keep track of the password, you will need it to check the work
- [ ] Finish logging in and return to the OIDC sample app
- [ ] Log into your local rails console `rails c`
- [ ] perform the following steps in your console

```ruby
profile = Profile.last
path = Rails.root.join('tmp', 'encrypted_attempt_events', 'attempt_events', profile.user.uuid, profile.id.to_s, profile.encrypted_attempts_file_reference)
File.exist?(path)
# should return true

JSON.parse(File.read(path))
# should be a hash with "encrypted_data", "salt", "cost" as keys

profile.decrypt_user_proofing_events(password: $USER_PASSWORD)
# should return a JSON string that looks like:
# "[{\"idv-document-uploaded\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}},{\"idv-document-upload-submitted\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}},{\"idv-ssn-submitted\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}},{\"idv-device-risk-assessment\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}},{\"idv-verification-submitted\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}},{\"idv-phone-submitted\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}},{\"idv-phone-verified\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}},{\"idv-phone-otp-sent\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}},{\"idv-phone-otp-submitted\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}},{\"idv-enrollment-complete\":{\"user_uuid\":\"28b21a9b-e805-4164-a698-1096370622fd\"}}]"
```

 

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
