### PR TITLE
Deploy RC 574 to Production

### DIFF
--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -7,19 +7,24 @@ module Idv
 
     def record_user_proofing_events(password)
       return unless historical_events_enabled?
+      # TODO: move UserProofingEvent creation to the Profile object
       @password = password
 
       new_events = user_session['idv/attempts'] || []
 
-      encrypted_events = encrypt_attempt_events_bundle(new_events)
-      encrypted_events_json = JSON.parse(encrypted_events)
-      new_user_proofing_event = UserProofingEvent.new(
-        encrypted_events:,
-        profile_id: current_user.active_profile.id,
-        service_providers_sent: [],
-        cost: encrypted_events_json['cost'],
-        salt: encrypted_events_json['salt'],
-      )
+      encrypted_events_json = encrypt_attempt_events_bundle(new_events)
+      encrypted_events = JSON.parse(encrypted_events_json)
+
+      # TODO: Write encrypted_events['encrypted_data'] to S3
+      # TODO: Save reference to S3 object in current_user.active_profile
+
+      new_user_proofing_event = current_user
+        .active_profile
+        .build_user_proofing_event(
+          cost: encrypted_events['cost'],
+          salt: encrypted_events['salt'],
+        )
+
       new_user_proofing_event.save
 
       # Now that proofing events are saved, remove the plaintext events from user_session
@@ -27,7 +32,7 @@ module Idv
     end
 
     def cache_user_proofing_events(password)
-      return unless historical_events_need_be_sent? && existing_user_proofing_event
+      return unless historical_events_need_be_sent?
       @password = password
 
       existing_events = decrypt_user_proofing_events
@@ -43,12 +48,9 @@ module Idv
 
     def historical_events_need_be_sent?
       return false unless historical_events_enabled?
+      return false if existing_user_proofing_event.blank?
 
-      sent_to_aaca = existing_user_proofing_event&.service_providers_sent&.include?(
-        current_sp.issuer,
-      )
-
-      return !sent_to_aaca
+      return !existing_user_proofing_event.already_sent_to_sp?(current_sp.id)
     end
 
     def historical_events_enabled?
@@ -58,9 +60,7 @@ module Idv
     end
 
     def existing_user_proofing_event
-      @existing_user_proofing_event ||= UserProofingEvent.find_by(
-        profile_id: current_user.active_profile.id,
-      )
+      @existing_user_proofing_event ||= current_user.active_profile.user_proofing_event
     end
 
     def encrypt_attempt_events_bundle(bundle)
@@ -68,7 +68,15 @@ module Idv
     end
 
     def decrypt_user_proofing_events
-      pii_encryptor.decrypt(existing_user_proofing_event['encrypted_events'], user_uuid:)
+      # TODO: Retrieve encrypted_events from S3 or locally
+      # Currently this is not in use, so passing in dummy data
+      data = pii_encryptor.encrypt(
+        [
+          { 'idv-ssn-submitted' => { 'user_uuid' => user_uuid } },
+        ].to_json,
+        user_uuid:,
+      )
+      pii_encryptor.decrypt(data, user_uuid:)
     end
 
     def pii_encryptor

--- a/app/controllers/concerns/one_account_concern.rb
+++ b/app/controllers/concerns/one_account_concern.rb
@@ -37,7 +37,17 @@ module OneAccountConcern
   end
 
   def user_eligible_for_one_account?
-    sp_eligible_for_one_account? && current_user&.active_profile
+    return false unless facial_match_request?
+
+    if global_detection_enabled?
+      current_user&.identity_verified_with_facial_match?
+    else
+      sp_eligible_for_one_account? && current_user&.identity_verified_with_facial_match?
+    end
+  end
+
+  def facial_match_request?
+    resolved_authn_context_result&.facial_match? || false
   end
 
   def sp_eligible_for_one_account?
@@ -48,10 +58,20 @@ module OneAccountConcern
     user_has_duplicate_account_profiles?
   end
 
+  def global_detection_enabled?
+    IdentityConfig.store.enable_one_account_global_detection
+  end
+
   def user_has_duplicate_account_profiles?
-    DuplicateProfileSet.involving_profile(
-      profile_id: current_user.active_profile.id,
-      service_provider: sp_from_sp_session&.issuer,
-    ).present?
+    if global_detection_enabled?
+      DuplicateProfileSet.involving_profile_global(
+        profile_id: current_user.active_profile.id,
+      ).present?
+    else
+      DuplicateProfileSet.involving_profile(
+        profile_id: current_user.active_profile.id,
+        service_provider: sp_from_sp_session&.issuer,
+      ).present?
+    end
   end
 end

--- a/app/controllers/duplicate_profiles_detected_controller.rb
+++ b/app/controllers/duplicate_profiles_detected_controller.rb
@@ -16,25 +16,29 @@ class DuplicateProfilesDetectedController < ApplicationController
   private
 
   def redirect_unless_user_has_active_duplicate_profile
-    if current_user&.active_profile.present?
-      if duplicate_profile_set.present?
-        return
-      end
-    end
-    redirect_to root_url
+    return redirect_to(root_url) unless current_user&.identity_verified_with_facial_match?
+    return redirect_to(root_url) unless duplicate_profile_set.present?
   end
 
   def duplicate_profile_set
-    @duplicate_profile_set ||= DuplicateProfileSet.involving_profile(
-      profile_id: current_user.active_profile.id,
-      service_provider: current_sp&.issuer,
-    )
+    return nil unless current_user&.active_profile
+
+    @duplicate_profile_set ||= if IdentityConfig.store.enable_one_account_global_detection
+                                 DuplicateProfileSet.involving_profile_global(
+                                   profile_id: current_user.active_profile.id,
+                                 )
+    else
+      DuplicateProfileSet.involving_profile(
+        profile_id: current_user.active_profile.id,
+        service_provider: current_sp&.issuer,
+      )
+    end
   end
 
   def notify_users_of_duplicate_profile(source:)
     return unless duplicate_profile_set
     return if user_session[:dupe_profiles_notified]
-    agency_name = current_sp.friendly_name || current_sp.agency&.name
+    agency_name = current_sp&.friendly_name || current_sp&.agency&.name
 
     duplicate_profile_set.profile_ids.each do |profile_id|
       next if current_user&.active_profile&.id == profile_id

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -141,28 +141,26 @@ module SignUp
     end
 
     def send_historical_events
-      return unless user_proofing_event && current_sp.issuer
+      # TODO: send to redis queue
 
-      # send to redis queue and update sp_sent
-
-      user_proofing_event.add_sp_sent(current_sp.issuer)
+      user_proofing_event.add_sp_sent(current_sp.id)
     end
 
     def historical_events_need_be_sent?
-      globally_enabled = IdentityConfig.store.historical_attempts_api_enabled
-      aaca = current_sp.attempts_api_enabled?
-      idv = ial2_requested?
+      return false unless IdentityConfig.store.historical_attempts_api_enabled
+      return false unless current_sp.attempts_api_enabled?
+      return false unless ial2_requested?
+      return false unless user_proofing_event.present?
 
-      return false unless globally_enabled && aaca && idv
+      return !sent_to_aaca?
+    end
 
-      sent_to_aaca = user_proofing_event&.service_providers_sent&.include?(current_sp.issuer)
-
-      return !sent_to_aaca
+    def sent_to_aaca?
+      user_proofing_event&.already_sent_to_sp?(current_sp.id)
     end
 
     def user_proofing_event
-      @user_proofing_event ||=
-        UserProofingEvent.find_by(profile_id: current_user&.active_profile&.id)
+      @user_proofing_event ||= current_user&.active_profile&.user_proofing_event
     end
 
     def pii

--- a/app/models/duplicate_profile_set.rb
+++ b/app/models/duplicate_profile_set.rb
@@ -21,6 +21,26 @@ class DuplicateProfileSet < ApplicationRecord
       .where('? = ANY(profile_ids)', profile_id)
   end
 
+  def self.set_for_profiles_global(profile_ids:)
+    where(service_provider: nil)
+      .where('profile_ids && ?', "{#{profile_ids.join(',')}}")
+      .first
+  end
+
+  def self.involving_profile_global(profile_id:)
+    open
+      .where(service_provider: nil)
+      .where('? = ANY(profile_ids)', profile_id)
+      .first
+  end
+
+  def self.close_sp_scoped_sets_for_profile(profile_id:)
+    open
+      .where.not(service_provider: nil)
+      .where('? = ANY(profile_ids)', profile_id)
+      .find_each { |set| set.update!(closed_at: Time.zone.now) }
+  end
+
   def open?
     closed_at.nil?
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -284,7 +284,7 @@ class Profile < ApplicationRecord
     raise 'Profile not a duplicate' unless DuplicateProfileSet.open.exists?(
       ['? = ANY(profile_ids)', id],
     )
-
+    # rubocop:disable Metrics/BlockLength
     transaction do
       update!(
         active: false,
@@ -304,15 +304,20 @@ class Profile < ApplicationRecord
           )
         end
 
-        service_provider = ServiceProvider.find_sole_by(issuer: duplicate_profile.service_provider)
+        agency_name = if duplicate_profile.service_provider.present?
+                        ServiceProvider.find_sole_by(
+                          issuer: duplicate_profile.service_provider,
+                        )&.friendly_name
+        end
         user.confirmed_email_addresses.each do |email_address|
           mailer = UserMailer.with(user: user, email_address: email_address)
           mailer.dupe_profile_account_review_complete_locked(
-            agency_name: service_provider.friendly_name,
+            agency_name: agency_name,
           ).deliver_now_or_later
         end
       end
     end
+    # rubocop:enable Metrics/BlockLength
   end
 
   def clear_duplicate

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -2,12 +2,17 @@
 
 class UserProofingEvent < ApplicationRecord
   belongs_to :profile
+  self.ignored_columns = %w[encrypted_events service_providers_sent]
 
-  # @param [String] issuer Client ID of service provider to add to "sent" list
-  def add_sp_sent(issuer)
-    return if self.service_providers_sent.include? issuer
+  # @param [Integer] id ID of service provider to add to "sent" list
+  def add_sp_sent(id)
+    return if self.service_provider_ids_sent.include?(id)
 
-    self.service_providers_sent.push(issuer)
+    self.service_provider_ids_sent.push(id)
     self.save!
+  end
+
+  def already_sent_to_sp?(id)
+    service_provider_ids_sent.include?(id)
   end
 end

--- a/app/presenters/duplicate_profiles_detected_presenter.rb
+++ b/app/presenters/duplicate_profiles_detected_presenter.rb
@@ -18,15 +18,21 @@ class DuplicateProfilesDetectedPresenter
     profiles = Profile.where(id: duplicate_profile_set.profile_ids)
     profiles.map do |profile|
       dupe_user = profile.user
-      sp_identity = ServiceProviderIdentity.find_by(
-        user_id: dupe_user.id,
-        service_provider: duplicate_profile_set.service_provider,
-      )
-      email = dupe_user.last_sign_in_email_address.email
+      email_address = dupe_user.last_sign_in_email_address
+      email = email_address.email
+      last_sign_in = if duplicate_profile_set.service_provider.present?
+                       sp_identity = ServiceProviderIdentity.find_by(
+                         user_id: dupe_user.id,
+                         service_provider: duplicate_profile_set.service_provider,
+                       )
+                       sp_identity&.last_authenticated_at
+                     else
+                       email_address.last_sign_in_at
+                     end
       {
         email: email,
         masked_email: EmailMasker.mask(email),
-        last_sign_in: sp_identity&.last_authenticated_at,
+        last_sign_in: last_sign_in,
         created_at: dupe_user.created_at,
         connected_accts: user.connected_apps.count,
         current_account: dupe_user.id == user.id,

--- a/app/services/duplicate_profile_checker.rb
+++ b/app/services/duplicate_profile_checker.rb
@@ -29,17 +29,30 @@ class DuplicateProfileChecker
 
   private
 
+  def global_detection_enabled?
+    IdentityConfig.store.enable_one_account_global_detection
+  end
+
   def find_duplicate_profiles(ssn)
-    Idv::DuplicateSsnFinder
-      .new(user: user, ssn: ssn)
-      .duplicate_facial_match_profiles(service_provider: sp.issuer)
+    finder = Idv::DuplicateSsnFinder.new(user: user, ssn: ssn)
+    if global_detection_enabled?
+      finder.duplicate_facial_match_profiles_global
+    else
+      finder.duplicate_facial_match_profiles(service_provider: sp.issuer)
+    end
   end
 
   def close_existing_duplicate_set_if_present
-    existing_duplicate_profile_set = DuplicateProfileSet.involving_profile(
-      profile_id: profile.id,
-      service_provider: sp.issuer,
-    )
+    if global_detection_enabled?
+      existing_duplicate_profile_set = DuplicateProfileSet.involving_profile_global(
+        profile_id: profile.id,
+      )
+    else
+      existing_duplicate_profile_set = DuplicateProfileSet.involving_profile(
+        profile_id: profile.id,
+        service_provider: sp.issuer,
+      )
+    end
 
     return unless existing_duplicate_profile_set.present?
     closed_at = Time.zone.now
@@ -54,6 +67,9 @@ class DuplicateProfileChecker
   def handle_duplicate_profiles_found(associated_profiles)
     new_profiles_ids = (associated_profiles.map(&:id) + [profile.id]).uniq.sort
 
+    if global_detection_enabled?
+      DuplicateProfileSet.close_sp_scoped_sets_for_profile(profile_id: profile.id)
+    end
     find_or_create_duplicate_profile_set(new_profiles_ids)
   end
 
@@ -69,10 +85,14 @@ class DuplicateProfileChecker
   end
 
   def find_existing_duplicate_profile_set(profile_ids)
-    DuplicateProfileSet.set_for_profiles_and_service_provider(
-      profile_ids: profile_ids,
-      service_provider: sp.issuer,
-    )
+    if global_detection_enabled?
+      DuplicateProfileSet.set_for_profiles_global(profile_ids: profile_ids)
+    else
+      DuplicateProfileSet.set_for_profiles_and_service_provider(
+        profile_ids: profile_ids,
+        service_provider: sp.issuer,
+      )
+    end
   end
 
   def update_existing_duplicate_set(existing_duplicate_profile_set, new_profile_ids)
@@ -96,7 +116,7 @@ class DuplicateProfileChecker
 
   def create_duplicate_profile_set(profile_ids)
     set = DuplicateProfileSet.create(
-      service_provider: sp&.issuer,
+      service_provider: global_detection_enabled? ? nil : sp&.issuer,
       profile_ids: profile_ids,
     )
     analytics.one_account_duplicate_profile_created
@@ -108,7 +128,11 @@ class DuplicateProfileChecker
   end
 
   def should_check_for_duplicates?
-    user_has_ial2_profile? && user_sp_eligible_for_one_account?
+    if global_detection_enabled?
+      user_has_ial2_profile?
+    else
+      user_has_ial2_profile? && user_sp_eligible_for_one_account?
+    end
   end
 
   def fetch_ssn

--- a/app/services/idv/duplicate_ssn_finder.rb
+++ b/app/services/idv/duplicate_ssn_finder.rb
@@ -29,6 +29,15 @@ module Idv
         .distinct
     end
 
+    def duplicate_facial_match_profiles_global
+      Profile
+        .active
+        .facial_match
+        .where(ssn_signature: ssn_signatures)
+        .where.not(user_id: user.id)
+        .distinct
+    end
+
     # Due to potentially inconsistent normalization of stored SSNs in the past, we must check:
     # - No dashes, ex: 123456789
     # - Dashes, ex: 123-45-6789

--- a/app/services/proofing/resolution/plugins/aamva_plugin.rb
+++ b/app/services/proofing/resolution/plugins/aamva_plugin.rb
@@ -50,24 +50,36 @@ module Proofing
               applicant_pii
             end
 
-          timer.time('state_id') do
+          result = timer.time('state_id') do
             proofer.proof(applicant_pii_with_state_id_address)
-          end.tap do |result|
-            if result.exception.blank?
-              Db::SpCost::AddSpCost.call(
-                current_sp,
-                :aamva,
-                transaction_id: result.transaction_id,
-              )
-            end
-
-            if doc_auth_flow
-              log_state_id_validation(
-                analytics:, result: result.to_h, applicant_pii:, ipp_enrollment_in_progress:,
-                aamva_checked: result.exception.blank?
-              )
-            end
           end
+
+          if result.exception.blank?
+            Db::SpCost::AddSpCost.call(
+              current_sp,
+              :aamva,
+              transaction_id: result.transaction_id,
+            )
+          end
+
+          log_state_id_validation(
+            analytics:, result: result.to_h, applicant_pii:, ipp_enrollment_in_progress:,
+            aamva_checked: result.exception.blank?
+          )
+          if contains_bypass_exception_id?(result.exception)
+            return skipped_result(exception: result.exception)
+          end
+
+          result
+        end
+
+        def contains_bypass_exception_id?(result_exception)
+          return false if result_exception.blank?
+
+          IdentityConfig.store.idv_aamva_bypass_exception_ids.each do |exception_id|
+            return true if result_exception.to_s.include?("ExceptionId: #{exception_id}")
+          end
+          false
         end
 
         def aamva_supports_state_id_jurisdiction?(applicant_pii)
@@ -85,10 +97,10 @@ module Proofing
         end
 
         # @return [Proofing::StateIdResult] A result signifying that the AAMVA plugin was skipped.
-        def skipped_result
+        def skipped_result(exception: nil)
           Proofing::StateIdResult.new(
             errors: {},
-            exception: nil,
+            exception: exception,
             success: true,
             vendor_name: Idp::Constants::Vendors::AAMVA_CHECK_SKIPPED,
           )

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -170,6 +170,7 @@ email_registrations_per_ip_period: 20
 email_registrations_per_ip_track_only_mode: false
 enable_add_mfa_redirect_for_personal_key: false
 enable_load_testing_mode: false
+enable_one_account_global_detection: false
 enable_rate_limiting: true
 enable_test_routes: true
 encrypted_document_storage_s3_bucket: 'test-bucket'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -204,6 +204,7 @@ identity_verification_outcomes_report_emails: '[]'
 identity_verification_outcomes_report_issuers: '[]'
 idv_aamva_at_doc_auth_enabled: false
 idv_aamva_at_doc_auth_ipp_enabled: false
+idv_aamva_bypass_exception_ids: '[]'
 idv_aamva_split_last_name_states: '[]'
 idv_account_verified_email_campaign_id: '20241028'
 idv_acuant_sdk_upgrade_a_b_testing_enabled: false

--- a/db/primary_migrate/20260331000000_allow_null_service_provider_on_duplicate_profile_sets.rb
+++ b/db/primary_migrate/20260331000000_allow_null_service_provider_on_duplicate_profile_sets.rb
@@ -8,8 +8,8 @@ class AllowNullServiceProviderOnDuplicateProfileSets < ActiveRecord::Migration[7
 
     # Add index where SP is null
     # This allows for multiple open duplicate profile sets for different SPs
-    # But only one open duplicate profile set without an SP
-    # Will modify after change is permanent
+    # But only one open duplicate profile set with a null SP. 
+    # Want to change to just this after we have no need for SP. 
     add_index :duplicate_profile_sets, :profile_ids,
               unique: true,
               where: 'service_provider IS NULL',

--- a/db/primary_migrate/20260429160306_update_user_proofing_events.rb
+++ b/db/primary_migrate/20260429160306_update_user_proofing_events.rb
@@ -1,0 +1,13 @@
+class UpdateUserProofingEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :user_proofing_events,
+               :service_provider_ids_sent,
+               :bigint,
+               null: false,
+               default: [],
+               array: true,
+               comment: 'sensitive=false'
+
+    change_column_null(:user_proofing_events, :encrypted_events, true)
+  end
+end

--- a/db/primary_migrate/20260430204118_add_encrypted_attempts_file_reference_to_profiles.rb
+++ b/db/primary_migrate/20260430204118_add_encrypted_attempts_file_reference_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddEncryptedAttemptsFileReferenceToProfiles < ActiveRecord::Migration[8.0]
+  def change
+    add_column :profiles, :encrypted_attempts_file_reference, :string, comment: 'sensitive=false'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_31_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_30_204118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -497,6 +497,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_31_000000) do
     t.text "encrypted_pii_recovery_multi_region", comment: "sensitive=true"
     t.datetime "gpo_verification_expired_at", comment: "sensitive=false"
     t.integer "idv_level", comment: "sensitive=false"
+    t.string "encrypted_attempts_file_reference", comment: "sensitive=false"
     t.index ["fraud_pending_reason"], name: "index_profiles_on_fraud_pending_reason"
     t.index ["fraud_rejection_at"], name: "index_profiles_on_fraud_rejection_at"
     t.index ["fraud_review_pending_at"], name: "index_profiles_on_fraud_review_pending_at"
@@ -644,13 +645,14 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_31_000000) do
   end
 
   create_table "user_proofing_events", id: :serial, force: :cascade do |t|
-    t.string "encrypted_events", null: false, comment: "sensitive=true"
+    t.string "encrypted_events", comment: "sensitive=true"
     t.bigint "profile_id", null: false, comment: "sensitive=false"
     t.jsonb "service_providers_sent", default: [], null: false, comment: "sensitive=false"
     t.string "cost", null: false, comment: "sensitive=true"
     t.string "salt", null: false, comment: "sensitive=true"
     t.datetime "created_at", null: false, comment: "sensitive=false"
     t.datetime "updated_at", null: false, comment: "sensitive=false"
+    t.bigint "service_provider_ids_sent", default: [], null: false, comment: "sensitive=false", array: true
     t.index ["profile_id"], name: "index_user_proofing_events_on_profile_id"
   end
 

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -265,6 +265,7 @@ module IdentityConfig
     config.add(:idv_socure_reason_codes_docv_selfie_not_processed, type: :json)
     config.add(:idv_socure_reason_codes_docv_selfie_pass, type: :json)
     config.add(:idv_sp_required, type: :boolean)
+    config.add(:idv_aamva_bypass_exception_ids, type: :json)
     config.add(:idv_aamva_split_last_name_states, type: :json)
     config.add(:in_person_completion_survey_delivery_enabled, type: :boolean)
     config.add(:in_person_completion_survey_url, type: :string)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -179,6 +179,7 @@ module IdentityConfig
     config.add(:dos_passport_mrz_maxretry, type: :integer)
     config.add(:dos_passport_mrz_timeout_seconds, type: :integer)
     config.add(:eligible_one_account_providers, type: :json)
+    config.add(:enable_one_account_global_detection, type: :boolean)
     config.add(:email_from, type: :string)
     config.add(:email_from_display_name, type: :string)
     config.add(:email_registrations_per_ip_limit, type: :integer)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -615,6 +615,7 @@ RSpec.describe ApplicationController do
         .and_return([issuer])
       allow(controller).to receive(:sp_from_sp_session)
         .and_return(sp)
+      allow(controller).to receive(:facial_match_request?).and_return(true)
     end
 
     context 'when SP is not eligible for one account' do

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
   let(:sp) { create(:service_provider, ial: 2, issuer: issuer) }
   let(:profile) { create(:profile, :active, :verified) }
   let(:applicant) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE }
-  let(:user_proofing_event_new) { build(:user_proofing_event) }
   let(:encryptor_mock) { double }
   let(:encrypted_events) do
     {
@@ -23,18 +22,14 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       'cost' => '000$0$0$',
     }
   end
-  let(:test_data) { { test_data: 'data' } }
-  let(:old_data) { { old_data: 'data' } }
   let(:idv_attempts) do
     [
-      { 'idv-ssn-submitted' => test_data },
-      { 'idv-enrollment-complete' => test_data },
+      { 'idv-ssn-submitted' => { 'user_uuid' => registered_user.uuid } },
     ]
   end
   let(:pii_encryptor) { Encryption::Encryptors::PiiEncryptor.new(registered_user.password) }
-  let(:existing_events) { [{ 'old_attempt' => old_data }] }
   let(:encrypted_existing_events) do
-    pii_encryptor.encrypt(existing_events.to_json, user_uuid: registered_user.uuid)
+    pii_encryptor.encrypt(idv_attempts.to_json, user_uuid: registered_user.uuid)
   end
 
   controller ApplicationController do
@@ -61,9 +56,8 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       historical_attempts_api_enabled: true,
     )
 
-    allow(UserProofingEvent).to receive(:new).and_return(user_proofing_event_new)
-    allow(user_proofing_event_new).to receive(:save).and_return(true)
-    allow(UserProofingEvent).to receive(:save).and_return(true)
+    allow(UserProofingEvent).to receive(:new).and_call_original
+    allow(UserProofingEvent).to receive(:save).and_call_original
     allow(Encryption::Encryptors::PiiEncryptor).to receive(:new).and_return(pii_encryptor)
     allow(pii_encryptor).to receive(:decrypt).and_call_original
     allow(pii_encryptor).to receive(:encrypt).and_call_original
@@ -74,7 +68,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       controller.record_user_proofing_events(password)
     end
 
-    context 'historical_attempts_api_enabled is false at the secrets level' do
+    context 'historical_attempts_api_enabled feature flag is false' do
       before do
         allow(IdentityConfig.store).to receive(
           :historical_attempts_api_enabled,
@@ -89,22 +83,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       end
     end
 
-    context 'service_provider is not an allowed_attempts_providers' do
-      before do
-        allow(IdentityConfig.store).to receive(
-          :allowed_attempts_providers,
-        ).and_return([])
-      end
-
-      it 'does not modify or create a UserProofingEvent' do
-        record_user_proofing_events
-
-        expect(UserProofingEvent).to_not have_received(:new)
-        expect(UserProofingEvent).to_not have_received(:save)
-      end
-    end
-
-    context 'when historical events need to be sent' do
+    context 'historical_attempts_api_enabled feature flag is true' do
       before do
         allow(Encryption::Encryptors::PiiEncryptor).to receive(:new).and_return(encryptor_mock)
         allow(encryptor_mock).to receive(:encrypt).and_return(encrypted_events.to_json)
@@ -113,17 +92,13 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
       it 'creates and saves a UserProofingEvent' do
         expect(UserProofingEvent).to have_received(:new)
-        expect(user_proofing_event_new).to have_received(:save)
       end
 
-      it 'includes the encrypted_events' do
-        expect(UserProofingEvent).to have_received(:new).with(
-          encrypted_events: encrypted_events.to_json,
-          profile_id: registered_user.active_profile.id,
-          service_providers_sent: [],
-          cost: encrypted_events['cost'],
-          salt: encrypted_events['salt'],
-        )
+      it 'includes the encrypted event metadata' do
+        user_proofing_event = UserProofingEvent.last
+        expect(user_proofing_event.cost).to eq(encrypted_events['cost'])
+        expect(user_proofing_event.salt).to eq(encrypted_events['salt'])
+        expect(user_proofing_event.profile).to eq(profile)
       end
     end
   end
@@ -133,43 +108,53 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       controller.cache_user_proofing_events(password)
     end
 
-    let(:user_proofing_event) do
-      create(
-        :user_proofing_event,
-        encrypted_events: encrypted_existing_events,
-        service_providers_sent: [],
+    let!(:user_proofing_event) do
+      registered_user.active_profile.build_user_proofing_event(
         cost: JSON.parse(encrypted_existing_events)['cost'],
         salt: JSON.parse(encrypted_existing_events)['salt'],
-        profile_id: registered_user.active_profile.id,
       )
     end
 
-    before do
-      allow(UserProofingEvent).to receive(:find_by).and_return(user_proofing_event)
-      allow(user_proofing_event).to receive(:update_encrypted_events).and_return(true)
+    context 'historical_attempts_api_enabled feature flag is false' do
+      before do
+        allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
+      end
+
+      it 'does not decrypt or encrypt events' do
+        expect(pii_encryptor).to_not receive(:decrypt)
+        expect(pii_encryptor).to_not receive(:encrypt)
+
+        cache_user_proofing_events
+      end
     end
 
-    context 'historical events are disallowed' do
-      context 'historical_attempts_api_enabled is false at the secrets level' do
-        before do
-          allow(IdentityConfig.store).to receive(
-            :historical_attempts_api_enabled,
-          ).and_return(false)
-        end
+    context 'historical_attempts_api_enabled feature flag is true' do
+      let(:mock_session_encryptor) { double }
+      let(:kms_encrypted_events) { 'kms_encrypted_events' }
 
-        it 'does not decrypt or encrypt events' do
-          expect(pii_encryptor).to_not receive(:decrypt)
-          expect(pii_encryptor).to_not receive(:encrypt)
+      before do
+        allow(SessionEncryptor).to receive(:new).and_return(mock_session_encryptor)
+        allow(mock_session_encryptor).to receive(:kms_encrypt).and_return(kms_encrypted_events)
+        cache_user_proofing_events
+      end
 
-          cache_user_proofing_events
-        end
+      it 'decrypts the appropriate UserProofingEvent' do
+        expect(pii_encryptor).to have_received(:decrypt).once
+      end
+
+      it 'encrypts with the kms session key' do
+        expect(mock_session_encryptor).to have_received(:kms_encrypt).once.with(
+          idv_attempts.to_json,
+        )
+      end
+
+      it 'updates the session with the UserProofingEvent' do
+        expect(controller.user_session[:encrypted_proofing_events]).to eq(kms_encrypted_events)
       end
 
       context 'service_provider is not an allowed_attempts_providers' do
         before do
-          allow(IdentityConfig.store).to receive(
-            :allowed_attempts_providers,
-          ).and_return([])
+          allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return([])
         end
 
         it 'does not decrypt or encrypt events' do
@@ -182,18 +167,11 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
       context 'events already sent to SP' do
         let(:user_proofing_event) do
-          create(
-            :user_proofing_event,
-            encrypted_events: encrypted_existing_events,
-            service_providers_sent: [sp.issuer],
+          registered_user.active_profile.build_user_proofing_event(
             cost: JSON.parse(encrypted_existing_events)['cost'],
             salt: JSON.parse(encrypted_existing_events)['salt'],
-            profile_id: registered_user.active_profile.id,
+            service_provider_ids_sent: [sp.id],
           )
-        end
-
-        before do
-          allow(UserProofingEvent).to receive(:find_by).and_return(user_proofing_event)
         end
 
         it 'does not decrypt or encrypt events' do
@@ -203,33 +181,13 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
           cache_user_proofing_events
         end
       end
-    end
 
-    context 'historical events are permitted' do
-      let(:mock_session_encryptor) { double }
-      let(:kms_encrypted_events) { 'kms_encrypted_events' }
+      context 'when no UserProofingEvent exists for the profile' do
+        let(:user_proofing_event) { nil }
 
-      before do
-        allow(SessionEncryptor).to receive(:new).and_return(mock_session_encryptor)
-        allow(mock_session_encryptor).to receive(:kms_encrypt).and_return(kms_encrypted_events)
-        cache_user_proofing_events
-      end
-
-      it 'decrypts the appropriate UserProofingEvent' do
-        expect(pii_encryptor).to have_received(:decrypt).once.with(
-          user_proofing_event.encrypted_events,
-          user_uuid: registered_user.uuid,
-        )
-      end
-
-      it 'encrypts with the kms session key' do
-        expect(mock_session_encryptor).to have_received(:kms_encrypt).once.with(
-          existing_events.to_json,
-        )
-      end
-
-      it 'updates the session with the UserProofingEvent' do
-        expect(controller.user_session[:encrypted_proofing_events]).to eq(kms_encrypted_events)
+        it 'does not raise an error' do
+          expect { cache_user_proofing_events }.to_not raise_error
+        end
       end
     end
   end

--- a/spec/controllers/duplicate_profiles_detected_controller_spec.rb
+++ b/spec/controllers/duplicate_profiles_detected_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe DuplicateProfilesDetectedController, type: :controller do
   before do
     stub_sign_in(user)
     stub_analytics
+    allow(IdentityConfig.store).to receive(:enable_one_account_global_detection).and_return(false)
     duplicate_profile_set
     allow(controller).to receive(:current_sp).and_return(current_sp)
   end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1125,27 +1125,21 @@ RSpec.describe Idv::EnterPasswordController do
 
     describe 'historical events tracking' do
       let(:idv_attempt) do
-        AttemptsApi::AttemptEvent.new(
-          event_type: 'idv-enrollment-complete',
-          session_id: 0,
-          occurred_at: Time.zone.now,
-          event_metadata: { event_type: 'idv-enrollment-complete', data: 'event data' },
-        )
+        {
+          'idv/attempts' => [
+            { 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } },
+          ],
+        }
       end
+
       let(:mock_user_session) { { 'idv/attempts' => [idv_attempt] } }
-      let(:mock) { double }
 
       before do
-        allow(UserProofingEvent).to receive(:new).and_return(mock)
-        allow(mock).to receive(:save).and_return(true)
         allow(IdentityConfig.store).to receive_messages(
           attempts_api_enabled: true,
           historical_attempts_api_enabled: true,
           allowed_attempts_providers: [{ 'issuer' => sp.issuer }],
         )
-        session['warden.user.user.session'] = mock_user_session
-        # at this point in the flow, the applicant should have a UUID
-        subject.idv_session.applicant['uuid'] = 'aabbccdd-0000-00000-0000-aabbccddeeff'
       end
 
       after do
@@ -1163,22 +1157,11 @@ RSpec.describe Idv::EnterPasswordController do
         end
 
         context 'with a newly proofed user' do
-          it 'creates a new UserProofingEvent' do
-            expect(UserProofingEvent).to receive(:new)
-            expect(mock).to receive(:save)
+          it 'creates a UserProofingEvent for the profile' do
             put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-          end
-        end
+            event = UserProofingEvent.last
 
-        context 'with a proofed user who has already sent attempts to this SP' do
-          before do
-            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
-          end
-
-          it 'does not create a new UserProofingEvent' do
-            expect(UserProofingEvent).to_not receive(:new)
-            expect(mock).to_not receive(:save)
-            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+            expect(event.profile_id).to eq(user.profiles.last.id)
           end
         end
       end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -645,10 +645,11 @@ RSpec.describe OpenidConnect::AuthorizationController do
               end
 
               context 'when duplicate profiles are detected for user' do
+                let(:user) do
+                  create(:profile, :active, :verified, :facial_match_proof).user
+                end
                 let(:user2) do
-                  create(
-                    :profile, :active, :verified, proofing_components: { liveness_check: true }
-                  ).user
+                  create(:profile, :active, :verified, :facial_match_proof).user
                 end
                 let(:duplicate_profile_set) do
                   create(
@@ -658,11 +659,15 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 end
 
                 before do
+                  params[:acr_values] = Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF
                   allow(IdentityConfig.store).to receive(:eligible_one_account_providers).and_return([service_provider.issuer])
+                  allow(IdentityConfig.store).to receive(:facial_match_general_availability_enabled)
+                    .and_return(true)
                   allow_any_instance_of(DuplicateProfileChecker)
                     .to receive(:dupe_profile_set_for_user).and_return(duplicate_profile_set)
                   allow(controller).to receive(:user_signed_in?).and_return(true)
                   allow(controller).to receive(:current_user).and_return(user)
+                  allow(controller).to receive(:pii_requested_but_locked?).and_return(false)
                 end
 
                 it 'redirects user to duplicate profiles detected page' do

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -651,6 +651,14 @@ RSpec.describe SamlIdpController do
         },
       )
     end
+    let(:ial2_facial_match_settings) do
+      saml_settings(
+        overrides: {
+          issuer: sp1_issuer,
+          authn_context: Saml::Idp::Constants::IAL2_BIO_REQUIRED_AUTHN_CONTEXT_CLASSREF,
+        },
+      )
+    end
     let(:ialmax_settings) do
       saml_settings(
         overrides: {
@@ -819,10 +827,9 @@ RSpec.describe SamlIdpController do
       end
 
       context 'user has a duplicate profile in another account' do
+        let(:user) { create(:profile, :active, :verified, :facial_match_proof).user }
         let(:user2) do
-          create(
-            :profile, :active, :verified, proofing_components: { liveness_check: true }
-          ).user
+          create(:profile, :active, :verified, :facial_match_proof).user
         end
         let(:duplicate_profile_set) do
           create(
@@ -838,13 +845,15 @@ RSpec.describe SamlIdpController do
           allow(IdentityConfig.store)
             .to receive(:eligible_one_account_providers)
             .and_return([service_provider.issuer])
+          allow(IdentityConfig.store).to receive(:facial_match_general_availability_enabled)
+            .and_return(true)
           allow_any_instance_of(DuplicateProfileChecker)
             .to receive(:dupe_profile_set_for_user).and_return(duplicate_profile_set)
           allow(controller).to receive(:current_user).and_return(user)
         end
 
         it 'redirects user to duplicate profiles detected page' do
-          saml_get_auth(ial2_settings)
+          saml_get_auth(ial2_facial_match_settings)
           expect(response).to redirect_to(duplicate_profiles_detected_url(source: :sign_in))
         end
       end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -388,7 +388,7 @@ RSpec.describe SignUp::CompletionsController do
           )
         end
 
-        context 'issuer is an allowed attempts provider' do
+        context 'service_provider is an allowed attempts provider' do
           before do
             allow(IdentityConfig.store).to receive(:allowed_attempts_providers)
               .and_return([{ 'issuer' => sp.issuer }])
@@ -403,7 +403,7 @@ RSpec.describe SignUp::CompletionsController do
               )
             end
 
-            it 'should update the appropriate user proofing event' do
+            it 'updates the associated user proofing event' do
               stub_sign_in(user)
 
               subject.session[:sp] = {
@@ -413,11 +413,11 @@ RSpec.describe SignUp::CompletionsController do
                 requested_attributes: %w[email first_name verified_at],
               }
 
-              expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-                .to_not include(sp.issuer)
+              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
+                .to_not include(sp.id)
               patch :update
-              expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-                .to include(sp.issuer)
+              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
+                .to include(sp.id)
             end
           end
 
@@ -427,11 +427,11 @@ RSpec.describe SignUp::CompletionsController do
                 :user_proofing_event,
                 :existing,
                 profile_id: profile.id,
-                service_providers_sent: [sp.issuer],
+                service_provider_ids_sent: [sp.id],
               )
             end
 
-            it 'should not update the user proofing event' do
+            it 'does not update the user proofing event' do
               stub_sign_in(user)
 
               subject.session[:sp] = {
@@ -441,11 +441,9 @@ RSpec.describe SignUp::CompletionsController do
                 requested_attributes: %w[email first_name verified_at],
               }
 
-              expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-                .to include(sp.issuer).once
               patch :update
-              expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-                .to include(sp.issuer).once
+              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
+                .to include(sp.id).once
             end
           end
         end
@@ -464,7 +462,7 @@ RSpec.describe SignUp::CompletionsController do
               .and_return([])
           end
 
-          it 'should not update the user proofing event' do
+          it 'does not update the user proofing event' do
             stub_sign_in(user)
 
             subject.session[:sp] = {
@@ -474,10 +472,9 @@ RSpec.describe SignUp::CompletionsController do
               requested_attributes: %w[email first_name verified_at],
             }
 
-            expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
-              .to_not include(sp.issuer)
             patch :update
-            expect(UserProofingEvent.find(proofing_event.id).service_providers_sent)
+
+            expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
               .to_not include(sp.issuer)
           end
         end

--- a/spec/factories/duplicate_profile_sets.rb
+++ b/spec/factories/duplicate_profile_sets.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     service_provider { OidcAuthHelper::OIDC_FACIAL_MATCH_ISSUER }
     created_at { Time.zone.now }
     updated_at { Time.zone.now }
+
+    trait :global do
+      service_provider { nil }
+    end
   end
 end

--- a/spec/factories/user_proofing_events.rb
+++ b/spec/factories/user_proofing_events.rb
@@ -1,14 +1,12 @@
 FactoryBot.define do
   factory :user_proofing_event do
-    encrypted_events { nil }
-    service_providers_sent { [] }
+    service_provider_ids_sent { [] }
     cost { nil }
     salt { nil }
     profile_id { nil }
 
     trait :existing do
-      encrypted_events { '6d79206576656e74732061726520656e63727970746564' }
-      service_providers_sent { [] }
+      service_provider_ids_sent { [] }
       cost { '0$0$0$' }
       salt { '73616c74' }
       association :profile

--- a/spec/features/one_account/global_detection_spec.rb
+++ b/spec/features/one_account/global_detection_spec.rb
@@ -1,0 +1,325 @@
+require 'rails_helper'
+
+RSpec.feature 'One Account Global Detection' do
+  include OidcAuthHelper
+
+  let(:issuer) { OidcAuthHelper::OIDC_ISSUER }
+  let(:current_sp) { ServiceProvider.find_by(issuer: issuer) }
+  let(:redirect_url_pattern) { 'http://localhost:7654/auth/result' }
+  let(:verified_attributes) do
+    ['email', 'given_name', 'family_name', 'social_security_number']
+  end
+  let(:pii_attrs) do
+    {
+      first_name: 'Faker',
+      last_name: 'Fakerson',
+      ssn: '123-45-6789',
+      dob: '1980-01-01',
+      address1: '123 Main St',
+      city: 'Anytown',
+      state: 'NY',
+      zipcode: '12345',
+    }
+  end
+  let(:different_pii_attrs) do
+    pii_attrs.merge(ssn: '987-65-4321')
+  end
+
+  let(:user1) { create(:user, :fully_registered) }
+  let(:user2) { create(:user, :fully_registered) }
+
+  let!(:profile1) do
+    create(
+      :profile,
+      :active,
+      :facial_match_proof,
+      pii: pii_attrs,
+      user: user1,
+    )
+  end
+  let!(:profile2) do
+    create(
+      :profile,
+      :active,
+      :facial_match_proof,
+      pii: pii_attrs,
+      user: user2,
+    )
+  end
+
+  context 'with global detection enabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:enable_one_account_global_detection)
+        .and_return(true)
+      reload_ab_tests
+    end
+
+    context 'when two users have matching SSN signatures across any SP' do
+      before do
+        link_identity(user1, current_sp, 2)
+      end
+
+      scenario 'User1 is shown duplicate profiles warning on sign-in' do
+        complete_sign_in(user1)
+
+        expect_duplicate_warning
+      end
+
+      scenario 'duplicate profile set is created with null service_provider' do
+        complete_sign_in(user1)
+
+        dupe_set = DuplicateProfileSet.involving_profile_global(profile_id: profile1.id)
+        expect(dupe_set).to be_present
+        expect(dupe_set.service_provider).to be_nil
+        expect(dupe_set.profile_ids).to match_array([profile1.id, profile2.id])
+      end
+    end
+
+    context 'when User2 is NOT linked to the same SP' do
+      let(:different_sp) do
+        create(:service_provider, :active, issuer: 'urn:gov:gsa:openidconnect:sp:different')
+      end
+
+      before do
+        link_identity(user1, current_sp, 2)
+        link_identity(user2, different_sp, 2)
+      end
+
+      scenario 'User1 still sees duplicate warning (global ignores SP)' do
+        complete_sign_in(user1)
+
+        expect_duplicate_warning
+      end
+    end
+
+    context 'when User2 has no SP identity at all' do
+      before do
+        link_identity(user1, current_sp, 2)
+        # user2 has no SP identity — but global detection still finds them
+      end
+
+      scenario 'User1 still sees duplicate warning' do
+        complete_sign_in(user1)
+
+        expect_duplicate_warning
+      end
+    end
+
+    context 'when SSNs do not match' do
+      let!(:profile2) do
+        create(
+          :profile,
+          :active,
+          :facial_match_proof,
+          pii: different_pii_attrs,
+          user: user2,
+        )
+      end
+
+      before do
+        link_identity(user1, current_sp, 2)
+        link_identity(user2, current_sp, 2)
+      end
+
+      scenario 'User1 is not shown duplicate warning' do
+        complete_sign_in(user1)
+
+        expect_no_duplicate_warning
+      end
+    end
+
+    context 'when User1 signs in to a non-IAL2 SP' do
+      before do
+        link_identity(user1, current_sp, 2)
+      end
+
+      scenario 'User1 is not shown duplicate warning' do
+        visit_idp_from_ial1_oidc_sp
+        sign_in_user(user1)
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        expect(page).to have_current_path(sign_up_completed_path)
+      end
+    end
+
+    context 'when User1 signs in to an IAL2 SP that does not require facial match' do
+      before do
+        link_identity(user1, current_sp, 2)
+      end
+
+      scenario 'User1 is not shown duplicate warning' do
+        visit_idp_from_ial2_oidc_sp
+        sign_in_user(user1)
+        fill_in_code_with_last_phone_otp
+        click_submit_default
+
+        expect(page).to have_current_path(sign_up_completed_path)
+      end
+    end
+
+    context 'when an existing SP-scoped duplicate set exists' do
+      before do
+        link_identity(user1, current_sp, 2)
+        link_identity(user2, current_sp, 2)
+        create(
+          :duplicate_profile_set,
+          profile_ids: [profile1.id, profile2.id],
+          service_provider: issuer,
+        )
+      end
+
+      scenario 'SP-scoped set is closed and global set is created on sign-in' do
+        complete_sign_in(user1)
+
+        expect_duplicate_warning
+
+        sp_set = DuplicateProfileSet.where(service_provider: issuer)
+          .where('? = ANY(profile_ids)', profile1.id).first
+        expect(sp_set.closed_at).not_to be_nil
+
+        global_set = DuplicateProfileSet.involving_profile_global(profile_id: profile1.id)
+        expect(global_set).to be_present
+        expect(global_set.service_provider).to be_nil
+        expect(global_set.closed_at).to be_nil
+      end
+    end
+
+    context 'when the SP is not in eligible_one_account_providers' do
+      before do
+        allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
+          .and_return([])
+        link_identity(user1, current_sp, 2)
+        link_identity(user2, current_sp, 2)
+      end
+
+      scenario 'User1 still sees duplicate warning (global bypasses SP eligibility)' do
+        complete_sign_in(user1)
+
+        expect_duplicate_warning
+      end
+    end
+  end
+
+  context 'with global detection disabled (SP-scoped behavior)' do
+    before do
+      allow(IdentityConfig.store).to receive(:enable_one_account_global_detection)
+        .and_return(false)
+      allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
+        .and_return([issuer])
+      reload_ab_tests
+    end
+
+    context 'when both users are linked to the same eligible SP' do
+      before do
+        link_identity(user1, current_sp, 2)
+        link_identity(user2, current_sp, 2)
+      end
+
+      scenario 'User1 is shown duplicate profiles warning' do
+        complete_sign_in(user1)
+
+        expect_duplicate_warning
+      end
+
+      scenario 'duplicate profile set is created with service_provider set' do
+        complete_sign_in(user1)
+
+        dupe_set = DuplicateProfileSet.involving_profile(
+          profile_id: profile1.id,
+          service_provider: issuer,
+        )
+        expect(dupe_set).to be_present
+        expect(dupe_set.service_provider).to eq(issuer)
+      end
+    end
+
+    context 'when User2 is linked to a different SP' do
+      let(:different_sp) do
+        create(:service_provider, :active, issuer: 'urn:gov:gsa:openidconnect:sp:different')
+      end
+
+      before do
+        link_identity(user1, current_sp, 2)
+        link_identity(user2, different_sp, 2)
+        mark_identity_verified_for_one_account(user1)
+      end
+
+      scenario 'User1 is NOT shown duplicate warning (SP-scoped only checks same SP)' do
+        complete_sign_in(user1)
+
+        expect_no_duplicate_warning
+      end
+    end
+
+    context 'when SP is not in eligible_one_account_providers' do
+      before do
+        allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
+          .and_return([])
+        link_identity(user1, current_sp, 2)
+        link_identity(user2, current_sp, 2)
+        mark_identity_verified_for_one_account(user1)
+      end
+
+      scenario 'User1 is NOT shown duplicate warning (SP not eligible)' do
+        complete_sign_in(user1)
+
+        expect_no_duplicate_warning
+      end
+    end
+  end
+
+  context 'rollback: global detection disabled after being enabled' do
+    let!(:orphaned_global_set) do
+      create(
+        :duplicate_profile_set, :global,
+        profile_ids: [profile1.id, profile2.id]
+      )
+    end
+
+    before do
+      allow(IdentityConfig.store).to receive(:enable_one_account_global_detection)
+        .and_return(false)
+      allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
+        .and_return([issuer])
+      link_identity(user1, current_sp, 2)
+      link_identity(user2, current_sp, 2)
+      reload_ab_tests
+    end
+
+    scenario 'SP-scoped duplicate set is created; orphaned global set is ignored' do
+      complete_sign_in(user1)
+
+      expect_duplicate_warning
+
+      sp_set = DuplicateProfileSet.involving_profile(
+        profile_id: profile1.id,
+        service_provider: issuer,
+      )
+      expect(sp_set).to be_present
+      expect(sp_set.service_provider).to eq(issuer)
+
+      expect(orphaned_global_set.reload.closed_at).to be_nil
+    end
+  end
+
+  def complete_sign_in(user, facial_match_required: true)
+    visit_idp_from_ial2_oidc_sp(facial_match_required: facial_match_required)
+    sign_in_user(user)
+    fill_in_code_with_last_phone_otp
+    click_submit_default
+  end
+
+  def expect_duplicate_warning
+    expect(page).to have_current_path(duplicate_profiles_detected_path(source: :sign_in))
+  end
+
+  def expect_no_duplicate_warning
+    expect(page).not_to have_current_path(duplicate_profiles_detected_path(source: :sign_in))
+  end
+
+  def mark_identity_verified_for_one_account(user)
+    identity = user.identities.find_by(service_provider: current_sp.issuer)
+    identity.update!(verified_attributes: verified_attributes)
+  end
+end

--- a/spec/models/duplicate_profile_set_spec.rb
+++ b/spec/models/duplicate_profile_set_spec.rb
@@ -42,4 +42,94 @@ RSpec.describe DuplicateProfileSet, type: :model do
 
     expect(result).to eq(nil)
   end
+
+  describe '.set_for_profiles_global' do
+    let!(:global_set) do
+      create(
+        :duplicate_profile_set, :global,
+        profile_ids: [profile_id, other_profile_id]
+      )
+    end
+
+    it 'returns record matching profile_ids with null service_provider' do
+      result = described_class.set_for_profiles_global(profile_ids: [profile_id])
+      expect(result).to eq(global_set)
+    end
+
+    it 'returns nil when no global set overlaps' do
+      result = described_class.set_for_profiles_global(profile_ids: [777])
+      expect(result).to be_nil
+    end
+
+    context 'when SP scoped set overlaps but no global set overlaps' do
+      it 'returns nil' do
+        global_set.delete
+        result = described_class.set_for_profiles_global(profile_ids: [profile_id])
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe '.involving_profile_global' do
+    let!(:global_set) do
+      create(
+        :duplicate_profile_set, :global,
+        profile_ids: [profile_id, other_profile_id]
+      )
+    end
+
+    it 'returns open global set containing the profile_id' do
+      result = described_class.involving_profile_global(profile_id: profile_id)
+      expect(result).to eq(global_set)
+    end
+
+    it 'does not return closed global sets' do
+      global_set.update!(closed_at: Time.zone.now)
+      result = described_class.involving_profile_global(profile_id: profile_id)
+      expect(result).to be_nil
+    end
+
+    it 'returns nil when profile is not in any global set' do
+      result = described_class.involving_profile_global(profile_id: 777)
+      expect(result).to be_nil
+    end
+
+    context 'when SP scoped set overlaps but no global set overlaps' do
+      it 'returns nil' do
+        global_set.delete
+        result = described_class.set_for_profiles_global(profile_ids: [profile_id])
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe '.close_sp_scoped_sets_for_profile' do
+    it 'closes open SP-scoped sets containing the profile' do
+      expect(matching_profile.closed_at).to be_nil
+      described_class.close_sp_scoped_sets_for_profile(profile_id: profile_id)
+      expect(matching_profile.reload.closed_at).not_to be_nil
+    end
+
+    it 'closes multiple SP-scoped sets for the same profile' do
+      expect(non_matching_service.closed_at).to be_nil
+      described_class.close_sp_scoped_sets_for_profile(profile_id: profile_id)
+      expect(matching_profile.reload.closed_at).not_to be_nil
+      expect(non_matching_service.reload.closed_at).not_to be_nil
+      expect(non_matching_profile.reload.closed_at).to be_nil
+    end
+
+    it 'does not close global (null SP) sets' do
+      global_set = create(
+        :duplicate_profile_set, :global,
+        profile_ids: [profile_id, other_profile_id]
+      )
+      described_class.close_sp_scoped_sets_for_profile(profile_id: profile_id)
+      expect(global_set.reload.closed_at).to be_nil
+    end
+
+    it 'does not close sets that do not contain the profile' do
+      described_class.close_sp_scoped_sets_for_profile(profile_id: profile_id)
+      expect(non_matching_profile.reload.closed_at).to be_nil
+    end
+  end
 end

--- a/spec/models/user_proofing_event_spec.rb
+++ b/spec/models/user_proofing_event_spec.rb
@@ -3,31 +3,30 @@ require 'rails_helper'
 RSpec.describe UserProofingEvent, type: :model do
   let(:user_proofing_event) do
     UserProofingEvent.new(
-      encrypted_events: 'these_events_are_encrypted',
       profile_id: 1,
-      service_providers_sent: [],
+      service_provider_ids_sent: [],
       cost: '0$cost$',
       salt: 'salt0',
     )
   end
 
   describe '#add_sp_sent' do
-    let(:issuer) { 'a:test:issuer' }
+    let(:sp) { create(:service_provider) }
 
     before do
-      user_proofing_event.add_sp_sent(issuer)
+      user_proofing_event.add_sp_sent(sp.id)
     end
 
-    it 'should add a given issuer to the list of service_providers_sent' do
-      expect(user_proofing_event.service_providers_sent).to eq([issuer])
+    it 'should add a given id to the list of service_provider_ids_sent' do
+      expect(user_proofing_event.service_provider_ids_sent).to eq([sp.id])
     end
 
     it 'should be idempotent' do
-      expect(user_proofing_event.service_providers_sent.length).to eq(1)
+      expect(user_proofing_event.service_provider_ids_sent.length).to eq(1)
 
-      user_proofing_event.add_sp_sent(issuer)
+      user_proofing_event.add_sp_sent(sp.id)
 
-      expect(user_proofing_event.service_providers_sent).to eq([issuer])
+      expect(user_proofing_event.service_provider_ids_sent).to eq([sp.id])
     end
   end
 end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe AttemptsApi::Tracker do
       end
     end
 
-    context 'with historical_attempts_api_enabled' do
+    context 'when historical_attempts_api_enabled is true' do
       before do
         allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(true)
       end
@@ -337,6 +337,19 @@ RSpec.describe AttemptsApi::Tracker do
             )
           end
         end
+
+        context 'there is already an event in the session' do
+          it 'appends to the existing events' do
+            user_session['idv/attempts'] = [{ 'idv-something' => { 'user_uuid' => user.uuid } }]
+            subject.idv_enrollment_complete(reproof: false)
+            expect(user_session['idv/attempts']).to eq(
+              [
+                { 'idv-something' => { 'user_uuid' => user.uuid } },
+                { 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } },
+              ],
+            )
+          end
+        end
       end
 
       it 'does not fail if the request is missing' do
@@ -355,6 +368,33 @@ RSpec.describe AttemptsApi::Tracker do
       end
     end
 
+    context 'when historical_attempts_api_enabled is false' do
+      before do
+        allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
+      end
+
+      context 'with Devise session' do
+        let(:mock_session) { { 'warden.user.user.session' => {} } }
+
+        it 'records to redis' do
+          freeze_time do
+            subject.idv_enrollment_complete(reproof: false)
+
+            events = AttemptsApi::RedisClient.new.read_events(
+              issuer: service_provider.issuer,
+            )
+
+            expect(events.values.length).to eq(1)
+          end
+        end
+
+        it 'does not populate the historical session info' do
+          subject.idv_enrollment_complete(reproof: false)
+          expect(mock_session).to eq({ 'warden.user.user.session' => {} })
+        end
+      end
+    end
+
     context 'the attempts API is not enabled' do
       let(:attempts_api_enabled) { false }
 
@@ -369,31 +409,6 @@ RSpec.describe AttemptsApi::Tracker do
           expect(events.values.length).to eq(0)
         end
       end
-    end
-  end
-
-  context 'with a Devise session and historical_attempts_api_disabled' do
-    let(:mock_session) { { 'warden.user.user.session' => {} } }
-
-    before do
-      allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
-    end
-
-    it 'records to redis' do
-      freeze_time do
-        subject.idv_enrollment_complete(reproof: false)
-
-        events = AttemptsApi::RedisClient.new.read_events(
-          issuer: service_provider.issuer,
-        )
-
-        expect(events.values.length).to eq(1)
-      end
-    end
-
-    it 'does not populate the historical session info' do
-      subject.idv_enrollment_complete(reproof: false)
-      expect(mock_session).to eq({ 'warden.user.user.session' => {} })
     end
   end
 

--- a/spec/services/duplicate_profile_checker_spec.rb
+++ b/spec/services/duplicate_profile_checker_spec.rb
@@ -344,4 +344,170 @@ RSpec.describe DuplicateProfileChecker do
       end
     end
   end
+
+  describe '#dupe_profile_set_for_user (global detection)' do
+    before do
+      allow(IdentityConfig.store).to receive(:enable_one_account_global_detection)
+        .and_return(true)
+      profile.encrypt_pii(active_pii, user.password)
+      profile.save
+      session[:encrypted_profiles] = {
+        profile.id.to_s => SessionEncryptor.new.kms_encrypt(active_pii.to_json),
+      }
+      stub_analytics
+    end
+
+    context 'when user has facial match profile' do
+      context 'when SP is not in eligible_one_account_providers' do
+        it 'still checks for duplicates (no SP gating)' do
+          allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
+            .and_return([])
+
+          allow_any_instance_of(Idv::DuplicateSsnFinder)
+            .to receive(:duplicate_facial_match_profiles_global)
+            .and_return([])
+
+          dupe_profile_checker = DuplicateProfileChecker.new(
+            user: user,
+            user_session: session,
+            sp: sp,
+            analytics: @analytics,
+          )
+          # Should not return early — it proceeds past should_check_for_duplicates?
+          expect(dupe_profile_checker.dupe_profile_set_for_user).to be_nil
+        end
+      end
+
+      context 'when matching profiles are found globally' do
+        let(:user2) { create(:user, :fully_registered) }
+        let!(:profile2) do
+          create(
+            :profile,
+            :active,
+            :facial_match_proof,
+            user: user2,
+          )
+        end
+
+        before do
+          allow_any_instance_of(Idv::DuplicateSsnFinder)
+            .to receive(:duplicate_facial_match_profiles_global)
+            .and_return([profile2])
+        end
+
+        it 'creates a global duplicate profile set with null service_provider' do
+          dupe_profile_checker = DuplicateProfileChecker.new(
+            user: user,
+            user_session: session,
+            sp: sp,
+            analytics: @analytics,
+          )
+          dupe_profile_set = dupe_profile_checker.dupe_profile_set_for_user
+
+          expect(dupe_profile_set).to be_present
+          expect(dupe_profile_set.service_provider).to be_nil
+          expect(dupe_profile_set.profile_ids).to match_array([profile.id, profile2.id])
+          expect(@analytics).to have_logged_event(:one_account_duplicate_profile_created)
+        end
+
+        it 'closes existing SP-scoped sets for the profile' do
+          sp_scoped_set = create(
+            :duplicate_profile_set,
+            profile_ids: [profile.id, profile2.id],
+            service_provider: sp.issuer,
+          )
+
+          dupe_profile_checker = DuplicateProfileChecker.new(
+            user: user,
+            user_session: session,
+            sp: sp,
+            analytics: @analytics,
+          )
+          dupe_profile_checker.dupe_profile_set_for_user
+
+          expect(sp_scoped_set.reload.closed_at).not_to be_nil
+        end
+      end
+
+      context 'when no duplicates are found globally' do
+        before do
+          allow_any_instance_of(Idv::DuplicateSsnFinder)
+            .to receive(:duplicate_facial_match_profiles_global)
+            .and_return([])
+        end
+
+        context 'when an existing global set exists' do
+          let(:user2) { create(:user, :fully_registered) }
+          let!(:profile2) do
+            create(:profile, :active, :facial_match_proof, user: user2)
+          end
+          let!(:existing_global_set) do
+            create(
+              :duplicate_profile_set, :global,
+              profile_ids: [profile.id, profile2.id]
+            )
+          end
+
+          it 'closes the existing global set' do
+            freeze_time do
+              dupe_profile_checker = DuplicateProfileChecker.new(
+                user: user,
+                user_session: session,
+                sp: sp,
+                analytics: @analytics,
+              )
+              dupe_profile_checker.dupe_profile_set_for_user
+
+              expect(existing_global_set.reload.closed_at).to eq(Time.zone.now)
+              expect(@analytics).to have_logged_event(:one_account_duplicate_profile_closed)
+            end
+          end
+        end
+      end
+    end
+
+    context 'rollback: when global detection is disabled after being enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:enable_one_account_global_detection)
+          .and_return(false)
+        allow(IdentityConfig.store).to receive(:eligible_one_account_providers)
+          .and_return([sp.issuer])
+      end
+
+      let(:user2) { create(:user, :fully_registered) }
+      let!(:user2_identity) do
+        create(
+          :service_provider_identity,
+          user: user2,
+          service_provider: sp.issuer,
+        )
+      end
+      let!(:profile2) do
+        create(:profile, :active, :facial_match_proof, user: user2)
+      end
+
+      it 'creates SP-scoped sets again (ignoring orphaned global sets)' do
+        # Simulate an orphaned global set from when flag was on
+        create(
+          :duplicate_profile_set, :global,
+          profile_ids: [profile.id, profile2.id]
+        )
+
+        allow_any_instance_of(Idv::DuplicateSsnFinder)
+          .to receive(:duplicate_facial_match_profiles)
+          .and_return([profile2])
+
+        dupe_profile_checker = DuplicateProfileChecker.new(
+          user: user,
+          user_session: session,
+          sp: sp,
+          analytics: @analytics,
+        )
+        dupe_profile_set = dupe_profile_checker.dupe_profile_set_for_user
+
+        expect(dupe_profile_set.service_provider).to eq(sp.issuer)
+        expect(dupe_profile_set.profile_ids).to match_array([profile.id, profile2.id])
+      end
+    end
+  end
 end

--- a/spec/services/idv/duplicate_ssn_finder_spec.rb
+++ b/spec/services/idv/duplicate_ssn_finder_spec.rb
@@ -146,4 +146,90 @@ RSpec.describe Idv::DuplicateSsnFinder do
       end
     end
   end
+
+  describe '#duplicate_facial_match_profiles_global' do
+    let(:ssn) { '123-45-6789' }
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let!(:profile) do
+      create(
+        :profile,
+        idv_level: :unsupervised_with_selfie,
+        pii: { ssn: ssn },
+        user: user,
+        active: true,
+      )
+    end
+    let(:other_profile_idv_level) { :unsupervised_with_selfie }
+    let(:other_profile_ssn) { ssn }
+    let(:other_profile_active) { true }
+    let!(:other_profile) do
+      create(
+        :profile,
+        idv_level: other_profile_idv_level,
+        pii: { ssn: other_profile_ssn },
+        user: other_user,
+        active: other_profile_active,
+      )
+    end
+
+    subject { described_class.new(ssn: ssn, user: user) }
+
+    context 'when the other profile is active, has matching SSN and is at facial match level' do
+      it 'returns the matching profile regardless of service provider' do
+        expect(subject.duplicate_facial_match_profiles_global.map(&:id))
+          .to include(other_profile.id)
+      end
+    end
+
+    context 'when the other profile has no service provider identity' do
+      it 'still returns the matching profile' do
+        expect(subject.duplicate_facial_match_profiles_global.map(&:id))
+          .to include(other_profile.id)
+      end
+    end
+
+    context 'when the other profile is not at facial match IDV level' do
+      let(:other_profile_idv_level) { :legacy_unsupervised }
+
+      it 'is empty' do
+        expect(subject.duplicate_facial_match_profiles_global).to be_empty
+      end
+    end
+
+    context 'when the other profile has a different SSN' do
+      let(:other_profile_ssn) { '555-66-7788' }
+
+      it 'is empty' do
+        expect(subject.duplicate_facial_match_profiles_global).to be_empty
+      end
+    end
+
+    context 'when the other profile is not active' do
+      let(:other_profile_active) { false }
+
+      it 'is empty' do
+        expect(subject.duplicate_facial_match_profiles_global).to be_empty
+      end
+    end
+
+    context 'when multiple profiles across different SPs match' do
+      let(:third_user) { create(:user) }
+      let!(:third_profile) do
+        create(
+          :profile,
+          idv_level: :in_person,
+          pii: { ssn: ssn },
+          user: third_user,
+          active: true,
+        )
+      end
+
+      it 'returns all matching profiles' do
+        result_ids = subject.duplicate_facial_match_profiles_global.map(&:id)
+        expect(result_ids).to include(other_profile.id, third_profile.id)
+        expect(result_ids).not_to include(profile.id)
+      end
+    end
+  end
 end

--- a/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
+++ b/spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb
@@ -846,6 +846,28 @@ RSpec.describe Proofing::Resolution::Plugins::AamvaPlugin do
               )
             end
           end
+
+          context 'when aamva returns a bypassed exception' do
+            let(:proofer_result) do
+              Proofing::StateIdResult.new(
+                success: false,
+                vendor_name: 'state_id:aamva',
+                transaction_id: proofer_transaction_id,
+                exception: RuntimeError.new('ExceptionId: bypass_id'),
+              )
+            end
+            let(:proofer_result_hash) { proofer_result.to_h }
+
+            it 'returns a skipped result' do
+              allow(IdentityConfig.store).to receive(:idv_aamva_bypass_exception_ids).and_return(
+                ['test_id', 'bypass_id'],
+              )
+              call.tap do |result|
+                expect(result.success?).to eq(true)
+                expect(result.vendor_name).to eq(Idp::Constants::Vendors::AAMVA_CHECK_SKIPPED)
+              end
+            end
+          end
         end
       end
 


### PR DESCRIPTION
## User-Facing Improvements
- Doc Auth: Allow bypass aamva exception ids ([#13068](https://github.com/18F/identity-idp/pull/13068))

## Internal
-  One Account: User adds sp on duplicate profile sets ([#13011](https://github.com/18F/identity-idp/pull/13011))

## Upcoming Features
- Historical Attempts Data: Update tables for updated data storage design ([#13067](https://github.com/18F/identity-idp/pull/13067))
