### PR TITLE
LG-17552: update user session for email selection if outdated. 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -240,6 +240,21 @@ class ApplicationController < ActionController::Base
     @service_provider_request ||= ServiceProviderRequestProxy.from_uuid(params[:request_id])
   end
 
+  def selected_email_for_linked_identity
+    return if current_user.blank?
+
+    selected_email_id = user_session[:selected_email_id_for_linked_identity]
+    return if selected_email_id.blank?
+
+    current_user.confirmed_email_addresses.find_by(id: selected_email_id).tap do |email_address|
+      user_session.delete(:selected_email_id_for_linked_identity) if email_address.nil?
+    end
+  end
+
+  def selected_email_id_for_linked_identity
+    selected_email_for_linked_identity&.id
+  end
+
   def fix_broken_personal_key_url
     flash[:info] = t('account.personal_key.needs_new')
 

--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -151,8 +151,8 @@ module SamlIdpAuthConcern
   def email_address_id
     identity = current_user.identities.find_by(service_provider: sp_session[:issuer])
     return nil if !identity&.verified_single_email_attribute?
-    if user_session[:selected_email_id_for_linked_identity].present?
-      return user_session[:selected_email_id_for_linked_identity]
+    if selected_email_id_for_linked_identity.present?
+      return selected_email_id_for_linked_identity
     end
     email_id = identity&.email_address_id
     return email_id if email_id.is_a? Integer

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -98,8 +98,8 @@ module OpenidConnect
     def email_address_id
       identity = current_user.identities.find_by(service_provider: sp_session[:issuer])
       return nil if !identity&.verified_single_email_attribute?
-      if user_session[:selected_email_id_for_linked_identity].present?
-        return user_session[:selected_email_id_for_linked_identity]
+      if selected_email_id_for_linked_identity.present?
+        return selected_email_id_for_linked_identity
       end
 
       identity&.email_address_id

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -25,7 +25,7 @@ module SignUp
       send_in_person_completion_survey
       notify_user_of_connected_sp
       send_historical_events if historical_events_need_be_sent?
-      if user_session[:selected_email_id_for_linked_identity].nil?
+      if selected_email_id_for_linked_identity.nil?
         user_session[:selected_email_id_for_linked_identity] = current_user
           .last_sign_in_email_address.id
       end
@@ -62,7 +62,7 @@ module SignUp
         requested_attributes: decorated_sp_session.requested_attributes.map(&:to_sym),
         ial2_requested: ial2_requested?,
         completion_context: needs_completion_screen_reason,
-        selected_email_id: user_session[:selected_email_id_for_linked_identity],
+        selected_email_id: selected_email_id_for_linked_identity,
       )
     end
 

--- a/app/controllers/sign_up/select_email_controller.rb
+++ b/app/controllers/sign_up/select_email_controller.rb
@@ -47,11 +47,7 @@ module SignUp
     end
 
     def last_email
-      if user_session[:selected_email_id_for_linked_identity]
-        user_emails.find(user_session[:selected_email_id_for_linked_identity]).email
-      else
-        current_user.last_sign_in_email_address.email
-      end
+      selected_email_for_linked_identity&.email || current_user.last_sign_in_email_address.email
     end
 
     def verify_needs_completions_screen

--- a/app/services/displayable_pii_formatter.rb
+++ b/app/services/displayable_pii_formatter.rb
@@ -38,11 +38,8 @@ class DisplayablePiiFormatter
   private
 
   def email
-    if @selected_email_id
-      current_user.confirmed_email_addresses.find(@selected_email_id).email
-    else
+    current_user.confirmed_email_addresses.find_by(id: selected_email_id)&.email ||
       current_user.last_sign_in_email_address.email
-    end
   end
 
   def all_emails

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1105,6 +1105,33 @@ RSpec.describe OpenidConnect::AuthorizationController do
           identity.reload
           expect(identity.email_address_id).to eq(shared_email_address.id)
         end
+
+        context 'when the session email is no longer confirmed' do
+          let!(:unconfirmed_email_address) do
+            create(
+              :email_address,
+              email: 'pending@email.com',
+              user: user,
+              confirmed_at: nil,
+            )
+          end
+
+          before do
+            identity.update!(email_address_id: shared_email_address.id)
+            controller.user_session[:selected_email_id_for_linked_identity] =
+              unconfirmed_email_address.id
+          end
+
+          it 'ignores the stale session value and clears it' do
+            identity = user.identities.find_by(service_provider: service_provider.issuer)
+
+            action
+            identity.reload
+
+            expect(identity.email_address_id).to eq(shared_email_address.id)
+            expect(controller.user_session[:selected_email_id_for_linked_identity]).to be_nil
+          end
+        end
       end
 
       context 'with SP requesting a single email and all emails' do

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -268,6 +268,24 @@ RSpec.describe SignUp::CompletionsController do
         expect(response).to redirect_to account_path
       end
 
+      it 'replaces a stale selected email session value with the last sign in email' do
+        stale_email = create(:email_address, user: user, confirmed_at: nil)
+
+        stub_sign_in(user)
+        subject.session[:sp] = {
+          acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          issuer: current_sp.issuer,
+          request_url: 'http://example.com',
+        }
+        subject.user_session[:selected_email_id_for_linked_identity] = stale_email.id
+
+        patch :update
+
+        expect(subject.user_session[:selected_email_id_for_linked_identity].to_i).to eq(
+          user.last_sign_in_email_address.id,
+        )
+      end
+
       context 'with a disposable email address' do
         let(:user) { create(:user, :fully_registered, email: temporary_email) }
 

--- a/spec/controllers/sign_up/select_email_controller_spec.rb
+++ b/spec/controllers/sign_up/select_email_controller_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe SignUp::SelectEmailController do
   describe '#show' do
     subject(:response) { get :show }
 
+    let!(:unconfirmed_email_address) do
+      create(:email_address, user: user, confirmed_at: nil, email: 'pending@example.com')
+    end
+
     it 'logs analytics event' do
       stub_analytics
 
@@ -61,6 +65,20 @@ RSpec.describe SignUp::SelectEmailController do
       it 'can add email variable set to false' do
         response
         expect(assigns(:can_add_email)).to eq(false)
+      end
+    end
+
+    context 'when the session email is no longer confirmed' do
+      before do
+        controller.user_session[:selected_email_id_for_linked_identity] =
+          unconfirmed_email_address.id
+      end
+
+      it 'falls back to the last sign in email and clears the stale session value' do
+        response
+
+        expect(assigns(:last_sign_in_email_address)).to eq(user.last_sign_in_email_address.email)
+        expect(controller.user_session[:selected_email_id_for_linked_identity]).to be_nil
       end
     end
   end

--- a/spec/services/displayable_pii_formatter_spec.rb
+++ b/spec/services/displayable_pii_formatter_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe DisplayablePiiFormatter do
         expect(result.birthdate).to eq('January 1, 1990')
         expect(result.phone).to eq('+1 202-212-1000')
       end
+
+      context 'when the selected email is no longer confirmed' do
+        let(:selected_email_id) do
+          current_user.email_addresses.find { |email_address| !email_address.confirmed? }.id
+        end
+
+        it 'falls back to the last sign in email' do
+          expect(formatter.format.email).to eq(last_sign_in_email_address)
+        end
+      end
     end
 
     describe '#verified_at' do


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-17552](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17552)

## 🛠 Summary of changes

This makes it so we dont throw errors if for some reason email address isnt in the system for someone 


[LG-17552]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17552