### PR TITLE
LG-17454: Disable SP dont throw 500s (dont show to users)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -474,7 +474,7 @@ class User < ApplicationRecord
   end
 
   def connected_apps
-    identities.not_deleted.order('created_at DESC')
+    identities.not_deleted.joins(:service_provider_record).order(created_at: :desc)
   end
 
   def delete_account_bullet_key

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1774,14 +1774,21 @@ RSpec.describe User do
 
   describe '#connected_apps' do
     let(:user) { create(:user) }
-    let(:app) { create(:service_provider_identity, service_provider: 'aaa') }
+    let(:app) { create(:service_provider_identity) }
     let(:deleted_app) do
-      create(:service_provider_identity, service_provider: 'bbb', deleted_at: 5.days.ago)
+      create(:service_provider_identity, deleted_at: 5.days.ago)
+    end
+    let(:missing_service_provider_app) do
+      create(
+        :service_provider_identity,
+        service_provider_record: nil,
+        service_provider: 'ccc',
+      )
     end
 
-    before { user.identities << app << deleted_app }
+    before { user.identities << app << deleted_app << missing_service_provider_app }
 
-    it 'omits deleted apps' do
+    it 'omits deleted apps and apps with missing service providers' do
       expect(user.connected_apps).to eq([app])
     end
   end

--- a/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/connected_accounts/show.html.erb_spec.rb
@@ -100,5 +100,23 @@ RSpec.describe 'accounts/connected_accounts/show.html.erb' do
         )
       end
     end
+
+    context 'when another identity references a missing service provider' do
+      before do
+        create(
+          :service_provider_identity,
+          user:,
+          service_provider_record: nil,
+          service_provider: 'urn:gov:gsa:missing-service-provider',
+        )
+      end
+
+      it 'renders only connected apps with existing service providers' do
+        expect { render }.not_to raise_error
+
+        expect(rendered).to have_css('li', count: 1)
+        expect(rendered).to have_content(identity.display_name)
+      end
+    end
   end
 end


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-17454](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17454)

## 🛠 Summary of changes

Prevent users from failing if the SP they are using is disabled in our system. 

[LG-17454]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17454