### PR TITLE
[LG-17453] Normalize for character cases when rate limiting password reset

### DIFF
--- a/app/services/request_password_reset.rb
+++ b/app/services/request_password_reset.rb
@@ -6,7 +6,7 @@ RequestPasswordReset = RedactedStruct.new(
   allowed_members: [:request_id]
 ) do
   def perform
-    rate_limiter = RateLimiter.new(target: email, rate_limit_type: :reset_password_email)
+    rate_limiter = RateLimiter.new(target: email.downcase, rate_limit_type: :reset_password_email)
     rate_limiter.increment!
     if rate_limiter.limited?
       analytics.rate_limit_reached(limiter_type: :reset_password_email)

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RequestPasswordReset do
     let(:user) { create(:user) }
     let(:request_id) { SecureRandom.uuid }
     let(:email_address) { user.email_addresses.first }
-    let(:email) { email_address.email.downcase }
+    let(:email) { email_address.email }
 
     context 'when the user is not found' do
       it 'sends the user missing email' do
@@ -252,12 +252,13 @@ RSpec.describe RequestPasswordReset do
 
       it 'rate limits the email sending when capitalization changes between attempts' do
         max_attempts = IdentityConfig.store.reset_password_email_max_attempts
+        lowercased_email = email_address.email.downcase
         upcased_email = email_address.email.upcase
 
         (max_attempts - 1).times do
           expect do
             RequestPasswordReset.new(
-              email:,
+              email: lowercased_email,
               analytics:,
               attempts_api_tracker:,
             ).perform

--- a/spec/services/request_password_reset_spec.rb
+++ b/spec/services/request_password_reset_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RequestPasswordReset do
     let(:user) { create(:user) }
     let(:request_id) { SecureRandom.uuid }
     let(:email_address) { user.email_addresses.first }
-    let(:email) { email_address.email }
+    let(:email) { email_address.email.downcase }
 
     context 'when the user is not found' do
       it 'sends the user missing email' do
@@ -243,6 +243,34 @@ RSpec.describe RequestPasswordReset do
           ).perform
         end
           .to_not(change { user.reload.reset_password_token })
+
+        expect(analytics).to have_logged_event(
+          'Rate Limit Reached',
+          limiter_type: :reset_password_email,
+        )
+      end
+
+      it 'rate limits the email sending when capitalization changes between attempts' do
+        max_attempts = IdentityConfig.store.reset_password_email_max_attempts
+        upcased_email = email_address.email.upcase
+
+        (max_attempts - 1).times do
+          expect do
+            RequestPasswordReset.new(
+              email:,
+              analytics:,
+              attempts_api_tracker:,
+            ).perform
+          end
+            .to(change { user.reload.reset_password_token })
+        end
+
+        # extra time, rate limited using the same email string capitalized
+        RequestPasswordReset.new(
+          email: upcased_email,
+          analytics:,
+          attempts_api_tracker:,
+        ).perform
 
         expect(analytics).to have_logged_event(
           'Rate Limit Reached',


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17453](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17453)



## 🛠 Summary of changes

Currently, a user can bypass rate limiting when requesting a password reset by changing the capitalization in their provided email string.  This ensures that `JosH.alley@gsa.gov` is treated the same as `josh.alley@gsa.gov` in regards to rate limiting.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1: Lower the default rate limit in `application.yml` with the `reset_password_email_max_attempts` key.
- [ ] Step 2: Attempt the reach the rate limit but continuously requesting a password reset email at `http://localhost:3000/users/password/new`
- [ ] Step 3: Try to change the case of the email on the next attempt.  You should still be rate limited (not sent an email).


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17453]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17453