### PR TITLE
[LG-17276] Rename emails_sent in the analytics event create_new_device_alert_job_emails_sent to users_notified 

### DIFF
--- a/app/jobs/create_new_device_alert_job.rb
+++ b/app/jobs/create_new_device_alert_job.rb
@@ -4,14 +4,14 @@ class CreateNewDeviceAlertJob < ApplicationJob
   queue_as :long_running
 
   def perform(now)
-    emails_sent = 0
+    users_notified = 0
     users_signing_in_with_new_device(now).limit(1_000).find_each(batch_size: 100) do |user|
-      emails_sent += 1 if expire_sign_in_notification_timeframe_and_send_alert(user)
+      users_notified += 1 if expire_sign_in_notification_timeframe_and_send_alert(user)
     end
 
-    analytics.create_new_device_alert_job_emails_sent(count: emails_sent)
+    analytics.create_new_device_alert_job_users_notified(count: users_notified)
 
-    emails_sent
+    users_notified
   end
 
   private

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -514,8 +514,8 @@ module AnalyticsEvents
 
   # New device sign-in alerts sent after expired notification timeframe
   # @param [Integer] count Number of emails sent
-  def create_new_device_alert_job_emails_sent(count:, **extra)
-    track_event(:create_new_device_alert_job_emails_sent, count:, **extra)
+  def create_new_device_alert_job_users_notified(count:, **extra)
+    track_event(:create_new_device_alert_job_users_notified, count:, **extra)
   end
 
   # User directed to this page after TMX returns a failure

--- a/spec/jobs/create_new_device_alert_job_spec.rb
+++ b/spec/jobs/create_new_device_alert_job_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe CreateNewDeviceAlertJob do
         let(:sign_in_new_device_at) { nil }
 
         it 'disregards the user' do
-          emails_sent = CreateNewDeviceAlertJob.new.perform(now)
-          expect(emails_sent).to eq(0)
+          users_notified = CreateNewDeviceAlertJob.new.perform(now)
+          expect(users_notified).to eq(0)
         end
       end
 
@@ -39,8 +39,8 @@ RSpec.describe CreateNewDeviceAlertJob do
         let(:sign_in_new_device_at) { end_window + 1.second }
 
         it 'disregards the user' do
-          emails_sent = CreateNewDeviceAlertJob.new.perform(now)
-          expect(emails_sent).to eq(0)
+          users_notified = CreateNewDeviceAlertJob.new.perform(now)
+          expect(users_notified).to eq(0)
         end
       end
 
@@ -48,8 +48,8 @@ RSpec.describe CreateNewDeviceAlertJob do
         let(:sign_in_new_device_at) { start_window - 1.second }
 
         it 'disregards the user' do
-          emails_sent = CreateNewDeviceAlertJob.new.perform(now)
-          expect(emails_sent).to eq(0)
+          users_notified = CreateNewDeviceAlertJob.new.perform(now)
+          expect(users_notified).to eq(0)
         end
       end
 
@@ -57,8 +57,8 @@ RSpec.describe CreateNewDeviceAlertJob do
         let(:sign_in_new_device_at) { rand(start_window..end_window) }
 
         it 'sends an email for matching user' do
-          emails_sent = CreateNewDeviceAlertJob.new.perform(now)
-          expect(emails_sent).to eq(1)
+          users_notified = CreateNewDeviceAlertJob.new.perform(now)
+          expect(users_notified).to eq(1)
           email_sent_again = CreateNewDeviceAlertJob.new.perform(now)
           expect(email_sent_again).to eq(0)
         end
@@ -75,7 +75,10 @@ RSpec.describe CreateNewDeviceAlertJob do
 
           alert.perform(now)
 
-          expect(analytics).to have_logged_event(:create_new_device_alert_job_emails_sent, count: 1)
+          expect(analytics).to have_logged_event(
+            :create_new_device_alert_job_users_notified,
+            count: 1,
+          )
         end
       end
     end
@@ -87,8 +90,8 @@ RSpec.describe CreateNewDeviceAlertJob do
         let(:sign_in_new_device_at) { nil }
 
         it 'disregards the user' do
-          emails_sent = CreateNewDeviceAlertJob.new.perform(now)
-          expect(emails_sent).to eq(0)
+          users_notified = CreateNewDeviceAlertJob.new.perform(now)
+          expect(users_notified).to eq(0)
         end
       end
 
@@ -96,8 +99,8 @@ RSpec.describe CreateNewDeviceAlertJob do
         let(:sign_in_new_device_at) { end_window + 1.second }
 
         it 'disregards the user' do
-          emails_sent = CreateNewDeviceAlertJob.new.perform(now)
-          expect(emails_sent).to eq(0)
+          users_notified = CreateNewDeviceAlertJob.new.perform(now)
+          expect(users_notified).to eq(0)
         end
       end
 
@@ -105,8 +108,8 @@ RSpec.describe CreateNewDeviceAlertJob do
         let(:sign_in_new_device_at) { end_window - rand(60).seconds }
 
         it 'sends an email for matching user' do
-          emails_sent = CreateNewDeviceAlertJob.new.perform(now)
-          expect(emails_sent).to eq(1)
+          users_notified = CreateNewDeviceAlertJob.new.perform(now)
+          expect(users_notified).to eq(1)
           email_sent_again = CreateNewDeviceAlertJob.new.perform(now)
           expect(email_sent_again).to eq(0)
         end
@@ -123,7 +126,10 @@ RSpec.describe CreateNewDeviceAlertJob do
 
           alert.perform(now)
 
-          expect(analytics).to have_logged_event(:create_new_device_alert_job_emails_sent, count: 1)
+          expect(analytics).to have_logged_event(
+            :create_new_device_alert_job_users_notified,
+            count: 1,
+          )
         end
       end
     end


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-17276](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17276)



## 🛠 Summary of changes
Simply renaming variable names to better represent what they are being used for.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17276]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17276