### PR TITLE
Add historical events to queue

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -213,6 +213,9 @@ module Idv
 
       current_user.active_profile.create_user_proofing_event(password:, attempt_events:)
 
+      # TODO:Historical Attempts Data: Save encrypted proofing events to
+      # the user session idv/encrypted_proofing_events so a user
+      # who has just identity proofed has available events
       user_session.delete('idv/attempts')
     end
 

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -142,10 +142,14 @@ module SignUp
     end
 
     def send_historical_events
-      # TODO: send to redis queue
+      # TODO:Historical Attempts Data: Should we extend the Pii::Cacher?
+      encrypted_proofing_events = user_session[:encrypted_proofing_events]
+      return unless encrypted_proofing_events.present?
 
-      user_proofing_event.add_sp_sent(current_sp.id)
-    end
+      historical_attempts = JSON.parse(
+        SessionEncryptor.new.kms_decrypt(encrypted_proofing_events),
+      )
+      AttemptsApi::Tracker.write_existing_user_events(historical_attempts:, sp: current_sp)
 
       existing_user_proofing_event.add_sp_sent(current_sp.id)
     end

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -3,6 +3,7 @@
 module SignUp
   class CompletionsController < ApplicationController
     include SecureHeadersConcern
+    include Idv::HistoricalAttemptsConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_identity_verified, if: :identity_proofing_required?
@@ -146,21 +147,7 @@ module SignUp
       user_proofing_event.add_sp_sent(current_sp.id)
     end
 
-    def historical_events_need_be_sent?
-      return false unless IdentityConfig.store.historical_attempts_api_enabled
-      return false unless current_sp.attempts_api_enabled?
-      return false unless ial2_requested?
-      return false unless user_proofing_event.present?
-
-      return !sent_to_aaca?
-    end
-
-    def sent_to_aaca?
-      user_proofing_event&.already_sent_to_sp?(current_sp.id)
-    end
-
-    def user_proofing_event
-      @user_proofing_event ||= current_user&.active_profile&.user_proofing_event
+      existing_user_proofing_event.add_sp_sent(current_sp.id)
     end
 
     def pii

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -26,6 +26,36 @@ module AttemptsApi
 
     include TrackerEvents
 
+    def self.write_existing_user_events(sp:, historical_attempts: [])
+      historical_attempts.each do |saved_event|
+        # TODO:Historical attempts API:
+        # Clean up the data structure being used when including the whole event data
+        # And make it work with a tracker instance method.
+        event_data = saved_event.values[0]
+
+        event = AttemptEvent.new(
+          event_type: saved_event.keys[0],
+          session_id: event_data['session_id'],
+          occurred_at: event_data['occurred_at'] || Time.zone.now,
+          event_metadata: event_data['event_metadata'],
+          jti: event_data['jti'] || SecureRandom.uuid,
+          # iat: event_data['iat'],
+        )
+
+        jwe = event.to_jwe(
+          issuer: sp.issuer,
+          public_key: sp.attempts_public_key,
+        )
+
+        AttemptsApi::RedisClient.new.write_event(
+          event_key: event.jti,
+          jwe:,
+          timestamp: event.occurred_at,
+          issuer: sp.issuer,
+        )
+      end
+    end
+
     def track_event(event_type, metadata = {})
       return unless should_track?(event_type)
 
@@ -75,7 +105,7 @@ module AttemptsApi
 
       session['warden.user.user.session']['idv/attempts'] ||= []
       session['warden.user.user.session']['idv/attempts'].push(
-        event.event_type => { 'user_uuid' => user.uuid },
+        event.event_type => { 'user_uuid' => user.uuid, 'jti' => event.jti },
       )
     end
 

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -27,7 +27,7 @@ module AttemptsApi
     include TrackerEvents
 
     def track_event(event_type, metadata = {})
-      return unless will_track?(event_type)
+      return unless should_track?(event_type)
 
       user_id = metadata.delete(:user_id)
 
@@ -42,9 +42,9 @@ module AttemptsApi
         event_metadata: event_metadata(event_type:, metadata:),
       )
 
-      log_history(event) if will_log_history?(event_type)
+      log_history(event) if should_log_history?(event_type)
 
-      return unless will_send_event?
+      return unless should_send_event?
 
       redis_client.write_event(
         event_key: event.jti,
@@ -151,19 +151,19 @@ module AttemptsApi
       Digest::SHA1.hexdigest(user&.unique_session_id)
     end
 
-    def will_track?(event_type)
+    def should_track?(event_type)
       return false unless IdentityConfig.store.attempts_api_enabled
 
-      will_send_event? || will_log_history?(event_type)
+      should_send_event? || should_log_history?(event_type)
     end
 
-    def will_log_history?(event_type)
+    def should_log_history?(event_type)
       return false unless IdentityConfig.store.historical_attempts_api_enabled
 
       event_type.start_with?(*LOG_HISTORY_PREFIXES)
     end
 
-    def will_send_event?
+    def should_send_event?
       @enabled_for_session
     end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -2,10 +2,9 @@ require 'rails_helper'
 
 RSpec.describe SignUp::CompletionsController do
   let(:temporary_email) { 'name@temporary.com' }
+  let(:current_sp) { create(:service_provider) }
 
   describe '#show' do
-    let(:current_sp) { create(:service_provider) }
-
     context 'user signed in, sp info present' do
       before do
         stub_analytics
@@ -203,7 +202,6 @@ RSpec.describe SignUp::CompletionsController do
 
   describe '#update' do
     let(:now) { Time.zone.now.change(usec: 0) }
-    let(:current_sp) { create(:service_provider) }
 
     before do
       stub_analytics
@@ -397,8 +395,8 @@ RSpec.describe SignUp::CompletionsController do
       context 'historical attempts api is enabled' do
         let(:profile) { create(:profile, :verified, :active) }
         let(:user) { create(:user, profiles: [profile]) }
-        let(:sp) { create(:service_provider, :idv, :active) }
-        let(:allowed_attempts_providers) { [{ 'issuer' => sp.issuer }] }
+        let(:current_sp) { create(:service_provider, :idv, :active) }
+        let(:allowed_attempts_providers) { [{ 'issuer' => current_sp.issuer }] }
 
         before do
           allow(IdentityConfig.store).to receive_messages(
@@ -431,7 +429,7 @@ RSpec.describe SignUp::CompletionsController do
             stub_sign_in(user)
 
             subject.session[:sp] = {
-              issuer: sp.issuer,
+              issuer: current_sp.issuer,
               acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
               request_url: 'http://example.com',
               requested_attributes: %w[email first_name verified_at],
@@ -452,19 +450,20 @@ RSpec.describe SignUp::CompletionsController do
               end
 
               it 'updates the associated user proofing event' do
-                expect(proofing_event.service_provider_ids_sent).to_not include(sp.id)
+                expect(proofing_event.service_provider_ids_sent).to_not include(current_sp.id)
                 patch :update
 
                 proofing_event.reload
                 expect(AttemptsApi::Tracker).to have_received(:write_existing_user_events).with(
-                  idv_attempts,
+                  historical_attempts: JSON.parse(idv_attempts),
+                  sp: current_sp,
                 )
-                expect(proofing_event.service_provider_ids_sent).to include(sp.id)
+                expect(proofing_event.service_provider_ids_sent).to include(current_sp.id)
               end
             end
 
             context 'user proofing events have already been sent to this SP' do
-              let(:service_provider_ids_sent) { [sp.id] }
+              let(:service_provider_ids_sent) { [current_sp.id] }
 
               it 'does not update the user proofing event' do
                 patch :update
@@ -472,7 +471,7 @@ RSpec.describe SignUp::CompletionsController do
                 expect(AttemptsApi::Tracker).to_not have_received(:write_existing_user_events)
 
                 proofing_event.reload
-                expect(proofing_event.service_provider_ids_sent).to eq([sp.id])
+                expect(proofing_event.service_provider_ids_sent).to eq([current_sp.id])
               end
             end
           end
@@ -485,7 +484,7 @@ RSpec.describe SignUp::CompletionsController do
 
               expect(AttemptsApi::Tracker).to_not have_received(:write_existing_user_events)
               expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
-                .to_not include(sp.issuer)
+                .to_not include(current_sp.issuer)
             end
           end
         end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -398,89 +398,36 @@ RSpec.describe SignUp::CompletionsController do
         let(:profile) { create(:profile, :verified, :active) }
         let(:user) { create(:user, profiles: [profile]) }
         let(:sp) { create(:service_provider, :idv, :active) }
+        let(:allowed_attempts_providers) { [{ 'issuer' => sp.issuer }] }
 
         before do
           allow(IdentityConfig.store).to receive_messages(
             attempts_api_enabled: true,
             historical_attempts_api_enabled: true,
+            allowed_attempts_providers:,
           )
         end
 
-        context 'service_provider is an allowed attempts provider' do
-          before do
-            allow(IdentityConfig.store).to receive(:allowed_attempts_providers)
-              .and_return([{ 'issuer' => sp.issuer }])
-          end
+        context 'user has existing proofing events' do
+          let(:service_provider_ids_sent) { [] }
 
-          context 'user proofing events have not been sent to this SP' do
-            let(:proofing_event) do
-              create(
-                :user_proofing_event,
-                :existing,
-                profile_id: profile.id,
-              )
-            end
-
-            it 'updates the associated user proofing event' do
-              stub_sign_in(user)
-
-              subject.session[:sp] = {
-                issuer: sp.issuer,
-                acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-                request_url: 'http://example.com',
-                requested_attributes: %w[email first_name verified_at],
-              }
-
-              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
-                .to_not include(sp.id)
-              patch :update
-              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
-                .to include(sp.id)
-            end
-          end
-
-          context 'user proofing events have already been sent to this SP' do
-            let(:proofing_event) do
-              create(
-                :user_proofing_event,
-                :existing,
-                profile_id: profile.id,
-                service_provider_ids_sent: [sp.id],
-              )
-            end
-
-            it 'does not update the user proofing event' do
-              stub_sign_in(user)
-
-              subject.session[:sp] = {
-                issuer: sp.issuer,
-                acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
-                request_url: 'http://example.com',
-                requested_attributes: %w[email first_name verified_at],
-              }
-
-              patch :update
-              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
-                .to include(sp.id).once
-            end
-          end
-        end
-
-        context 'issuer is not an allowed attempts provider' do
           let(:proofing_event) do
             create(
               :user_proofing_event,
               :existing,
               profile_id: profile.id,
+              service_provider_ids_sent:,
             )
+          end
+          let(:idv_attempts) do
+            [
+              { 'idv-ssn-submitted' => { 'user_uuid' => user.uuid } },
+            ].to_json
           end
 
           before do
-            allow(IdentityConfig.store).to receive(:allowed_attempts_providers)
-              .and_return([])
-          end
+            allow(AttemptsApi::Tracker).to receive(:write_existing_user_events)
 
-          it 'does not update the user proofing event' do
             stub_sign_in(user)
 
             subject.session[:sp] = {
@@ -490,10 +437,56 @@ RSpec.describe SignUp::CompletionsController do
               requested_attributes: %w[email first_name verified_at],
             }
 
-            patch :update
+            kms_encrypted_events = SessionEncryptor.new.kms_encrypt(idv_attempts)
+            subject.user_session[:encrypted_proofing_events] = kms_encrypted_events
+          end
 
-            expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
-              .to_not include(sp.issuer)
+          context 'service_provider is an allowed attempts provider' do
+            context 'user proofing events have not been sent to this SP' do
+              let(:proofing_event) do
+                create(
+                  :user_proofing_event,
+                  :existing,
+                  profile_id: profile.id,
+                )
+              end
+
+              it 'updates the associated user proofing event' do
+                expect(proofing_event.service_provider_ids_sent).to_not include(sp.id)
+                patch :update
+
+                proofing_event.reload
+                expect(AttemptsApi::Tracker).to have_received(:write_existing_user_events).with(
+                  idv_attempts,
+                )
+                expect(proofing_event.service_provider_ids_sent).to include(sp.id)
+              end
+            end
+
+            context 'user proofing events have already been sent to this SP' do
+              let(:service_provider_ids_sent) { [sp.id] }
+
+              it 'does not update the user proofing event' do
+                patch :update
+
+                expect(AttemptsApi::Tracker).to_not have_received(:write_existing_user_events)
+
+                proofing_event.reload
+                expect(proofing_event.service_provider_ids_sent).to eq([sp.id])
+              end
+            end
+          end
+
+          context 'issuer is not an allowed attempts provider' do
+            let(:allowed_attempts_providers) { [] }
+
+            it 'does not update the user proofing event' do
+              patch :update
+
+              expect(AttemptsApi::Tracker).to_not have_received(:write_existing_user_events)
+              expect(UserProofingEvent.find(proofing_event.id).service_provider_ids_sent)
+                .to_not include(sp.issuer)
+            end
           end
         end
       end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -452,4 +452,39 @@ RSpec.describe AttemptsApi::Tracker do
       expect(test_failure_reason).to eq(mock_error_message)
     end
   end
+
+  describe '#self.write_existing_user_events' do
+    let(:sp) { service_provider }
+    let(:mock_session) { { 'warden.user.user.session' => {} } }
+    let(:user_session) { mock_session['warden.user.user.session'] }
+    let(:redis_client) { double AttemptsApi::RedisClient }
+    let(:time) { Time.zone.now }
+
+    before do
+      allow(request).to receive(:session).and_return(mock_session)
+
+      allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(true)
+      subject.idv_enrollment_complete(reproof: false)
+      subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
+      allow(Time).to receive(:zone_now).and_return(time)
+    end
+
+    it 'writes existing user events to redis' do
+      expect(AttemptsApi::RedisClient).to receive(:new).and_return(redis_client)
+      expect_any_instance_of(AttemptsApi::AttemptEvent).to receive(:to_jwe).and_return('jwe_data')
+
+      event_data = user_session['idv/attempts'].first.values[0]
+      expect(redis_client).to receive(:write_event).with(
+        event_key: event_data['jti'],
+        jwe: 'jwe_data',
+        timestamp: event_data['occurred_at'],
+        issuer: sp.issuer,
+      )
+
+      described_class.write_existing_user_events(
+        sp:,
+        historical_attempts: user_session['idv/attempts'],
+      )
+    end
+  end
 end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -251,8 +251,8 @@ RSpec.describe AttemptsApi::Tracker do
           allow(request).to receive(:session).and_return(mock_session)
         end
 
-        context 'it is an event prefixed with "idv"' do
-          it 'populates the session info' do
+        context 'when an event prefixed with "idv-" is tracked' do
+          it 'populates the session info with that event data' do
             subject.idv_enrollment_complete(reproof: false)
 
             event = user_session['idv/attempts'].first
@@ -262,7 +262,7 @@ RSpec.describe AttemptsApi::Tracker do
             )
           end
 
-          it 'records to redis' do
+          it 'records the event to redis' do
             freeze_time do
               subject.idv_enrollment_complete(reproof: false)
 
@@ -275,13 +275,13 @@ RSpec.describe AttemptsApi::Tracker do
           end
         end
 
-        context 'it is an event not prefixed with "idv"' do
-          it 'does not populate the session info' do
+        context 'when an event not prefixed with "idv" is tracked' do
+          it 'does not populate the event data into the session' do
             subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
             expect(user_session).to eq({})
           end
 
-          it 'records to redis' do
+          it 'records the event to redis' do
             freeze_time do
               subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
 
@@ -294,8 +294,8 @@ RSpec.describe AttemptsApi::Tracker do
           end
         end
 
-        context 'both prefixed and not prefixed events are recorded' do
-          it 'does not populate the event is not prefixed with idv-' do
+        context 'both prefixed and not prefixed events are tracked' do
+          it 'only populates the event prefixed with idv- in the session' do
             subject.idv_enrollment_complete(reproof: false)
             subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
 
@@ -307,7 +307,7 @@ RSpec.describe AttemptsApi::Tracker do
             )
           end
 
-          it 'records both to redis' do
+          it 'records both events to redis' do
             freeze_time do
               subject.idv_enrollment_complete(reproof: false)
 

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -239,6 +239,9 @@ RSpec.describe AttemptsApi::Tracker do
       before do
         allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(true)
       end
+      let(:secure_random_regex_pattern) do
+        /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
+      end
 
       context 'with Devise session' do
         let(:mock_session) { { 'warden.user.user.session' => {} } }
@@ -251,8 +254,11 @@ RSpec.describe AttemptsApi::Tracker do
         context 'it is an event prefixed with "idv"' do
           it 'populates the session info' do
             subject.idv_enrollment_complete(reproof: false)
-            expect(user_session['idv/attempts']).to eq(
-              [{ 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } }],
+
+            event = user_session['idv/attempts'].first
+            expect(event['idv-enrollment-complete']['user_uuid']).to eq(user.uuid)
+            expect(event['idv-enrollment-complete']['jti']).to match(
+              secure_random_regex_pattern,
             )
           end
 
@@ -292,8 +298,12 @@ RSpec.describe AttemptsApi::Tracker do
           it 'does not populate the event is not prefixed with idv-' do
             subject.idv_enrollment_complete(reproof: false)
             subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
-            expect(user_session['idv/attempts']).to eq(
-              [{ 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } }],
+
+            expect(user_session['idv/attempts'].count).to be(1)
+            event = user_session['idv/attempts'].first
+            expect(event['idv-enrollment-complete']['user_uuid']).to eq(user.uuid)
+            expect(event['idv-enrollment-complete']['jti']).to match(
+              secure_random_regex_pattern,
             )
           end
 
@@ -332,8 +342,11 @@ RSpec.describe AttemptsApi::Tracker do
 
           it 'still populates the session info' do
             subject.idv_enrollment_complete(reproof: false)
-            expect(user_session['idv/attempts']).to eq(
-              [{ 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } }],
+
+            event = user_session['idv/attempts'].first
+            expect(event['idv-enrollment-complete']['user_uuid']).to eq(user.uuid)
+            expect(event['idv-enrollment-complete']['jti']).to match(
+              secure_random_regex_pattern,
             )
           end
         end
@@ -342,11 +355,13 @@ RSpec.describe AttemptsApi::Tracker do
           it 'appends to the existing events' do
             user_session['idv/attempts'] = [{ 'idv-something' => { 'user_uuid' => user.uuid } }]
             subject.idv_enrollment_complete(reproof: false)
-            expect(user_session['idv/attempts']).to eq(
-              [
-                { 'idv-something' => { 'user_uuid' => user.uuid } },
-                { 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } },
-              ],
+
+            event = user_session['idv/attempts'].first
+            expect(event['idv-something']['user_uuid']).to eq(user.uuid)
+            event2 = user_session['idv/attempts'][1]
+            expect(event2['idv-enrollment-complete']['user_uuid']).to eq(user.uuid)
+            expect(event2['idv-enrollment-complete']['jti']).to match(
+              secure_random_regex_pattern,
             )
           end
         end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -466,25 +466,27 @@ RSpec.describe AttemptsApi::Tracker do
       allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(true)
       subject.idv_enrollment_complete(reproof: false)
       subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
-      allow(Time).to receive(:zone_now).and_return(time)
     end
 
     it 'writes existing user events to redis' do
-      expect(AttemptsApi::RedisClient).to receive(:new).and_return(redis_client)
-      expect_any_instance_of(AttemptsApi::AttemptEvent).to receive(:to_jwe).and_return('jwe_data')
+      freeze_time do
+        allow(Time).to receive(:zone_now).and_return(time)
+        expect(AttemptsApi::RedisClient).to receive(:new).and_return(redis_client)
+        expect_any_instance_of(AttemptsApi::AttemptEvent).to receive(:to_jwe).and_return('jwe_data')
 
-      event_data = user_session['idv/attempts'].first.values[0]
-      expect(redis_client).to receive(:write_event).with(
-        event_key: event_data['jti'],
-        jwe: 'jwe_data',
-        timestamp: event_data['occurred_at'],
-        issuer: sp.issuer,
-      )
+        event_data = user_session['idv/attempts'].first.values[0]
+        expect(redis_client).to receive(:write_event).with(
+          event_key: event_data['jti'],
+          jwe: 'jwe_data',
+          timestamp: time,
+          issuer: sp.issuer,
+        )
 
-      described_class.write_existing_user_events(
-        sp:,
-        historical_attempts: user_session['idv/attempts'],
-      )
+        described_class.write_existing_user_events(
+          sp:,
+          historical_attempts: user_session['idv/attempts'],
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 92](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/92)

## 🛠 Summary of changes
This ticket wires the historical attempts events that have been saved and encrypted into s3/the user session into the Redis queue.

There are a couple of open TODOs that came up in the course of this code change.
1. We need to ensure that the historical events are cached as soon as they are saved
2. Should we extend the Pii::Cacher to encrypt/decrypt the events in the session? It is doing the same work, but very specifically related to the PII bundle
3. When we are working with the full event metadata, there is probably a lot of cleanup possible to create a tracker object and use existing events, rather than doing it all in one method. But that's too complicated while working with a reduced payload.

Code changes:
- Cleans up some specs/method names
- Includes the HistoricalAttemptsConcern in the CompletionsController to reuse methods
- decrypts historical attempt events from the user session
- Adds them to the Redis queue


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
Setup:
- Set up the SAML and OIDC sample apps locally. 
- OIDC should be set up to be a consumer of the Attempts API, SAML should not. Instructions [here](https://docs.google.com/document/d/13493HHf2zkGgxmCP5ibNTpl1CXd1XOgSawn2Q0sGpUU/edit?tab=t.0#heading=h.vgastpg18oy5)

- [ ] Navigate to the SAML app (http://localhost:4567)
- [ ] Select the "Level of Service" dropdown. 
- [ ] Select "Identity-Verified"
- [ ] Click "Sign in"
- [ ] Create a new account
- [ ] Consent to sharing
- [ ] Sign out of Login.gov (this is important for it to work, see the first TODO above)
- [ ] Navigate to the OIDC sample app (http://localhost:9292/)
- [ ] Select the "Level of Service" dropdown. 
- [ ] Select "Identity-Verified"
- [ ] Click "Sign in"
- [ ] Log in via the account you just made
- [ ] Consent to sending your data back to the OIDC sample app
- [ ] Navigate to the Attemps Api viewer (http://localhost:9292/attempts-api)
- [ ] You should see some events like the below screenshot!

<img width="1029" height="674" alt="Screenshot of historical attempts events populated" src="https://github.com/user-attachments/assets/2b42e344-4b10-4a40-acd3-9c2120cf1e8c" />

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
