### PR TITLE
Update S3 storage method to match local storage method

### DIFF
--- a/app/services/encrypted_doc_storage/attempt_data_retriever.rb
+++ b/app/services/encrypted_doc_storage/attempt_data_retriever.rb
@@ -7,7 +7,7 @@ module EncryptedDocStorage
     end
 
     def retrieve_user_proofing_events(file_path:, file_name:)
-      storage.retrieve(file_path:, file_name:)
+      storage.retrieve_attempt_object(file_path:, file_name:)
     end
 
     private

--- a/app/services/encrypted_doc_storage/local_storage.rb
+++ b/app/services/encrypted_doc_storage/local_storage.rb
@@ -20,7 +20,7 @@ module EncryptedDocStorage
       end
     end
 
-    def retrieve(file_path:, file_name:)
+    def retrieve_attempt_object(file_path:, file_name:)
       full_path = tmp_attempt_events_dir.join(file_path, file_name)
 
       File.read(full_path) if File.exist?(full_path)

--- a/app/services/encrypted_doc_storage/s3_storage.rb
+++ b/app/services/encrypted_doc_storage/s3_storage.rb
@@ -22,7 +22,7 @@ module EncryptedDocStorage
 
     def retrieve_attempt_object(file_path:, file_name:)
       full_path = "#{file_path}/#{file_name}"
-      
+
       s3_client.get_object(
         bucket:,
         key: full_path,

--- a/app/services/encrypted_doc_storage/s3_storage.rb
+++ b/app/services/encrypted_doc_storage/s3_storage.rb
@@ -20,10 +20,12 @@ module EncryptedDocStorage
       )
     end
 
-    def retrieve_attempt_object(path:)
+    def retrieve_attempt_object(file_path:, file_name:)
+      full_path = "#{file_path}/#{file_name}"
+      
       s3_client.get_object(
         bucket:,
-        key: path,
+        key: full_path,
       )
     end
 

--- a/spec/services/encrypted_doc_storage/attempt_data_retriever_spec.rb
+++ b/spec/services/encrypted_doc_storage/attempt_data_retriever_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe EncryptedDocStorage::AttemptDataRetriever do
     end
 
     it 'defaults to retrieving events from local storage' do
-      expect(local_storage).to receive(:retrieve).with(file_path:, file_name:)
+      expect(local_storage).to receive(:retrieve_attempt_object).with(file_path:, file_name:)
       subject.retrieve_user_proofing_events(file_path:, file_name:)
     end
 
@@ -24,7 +24,7 @@ RSpec.describe EncryptedDocStorage::AttemptDataRetriever do
       end
 
       it 'retrieves events from S3 storage' do
-        expect(s3_storage).to receive(:retrieve).with(file_path:, file_name:)
+        expect(s3_storage).to receive(:retrieve_attempt_object).with(file_path:, file_name:)
         subject.retrieve_user_proofing_events(file_path:, file_name:)
       end
     end

--- a/spec/services/encrypted_doc_storage/local_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/local_storage_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe EncryptedDocStorage::LocalStorage do
         encrypted_attempt_events:,
       )
 
-      result = EncryptedDocStorage::LocalStorage.new.retrieve(file_path: path, file_name: name)
+      result = EncryptedDocStorage::LocalStorage.new.retrieve_attempt_object(file_path: path, file_name: name)
 
       # cleanup
       File.delete(Rails.root.join('tmp', 'encrypted_attempt_events', path, name))

--- a/spec/services/encrypted_doc_storage/local_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/local_storage_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe EncryptedDocStorage::LocalStorage do
         encrypted_attempt_events:,
       )
 
-      result = EncryptedDocStorage::LocalStorage.new.retrieve_attempt_object(file_path: path, file_name: name)
+      result = EncryptedDocStorage::LocalStorage.new.retrieve_attempt_object(
+        file_path: path, file_name: name,
+      )
 
       # cleanup
       File.delete(Rails.root.join('tmp', 'encrypted_attempt_events', path, name))

--- a/spec/services/encrypted_doc_storage/s3_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/s3_storage_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe EncryptedDocStorage::S3Storage do
 
     describe '#retrieve_attempt_object' do
       let(:stubbed_s3_client) { Aws::S3::Client.new(stub_responses: true) }
-      let(:name) { SecureRandom.uuid }
-      let(:path) { 'attempt_events/123abc' }
+      let(:file_name) { SecureRandom.uuid }
+      let(:file_path) { 'attempt_events/123abc' }
       let(:encrypted_attempt_events) { 'abcdefg' }
 
       before do
@@ -62,11 +62,11 @@ RSpec.describe EncryptedDocStorage::S3Storage do
       end
 
       it 'retrieves the attempt events from S3' do
-        subject.retrieve_attempt_object(path:)
+        subject.retrieve_attempt_object(file_path:, file_name:)
 
         expect(stubbed_s3_client).to have_received(:get_object).with(
           bucket: IdentityConfig.store.encrypted_document_storage_s3_bucket,
-          key: path,
+          key: "#{file_path}/#{file_name}",
         )
       end
     end

--- a/spec/services/encrypted_doc_storage/s3_storage_spec.rb
+++ b/spec/services/encrypted_doc_storage/s3_storage_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe EncryptedDocStorage::S3Storage do
       let(:stubbed_s3_client) { Aws::S3::Client.new(stub_responses: true) }
       let(:file_name) { SecureRandom.uuid }
       let(:file_path) { 'attempt_events/123abc' }
-      let(:encrypted_attempt_events) { 'abcdefg' }
 
       before do
         allow(subject).to receive(:s3_client).and_return(stubbed_s3_client)


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 92](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/92)

## 🛠 Summary of changes

This code unlocks the data fetching in `dev` environment. The retrieval methods didn't match, meaning that attempts to retrieve the data would not be successful.



<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
