### PR TITLE
Save full event

### DIFF
--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -98,9 +98,22 @@ module AttemptsApi
     def log_history(event)
       return unless session && session['warden.user.user.session']
 
+      if IdentityConfig.store.historical_attempts_pii_enabled
+        event_data = event.as_json
+      else
+        event_data = {
+          'event_type' => event.event_type,
+          'jti' => event.jti,
+          'event_metadata' => {
+            user_uuid: event.event_metadata[:user_uuid],
+          },
+        }
+
+      end
+
       session['warden.user.user.session']['idv/attempts'] ||= []
       session['warden.user.user.session']['idv/attempts'].push(
-        event.as_json,
+        event_data,
       )
     end
 

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -27,19 +27,14 @@ module AttemptsApi
     include TrackerEvents
 
     def self.write_existing_user_events(sp:, historical_attempts: [])
-      historical_attempts.each do |saved_event|
-        # TODO:Historical attempts API:
-        # Clean up the data structure being used when including the whole event data
-        # And make it work with a tracker instance method.
-        event_data = saved_event.values[0]
-
+      historical_attempts.each do |event_data|
         event = AttemptEvent.new(
-          event_type: saved_event.keys[0],
+          event_type: event_data['event_type'],
           session_id: event_data['session_id'],
-          occurred_at: event_data['occurred_at'] || Time.zone.now,
+          occurred_at: event_data['occurred_at'],
           event_metadata: event_data['event_metadata'],
-          jti: event_data['jti'] || SecureRandom.uuid,
-          # iat: event_data['iat'],
+          jti: event_data['jti'],
+          iat: event_data['iat'],
         )
 
         jwe = event.to_jwe(
@@ -105,7 +100,7 @@ module AttemptsApi
 
       session['warden.user.user.session']['idv/attempts'] ||= []
       session['warden.user.user.session']['idv/attempts'].push(
-        event.event_type => { 'user_uuid' => user.uuid, 'jti' => event.jti },
+        event.as_json,
       )
     end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -198,6 +198,7 @@ gpo_designated_receiver_pii: '{}'
 gpo_max_profile_age_to_send_letter_in_days: 30
 hide_phone_mfa_signup: false
 historical_attempts_api_enabled: false
+historical_attempts_pii_enabled: false
 historical_attempts_s3_storage_enabled: false
 hmac_fingerprinter_key:
 hmac_fingerprinter_key_queue: '[]'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -214,6 +214,7 @@ module IdentityConfig
     config.add(:gpo_max_profile_age_to_send_letter_in_days, type: :integer)
     config.add(:hide_phone_mfa_signup, type: :boolean)
     config.add(:historical_attempts_api_enabled, type: :boolean)
+    config.add(:historical_attempts_pii_enabled, type: :boolean)
     config.add(:historical_attempts_s3_storage_enabled, type: :boolean)
     config.add(:hmac_fingerprinter_key, type: :string)
     config.add(:hmac_fingerprinter_key_queue, type: :json)

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1466,7 +1466,12 @@ RSpec.describe Profile do
       FileUtils.rm_rf(dir_path) if Dir.exist?(dir_path)
     end
 
-    let(:attempt_events) { [{ 'idv-ssn-submitted' => { 'user_uuid' => user.uuid } }] }
+    let(:attempt_events) do
+      [{ 'jti' => 'some-jti',
+         'event_metadata' => { 'user_uuid' => user.uuid },
+         'event_type' => 'idv-ssn-submitted' }]
+    end
+
     it 'decrypts user proofing events' do
       profile.create_user_proofing_event(
         password: 'password',

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -236,9 +236,14 @@ RSpec.describe AttemptsApi::Tracker do
     end
 
     context 'when historical_attempts_api_enabled is true' do
+      let(:historical_attempts_pii_enabled) { true }
       before do
-        allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(true)
+        allow(IdentityConfig.store).to receive_messages(
+          historical_attempts_api_enabled: true,
+          historical_attempts_pii_enabled:,
+        )
       end
+
       let(:secure_random_regex_pattern) do
         /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
       end
@@ -369,6 +374,18 @@ RSpec.describe AttemptsApi::Tracker do
             expect(event_data2['event_metadata']['user_uuid']).to eq(agency_uuid)
             expect(event_data2['jti']).to match(secure_random_regex_pattern)
             expect(event_data2['event_type']).to eq('idv-enrollment-complete')
+          end
+        end
+
+        context 'when historical_attempts_pii_enabled is false' do
+          let(:historical_attempts_pii_enabled) { false }
+
+          it 'does not populate the historical session info' do
+            subject.idv_enrollment_complete(reproof: false)
+            event_data = user_session['idv/attempts'].first
+
+            expect(event_data['event_metadata']).to eq({ user_uuid: agency_uuid })
+            expect(event_data['event_type']).to eq('idv-enrollment-complete')
           end
         end
       end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -246,6 +246,9 @@ RSpec.describe AttemptsApi::Tracker do
       context 'with Devise session' do
         let(:mock_session) { { 'warden.user.user.session' => {} } }
         let(:user_session) { mock_session['warden.user.user.session'] }
+        let(:agency_uuid) do
+          AgencyIdentityLinker.for(user:, service_provider:, skip_create: false).uuid
+        end
 
         before do
           allow(request).to receive(:session).and_return(mock_session)
@@ -255,11 +258,10 @@ RSpec.describe AttemptsApi::Tracker do
           it 'populates the session info with that event data' do
             subject.idv_enrollment_complete(reproof: false)
 
-            event = user_session['idv/attempts'].first
-            expect(event['idv-enrollment-complete']['user_uuid']).to eq(user.uuid)
-            expect(event['idv-enrollment-complete']['jti']).to match(
-              secure_random_regex_pattern,
-            )
+            event_data = user_session['idv/attempts'].first
+            expect(event_data['event_metadata']['user_uuid']).to eq(agency_uuid)
+            expect(event_data['jti']).to match(secure_random_regex_pattern)
+            expect(event_data['event_type']).to eq('idv-enrollment-complete')
           end
 
           it 'records the event to redis' do
@@ -300,11 +302,10 @@ RSpec.describe AttemptsApi::Tracker do
             subject.user_registration_email_confirmed(success: true, email: 'email@example.com')
 
             expect(user_session['idv/attempts'].count).to be(1)
-            event = user_session['idv/attempts'].first
-            expect(event['idv-enrollment-complete']['user_uuid']).to eq(user.uuid)
-            expect(event['idv-enrollment-complete']['jti']).to match(
-              secure_random_regex_pattern,
-            )
+            event_data = user_session['idv/attempts'].first
+            expect(event_data['event_metadata']['user_uuid']).to eq(agency_uuid)
+            expect(event_data['jti']).to match(secure_random_regex_pattern)
+            expect(event_data['event_type']).to eq('idv-enrollment-complete')
           end
 
           it 'records both events to redis' do
@@ -343,26 +344,31 @@ RSpec.describe AttemptsApi::Tracker do
           it 'still populates the session info' do
             subject.idv_enrollment_complete(reproof: false)
 
-            event = user_session['idv/attempts'].first
-            expect(event['idv-enrollment-complete']['user_uuid']).to eq(user.uuid)
-            expect(event['idv-enrollment-complete']['jti']).to match(
-              secure_random_regex_pattern,
-            )
+            event_data = user_session['idv/attempts'].first
+            expect(event_data['event_metadata']['user_uuid']).to eq(agency_uuid)
+            expect(event_data['jti']).to match(secure_random_regex_pattern)
+            expect(event_data['event_type']).to eq('idv-enrollment-complete')
           end
         end
 
         context 'there is already an event in the session' do
           it 'appends to the existing events' do
-            user_session['idv/attempts'] = [{ 'idv-something' => { 'user_uuid' => user.uuid } }]
+            user_session['idv/attempts'] = [
+              { 'jti' => 'some-jti',
+                'event_metadata' => { 'user_uuid' => user.uuid },
+                'event_type' => 'idv-something' },
+            ]
             subject.idv_enrollment_complete(reproof: false)
 
-            event = user_session['idv/attempts'].first
-            expect(event['idv-something']['user_uuid']).to eq(user.uuid)
-            event2 = user_session['idv/attempts'][1]
-            expect(event2['idv-enrollment-complete']['user_uuid']).to eq(user.uuid)
-            expect(event2['idv-enrollment-complete']['jti']).to match(
-              secure_random_regex_pattern,
-            )
+            event_data = user_session['idv/attempts'].first
+            expect(event_data['event_metadata']['user_uuid']).to eq(user.uuid)
+            expect(event_data['jti']).to match('some-jti')
+            expect(event_data['event_type']).to eq('idv-something')
+
+            event_data2 = user_session['idv/attempts'].last
+            expect(event_data2['event_metadata']['user_uuid']).to eq(agency_uuid)
+            expect(event_data2['jti']).to match(secure_random_regex_pattern)
+            expect(event_data2['event_type']).to eq('idv-enrollment-complete')
           end
         end
       end
@@ -458,7 +464,6 @@ RSpec.describe AttemptsApi::Tracker do
     let(:mock_session) { { 'warden.user.user.session' => {} } }
     let(:user_session) { mock_session['warden.user.user.session'] }
     let(:redis_client) { double AttemptsApi::RedisClient }
-    let(:time) { Time.zone.now }
 
     before do
       allow(request).to receive(:session).and_return(mock_session)
@@ -469,24 +474,21 @@ RSpec.describe AttemptsApi::Tracker do
     end
 
     it 'writes existing user events to redis' do
-      freeze_time do
-        allow(Time).to receive(:zone_now).and_return(time)
-        expect(AttemptsApi::RedisClient).to receive(:new).and_return(redis_client)
-        expect_any_instance_of(AttemptsApi::AttemptEvent).to receive(:to_jwe).and_return('jwe_data')
+      expect(AttemptsApi::RedisClient).to receive(:new).and_return(redis_client)
+      expect_any_instance_of(AttemptsApi::AttemptEvent).to receive(:to_jwe).and_return('jwe_data')
 
-        event_data = user_session['idv/attempts'].first.values[0]
-        expect(redis_client).to receive(:write_event).with(
-          event_key: event_data['jti'],
-          jwe: 'jwe_data',
-          timestamp: time,
-          issuer: sp.issuer,
-        )
+      event_data = user_session['idv/attempts'].first
+      expect(redis_client).to receive(:write_event).with(
+        event_key: event_data['jti'],
+        jwe: 'jwe_data',
+        timestamp: event_data['occurred_at'],
+        issuer: sp.issuer,
+      )
 
-        described_class.write_existing_user_events(
-          sp:,
-          historical_attempts: user_session['idv/attempts'],
-        )
-      end
+      described_class.write_existing_user_events(
+        sp:,
+        historical_attempts: user_session['idv/attempts'],
+      )
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 93](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/93)

## 🛠 Summary of changes
This change:

- Adds feature flag `historical_attempts_pii_enabled`
- If it is disabled, the historic event flow only saves the JTI and user uuid
- If it is enabled, it saves all the attempt event data.
- Updates specs

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
