### PR TITLE
Add step to local dev README for installing Postgres

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -60,6 +60,13 @@ If using Devenv.sh:
    nix-env --install --attr devenv -f https://github.com/NixOS/nixpkgs/tarball/nixpkgs-unstable
    ```
 
+1. Install `postgres`
+
+   ```
+   brew install postgresql
+   brew services start postgres
+   ```
+
 1. Activate your development environment, and launch Postgres and Redis:
 
    ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,6 +8,12 @@ $ bundle install
 $ npm install
 ```
 
+If you receive the an error `connection to server at "127.0.0.1", port 5432 failed: Connection refused`, check that you have Postgres installed and running:
+```
+brew install postgresql
+brew services start postgres
+```
+
 ## I am receiving errors when creating the development and test databases
 
 If you receive the following error (where _whoami_ == _your username_):


### PR DESCRIPTION
* changelog: Internal, Developer setup, add step to local dev README for installing Postgres

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->


## 🛠 Summary of changes

When setting up my local dev environment in the `identity-idp` repo, I was facing a `rake db:create` error during the `make setup` step (see [slack thread](https://gsa-tts.slack.com/archives/CMW9H0RFX/p1778612237971159)). The error was caused because I did not have postgres installed on my local machine, so the DB background process never started when running `devenv up -d`.

The issue was fixed when I ran `brew install postgresql@18` and then re-ran `devenv up -d`.



<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
