### PR TITLE
Dmm/cache encrypted events on creation

### DIFF
--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -5,7 +5,7 @@ module Idv
   module HistoricalAttemptsConcern
     extend ActiveSupport::Concern
 
-    def cache_user_proofing_events(password)
+    def cache_user_proofing_events(password:)
       return unless historical_events_need_be_sent?
 
       existing_events = current_user

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -213,9 +213,9 @@ module Idv
 
       current_user.active_profile.create_user_proofing_event(password:, attempt_events:)
 
-      # TODO:Historical Attempts Data: Save encrypted proofing events to
-      # the user session idv/encrypted_proofing_events so a user
-      # who has just identity proofed has available events
+      kms_encrypted_events = SessionEncryptor.new.kms_encrypt(attempt_events.to_json)
+      user_session[:encrypted_proofing_events] = kms_encrypted_events
+
       user_session.delete('idv/attempts')
     end
 

--- a/app/controllers/password_capture_controller.rb
+++ b/app/controllers/password_capture_controller.rb
@@ -40,7 +40,7 @@ class PasswordCaptureController < ApplicationController
 
   def handle_valid_password
     cache_profiles(password)
-    cache_user_proofing_events(password)
+    cache_user_proofing_events(password:)
     session[:password_attempts] = 0
     redirect_to after_sign_in_path_for(current_user)
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -202,7 +202,7 @@ module Users
       rate_limiter&.reset!
       sign_in(resource_name, resource)
       cache_profiles(auth_params[:password])
-      cache_user_proofing_events(auth_params[:password])
+      cache_user_proofing_events(password: auth_params[:password])
       set_new_device_session(nil)
       event, = create_user_event(:sign_in_before_2fa)
       UserAlerts::AlertUserAboutNewDevice.schedule_alert(event:) if new_device?

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -31,7 +31,7 @@ module AttemptsApi
         event = AttemptEvent.new(
           event_type: event_data['event_type'],
           session_id: event_data['session_id'],
-          occurred_at: event_data['occurred_at'],
+          occurred_at: event_data['occurred_at'] || Time.zone.now,
           event_metadata: event_data['event_metadata'],
           jti: event_data['jti'],
           iat: event_data['iat'],
@@ -104,6 +104,8 @@ module AttemptsApi
         event_data = {
           'event_type' => event.event_type,
           'jti' => event.jti,
+          'iat' => event.iat,
+          'occurred_at' => event.occurred_at,
           'event_metadata' => {
             user_uuid: event.event_metadata[:user_uuid],
           },

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -31,7 +31,7 @@ module AttemptsApi
         event = AttemptEvent.new(
           event_type: event_data['event_type'],
           session_id: event_data['session_id'],
-          occurred_at: event_data['occurred_at'] || Time.zone.now,
+          occurred_at: event_data['occurred_at'],
           event_metadata: event_data['event_metadata'],
           jti: event_data['jti'],
           iat: event_data['iat'],

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
   describe '#cache_user_proofing_events' do
     subject(:cache_user_proofing_events) do
-      controller.cache_user_proofing_events(password)
+      controller.cache_user_proofing_events(password:)
     end
 
     let!(:user_proofing_event) do

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1126,13 +1126,14 @@ RSpec.describe Idv::EnterPasswordController do
     describe 'historical events tracking' do
       let(:idv_attempt) do
         {
-          'idv/attempts' => [
-            { 'idv-enrollment-complete' => { 'user_uuid' => user.uuid } },
-          ],
+          'event_type' => 'idv-enrollment-complete',
+          'jti' => 'random-jti',
+          'event_metadata' => {
+            'user_uuid' => user.uuid,
+          },
         }
       end
 
-      let(:mock_user_session) { { 'idv/attempts' => [idv_attempt] } }
       let(:historical_attempts_api_enabled) { true }
 
       before do
@@ -1140,6 +1141,7 @@ RSpec.describe Idv::EnterPasswordController do
           historical_attempts_api_enabled:,
           allowed_attempts_providers: [{ 'issuer' => sp.issuer }],
         )
+        allow(controller).to receive(:user_session).and_return({ 'idv/attempts' => [idv_attempt] })
       end
 
       after do
@@ -1163,6 +1165,16 @@ RSpec.describe Idv::EnterPasswordController do
               event = UserProofingEvent.last
 
               expect(event.profile_id).to eq(user.profiles.last.id)
+            end
+
+            it 'caches user proofing events' do
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+              data = controller.user_session[:encrypted_proofing_events]
+              historical_attempts = JSON.parse(
+                SessionEncryptor.new.kms_decrypt(data),
+              )
+
+              expect(historical_attempts).to eq([idv_attempt])
             end
           end
         end


### PR DESCRIPTION
## 🎫 Ticket

## 🛠 Summary of changes
This is a small update to cache the historical attempt events as soon as they are saved, so that if a user immediately logs into another service provider, the events will be available.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
