### PR TITLE
Save/Render occurred_at correctly

### DIFF
--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -105,7 +105,7 @@ module AttemptsApi
           'event_type' => event.event_type,
           'jti' => event.jti,
           'iat' => event.iat,
-          'occurred_at' => event.occurred_at,
+          'occurred_at' => event.occurred_at.to_f,
           'event_metadata' => {
             user_uuid: event.event_metadata[:user_uuid],
           },


### PR DESCRIPTION
## 🛠 Summary of changes
While testing acceptance for https://github.com/18F/identity-idp/pull/13116, I noticed that the `occurred_at` field was not being saved correctly. This saves the unix time float, rather than attempting to save a time object to JSON. 


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
