### PR TITLE
Historical attempts data transformation

### DIFF
--- a/app/services/attempts_api/historical_attempt_event.rb
+++ b/app/services/attempts_api/historical_attempt_event.rb
@@ -14,13 +14,13 @@ module AttemptsApi
     end
 
     def transformed_metadata(metadata:, sp:)
-      user = AgencyIdentity.find_by(uuid: metadata['user_uuid']).user
+      user = AgencyIdentity.find_by(uuid: metadata['user_uuid'])&.user
+      user_uuid = user.present? ?
+        AgencyIdentityLinker.for(user:, service_provider: sp, skip_create: true).uuid :
+        nil
 
       metadata.merge(
-        'user_uuid' => AgencyIdentityLinker.for(
-          user:, service_provider: sp,
-          skip_create: true
-        ).uuid,
+        'user_uuid' => user_uuid,
         'application_url' => nil,
         'client_port' => nil,
       )

--- a/app/services/attempts_api/historical_attempt_event.rb
+++ b/app/services/attempts_api/historical_attempt_event.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module AttemptsApi
+  class HistoricalAttemptEvent < AttemptEvent
+    def initialize(event_data:, sp:)
+      super(
+        jti: event_data['jti'],
+        iat: event_data['iat'],
+        event_type: event_data['event_type'],
+        session_id: event_data['session_id'],
+        occurred_at: Time.zone.parse(event_data['occurred_at']),
+        event_metadata: transformed_metadata(metadata: event_data['event_metadata'], sp:),
+      )
+    end
+
+    def transformed_metadata(metadata:, sp:)
+      user = AgencyIdentity.find_by(uuid: metadata['user_uuid']).user
+
+      metadata.merge(
+        'user_uuid' => AgencyIdentityLinker.for(
+          user:, service_provider: sp,
+          skip_create: true
+        ).uuid,
+        'application_url' => nil,
+        'client_port' => nil,
+      )
+    end
+  end
+end

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -28,19 +28,9 @@ module AttemptsApi
 
     def self.write_existing_user_events(sp:, historical_attempts: [])
       historical_attempts.each do |event_data|
-        event = AttemptEvent.new(
-          event_type: event_data['event_type'],
-          session_id: event_data['session_id'],
-          occurred_at: event_data['occurred_at'],
-          event_metadata: event_data['event_metadata'],
-          jti: event_data['jti'],
-          iat: event_data['iat'],
-        )
+        event = HistoricalAttemptEvent.new(event_data:, sp:)
 
-        jwe = event.to_jwe(
-          issuer: sp.issuer,
-          public_key: sp.attempts_public_key,
-        )
+        jwe = event.to_jwe(issuer: sp.issuer, public_key: sp.attempts_public_key)
 
         AttemptsApi::RedisClient.new.write_event(
           event_key: event.jti,
@@ -102,14 +92,14 @@ module AttemptsApi
         event_data = event.as_json
       else
         event_data = {
-          'event_type' => event.event_type,
-          'jti' => event.jti,
-          'iat' => event.iat,
-          'occurred_at' => event.occurred_at.to_f,
-          'event_metadata' => {
+          event_type: event.event_type,
+          jti: event.jti,
+          iat: event.iat,
+          occurred_at: Time.zone.at(event.occurred_at).iso8601,
+          event_metadata: {
             user_uuid: event.event_metadata[:user_uuid],
           },
-        }
+        }.as_json
 
       end
 

--- a/spec/services/attempts_api/historical_attempt_event_spec.rb
+++ b/spec/services/attempts_api/historical_attempt_event_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AttemptsApi::HistoricalAttemptEvent do
   let(:attempts_api_public_key) { attempts_api_private_key.public_key }
 
   let(:signing_key) { OpenSSL::PKey::EC.generate('prime256v1') }
-  let(:singing_private_key) { signing_key.private_to_pem }
+  let(:signing_private_key) { signing_key.private_to_pem }
   let(:signing_public_key) { OpenSSL::PKey::EC.new(signing_key.public_to_pem) }
 
   let(:jti) { 'test-unique-id' }

--- a/spec/services/attempts_api/historical_attempt_event_spec.rb
+++ b/spec/services/attempts_api/historical_attempt_event_spec.rb
@@ -22,17 +22,17 @@ RSpec.describe AttemptsApi::HistoricalAttemptEvent do
   end
   let(:event_data) do
     {
-      'jti' => jti,
-      'iat' => iat,
-      'occurred_at' => occurred_at.to_f,
-      'event_type' => event_type,
-      'session_id' => session_id,
-      'event_metadata' => {
-        'user_uuid' => proofing_identity.uuid,
-        'application_url' => 'https://example.com/app',
-        'client_port' => '8080',
+      jti:,
+      iat:,
+      occurred_at:,
+      event_type:,
+      session_id:,
+      event_metadata: {
+        user_uuid: proofing_identity.uuid,
+        application_url: 'https://example.com/app',
+        client_port: '8080',
       },
-    }
+    }.as_json
   end
 
   subject do

--- a/spec/services/attempts_api/historical_attempt_event_spec.rb
+++ b/spec/services/attempts_api/historical_attempt_event_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe AttemptsApi::HistoricalAttemptEvent do
+  let(:attempts_api_private_key) { OpenSSL::PKey::RSA.new(2048) }
+  let(:attempts_api_public_key) { attempts_api_private_key.public_key }
+
+  let(:signing_key) { OpenSSL::PKey::EC.generate('prime256v1') }
+  let(:singing_private_key) { signing_key.private_to_pem }
+  let(:signing_public_key) { OpenSSL::PKey::EC.new(signing_key.public_to_pem) }
+
+  let(:jti) { 'test-unique-id' }
+  let(:iat) { Time.zone.now.to_i }
+  let(:event_type) { 'idv-test-event' }
+  let(:session_id) { 'test-session-id' }
+  let(:occurred_at) { Time.zone.now.round }
+  let(:service_provider) { create(:service_provider, :idv) }
+  let(:user) { create(:user) }
+  let(:proofing_identity) { AgencyIdentityLinker.for(user:, service_provider:, skip_create: false) }
+  let(:aaca_sp) { create(:service_provider, :idv) }
+  let!(:aaca_identity) do
+    AgencyIdentityLinker.for(user:, service_provider: aaca_sp, skip_create: false)
+  end
+  let(:event_data) do
+    {
+      'jti' => jti,
+      'iat' => iat,
+      'occurred_at' => occurred_at.to_f,
+      'event_type' => event_type,
+      'session_id' => session_id,
+      'event_metadata' => {
+        'user_uuid' => proofing_identity.uuid,
+        'application_url' => 'https://example.com/app',
+        'client_port' => '8080',
+      },
+    }
+  end
+
+  subject do
+    described_class.new(event_data:, sp: aaca_sp)
+  end
+
+  describe '#initialize' do
+    it 'initializes the event with the correct event data' do
+      expect(subject.jti).to eq(jti)
+      expect(subject.iat).to eq(iat)
+      expect(subject.event_type).to eq(event_type)
+      expect(subject.session_id).to eq(session_id)
+      expect(subject.occurred_at).to eq(occurred_at)
+      expect(subject.event_metadata).to eq(
+        {
+          'user_uuid' => aaca_identity.uuid,
+          'application_url' => nil,
+          'client_port' => nil,
+        },
+      )
+    end
+  end
+end

--- a/spec/services/attempts_api/historical_attempt_event_spec.rb
+++ b/spec/services/attempts_api/historical_attempt_event_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe AttemptsApi::HistoricalAttemptEvent do
   let!(:aaca_identity) do
     AgencyIdentityLinker.for(user:, service_provider: aaca_sp, skip_create: false)
   end
+  let(:user_uuid) { proofing_identity.uuid }
+
   let(:event_data) do
     {
       jti:,
@@ -28,7 +30,7 @@ RSpec.describe AttemptsApi::HistoricalAttemptEvent do
       event_type:,
       session_id:,
       event_metadata: {
-        user_uuid: proofing_identity.uuid,
+        user_uuid:,
         application_url: 'https://example.com/app',
         client_port: '8080',
       },
@@ -53,6 +55,14 @@ RSpec.describe AttemptsApi::HistoricalAttemptEvent do
           'client_port' => nil,
         },
       )
+    end
+
+    context 'when the user is not found' do
+      let(:user_uuid) { 'non-existent-uuid' }
+
+      it 'initializes the event with nil user_uuid in metadata' do
+        expect(subject.event_metadata['user_uuid']).to be_nil
+      end
     end
   end
 end

--- a/spec/services/attempts_api/tracker_spec.rb
+++ b/spec/services/attempts_api/tracker_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe AttemptsApi::Tracker do
             subject.idv_enrollment_complete(reproof: false)
             event_data = user_session['idv/attempts'].first
 
-            expect(event_data['event_metadata']).to eq({ user_uuid: agency_uuid })
+            expect(event_data['event_metadata']).to eq({ 'user_uuid' => agency_uuid })
             expect(event_data['event_type']).to eq('idv-enrollment-complete')
           end
         end
@@ -477,7 +477,14 @@ RSpec.describe AttemptsApi::Tracker do
   end
 
   describe '#self.write_existing_user_events' do
-    let(:sp) { service_provider }
+    let(:user) { create(:user) }
+    let(:proofing_identity) do
+      AgencyIdentityLinker.for(user:, service_provider:, skip_create: false)
+    end
+    let(:aaca_sp) { create(:service_provider, :idv) }
+    let!(:aaca_identity) do
+      AgencyIdentityLinker.for(user:, service_provider: aaca_sp, skip_create: false)
+    end
     let(:mock_session) { { 'warden.user.user.session' => {} } }
     let(:user_session) { mock_session['warden.user.user.session'] }
     let(:redis_client) { double AttemptsApi::RedisClient }
@@ -498,14 +505,39 @@ RSpec.describe AttemptsApi::Tracker do
       expect(redis_client).to receive(:write_event).with(
         event_key: event_data['jti'],
         jwe: 'jwe_data',
-        timestamp: event_data['occurred_at'],
-        issuer: sp.issuer,
+        timestamp: Time.zone.at(Time.zone.parse(event_data['occurred_at']).to_f),
+        issuer: service_provider.issuer,
       )
 
       described_class.write_existing_user_events(
-        sp:,
+        sp: service_provider,
         historical_attempts: user_session['idv/attempts'],
       )
+    end
+
+    context 'when historical_attempts_pii_enabled is true' do
+      before do
+        allow(IdentityConfig.store).to receive(:historical_attempts_pii_enabled).and_return(true)
+      end
+
+      it 'writes existing user events to redis with PII' do
+        expect(AttemptsApi::RedisClient).to receive(:new).and_return(redis_client)
+        expect_any_instance_of(AttemptsApi::AttemptEvent).to receive(:to_jwe).and_return('jwe_data')
+
+        event_data = user_session['idv/attempts'].first
+
+        expect(redis_client).to receive(:write_event).with(
+          event_key: event_data['jti'],
+          jwe: 'jwe_data',
+          timestamp: Time.zone.at(Time.zone.parse(event_data['occurred_at']).to_f),
+          issuer: service_provider.issuer,
+        )
+
+        described_class.write_existing_user_events(
+          sp: service_provider,
+          historical_attempts: user_session['idv/attempts'],
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 91](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/91)

## 🛠 Summary of changes

This code sanitizes attempt event data to avoid leaking provider information. 

- Creates a HistoricalAttemptEvent class to handle the necessary transformations
- Updates the user uuid to be the uuid of the consumer application
- Removes the `application_url` value if it exists
- Removes the `client_port` value if it exists


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
