### PR TITLE
LG-17585: add configurable custom headers for proofing agent webhooks

### DIFF
--- a/app/services/proofing_agent/config.rb
+++ b/app/services/proofing_agent/config.rb
@@ -21,5 +21,9 @@ module ProofingAgent
     def webhook_secret
       issuer_config&.dig('webhook', 'secret')
     end
+
+    def webhook_custom_headers
+      issuer_config&.dig('webhook', 'headers') || {}
+    end
   end
 end

--- a/app/services/proofing_agent/webhook_caller.rb
+++ b/app/services/proofing_agent/webhook_caller.rb
@@ -58,7 +58,7 @@ module ProofingAgent
 
       timeout = 15
 
-      Faraday.new(url: URI.join(webhook_url).to_s, headers: request_headers) do |conn|
+      Faraday.new(url: URI.join(webhook_url).to_s) do |conn|
         conn.request :retry, retry_options
         conn.request :instrumentation, name: 'request_metric.faraday'
         conn.adapter :net_http
@@ -66,13 +66,11 @@ module ProofingAgent
         conn.options.read_timeout = timeout
         conn.options.open_timeout = timeout
         conn.options.write_timeout = timeout
+        conn.headers['Authorization'] = "Bearer #{webhook_secret}" if webhook_secret.present?
+        conn.headers['X-Correlation-ID'] = correlation_id
+        conn.headers['Content-Type'] = 'application/json'
+        conn.headers.merge!(webhook_custom_headers)
       end
-    end
-
-    def request_headers
-      headers = { 'Content-Type' => 'application/json', 'X-Correlation-ID' => correlation_id }
-      headers['Authorization'] = "Bearer #{webhook_secret}" if webhook_secret.present?
-      headers
     end
 
     def document_capture_session

--- a/spec/jobs/proofing_agent_job_spec.rb
+++ b/spec/jobs/proofing_agent_job_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ProofingAgentJob, type: :job do
   let(:webhook_url) { 'https://example.test/webhook' }
   let(:webhook_secret) { 'webhook-secret' }
   let(:webhook_status) { 200 }
+  let(:webhook_headers) { nil }
   let(:idv_proofing_agent_config) do
     [
       {
@@ -32,6 +33,7 @@ RSpec.describe ProofingAgentJob, type: :job do
         webhook: {
           url: webhook_url,
           secret: webhook_secret,
+          headers: webhook_headers,
         },
       }.with_indifferent_access,
     ]
@@ -104,6 +106,24 @@ RSpec.describe ProofingAgentJob, type: :job do
             transaction_id: transaction_id,
             correlation_id: correlation_id,
           )
+        end
+      end
+
+      context 'when the webhook URL is configured with additional headers' do
+        let(:webhook_headers) { { 'X-Test-Header' => 'test-value' } }
+        it 'includes the additional headers in the webhook request' do
+          expect { perform }.to have_enqueued_job(ProofingAgentWebhookJob).with(
+            success: true,
+            reason: nil,
+            transaction_id: transaction_id,
+            correlation_id: correlation_id,
+          )
+
+          result = document_capture_session.reload.load_agent_proofed_user
+          expect(result[:success]).to be true
+          expect(result[:reason]).to be_nil
+          expect(result[:resolution][:success]).to be true
+          expect(result[:resolution][:exception]).to be_nil
         end
       end
 
@@ -273,6 +293,11 @@ RSpec.describe ProofingAgentJob, type: :job do
         end
         expect(body['transaction_id']).to eq(transaction_id)
         expect(req.headers['X-Correlation-Id']).to eq(correlation_id)
+
+        webhook_headers&.each do |key, value|
+          expect(req.headers[key]).to eq(value)
+        end
+
         if webhook_secret.present?
           expect(req.headers['Authorization']).to eq("Bearer #{webhook_secret}")
         else


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-17585](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17585)

## 🛠 Summary of changes
Proofing agent webhooks include custom headers when the proofing agent issuer configure has webhool headers defined.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17585]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17585