### PR TITLE
LG-17366: Fix reproof event for users activation

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -121,8 +121,13 @@ class Profile < ApplicationRecord
 
     now = Time.zone.now
     profile_to_deactivate = Profile.find_by(user_id: user_id, active: true)
-    is_reproof = profile_to_deactivate.present?
-    is_facial_match_upgrade = is_reproof && facial_match? && !profile_to_deactivate.facial_match?
+    is_reproof = activated_at.present? ||
+                 user.profiles.where.not(id: id).where.not(activated_at: nil).exists?
+    # Must guard on profile_to_deactivate (not is_reproof): on the password_reset
+    # path the prior profile is deactivated, so is_reproof is true but
+    # profile_to_deactivate is nil — calling .facial_match? on it would raise.
+    is_facial_match_upgrade = profile_to_deactivate.present? && facial_match? &&
+                              !profile_to_deactivate.facial_match?
 
     attrs = {
       active: true,

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -431,34 +431,53 @@ RSpec.describe Profile do
       expect(profile.verified_at).to be_present # changed
     end
 
-    # this spec will pass for a deactivated profile which is non-active,
-    # but will fail for password_reset and encryption_error profiles,
-    # which are non-active, but are not activate-able
-    it 'does not send a reproof event when there is a non active profile' do
-      expect(PushNotification::HttpPush).to_not receive(:deliver)
-
+    it 'sends a reproof event when reactivating a previously active profile' do
       profile = create(:profile, :deactivated)
 
       expect(profile.activated_at).to be_present
       expect(profile.active).to eq(false) # to change
       expect(profile.deactivation_reason).to be_nil
-      expect(profile.fraud_review_pending?).to eq(false)
-      expect(profile.gpo_verification_pending_at).to be_nil
-      expect(profile.in_person_verification_pending_at).to be_nil
-      expect(profile.initiating_service_provider).to be_nil
-      expect(profile.verified_at).to be_nil # to change
 
       expect(profile.user.analytics).to receive(:idv_profile_activated).once
+      expect(PushNotification::HttpPush).to receive(:deliver)
+        .with(PushNotification::ReproofCompletedEvent.new(user: profile.user))
+
       profile.activate
 
       expect(profile.activated_at).to be_present
       expect(profile.active).to eq(true) # changed
-      expect(profile.deactivation_reason).to be_nil
-      expect(profile.fraud_review_pending?).to eq(false)
-      expect(profile.gpo_verification_pending_at).to be_nil
-      expect(profile.in_person_verification_pending_at).to be_nil
-      expect(profile.initiating_service_provider).to be_nil
       expect(profile.verified_at).to be_present # changed
+    end
+
+    it 'sends a reproof event after a password_reset reactivation' do
+      profile = create(:profile, :active, user: user)
+      profile.deactivate(:password_reset)
+
+      expect(profile.activated_at).to be_present
+      expect(profile.active).to eq(false)
+      expect(profile.deactivation_reason).to eq('password_reset')
+
+      expect(profile.user.analytics).to receive(:idv_profile_activated).once
+      expect(PushNotification::HttpPush).to receive(:deliver)
+        .with(PushNotification::ReproofCompletedEvent.new(user: user))
+
+      profile.clear_password_reset_deactivation_reason
+
+      expect(profile.active).to eq(true)
+      expect(profile.deactivation_reason).to be_nil
+    end
+
+    it 'sends a reproof event for a new profile when the user has a prior activated profile' do
+      old_profile = create(:profile, :active, user: user)
+      old_profile.deactivate(:password_reset)
+
+      new_profile = create(:profile, user: user)
+
+      expect(new_profile.user.analytics).to receive(:idv_profile_activated).once
+      expect(PushNotification::HttpPush).to receive(:deliver)
+        .with(PushNotification::ReproofCompletedEvent.new(user: user))
+
+      new_profile.activate
     end
 
     it 'does not send a reproof event when there is no active profile' do


### PR DESCRIPTION
                                                                                                 
  ## 🎫 Ticket                                                                                                          
                                                                                                                        
  [LG-17366](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17366)                                             
                                                                                                                        
  ## 🛠 Summary of changes                                                                                               
                                                                                                                      
  The `idv_reproof` / `ReproofCompletedEvent` push notification was only being emitted                                  
  when `Profile#activate` found another *currently active* profile to deactivate. That
  meant any reproof following a `password_reset` (or other non-active) deactivation —                                   
  where the user has no currently active profile but does have a previously activated                                   
  one — was silently skipped.                                                                                           
                                                                                                                        
  This change redefines `is_reproof` to mean "the user has previously completed                                         
  proofing":                                                                                                          
                                                                                                                        
  - True if the profile being activated was activated before (`activated_at.present?`),                               
    which covers the reactivation path (e.g. clearing a `password_reset`
    deactivation reason).                                                                                               
  - True if the user has any *other* profile with an `activated_at`, which covers
    proofing a brand-new profile after the previous one was deactivated.                                                
                                                                                                                        
  The `is_facial_match_upgrade` check was decoupled from `is_reproof` so it continues
  to depend on there being an active profile to compare against.                                                        
                                                                                                                        
  ## 📜 Testing Plan
                                                                                                                        
  - [ ] `bundle exec rspec spec/models/profile_spec.rb` passes, including the new                                       
        specs:
    - sends a reproof event when reactivating a previously active profile                                               
    - sends a reproof event after a `password_reset` reactivation                                                       
    - sends a reproof event when a new profile is activated after a `password_reset`
  - [ ] Manually verify a reproof event is emitted when a user completes IdV again                                      
        after a password reset (previously this did not fire).                                                          
  - [ ] Verify no reproof event is emitted for a user's first-ever proofing                                             
        (no prior activated profile).                                                                                   
  - [ ] Verify facial-match upgrade behavior is unchanged for users with an                                           
        existing active non-facial-match profile.   

[LG-17366]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17366