### PR TITLE
Add dual vendor check to phone verification step

### DIFF
--- a/app/services/proofing/address_proofer.rb
+++ b/app/services/proofing/address_proofer.rb
@@ -13,6 +13,13 @@ module Proofing
       socure: :socure_address,
     }.freeze
 
+    DUAL_VENDOR_CHECK_ADDRESS_VENDORS = {
+      lexis_nexis_ddp: [:lexis_nexis_ddp, :socure],
+      socure: [:socure, :lexis_nexis_ddp],
+      lexis_nexis: [:lexis_nexis],
+      mock: [:mock],
+    }.freeze
+
     def initialize(user_uuid:, user_email:)
       @user_uuid = user_uuid
       @user_email = user_email
@@ -104,7 +111,15 @@ module Proofing
     end
 
     def address_vendors
-      [primary_vendor, secondary_vendor].uniq.compact
+      if FeatureManagement.dual_vendor_check_enabled?
+        determine_dual_vendors(primary_vendor)
+      else
+        [primary_vendor, secondary_vendor].uniq.compact
+      end
+    end
+
+    def determine_dual_vendors(primary_vendor)
+      DUAL_VENDOR_CHECK_ADDRESS_VENDORS[primary_vendor]
     end
   end
 end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -228,6 +228,7 @@ idv_max_attempts: 5
 idv_min_age_years: 13
 idv_phone_confirmation_manual_review_validity_hours: 0
 idv_phone_precheck_percent: 0
+idv_phone_verification_dual_vendor_check_enabled: false
 idv_proofing_agent_config: '[]'
 idv_proofing_agent_enabled: false
 idv_proofing_agent_result_expiration_seconds: 10

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -196,4 +196,9 @@ class FeatureManagement
   def self.account_creation_passkey_auto_prompt_enabled?
     IdentityConfig.store.feature_account_creation_passkey_auto_prompt
   end
+
+  # @returns [Boolean] Whether the phone verification dual vendor check is enabled
+  def self.dual_vendor_check_enabled?
+    IdentityConfig.store.idv_phone_verification_dual_vendor_check_enabled
+  end
 end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -242,6 +242,7 @@ module IdentityConfig
     config.add(:idv_min_age_years, type: :integer)
     config.add(:idv_phone_confirmation_manual_review_validity_hours, type: :float)
     config.add(:idv_phone_precheck_percent, type: :integer)
+    config.add(:idv_phone_verification_dual_vendor_check_enabled, type: :boolean)
     config.add(:idv_proofing_agent_config, type: :json)
     config.add(:idv_proofing_agent_enabled, type: :boolean)
     config.add(:idv_proofing_agent_result_expiration_seconds, type: :integer)

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -500,4 +500,29 @@ RSpec.describe 'FeatureManagement' do
       end
     end
   end
+
+  describe '#dual_vendor_check_enabled?' do
+    let(:enabled) { nil }
+
+    before do
+      allow(IdentityConfig.store).to receive(:idv_phone_verification_dual_vendor_check_enabled)
+        .and_return(enabled)
+    end
+
+    context 'when idv_phone_verification_dual_vendor_check_enabled is true' do
+      let(:enabled) { true }
+
+      it 'returns true' do
+        expect(FeatureManagement.dual_vendor_check_enabled?).to be(true)
+      end
+    end
+
+    context 'when idv_phone_verification_dual_vendor_check_enabled is false' do
+      let(:enabled) { false }
+
+      it 'returns false' do
+        expect(FeatureManagement.dual_vendor_check_enabled?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/services/proofing/address_proofer_spec.rb
+++ b/spec/services/proofing/address_proofer_spec.rb
@@ -1,0 +1,356 @@
+require 'rails_helper'
+
+RSpec.describe Proofing::AddressProofer do
+  let(:user_uuid) { Faker::Internet.uuid }
+  let(:user_email) { Faker::Internet.email }
+  let(:ddp_phone_finder_proofer) { instance_double(Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer) }
+  let(:ddp_phone_finder_result) do
+    Proofing::AddressResult.new(
+      success: true,
+      errors: [],
+      exception: nil,
+      vendor_name: 'lexis_nexis:phone_finder_ddp',
+      transaction_id: Faker::Internet.uuid,
+    )
+  end
+  let(:phone_risk_proofer) { instance_double(Proofing::Socure::IdPlus::Proofers::PhoneRiskProofer) }
+  let(:socure_phone_risk_result) do
+    Proofing::AddressResult.new(
+      success: true,
+      errors: [],
+      exception: nil,
+      vendor_name: 'socure_phonerisk',
+      transaction_id: Faker::Internet.uuid,
+    )
+  end
+
+  subject { described_class.new(user_uuid:, user_email:) }
+
+  before do
+    allow(ddp_phone_finder_proofer).to receive(:proof).and_return(ddp_phone_finder_result)
+    allow(Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer).to receive(:new)
+      .and_return(ddp_phone_finder_proofer)
+    allow(phone_risk_proofer).to receive(:proof).and_return(socure_phone_risk_result)
+    allow(Proofing::Socure::IdPlus::Proofers::PhoneRiskProofer).to receive(:new)
+      .and_return(phone_risk_proofer)
+  end
+
+  describe '#proof' do
+    let(:applicant_pii) do
+      {
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name,
+      }
+    end
+    let(:service_provider) { Faker::Business.name }
+
+    context 'when dual vendor check is disabled' do
+      before do
+        allow(FeatureManagement).to receive(:dual_vendor_check_enabled?).and_return(false)
+      end
+
+      context 'when secondary address proofer is not configured' do
+        before do
+          allow(IdentityConfig.store).to receive(:idv_address_secondary_vendor).and_return(nil)
+          allow(IdentityConfig.store).to receive(:idv_address_vendor_socure_percent).and_return(0)
+        end
+
+        context 'when the primary vendor is lexis_nexis_ddp' do
+          before do
+            allow(IdentityConfig.store).to receive(:idv_address_primary_vendor)
+              .and_return(:lexis_nexis_ddp)
+            expect(Db::SpCost::AddSpCost).to receive(:call).with(
+              service_provider,
+              :lexis_nexis_address,
+              transaction_id: ddp_phone_finder_result.transaction_id,
+            )
+          end
+
+          it 'returns a lexis_nexis_ddp hash result' do
+            expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+              ddp_phone_finder_result.to_h,
+            )
+          end
+        end
+
+        context 'when the primary vendor is socure' do
+          before do
+            allow(IdentityConfig.store).to receive(:idv_address_primary_vendor)
+              .and_return(:socure)
+            expect(Db::SpCost::AddSpCost).to receive(:call).with(
+              service_provider,
+              :socure_address,
+              transaction_id: socure_phone_risk_result.transaction_id,
+            )
+          end
+
+          it 'returns a socure hash result' do
+            expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+              socure_phone_risk_result.to_h,
+            )
+          end
+        end
+
+        context 'when a primary vendor is configured' do
+          before do
+            allow(IdentityConfig.store).to receive(:idv_address_primary_vendor)
+              .and_return(:lexis_nexis)
+          end
+
+          context 'when socure percent is configured at 100' do
+            before do
+              allow(IdentityConfig.store).to receive(:idv_address_vendor_socure_percent)
+                .and_return(100)
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :socure_address,
+                transaction_id: socure_phone_risk_result.transaction_id,
+              )
+            end
+
+            it 'returns a socure hash result' do
+              expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+                socure_phone_risk_result.to_h,
+              )
+            end
+          end
+        end
+      end
+
+      context 'when secondary address proofer is configured' do
+        before do
+          allow(IdentityConfig.store).to receive(:idv_address_secondary_vendor).and_return(:socure)
+        end
+
+        context 'when the primary vendor is different from the secondary' do
+          before do
+            allow(IdentityConfig.store).to receive(:idv_address_primary_vendor)
+              .and_return(:lexis_nexis_ddp)
+          end
+
+          context 'when the primary proofing request is successful' do
+            before do
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :lexis_nexis_address,
+                transaction_id: ddp_phone_finder_result.transaction_id,
+              )
+            end
+
+            it 'returns a lexis_nexis_ddp result hash' do
+              expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+                ddp_phone_finder_result.to_h,
+              )
+            end
+          end
+
+          context 'when the primary proofing request fails' do
+            let(:ddp_phone_finder_result) do
+              Proofing::AddressResult.new(
+                success: false,
+                errors: [{ message: 'Unsuccessful result' }],
+                exception: nil,
+                vendor_name: 'lexis_nexis:phone_finder_ddp',
+                transaction_id: Faker::Internet.uuid,
+              )
+            end
+
+            before do
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :lexis_nexis_address,
+                transaction_id: ddp_phone_finder_result.transaction_id,
+              )
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :socure_address,
+                transaction_id: socure_phone_risk_result.transaction_id,
+              )
+            end
+
+            it 'returns a results hash with both vendor checks' do
+              expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+                socure_phone_risk_result.to_h.merge(alternate_result: ddp_phone_finder_result.to_h),
+              )
+            end
+          end
+        end
+
+        context 'when the primary vendor is the same as the secondary' do
+          before do
+            allow(IdentityConfig.store).to receive(:idv_address_primary_vendor).and_return(:socure)
+          end
+
+          context 'when the primary proofing request is successful' do
+            before do
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :socure_address,
+                transaction_id: socure_phone_risk_result.transaction_id,
+              )
+            end
+
+            it 'returns a socure result hash' do
+              expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+                socure_phone_risk_result.to_h,
+              )
+            end
+          end
+
+          context 'when the primary proofing request fails' do
+            let(:socure_phone_risk_result) do
+              Proofing::AddressResult.new(
+                success: false,
+                errors: [{ message: 'Unsuccessful result' }],
+                exception: nil,
+                vendor_name: 'socure_phonerisk',
+                transaction_id: Faker::Internet.uuid,
+              )
+            end
+
+            before do
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :socure_address,
+                transaction_id: socure_phone_risk_result.transaction_id,
+              )
+            end
+
+            it 'returns a results hash' do
+              expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+                socure_phone_risk_result.to_h,
+              )
+            end
+          end
+        end
+      end
+    end
+
+    context 'when dual vendor check is enabled' do
+      before do
+        allow(FeatureManagement).to receive(:dual_vendor_check_enabled?).and_return(true)
+        allow(IdentityConfig.store).to receive(:idv_address_vendor_socure_percent).and_return(0)
+      end
+
+      context 'when the primary vendor is lexis_nexis_ddp' do
+        before do
+          allow(IdentityConfig.store).to receive(:idv_address_primary_vendor)
+            .and_return(:lexis_nexis_ddp)
+        end
+
+        context 'when the lexis_nexis_ddp proofing request is successful' do
+          before do
+            expect(Db::SpCost::AddSpCost).to receive(:call).with(
+              service_provider,
+              :lexis_nexis_address,
+              transaction_id: ddp_phone_finder_result.transaction_id,
+            )
+          end
+
+          it 'returns a lexis_nexis_ddp result hash' do
+            expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+              ddp_phone_finder_result.to_h,
+            )
+          end
+        end
+
+        context 'when the lexis_nexis_ddp proofing request fails' do
+          let(:ddp_phone_finder_result) do
+            Proofing::AddressResult.new(
+              success: false,
+              errors: [{ message: 'Unsuccessful result' }],
+              exception: nil,
+              vendor_name: 'lexis_nexis:phone_finder_ddp',
+              transaction_id: Faker::Internet.uuid,
+            )
+          end
+
+          before do
+            expect(Db::SpCost::AddSpCost).to receive(:call).with(
+              service_provider,
+              :lexis_nexis_address,
+              transaction_id: ddp_phone_finder_result.transaction_id,
+            )
+            expect(Db::SpCost::AddSpCost).to receive(:call).with(
+              service_provider,
+              :socure_address,
+              transaction_id: socure_phone_risk_result.transaction_id,
+            )
+          end
+
+          it 'returns a results hash with both vendor checks' do
+            expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+              socure_phone_risk_result.to_h.merge(alternate_result: ddp_phone_finder_result.to_h),
+            )
+          end
+        end
+      end
+
+      context 'when the primary vendor is socure' do
+        before do
+          allow(IdentityConfig.store).to receive(:idv_address_primary_vendor).and_return(:socure)
+        end
+
+        context 'when the socure proofing request is successful' do
+          before do
+            expect(Db::SpCost::AddSpCost).to receive(:call).with(
+              service_provider,
+              :socure_address,
+              transaction_id: socure_phone_risk_result.transaction_id,
+            )
+          end
+
+          it 'returns a socure result hash' do
+            expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+              socure_phone_risk_result.to_h,
+            )
+          end
+        end
+
+        context 'when the socure proofing request fails' do
+          let(:socure_phone_risk_result) do
+            Proofing::AddressResult.new(
+              success: false,
+              errors: [{ message: 'Unsuccessful result' }],
+              exception: nil,
+              vendor_name: 'socure_phonerisk',
+              transaction_id: Faker::Internet.uuid,
+            )
+          end
+
+          before do
+            expect(Db::SpCost::AddSpCost).to receive(:call).with(
+              service_provider,
+              :socure_address,
+              transaction_id: socure_phone_risk_result.transaction_id,
+            )
+            expect(Db::SpCost::AddSpCost).to receive(:call).with(
+              service_provider,
+              :lexis_nexis_address,
+              transaction_id: ddp_phone_finder_result.transaction_id,
+            )
+          end
+
+          it 'returns a results hash with both vendor checks' do
+            expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+              ddp_phone_finder_result.to_h.merge(alternate_result: socure_phone_risk_result.to_h),
+            )
+          end
+        end
+      end
+    end
+
+    context 'when the configured vendor does not have a proofer' do
+      before do
+        allow(IdentityConfig.store).to receive(:idv_address_primary_vendor)
+          .and_return(:unknown_vendor)
+      end
+
+      it 'throws an InvalidAddressVendorError' do
+        expect { subject.proof(applicant_pii:, current_sp: service_provider) }.to raise_error(
+          Proofing::AddressProofer::InvalidAddressVendorError,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[joan-67](https://gitlab.login.gov/lg-teams/joan/joan/-/issues/67)

## 🛠 Summary of changes

Added dual vendor check to the phone verification step. This feature can be toggled on/off with the `idv_phone_verification_dual_vendor_check_enabled` config flag.

## 📜 Testing Plan

Configurations:
```yaml
idv_phone_verification_dual_vendor_check_enabled: true
```

**Scenario: Dual Vendor check enabled: When `Phone Finder` fails**
```cucumber
Given the Dual Vendor check feature is enabled
When the user is bucketed to use "Phone Finder" for phone verification
And the "Phone Finder" check fails
Then a "Phone Risk" check is performed
And both vendor check results are logged

When "Phone Risk" check passes
Then user is navigated to phone OTP page

When "Phone Risk" check fails
Then user is navigated to the phone error page
```

**Scenario: Dual Vendor check enabled: When `Phone Risk` fails**
```cucumber
Given the Dual Vendor check feature is enabled
When the user is bucketed to use "Phone Risk" for phone verification
And the "Phone Risk" check fails
Then a "Phone Finder" check is performed
And both vendor check results are logged

When "Phone Finder" check passes
Then user is navigated to phone OTP page

When "Phone Finder" check fails
Then user is navigated to the phone error page
```
