### PR TITLE
Update encryption when PW changes

### DIFF
--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -6,7 +6,9 @@ module Idv
     extend ActiveSupport::Concern
 
     def cache_user_proofing_events(password:)
-      return unless historical_events_need_be_sent?
+      # we always need to cache events if the feature is enabled
+      # in case we have to re-encrypt them
+      return unless IdentityConfig.store.historical_attempts_api_enabled
 
       existing_events = current_user
         .active_profile
@@ -38,10 +40,6 @@ module Idv
 
     def existing_user_proofing_event
       @existing_user_proofing_event ||= current_user.active_profile.user_proofing_event
-    end
-
-    def user_uuid
-      @user_uuid ||= current_user['uuid']
     end
   end
 end

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -9,6 +9,7 @@ module Idv
       # we always need to cache events if the feature is enabled
       # in case we have to re-encrypt them
       return unless IdentityConfig.store.historical_attempts_api_enabled
+      return unless current_user.active_profile.present?
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)
     end

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -10,12 +10,7 @@ module Idv
       # in case we have to re-encrypt them
       return unless IdentityConfig.store.historical_attempts_api_enabled
 
-      existing_events = current_user
-        .active_profile
-        .decrypt_user_proofing_events(password:)
-
-      kms_encrypted_events = SessionEncryptor.new.kms_encrypt(existing_events)
-      user_session[:encrypted_proofing_events] = kms_encrypted_events
+      AttemptsApi::Cacher.new(current_user, user_session).save(password:)
     end
 
     private

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -213,8 +213,7 @@ module Idv
 
       current_user.active_profile.create_user_proofing_event(password:, attempt_events:)
 
-      kms_encrypted_events = SessionEncryptor.new.kms_encrypt(attempt_events.to_json)
-      user_session[:encrypted_proofing_events] = kms_encrypted_events
+      AttemptsApi::Cacher.new(current_user, user_session).save(password:)
 
       user_session.delete('idv/attempts')
     end

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -142,13 +142,8 @@ module SignUp
     end
 
     def send_historical_events
-      # TODO:Historical Attempts Data: Should we extend the Pii::Cacher?
-      encrypted_proofing_events = user_session[:encrypted_proofing_events]
-      return unless encrypted_proofing_events.present?
+      historical_attempts = AttemptsApi::Cacher.new(current_user, user_session).fetch
 
-      historical_attempts = JSON.parse(
-        SessionEncryptor.new.kms_decrypt(encrypted_proofing_events),
-      )
       AttemptsApi::Tracker.write_existing_user_events(historical_attempts:, sp: current_sp)
 
       existing_user_proofing_event.add_sp_sent(current_sp.id)

--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -49,12 +49,7 @@ module Users
     end
 
     def decrypted_attempt_events
-      encrypted_proofing_events = user_session[:encrypted_proofing_events]
-      return unless encrypted_proofing_events.present?
-
-      JSON.parse(
-        SessionEncryptor.new.kms_decrypt(encrypted_proofing_events),
-      )
+      AttemptsApi::Cacher.new(current_user, user_session).fetch
     end
   end
 end

--- a/app/controllers/users/verify_password_controller.rb
+++ b/app/controllers/users/verify_password_controller.rb
@@ -44,6 +44,16 @@ module Users
         user: current_user,
         password: params.require(:user).permit(:password)[:password],
         decrypted_pii: reactivate_account_session.decrypted_pii,
+        decrypted_attempt_events:,
+      )
+    end
+
+    def decrypted_attempt_events
+      encrypted_proofing_events = user_session[:encrypted_proofing_events]
+      return unless encrypted_proofing_events.present?
+
+      JSON.parse(
+        SessionEncryptor.new.kms_decrypt(encrypted_proofing_events),
       )
     end
   end

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -33,6 +33,7 @@ class UpdateUserPasswordForm
   def encrypt_user_profiles
     return if user.active_or_pending_profile.blank?
 
+    reencrypt_attempt_events
     encryptor.encrypt
   end
 
@@ -51,5 +52,14 @@ class UpdateUserPasswordForm
       user_id: user.uuid,
       required_password_change: required_password_change,
     }
+  end
+
+  def reencrypt_attempt_events
+    return if user.active_profile.blank?
+
+    decrypted_events = AttemptsApi::Cacher.new(user, user_session).fetch
+    return if decrypted_events.blank?
+
+    user.active_profile.reencrypt_user_proofing_events(password:, attempt_events: decrypted_events)
   end
 end

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -56,6 +56,7 @@ class UpdateUserPasswordForm
 
   def reencrypt_attempt_events
     return if user.active_profile.blank?
+    return if user_session.blank?
 
     decrypted_events = AttemptsApi::Cacher.new(user, user_session).fetch
     return if decrypted_events.blank?

--- a/app/forms/verify_password_form.rb
+++ b/app/forms/verify_password_form.rb
@@ -6,18 +6,22 @@ class VerifyPasswordForm
   validates :password, presence: true
   validate :validate_password
 
-  attr_reader :user, :password, :decrypted_pii, :personal_key
+  attr_reader :user, :password, :decrypted_pii, :personal_key, :decrypted_attempt_events
 
-  def initialize(user:, password:, decrypted_pii:)
+  def initialize(user:, password:, decrypted_pii:, decrypted_attempt_events: nil)
     @user = user
     @password = password
     @decrypted_pii = decrypted_pii
+    @decrypted_attempt_events = decrypted_attempt_events
   end
 
   def submit
     success = valid?
 
     @personal_key = reencrypt_pii if success
+    if success && decrypted_attempt_events.present?
+      profile.reencrypt_user_proofing_events(password:, attempt_events: decrypted_attempt_events)
+    end
 
     FormResponse.new(success:, errors:)
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -426,6 +426,7 @@ class Profile < ApplicationRecord
   end
 
   def create_user_proofing_event(password:, attempt_events:)
+    # TODO: refactor to use reencrypt_user_proofing_events
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
     encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
     encrypted_events = JSON.parse(encrypted_events_json)
@@ -438,6 +439,8 @@ class Profile < ApplicationRecord
     update!(encrypted_attempts_file_reference: result.name)
 
     new_user_proofing_event = build_user_proofing_event(
+      # TODO refactor to remove cost and salt from the event
+      # They are saved in s3 with the bundle
       cost: encrypted_events['cost'],
       salt: encrypted_events['salt'],
     )
@@ -454,6 +457,17 @@ class Profile < ApplicationRecord
     )
 
     encryptor.decrypt(data, user_uuid: user.uuid)
+  end
+
+  def reencrypt_user_proofing_events(password:, attempt_events:)
+    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
+    encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
+
+    encrypted_doc_writer.write_encrypted_attempt_events(
+      file_path: attempt_events_file_path,
+      encrypted_attempt_events: encrypted_events_json,
+      name: encrypted_attempts_file_reference,
+    )
   end
 
   private

--- a/app/services/attempts_api/cacher.rb
+++ b/app/services/attempts_api/cacher.rb
@@ -15,7 +15,7 @@ module AttemptsApi
     end
 
     def fetch
-      return unless user_session[:encrypted_proofing_events].present?
+      return if user_session[:encrypted_proofing_events].blank?
 
       encrypted_events = user_session[:encrypted_proofing_events]
       JSON.parse(SessionEncryptor.new.kms_decrypt(encrypted_events))

--- a/app/services/attempts_api/cacher.rb
+++ b/app/services/attempts_api/cacher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AttemptsApi
   class Cacher
     attr_reader :user, :user_session

--- a/app/services/attempts_api/cacher.rb
+++ b/app/services/attempts_api/cacher.rb
@@ -1,0 +1,24 @@
+module AttemptsApi
+  class Cacher
+    attr_reader :user, :user_session
+
+    def initialize(user, user_session)
+      @user = user
+      @user_session = user_session
+    end
+
+    def save(password:)
+      decrypted_events = user.active_profile.decrypt_user_proofing_events(password:)
+
+      kms_encrypted_events = SessionEncryptor.new.kms_encrypt(decrypted_events)
+      user_session[:encrypted_proofing_events] = kms_encrypted_events
+    end
+
+    def fetch
+      return unless user_session[:encrypted_proofing_events].present?
+
+      encrypted_events = user_session[:encrypted_proofing_events]
+      JSON.parse(SessionEncryptor.new.kms_decrypt(encrypted_events))
+    end
+  end
+end

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -40,14 +40,12 @@ module EncryptedDocStorage
       )
     end
 
-    def write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
-      name = SecureRandom.uuid
+    def write_encrypted_attempt_events(file_path:, encrypted_attempt_events:,
+                                       name: SecureRandom.uuid)
       path = "#{file_path}/#{name}"
 
-      storage.write_attempt_events(
-        path:,
-        encrypted_attempt_events:,
-      )
+      storage.write_attempt_events(path:, encrypted_attempt_events:)
+
       Result.new(name:, encryption_key: nil)
     end
 

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -2,26 +2,19 @@ require 'rails_helper'
 
 RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
   let(:password) { ControllerHelper::VALID_PASSWORD }
-  let(:registered_user) do
-    create(
-      :user,
-      :fully_registered,
-      password:,
-      email: 'email@example.com',
-    )
-  end
   let(:issuer) { 'this:is:a:test' }
   let(:sp) { create(:service_provider, ial: 2, issuer:) }
-  let(:profile) { create(:profile, :active, :verified) }
+  let(:profile) { create(:profile, :active, :verified, encrypted_attempts_file_reference: 'test') }
+  let(:user) { create(:user, :fully_registered, password:, profiles: [profile]) }
   let(:idv_attempts) do
     [
-      { 'idv-ssn-submitted' => { 'user_uuid' => registered_user.uuid } },
+      { 'idv-ssn-submitted' => { 'user_uuid' => user.uuid } },
     ]
   end
   let(:allowed_attempts_providers) { [{ 'issuer' => sp.issuer }] }
-  let(:pii_encryptor) { Encryption::Encryptors::PiiEncryptor.new(registered_user.password) }
+  let(:pii_encryptor) { Encryption::Encryptors::PiiEncryptor.new(user.password) }
   let(:encrypted_existing_events) do
-    pii_encryptor.encrypt(idv_attempts.to_json, user_uuid: registered_user.uuid)
+    pii_encryptor.encrypt(idv_attempts.to_json, user_uuid: user.uuid)
   end
 
   controller ApplicationController do
@@ -29,34 +22,31 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
   end
 
   before do
-    sign_in(registered_user)
+    sign_in(user)
 
     allow(controller).to receive_messages(
       current_sp: sp,
-      current_user: registered_user,
+      current_user: user,
       sp_from_sp_session: sp,
       sp_session: {
         acr_values: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
       },
       user_session: { 'idv/attempts' => idv_attempts },
     )
-    allow(registered_user).to receive_messages(
-      active_profile: profile,
-    )
     allow(IdentityConfig.store).to receive_messages(
       allowed_attempts_providers:,
       attempts_api_enabled: true,
       historical_attempts_api_enabled: true,
     )
+
+    allow(user.active_profile).to receive(:decrypt_user_proofing_events).and_return(
+      idv_attempts.to_json,
+    )
   end
 
   describe '#cache_user_proofing_events' do
-    subject(:cache_user_proofing_events) do
-      controller.cache_user_proofing_events(password:)
-    end
-
     let!(:user_proofing_event) do
-      registered_user.active_profile.build_user_proofing_event(
+      user.active_profile.build_user_proofing_event(
         cost: JSON.parse(encrypted_existing_events)['cost'],
         salt: JSON.parse(encrypted_existing_events)['salt'],
       )
@@ -65,13 +55,12 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
     context 'historical_attempts_api_enabled feature flag is false' do
       before do
         allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
-        allow(profile).to receive(:decrypt_user_proofing_events)
       end
 
       it 'does not decrypt events' do
-        expect(profile).to_not receive(:decrypt_user_proofing_events)
+        expect(user.active_profile).to_not receive(:decrypt_user_proofing_events)
 
-        cache_user_proofing_events
+        controller.cache_user_proofing_events(password:)
       end
     end
 
@@ -82,12 +71,11 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       before do
         allow(SessionEncryptor).to receive(:new).and_return(mock_session_encryptor)
         allow(mock_session_encryptor).to receive(:kms_encrypt).and_return(kms_encrypted_events)
-        allow(profile).to receive(:decrypt_user_proofing_events).and_return(idv_attempts.to_json)
-        cache_user_proofing_events
+        controller.cache_user_proofing_events(password:)
       end
 
       it 'decrypts the appropriate UserProofingEvent' do
-        expect(profile).to have_received(:decrypt_user_proofing_events).once
+        expect(user.active_profile).to have_received(:decrypt_user_proofing_events).once
       end
 
       it 'encrypts with the kms session key' do
@@ -105,26 +93,22 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
           allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return([])
         end
 
-        it 'does not decrypt events' do
-          expect(profile).to_not receive(:decrypt_user_proofing_events)
-
-          cache_user_proofing_events
+        it 'decrypts events' do
+          expect(user.active_profile).to have_received(:decrypt_user_proofing_events).once
         end
       end
 
       context 'events already sent to SP' do
         let(:user_proofing_event) do
-          registered_user.active_profile.build_user_proofing_event(
+          user.active_profile.build_user_proofing_event(
             cost: JSON.parse(encrypted_existing_events)['cost'],
             salt: JSON.parse(encrypted_existing_events)['salt'],
             service_provider_ids_sent: [sp.id],
           )
         end
 
-        it 'does not decrypt events' do
-          expect(profile).to_not receive(:decrypt_user_proofing_events)
-
-          cache_user_proofing_events
+        it 'decrypts events' do
+          expect(user.active_profile).to have_received(:decrypt_user_proofing_events).once
         end
       end
 
@@ -132,7 +116,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
         let(:user_proofing_event) { nil }
 
         it 'does not raise an error' do
-          expect { cache_user_proofing_events }.to_not raise_error
+          expect { controller.cache_user_proofing_events(password:) }.to_not raise_error
         end
       end
     end

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -45,13 +45,6 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
   end
 
   describe '#cache_user_proofing_events' do
-    let!(:user_proofing_event) do
-      user.active_profile.build_user_proofing_event(
-        cost: JSON.parse(encrypted_existing_events)['cost'],
-        salt: JSON.parse(encrypted_existing_events)['salt'],
-      )
-    end
-
     context 'historical_attempts_api_enabled feature flag is false' do
       before do
         allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(false)
@@ -74,49 +67,67 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
         controller.cache_user_proofing_events(password:)
       end
 
-      it 'decrypts the appropriate UserProofingEvent' do
-        expect(user.active_profile).to have_received(:decrypt_user_proofing_events).once
-      end
+      context 'user does not have an active profile' do
+        let(:user) { create(:user, :fully_registered, password:, profiles: []) }
+        it 'does not attempt to decrypt events' do
+          expect(user.active_profile).to_not receive(:decrypt_user_proofing_events)
 
-      it 'encrypts with the kms session key' do
-        expect(mock_session_encryptor).to have_received(:kms_encrypt).once.with(
-          idv_attempts.to_json,
-        )
-      end
-
-      it 'updates the session with the UserProofingEvent' do
-        expect(controller.user_session[:encrypted_proofing_events]).to eq(kms_encrypted_events)
-      end
-
-      context 'service_provider is not an allowed_attempts_providers' do
-        before do
-          allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return([])
-        end
-
-        it 'decrypts events' do
-          expect(user.active_profile).to have_received(:decrypt_user_proofing_events).once
+          controller.cache_user_proofing_events(password:)
         end
       end
 
-      context 'events already sent to SP' do
-        let(:user_proofing_event) do
+      context 'when user has an active profile' do
+        let!(:user_proofing_event) do
           user.active_profile.build_user_proofing_event(
             cost: JSON.parse(encrypted_existing_events)['cost'],
             salt: JSON.parse(encrypted_existing_events)['salt'],
-            service_provider_ids_sent: [sp.id],
           )
         end
 
-        it 'decrypts events' do
+        it 'decrypts the appropriate UserProofingEvent' do
           expect(user.active_profile).to have_received(:decrypt_user_proofing_events).once
         end
-      end
 
-      context 'when no UserProofingEvent exists for the profile' do
-        let(:user_proofing_event) { nil }
+        it 'encrypts with the kms session key' do
+          expect(mock_session_encryptor).to have_received(:kms_encrypt).once.with(
+            idv_attempts.to_json,
+          )
+        end
 
-        it 'does not raise an error' do
-          expect { controller.cache_user_proofing_events(password:) }.to_not raise_error
+        it 'updates the session with the UserProofingEvent' do
+          expect(controller.user_session[:encrypted_proofing_events]).to eq(kms_encrypted_events)
+        end
+
+        context 'service_provider is not an allowed_attempts_providers' do
+          before do
+            allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return([])
+          end
+
+          it 'decrypts events' do
+            expect(user.active_profile).to have_received(:decrypt_user_proofing_events).once
+          end
+        end
+
+        context 'events already sent to SP' do
+          let(:user_proofing_event) do
+            user.active_profile.build_user_proofing_event(
+              cost: JSON.parse(encrypted_existing_events)['cost'],
+              salt: JSON.parse(encrypted_existing_events)['salt'],
+              service_provider_ids_sent: [sp.id],
+            )
+          end
+
+          it 'decrypts events' do
+            expect(user.active_profile).to have_received(:decrypt_user_proofing_events).once
+          end
+        end
+
+        context 'when no UserProofingEvent exists for the profile' do
+          let(:user_proofing_event) { nil }
+
+          it 'does not raise an error' do
+            expect { controller.cache_user_proofing_events(password:) }.to_not raise_error
+          end
         end
       end
     end

--- a/spec/controllers/users/verify_password_controller_spec.rb
+++ b/spec/controllers/users/verify_password_controller_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Users::VerifyPasswordController do
   end
 
   context 'with password reset profile' do
-    let(:profiles) { [create(:profile, :verified, :password_reset)] }
+    let(:profile) { create(:profile, :verified, :password_reset) }
+    let(:profiles) { [profile] }
 
     context 'without personal key flag set' do
       describe '#new' do
@@ -65,6 +66,7 @@ RSpec.describe Users::VerifyPasswordController do
 
         context 'with valid password' do
           let(:password) { user.password }
+          let(:encrypted_proofing_events) { nil }
 
           before do
             pii = Pii::Attributes.new_from_hash(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN)
@@ -73,22 +75,48 @@ RSpec.describe Users::VerifyPasswordController do
               user_session: controller.user_session,
             ).store_decrypted_pii(pii)
 
-            put :update, params: user_params
+            controller.user_session[:encrypted_proofing_events] = encrypted_proofing_events
           end
 
-          it 'logs an appropriate analytics event' do
-            expect(@analytics).to have_logged_event(
-              :reactivate_account_verify_password_submitted,
-              success: true,
-            )
+          context 'with no stored historical attempt events' do
+            before do
+              put :update, params: user_params
+            end
+
+            it 'logs an appropriate analytics event' do
+              expect(@analytics).to have_logged_event(
+                :reactivate_account_verify_password_submitted,
+                success: true,
+              )
+            end
+
+            it 'redirects to the manage personal key page' do
+              expect(response).to redirect_to(manage_personal_key_url)
+            end
+
+            it 'sets the new personal key as a user session value' do
+              expect(controller.user_session[:personal_key]).to match(/^([A-Z0-9]{4}(-|$)){4}/)
+            end
           end
 
-          it 'redirects to the manage personal key page' do
-            expect(response).to redirect_to(manage_personal_key_url)
-          end
+          context 'with stored historical attempt events' do
+            let(:attempt_events) { [{ 'event' => 'event1' }, { 'event' => 'event2' }] }
+            let(:encrypted_proofing_events) do
+              SessionEncryptor.new.kms_encrypt(attempt_events.to_json)
+            end
 
-          it 'sets the new personal key as a user session value' do
-            expect(controller.user_session[:personal_key]).to match(/^([A-Z0-9]{4}(-|$)){4}/)
+            before do
+              allow(user).to receive(:password_reset_profile).and_return(profile)
+              allow(profile).to receive(:reencrypt_user_proofing_events)
+            end
+
+            it 're-encrypts the historical events with the new password' do
+              put :update, params: user_params
+              expect(profile).to have_received(:reencrypt_user_proofing_events).with(
+                password:,
+                attempt_events:,
+              )
+            end
           end
         end
 

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
           error_details: hash_including(:password, :password_confirmation),
         )
       end
+
+      it 'does not attempt to reencrypt the attempt events' do
+        expect(AttemptsApi::Cacher).not_to receive(:new)
+        subject.submit(params)
+      end
     end
 
     context 'when the password is valid' do
@@ -85,6 +90,44 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
           pending_profile_present: false,
         )
       end
+
+      context 'there are no existing attempt events cached in the session' do
+        it 'does not attempt to reencrypt the attempt events' do
+          expect(AttemptsApi::Cacher).to receive(:new).with(user, user_session).and_call_original
+          expect_any_instance_of(Profile).not_to receive(:reencrypt_user_proofing_events)
+
+          subject.submit(params)
+        end
+      end
+
+      context 'there are existing attempt events cached in the session' do
+        let(:decrypted_events) do
+          [
+            { event_type: 'idv-event', jti: 'some-jti' },
+            { event_type: 'idv-another-event', jti: 'another-jti' },
+          ]
+        end
+
+        let(:user_session) do
+          {
+            encrypted_proofing_events: SessionEncryptor.new.kms_encrypt(decrypted_events.to_json),
+          }
+        end
+
+        before do
+          allow_any_instance_of(Profile).to receive(:reencrypt_user_proofing_events)
+        end
+
+        it 'attempts to reencrypt the attempt events with the new password' do
+          expect(AttemptsApi::Cacher).to receive(:new).with(user, user_session).and_call_original
+          expect_any_instance_of(Profile).to receive(:reencrypt_user_proofing_events).with(
+            password:,
+            attempt_events: decrypted_events.as_json,
+          )
+
+          subject.submit(params)
+        end
+      end
     end
 
     context 'the user has a pending profile' do
@@ -115,6 +158,11 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
           pending_profile_present: true,
         )
       end
+
+      it 'does not attempt to reencrypt the attempt events' do
+        expect(AttemptsApi::Cacher).not_to receive(:new)
+        subject.submit(params)
+      end
     end
 
     context 'when the user does not have a profile' do
@@ -131,6 +179,11 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
           active_profile_present: false,
           pending_profile_present: false,
         )
+      end
+
+      it 'does not attempt to reencrypt the attempt events' do
+        expect(AttemptsApi::Cacher).not_to receive(:new)
+        subject.submit(params)
       end
     end
   end

--- a/spec/forms/verify_password_form_spec.rb
+++ b/spec/forms/verify_password_form_spec.rb
@@ -2,18 +2,23 @@ require 'rails_helper'
 
 RSpec.describe VerifyPasswordForm, type: :model do
   describe '#submit' do
+    let(:password) { 'cab123DZN456' }
+    let(:user) { create(:user, password:) }
+    let(:pii) { { ssn: '111111111' } }
+    let(:profile) { create(:profile, :verified, :password_reset, user:, pii:) }
+    let(:decrypted_attempt_events) { nil }
+    let(:form) do
+      VerifyPasswordForm.new(
+        user: user, password: attempted_password,
+        decrypted_pii: Pii::Attributes.new_from_hash(pii),
+        decrypted_attempt_events:
+      )
+    end
+
     context 'when the form is valid' do
+      let(:attempted_password) { password }
+
       it 'is successful' do
-        password = 'cab123DZN456'
-        user = create(:user, password: password)
-        pii = { ssn: '111111111' }
-        profile = create(:profile, :verified, :password_reset, user: user, pii: pii)
-
-        form = VerifyPasswordForm.new(
-          user: user, password: password,
-          decrypted_pii: Pii::Attributes.new_from_hash(pii)
-        )
-
         expect(profile.reload.active?).to eq false
 
         result = form.submit
@@ -21,20 +26,29 @@ RSpec.describe VerifyPasswordForm, type: :model do
         expect(profile.reload.active?).to eq true
         expect(result.to_h).to eq(success: true)
       end
+
+      context 'when decrypted attempt events are present' do
+        let(:decrypted_attempt_events) { [{ event: 'test_event' }] }
+
+        before do
+          allow(user).to receive(:password_reset_profile).and_return(profile)
+        end
+
+        it 'reencrypts the attempt events' do
+          expect(profile).to receive(:reencrypt_user_proofing_events).with(
+            password: attempted_password,
+            attempt_events: decrypted_attempt_events,
+          )
+
+          form.submit
+        end
+      end
     end
 
     context 'when the password is invalid' do
+      let(:attempted_password) { 'wrong-password' }
+
       it 'returns errors' do
-        password = 'cab123DZN456'
-        user = create(:user, password: password)
-        pii = { ssn: '111111111' }
-        profile = create(:profile, :verified, :password_reset, user: user, pii: pii)
-
-        form = VerifyPasswordForm.new(
-          user: user, password: "#{password}a",
-          decrypted_pii: Pii::Attributes.new_from_hash(pii)
-        )
-
         expect(profile.reload.active?).to eq false
 
         result = form.submit

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1517,4 +1517,42 @@ RSpec.describe Profile do
       ).to eq(attempt_events.to_json)
     end
   end
+
+  describe '#reencrypt_user_proofing_events' do
+    let(:dir_path) do
+      Rails.root.join('tmp', 'encrypted_attempt_events', 'attempt_events', profile.user.uuid)
+    end
+
+    after do
+      FileUtils.rm_rf(dir_path) if Dir.exist?(dir_path)
+    end
+
+    let(:attempt_events) do
+      [
+        {
+          'jti' => 'some-jti',
+          'event_metadata' => { 'user_uuid' => user.uuid },
+          'event_type' => 'idv-ssn-submitted',
+        },
+      ]
+    end
+
+    it 'reencrypts user proofing events' do
+      profile.create_user_proofing_event(
+        password: 'password',
+        attempt_events:,
+      )
+      events_path = dir_path.join(profile.id.to_s, profile.encrypted_attempts_file_reference)
+
+      encrypted_events = File.read(events_path)
+
+      expect do
+        profile.reencrypt_user_proofing_events(password: 'new-password', attempt_events:)
+      end.to_not change { UserProofingEvent.last }
+
+      reencrypted_events = File.read(events_path)
+
+      expect(reencrypted_events).to_not eq(encrypted_events)
+    end
+  end
 end

--- a/spec/services/attempts_api/cacher_spec.rb
+++ b/spec/services/attempts_api/cacher_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe AttemptsApi::Cacher do
+  let(:user) { create(:user, :proofed) }
+  let(:user_session) { {} }
+  let(:password) { 'correct horse battery staple' }
+  let(:profile) { user.active_profile }
+  subject(:cacher) { described_class.new(user, user_session) }
+  let(:decrypted_events) do
+    [
+      { event_type: 'idv-event', jti: 'some-jti' },
+      { event_type: 'idv-another-event', jti: 'another-jti' },
+    ]
+  end
+
+  describe '#save' do
+    before do
+      allow(user).to receive(:active_profile).and_return(profile)
+      allow(profile).to receive(:decrypt_user_proofing_events).with(password:).and_return(
+        decrypted_events.to_json,
+      )
+    end
+
+    it 'encrypts and saves proofing events in the session' do
+      subject.save(password:)
+
+      expect(user_session[:encrypted_proofing_events]).to be_present
+
+      result = JSON.parse(SessionEncryptor.new.kms_decrypt(user_session[:encrypted_proofing_events]))
+      expect(result).to eq(decrypted_events.as_json)
+    end
+  end
+
+  describe '#fetch' do
+    context 'when there are no encrypted events in the session' do
+      it 'returns nil' do
+        expect(cacher.fetch).to be_nil
+      end
+    end
+
+    context 'when there are encrypted events in the session' do
+      let(:user_session) do
+        {
+          encrypted_proofing_events: SessionEncryptor.new.kms_encrypt(decrypted_events.to_json),
+        }
+      end
+      it 'fetches and decrypts the events in the session' do
+        expect(cacher.fetch).to eq(decrypted_events.as_json)
+      end
+    end
+  end
+end

--- a/spec/services/attempts_api/cacher_spec.rb
+++ b/spec/services/attempts_api/cacher_spec.rb
@@ -26,7 +26,11 @@ RSpec.describe AttemptsApi::Cacher do
 
       expect(user_session[:encrypted_proofing_events]).to be_present
 
-      result = JSON.parse(SessionEncryptor.new.kms_decrypt(user_session[:encrypted_proofing_events]))
+      result = JSON.parse(
+        SessionEncryptor.new.kms_decrypt(
+          user_session[:encrypted_proofing_events],
+        ),
+      )
       expect(result).to eq(decrypted_events.as_json)
     end
   end

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
     end
 
     it 'writes the encrypted attempt events to storage' do
+      expect(SecureRandom).to receive(:uuid).and_return(uuid)
       expect_any_instance_of(EncryptedDocStorage::LocalStorage).to receive(
         :write_attempt_events,
       ).with(
@@ -122,6 +123,26 @@ RSpec.describe EncryptedDocStorage::DocWriter do
 
       result = subject.write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
       expect(result.name).to eq(uuid)
+    end
+
+    context 'when a file name is passed in' do
+      let(:name) { 'test-name' }
+      let(:path) { "#{file_path}/#{name}" }
+      it 'writes the encrypted attempt events to storage with the provided name' do
+        expect(SecureRandom).not_to receive(:uuid)
+        expect_any_instance_of(EncryptedDocStorage::LocalStorage).to receive(
+          :write_attempt_events,
+        ).with(
+          path:,
+          encrypted_attempt_events:,
+        )
+
+        subject.write_encrypted_attempt_events(
+          file_path:,
+          encrypted_attempt_events:,
+          name:,
+        )
+      end
     end
 
     context 'when S3Storage is initalized' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 109](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/109)

## 🛠 Summary of changes
This change updates the encryption of the historic attempt bundle when a password is updated. Because I didn't quite understand the code at first, this change includes BOTH the cases of when a user updates their password from the Login.gov account management page, as well as a reactivation of the account, which I think happens when it is deactivated for fraud purposes.

This change does NOT include password resets; that is later work (which will force us to encrypt the attempt event bundle with the recovery key, and save that.)

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

Setup:
- Set up the SAML and OIDC sample apps locally.
- OIDC should be set up to be a consumer of the Attempts API, SAML should not. Instructions [here](https://docs.google.com/document/d/13493HHf2zkGgxmCP5ibNTpl1CXd1XOgSawn2Q0sGpUU/edit?tab=t.0#heading=h.vgastpg18oy5)

- [ ]  Navigate to the SAML app (http://localhost:4567/)
- [ ]  Select the "Level of Service" dropdown.
- [ ]  Select "Identity-Verified"
- [ ] Click "Sign in"
- [ ] Create a new account
- [ ] Consent to sharing
- [ ] Navigate to the Local idp (http://localhost:3000/)
- [ ] Click "Edit password"
- [ ] Update your password (don't lose track of the password, you will need to sign in again)
- [ ] Log out to remove the encrypted events from the user session
- [ ]  Navigate to the OIDC sample app (http://localhost:9292/)
- [ ]  Select the "Level of Service" dropdown.
- [ ]  Select "Identity-Verified"
- [ ]  Click "Sign in"
- [ ]  Log in via the account you just made
- [ ]  Consent to sending your data back to the OIDC sample app
- [ ]  Navigate to the Attemps Api viewer (http://localhost:9292/attempts-api)
- [ ] You should see events that start with `idv-` in the viewer!
 

-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
