### PR TITLE
Add failure reason logic to dual vendor check

### DIFF
--- a/app/services/proofing/address_proofer.rb
+++ b/app/services/proofing/address_proofer.rb
@@ -38,7 +38,7 @@ module Proofing
             )
           end
         results << result
-        break if result.success?
+        break if stop_processing_vendors?(result)
       end
 
       if results.many?
@@ -120,6 +120,12 @@ module Proofing
 
     def determine_dual_vendors(primary_vendor)
       DUAL_VENDOR_CHECK_ADDRESS_VENDORS[primary_vendor]
+    end
+
+    def stop_processing_vendors?(result)
+      FeatureManagement.dual_vendor_check_enabled? ?
+        result.success || !result.dual_vendor_check_eligible :
+        result.success
     end
   end
 end

--- a/app/services/proofing/address_result.rb
+++ b/app/services/proofing/address_result.rb
@@ -9,7 +9,8 @@ module Proofing
                 :transaction_id,
                 :reference,
                 :vendor_workflow,
-                :result
+                :result,
+                :dual_vendor_check_eligible
 
     def initialize(
       success:,
@@ -19,7 +20,8 @@ module Proofing
       transaction_id: '',
       reference: '',
       vendor_workflow: nil,
-      result: nil
+      result: nil,
+      dual_vendor_check_eligible: false
     )
       @success = success
       @errors = errors
@@ -29,6 +31,7 @@ module Proofing
       @reference = reference
       @vendor_workflow = vendor_workflow
       @result = result
+      @dual_vendor_check_eligible = dual_vendor_check_eligible
     end
 
     def success?

--- a/app/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer.rb
@@ -5,6 +5,8 @@ module Proofing
     module Ddp
       module Proofers
         class PhoneFinderProofer < Proofing::LexisNexis::Ddp::Proofer
+          NOT_VERIFIED_TO_NAME = 'Input phone number could not be verified to name'
+
           private
 
           def build_result_from_response(verification_response)
@@ -17,6 +19,7 @@ module Proofing
               exception: nil,
               vendor_name: 'lexisnexis:phone_finder_ddp',
               transaction_id: parsed_response.conversation_id,
+              dual_vendor_check_eligible: dual_vendor_check_eligible?(parsed_response),
             )
           end
 
@@ -63,6 +66,21 @@ module Proofing
             end
 
             raise 'LexisNexis PhoneFinder DDP returned no tps_vendor_raw_response'
+          end
+
+          def dual_vendor_check_eligible?(response)
+            has_name_verification_error?(response) && !has_additional_verification_errors?(response)
+          end
+
+          def has_name_verification_error?(response)
+            !!response
+              .verification_errors
+              .dig(:'PhoneFinder Checks', 'ProductReason', 'Description')
+              &.match?(NOT_VERIFIED_TO_NAME)
+          end
+
+          def has_additional_verification_errors?(response)
+            response.verification_errors.dig(:PhoneFinder, 'ProductStatus') == 'fail'
           end
         end
       end

--- a/app/services/proofing/socure/id_plus/proofers/phone_risk_proofer.rb
+++ b/app/services/proofing/socure/id_plus/proofers/phone_risk_proofer.rb
@@ -32,6 +32,7 @@ module Proofing
               reference:,
               transaction_id: reference,
               result: response.to_h,
+              dual_vendor_check_eligible: response.dual_vendor_check_eligible?,
             )
           end
 

--- a/app/services/proofing/socure/id_plus/response.rb
+++ b/app/services/proofing/socure/id_plus/response.rb
@@ -17,6 +17,10 @@ module Proofing
           http_response.body.dig('customerProfile', 'customerUserId')
         end
 
+        def dual_vendor_check_eligible?
+          false
+        end
+
         private
 
         attr_reader :http_response

--- a/app/services/proofing/socure/id_plus/responses/phone_risk_response.rb
+++ b/app/services/proofing/socure/id_plus/responses/phone_risk_response.rb
@@ -25,6 +25,11 @@ module Proofing
             name_correlation_successful? && phonerisk_successful? && !has_autofail_reason_codes?
           end
 
+          def dual_vendor_check_eligible?
+            has_name_verification_error_reason_codes? &&
+              !has_additional_verification_error_reason_codes?
+          end
+
           private
 
           attr_reader :http_response
@@ -80,6 +85,25 @@ module Proofing
           def has_autofail_reason_codes?
             (phonerisk_reason_codes & auto_failure_reason_codes).any? ||
               (name_phone_correlation_reason_codes & auto_failure_reason_codes).any?
+          end
+
+          def has_name_verification_error_reason_codes?
+            (phonerisk_reason_codes & name_verification_error_reason_codes).any? ||
+              (name_phone_correlation_reason_codes & name_verification_error_reason_codes).any?
+          end
+
+          def has_additional_verification_error_reason_codes?
+            (error_reason_codes - name_verification_error_reason_codes).any?
+          end
+
+          def error_reason_codes
+            (phonerisk_reason_codes | name_phone_correlation_reason_codes).select do |code|
+              code.match?(/^R\d+/)
+            end
+          end
+
+          def name_verification_error_reason_codes
+            IdentityConfig.store.idv_phone_verification_dual_vendor_check_socure_reason_codes
           end
 
           def auto_failure_reason_codes

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -229,6 +229,7 @@ idv_min_age_years: 13
 idv_phone_confirmation_manual_review_validity_hours: 0
 idv_phone_precheck_percent: 0
 idv_phone_verification_dual_vendor_check_enabled: false
+idv_phone_verification_dual_vendor_check_socure_reason_codes: '[]'
 idv_proofing_agent_config: '[]'
 idv_proofing_agent_enabled: false
 idv_proofing_agent_result_expiration_seconds: 10

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -243,6 +243,7 @@ module IdentityConfig
     config.add(:idv_phone_confirmation_manual_review_validity_hours, type: :float)
     config.add(:idv_phone_precheck_percent, type: :integer)
     config.add(:idv_phone_verification_dual_vendor_check_enabled, type: :boolean)
+    config.add(:idv_phone_verification_dual_vendor_check_socure_reason_codes, type: :json)
     config.add(:idv_proofing_agent_config, type: :json)
     config.add(:idv_proofing_agent_enabled, type: :boolean)
     config.add(:idv_proofing_agent_result_expiration_seconds, type: :integer)

--- a/spec/jobs/socure_shadow_mode_phone_risk_job_spec.rb
+++ b/spec/jobs/socure_shadow_mode_phone_risk_job_spec.rb
@@ -120,7 +120,10 @@ RSpec.describe SocureShadowModePhoneRiskJob do
       let(:expected_event_body) do
         {
           user_id: user.uuid,
-          phone_result: proofing_result.to_h.merge(vendor_workflow: nil),
+          phone_result: proofing_result.to_h.merge(
+            vendor_workflow: nil,
+            dual_vendor_check_eligible: false,
+          ),
           socure_result: {
             # attributes_requiring_additional_verification: [],
             # can_pass_with_additional_verification: false,

--- a/spec/services/proofing/address_proofer_spec.rb
+++ b/spec/services/proofing/address_proofer_spec.rb
@@ -255,33 +255,62 @@ RSpec.describe Proofing::AddressProofer do
         end
 
         context 'when the lexis_nexis_ddp proofing request fails' do
-          let(:ddp_phone_finder_result) do
-            Proofing::AddressResult.new(
-              success: false,
-              errors: [{ message: 'Unsuccessful result' }],
-              exception: nil,
-              vendor_name: 'lexis_nexis:phone_finder_ddp',
-              transaction_id: Faker::Internet.uuid,
-            )
+          context 'when the response is dual vendor eligible' do
+            let(:ddp_phone_finder_result) do
+              Proofing::AddressResult.new(
+                success: false,
+                errors: [{ message: 'Unsuccessful result' }],
+                exception: nil,
+                vendor_name: 'lexis_nexis:phone_finder_ddp',
+                transaction_id: Faker::Internet.uuid,
+                dual_vendor_check_eligible: true,
+              )
+            end
+
+            before do
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :lexis_nexis_address,
+                transaction_id: ddp_phone_finder_result.transaction_id,
+              )
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :socure_address,
+                transaction_id: socure_phone_risk_result.transaction_id,
+              )
+            end
+
+            it 'returns a results hash with both vendor checks' do
+              expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+                socure_phone_risk_result.to_h.merge(alternate_result: ddp_phone_finder_result.to_h),
+              )
+            end
           end
 
-          before do
-            expect(Db::SpCost::AddSpCost).to receive(:call).with(
-              service_provider,
-              :lexis_nexis_address,
-              transaction_id: ddp_phone_finder_result.transaction_id,
-            )
-            expect(Db::SpCost::AddSpCost).to receive(:call).with(
-              service_provider,
-              :socure_address,
-              transaction_id: socure_phone_risk_result.transaction_id,
-            )
-          end
+          context 'when the response is not dual vendor eligible' do
+            let(:ddp_phone_finder_result) do
+              Proofing::AddressResult.new(
+                success: false,
+                errors: [{ message: 'Unsuccessful result' }],
+                exception: nil,
+                vendor_name: 'lexis_nexis:phone_finder_ddp',
+                transaction_id: Faker::Internet.uuid,
+              )
+            end
 
-          it 'returns a results hash with both vendor checks' do
-            expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
-              socure_phone_risk_result.to_h.merge(alternate_result: ddp_phone_finder_result.to_h),
-            )
+            before do
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :lexis_nexis_address,
+                transaction_id: ddp_phone_finder_result.transaction_id,
+              )
+            end
+
+            it 'returns a lexis_nexis_ddp results hash' do
+              expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+                ddp_phone_finder_result.to_h,
+              )
+            end
           end
         end
       end
@@ -308,33 +337,62 @@ RSpec.describe Proofing::AddressProofer do
         end
 
         context 'when the socure proofing request fails' do
-          let(:socure_phone_risk_result) do
-            Proofing::AddressResult.new(
-              success: false,
-              errors: [{ message: 'Unsuccessful result' }],
-              exception: nil,
-              vendor_name: 'socure_phonerisk',
-              transaction_id: Faker::Internet.uuid,
-            )
+          context 'when the response is dual vendor eligible' do
+            let(:socure_phone_risk_result) do
+              Proofing::AddressResult.new(
+                success: false,
+                errors: [{ message: 'Unsuccessful result' }],
+                exception: nil,
+                vendor_name: 'socure_phonerisk',
+                transaction_id: Faker::Internet.uuid,
+                dual_vendor_check_eligible: true,
+              )
+            end
+
+            before do
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :socure_address,
+                transaction_id: socure_phone_risk_result.transaction_id,
+              )
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :lexis_nexis_address,
+                transaction_id: ddp_phone_finder_result.transaction_id,
+              )
+            end
+
+            it 'returns a results hash with both vendor checks' do
+              expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+                ddp_phone_finder_result.to_h.merge(alternate_result: socure_phone_risk_result.to_h),
+              )
+            end
           end
 
-          before do
-            expect(Db::SpCost::AddSpCost).to receive(:call).with(
-              service_provider,
-              :socure_address,
-              transaction_id: socure_phone_risk_result.transaction_id,
-            )
-            expect(Db::SpCost::AddSpCost).to receive(:call).with(
-              service_provider,
-              :lexis_nexis_address,
-              transaction_id: ddp_phone_finder_result.transaction_id,
-            )
-          end
+          context 'when the response is not dual vendor eligible' do
+            let(:socure_phone_risk_result) do
+              Proofing::AddressResult.new(
+                success: false,
+                errors: [{ message: 'Unsuccessful result' }],
+                exception: nil,
+                vendor_name: 'socure_phonerisk',
+                transaction_id: Faker::Internet.uuid,
+              )
+            end
 
-          it 'returns a results hash with both vendor checks' do
-            expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
-              ddp_phone_finder_result.to_h.merge(alternate_result: socure_phone_risk_result.to_h),
-            )
+            before do
+              expect(Db::SpCost::AddSpCost).to receive(:call).with(
+                service_provider,
+                :socure_address,
+                transaction_id: socure_phone_risk_result.transaction_id,
+              )
+            end
+
+            it 'returns a socure_phonerisk results hash' do
+              expect(subject.proof(applicant_pii:, current_sp: service_provider)).to eq(
+                socure_phone_risk_result.to_h,
+              )
+            end
           end
         end
       end

--- a/spec/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
           expect(result.errors).to be_empty
           expect(result.transaction_id).to eq('super-cool-test-session-id')
           expect(result.vendor_name).to eq('lexisnexis:phone_finder_ddp')
+          expect(result.dual_vendor_check_eligible).to be(false)
         end
       end
 
@@ -113,20 +114,152 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
           expect(result.success?).to eq(false)
           expect(result.errors).to be_empty
           expect(result.exception).to eq(error)
+          expect(result.dual_vendor_check_eligible).to be(false)
         end
       end
 
-      context 'when the response  is a failure' do
+      context 'when the response is a failure' do
         let(:response_body) { LexisNexisFixtures.ddp_phone_finder_fail_response_json }
 
-        it 'is a failure result' do
-          result = proofer.proof(proofing_applicant)
-          result_json_hash = result.errors[:'PhoneFinder Checks'].first
+        context 'when the failure is "could not be verified to name" without additional errors' do
+          it 'is a failure result' do
+            result = proofer.proof(proofing_applicant)
+            result_json_hash = result.errors[:'PhoneFinder Checks'].first
 
-          expect(result.success?).to eq(false)
-          expect(result_json_hash['ProductStatus']).to eq('fail')
-          expect(result.transaction_id).to eq('super-cool-test-session-id')
-          expect(result.vendor_name).to eq('lexisnexis:phone_finder_ddp')
+            expect(result.success?).to eq(false)
+            expect(result_json_hash['ProductStatus']).to eq('fail')
+            expect(result.transaction_id).to eq('super-cool-test-session-id')
+            expect(result.vendor_name).to eq('lexisnexis:phone_finder_ddp')
+            expect(result.dual_vendor_check_eligible).to be(true)
+          end
+        end
+
+        context 'when the failure is "could not be verified to name" with additional errors' do
+          let(:response_body) do
+            {
+              'integration_hub_results' => {
+                'test_org_id:test-policy' => {
+                  'Phone Finder' => {
+                    'tps_vendor_raw_response' => {
+                      'Products' => [
+                        {
+                          'ExecutedStepName' => 'PhoneFinder',
+                          'ProductStatus' => 'fail',
+                          'ProductType' => 'PhoneFinder',
+                          'ProductReason' => {
+                            'Code' => 'phone_finder_fail',
+                            'Description' => 'Phone Finder Fail',
+                          },
+                          'Items' => [
+                            {
+                              'ItemName' => 'VOIPPhone',
+                              'ItemReason' => {
+                                'Code' => 'VOIPPHONE.HIGH',
+                                'Description' => 'VOIP phone detected',
+                              },
+                              'ItemStatus' => 'fail',
+                            },
+                          ],
+                        }, {
+                          'ExecutedStepName' => 'PhoneFinder Checks',
+                          'ProductType' => 'PhoneFinder_Decision',
+                          'ProductStatus' => 'fail',
+                          'ProductReason' => {
+                            'Code' => 'phone_finder_fail',
+                            'Description' =>
+                              'Failed - Input phone number could not be verified to name',
+                          },
+                        }
+                      ],
+                      'Status' => {
+                        'ConversationId' => 'super-cool-test-session-id',
+                        'TransactionReasonCode' => {
+                          'Code' => 'phone_finder_fail',
+                          'Description' =>
+                            'Failed - Input phone number could not be verified to name',
+                        },
+                        'TransactionStatus' => 'failed',
+                      },
+                    },
+                  },
+                },
+              },
+            }.to_json
+          end
+
+          it 'is a failure result' do
+            result = proofer.proof(proofing_applicant)
+            result_json_hash = result.errors[:'PhoneFinder Checks'].first
+
+            expect(result.success?).to eq(false)
+            expect(result_json_hash['ProductStatus']).to eq('fail')
+            expect(result.transaction_id).to eq('super-cool-test-session-id')
+            expect(result.vendor_name).to eq('lexisnexis:phone_finder_ddp')
+            expect(result.dual_vendor_check_eligible).to be(false)
+          end
+        end
+
+        context 'when the response fails with "Risk Indicators match determined"' do
+          let(:response_body) do
+            {
+              'integration_hub_results' => {
+                'test_org_id:test-policy' => {
+                  'Phone Finder' => {
+                    'tps_vendor_raw_response' => {
+                      'Products' => [
+                        {
+                          'ExecutedStepName' => 'PhoneFinder',
+                          'ProductStatus' => 'fail',
+                          'ProductType' => 'PhoneFinder',
+                          'ProductReason' => {
+                            'Code' => 'phone_finder_fail',
+                            'Description' => 'Phone Finder Fail',
+                          },
+                          'Items' => [
+                            {
+                              'ItemName' => 'VOIPPhone',
+                              'ItemReason' => {
+                                'Code' => 'VOIPPHONE.HIGH',
+                                'Description' => 'VOIP phone detected',
+                              },
+                              'ItemStatus' => 'fail',
+                            },
+                          ],
+                        }, {
+                          'ExecutedStepName' => 'PhoneFinder Checks',
+                          'ProductType' => 'PhoneFinder_Decision',
+                          'ProductStatus' => 'fail',
+                          'ProductReason' => {
+                            'Code' => 'phone_finder_fail',
+                            'Description' => 'Fail - Risk Indicators match determined',
+                          },
+                        }
+                      ],
+                      'Status' => {
+                        'ConversationId' => 'super-cool-test-session-id',
+                        'TransactionReasonCode' => {
+                          'Code' => 'phone_finder_fail',
+                          'Description' => 'Fail - Risk Indicators match determined',
+                        },
+                        'TransactionStatus' => 'failed',
+                      },
+                    },
+                  },
+                },
+              },
+            }.to_json
+          end
+
+          it 'is a failure result' do
+            result = proofer.proof(proofing_applicant)
+            result_json_hash = result.errors[:'PhoneFinder Checks'].first
+
+            expect(result.success?).to eq(false)
+            expect(result_json_hash['ProductStatus']).to eq('fail')
+            expect(result.transaction_id).to eq('super-cool-test-session-id')
+            expect(result.vendor_name).to eq('lexisnexis:phone_finder_ddp')
+            expect(result.dual_vendor_check_eligible).to be(false)
+          end
         end
       end
 
@@ -160,6 +293,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
             expect(result.exception).to be_a(Proofing::TimeoutError)
             expect(result.exception.message)
               .to eq('LexisNexis PhoneFinder DDP timed out')
+            expect(result.dual_vendor_check_eligible).to be(false)
           end
         end
 
@@ -179,6 +313,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
             expect(result.exception).to be_a(RuntimeError)
             expect(result.exception.message)
               .to eq('LexisNexis PhoneFinder DDP returned no tps_vendor_raw_response')
+            expect(result.dual_vendor_check_eligible).to be(false)
           end
         end
 
@@ -198,6 +333,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
             expect(result.exception).to be_a(RuntimeError)
             expect(result.exception.message)
               .to eq('LexisNexis PhoneFinder DDP returned no tps_vendor_raw_response')
+            expect(result.dual_vendor_check_eligible).to be(false)
           end
         end
       end

--- a/spec/services/proofing/socure/id_plus/proofers/phone_risk_proofer_spec.rb
+++ b/spec/services/proofing/socure/id_plus/proofers/phone_risk_proofer_spec.rb
@@ -144,6 +144,36 @@ RSpec.describe Proofing::Socure::IdPlus::Proofers::PhoneRiskProofer do
         end
       end
     end
+
+    context 'when response contains dual vendor check eligible reason codes' do
+      let(:phonerisk_reason_codes) { ['I123', 'R666'] }
+      let(:name_phone_reason_codes) { ['I123', 'R777'] }
+
+      before do
+        allow(IdentityConfig.store).to receive(
+          :idv_phone_verification_dual_vendor_check_socure_reason_codes,
+        ).and_return(['R666', 'R777'])
+      end
+
+      it 'returns a result with dual_vendor_check_eligible set to true' do
+        expect(result.dual_vendor_check_eligible).to eql(true)
+      end
+    end
+
+    context 'when response does not contain dual vendor check eligible reason codes' do
+      let(:phonerisk_reason_codes) { ['I123', 'R800'] }
+      let(:name_phone_reason_codes) { ['I123', 'R500'] }
+
+      before do
+        allow(IdentityConfig.store).to receive(
+          :idv_phone_verification_dual_vendor_check_socure_reason_codes,
+        ).and_return(['R666'])
+      end
+
+      it 'returns a result with dual_vendor_check_eligible set to false' do
+        expect(result.dual_vendor_check_eligible).to eql(false)
+      end
+    end
   end
 
   context 'when phonerisk score is above threshold' do

--- a/spec/services/proofing/socure/id_plus/responses/phone_risk_response_spec.rb
+++ b/spec/services/proofing/socure/id_plus/responses/phone_risk_response_spec.rb
@@ -3,22 +3,18 @@ require 'rails_helper'
 RSpec.describe Proofing::Socure::IdPlus::Responses::PhoneRiskResponse do
   let(:phonerisk_low) { true }
   let(:name_phone_high) { true }
+  let(:correlation_reason_codes) { ['I123', 'R567', 'R890'] }
+  let(:phone_risk_reason_codes) { ['I123', 'R567'] }
+  let(:name_verification_error_reason_codes) { ['R666', 'R777', 'R888'] }
   let(:response_body) do
     {
       'referenceId' => 'some-reference-id',
       'namePhoneCorrelation' => {
-        'reasonCodes' => [
-          'I123',
-          'R567',
-          'R890',
-        ],
+        'reasonCodes' => correlation_reason_codes,
         'score' => name_phone_high ? 0.99 : 0.01,
       },
       'phoneRisk' => {
-        'reasonCodes' => [
-          'I123',
-          'R567',
-        ],
+        'reasonCodes' => phone_risk_reason_codes,
         'score' => phonerisk_low ? 0.01 : 0.99,
         'signals' => {
           'phone' => {},
@@ -34,6 +30,12 @@ RSpec.describe Proofing::Socure::IdPlus::Responses::PhoneRiskResponse do
     instance_double(Faraday::Response).tap do |r|
       allow(r).to receive(:body).and_return(response_body)
     end
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive(
+      :idv_phone_verification_dual_vendor_check_socure_reason_codes,
+    ).and_return(name_verification_error_reason_codes)
   end
 
   subject do
@@ -59,6 +61,7 @@ RSpec.describe Proofing::Socure::IdPlus::Responses::PhoneRiskResponse do
       end
     end
   end
+
   describe '#reference_id' do
     it 'returns referenceId' do
       expect(subject.reference_id).to eql('some-reference-id')
@@ -75,9 +78,9 @@ RSpec.describe Proofing::Socure::IdPlus::Responses::PhoneRiskResponse do
     it 'returns the correct reason codes' do
       to_h = subject.to_h
 
-      expect(to_h.dig(:phonerisk, :reason_codes).keys).to eq(['I123', 'R567'])
+      expect(to_h.dig(:phonerisk, :reason_codes).keys).to eq(phone_risk_reason_codes)
       expect(to_h.dig(:phonerisk, :score)).to eq(0.01)
-      expect(to_h.dig(:name_phone_correlation, :reason_codes).keys).to eq(['I123', 'R567', 'R890'])
+      expect(to_h.dig(:name_phone_correlation, :reason_codes).keys).to eq(correlation_reason_codes)
       expect(to_h.dig(:name_phone_correlation, :score)).to eq(0.99)
     end
 
@@ -112,6 +115,53 @@ RSpec.describe Proofing::Socure::IdPlus::Responses::PhoneRiskResponse do
         expect do
           subject.to_h
         end.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  describe '#dual_vendor_check_eligible?' do
+    let(:phone_risk_reason_codes) { ['I123', 'I801'] }
+    let(:correlation_reason_codes) { ['I123', 'I800'] }
+
+    context 'when phone risk reason codes contains a dual vendor eligible reason code' do
+      let(:phone_risk_reason_codes) { ['I123', 'R666'] }
+
+      context 'when no additional error reason codes are present' do
+        it 'returns true' do
+          expect(subject.dual_vendor_check_eligible?).to be(true)
+        end
+      end
+
+      context 'when additional error reason codes are present' do
+        let(:phone_risk_reason_codes) { ['I123', 'R666', 'R680'] }
+
+        it 'returns false' do
+          expect(subject.dual_vendor_check_eligible?).to be(false)
+        end
+      end
+    end
+
+    context 'when correlation reason codes contains a dual vendor eligible reason code' do
+      let(:correlation_reason_codes) { ['I123', 'R888'] }
+
+      context 'when no additional error reason codes are present' do
+        it 'returns true' do
+          expect(subject.dual_vendor_check_eligible?).to be(true)
+        end
+      end
+
+      context 'when additional error reason codes are present' do
+        let(:correlation_reason_codes) { ['I123', 'R777', 'R680'] }
+
+        it 'returns false' do
+          expect(subject.dual_vendor_check_eligible?).to be(false)
+        end
+      end
+    end
+
+    context 'when both reason codes do not contain dual vendor eligible reason codes' do
+      it 'returns false' do
+        expect(subject.dual_vendor_check_eligible?).to be(false)
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[joan-69](https://gitlab.login.gov/lg-teams/joan/joan/-/issues/69)

## 🛠 Summary of changes

Add failure reason logic to phone verification dual vendor check.

## 📜 Testing Plan

Configurations:
```yaml
idv_phone_verification_dual_vendor_check_enabled: true
idv_phone_verification_dual_vendor_check_socure_reason_codes: '["R888"]'
```

**Scenario: Dual Vendor check enabled: When `Phone Finder` fails**
```cucumber
Given the Dual Vendor check feature is enabled
When the user is bucketed to use "Phone Finder" for phone verification
And the "Phone Finder" check fails with "could not be verified to name" error
And no additional verification errors are present
Then a "Phone Risk" check is performed
And both vendor check results are logged

When "Phone Risk" check passes
Then user is navigated to phone OTP page

When "Phone Risk" check fails
Then user is navigated to the phone error page
```

**Scenario: Dual Vendor check enabled: When `Phone Risk` fails**
```cucumber
Given the Dual Vendor check feature is enabled
When the user is bucketed to use "Phone Risk" for phone verification
And the "Phone Risk" check fails with one of the configured reason codes
And no additional verification errors are present
Then a "Phone Finder" check is performed
And both vendor check results are logged

When "Phone Finder" check passes
Then user is navigated to phone OTP page

When "Phone Finder" check fails
Then user is navigated to the phone error page
```
