### PR TITLE
LG-17510 proofing components for an agent proofed user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -283,7 +283,6 @@ class ApplicationController < ActionController::Base
     return manage_password_url if session[:redirect_to_change_password].present?
     return authentication_methods_setup_url if user_needs_sp_auth_method_setup?
     return fix_broken_personal_key_url if current_user.broken_personal_key?
-    return idv_enter_dob_ssn_path if current_user.proofing_agent_pending?
     return user_session.delete(:stored_location) if user_session.key?(:stored_location)
     return setup_piv_cac_url if user_session[:add_piv_cac_after_2fa]
     return login_add_piv_cac_prompt_url if session[:needs_to_setup_piv_cac_after_sign_in].present?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -283,6 +283,7 @@ class ApplicationController < ActionController::Base
     return manage_password_url if session[:redirect_to_change_password].present?
     return authentication_methods_setup_url if user_needs_sp_auth_method_setup?
     return fix_broken_personal_key_url if current_user.broken_personal_key?
+    return idv_enter_dob_ssn_path if current_user.proofing_agent_pending?
     return user_session.delete(:stored_location) if user_session.key?(:stored_location)
     return setup_piv_cac_url if user_session[:add_piv_cac_after_2fa]
     return login_add_piv_cac_prompt_url if session[:needs_to_setup_piv_cac_after_sign_in].present?

--- a/app/services/idv/proofing_components.rb
+++ b/app/services/idv/proofing_components.rb
@@ -6,6 +6,10 @@ module Idv
       @idv_session = idv_session
     end
 
+    def agent_proofed
+      idv_session.agent_proofed
+    end
+
     def document_check
       idv_session.doc_auth_vendor
     end
@@ -58,6 +62,7 @@ module Idv
 
     def to_h
       {
+        agent_proofed:,
         document_check:,
         document_type_received:,
         source_check:,

--- a/spec/services/idv/proofing_components_spec.rb
+++ b/spec/services/idv/proofing_components_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Idv::ProofingComponents do
   end
 
   let(:pii_from_doc) { nil }
+  let(:agent_proofed) { nil }
   let(:hybrid_device_profiling) { :disabled }
   let(:hybrid_mobile_tmx_review_status) { nil }
 
@@ -41,6 +42,7 @@ RSpec.describe Idv::ProofingComponents do
       idv_session.address_verification_mechanism = 'gpo'
       allow(FeatureManagement).to receive(:proofing_device_profiling_collecting_enabled?)
         .and_return(true)
+      idv_session.agent_proofed = agent_proofed
       idv_session.threatmetrix_review_status = 'pass'
       idv_session.source_check_vendor = 'aamva'
       idv_session.resolution_vendor = 'lexis_nexis'
@@ -64,6 +66,25 @@ RSpec.describe Idv::ProofingComponents do
           },
         )
       end
+
+      context 'with proofing agent' do
+        let(:agent_proofed) { true }
+
+        it 'returns expected result' do
+          expect(subject.to_h).to eql(
+            {
+              agent_proofed: true,
+              document_check: 'feedabee',
+              document_type_received: 'drivers_license',
+              source_check: 'aamva',
+              resolution_check: 'lexis_nexis',
+              address_check: 'gpo_letter',
+              threatmetrix: true,
+              threatmetrix_review_status: 'pass',
+            },
+          )
+        end
+      end
     end
 
     context 'with state_id' do
@@ -82,6 +103,25 @@ RSpec.describe Idv::ProofingComponents do
           },
         )
       end
+
+      context 'with proofing agent' do
+        let(:agent_proofed) { true }
+
+        it 'returns expected result' do
+          expect(subject.to_h).to eql(
+            {
+              agent_proofed: true,
+              document_check: 'feedabee',
+              document_type_received: 'state_id',
+              source_check: 'aamva',
+              resolution_check: 'lexis_nexis',
+              address_check: 'gpo_letter',
+              threatmetrix: true,
+              threatmetrix_review_status: 'pass',
+            },
+          )
+        end
+      end
     end
 
     context 'with passport' do
@@ -99,6 +139,25 @@ RSpec.describe Idv::ProofingComponents do
             threatmetrix_review_status: 'pass',
           },
         )
+      end
+
+      context 'with proofing agent' do
+        let(:agent_proofed) { true }
+
+        it 'returns expected result' do
+          expect(subject.to_h).to eql(
+            {
+              agent_proofed: true,
+              document_check: 'feedabee',
+              document_type_received: 'passport',
+              source_check: 'aamva',
+              resolution_check: 'lexis_nexis',
+              address_check: 'gpo_letter',
+              threatmetrix: true,
+              threatmetrix_review_status: 'pass',
+            },
+          )
+        end
       end
     end
 
@@ -120,6 +179,22 @@ RSpec.describe Idv::ProofingComponents do
             hybrid_mobile_threatmetrix_review_status: 'pass',
           },
         )
+      end
+    end
+  end
+
+  describe '#agent_proofed' do
+    context 'idv_session.agent_proofed is nil' do
+      it 'returns nil' do
+        expect(subject.agent_proofed).to eq nil
+      end
+    end
+
+    context 'idv_session.agent_proofed is true' do
+      before { idv_session.agent_proofed = true }
+
+      it 'returns true' do
+        expect(subject.agent_proofed).to eq true
       end
     end
   end


### PR DESCRIPTION
changelog: Internal, IdV Proofing Agent, proofing_components for proofing agent user

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17508](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17508)



## 🛠 Summary of changes

Added agent_proofed user check for proofing components.

Note: https://github.com/18F/identity-idp/pull/13147 needs to be merged in before this one.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Ensure specs pass



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17508]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17508