### PR TITLE
Ensure sp id is saved on write

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -211,7 +211,11 @@ module Idv
     def record_user_proofing_events
       return unless historical_events_enabled?
 
-      current_user.active_profile.create_user_proofing_event(password:, attempt_events:)
+      current_user.active_profile.create_user_proofing_event(
+        password:,
+        attempt_events:,
+        sent_to_sp: attempts_api_enabled_for_session?,
+      )
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -429,7 +429,6 @@ class Profile < ApplicationRecord
     # TODO: refactor to use reencrypt_user_proofing_events
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
     encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
-    encrypted_events = JSON.parse(encrypted_events_json)
 
     result = encrypted_doc_writer.write_encrypted_attempt_events(
       file_path: attempt_events_file_path,
@@ -439,10 +438,6 @@ class Profile < ApplicationRecord
     update!(encrypted_attempts_file_reference: result.name)
 
     new_user_proofing_event = build_user_proofing_event(
-      # TODO refactor to remove cost and salt from the event
-      # They are saved in s3 with the bundle
-      cost: encrypted_events['cost'],
-      salt: encrypted_events['salt'],
       service_provider_ids_sent: service_provider_ids_sent(sent_to_sp:),
     )
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -425,7 +425,7 @@ class Profile < ApplicationRecord
     FACIAL_MATCH_IDV_LEVELS.include?(idv_level)
   end
 
-  def create_user_proofing_event(password:, attempt_events:)
+  def create_user_proofing_event(password:, attempt_events:, sent_to_sp: false)
     # TODO: refactor to use reencrypt_user_proofing_events
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
     encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
@@ -443,6 +443,7 @@ class Profile < ApplicationRecord
       # They are saved in s3 with the bundle
       cost: encrypted_events['cost'],
       salt: encrypted_events['salt'],
+      service_provider_ids_sent: service_provider_ids_sent(sent_to_sp:),
     )
 
     new_user_proofing_event.save
@@ -525,5 +526,13 @@ class Profile < ApplicationRecord
       idv_level: idv_level,
       issuer: initiating_service_provider_issuer,
     )
+  end
+
+  def service_provider_ids_sent(sent_to_sp:)
+    return [] unless sent_to_sp
+
+    # if sent_to_sp is true, there SHOULD be an initiating_service_provider
+    # but would rather err on the side of a guard
+    [initiating_service_provider&.id].compact
   end
 end

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -2,7 +2,7 @@
 
 class UserProofingEvent < ApplicationRecord
   belongs_to :profile
-  self.ignored_columns = %w[encrypted_events service_providers_sent]
+  self.ignored_columns = %w[encrypted_events service_providers_sent cost salt]
 
   # @param [Integer] id ID of service provider to add to "sent" list
   def add_sp_sent(id)

--- a/db/primary_migrate/20260526164414_allow_cost_and_salt_to_be_null_in_user_proofing_event.rb
+++ b/db/primary_migrate/20260526164414_allow_cost_and_salt_to_be_null_in_user_proofing_event.rb
@@ -1,0 +1,11 @@
+class AllowCostAndSaltToBeNullInUserProofingEvent < ActiveRecord::Migration[8.0]
+  def up
+    change_column :user_proofing_events, :cost, :string, null: true
+    change_column :user_proofing_events, :salt, :string, null: true
+  end
+
+  def down
+    change_column :user_proofing_events, :cost, :string, null: false
+    change_column :user_proofing_events, :salt, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_07_152408) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_26_164414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -650,8 +650,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_07_152408) do
     t.string "encrypted_events", comment: "sensitive=true"
     t.bigint "profile_id", null: false, comment: "sensitive=false"
     t.jsonb "service_providers_sent", default: [], null: false, comment: "sensitive=false"
-    t.string "cost", null: false, comment: "sensitive=true"
-    t.string "salt", null: false, comment: "sensitive=true"
+    t.string "cost", comment: "sensitive=true"
+    t.string "salt", comment: "sensitive=true"
     t.datetime "created_at", null: false, comment: "sensitive=false"
     t.datetime "updated_at", null: false, comment: "sensitive=false"
     t.bigint "service_provider_ids_sent", default: [], null: false, comment: "sensitive=false", array: true

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -78,10 +78,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
       context 'when user has an active profile' do
         let!(:user_proofing_event) do
-          user.active_profile.build_user_proofing_event(
-            cost: JSON.parse(encrypted_existing_events)['cost'],
-            salt: JSON.parse(encrypted_existing_events)['salt'],
-          )
+          user.active_profile.build_user_proofing_event
         end
 
         it 'decrypts the appropriate UserProofingEvent' do
@@ -111,8 +108,6 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
         context 'events already sent to SP' do
           let(:user_proofing_event) do
             user.active_profile.build_user_proofing_event(
-              cost: JSON.parse(encrypted_existing_events)['cost'],
-              salt: JSON.parse(encrypted_existing_events)['salt'],
               service_provider_ids_sent: [sp.id],
             )
           end

--- a/spec/factories/user_proofing_events.rb
+++ b/spec/factories/user_proofing_events.rb
@@ -1,14 +1,10 @@
 FactoryBot.define do
   factory :user_proofing_event do
     service_provider_ids_sent { [] }
-    cost { nil }
-    salt { nil }
     profile_id { nil }
 
     trait :existing do
       service_provider_ids_sent { [] }
-      cost { '0$0$0$' }
-      salt { '73616c74' }
       association :profile
     end
   end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1485,6 +1485,34 @@ RSpec.describe Profile do
       end.to change { UserProofingEvent.count }.by(1)
 
       expect(UserProofingEvent.last.profile).to eq(profile)
+      expect(UserProofingEvent.last.service_provider_ids_sent).to eq([])
+    end
+
+    context 'if sent_to_sp is true' do
+      let(:initiating_service_provider) { create(:service_provider, :active) }
+
+      before do
+        profile.update!(initiating_service_provider: initiating_service_provider)
+
+        profile.create_user_proofing_event(
+          password: 'password',
+          attempt_events: [{ 'event' => 'test' }],
+          sent_to_sp: true,
+        )
+      end
+      it 'creates a user proofing events object with the correct service_provider_ids_sent value' do
+        expect(UserProofingEvent.last.service_provider_ids_sent).to eq(
+          [profile.initiating_service_provider.id],
+        )
+      end
+
+      context 'there is no initiating service provider' do
+        let(:initiating_service_provider) { nil }
+
+        it 'does not include the service provider id in the service_provider_ids_sent' do
+          expect(UserProofingEvent.last.service_provider_ids_sent).to eq([])
+        end
+      end
     end
   end
 

--- a/spec/models/user_proofing_event_spec.rb
+++ b/spec/models/user_proofing_event_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe UserProofingEvent, type: :model do
     UserProofingEvent.new(
       profile_id: 1,
       service_provider_ids_sent: [],
-      cost: '0$cost$',
-      salt: 'salt0',
     )
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes
When testing, I realized that when identity proofing on an Attempts API Consumer Application, the UserProofingEvent was not being instantiated with the service provider's id in the `service_provider_ids_sent` field.

This change fixes that, as well as begins the process of removing the `cost` and `salt` fields from the UserProofingEvent object, starting with allowing those columns to be `null` and ignoring them.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
