### PR TITLE
LG-17600: Add configurable offset to IPP ID expiration time

### DIFF
--- a/app/services/usps_in_person_proofing/applicant.rb
+++ b/app/services/usps_in_person_proofing/applicant.rb
@@ -15,6 +15,15 @@ module UspsInPersonProofing
     :email, :document_type, :document_number, :document_expiration_date, keyword_init: true
   ) do
     def self.from_usps_applicant_and_enrollment(applicant, enrollment)
+      id_expiration = Time.zone.parse(applicant&.id_expiration || '')
+      document_expiration_date =
+        if id_expiration.present?
+          offset = IdentityConfig.store.in_person_expiration_time_offset_hours.hours
+          (id_expiration + offset).to_i
+        else
+          0
+        end
+
       self.new(
         unique_id: enrollment.unique_id,
         first_name: transliterate(applicant.first_name),
@@ -25,8 +34,7 @@ module UspsInPersonProofing
         zip_code: applicant.zipcode,
         email: IdentityConfig.store.usps_ipp_enrollment_status_update_email_address.presence,
         document_number: applicant.id_number,
-        document_expiration_date:
-          Time.zone.parse(applicant&.id_expiration || '').to_i,
+        document_expiration_date:,
         document_type: USPS_DOCUMENT_TYPE_MAPPINGS[enrollment.document_type],
       )
     end

--- a/app/services/usps_in_person_proofing/applicant.rb
+++ b/app/services/usps_in_person_proofing/applicant.rb
@@ -20,8 +20,6 @@ module UspsInPersonProofing
         if id_expiration.present?
           offset = IdentityConfig.store.in_person_expiration_time_offset_hours.hours
           (id_expiration + offset).to_i
-        else
-          0
         end
 
       self.new(

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -268,6 +268,7 @@ in_person_enrollments_ready_job_max_number_of_messages: 10
 in_person_enrollments_ready_job_queue_url: ''
 in_person_enrollments_ready_job_visibility_timeout_seconds: 30
 in_person_enrollments_ready_job_wait_time_seconds: 20
+in_person_expiration_time_offset_hours: 0
 in_person_opt_in_available_completion_survey_url: 'https://handbook.login.gov'
 in_person_outage_emailed_by_date: 'November 1, 2024'
 # in_person_outage_expected_update_date and in_person_outage_emailed_by_date below

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -288,6 +288,7 @@ module IdentityConfig
     config.add(:in_person_enrollments_ready_job_queue_url, type: :string)
     config.add(:in_person_enrollments_ready_job_visibility_timeout_seconds, type: :integer)
     config.add(:in_person_enrollments_ready_job_wait_time_seconds, type: :integer)
+    config.add(:in_person_expiration_time_offset_hours, type: :integer)
     config.add(:in_person_opt_in_available_completion_survey_url, type: :string)
     config.add(:in_person_password_reset_expiration_days, type: :integer)
     config.add(:in_person_outage_emailed_by_date, type: :string)

--- a/spec/services/usps_in_person_proofing/applicant_spec.rb
+++ b/spec/services/usps_in_person_proofing/applicant_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe UspsInPersonProofing::Applicant do
   let(:document_expiration_date) { Faker::Date.in_date_period(year: 2030).strftime('%Y-%m-%d') }
+  let(:expiration_time_offset_hours) { 0 }
   let(:document_expiration_date_in_epoch) do
     Time.zone.parse(document_expiration_date).to_i
   end
@@ -21,6 +22,16 @@ RSpec.describe UspsInPersonProofing::Applicant do
       id_expiration: document_expiration_date,
     }
   end
+  let(:applicant) { Pii::UspsApplicant.new(**applicant_pii) }
+  let(:enrollment) { build('in_person_enrollment', document_type: document_type) }
+  let(:email) { Faker::Internet.email(name: 'noreply') }
+
+  before do
+    allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_status_update_email_address)
+      .and_return(email)
+    allow(IdentityConfig.store).to receive(:in_person_expiration_time_offset_hours)
+      .and_return(expiration_time_offset_hours)
+  end
 
   describe '.from_usps_applicant_and_enrollment' do
     shared_examples 'when values contains transliterable characters' do
@@ -33,13 +44,6 @@ RSpec.describe UspsInPersonProofing::Applicant do
             city: 'Qüertyton',
           ),
         )
-      end
-      let(:enrollment) { build('in_person_enrollment', document_type: document_type) }
-      let(:email) { Faker::Internet.email(name: 'noreply') }
-
-      before do
-        allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_status_update_email_address)
-          .and_return(email)
       end
 
       it 'returns a UspsInPersonProofing::Applicant' do
@@ -77,15 +81,6 @@ RSpec.describe UspsInPersonProofing::Applicant do
     end
 
     context 'when values do not contain transliterable characters' do
-      let(:applicant) { Pii::UspsApplicant.new(**applicant_pii) }
-      let(:enrollment) { build('in_person_enrollment', document_type: document_type) }
-      let(:email) { Faker::Internet.email(name: 'noreply') }
-
-      before do
-        allow(IdentityConfig.store).to receive(:usps_ipp_enrollment_status_update_email_address)
-          .and_return(email)
-      end
-
       it 'returns a UspsInPersonProofing::Applicant' do
         expect(
           described_class.from_usps_applicant_and_enrollment(
@@ -105,6 +100,40 @@ RSpec.describe UspsInPersonProofing::Applicant do
           email:,
           document_type: usps_expected_document_type,
         )
+      end
+    end
+
+    context 'with an offset to the expiration time' do
+      context 'with an offset of zero' do
+        it 'shows the previous date if interpreted in US timezone' do
+          exp_date = described_class.from_usps_applicant_and_enrollment(
+            applicant,
+            enrollment,
+          ).document_expiration_date
+          expect(
+            Time.at(
+              exp_date,
+              in: '-07:00',
+            ).strftime('%Y-%m-%d'),
+          ).not_to eq document_expiration_date
+        end
+      end
+
+      context 'with an offset of 23 hrs' do
+        let(:expiration_time_offset_hours) { 23 }
+
+        it 'shows the correct date if interpreted in US timezone' do
+          exp_date = described_class.from_usps_applicant_and_enrollment(
+            applicant,
+            enrollment,
+          ).document_expiration_date
+          expect(
+            Time.at(
+              exp_date,
+              in: '-07:00',
+            ).strftime('%Y-%m-%d'),
+          ).to eq document_expiration_date
+        end
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17600](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17600)

## 🛠 Summary of changes

Adds a new config, `in_person_expiration_time_offset_hours`, to allow us to save the expiration "date" as an Epoch time not at 00:00 UTC which *may* be misinterpreted as the previous day in most US timezones.

changelog: Internal, In Person Proofing, allow adjustment of the expiration date to correct for potential timezone issues.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->


[LG-16708]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-16708

[LG-17600]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17600