### PR TITLE
Adding personal key encryption to historic attempts data

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -269,7 +269,6 @@ class ApplicationController < ActionController::Base
       profile = current_user.active_profile
       user_session[:personal_key] = profile.encrypt_recovery_pii(cacher.fetch(profile.id))
 
-      # If there is attempts data, reencrypt it here
       attempt_events = AttemptsApi::Cacher.new(current_user, user_session).fetch
       if attempt_events.present?
         profile.reencrypt_recovery_attempts_data(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -268,6 +268,16 @@ class ApplicationController < ActionController::Base
       cacher = Pii::Cacher.new(current_user, user_session)
       profile = current_user.active_profile
       user_session[:personal_key] = profile.encrypt_recovery_pii(cacher.fetch(profile.id))
+
+      # If there is attempts data, reencrypt it here
+      attempt_events = AttemptsApi::Cacher.new(current_user, user_session).fetch
+      if attempts_data.present?
+        profile.reencrypt_recovery_attempts_data(
+          attempt_events:,
+          personal_key: user_session[:personal_key],
+        )
+      end
+
       profile.save!
 
       analytics.broken_personal_key_regenerated

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -271,7 +271,7 @@ class ApplicationController < ActionController::Base
 
       # If there is attempts data, reencrypt it here
       attempt_events = AttemptsApi::Cacher.new(current_user, user_session).fetch
-      if attempts_data.present?
+      if attempt_events.present?
         profile.reencrypt_recovery_attempts_data(
           attempt_events:,
           personal_key: user_session[:personal_key],

--- a/app/controllers/concerns/personal_key_concern.rb
+++ b/app/controllers/concerns/personal_key_concern.rb
@@ -19,8 +19,8 @@ module PersonalKeyConcern
           attempt_events:,
           personal_key: active_profile.personal_key,
         )
-        active_profile.personal_key
       end
+      active_profile.personal_key
     else
       PersonalKeyGenerator.new(current_user).generate!
     end

--- a/app/controllers/concerns/personal_key_concern.rb
+++ b/app/controllers/concerns/personal_key_concern.rb
@@ -12,7 +12,16 @@ module PersonalKeyConcern
   def create_new_code
     if active_profile.present?
       Pii::ReEncryptor.new(user: current_user, user_session: user_session).perform
-      active_profile.personal_key
+
+      # If there is attempts data, reencrypt it here
+      attempt_events = AttemptsApi::Cacher.new(current_user, user_session).fetch
+      if attempts_data.present?
+        profile.reencrypt_recovery_attempts_data(
+          attempt_events:,
+          personal_key: active_profile.personal_key,
+        )
+        active_profile.personal_key
+      end
     else
       PersonalKeyGenerator.new(current_user).generate!
     end

--- a/app/controllers/concerns/personal_key_concern.rb
+++ b/app/controllers/concerns/personal_key_concern.rb
@@ -13,7 +13,6 @@ module PersonalKeyConcern
     if active_profile.present?
       Pii::ReEncryptor.new(user: current_user, user_session: user_session).perform
 
-      # If there is attempts data, reencrypt it here
       attempt_events = AttemptsApi::Cacher.new(current_user, user_session).fetch
       if attempt_events.present?
         active_profile.reencrypt_recovery_attempts_data(

--- a/app/controllers/concerns/personal_key_concern.rb
+++ b/app/controllers/concerns/personal_key_concern.rb
@@ -15,8 +15,8 @@ module PersonalKeyConcern
 
       # If there is attempts data, reencrypt it here
       attempt_events = AttemptsApi::Cacher.new(current_user, user_session).fetch
-      if attempts_data.present?
-        profile.reencrypt_recovery_attempts_data(
+      if attempt_events.present?
+        active_profile.reencrypt_recovery_attempts_data(
           attempt_events:,
           personal_key: active_profile.personal_key,
         )

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -224,8 +224,8 @@ module Idv
       current_user.active_profile.create_user_proofing_event(
         attempt_events:,
         password:,
-        sent_to_sp: attempts_api_enabled_for_session?,
         personal_key: idv_session.personal_key,
+        sent_to_sp: attempts_api_enabled_for_session?,
       )
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -222,9 +222,10 @@ module Idv
       return unless historical_events_enabled?
 
       current_user.active_profile.create_user_proofing_event(
-        password:,
         attempt_events:,
+        password:,
         sent_to_sp: attempts_api_enabled_for_session?,
+        personal_key: idv_session.personal_key,
       )
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -74,7 +74,18 @@ module Users
     def handle_success(decrypted_pii:)
       analytics.personal_key_reactivation
       reactivate_account_session.store_decrypted_pii(decrypted_pii)
+      cache_attempt_events
       redirect_to verify_password_url
+    end
+
+    def cache_attempt_events
+      AttemptsApi::Cacher.new(current_user, user_session)
+        .save_with_personal_key(personal_key: params.permit(:personal_key)[:personal_key])
+    end
+
+    def decrypted_attempt_events
+      @decrypted_attempt_events ||= password_reset_profile
+        .recover_attempt_events(personal_key:)
     end
 
     def handle_failure(result)

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -83,11 +83,6 @@ module Users
         .save_with_personal_key(personal_key: params.permit(:personal_key)[:personal_key])
     end
 
-    def decrypted_attempt_events
-      @decrypted_attempt_events ||= password_reset_profile
-        .recover_attempt_events(personal_key:)
-    end
-
     def handle_failure(result)
       flash[:error] = result.errors[:personal_key].last
       redirect_to verify_personal_key_url

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -79,8 +79,10 @@ module Users
     end
 
     def cache_attempt_events
-      AttemptsApi::Cacher.new(current_user, user_session)
-        .save_with_personal_key(personal_key: params.permit(:personal_key)[:personal_key])
+      personal_key = PersonalKeyGenerator
+        .new(current_user)
+        .normalize(personal_key_params)
+      AttemptsApi::Cacher.new(current_user, user_session).save_with_personal_key(personal_key:)
     end
 
     def handle_failure(result)
@@ -91,8 +93,12 @@ module Users
     def personal_key_form
       VerifyPersonalKeyForm.new(
         user: current_user,
-        personal_key: params.permit(:personal_key)[:personal_key],
+        personal_key: personal_key_params,
       )
+    end
+
+    def personal_key_params
+      params.permit(:personal_key)[:personal_key]
     end
   end
 end

--- a/app/controllers/users/verify_personal_key_controller.rb
+++ b/app/controllers/users/verify_personal_key_controller.rb
@@ -79,10 +79,9 @@ module Users
     end
 
     def cache_attempt_events
-      personal_key = PersonalKeyGenerator
-        .new(current_user)
-        .normalize(personal_key_params)
-      AttemptsApi::Cacher.new(current_user, user_session).save_with_personal_key(personal_key:)
+      AttemptsApi::Cacher.new(current_user, user_session).save_with_personal_key(
+        personal_key: personal_key_params,
+      )
     end
 
     def handle_failure(result)

--- a/app/forms/update_user_password_form.rb
+++ b/app/forms/update_user_password_form.rb
@@ -33,8 +33,8 @@ class UpdateUserPasswordForm
   def encrypt_user_profiles
     return if user.active_or_pending_profile.blank?
 
-    reencrypt_attempt_events
     encryptor.encrypt
+    encrypt_attempt_events
   end
 
   def encryptor
@@ -54,13 +54,15 @@ class UpdateUserPasswordForm
     }
   end
 
-  def reencrypt_attempt_events
+  def encrypt_attempt_events
     return if user.active_profile.blank?
     return if user_session.blank?
 
     decrypted_events = AttemptsApi::Cacher.new(user, user_session).fetch
     return if decrypted_events.blank?
 
-    user.active_profile.reencrypt_user_proofing_events(password:, attempt_events: decrypted_events)
+    user
+      .active_profile
+      .reencrypt_user_proofing_events(password:, personal_key:, attempt_events: decrypted_events)
   end
 end

--- a/app/forms/verify_password_form.rb
+++ b/app/forms/verify_password_form.rb
@@ -20,7 +20,11 @@ class VerifyPasswordForm
 
     @personal_key = reencrypt_pii if success
     if success && decrypted_attempt_events.present?
-      profile.reencrypt_user_proofing_events(password:, attempt_events: decrypted_attempt_events)
+      profile.reencrypt_user_proofing_events(
+        password:,
+        attempt_events: decrypted_attempt_events,
+        personal_key:,
+      )
     end
 
     FormResponse.new(success:, errors:)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -436,11 +436,9 @@ class Profile < ApplicationRecord
     FACIAL_MATCH_IDV_LEVELS.include?(idv_level)
   end
 
-  def create_user_proofing_event(password:, attempt_events:, sent_to_sp: false)
-    user_proofing_event = build_user_proofing_event(
-      service_provider_ids_sent: service_provider_ids_sent(sent_to_sp:),
-    )
-    result = user_proofing_event.write_events(password:, attempt_events:)
+  def create_user_proofing_event(password:, personal_key:, attempt_events:, sent_to_sp: false)
+    build_user_proofing_event(service_provider_ids_sent: service_provider_ids_sent(sent_to_sp:))
+    result = user_proofing_event.write_events(password:, personal_key:, attempt_events:)
 
     update!(encrypted_attempts_file_reference: result.name)
 
@@ -451,8 +449,12 @@ class Profile < ApplicationRecord
     user_proofing_event.decrypt_events(password:)
   end
 
-  def reencrypt_user_proofing_events(password:, attempt_events:)
-    user_proofing_event.write_events(password:, attempt_events:)
+  def reencrypt_user_proofing_events(password:, personal_key:, attempt_events:)
+    user_proofing_event.write_events(password:, personal_key:, attempt_events:)
+  end
+
+  def reencrypt_recovery_attempt_data(attempt_events:, personal_key:)
+    user_proofing_event.rewrite_recovery_attempt_data(personal_key:, attempt_events:)
   end
 
   private

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -438,7 +438,11 @@ class Profile < ApplicationRecord
 
   def create_user_proofing_event(password:, personal_key:, attempt_events:, sent_to_sp: false)
     build_user_proofing_event(service_provider_ids_sent: service_provider_ids_sent(sent_to_sp:))
-    result = user_proofing_event.write_events(password:, personal_key:, attempt_events:)
+    result = user_proofing_event.write_events(
+      password:,
+      personal_key: personal_key_generator.normalize(personal_key),
+      attempt_events:,
+    )
 
     update!(encrypted_attempts_file_reference: result.name)
 
@@ -450,11 +454,18 @@ class Profile < ApplicationRecord
   end
 
   def reencrypt_user_proofing_events(password:, personal_key:, attempt_events:)
-    user_proofing_event&.write_events(password:, personal_key:, attempt_events:)
+    user_proofing_event&.write_events(
+      password:,
+      personal_key: personal_key_generator.normalize(personal_key),
+      attempt_events:,
+    )
   end
 
   def reencrypt_recovery_attempts_data(attempt_events:, personal_key:)
-    user_proofing_event&.reencrypt_recovery_attempts_data(personal_key:, attempt_events:)
+    user_proofing_event&.reencrypt_recovery_attempts_data(
+      personal_key: personal_key_generator.normalize(personal_key),
+      attempt_events:,
+    )
   end
 
   def recover_attempt_events(personal_key:)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -453,8 +453,12 @@ class Profile < ApplicationRecord
     user_proofing_event.write_events(password:, personal_key:, attempt_events:)
   end
 
-  def reencrypt_recovery_attempt_data(attempt_events:, personal_key:)
-    user_proofing_event.rewrite_recovery_attempt_data(personal_key:, attempt_events:)
+  def reencrypt_recovery_attempts_data(attempt_events:, personal_key:)
+    user_proofing_event.reencrypt_recovery_attempts_data(personal_key:, attempt_events:)
+  end
+
+  def recover_attempt_events(personal_key:)
+    user_proofing_event.recover_attempt_events(personal_key:)
   end
 
   private

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -437,70 +437,28 @@ class Profile < ApplicationRecord
   end
 
   def create_user_proofing_event(password:, attempt_events:, sent_to_sp: false)
-    # TODO: refactor to use reencrypt_user_proofing_events
-    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-    encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
-
-    result = encrypted_doc_writer.write_encrypted_attempt_events(
-      file_path: attempt_events_file_path,
-      encrypted_attempt_events: encrypted_events_json,
+    user_proofing_event = build_user_proofing_event(
+      service_provider_ids_sent: service_provider_ids_sent(sent_to_sp:),
     )
+    result = user_proofing_event.write_events(password:, attempt_events:)
 
     update!(encrypted_attempts_file_reference: result.name)
 
-    new_user_proofing_event = build_user_proofing_event(
-      service_provider_ids_sent: service_provider_ids_sent(sent_to_sp:),
-    )
-
-    new_user_proofing_event.save
+    user_proofing_event.save
   end
 
   def decrypt_user_proofing_events(password:)
-    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-
-    data = attempt_data_retriever.retrieve_user_proofing_events(
-      file_path: attempt_events_file_path,
-      file_name: encrypted_attempts_file_reference,
-    )
-
-    encryptor.decrypt(data, user_uuid: user.uuid)
+    user_proofing_event.decrypt_events(password:)
   end
 
   def reencrypt_user_proofing_events(password:, attempt_events:)
-    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-    encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
-
-    encrypted_doc_writer.write_encrypted_attempt_events(
-      file_path: attempt_events_file_path,
-      encrypted_attempt_events: encrypted_events_json,
-      name: encrypted_attempts_file_reference,
-    )
+    user_proofing_event.write_events(password:, attempt_events:)
   end
 
   private
 
   def confirm_that_profile_can_be_activated!
     raise reason_not_to_activate if reason_not_to_activate
-  end
-
-  def encrypted_doc_writer
-    @encrypted_doc_writer ||= EncryptedDocStorage::DocWriter.new(
-      s3_enabled: historical_attempts_s3_storage_enabled?,
-    )
-  end
-
-  def attempt_data_retriever
-    @attempt_data_retriever ||= EncryptedDocStorage::AttemptDataRetriever.new(
-      s3_enabled: historical_attempts_s3_storage_enabled?,
-    )
-  end
-
-  def attempt_events_file_path
-    "attempt_events/#{user.uuid}/#{self.id}"
-  end
-
-  def historical_attempts_s3_storage_enabled?
-    IdentityConfig.store.historical_attempts_s3_storage_enabled
   end
 
   def personal_key_generator

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -446,19 +446,19 @@ class Profile < ApplicationRecord
   end
 
   def decrypt_user_proofing_events(password:)
-    user_proofing_event.decrypt_events(password:)
+    user_proofing_event&.decrypt_events(password:)
   end
 
   def reencrypt_user_proofing_events(password:, personal_key:, attempt_events:)
-    user_proofing_event.write_events(password:, personal_key:, attempt_events:)
+    user_proofing_event&.write_events(password:, personal_key:, attempt_events:)
   end
 
   def reencrypt_recovery_attempts_data(attempt_events:, personal_key:)
-    user_proofing_event.reencrypt_recovery_attempts_data(personal_key:, attempt_events:)
+    user_proofing_event&.reencrypt_recovery_attempts_data(personal_key:, attempt_events:)
   end
 
   def recover_attempt_events(personal_key:)
-    user_proofing_event.recover_attempt_events(personal_key:)
+    user_proofing_event&.recover_attempt_events(personal_key:)
   end
 
   private

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -469,7 +469,9 @@ class Profile < ApplicationRecord
   end
 
   def recover_attempt_events(personal_key:)
-    user_proofing_event&.recover_attempt_events(personal_key:)
+    user_proofing_event&.recover_attempt_events(
+      personal_key: personal_key_generator.normalize(personal_key),
+    )
   end
 
   private

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -16,6 +16,20 @@ class UserProofingEvent < ApplicationRecord
     service_provider_ids_sent.include?(id)
   end
 
+  # Stored data looks like this:
+  # {
+  #   'password_encrypted_events' => {
+  #     encrypted_data: "encrypted_string",
+  #     cost: 'cost',
+  #     salt: 'salt'
+  #     }.to_json,
+  #   'personal_key_encrypted_events' => {
+  #     encrypted_data: "encrypted_string",
+  #     cost: 'cost',
+  #     salt: 'salt'
+  #     }.to_json
+  # }
+
   def write_events(attempt_events:, password:, personal_key:)
     encrypted_attempt_events = {
       password_encrypted_events: encrypted_json(password, attempt_events),
@@ -26,10 +40,11 @@ class UserProofingEvent < ApplicationRecord
   end
 
   def decrypt_events(password:)
-    return nil if retrieved_attempts_data.blank?
+    attempts_data = retrieved_attempts_data
+    return nil if attempts_data.blank?
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
 
-    encryptor.decrypt(retrieved_attempts_data['password_encrypted_events'], user_uuid: user.uuid)
+    encryptor.decrypt(attempts_data['password_encrypted_events'], user_uuid: user.uuid)
   end
 
   def reencrypt_recovery_attempts_data(attempt_events:, personal_key:)
@@ -38,17 +53,18 @@ class UserProofingEvent < ApplicationRecord
     # merge the new personal key encrypted data in
     encrypted_attempt_events = retrieved_attempts_data.merge(
       'personal_key_encrypted_events' => personal_key_encrypted_events,
-    )
+    ).to_json
     # rewrite the data
     write_attempts_data(encrypted_attempt_events:)
   end
 
   def recover_attempt_events(personal_key:)
-    return nil if retrieved_attempts_data.blank?
+    attempt_data = retrieved_attempts_data
+    return nil if attempt_data.blank?
     encryptor = Encryption::Encryptors::PiiEncryptor.new(personal_key)
 
     encryptor.decrypt(
-      retrieved_attempts_data['personal_key_encrypted_events'],
+      attempt_data['personal_key_encrypted_events'],
       user_uuid: user.uuid,
     )
   end
@@ -68,20 +84,6 @@ class UserProofingEvent < ApplicationRecord
 
     JSON.parse(data) if data.present?
   end
-
-  # Stored data looks like this:
-  # {
-  #   'password_encrypted_events' => {
-  #     encrypted_data: "encrypted_string",
-  #     cost: 'cost',
-  #     salt: 'salt'
-  #     }.to_json,
-  #   'personal_key_encrypted_events' => {
-  #     encrypted_data: "encrypted_string",
-  #     cost: 'cost',
-  #     salt: 'salt'
-  #     }.to_json
-  # }
 
   def user
     @user ||= profile.user
@@ -109,7 +111,7 @@ class UserProofingEvent < ApplicationRecord
   end
 
   def attempt_events_file_path
-    "attempt_events/#{profile.user.uuid}/#{profile.id}"
+    "attempt_events/#{user.uuid}/#{profile.id}"
   end
 
   def historical_attempts_s3_storage_enabled?

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -26,12 +26,13 @@ class UserProofingEvent < ApplicationRecord
   end
 
   def decrypt_events(password:)
+    return nil if retrieved_attempts_data.blank?
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
 
     encryptor.decrypt(retrieved_attempts_data['password_encrypted_events'], user_uuid: user.uuid)
   end
 
-  def reencrypt_recovery_attempt_data(attempt_events:, personal_key:)
+  def reencrypt_recovery_attempts_data(attempt_events:, personal_key:)
     personal_key_encrypted_events = encrypted_json(personal_key, attempt_events)
 
     # merge the new personal key encrypted data in
@@ -42,6 +43,16 @@ class UserProofingEvent < ApplicationRecord
     write_attempts_data(encrypted_attempt_events:)
   end
 
+  def recover_attempt_events(personal_key:)
+    return nil if retrieved_attempts_data.blank?
+    encryptor = Encryption::Encryptors::PiiEncryptor.new(personal_key)
+
+    encryptor.decrypt(
+      retrieved_attempts_data['personal_key_encrypted_events'],
+      user_uuid: user.uuid,
+    )
+  end
+
   private
 
   def encrypted_json(key, data)
@@ -50,12 +61,12 @@ class UserProofingEvent < ApplicationRecord
   end
 
   def retrieved_attempts_data
-    JSON.parse(
-      attempt_data_retriever.retrieve_user_proofing_events(
-        file_path: attempt_events_file_path,
-        file_name: profile.encrypted_attempts_file_reference,
-      ),
+    data = attempt_data_retriever.retrieve_user_proofing_events(
+      file_path: attempt_events_file_path,
+      file_name: profile.encrypted_attempts_file_reference,
     )
+
+    JSON.parse(data) if data.present?
   end
 
   # Stored data looks like this:

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -15,4 +15,52 @@ class UserProofingEvent < ApplicationRecord
   def already_sent_to_sp?(id)
     service_provider_ids_sent.include?(id)
   end
+
+  def write_events(password:, attempt_events:)
+    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
+    encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
+
+    encrypted_doc_writer.write_encrypted_attempt_events(
+      file_path: attempt_events_file_path,
+      encrypted_attempt_events: encrypted_events_json,
+      name: profile.encrypted_attempts_file_reference,
+    )
+  end
+
+  def decrypt_events(password:)
+    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
+
+    data = attempt_data_retriever.retrieve_user_proofing_events(
+      file_path: attempt_events_file_path,
+      file_name: profile.encrypted_attempts_file_reference,
+    )
+
+    encryptor.decrypt(data, user_uuid: user.uuid)
+  end
+
+  private
+
+  def user
+    @user ||= profile.user
+  end
+
+  def encrypted_doc_writer
+    @encrypted_doc_writer ||= EncryptedDocStorage::DocWriter.new(
+      s3_enabled: historical_attempts_s3_storage_enabled?,
+    )
+  end
+
+  def attempt_data_retriever
+    @attempt_data_retriever ||= EncryptedDocStorage::AttemptDataRetriever.new(
+      s3_enabled: historical_attempts_s3_storage_enabled?,
+    )
+  end
+
+  def attempt_events_file_path
+    "attempt_events/#{profile.user.uuid}/#{profile.id}"
+  end
+
+  def historical_attempts_s3_storage_enabled?
+    IdentityConfig.store.historical_attempts_s3_storage_enabled
+  end
 end

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -16,51 +16,73 @@ class UserProofingEvent < ApplicationRecord
     service_provider_ids_sent.include?(id)
   end
 
-  def write_events(password:, attempt_events:)
-    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-    encrypted_events_json = encryptor.encrypt(attempt_events.to_json, user_uuid: user.uuid)
+  def write_events(attempt_events:, password:, personal_key:)
+    encrypted_attempt_events = {
+      password_encrypted_events: encrypted_json(password, attempt_events),
+      personal_key_encrypted_events: encrypted_json(personal_key, attempt_events),
+    }.to_json
 
-    encrypted_doc_writer.write_encrypted_attempt_events(
-      file_path: attempt_events_file_path,
-      encrypted_attempt_events: formatted_events(password_encrypted_events: encrypted_events_json),
-      name: profile.encrypted_attempts_file_reference,
-    )
+    write_attempts_data(encrypted_attempt_events:)
   end
 
   def decrypt_events(password:)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
 
-    data = JSON.parse(
+    encryptor.decrypt(retrieved_attempts_data['password_encrypted_events'], user_uuid: user.uuid)
+  end
+
+  def reencrypt_recovery_attempt_data(attempt_events:, personal_key:)
+    personal_key_encrypted_events = encrypted_json(personal_key, attempt_events)
+
+    # merge the new personal key encrypted data in
+    encrypted_attempt_events = retrieved_attempts_data.merge(
+      'personal_key_encrypted_events' => personal_key_encrypted_events,
+    )
+    # rewrite the data
+    write_attempts_data(encrypted_attempt_events:)
+  end
+
+  private
+
+  def encrypted_json(key, data)
+    encryptor = Encryption::Encryptors::PiiEncryptor.new(key)
+    encryptor.encrypt(data.to_json, user_uuid: user.uuid)
+  end
+
+  def retrieved_attempts_data
+    JSON.parse(
       attempt_data_retriever.retrieve_user_proofing_events(
         file_path: attempt_events_file_path,
         file_name: profile.encrypted_attempts_file_reference,
       ),
     )
-    encryptor.decrypt(data['password_encrypted_events'], user_uuid: user.uuid)
   end
 
-  private
-
-  def formatted_events(password_encrypted_events:)
-    { password_encrypted_events: }.to_json
-  end
-
-  # We will need the data in storage to look like this:
+  # Stored data looks like this:
   # {
-  #   password_encrypted_events: {
+  #   'password_encrypted_events' => {
   #     encrypted_data: "encrypted_string",
   #     cost: 'cost',
   #     salt: 'salt'
-  #     },
-  #   personal_key_encrypted_events: {
+  #     }.to_json,
+  #   'personal_key_encrypted_events' => {
   #     encrypted_data: "encrypted_string",
   #     cost: 'cost',
   #     salt: 'salt'
-  #     }
+  #     }.to_json
   # }
 
   def user
     @user ||= profile.user
+  end
+
+  def write_attempts_data(encrypted_attempt_events:)
+    encrypted_doc_writer.write_encrypted_attempt_events(
+      file_path: attempt_events_file_path,
+      encrypted_attempt_events:,
+      # on first write name will be `nil`. the DocWriter will take care of that
+      name: profile.encrypted_attempts_file_reference,
+    )
   end
 
   def encrypted_doc_writer

--- a/app/models/user_proofing_event.rb
+++ b/app/models/user_proofing_event.rb
@@ -22,7 +22,7 @@ class UserProofingEvent < ApplicationRecord
 
     encrypted_doc_writer.write_encrypted_attempt_events(
       file_path: attempt_events_file_path,
-      encrypted_attempt_events: encrypted_events_json,
+      encrypted_attempt_events: formatted_events(password_encrypted_events: encrypted_events_json),
       name: profile.encrypted_attempts_file_reference,
     )
   end
@@ -30,15 +30,34 @@ class UserProofingEvent < ApplicationRecord
   def decrypt_events(password:)
     encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
 
-    data = attempt_data_retriever.retrieve_user_proofing_events(
-      file_path: attempt_events_file_path,
-      file_name: profile.encrypted_attempts_file_reference,
+    data = JSON.parse(
+      attempt_data_retriever.retrieve_user_proofing_events(
+        file_path: attempt_events_file_path,
+        file_name: profile.encrypted_attempts_file_reference,
+      ),
     )
-
-    encryptor.decrypt(data, user_uuid: user.uuid)
+    encryptor.decrypt(data['password_encrypted_events'], user_uuid: user.uuid)
   end
 
   private
+
+  def formatted_events(password_encrypted_events:)
+    { password_encrypted_events: }.to_json
+  end
+
+  # We will need the data in storage to look like this:
+  # {
+  #   password_encrypted_events: {
+  #     encrypted_data: "encrypted_string",
+  #     cost: 'cost',
+  #     salt: 'salt'
+  #     },
+  #   personal_key_encrypted_events: {
+  #     encrypted_data: "encrypted_string",
+  #     cost: 'cost',
+  #     salt: 'salt'
+  #     }
+  # }
 
   def user
     @user ||= profile.user

--- a/app/services/attempts_api/cacher.rb
+++ b/app/services/attempts_api/cacher.rb
@@ -10,7 +10,8 @@ module AttemptsApi
     end
 
     def save(password:)
-      return unless user.active_profile.encrypted_attempts_file_reference.present?
+      return unless user&.active_profile&.encrypted_attempts_file_reference.present?
+
       decrypted_events = user.active_profile.decrypt_user_proofing_events(password:)
       return if decrypted_events.blank?
 
@@ -19,7 +20,7 @@ module AttemptsApi
     end
 
     def save_with_personal_key(personal_key:)
-      decrypted_events = user.active_profile.recover_attempt_events(personal_key:)
+      decrypted_events = user&.active_profile&.recover_attempt_events(personal_key:)
       return if decrypted_events.blank?
 
       kms_encrypted_events = SessionEncryptor.new.kms_encrypt(decrypted_events)

--- a/app/services/attempts_api/cacher.rb
+++ b/app/services/attempts_api/cacher.rb
@@ -12,6 +12,15 @@ module AttemptsApi
     def save(password:)
       return unless user.active_profile.encrypted_attempts_file_reference.present?
       decrypted_events = user.active_profile.decrypt_user_proofing_events(password:)
+      return if decrypted_events.blank?
+
+      kms_encrypted_events = SessionEncryptor.new.kms_encrypt(decrypted_events)
+      user_session[:encrypted_proofing_events] = kms_encrypted_events
+    end
+
+    def save_with_personal_key(personal_key:)
+      decrypted_events = user.active_profile.recover_attempt_events(personal_key:)
+      return if decrypted_events.blank?
 
       kms_encrypted_events = SessionEncryptor.new.kms_encrypt(decrypted_events)
       user_session[:encrypted_proofing_events] = kms_encrypted_events

--- a/app/services/attempts_api/cacher.rb
+++ b/app/services/attempts_api/cacher.rb
@@ -20,7 +20,8 @@ module AttemptsApi
     end
 
     def save_with_personal_key(personal_key:)
-      decrypted_events = user&.active_profile&.recover_attempt_events(personal_key:)
+      profile = user.active_profile || user.password_reset_profile
+      decrypted_events = profile.recover_attempt_events(personal_key:)
       return if decrypted_events.blank?
 
       kms_encrypted_events = SessionEncryptor.new.kms_encrypt(decrypted_events)

--- a/app/services/attempts_api/cacher.rb
+++ b/app/services/attempts_api/cacher.rb
@@ -21,6 +21,9 @@ module AttemptsApi
 
     def save_with_personal_key(personal_key:)
       profile = user.active_profile || user.password_reset_profile
+
+      return if profile.blank?
+
       decrypted_events = profile.recover_attempt_events(personal_key:)
       return if decrypted_events.blank?
 

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -40,8 +40,8 @@ module EncryptedDocStorage
       )
     end
 
-    def write_encrypted_attempt_events(file_path:, encrypted_attempt_events:,
-                                       name: SecureRandom.uuid)
+    def write_encrypted_attempt_events(file_path:, encrypted_attempt_events:, name:)
+      name = name.presence || SecureRandom.uuid
       path = "#{file_path}/#{name}"
 
       storage.write_attempt_events(path:, encrypted_attempt_events:)

--- a/spec/controllers/users/verify_password_controller_spec.rb
+++ b/spec/controllers/users/verify_password_controller_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Users::VerifyPasswordController do
               expect(profile).to have_received(:reencrypt_user_proofing_events).with(
                 password:,
                 attempt_events:,
+                personal_key: controller.user_session[:personal_key],
               )
             end
           end

--- a/spec/factories/user_proofing_events.rb
+++ b/spec/factories/user_proofing_events.rb
@@ -1,10 +1,11 @@
 FactoryBot.define do
   factory :user_proofing_event do
     service_provider_ids_sent { [] }
+    cost { '0$0$0$' }
+    salt { '73616c74' }
     profile_id { nil }
 
     trait :existing do
-      service_provider_ids_sent { [] }
       association :profile
     end
   end

--- a/spec/factories/user_proofing_events.rb
+++ b/spec/factories/user_proofing_events.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
   factory :user_proofing_event do
     service_provider_ids_sent { [] }
-    cost { '0$0$0$' }
-    salt { '73616c74' }
     profile_id { nil }
 
     trait :existing do

--- a/spec/forms/update_user_password_form_spec.rb
+++ b/spec/forms/update_user_password_form_spec.rb
@@ -114,7 +114,9 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
           }
         end
 
+        let(:personal_key) { 'personal-key' }
         before do
+          allow_any_instance_of(Profile).to receive(:encrypt_pii).and_return(personal_key)
           allow_any_instance_of(Profile).to receive(:reencrypt_user_proofing_events)
         end
 
@@ -123,6 +125,7 @@ RSpec.describe UpdateUserPasswordForm, type: :model do
           expect_any_instance_of(Profile).to receive(:reencrypt_user_proofing_events).with(
             password:,
             attempt_events: decrypted_events.as_json,
+            personal_key:,
           )
 
           subject.submit(params)

--- a/spec/forms/verify_password_form_spec.rb
+++ b/spec/forms/verify_password_form_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe VerifyPasswordForm, type: :model do
           expect(profile).to receive(:reencrypt_user_proofing_events).with(
             password: attempted_password,
             attempt_events: decrypted_attempt_events,
+            personal_key: String,
           )
 
           form.submit

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1572,7 +1572,7 @@ RSpec.describe Profile do
     let(:dir_path) do
       Rails.root.join('tmp', 'encrypted_attempt_events', 'attempt_events', profile.user.uuid)
     end
-    let(:personal_key) { 'personal-key ' }
+    let(:personal_key) { 'personal-key' }
 
     after do
       FileUtils.rm_rf(dir_path) if Dir.exist?(dir_path)

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1500,6 +1500,7 @@ RSpec.describe Profile do
         profile.create_user_proofing_event(
           password: 'password',
           attempt_events: [{ 'event' => 'test' }],
+          personal_key: 'personal_key',
         )
       end.to change { UserProofingEvent.count }.by(1)
 
@@ -1515,6 +1516,7 @@ RSpec.describe Profile do
 
         profile.create_user_proofing_event(
           password: 'password',
+          personal_key: 'personal-key',
           attempt_events: [{ 'event' => 'test' }],
           sent_to_sp: true,
         )
@@ -1557,6 +1559,7 @@ RSpec.describe Profile do
       profile.create_user_proofing_event(
         password: 'password',
         attempt_events:,
+        personal_key: 'personal-key',
       )
 
       expect(
@@ -1569,6 +1572,7 @@ RSpec.describe Profile do
     let(:dir_path) do
       Rails.root.join('tmp', 'encrypted_attempt_events', 'attempt_events', profile.user.uuid)
     end
+    let(:personal_key) { 'personal-key ' }
 
     after do
       FileUtils.rm_rf(dir_path) if Dir.exist?(dir_path)
@@ -1588,13 +1592,18 @@ RSpec.describe Profile do
       profile.create_user_proofing_event(
         password: 'password',
         attempt_events:,
+        personal_key:,
       )
       events_path = dir_path.join(profile.id.to_s, profile.encrypted_attempts_file_reference)
 
       encrypted_events = File.read(events_path)
 
       expect do
-        profile.reencrypt_user_proofing_events(password: 'new-password', attempt_events:)
+        profile.reencrypt_user_proofing_events(
+          password: 'new-password',
+          attempt_events:,
+          personal_key:,
+        )
       end.to_not change { UserProofingEvent.last }
 
       reencrypted_events = File.read(events_path)

--- a/spec/models/user_proofing_event_spec.rb
+++ b/spec/models/user_proofing_event_spec.rb
@@ -108,9 +108,19 @@ RSpec.describe UserProofingEvent, type: :model do
 
       expect(user_proofing_event.decrypt_events(password:)).to eq(attempt_events.to_json)
     end
+
+    context 'when there is no data retrieved' do
+      before do
+        allow(doc_retriever).to receive(:retrieve_user_proofing_events).and_return(nil)
+      end
+
+      it 'returns an empty JSON object' do
+        expect(user_proofing_event.decrypt_events(password:)).to be nil
+      end
+    end
   end
 
-  describe '#reencrypt_recovery_attempt_data' do
+  describe '#reencrypt_recovery_attempts_data' do
     let(:new_personal_key) { 'new-personal-key' }
 
     before do
@@ -139,7 +149,7 @@ RSpec.describe UserProofingEvent, type: :model do
         name: 'test-file-reference',
       )
 
-      user_proofing_event.reencrypt_recovery_attempt_data(
+      user_proofing_event.reencrypt_recovery_attempts_data(
         attempt_events:,
         personal_key: new_personal_key,
       )

--- a/spec/models/user_proofing_event_spec.rb
+++ b/spec/models/user_proofing_event_spec.rb
@@ -79,7 +79,10 @@ RSpec.describe UserProofingEvent, type: :model do
     let(:user_proofing_event) { create(:user_proofing_event, profile:) }
     let(:encrypted_data) do
       encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-      encryptor.encrypt(attempt_events.to_json, user_uuid: profile.user.uuid)
+      { password_encrypted_events: encryptor.encrypt(
+        attempt_events.to_json,
+        user_uuid: profile.user.uuid,
+      ) }.to_json
     end
 
     before do
@@ -91,7 +94,7 @@ RSpec.describe UserProofingEvent, type: :model do
       expect(doc_retriever).to receive(:retrieve_user_proofing_events).with(
         file_path: "attempt_events/#{profile.user.uuid}/#{profile.id}",
         file_name: 'test-file-reference',
-      )
+      ).and_return(encrypted_data)
 
       expect(user_proofing_event.decrypt_events(password:)).to eq(attempt_events.to_json)
     end

--- a/spec/models/user_proofing_event_spec.rb
+++ b/spec/models/user_proofing_event_spec.rb
@@ -27,4 +27,73 @@ RSpec.describe UserProofingEvent, type: :model do
       expect(user_proofing_event.service_provider_ids_sent).to eq([sp.id])
     end
   end
+
+  describe '#already_sent_to_sp?' do
+    let(:sp) { create(:service_provider) }
+
+    context 'when the given id is in the list of service_provider_ids_sent' do
+      before do
+        user_proofing_event.add_sp_sent(sp.id)
+      end
+
+      it 'should return true' do
+        expect(user_proofing_event.already_sent_to_sp?(sp.id)).to eq(true)
+      end
+    end
+
+    context 'when the given id is not in the list of service_provider_ids_sent' do
+      it 'should return false' do
+        expect(user_proofing_event.already_sent_to_sp?(sp.id)).to eq(false)
+      end
+    end
+  end
+
+  describe '#write_events' do
+    let(:doc_writer) { EncryptedDocStorage::DocWriter.new(s3_enabled: false) }
+    let(:password) { 'password' }
+    let(:attempt_events) { [{ event_type: 'idv-something' }, { event_type: 'idv-nothing-else' }] }
+    let(:profile) { create(:profile, encrypted_attempts_file_reference: 'test-file-reference') }
+    let(:user_proofing_event) { create(:user_proofing_event, profile:) }
+
+    before do
+      allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(doc_writer)
+      allow(doc_writer).to receive(:write_encrypted_attempt_events)
+    end
+
+    it 'encrypts and writes the events to storage' do
+      expect(doc_writer).to receive(:write_encrypted_attempt_events).with(
+        file_path: "attempt_events/#{profile.user.uuid}/#{profile.id}",
+        encrypted_attempt_events: instance_of(String),
+        name: 'test-file-reference',
+      )
+
+      user_proofing_event.write_events(password:, attempt_events:)
+    end
+  end
+
+  describe '#decrypt_events' do
+    let(:doc_retriever) { EncryptedDocStorage::AttemptDataRetriever.new(s3_enabled: false) }
+    let(:password) { 'password' }
+    let(:attempt_events) { [{ event_type: 'idv-something' }, { event_type: 'idv-nothing-else' }] }
+    let(:profile) { create(:profile, encrypted_attempts_file_reference: 'test-file-reference') }
+    let(:user_proofing_event) { create(:user_proofing_event, profile:) }
+    let(:encrypted_data) do
+      encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
+      encryptor.encrypt(attempt_events.to_json, user_uuid: profile.user.uuid)
+    end
+
+    before do
+      allow(EncryptedDocStorage::AttemptDataRetriever).to receive(:new).and_return(doc_retriever)
+      allow(doc_retriever).to receive(:retrieve_user_proofing_events).and_return(encrypted_data)
+    end
+
+    it 'retrieves and decrypts the events from storage' do
+      expect(doc_retriever).to receive(:retrieve_user_proofing_events).with(
+        file_path: "attempt_events/#{profile.user.uuid}/#{profile.id}",
+        file_name: 'test-file-reference',
+      )
+
+      expect(user_proofing_event.decrypt_events(password:)).to eq(attempt_events.to_json)
+    end
+  end
 end

--- a/spec/models/user_proofing_event_spec.rb
+++ b/spec/models/user_proofing_event_spec.rb
@@ -3,9 +3,30 @@ require 'rails_helper'
 RSpec.describe UserProofingEvent, type: :model do
   let(:user_proofing_event) do
     UserProofingEvent.new(
-      profile_id: 1,
+      profile_id: profile.id,
       service_provider_ids_sent: [],
     )
+  end
+  let(:doc_retriever) { EncryptedDocStorage::AttemptDataRetriever.new(s3_enabled: false) }
+  let(:doc_writer) { EncryptedDocStorage::DocWriter.new(s3_enabled: false) }
+  let(:attempt_events) { [{ event_type: 'idv-something' }, { event_type: 'idv-nothing-else' }] }
+  let(:password) { 'password' }
+  let(:personal_key) { 'personal-key' }
+  let(:profile) { create(:profile, encrypted_attempts_file_reference: 'test-file-reference') }
+  let(:personal_key_encrypted_events) do
+    key_encryptor = Encryption::Encryptors::PiiEncryptor.new(personal_key)
+    key_encryptor.encrypt(attempt_events.to_json, user_uuid: profile.user.uuid)
+  end
+  let(:password_encrypted_events) do
+    encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
+    encryptor.encrypt(attempt_events.to_json, user_uuid: profile.user.uuid)
+  end
+
+  let(:stored_event_data) do
+    {
+      password_encrypted_events:,
+      personal_key_encrypted_events:,
+    }.to_json
   end
 
   describe '#add_sp_sent' do
@@ -49,9 +70,7 @@ RSpec.describe UserProofingEvent, type: :model do
   end
 
   describe '#write_events' do
-    let(:doc_writer) { EncryptedDocStorage::DocWriter.new(s3_enabled: false) }
     let(:password) { 'password' }
-    let(:attempt_events) { [{ event_type: 'idv-something' }, { event_type: 'idv-nothing-else' }] }
     let(:profile) { create(:profile, encrypted_attempts_file_reference: 'test-file-reference') }
     let(:user_proofing_event) { create(:user_proofing_event, profile:) }
 
@@ -67,36 +86,63 @@ RSpec.describe UserProofingEvent, type: :model do
         name: 'test-file-reference',
       )
 
-      user_proofing_event.write_events(password:, attempt_events:)
+      user_proofing_event.write_events(password:, attempt_events:, personal_key: 'personal-key')
     end
   end
 
   describe '#decrypt_events' do
-    let(:doc_retriever) { EncryptedDocStorage::AttemptDataRetriever.new(s3_enabled: false) }
     let(:password) { 'password' }
     let(:attempt_events) { [{ event_type: 'idv-something' }, { event_type: 'idv-nothing-else' }] }
-    let(:profile) { create(:profile, encrypted_attempts_file_reference: 'test-file-reference') }
     let(:user_proofing_event) { create(:user_proofing_event, profile:) }
-    let(:encrypted_data) do
-      encryptor = Encryption::Encryptors::PiiEncryptor.new(password)
-      { password_encrypted_events: encryptor.encrypt(
-        attempt_events.to_json,
-        user_uuid: profile.user.uuid,
-      ) }.to_json
-    end
 
     before do
       allow(EncryptedDocStorage::AttemptDataRetriever).to receive(:new).and_return(doc_retriever)
-      allow(doc_retriever).to receive(:retrieve_user_proofing_events).and_return(encrypted_data)
+      allow(doc_retriever).to receive(:retrieve_user_proofing_events).and_return(stored_event_data)
     end
 
     it 'retrieves and decrypts the events from storage' do
       expect(doc_retriever).to receive(:retrieve_user_proofing_events).with(
         file_path: "attempt_events/#{profile.user.uuid}/#{profile.id}",
         file_name: 'test-file-reference',
-      ).and_return(encrypted_data)
+      ).and_return(stored_event_data)
 
       expect(user_proofing_event.decrypt_events(password:)).to eq(attempt_events.to_json)
+    end
+  end
+
+  describe '#reencrypt_recovery_attempt_data' do
+    let(:new_personal_key) { 'new-personal-key' }
+
+    before do
+      allow(EncryptedDocStorage::AttemptDataRetriever).to receive(:new).and_return(doc_retriever)
+      allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(doc_writer)
+
+      allow(doc_retriever).to receive(:retrieve_user_proofing_events).and_return(stored_event_data)
+      allow(doc_writer).to receive(:write_encrypted_attempt_events)
+    end
+
+    it 'retrieves and decrypts the events from storage' do
+      expect(doc_retriever).to receive(:retrieve_user_proofing_events).with(
+        file_path: "attempt_events/#{profile.user.uuid}/#{profile.id}",
+        file_name: 'test-file-reference',
+      ).and_return(stored_event_data)
+
+      # using `satisfy` is not ideal but i wanted this spec to test that
+      # the password_encrypted_events don't change while the personal_key_encrypted
+      # events do
+      expect(doc_writer).to receive(:write_encrypted_attempt_events).with(
+        file_path: "attempt_events/#{profile.user.uuid}/#{profile.id}",
+        encrypted_attempt_events: satisfy do |arg|
+          arg['password_encrypted_events'] == password_encrypted_events &&
+          arg['personal_key_encrypted_events'] != personal_key_encrypted_events
+        end,
+        name: 'test-file-reference',
+      )
+
+      user_proofing_event.reencrypt_recovery_attempt_data(
+        attempt_events:,
+        personal_key: new_personal_key,
+      )
     end
   end
 end

--- a/spec/models/user_proofing_event_spec.rb
+++ b/spec/models/user_proofing_event_spec.rb
@@ -143,8 +143,8 @@ RSpec.describe UserProofingEvent, type: :model do
       expect(doc_writer).to receive(:write_encrypted_attempt_events).with(
         file_path: "attempt_events/#{profile.user.uuid}/#{profile.id}",
         encrypted_attempt_events: satisfy do |arg|
-          arg['password_encrypted_events'] == password_encrypted_events &&
-          arg['personal_key_encrypted_events'] != personal_key_encrypted_events
+          JSON.parse(arg)['password_encrypted_events'] == password_encrypted_events &&
+          JSON.parse(arg)['personal_key_encrypted_events'] != personal_key_encrypted_events
         end,
         name: 'test-file-reference',
       )
@@ -153,6 +153,62 @@ RSpec.describe UserProofingEvent, type: :model do
         attempt_events:,
         personal_key: new_personal_key,
       )
+    end
+  end
+
+  context 'round-trip specs' do
+    let(:normalizer) { PersonalKeyGenerator.new(profile.user) }
+    after do
+      path = Rails.root.join(
+        'tmp',
+        'encrypted_attempt_events',
+        'attempt_events',
+        profile.user.uuid.to_s,
+      )
+      # cleanup
+      FileUtils.rm_rf(path) if Dir.exist?(path)
+    end
+
+    describe '#decrypt_events' do
+      it 'retrieves and decrypts the events from storage' do
+        user_proofing_event.write_events(
+          attempt_events:, password:,
+          personal_key: normalizer.normalize(personal_key)
+        )
+        expect(user_proofing_event.decrypt_events(password:)).to eq(attempt_events.to_json)
+      end
+    end
+
+    describe '#reencrypting with personal key' do
+      let(:new_personal_key) { 'new-personal-key' }
+
+      context 'with stored data' do
+        before do
+          user_proofing_event.write_events(attempt_events:, password:, personal_key:)
+          user_proofing_event.reencrypt_recovery_attempts_data(
+            attempt_events:,
+            personal_key: new_personal_key,
+          )
+        end
+        it 'reencrypts the events in storage so they are recoverable with the new key' do
+          expect(
+            user_proofing_event.recover_attempt_events(personal_key: new_personal_key),
+          ).to eq(attempt_events.to_json)
+        end
+      end
+
+      context 'if stored data does not exist' do
+        # This method is only called if event data is cached in the session
+        # If the session data exists but stored data does not, something is weird.
+        it 'crashes on reencryption because that is a bad state' do
+          expect do
+            user_proofing_event.reencrypt_recovery_attempts_data(
+              attempt_events:,
+              personal_key:,
+            )
+          end.to raise_error NoMethodError, "undefined method 'merge' for nil"
+        end
+      end
     end
   end
 end

--- a/spec/services/attempts_api/cacher_spec.rb
+++ b/spec/services/attempts_api/cacher_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AttemptsApi::Cacher do
   let(:password) { 'correct horse battery staple' }
   let(:encrypted_attempts_file_reference) { 'file-name' }
   let(:profile) { create(:profile, :active, encrypted_attempts_file_reference:) }
+  let(:personal_key) { 'abcd efgh ijkl mno1' }
   subject(:cacher) { described_class.new(user, user_session) }
   let(:decrypted_events) do
     [
@@ -13,12 +14,13 @@ RSpec.describe AttemptsApi::Cacher do
       { event_type: 'idv-another-event', jti: 'another-jti' },
     ]
   end
+  let(:returned_events) { decrypted_events.to_json }
 
   describe '#save' do
     before do
       allow(user).to receive(:active_profile).and_return(profile)
       allow(profile).to receive(:decrypt_user_proofing_events).with(password:).and_return(
-        decrypted_events.to_json,
+        returned_events,
       )
     end
 
@@ -37,8 +39,43 @@ RSpec.describe AttemptsApi::Cacher do
 
     context 'profile does not have an encrypted_attempts_file_reference' do
       let(:encrypted_attempts_file_reference) { nil }
-      it 'does not attempt to retrieve the events' do
-        subject.save(password:)
+
+      context 'no decrypted events are returned' do
+        let(:returned_events) { nil }
+        it 'does not attempt to encrypt events' do
+          expect { subject.save(password:) }.to_not raise_error
+
+          expect(user_session[:encrypted_proofing_events]).to be_blank
+        end
+      end
+    end
+  end
+
+  describe '#save_with_personal_key' do
+    before do
+      allow(user).to receive(:active_profile).and_return(profile)
+      allow(profile).to receive(:recover_attempt_events).with(personal_key:).and_return(
+        returned_events,
+      )
+    end
+
+    it 'encrypts and saves proofing events in the session' do
+      subject.save_with_personal_key(personal_key:)
+
+      expect(user_session[:encrypted_proofing_events]).to be_present
+
+      result = JSON.parse(
+        SessionEncryptor.new.kms_decrypt(
+          user_session[:encrypted_proofing_events],
+        ),
+      )
+      expect(result).to eq(decrypted_events.as_json)
+    end
+
+    context 'no decrypted events are returned' do
+      let(:returned_events) { nil }
+      it 'does not attempt to encrypt events' do
+        expect { subject.save_with_personal_key(personal_key:) }.to_not raise_error
 
         expect(user_session[:encrypted_proofing_events]).to be_blank
       end

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -121,7 +121,10 @@ RSpec.describe EncryptedDocStorage::DocWriter do
         encrypted_attempt_events:,
       )
 
-      result = subject.write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
+      result = subject.write_encrypted_attempt_events(
+        file_path:, encrypted_attempt_events:,
+        name: nil
+      )
       expect(result.name).to eq(uuid)
     end
 
@@ -161,7 +164,10 @@ RSpec.describe EncryptedDocStorage::DocWriter do
           :write_attempt_events,
         )
 
-        result = subject.write_encrypted_attempt_events(file_path:, encrypted_attempt_events:)
+        result = subject.write_encrypted_attempt_events(
+          file_path:, encrypted_attempt_events:,
+          name: nil
+        )
         expect(result.name).to eq(uuid)
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 110](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/110)

## 🛠 Summary of changes
This allows the idp to encrypt and recover the attempt events via a personal key. This is needed because sometimes a user forgets their password, but retains the personal key, and unlocks their PII that way. If they can unlock their profile, we need to be able to unlock the attempt events as well.

This change:
- Refactors the encryptions/document writing business logic to the UserProofingEvent, which is a better place than the Profile, although maybe not the best place???
- Maintains some call-through methods, which may or may not be useful for reading comprehension/maintainability (feedback welcome!)
- Updates  the data structure of the data written to S3 to have two top-level keys, one for the password encrypted data and one for the personal key encrypted data
- Writes to both when a password is confirmed or updated (personal key generation is part of the password saving process, and it changes when the password changes
- Replaces the personal key encrypted data when the personal key changes (the personal key can change without a password change)
- Recovers the attempt event data when personal key is used to unlock PII
- Replace the password encrypted data when this happens


## 📜 Testing Plan

Acceptance steps:
- Make sure your local OIDC app is set up as an attempts api consumer
- Make sure you have the below values set in your application.yml config file

```
  historical_attempts_api_enabled: true
  historical_attempts_pii_enabled: true
```

- [ ] Navigate to local SAML app http://localhost:4567/
- [ ]  Select the "Level of Service" dropdown.
- [ ]  Select "Identity-Verified"
- [ ]  Click "Sign in"
- [ ]  Create a new account, go through identity verification - SSN must start with 666 or 900 to work
- [ ]  Consent to sharing
- [ ]  Find yourself redirected back to SAML app
- [ ]  Navigate to the IdP http://localhost:3000/
- [ ]  Log out of your account
- [ ] Click [Forgot your password?](http://localhost:3000/users/password/new)
- [ ]  Create a new password (don't lose it!)
- [ ] Copy the new personal key
- [ ]  Log out to make sure the encrypted session gets wiped
- [ ]  Navigate to the local OIDC app http://localhost:9292
- [ ] Check http://localhost:9292/attempts-api to make sure there are no existing events
- [ ]  Select the "Level of Service" dropdown.
- [ ]  Select "Identity-Verified"
- [ ]  Click "Sign in"
- [ ]  Log in via the account you just made
- [ ] Type in your recovery key to unlock your profile
- [ ] Type in your password when prompted
- [ ]  Consent to sending your data back to the OIDC sample app
- [ ]  Navigate to the Attemps API viewer http://localhost:9292/attempts-api
- [ ]  You should see some events that are prefixed with idv-

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
