### PR TITLE
Update facial-match-preferred behavior

### DIFF
--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -93,7 +93,7 @@ class AuthnContextResolver
   end
 
   def user_has_account_with_sp?
-    user.connected_apps.map(&:service_provider).include?(service_provider.issuer)
+    user.connected_apps.any? { |app| app.service_provider == service_provider.issuer }
   end
 
   def acr_aal_component_values

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -93,7 +93,8 @@ class AuthnContextResolver
   end
 
   def user_has_account_with_sp?
-    user.connected_apps.any? { |app| app.service_provider == service_provider.issuer }
+    return false unless user && service_provider
+    user.connected_apps.exists?(service_provider: service_provider.issuer)
   end
 
   def acr_aal_component_values

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -73,6 +73,8 @@ class AuthnContextResolver
     return result if user&.identity_verified_with_facial_match? ||
                      facial_match_is_required?(result)
 
+    return result unless user_has_account_with_sp?
+
     if user&.identity_verified?
       result.with(facial_match?: false, two_pieces_of_fair_evidence?: false)
     else
@@ -88,6 +90,10 @@ class AuthnContextResolver
     else
       result
     end
+  end
+
+  def user_has_account_with_sp?
+    user.connected_apps.map(&:service_provider).include?(service_provider.issuer)
   end
 
   def acr_aal_component_values

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -73,7 +73,9 @@ class AuthnContextResolver
     return result if user&.identity_verified_with_facial_match? ||
                      facial_match_is_required?(result)
 
-    return result unless user_has_account_with_sp?
+    if IdentityConfig.store.facial_match_preferred_on_connected_accounts
+      return result unless user_has_account_with_sp?
+    end
 
     if user&.identity_verified?
       result.with(facial_match?: false, two_pieces_of_fair_evidence?: false)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -178,6 +178,7 @@ enable_test_routes: true
 encrypted_document_storage_s3_bucket: 'test-bucket'
 event_disavowal_expiration_hours: 240
 facial_match_general_availability_enabled: true
+facial_match_preferred_on_connected_accounts: false
 feature_account_creation_passkey_auto_prompt: false
 feature_idv_force_gpo_verification_enabled: false
 feature_idv_hybrid_flow_enabled: true

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -194,6 +194,7 @@ module IdentityConfig
     config.add(:encrypted_document_storage_s3_bucket, type: :string)
     config.add(:event_disavowal_expiration_hours, type: :integer)
     config.add(:facial_match_general_availability_enabled, type: :boolean)
+    config.add(:facial_match_preferred_on_connected_accounts, type: :boolean)
     config.add(:feature_account_creation_passkey_auto_prompt, type: :boolean)
     config.add(:feature_idv_force_gpo_verification_enabled, type: :boolean)
     config.add(:feature_idv_hybrid_flow_enabled, type: :boolean)

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -476,6 +476,10 @@ RSpec.describe Analytics do
     end
 
     context 'and selects optional facial match identity proofing' do
+      before do
+        allow(IdentityConfig.store).to receive(:facial_match_preferred_on_connected_accounts)
+          .and_return(true)
+      end
       shared_examples 'with user scenarios' do |acr_values_list|
         context "using #{acr_values_list}" do
           let(:acr_values) { acr_values_list }

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -494,11 +494,72 @@ RSpec.describe Analytics do
             include_examples 'track event with :sp_request'
           end
 
-          context 'when the identity verified user has not proofed with facial match' do
-            let(:current_user) { build(:user, :proofed) }
+          context 'when the user is proofed w/basic idv but has an account with the SP' do
+            let(:current_user) do
+              build(
+                :user, :proofed,
+                identities: [build(:service_provider_identity, service_provider: 'http://localhost:3000')]
+              )
+            end
             let(:sp_request) do
               {
                 aal2: true,
+                identity_proofing: true,
+              }
+            end
+
+            include_examples 'track event with :sp_request'
+          end
+
+          context 'when the user is proofed w/basic idv but has no connected accounts' do
+            let(:current_user) { create(:user, :proofed) }
+            let(:sp_request) do
+              {
+                aal2: true,
+                facial_match: true,
+                two_pieces_of_fair_evidence: true,
+                identity_proofing: true,
+
+              }
+            end
+
+            include_examples 'track event with :sp_request'
+          end
+
+          context 'when the user is proofed w/basic idv but connected account is not sp' do
+            let(:current_user) do
+              create(:user, :proofed, identities: [create(:service_provider_identity)])
+            end
+            let(:sp_request) do
+              {
+                aal2: true,
+                facial_match: true,
+                two_pieces_of_fair_evidence: true,
+                identity_proofing: true,
+              }
+            end
+
+            include_examples 'track event with :sp_request'
+          end
+
+          context 'when user is proofed w/basic idv and connected but connection has been deleted' do
+            let(:current_user) do
+              build(
+                :user, :proofed,
+                identities: [
+                  build(
+                    :service_provider_identity,
+                    service_provider: 'http://localhost:3000',
+                    deleted_at: 5.minutes.ago,
+                  ),
+                ]
+              )
+            end
+            let(:sp_request) do
+              {
+                aal2: true,
+                facial_match: true,
+                two_pieces_of_fair_evidence: true,
                 identity_proofing: true,
               }
             end

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -542,7 +542,7 @@ RSpec.describe Analytics do
             include_examples 'track event with :sp_request'
           end
 
-          context 'when user is proofed w/basic idv and connected but connection has been deleted' do
+          context 'when user proofs w/basic idv and connected sp but connection has been deleted' do
             let(:current_user) do
               build(
                 :user, :proofed,

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -306,6 +306,15 @@ RSpec.describe AuthnContextResolver do
             Saml::Idp::Constants::IAL2_BIO_PREFERRED_AUTHN_CONTEXT_CLASSREF
           end
 
+          context 'when user is nil' do
+            let(:user) { nil }
+
+            it 'asserts facial match as true without raising' do
+              expect { result }.not_to raise_error
+              expect(result.facial_match?).to be true
+            end
+          end
+
           context 'when the user is already verified' do
             context 'without facial match comparison' do
               let(:user) { build(:user, :proofed) }
@@ -630,7 +639,7 @@ RSpec.describe AuthnContextResolver do
 
           context 'when the user is already verified' do
             context 'without facial match comparison' do
-              let(:user) { build(:user, :proofed) }
+              let(:user) { create(:user, :proofed) }
 
               it 'asserts facial match as true' do
                 expect(result.identity_proofing?).to be true
@@ -642,7 +651,7 @@ RSpec.describe AuthnContextResolver do
 
               context 'when the user has already connected with a service provider' do
                 let(:user) do
-                  build(
+                  create(
                     :user, :proofed,
                     identities: [
                       create(:service_provider_identity, service_provider_record:),
@@ -657,6 +666,29 @@ RSpec.describe AuthnContextResolver do
                     expect(result.facial_match?).to be false
                     expect(result.two_pieces_of_fair_evidence?).to be false
                     expect(result.aal2?).to be true
+                  end
+
+                  context 'when the connection has been soft-deleted' do
+                    let(:user) do
+                      create(
+                        :user, :proofed,
+                        identities: [
+                          create(
+                            :service_provider_identity,
+                            service_provider_record:,
+                            deleted_at: 5.minutes.ago,
+                          ),
+                        ]
+                      )
+                    end
+
+                    it 'asserts facial match comparison' do
+                      expect(result.identity_proofing?).to be true
+                      expect(result.facial_match?).to be true
+                      expect(result.two_pieces_of_fair_evidence?).to be true
+                      expect(result.aal2?).to be true
+                      expect(result.ialmax?).to be false
+                    end
                   end
                 end
 

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe AuthnContextResolver do
           ].join(' ')
         end
 
-        it 'asserts the AAL2 value, even though the ddefault aal value was passed in' do
+        it 'asserts the AAL2 value, even though the default aal value was passed in' do
           expect(subject.asserted_aal_acr).to eq Saml::Idp::Constants::AAL2_AUTHN_CONTEXT_CLASSREF
         end
 
@@ -310,11 +310,30 @@ RSpec.describe AuthnContextResolver do
             context 'without facial match comparison' do
               let(:user) { build(:user, :proofed) }
 
-              it 'falls back on proofing without facial match comparison' do
+              it 'asserts facial match as true' do
                 expect(result.identity_proofing?).to be true
-                expect(result.facial_match?).to be false
-                expect(result.two_pieces_of_fair_evidence?).to be false
+                expect(result.facial_match?).to be true
+                expect(result.two_pieces_of_fair_evidence?).to be true
                 expect(result.aal2?).to be true
+              end
+
+              context 'when the user has already connected with the service provider' do
+                let(:user) do
+                  build(
+                    :user,
+                    :proofed,
+                    identities: [
+                      create(:service_provider_identity, service_provider_record: service_provider),
+                    ],
+                  )
+                end
+
+                it 'falls back on proofing without facial match comparison' do
+                  expect(result.identity_proofing?).to be true
+                  expect(result.facial_match?).to be false
+                  expect(result.two_pieces_of_fair_evidence?).to be false
+                  expect(result.aal2?).to be true
+                end
               end
             end
 
@@ -595,12 +614,30 @@ RSpec.describe AuthnContextResolver do
             context 'without facial match comparison' do
               let(:user) { build(:user, :proofed) }
 
-              it 'falls back on proofing without facial match comparison' do
+              it 'asserts facial match as true' do
                 expect(result.identity_proofing?).to be true
-                expect(result.facial_match?).to be false
-                expect(result.two_pieces_of_fair_evidence?).to be false
+                expect(result.facial_match?).to be true
+                expect(result.two_pieces_of_fair_evidence?).to be true
                 expect(result.aal2?).to be true
                 expect(result.ialmax?).to be false
+              end
+
+              context 'when the user has already connected with the service provider' do
+                let(:user) do
+                  build(
+                    :user, :proofed,
+                    identities: [
+                      create(:service_provider_identity, service_provider_record: service_provider),
+                    ]
+                  )
+                end
+
+                it 'falls back on proofing without facial match comparison' do
+                  expect(result.identity_proofing?).to be true
+                  expect(result.facial_match?).to be false
+                  expect(result.two_pieces_of_fair_evidence?).to be false
+                  expect(result.aal2?).to be true
+                end
               end
             end
 

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -316,6 +316,12 @@ RSpec.describe AuthnContextResolver do
           end
 
           context 'when the user is already verified' do
+            let(:facial_match_preferred_on_connected_accounts) { true }
+            before do
+              allow(IdentityConfig.store).to receive(:facial_match_preferred_on_connected_accounts)
+                .and_return(facial_match_preferred_on_connected_accounts)
+            end
+
             context 'without facial match comparison' do
               let(:user) { build(:user, :proofed) }
 
@@ -349,6 +355,17 @@ RSpec.describe AuthnContextResolver do
                     expect(result.two_pieces_of_fair_evidence?).to be false
                     expect(result.aal2?).to be true
                   end
+
+                  context 'facial_match_preferred_on_connected_accounts is not enabled' do
+                    let(:facial_match_preferred_on_connected_accounts) { false }
+
+                    it 'falls back on proofing without facial match comparison' do
+                      expect(result.identity_proofing?).to be true
+                      expect(result.facial_match?).to be false
+                      expect(result.two_pieces_of_fair_evidence?).to be false
+                      expect(result.aal2?).to be true
+                    end
+                  end
                 end
 
                 context 'when the connected sp is a different sp' do
@@ -359,6 +376,17 @@ RSpec.describe AuthnContextResolver do
                     expect(result.facial_match?).to be true
                     expect(result.two_pieces_of_fair_evidence?).to be true
                     expect(result.aal2?).to be true
+                  end
+
+                  context 'facial_match_preferred_on_connected_accounts is not enabled' do
+                    let(:facial_match_preferred_on_connected_accounts) { false }
+
+                    it 'falls back on proofing without facial match comparison' do
+                      expect(result.identity_proofing?).to be true
+                      expect(result.facial_match?).to be false
+                      expect(result.two_pieces_of_fair_evidence?).to be false
+                      expect(result.aal2?).to be true
+                    end
                   end
                 end
               end
@@ -636,6 +664,11 @@ RSpec.describe AuthnContextResolver do
           let(:bio_acr_value) do
             Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_PREFERRED_ACR
           end
+          let(:facial_match_preferred_on_connected_accounts) { true }
+          before do
+            allow(IdentityConfig.store).to receive(:facial_match_preferred_on_connected_accounts)
+              .and_return(facial_match_preferred_on_connected_accounts)
+          end
 
           context 'when the user is already verified' do
             context 'without facial match comparison' do
@@ -689,6 +722,17 @@ RSpec.describe AuthnContextResolver do
                       expect(result.aal2?).to be true
                       expect(result.ialmax?).to be false
                     end
+
+                    context 'facial_match_preferred_on_connected_accounts is not enabled' do
+                      let(:facial_match_preferred_on_connected_accounts) { false }
+
+                      it 'falls back on proofing without facial match comparison' do
+                        expect(result.identity_proofing?).to be true
+                        expect(result.facial_match?).to be false
+                        expect(result.two_pieces_of_fair_evidence?).to be false
+                        expect(result.aal2?).to be true
+                      end
+                    end
                   end
                 end
 
@@ -700,6 +744,17 @@ RSpec.describe AuthnContextResolver do
                     expect(result.facial_match?).to be true
                     expect(result.two_pieces_of_fair_evidence?).to be true
                     expect(result.aal2?).to be true
+                  end
+
+                  context 'facial_match_preferred_on_connected_accounts is not enabled' do
+                    let(:facial_match_preferred_on_connected_accounts) { false }
+
+                    it 'falls back on proofing without facial match comparison' do
+                      expect(result.identity_proofing?).to be true
+                      expect(result.facial_match?).to be false
+                      expect(result.two_pieces_of_fair_evidence?).to be false
+                      expect(result.aal2?).to be true
+                    end
                   end
                 end
               end

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -317,22 +317,40 @@ RSpec.describe AuthnContextResolver do
                 expect(result.aal2?).to be true
               end
 
-              context 'when the user has already connected with the service provider' do
+              context 'when the user has already connected with a service provider' do
                 let(:user) do
                   build(
                     :user,
                     :proofed,
                     identities: [
-                      create(:service_provider_identity, service_provider_record: service_provider),
+                      create(
+                        :service_provider_identity,
+                        service_provider_record:,
+                      ),
                     ],
                   )
                 end
 
-                it 'falls back on proofing without facial match comparison' do
-                  expect(result.identity_proofing?).to be true
-                  expect(result.facial_match?).to be false
-                  expect(result.two_pieces_of_fair_evidence?).to be false
-                  expect(result.aal2?).to be true
+                context 'when the connected sp is the requesting sp' do
+                  let(:service_provider_record) { service_provider }
+
+                  it 'falls back on proofing without facial match comparison' do
+                    expect(result.identity_proofing?).to be true
+                    expect(result.facial_match?).to be false
+                    expect(result.two_pieces_of_fair_evidence?).to be false
+                    expect(result.aal2?).to be true
+                  end
+                end
+
+                context 'when the connected sp is a different sp' do
+                  let(:service_provider_record) { create(:service_provider) }
+
+                  it 'asserts facial match as true' do
+                    expect(result.identity_proofing?).to be true
+                    expect(result.facial_match?).to be true
+                    expect(result.two_pieces_of_fair_evidence?).to be true
+                    expect(result.aal2?).to be true
+                  end
                 end
               end
             end
@@ -622,21 +640,35 @@ RSpec.describe AuthnContextResolver do
                 expect(result.ialmax?).to be false
               end
 
-              context 'when the user has already connected with the service provider' do
+              context 'when the user has already connected with a service provider' do
                 let(:user) do
                   build(
                     :user, :proofed,
                     identities: [
-                      create(:service_provider_identity, service_provider_record: service_provider),
+                      create(:service_provider_identity, service_provider_record:),
                     ]
                   )
                 end
 
-                it 'falls back on proofing without facial match comparison' do
-                  expect(result.identity_proofing?).to be true
-                  expect(result.facial_match?).to be false
-                  expect(result.two_pieces_of_fair_evidence?).to be false
-                  expect(result.aal2?).to be true
+                context 'when the connected sp is the requesting sp' do
+                  let(:service_provider_record) { service_provider }
+                  it 'falls back on proofing without facial match comparison' do
+                    expect(result.identity_proofing?).to be true
+                    expect(result.facial_match?).to be false
+                    expect(result.two_pieces_of_fair_evidence?).to be false
+                    expect(result.aal2?).to be true
+                  end
+                end
+
+                context 'when the connected sp is a different sp' do
+                  let(:service_provider_record) { create(:service_provider) }
+
+                  it 'asserts facial match as true' do
+                    expect(result.identity_proofing?).to be true
+                    expect(result.facial_match?).to be true
+                    expect(result.two_pieces_of_fair_evidence?).to be true
+                    expect(result.aal2?).to be true
+                  end
                 end
               end
             end


### PR DESCRIPTION
## 🛠 Summary of changes
This PR implements the recommended code change outlined in https://docs.google.com/document/d/1y2F8r4vzdCmdMQR6oR67Mh01Bay97CBYddhZiNh_JZU/edit?tab=t.0

This code should NOT be merged until we have approval from partners.

> Login modifies facial-match-preferred to require facial match if the user is new to the SP, but allows the user through if they have an existing connected account


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
