### PR TITLE
LG-17612 fix nil applicant_pii fields that were passed to proofing agent job

### DIFF
--- a/app/services/proofing_agent/applicant_pii_transformer.rb
+++ b/app/services/proofing_agent/applicant_pii_transformer.rb
@@ -3,7 +3,7 @@
 module ProofingAgent
   class ApplicantPiiTransformer
     def initialize(proof_params)
-      @pii = proof_params.symbolize_keys
+      @pii = proof_params.deep_symbolize_keys
     end
 
     def transform

--- a/spec/services/proofing_agent/applicant_pii_transformer_spec.rb
+++ b/spec/services/proofing_agent/applicant_pii_transformer_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ProofingAgent::ApplicantPiiTransformer do
           described_class.new(
             applicant.merge(
               state_id: state_id,
-            ),
+            ).with_indifferent_access,
           )
         end
 
@@ -87,7 +87,7 @@ RSpec.describe ProofingAgent::ApplicantPiiTransformer do
             applicant.merge(
               state_id: state_id,
               residential_address: residential_address,
-            ),
+            ).with_indifferent_access,
           )
         end
 
@@ -129,7 +129,7 @@ RSpec.describe ProofingAgent::ApplicantPiiTransformer do
           applicant.merge(
             residential_address: residential_address,
             passport: passport,
-          ),
+          ).with_indifferent_access,
         )
       end
 


### PR DESCRIPTION


<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17612](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17612)



## 🛠 Summary of changes

Nil params were being passed in for state_id or passport because ApplicantPiiTransformer didn't symbolize the keys for the nested hashes since `proof_params` are passed in as a HashWithIndifferentAccess. Adding `deep_symbolize_keys` should fix that.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Ensure specs pass
- [ ] In `app/services/proofing_agent/applicant_pii_transformer.rb` Change` line 6 `@pii = proof_params.deep_symbolize_keys` to `@pii = proof_params.symbolize_keys`
- [ ] Run applicant_pii_transformer_spec.rb and observe that the tests fail because the values for the nested hashes will be nil


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17612]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17612