### PR TITLE
LG-17614: obfuscate web links in source attributions

### DIFF
--- a/app/services/proofing/socure/id_plus/proofers/kyc_proofer.rb
+++ b/app/services/proofing/socure/id_plus/proofers/kyc_proofer.rb
@@ -42,7 +42,15 @@ module Proofing
           end
 
           def log_result(result_hash)
+            result_hash[:source_attribution] =
+              sanitize_source_attribution(result_hash[:source_attribution])
             @analytics&.idv_socure_kyc_results(**result_hash)
+          end
+
+          def sanitize_source_attribution(attribution)
+            attribution.map do |source|
+              /https?:\/\//.match?(source) ? 'Web Proof' : source
+            end
           end
         end
       end

--- a/spec/services/proofing/socure/id_plus/proofers/kyc_proofer_spec.rb
+++ b/spec/services/proofing/socure/id_plus/proofers/kyc_proofer_spec.rb
@@ -20,19 +20,14 @@ RSpec.describe Proofing::Socure::IdPlus::Proofers::KycProofer do
   let(:idv_socure_kyc_auto_failure_reason_codes) { ['R995'] }
 
   let(:field_validation_overrides) { {} }
-  let(:reason_codes) do
-    [
-      'I919',
-      'I914',
-      'I905',
-    ]
-  end
+  let(:reason_codes) { %w[I919 I914 I905] }
+  let(:web_source) { nil }
   let(:source_attribution) do
     [
       'Credit',
       'Alternative Credit',
-      'https://example.com/',
-    ]
+      web_source,
+    ].compact
   end
 
   let(:response_body) do
@@ -77,7 +72,26 @@ RSpec.describe Proofing::Socure::IdPlus::Proofers::KycProofer do
   it 'calls proper analytics event' do
     result
     expect(analytics).to have_logged_event(:idv_socure_kyc_results)
-    expect(analytics.events[:idv_socure_kyc_results][0][:source_attribution]).to include 'Web Proof'
+  end
+
+  context 'with source attributions starting with http://' do
+    let(:web_source) { 'http://example.org/' }
+
+    it 'obfuscates web-sourced attributions' do
+      result
+      attribution = analytics.events[:idv_socure_kyc_results][0][:source_attribution]
+      expect(attribution).to include 'Web Proof'
+    end
+  end
+
+  context 'with source attributions starting with https://' do
+    let(:web_source) { 'https://example.org/' }
+
+    it 'obfuscates web-sourced attributions' do
+      result
+      attribution = analytics.events[:idv_socure_kyc_results][0][:source_attribution]
+      expect(attribution).to include 'Web Proof'
+    end
   end
 
   it 'reports reason codes as errors' do

--- a/spec/services/proofing/socure/id_plus/proofers/kyc_proofer_spec.rb
+++ b/spec/services/proofing/socure/id_plus/proofers/kyc_proofer_spec.rb
@@ -27,12 +27,20 @@ RSpec.describe Proofing::Socure::IdPlus::Proofers::KycProofer do
       'I905',
     ]
   end
+  let(:source_attribution) do
+    [
+      'Credit',
+      'Alternative Credit',
+      'https://example.com/',
+    ]
+  end
 
   let(:response_body) do
     {
       'referenceId' => 'a-really-unique-id',
       'kyc' => {
         'reasonCodes' => reason_codes,
+        'sourceAttribution' => source_attribution,
         'fieldValidations' => {
           'firstName' => 0.99,
           'surName' => 0.99,
@@ -69,6 +77,7 @@ RSpec.describe Proofing::Socure::IdPlus::Proofers::KycProofer do
   it 'calls proper analytics event' do
     result
     expect(analytics).to have_logged_event(:idv_socure_kyc_results)
+    expect(analytics.events[:idv_socure_kyc_results][0][:source_attribution]).to include 'Web Proof'
   end
 
   it 'reports reason codes as errors' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17614](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17614)

## 🛠 Summary of changes

Web links have the potential to leak PII so we'll log them as 'Web Proof'.

changelog: Internal, Logging, Obfuscate web links in source attribution.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17614]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17614