### PR TITLE
Harden facial-match-preferred resolver: nil safety, SQL lookup, test coverage

### DIFF
--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -94,7 +94,7 @@ class AuthnContextResolver
 
   def user_has_account_with_sp?
     return false unless user && service_provider
-    user.connected_apps.map(&:service_provider).include?(service_provider.issuer)
+    user.connected_apps.where(service_provider: service_provider.issuer).exists?
   end
 
   def acr_aal_component_values

--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -93,6 +93,7 @@ class AuthnContextResolver
   end
 
   def user_has_account_with_sp?
+    return false unless user && service_provider
     user.connected_apps.map(&:service_provider).include?(service_provider.issuer)
   end
 

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -319,13 +319,13 @@ RSpec.describe AuthnContextResolver do
 
               context 'when the user has already connected with the service provider' do
                 let(:user) do
-                  build(
-                    :user,
-                    :proofed,
-                    identities: [
-                      create(:service_provider_identity, service_provider_record: service_provider),
-                    ],
-                  )
+                  create(:user, :proofed).tap do |u|
+                    create(
+                      :service_provider_identity,
+                      user: u,
+                      service_provider_record: service_provider,
+                    )
+                  end
                 end
 
                 it 'falls back on proofing without facial match comparison' do
@@ -624,12 +624,13 @@ RSpec.describe AuthnContextResolver do
 
               context 'when the user has already connected with the service provider' do
                 let(:user) do
-                  build(
-                    :user, :proofed,
-                    identities: [
-                      create(:service_provider_identity, service_provider_record: service_provider),
-                    ]
-                  )
+                  create(:user, :proofed).tap do |u|
+                    create(
+                      :service_provider_identity,
+                      user: u,
+                      service_provider_record: service_provider,
+                    )
+                  end
                 end
 
                 it 'falls back on proofing without facial match comparison' do

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -335,6 +335,55 @@ RSpec.describe AuthnContextResolver do
                   expect(result.aal2?).to be true
                 end
               end
+
+              context 'when the user is connected only to a different service provider' do
+                let(:other_sp) { create(:service_provider) }
+                let(:user) do
+                  create(:user, :proofed).tap do |u|
+                    create(
+                      :service_provider_identity,
+                      user: u,
+                      service_provider_record: other_sp,
+                    )
+                  end
+                end
+
+                it 'asserts facial match as true' do
+                  expect(result.identity_proofing?).to be true
+                  expect(result.facial_match?).to be true
+                  expect(result.two_pieces_of_fair_evidence?).to be true
+                  expect(result.aal2?).to be true
+                end
+              end
+
+              context 'when the prior identity with this SP is soft-deleted' do
+                let(:user) do
+                  create(:user, :proofed).tap do |u|
+                    create(
+                      :service_provider_identity,
+                      :soft_deleted_5m_ago,
+                      user: u,
+                      service_provider_record: service_provider,
+                    )
+                  end
+                end
+
+                it 'asserts facial match as true (deleted identities do not count)' do
+                  expect(result.identity_proofing?).to be true
+                  expect(result.facial_match?).to be true
+                  expect(result.two_pieces_of_fair_evidence?).to be true
+                  expect(result.aal2?).to be true
+                end
+              end
+            end
+
+            context 'when the user is nil' do
+              let(:user) { nil }
+
+              it 'asserts facial match as true without raising' do
+                expect { result }.not_to raise_error
+                expect(result.facial_match?).to be true
+              end
             end
 
             context 'with facial match comparison' do


### PR DESCRIPTION
Stacked on top of #13160. Addresses several issues surfaced during my review of that PR.

## Summary

- **Nil safety** in `AuthnContextResolver#user_has_account_with_sp?`: guards `user` and `service_provider`, both of which can legitimately be nil (unauthenticated AuthnRequest resolution, no-SP contexts). Without the guard the new check raises `NoMethodError` and regresses prior behavior.
- **SQL existence check** instead of `connected_apps.map(&:service_provider).include?(...)`. O(1) indexed lookup vs. O(n) materialization, and reads more like vrajmohan's suggested `.any? { ... }`.
- **Spec setup fix**: the new contexts used `build(:user, ..., identities: [create(...)])`, which leaves the user unpersisted. Since `connected_apps` issues a SQL query scoped by `user_id`, those tests could pass for the wrong reason. Switched to `create(:user)` plus an identity tied to that user.
- **New coverage**:
  - user is connected only to a *different* SP (vrajmohan's review note)
  - prior identity with this SP is soft-deleted (locks in `not_deleted` scope behavior)
  - user is `nil` (regression test for the nil guard)

## Changes (organized as atomic commits for easier review!)

1. Guard nil user and service_provider in `user_has_account_with_sp?`
2. Use SQL existence check instead of loading all connected apps
3. Persist user in connected-app specs so the SQL check is exercised
4. Add coverage for nil user, other-SP, and soft-deleted identities
