### PR TITLE
fix CalendarService for Memorial Day

### DIFF
--- a/app/services/calendar_service.rb
+++ b/app/services/calendar_service.rb
@@ -99,7 +99,7 @@ class CalendarService
 
   # Last Monday of May
   def memorial
-    Date.new(year, 6, 1)
+    Date.new(year, 5, 31)
       .step(Date.new(year, 5, 1), -1)
       .find(&:monday?)
   end


### PR DESCRIPTION
[skip changelog]

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->


## 🛠 Summary of changes

Since today was a June 1st and a Monday, CalendarService thought today was Memorial Day. This PR checks the month of May instead of going backwards from June 1st.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Ensure Specs pass


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
