### PR TITLE
Guard against null values for the encrypted file name

### DIFF
--- a/app/services/attempts_api/cacher.rb
+++ b/app/services/attempts_api/cacher.rb
@@ -10,6 +10,7 @@ module AttemptsApi
     end
 
     def save(password:)
+      return unless user.active_profile.encrypted_attempts_file_reference.present?
       decrypted_events = user.active_profile.decrypt_user_proofing_events(password:)
 
       kms_encrypted_events = SessionEncryptor.new.kms_encrypt(decrypted_events)

--- a/spec/services/attempts_api/cacher_spec.rb
+++ b/spec/services/attempts_api/cacher_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe AttemptsApi::Cacher do
   let(:user) { create(:user, :proofed) }
   let(:user_session) { {} }
   let(:password) { 'correct horse battery staple' }
-  let(:profile) { user.active_profile }
+  let(:encrypted_attempts_file_reference) { 'file-name' }
+  let(:profile) { create(:profile, :active, encrypted_attempts_file_reference:) }
   subject(:cacher) { described_class.new(user, user_session) }
   let(:decrypted_events) do
     [
@@ -32,6 +33,15 @@ RSpec.describe AttemptsApi::Cacher do
         ),
       )
       expect(result).to eq(decrypted_events.as_json)
+    end
+
+    context 'profile does not have an encrypted_attempts_file_reference' do
+      let(:encrypted_attempts_file_reference) { nil }
+      it 'does not attempt to retrieve the events' do
+        subject.save(password:)
+
+        expect(user_session[:encrypted_proofing_events]).to be_blank
+      end
     end
   end
 


### PR DESCRIPTION
## 🛠 Summary of changes
@mmagsa discovered a bug in the Historic Attempts Flow, where we try to cache the attempt events whether or not a file reference exists on the profile for that user. This change guards against that.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
