### PR TITLE
LG-17600: Force the spec to use 'UTC'

### DIFF
--- a/spec/services/usps_in_person_proofing/applicant_spec.rb
+++ b/spec/services/usps_in_person_proofing/applicant_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe UspsInPersonProofing::Applicant do
       end
     end
 
-    context 'with an offset to the expiration time' do
+    context 'with an offset to the expiration time', timezone: 'UTC' do
       context 'with an offset of zero' do
         it 'shows the previous date if interpreted in US timezone' do
           exp_date = described_class.from_usps_applicant_and_enrollment(


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17600](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17600)

## 🛠 Summary of changes

Specs are run in a random timezone, but this was causing errors in specs written in #13157. This forces the system timezone to be UTC for those tests.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17600]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17600