### PR TITLE
Fix irreversible migration error

### DIFF
--- a/db/primary_migrate/20260529170050_update_email_addresses_encrypted_email_comment.rb
+++ b/db/primary_migrate/20260529170050_update_email_addresses_encrypted_email_comment.rb
@@ -1,5 +1,6 @@
 class UpdateEmailAddressesEncryptedEmailComment < ActiveRecord::Migration[8.0]
   def change
-    change_column_comment :email_addresses, :encrypted_email, "sensitive=false"
+    change_column_comment :email_addresses, :encrypted_email, to: 'sensitive=false',
+                                                              from: 'sensitive=true'
   end
 end


### PR DESCRIPTION
## 🛠 Summary of changes

Added to and from values to the `20260529170050_update_email_addresses_encrypted_email_comment` migration to fix an `ActiveRecord::IrreversibleMigration` error when rolling back.

## 📜 Testing Plan

Run migration and ensure it can be rolled back.

Original PR: https://github.com/18F/identity-idp/pull/13159