### PR TITLE
Only allow connected verified accounts to fall back onto Basic IdV

### DIFF
--- a/app/services/authn_context_resolver.rb
+++ b/app/services/authn_context_resolver.rb
@@ -74,7 +74,7 @@ class AuthnContextResolver
                      facial_match_is_required?(result)
 
     if IdentityConfig.store.facial_match_preferred_on_connected_accounts
-      return result unless user_has_account_with_sp?
+      return result unless user_has_verified_account_with_sp?
     end
 
     if user&.identity_verified?
@@ -94,9 +94,12 @@ class AuthnContextResolver
     end
   end
 
-  def user_has_account_with_sp?
+  def user_has_verified_account_with_sp?
     return false unless user && service_provider
-    user.connected_apps.exists?(service_provider: service_provider.issuer)
+    user.connected_apps
+      .where(service_provider: service_provider.issuer)
+      .where.not(verified_at: nil)
+      .exists?
   end
 
   def acr_aal_component_values

--- a/spec/services/analytics_spec.rb
+++ b/spec/services/analytics_spec.rb
@@ -498,16 +498,39 @@ RSpec.describe Analytics do
             include_examples 'track event with :sp_request'
           end
 
-          context 'when the user is proofed w/basic idv but has an account with the SP' do
-            let(:current_user) do
+          context 'when the user is proofed w/basic idv but has a verified account with the SP' do
+            let(:identity) do
               build(
-                :user, :proofed,
-                identities: [build(:service_provider_identity, service_provider: 'http://localhost:3000')]
+                :service_provider_identity,
+                service_provider: 'http://localhost:3000',
+                verified_at: 1.day.ago,
               )
             end
+            let(:current_user) { build(:user, :proofed, identities: [identity]) }
             let(:sp_request) do
               {
                 aal2: true,
+                identity_proofing: true,
+              }
+            end
+
+            include_examples 'track event with :sp_request'
+          end
+
+          context 'when the user is proofed w/basic idv but has an unverified account with the SP' do
+            let(:identity) do
+              build(
+                :service_provider_identity,
+                service_provider: 'http://localhost:3000',
+                verified_at: nil,
+              )
+            end
+            let(:current_user) { build(:user, :proofed, identities: [identity]) }
+            let(:sp_request) do
+              {
+                aal2: true,
+                facial_match: true,
+                two_pieces_of_fair_evidence: true,
                 identity_proofing: true,
               }
             end

--- a/spec/services/authn_context_resolver_spec.rb
+++ b/spec/services/authn_context_resolver_spec.rb
@@ -333,21 +333,32 @@ RSpec.describe AuthnContextResolver do
               end
 
               context 'when the user has already connected with a service provider' do
+                let(:verified_at) { 1.day.ago }
+                let(:identity) do
+                  create(:service_provider_identity, service_provider_record:, verified_at:)
+                end
+
                 let(:user) do
                   build(
                     :user,
                     :proofed,
-                    identities: [
-                      create(
-                        :service_provider_identity,
-                        service_provider_record:,
-                      ),
-                    ],
+                    identities: [identity],
                   )
                 end
 
                 context 'when the connected sp is the requesting sp' do
                   let(:service_provider_record) { service_provider }
+
+                  context 'when the connected identity has not been verified' do
+                    let(:verified_at) { nil }
+
+                    it 'asserts facial match as true' do
+                      expect(result.identity_proofing?).to be true
+                      expect(result.facial_match?).to be true
+                      expect(result.two_pieces_of_fair_evidence?).to be true
+                      expect(result.aal2?).to be true
+                    end
+                  end
 
                   it 'falls back on proofing without facial match comparison' do
                     expect(result.identity_proofing?).to be true
@@ -683,17 +694,26 @@ RSpec.describe AuthnContextResolver do
               end
 
               context 'when the user has already connected with a service provider' do
-                let(:user) do
-                  create(
-                    :user, :proofed,
-                    identities: [
-                      create(:service_provider_identity, service_provider_record:),
-                    ]
-                  )
+                let(:verified_at) { 1.day.ago }
+                let(:identity) do
+                  create(:service_provider_identity, service_provider_record:, verified_at:)
                 end
+                let(:user) { create(:user, :proofed, identities: [identity]) }
 
                 context 'when the connected sp is the requesting sp' do
                   let(:service_provider_record) { service_provider }
+
+                  context 'when the connected identity has not been verified' do
+                    let(:verified_at) { nil }
+
+                    it 'asserts facial match as true' do
+                      expect(result.identity_proofing?).to be true
+                      expect(result.facial_match?).to be true
+                      expect(result.two_pieces_of_fair_evidence?).to be true
+                      expect(result.aal2?).to be true
+                    end
+                  end
+
                   it 'falls back on proofing without facial match comparison' do
                     expect(result.identity_proofing?).to be true
                     expect(result.facial_match?).to be false


### PR DESCRIPTION
## 🛠 Summary of changes
Small follow up to https://github.com/18F/identity-idp/pull/13160 in order to only allow connected *verified* accounts to fall back onto basic IdV. 

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
