### PR TITLE
Add IALMAX spec to identity_linker_spec

### DIFF
--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -65,7 +65,7 @@ class IdentityLinker
   end
 
   def process_ial_at(now)
-    if @ial == Idp::Constants::IAL2 || (identity.verified_at.present? && @ial&.zero?)
+    if ial2? || ialmax_with_active_profile?
       identity.last_ial2_authenticated_at = now
     else
       identity.last_ial1_authenticated_at = now
@@ -73,8 +73,16 @@ class IdentityLinker
   end
 
   def process_verified_at(now)
-    return unless @ial == Idp::Constants::IAL2 && identity.verified_at.nil?
+    return unless (ial2? || ialmax_with_active_profile?) && identity.verified_at.nil?
     identity.verified_at = now
+  end
+
+  def ialmax_with_active_profile?
+    @ial == Idp::Constants::IAL_MAX && user.active_profile
+  end
+
+  def ial2?
+    @ial == Idp::Constants::IAL2
   end
 
   def identity

--- a/app/services/identity_linker.rb
+++ b/app/services/identity_linker.rb
@@ -59,12 +59,11 @@ class IdentityLinker
 
   def process_ial(ial)
     @ial = ial
-    now = Time.zone.now
-    process_ial_at(now)
-    process_verified_at(now)
+    process_ial_authenticated_at
+    process_verified_at
   end
 
-  def process_ial_at(now)
+  def process_ial_authenticated_at
     if ial2? || ialmax_with_active_profile?
       identity.last_ial2_authenticated_at = now
     else
@@ -72,7 +71,7 @@ class IdentityLinker
     end
   end
 
-  def process_verified_at(now)
+  def process_verified_at
     return unless (ial2? || ialmax_with_active_profile?) && identity.verified_at.nil?
     identity.verified_at = now
   end
@@ -87,6 +86,10 @@ class IdentityLinker
 
   def identity
     @identity ||= user.identities.create_or_find_by(service_provider: service_provider.issuer)
+  end
+
+  def now
+    @now ||= Time.zone.now
   end
 
   def identity_attributes

--- a/spec/factories/service_provider_identities.rb
+++ b/spec/factories/service_provider_identities.rb
@@ -19,5 +19,6 @@ FactoryBot.define do
 
   trait :verified do
     last_ial2_authenticated_at { Time.zone.now }
+    verified_at { Time.zone.now }
   end
 end

--- a/spec/factories/service_provider_identities.rb
+++ b/spec/factories/service_provider_identities.rb
@@ -18,6 +18,6 @@ FactoryBot.define do
   end
 
   trait :verified do
-    verified_at { Time.zone.now }
+    last_ial2_authenticated_at { Time.zone.now }
   end
 end

--- a/spec/services/db/identity/sp_user_counts_spec.rb
+++ b/spec/services/db/identity/sp_user_counts_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Db::Identity::SpUserCounts do
   subject { described_class }
+  let(:proofed_user) { create(:user, :proofed) }
 
   describe '.by_issuer' do
     let(:issuer) { 'foo' }
@@ -23,7 +24,7 @@ RSpec.describe Db::Identity::SpUserCounts do
         verified_at: Time.zone.now
       )
       ServiceProviderIdentity.create(
-        user_id: 4, service_provider: issuer2, uuid: 'foo4',
+        user_id: proofed_user.id, service_provider: issuer2, uuid: 'foo4',
         verified_at: Time.zone.now
       )
       result = { issuer: issuer, total: 3, ial1_total: 2, ial2_total: 1, app_id: app_id }.to_json
@@ -54,8 +55,11 @@ RSpec.describe Db::Identity::SpUserCounts do
     end
 
     it 'aggregates across all issuers' do
-      create(:service_provider_identity, user_id: 1, service_provider_record: sp1)
-      create(:service_provider_identity, :verified, user_id: 1, service_provider_record: sp2)
+      create(:service_provider_identity, user_id: proofed_user.id, service_provider_record: sp1)
+      create(
+        :service_provider_identity, :verified, user_id: proofed_user.id,
+                                               service_provider_record: sp2
+      )
 
       create(:service_provider_identity, user_id: 2, service_provider_record: sp1)
 

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -156,61 +156,84 @@ RSpec.describe IdentityLinker do
       IdentityLinker.new(user, service_provider2).link_identity(rails_session_id: rails_session_id)
     end
 
-    context 'identity.last_ial2_authenticated_at' do
-      context 'the request includes identity proofing' do
-        it 'sets the timestamp' do
-          IdentityLinker.new(user, service_provider).link_identity(ial: 2)
+    context '#identity.last_ial2_authenticated_at' do
+      let(:ial) { 2 }
+      before do
+        IdentityLinker.new(user, service_provider).link_identity(ial:)
+      end
 
+      context 'when the request includes identity proofing' do
+        it 'sets the timestamp' do
           expect(
             user.last_identity.last_ial2_authenticated_at,
           ).to be_within(1.second).of(Time.zone.now)
         end
       end
 
-      context 'the request does not include identity proofing' do
+      context 'when the request does not include identity proofing' do
+        let(:ial) { 1 }
         it 'does not set the timestamp' do
-          IdentityLinker.new(user, service_provider).link_identity(ial: 1)
-
           expect(user.last_identity.last_ial2_authenticated_at).to be_nil
         end
       end
 
-      context 'the request is IALMax and verified_at is null' do
-        it 'does not set the timestamp' do
-          IdentityLinker.new(user, service_provider).link_identity(ial: 0)
-
-          expect(user.last_identity.last_ial2_authenticated_at).to be_nil
+      context 'when the request is IALMax' do
+        let(:ial) { 0 }
+        context 'and the user is not verified' do
+          it 'does not set the timestamp' do
+            expect(user.last_identity.last_ial2_authenticated_at).to be_nil
+          end
         end
-      end
 
-      context 'the request is IALMax and verified_at is not null' do
-        it 'sets the timestamp' do
-          IdentityLinker.new(user, service_provider).link_identity(ial: 2)
-          IdentityLinker.new(user, service_provider).link_identity(ial: 0)
-
-          expect(
-            user.last_identity.last_ial2_authenticated_at,
-          ).to be_within(1.second).of(Time.zone.now)
+        context 'the user is verified' do
+          let(:user) { create(:user, :proofed) }
+          it 'sets the timestamp' do
+            expect(user.last_identity.last_ial2_authenticated_at).to be_within(
+              1.second,
+            ).of(Time.zone.now)
+          end
         end
       end
     end
 
     context 'identity.last_ial1_authenticated_at' do
+      let(:ial) { 2 }
+      before do
+        IdentityLinker.new(user, service_provider).link_identity(ial:)
+      end
+
       context 'the request includes identity proofing' do
         it 'does not set the timestamp' do
-          IdentityLinker.new(user, service_provider).link_identity(ial: 2)
-
           expect(user.last_identity.last_ial1_authenticated_at).to be_nil
         end
       end
 
       context 'the request does not include identity proofing' do
+        let(:ial) { 1 }
         it 'sets the timestamp' do
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)
 
           expect(
             user.last_identity.last_ial1_authenticated_at,
           ).to be_within(1.second).of(Time.zone.now)
+        end
+      end
+
+      context 'when the request is IALMax' do
+        let(:ial) { 0 }
+        context 'and the user is not verified' do
+          it 'sets the timestamp' do
+            expect(user.last_identity.last_ial1_authenticated_at).to be_within(
+              1.second,
+            ).of(Time.zone.now)
+          end
+        end
+
+        context 'the user is verified' do
+          let(:user) { create(:user, :proofed) }
+          it 'does not set the timestamp' do
+            expect(user.last_identity.last_ial1_authenticated_at).to be_nil
+          end
         end
       end
     end

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -280,6 +280,20 @@ RSpec.describe IdentityLinker do
 
             expect(user.last_identity.verified_at).to be_nil
           end
+
+          context 'when the user identity proofs elsewhere and returns' do
+            it 'sets the timestamp' do
+              freeze_time
+              travel_to 1.week.ago do
+                IdentityLinker.new(user, service_provider).link_identity(ial:)
+              end
+
+              user.update(profiles: [create(:profile, :active, user:)])
+
+              IdentityLinker.new(user, service_provider).link_identity(ial:)
+              expect(user.last_identity.verified_at).to be_within(1.second).of(Time.zone.now)
+            end
+          end
         end
       end
 

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -240,6 +240,26 @@ RSpec.describe IdentityLinker do
         end
       end
 
+      context 'the request inludes IAMLAX' do
+        context 'when the user is identity proofed' do
+          let(:user) { create(:user, :proofed) }
+
+          it 'sets the timestamp' do
+            IdentityLinker.new(user, service_provider).link_identity(ial: 0)
+
+            expect(user.last_identity.verified_at).to be_within(1.second).of(Time.zone.now)
+          end
+        end
+
+        context 'when the user is not identity proofed' do
+          it 'sets the timestamp' do
+            IdentityLinker.new(user, service_provider).link_identity(ial: 0)
+
+            expect(user.last_identity.verified_at).to be_nil
+          end
+        end
+      end
+
       context 'the request does not include identity proofing' do
         it 'does not set the timestamp' do
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -157,12 +157,12 @@ RSpec.describe IdentityLinker do
     end
 
     context 'identity.last_ial2_authenticated_at' do
-      let(:ial) { 2 }
+      let(:ial) { Idp::Constants::IAL2 }
       before do
         IdentityLinker.new(user, service_provider).link_identity(ial:)
       end
 
-      context 'when the request includes identity proofing' do
+      context 'when the request is for the identity proofing service level' do
         it 'sets the timestamp' do
           expect(
             user.last_identity.last_ial2_authenticated_at,
@@ -170,15 +170,15 @@ RSpec.describe IdentityLinker do
         end
       end
 
-      context 'when the request does not include identity proofing' do
-        let(:ial) { 1 }
+      context 'when the request is for the auth-only service level' do
+        let(:ial) { Idp::Constants::IAL1 }
         it 'does not set the timestamp' do
           expect(user.last_identity.last_ial2_authenticated_at).to be_nil
         end
       end
 
-      context 'when the request is IALMax' do
-        let(:ial) { 0 }
+      context 'when the request is for the IALMax service level' do
+        let(:ial) { Idp::Constants::IAL_MAX }
         context 'and the user is not verified' do
           it 'does not set the timestamp' do
             expect(user.last_identity.last_ial2_authenticated_at).to be_nil
@@ -197,7 +197,7 @@ RSpec.describe IdentityLinker do
     end
 
     context 'identity.last_ial1_authenticated_at' do
-      let(:ial) { 2 }
+      let(:ial) { Idp::Constants::IAL2 }
       before do
         IdentityLinker.new(user, service_provider).link_identity(ial:)
       end
@@ -209,7 +209,7 @@ RSpec.describe IdentityLinker do
       end
 
       context 'the request does not include identity proofing' do
-        let(:ial) { 1 }
+        let(:ial) { Idp::Constants::IAL1 }
         it 'sets the timestamp' do
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)
 
@@ -220,7 +220,7 @@ RSpec.describe IdentityLinker do
       end
 
       context 'when the request is IALMax' do
-        let(:ial) { 0 }
+        let(:ial) { Idp::Constants::IAL_MAX }
         context 'and the user is not verified' do
           it 'sets the timestamp' do
             expect(user.last_identity.last_ial1_authenticated_at).to be_within(
@@ -239,51 +239,52 @@ RSpec.describe IdentityLinker do
     end
 
     context 'identity.verified_at' do
-      context 'the request includes identity proofing and verified_at is null' do
+      let(:ial) { Idp::Constants::IAL2 }
+      context 'the request is for the identity proofing service level' do
         it 'sets the timestamp' do
-          IdentityLinker.new(user, service_provider).link_identity(ial: 2)
+          IdentityLinker.new(user, service_provider).link_identity(ial:)
 
           expect(
             user.last_identity.verified_at,
           ).to be_within(1.second).of(Time.zone.now)
         end
-      end
 
-      context 'the request includes identity proofing and verified_at is not null' do
-        it 'does not set the timestamp' do
-          freeze_time
-          travel_to 1.week.ago do
-            IdentityLinker.new(user, service_provider).link_identity(ial: 2)
+        context 'it is not the first connection to the service provider' do
+          it 'does not set the timestamp' do
+            freeze_time
+            travel_to 1.week.ago do
+              IdentityLinker.new(user, service_provider).link_identity(ial:)
+            end
+            IdentityLinker.new(user, service_provider).link_identity(ial:)
+
+            expect(user.last_identity.verified_at).to eq(1.week.ago)
           end
-          IdentityLinker.new(user, service_provider).link_identity(ial: 2)
-
-          expect(
-            user.last_identity.verified_at,
-          ).to eq(1.week.ago)
         end
       end
 
-      context 'the request inludes IALMAX' do
+      context 'the request is for an IALMAX service level' do
+        let(:ial) { Idp::Constants::IAL_MAX }
         context 'when the user is identity proofed' do
           let(:user) { create(:user, :proofed) }
 
           it 'sets the timestamp' do
-            IdentityLinker.new(user, service_provider).link_identity(ial: 0)
+            IdentityLinker.new(user, service_provider).link_identity(ial:)
 
             expect(user.last_identity.verified_at).to be_within(1.second).of(Time.zone.now)
           end
         end
 
         context 'when the user is not identity proofed' do
-          it 'sets the timestamp' do
-            IdentityLinker.new(user, service_provider).link_identity(ial: 0)
+          it 'does not set the timestamp' do
+            IdentityLinker.new(user, service_provider).link_identity(ial:)
 
             expect(user.last_identity.verified_at).to be_nil
           end
         end
       end
 
-      context 'the request does not include identity proofing' do
+      context 'the request is at an auth-only service level' do
+        let(:ial) { Idp::Constants::IAL1 }
         it 'does not set the timestamp' do
           IdentityLinker.new(user, service_provider).link_identity(ial: 1)
 

--- a/spec/services/identity_linker_spec.rb
+++ b/spec/services/identity_linker_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe IdentityLinker do
       IdentityLinker.new(user, service_provider2).link_identity(rails_session_id: rails_session_id)
     end
 
-    context '#identity.last_ial2_authenticated_at' do
+    context 'identity.last_ial2_authenticated_at' do
       let(:ial) { 2 }
       before do
         IdentityLinker.new(user, service_provider).link_identity(ial:)
@@ -263,7 +263,7 @@ RSpec.describe IdentityLinker do
         end
       end
 
-      context 'the request inludes IAMLAX' do
+      context 'the request inludes IALMAX' do
         context 'when the user is identity proofed' do
           let(:user) { create(:user, :proofed) }
 


### PR DESCRIPTION
These changes are the first two short-term fixes for addressing the verified_at data consistency. 
https://docs.google.com/document/d/1_WGdysvxMtTsauFporkU5G1uD3ecwjKpttgatXYqZho/edit?tab=t.0#heading=h.ja108fwpc4ig


## 🛠 Summary of changes
- Removes dependence on verified_at to determine last authentication date
- updates verified_at logic to include IALMAX users with an active profile

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
