### PR TITLE
LG-17509 mint proofing agent profile

### DIFF
--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -42,11 +42,14 @@ module Idv
     end
 
     def move_agent_proofed_user_pii_to_idv_session
-      agent_proofed_user = current_user.pending_agent_proofed_session&.load_agent_proofed_user
+      agent_proofed_user = current_user.pending_agent_proofed_user
       if agent_proofed_user
         session[:sp] = { issuer: current_user.pending_agent_proofed_session&.issuer }
         idv_session.applicant = agent_proofed_user&.pii
         idv_session.agent_proofed = true
+        # a successful agent proofed user should have phone precheck completed
+        idv_session.mark_phone_step_started!
+        idv_session.mark_phone_step_complete!
       else
         redirect_to idv_proofing_agent_expired_url
       end

--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -18,7 +18,7 @@ module Idv
       @dob_ssn_form = Idv::DobSsnForm.new(idv_session.applicant)
 
       form_response = @dob_ssn_form.submit(
-        ssn: dob_ssn_params[:ssn],
+        ssn: normalized_ssn,
         dob: parse_form_date,
       )
 
@@ -36,6 +36,10 @@ module Idv
 
     def dob_ssn_params
       params.require(:doc_auth).permit(:ssn, dob: [:month, :day, :year])
+    end
+
+    def normalized_ssn
+      SsnFormatter.normalize(dob_ssn_params[:ssn])
     end
 
     def parse_form_date
@@ -57,7 +61,7 @@ module Idv
     end
 
     def verify_dob_ssn_matches_applicant_pii?
-      ssn_match = idv_session.applicant[:ssn] == dob_ssn_params[:ssn]
+      ssn_match = idv_session.applicant[:ssn] == normalized_ssn
       dob_match = idv_session.applicant[:dob] == parse_form_date
 
       idv_session.proofing_agent_match = ssn_match && dob_match

--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -41,16 +41,14 @@ module Idv
       MemorableDateComponent.extract_date_param(dob_ssn_params[:dob])
     end
 
-    def sp
-      ServiceProvider.find_by(issuer: current_user.pending_agent_proofed_session&.issuer)
-    end
-
     def move_agent_proofed_user_pii_to_idv_session
       agent_proofed_user = current_user.pending_agent_proofed_session&.load_agent_proofed_user
       if agent_proofed_user
-        session[:sp] = current_user.pending_agent_proofed_session&.issuer
+        session[:sp] = { issuer: current_user.pending_agent_proofed_session&.issuer }
         idv_session.applicant = agent_proofed_user&.pii
         idv_session.agent_proofed = true
+      else
+        redirect_to idv_proofing_agent_expired_url
       end
     end
 

--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -8,7 +8,7 @@ module Idv
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_verification_needed
-    before_action :move_agent_proofed_user_pii_to_idv_session, only: [:new]
+    before_action :move_agent_proofed_user_pii_to_idv_session
 
     def new
       @dob_ssn_form = Idv::DobSsnForm.new(idv_session.applicant)
@@ -24,6 +24,7 @@ module Idv
 
       if form_response.success?
         return redirect_to idv_enter_password_url if verify_dob_ssn_matches_applicant_pii?
+        flash.now[:error] = t('idv.failure.dob_ssn.warning')
       else
         flash.now[:error] = form_response.first_error_message
       end

--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -41,9 +41,14 @@ module Idv
       MemorableDateComponent.extract_date_param(dob_ssn_params[:dob])
     end
 
+    def sp
+      ServiceProvider.find_by(issuer: current_user.pending_agent_proofed_session&.issuer)
+    end
+
     def move_agent_proofed_user_pii_to_idv_session
       agent_proofed_user = current_user.pending_agent_proofed_session&.load_agent_proofed_user
       if agent_proofed_user
+        session[:sp] = current_user.pending_agent_proofed_session&.issuer
         idv_session.applicant = agent_proofed_user&.pii
         idv_session.agent_proofed = true
       end

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -200,7 +200,7 @@ module Idv
 
     def remove_agent_proofed_profile_pending_status_if_needed
       # move this to user.rb probably
-      current_user.pending_agent_proofed_session.update!(pending_agent_proofed_user_at: nil)
+      current_user.pending_agent_proofed_session&.update!(pending_agent_proofed_user_at: nil)
     end
 
     def handle_request_enroll_exception(err)

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -154,7 +154,9 @@ module Idv
         attempts_api_tracker.idv_enrollment_complete(reproof:)
         fraud_ops_tracker.idv_enrollment_complete(reproof:)
 
-        remove_agent_proofed_profile_pending_status_if_needed
+        if current_user.proofing_agent_pending?
+          remove_agent_proofed_profile_pending_status_if_needed
+        end
       end
     end
 

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -153,6 +153,8 @@ module Idv
         )
         attempts_api_tracker.idv_enrollment_complete(reproof:)
         fraud_ops_tracker.idv_enrollment_complete(reproof:)
+
+        remove_agent_proofed_profile_pending_status_if_needed
       end
     end
 
@@ -192,6 +194,11 @@ module Idv
       else
         idv_personal_key_url
       end
+    end
+
+    def remove_agent_proofed_profile_pending_status_if_needed
+      # move this to user.rb probably
+      current_user.pending_agent_proofed_session.update!(pending_agent_proofed_user_at: nil)
     end
 
     def handle_request_enroll_exception(err)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -395,7 +395,8 @@ class User < ApplicationRecord
   end
 
   def pending_agent_proofed_session
-    document_capture_sessions.where.not(pending_agent_proofed_user_at: nil).first
+    document_capture_sessions.where.not(pending_agent_proofed_user_at: nil)
+      .order(pending_agent_proofed_user_at: :desc).first
   end
 
   def pending_agent_proofed_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -415,8 +415,8 @@ class User < ApplicationRecord
     return false unless session
 
     validity_hours = IdentityConfig.store.agent_proofed_user_time_validity_hours
-    if session.requested_at &&
-       (session.requested_at + validity_hours.hours) < Time.zone.now
+    if session.pending_agent_proofed_user_at &&
+       (session.pending_agent_proofed_user_at + validity_hours.hours) < Time.zone.now
       return true
     end
 

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -156,6 +156,7 @@ module Idv
         in_person_verification_needed: active_enrollment.present?,
         selfie_check_performed: session[:selfie_check_performed],
         proofing_components:,
+        proofing_agent_requested: agent_proofed,
       )
 
       profile.activate unless profile.reason_not_to_activate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1121,6 +1121,7 @@ idv.failure.attempts_html.one: You can try <strong>1 more time.</strong> Then yo
 idv.failure.attempts_html.other: You can try <strong>%{count} more times.</strong> Then you must wait 6 hours before trying again.
 idv.failure.button.try_online: Try again online
 idv.failure.button.warning: Try again
+idv.failure.dob_ssn.warning: Please check the information you entered and try again.
 idv.failure.exceptions.in_person_outage_error_message.post_cta.body: In the meantime, you can still begin the in-person verification process on %{app_name} and then visit a Post Office. If you urgently need access to services, please contact your agency directly.
 idv.failure.exceptions.in_person_outage_error_message.post_cta.title: We’re working on a technical issue. Your identity verification results may not be emailed to you until %{date}.
 idv.failure.exceptions.in_person_outage_error_message.ready_to_verify.body: You can still visit a Post Office to complete verifying your identity. If you urgently need access to services, please contact your agency directly.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1132,6 +1132,7 @@ idv.failure.attempts_html.one: Puede intentarlo <strong>una vez más.</strong> L
 idv.failure.attempts_html.other: Puede intentarlo <strong>%{count} veces más.</strong> Luego debe esperar 6 horas antes de volver a intentarlo.
 idv.failure.button.try_online: Vuelva a intentarlo en línea
 idv.failure.button.warning: Vuelva a intentarlo
+idv.failure.dob_ssn.warning: Revise la información que ingresó y vuelva a intentarlo.
 idv.failure.exceptions.in_person_outage_error_message.post_cta.body: Mientras tanto, todavía puede iniciar el proceso de verificación en persona en %{app_name} y luego acudir a una oficina de correos. Si necesita acceso urgente a los servicios, contacte directamente con su agencia.
 idv.failure.exceptions.in_person_outage_error_message.post_cta.title: Estamos resolviendo un problema técnico. Es posible que los resultados de su verificación de identidad no se le envíen por correo electrónico sino hasta el %{date}.
 idv.failure.exceptions.in_person_outage_error_message.ready_to_verify.body: Todavía puede acudir a una oficina de correos para completar el proceso de verificación de su identidad. Si necesita acceso urgente a los servicios, contacte directamente con su agencia.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1121,6 +1121,7 @@ idv.failure.attempts_html.one: Vous avez encore <strong>un essai.</strong> Vous 
 idv.failure.attempts_html.other: Vous pouvez encore essayer <strong>%{count} fois de plus.</strong> Ensuite vous devrez ensuite attendre 6 heures avant de réessayer.
 idv.failure.button.try_online: Réessayer en ligne
 idv.failure.button.warning: Réessayer
+idv.failure.dob_ssn.warning: Veuillez vérifier les informations que vous avez saisies et réessayer.
 idv.failure.exceptions.in_person_outage_error_message.post_cta.body: En attendant, vous pouvez toujours commencer la procédure de vérification en personne sur %{app_name} avant de vous rendre dans un bureau de poste. Si vous avez un besoin urgent d’accès aux services, veuillez contacter directement l’organisme concerné.
 idv.failure.exceptions.in_person_outage_error_message.post_cta.title: Nous travaillons à la résolution d’un problème technique. Il se peut que les résultats de votre vérification d’identité ne vous soient pas envoyés par e-mail avant le %{date}.
 idv.failure.exceptions.in_person_outage_error_message.ready_to_verify.body: Vous pouvez toujours vous rendre dans un bureau de poste pour achever la vérification de votre identité. Si vous avez un besoin urgent d’accès aux services, veuillez contacter directement l’organisme concerné.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1134,6 +1134,7 @@ idv.failure.attempts_html.one: 您可以再试<strong>1次。</strong> 然后您
 idv.failure.attempts_html.other: 您可以再试<strong>%{count}次。</strong> 然后您必须等6个小时才能再试。
 idv.failure.button.try_online: 在网上再试一下
 idv.failure.button.warning: 再试一下。
+idv.failure.dob_ssn.warning: 请检查一下你输入的信息，然后再试一下。
 idv.failure.exceptions.in_person_outage_error_message.post_cta.body: 与此同时，你仍然可以在 %{app_name}开始亲身验证身份流程，然后去邮局。如果你迫切需要得到服务，请直接联系该政府机构。
 idv.failure.exceptions.in_person_outage_error_message.post_cta.title: 我们正在解决一个技术问题。你身份验证结果可能要到 %{date} 才能寄到。
 idv.failure.exceptions.in_person_outage_error_message.ready_to_verify.body: 你仍然可以到邮局去完成验证你的身份。如果你迫切需要得到服务，请直接联系该政府机构。

--- a/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
+++ b/spec/controllers/concerns/idv/step_indicator_concern_spec.rb
@@ -137,7 +137,11 @@ RSpec.describe Idv::StepIndicatorConcern, type: :controller do
       end
 
       before do
-        DocumentCaptureSession.create!(user: user, pending_agent_proofed_user_at: Time.zone.now)
+        DocumentCaptureSession.create!(
+          user: user,
+          doc_auth_vendor: Idp::Constants::Vendors::PROOFING_AGENT,
+          pending_agent_proofed_user_at: Time.zone.now,
+        )
       end
 
       it 'returns doc auth proofing_agent steps' do

--- a/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
+++ b/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
@@ -17,7 +17,11 @@ RSpec.describe Idv::EnterDobSsnController do
   let(:sp) { create(:service_provider, :idv, :active) }
   let(:user) { create(:user, :fully_registered) }
   let(:document_capture_session) do
-    DocumentCaptureSession.create!(user: user, issuer: sp.issuer)
+    DocumentCaptureSession.create!(
+      user: user,
+      doc_auth_vendor: Idp::Constants::Vendors::PROOFING_AGENT,
+      issuer: sp.issuer,
+    )
   end
   let(:idv_session) { subject.idv_session }
   let(:resolved_authn_context_result) do
@@ -68,6 +72,12 @@ RSpec.describe Idv::EnterDobSsnController do
 
       it 'sets current_sp to the service provider from the agent proofed session' do
         expect(controller.current_sp).to eq(sp)
+      end
+
+      it 'sets phone step to completed' do
+        expect(subject.idv_session.address_verification_mechanism).to eq('phone')
+        expect(subject.idv_session.vendor_phone_confirmation).to eq true
+        expect(subject.idv_session.user_phone_confirmation).to eq true
       end
     end
   end

--- a/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
+++ b/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
@@ -14,13 +14,22 @@ RSpec.describe Idv::EnterDobSsnController do
       success: success,
     }
   end
+  let(:sp) { create(:service_provider, :idv, :active) }
   let(:user) { create(:user, :fully_registered) }
-  let(:document_capture_session) { DocumentCaptureSession.create!(user: user) }
+  let(:document_capture_session) do
+    DocumentCaptureSession.create!(user: user, issuer: sp.issuer)
+  end
   let(:idv_session) { subject.idv_session }
+  let(:resolved_authn_context_result) do
+    Component::Parser.new(acr_values: Saml::Idp::Constants::IAL_AUTH_ONLY_ACR).parse
+  end
 
   before do
     stub_sign_in(user)
     document_capture_session.store_agent_proofed_user(agent_proofed_user)
+    resolver_mock = instance_double(AuthnContextResolver)
+    allow(resolver_mock).to receive(:result).and_return(resolved_authn_context_result)
+    allow(AuthnContextResolver).to receive(:new).and_return(resolver_mock)
   end
 
   describe 'before_actions' do
@@ -51,6 +60,14 @@ RSpec.describe Idv::EnterDobSsnController do
     context 'user has proofing agent pending pii' do
       it 'moves agent proofed user pii to idv_session applicant' do
         expect(subject.idv_session.applicant).to eq(pii.stringify_keys)
+      end
+
+      it 'sets session[:sp] as a hash with the issuer' do
+        expect(session[:sp].with_indifferent_access[:issuer]).to eq(sp.issuer)
+      end
+
+      it 'sets current_sp to the service provider from the agent proofed session' do
+        expect(controller.current_sp).to eq(sp)
       end
     end
   end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -447,6 +447,12 @@ RSpec.describe Idv::EnterPasswordController do
         expect(events_count).to eq 1
       end
 
+      it 'does not attempt to clear agent proofed pending status' do
+        expect(controller).not_to receive(:remove_agent_proofed_profile_pending_status_if_needed)
+
+        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+      end
+
       context 'user was flagged by ThreatMetrix' do
         let(:threatmetrix_result) { 'reject' }
 
@@ -1203,6 +1209,41 @@ RSpec.describe Idv::EnterPasswordController do
           put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
           expect(UserProofingEvent.count).to eq(0)
         end
+      end
+    end
+
+    context 'user is agent-proofed' do
+      let(:document_capture_session) do
+        DocumentCaptureSession.create!(user: user, issuer: sp.issuer)
+      end
+
+      before do
+        document_capture_session.store_agent_proofed_user(
+          { pii: applicant, success: true, service_provider_issuer: sp.issuer },
+        )
+        subject.idv_session.agent_proofed = true
+        subject.idv_session.proofing_agent_match = true
+        subject.idv_session.vendor_phone_confirmation = true
+        subject.idv_session.user_phone_confirmation = true
+        session[:sp] = { issuer: sp.issuer }
+      end
+
+      it 'creates the profile with idv_level of proofing_agent' do
+        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+        expect(user.profiles.last.idv_level).to eq('proofing_agent')
+      end
+
+      it 'saves the initiating_service_provider_issuer on the profile' do
+        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+        expect(user.profiles.last.initiating_service_provider_issuer).to eq(sp.issuer)
+      end
+
+      it 'clears pending_agent_proofed_user_at on the document capture session' do
+        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+        expect(document_capture_session.reload.pending_agent_proofed_user_at).to be_nil
       end
     end
   end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1212,9 +1212,13 @@ RSpec.describe Idv::EnterPasswordController do
       end
     end
 
-    context 'user is agent-proofed' do
+    context 'user is agent proofed' do
       let(:document_capture_session) do
-        DocumentCaptureSession.create!(user: user, issuer: sp.issuer)
+        DocumentCaptureSession.create!(
+          user: user,
+          doc_auth_vendor: Idp::Constants::Vendors::PROOFING_AGENT,
+          issuer: sp.issuer,
+        )
       end
 
       before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -596,18 +596,21 @@ RSpec.describe User do
         user: user,
         doc_auth_vendor: 'proofing_agent',
         requested_at: 1.day.ago,
+        pending_agent_proofed_user_at: 1.day.ago,
       )
       session2 = create(
         :document_capture_session,
         user: user,
         doc_auth_vendor: 'proofing_agent',
         requested_at: 1.hour.ago,
+        pending_agent_proofed_user_at: 1.hour.ago,
       )
       create(
         :document_capture_session,
         user: user,
         doc_auth_vendor: 'lexisnexis',
         requested_at: 1.minute.ago,
+        pending_agent_proofed_user_at: 1.minute.ago,
       )
 
       expect(user.agent_proofing_document_capture_session).to eq(session2)
@@ -639,12 +642,13 @@ RSpec.describe User do
           :document_capture_session,
           user: user,
           doc_auth_vendor: 'proofing_agent',
-          requested_at: requested_at,
+          requested_at: pending_agent_proofed_user_at,
+          pending_agent_proofed_user_at: pending_agent_proofed_user_at,
         )
       end
 
       context 'when the session validity window has expired' do
-        let(:requested_at) { 49.hours.ago }
+        let(:pending_agent_proofed_user_at) { 49.hours.ago }
 
         it 'returns true' do
           expect(user.agent_proofing_expired?).to eq(true)
@@ -652,7 +656,7 @@ RSpec.describe User do
       end
 
       context 'when the session validity window has not expired' do
-        let(:requested_at) { 10.minutes.ago }
+        let(:pending_agent_proofed_user_at) { 10.minutes.ago }
 
         context 'when the redis cached data is present' do
           before do


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17509](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17509)



## 🛠 Summary of changes

Once a user is proofed via proofing agent, they then have to login to login.gov and enter their dob and ssn to verify it is them. They then enter their password like the regular IdV flow and it mints their profile and completes their IdV process.


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create a User
- [ ] Create an agent proofed document capture session for that user in rails console:
 ```
u = User.find_with_email(EMAIL)
d = DocumentCaptureSession.create(user: u, doc_auth_vendor: Idp::Constants::Vendors::PROOFING_AGENT, requested_at: Time.zone.now)
pii = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE
agent_proofing_result = { pii: pii, success: true }
d.store_agent_proofed_user(agent_proofing_result)
```
- [ ] Log back in and enter the Date of Birth and SSN (If using MOCK_IDV_APPLICANT_WITH_PHONE dob is 1938-10-6 and ssn is 900661234)
- [ ] Enter password
- [ ] Verify that IdV has been completed


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17509]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17509