### PR TITLE
handle template error  in mutiple_profiles_detected show page and rel…

### DIFF
--- a/app/controllers/duplicate_profiles_detected_controller.rb
+++ b/app/controllers/duplicate_profiles_detected_controller.rb
@@ -68,7 +68,6 @@ class DuplicateProfilesDetectedController < ApplicationController
       #{IdentityConfig.store.enable_one_account_global_detection}",
     )
 
-    flash[:error] = t('errors.messages.not_found')
     return redirect_to(root_url)
   end
 end

--- a/app/controllers/duplicate_profiles_detected_controller.rb
+++ b/app/controllers/duplicate_profiles_detected_controller.rb
@@ -3,6 +3,7 @@
 class DuplicateProfilesDetectedController < ApplicationController
   before_action :confirm_two_factor_authenticated
   before_action :redirect_unless_user_has_active_duplicate_profile
+  rescue_from ActionView::Template::Error, with: :handle_template_error
 
   def show
     @dupe_profiles_detected_presenter = DuplicateProfilesDetectedPresenter.new(
@@ -52,5 +53,22 @@ class DuplicateProfilesDetectedController < ApplicationController
     end
 
     user_session[:dupe_profiles_notified] = true
+  end
+
+  def handle_template_error(exception)
+    controller_info = "#{controller_path}##{action_name}"
+    analytics.unsafe_redirect_error(
+      controller: controller_info,
+      user_signed_in: user_signed_in?,
+      referer: request.referer,
+    )
+    Rails.logger.error(
+      "Template error in #{controller_info}: #{exception.message}
+      enable_one_account_global_detection:
+      #{IdentityConfig.store.enable_one_account_global_detection}",
+    )
+
+    flash[:error] = t('errors.messages.not_found')
+    return redirect_to(root_url)
   end
 end

--- a/app/controllers/duplicate_profiles_detected_controller.rb
+++ b/app/controllers/duplicate_profiles_detected_controller.rb
@@ -56,18 +56,15 @@ class DuplicateProfilesDetectedController < ApplicationController
   end
 
   def handle_template_error(exception)
-    controller_info = "#{controller_path}##{action_name}"
-    analytics.unsafe_redirect_error(
-      controller: controller_info,
-      user_signed_in: user_signed_in?,
-      referer: request.referer,
-    )
+    global_detection_enabled = IdentityConfig.store.enable_one_account_global_detection.to_s
+    sp_name = decorated_sp_session.try(:sp_name)
     Rails.logger.error(
-      "Template error in #{controller_info}: #{exception.message}
-      enable_one_account_global_detection:
-      #{IdentityConfig.store.enable_one_account_global_detection}",
+      "Template error in #{controller_path}##{action_name}-" \
+      "#{exception.message}-" \
+      "global_detection_enabled: #{global_detection_enabled}-" \
+      "sp_name: #{sp_name}",
     )
 
-    redirect_to root_url(locale: locale)
+    redirect_to root_url
   end
 end

--- a/app/controllers/duplicate_profiles_detected_controller.rb
+++ b/app/controllers/duplicate_profiles_detected_controller.rb
@@ -68,6 +68,6 @@ class DuplicateProfilesDetectedController < ApplicationController
       #{IdentityConfig.store.enable_one_account_global_detection}",
     )
 
-    return redirect_to(root_url)
+    redirect_to root_url(locale: locale)
   end
 end

--- a/spec/controllers/duplicate_profiles_detected_controller_spec.rb
+++ b/spec/controllers/duplicate_profiles_detected_controller_spec.rb
@@ -84,8 +84,15 @@ RSpec.describe DuplicateProfilesDetectedController, type: :controller do
       end
 
       it 'redirects to the root path' do
+        expect(Rails.logger).to receive(:error)
+          .with(a_string_including('Template error in duplicate_profiles_detected#show')
+            .and(a_string_including('global_detection_enabled: true'))
+            .and(a_string_including('no implicit conversion of nil into String'))
+            .and(a_string_including('sp_name: ')))
+
         get :show, params: { source: :account_page }
-        expect(response.status).to eq(302)
+        expect(response).to render_template(:show)
+        expect(response).to redirect_to(root_path)
       end
     end
   end

--- a/spec/controllers/duplicate_profiles_detected_controller_spec.rb
+++ b/spec/controllers/duplicate_profiles_detected_controller_spec.rb
@@ -66,5 +66,27 @@ RSpec.describe DuplicateProfilesDetectedController, type: :controller do
         )
       end
     end
+
+    context 'when service provider is not available and global detection is enabled' do
+      render_views
+
+      let(:global_duplicate_profile_set) do
+        create(:duplicate_profile_set, :global, profile_ids: [user.active_profile.id, profile2.id])
+      end
+
+      before do
+        global_duplicate_profile_set
+        allow(controller).to receive(:user_session).and_return(session)
+        allow(controller).to receive(:current_sp).and_return(nil)
+        allow(IdentityConfig.store)
+          .to receive(:enable_one_account_global_detection)
+          .and_return(true)
+      end
+
+      it 'redirects to the root path' do
+        get :show, params: { source: :account_page }
+        expect(response.status).to eq(302)
+      end
+    end
   end
 end


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17616](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17616)


## 🛠 Summary of changes
## 📝 Description

This PR resolves a `TypeError (no implicit conversion of nil into String)` occurring on the `duplicate_profiles_detected` show page. 

The error is triggered within a partial view when attempting to interpolate a missing service provider name. This edge case only affects a small subset of users under unclear circumstances, and user's are not intended to view this page without a service provider.

This change implements a `rescue_from` controller callback rather than adding defensive logic to the view. This approach allows us to intercept the resulting `ActionView::Template::Error`, safely redirect the user to the root URL.

### 🔍 Key Changes
* **Error Handling:** Implemented `rescue_from ActionView::Template::Error, with: :handle_template_error` to catch view exceptions at the controller level and prevent a 500 error page.
* **Redirection:** Configured the handler to gracefully route affected users back to `root_url`.
* **Test Coverage:** Added a new controller test replicating the one of the conditions that could trigger the bug to ensure the `rescue_from` callback triggers the redirect as intended.

## 📜 Testing Plan

- [x] Run the new controller spec to confirm it replicates the bug scenario and passes with the redirect to `root_url`.
- [x] Run the full test suite to verify no regressions were introduced.
- [x] Trigger the error state locally to verify the redirect to the homepage occurs smoothly.
- [x] Inspect local logs to confirm the analytics payload captures the correct context.


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17616]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17616