### PR TITLE
Lg 17519 503 http response for do s healthcheck causing 500s

### DIFF
--- a/app/services/doc_auth/dos/responses/health_check_response.rb
+++ b/app/services/doc_auth/dos/responses/health_check_response.rb
@@ -47,6 +47,8 @@ module DocAuth
 
         def parsed_body
           @parsed_body ||= body.present? && JSON.parse(body, symbolize_names: true)
+        rescue JSON::ParserError
+          { invalid_json: body }
         end
 
         def errors

--- a/spec/services/doc_auth/dos/requests/health_check_request_spec.rb
+++ b/spec/services/doc_auth/dos/requests/health_check_request_spec.rb
@@ -128,6 +128,29 @@ RSpec.describe DocAuth::Dos::Requests::HealthCheckRequest do
           end
         end
       end
+
+      context 'when there is an HTTP 503 error with a non-JSON response body' do
+        before do
+          stub_request(:get, endpoint).to_return(
+            status: 503,
+            body: '<html>Something went wrong</html>',
+            headers: { 'Content-Type' => 'text/html' },
+          )
+        end
+
+        it 'logs the request without raising' do
+          expect { result }.not_to raise_error
+
+          expect(analytics).to have_logged_event(
+            :passport_api_health_check,
+            hash_including(
+              success: false,
+              errors: { network: 503 },
+              exception: a_string_matching(/Faraday::/),
+            ),
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-17519](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17519)

## 🛠 Summary of changes

Updated the DoS passport health check handling so HTTP error responses with non-JSON bodies do not cause an unhandled exception during analytics logging.

Previously, a DoS `503` response with an HTML/plain-text body could cause `JSON.parse` to raise while building the health check response. That left the response object unset, and the `ensure` block then raised a `NoMethodError` while trying to log analytics. The user saw a 500 instead of the existing passport-unavailable fallback.

This change ensures invalid JSON response bodies are handled as failed health check responses, allowing the app to log analytics and continue to the expected “We cannot accept passports at this time” UX.

## 📜 Testing Plan

- [ ] Run `bundle exec rspec spec/services/doc_auth/dos/requests/health_check_request_spec.rb`
- [ ] Confirm the new `503` non-JSON response body regression test passes
- [ ] Manually verify selecting passport with a local `503` HTML health check response shows the passport-unavailable fallback instead of a Rails 500

### Manual testing

In local config, point the DoS passport health check at a local stub server and disable caching:

```yml
development:
  dos_passport_composite_healthcheck_endpoint: 'http://localhost:3999/composite-healthcheck'
  dos_passport_healthcheck_cache_expiration_seconds: 0
```

Run a local WEBrick server that returns a `503` with an HTML body:

```sh
ruby -rwebrick -e 'server = WEBrick::HTTPServer.new(Port: 3999); server.mount_proc("/composite-healthcheck") { |_req, res| res.status = 503; res["Content-Type"] = "text/html"; res.body = "<html>Service Unavailable</html>" }; trap("INT") { server.shutdown }; server.start'
```

Then restart the IdP, go through the IAL2 flow, choose passport as the ID type, and confirm the app shows the existing passport-unavailable fallback instead of raising a Rails 500.

## 👀 Screenshots

<details>
<summary>Before:</summary>
<img width="1366" height="1062" alt="before_fix" src="https://github.com/user-attachments/assets/b048d059-d724-4d72-890c-225a769f78ec" />
</details>

<details>
<summary>After:</summary>
<img width="1119" height="1185" alt="after_fix" src="https://github.com/user-attachments/assets/3cc19d52-97eb-4050-9f7e-c3503094d5db" />
</details>


[LG-17519]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17519