### PR TITLE
(bug) update fraud ops tracker

### DIFF
--- a/app/services/fraud_ops/tracker.rb
+++ b/app/services/fraud_ops/tracker.rb
@@ -4,6 +4,8 @@ module FraudOps
   class Tracker < AttemptsApi::Tracker
     include TrackerEvents
 
+    NO_PROVIDER_ISSUER = 'no_provider'
+
     def initialize(request:, user:, sp:, cookie_device_uuid:)
       super(
         session_id: nil,
@@ -67,9 +69,13 @@ module FraudOps
     def jwe(event)
       to_jwe(
         event: event,
-        issuer: sp.issuer,
+        issuer: event_issuer,
         public_key: public_key,
       )
+    end
+
+    def event_issuer
+      sp&.issuer || NO_PROVIDER_ISSUER
     end
 
     def to_jwe(event:, issuer:, public_key:)

--- a/spec/services/fraud_ops/tracker_spec.rb
+++ b/spec/services/fraud_ops/tracker_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe FraudOps::Tracker do
       expect(tracker).to respond_to(:session_timeout)
     end
 
+    it 'uses no_provider as the issuer when sp is nil' do
+      redis_wrapper = instance_double(FraudOps::RedisClient)
+      allow(FraudOps::RedisClient).to receive(:new).and_return(redis_wrapper)
+      allow(redis_wrapper).to receive(:write_event) do |**args|
+        decrypted_event = JWE.decrypt(args[:jwe], fraud_ops_private_key)
+        expect(JSON.parse(decrypted_event)['aud']).to eq('no_provider')
+      end
+
+      nil_sp_tracker = FraudOps::Tracker.new(
+        request: request,
+        user: user,
+        sp: nil,
+        cookie_device_uuid: cookie_device_uuid,
+      )
+
+      nil_sp_tracker.login_email_and_password_auth(email: user.email, success: true)
+
+      expect(redis_wrapper).to have_received(:write_event)
+    end
+
     it 'uses FraudOps::RedisClient for Redis operations' do
       redis_wrapper = instance_double(FraudOps::RedisClient)
       allow(FraudOps::RedisClient).to receive(:new).and_return(redis_wrapper)


### PR DESCRIPTION
changelog: Internal, Fraud Tracking, allow issuer to be nil for certain events and scenarios 



## 🛠 Summary of changes

Certain trackable events don't use a service provider (ex: direct log in)
We will track these events as well.

Currently these events cause an error and then are dropped.

<img width="1191" height="148" alt="image" src="https://github.com/user-attachments/assets/d18f6796-46c2-4cce-9fad-48ea8e2e78f7" />

