### PR TITLE
LG-17608 validate id type for proofing agent

### DIFF
--- a/app/forms/idv/proofing_agent/agent_pii_form.rb
+++ b/app/forms/idv/proofing_agent/agent_pii_form.rb
@@ -91,6 +91,11 @@ module Idv
 
           errors.add(:state_id_type, 'mis-matched type vs data', type: :id_type)
         when *Idp::Constants::DocumentTypes::SUPPORTED_PASSPORT_TYPES
+          if !FeatureManagement.idv_proofing_agent_passport_enabled?
+            errors.add(:unknown_id_type, 'unsupported id_type', type: :id_type)
+            return
+          end
+
           return if passport_present?
 
           errors.add(:passport_type, 'mis-matched type vs data', type: :id_type)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -235,6 +235,7 @@ idv_phone_verification_dual_vendor_check_socure_percent: 0
 idv_phone_verification_dual_vendor_check_socure_reason_codes: '[]'
 idv_proofing_agent_config: '[]'
 idv_proofing_agent_enabled: false
+idv_proofing_agent_passport_enabled: false
 idv_proofing_agent_result_expiration_seconds: 10
 idv_rdp_version_default: rdp_v2
 idv_rdp_version_switching_enabled: false

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -191,6 +191,10 @@ class FeatureManagement
     IdentityConfig.store.idv_proofing_agent_enabled
   end
 
+  def self.idv_proofing_agent_passport_enabled?
+    IdentityConfig.store.idv_proofing_agent_passport_enabled
+  end
+
   # Whether to prompt new users to set up a passkey immediately after email/password creation.
   # Only enabled in non-production environments as part of Test A experiment (LG-16912).
   def self.account_creation_passkey_auto_prompt_enabled?

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -249,6 +249,7 @@ module IdentityConfig
     config.add(:idv_phone_verification_dual_vendor_check_socure_reason_codes, type: :json)
     config.add(:idv_proofing_agent_config, type: :json)
     config.add(:idv_proofing_agent_enabled, type: :boolean)
+    config.add(:idv_proofing_agent_passport_enabled, type: :boolean)
     config.add(:idv_proofing_agent_result_expiration_seconds, type: :integer)
     config.add(:idv_rdp_version_default, type: :string)
     config.add(:idv_rdp_version_switching_enabled, type: :boolean)

--- a/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
+++ b/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
@@ -96,6 +96,7 @@ end
 RSpec.describe Api::ProofingAgent::ProofingAgentController do
   include Rails.application.routes.url_helpers
   let(:enabled) { false }
+  let(:idv_proofing_agent_passport_enabled) { false }
   let(:sp) { create(:service_provider) }
   let(:issuer) { sp.issuer }
   let(:correlation_id) { 'correlation-789' }
@@ -233,6 +234,8 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
       }],
     )
     allow(FeatureManagement).to receive(:idv_proofing_agent_enabled?).and_return(enabled)
+    allow(FeatureManagement).to receive(:idv_proofing_agent_passport_enabled?)
+      .and_return(idv_proofing_agent_passport_enabled)
     headers.each { |key, value| request.headers[key] = value }
   end
 
@@ -1625,6 +1628,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
       end
 
       context 'when the id_type is passport and with valid passport data' do
+        let(:idv_proofing_agent_passport_enabled) { true }
         let(:id_type) { passport_type }
         let(:passport) { valid_passport }
         let(:residential_address) { valid_residential_address }
@@ -1669,6 +1673,22 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
           it 'includes correlation_id in the response' do
             action
             expect(response.headers['X-Correlation-ID']).to be_present
+          end
+
+          context 'when passport id types are not supported' do
+            let(:idv_proofing_agent_passport_enabled) { false }
+            let(:body_errors) { { unknown_id_type: ['unsupported id_type'] } }
+
+            it 'returns 400 and logs events' do
+              expect(action.status).to eq(400)
+              expect(@analytics).to have_logged_event(
+                :idv_proofing_agent_request_failed,
+                **body_failure_event_attrs,
+              )
+
+              body = JSON.parse(response.body)
+              expect(body['unknown_id_type'][0]).to eq(body_errors[:unknown_id_type][0])
+            end
           end
         end
 


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-17608](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17608)


## 🛠 Summary of changes
Adding flag to check if we support passport in proofing agent flow. Returns and logs unsupported if we do not

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - ensure specs pass and flag is added correctly


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17608]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17608