### PR TITLE
TeamData-438-Replace described_class in spec reports

### DIFF
--- a/spec/jobs/reports/ab_tests_report_spec.rb
+++ b/spec/jobs/reports/ab_tests_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::AbTestsReport do
-  subject(:job) { AbTestsReport.new(report_date) }
+  subject(:job) { Reports::AbTestsReport.new(report_date) }
   let(:report_date) { Date.new(2023, 12, 25) }
   let(:email) { 'email@example.com' }
   let(:tested_percent) { 1 }
@@ -109,7 +109,7 @@ RSpec.describe Reports::AbTestsReport do
       it 'emails the table report' do
         expect(ReportMailer).to receive(:tables_report)
 
-        AbTestsReport.perform_now(report_date)
+        Reports::AbTestsReport.perform_now(report_date)
       end
     end
   end

--- a/spec/jobs/reports/ab_tests_report_spec.rb
+++ b/spec/jobs/reports/ab_tests_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::AbTestsReport do
-  subject(:job) { described_class.new(report_date) }
+  subject(:job) { AbTestsReport.new(report_date) }
   let(:report_date) { Date.new(2023, 12, 25) }
   let(:email) { 'email@example.com' }
   let(:tested_percent) { 1 }
@@ -109,7 +109,7 @@ RSpec.describe Reports::AbTestsReport do
       it 'emails the table report' do
         expect(ReportMailer).to receive(:tables_report)
 
-        described_class.perform_now(report_date)
+        AbTestsReport.perform_now(report_date)
       end
     end
   end

--- a/spec/jobs/reports/base_report_spec.rb
+++ b/spec/jobs/reports/base_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::BaseReport do
-  subject(:report) { described_class.new }
+  subject(:report) { BaseReport.new }
 
   before do
     allow(Identity::Hostdata).to receive(:env).and_return('test')

--- a/spec/jobs/reports/base_report_spec.rb
+++ b/spec/jobs/reports/base_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::BaseReport do
-  subject(:report) { BaseReport.new }
+  subject(:report) { Reports::BaseReport.new }
 
   before do
     allow(Identity::Hostdata).to receive(:env).and_return('test')

--- a/spec/jobs/reports/deleted_user_accounts_report_spec.rb
+++ b/spec/jobs/reports/deleted_user_accounts_report_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reports::DeletedUserAccountsReport do
   let(:uuid) { 'foo' }
   let(:last_authenticated_at) { '2020-01-02 12:03:04 UTC' }
 
-  subject { described_class.new }
+  subject { DeletedUserAccountsReport.new }
 
   it 'is does not send out an email with nothing configured' do
     expect(ReportMailer).to_not receive(:deleted_user_accounts_report)

--- a/spec/jobs/reports/deleted_user_accounts_report_spec.rb
+++ b/spec/jobs/reports/deleted_user_accounts_report_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reports::DeletedUserAccountsReport do
   let(:uuid) { 'foo' }
   let(:last_authenticated_at) { '2020-01-02 12:03:04 UTC' }
 
-  subject { DeletedUserAccountsReport.new }
+  subject { Reports::DeletedUserAccountsReport.new }
 
   it 'is does not send out an email with nothing configured' do
     expect(ReportMailer).to_not receive(:deleted_user_accounts_report)

--- a/spec/jobs/reports/demographics_metrics_s3_report_spec.rb
+++ b/spec/jobs/reports/demographics_metrics_s3_report_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
     allow(connection).to receive(:execute).and_return(mock_sql_results)
 
     # Mock BaseReport method
-    allow_any_instance_of(described_class).to receive(:generate_base_s3_path)
+    allow_any_instance_of(Reports::DemographicsMetricsS3Report).to receive(:generate_base_s3_path)
       .with(directory: 'idp').and_return('env/idp/')
 
     # Default S3 stubbing - files exist and are fresh
@@ -141,7 +141,7 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
     )
   end
 
-  subject(:job) { described_class.new(run_date, days_back, receiver, time_frame) }
+  subject(:job) { Reports::DemographicsMetricsS3Report.new(run_date, days_back, receiver, time_frame) }
 
   describe '#initialize' do
     context 'with valid parameters' do
@@ -154,29 +154,29 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
     end
 
     context 'with defaults' do
-      subject(:default_job) { described_class.new }
+      subject(:default_job) { Reports::DemographicsMetricsS3Report.new }
 
       it 'uses default values' do
         expect(default_job.run_date).to be_within(1.second).of(Time.zone.now)
-        expect(default_job.days_back_for_time_period).to eq(described_class::DEFAULT_LOOK_BACK_DAYS)
+        expect(default_job.days_back_for_time_period).to eq(Reports::DemographicsMetricsS3Report::DEFAULT_LOOK_BACK_DAYS)
         expect(default_job.report_receiver).to eq(:internal)
-        expect(default_job.time_frame).to eq(described_class::DEFAULT_TIME_FRAME)
+        expect(default_job.time_frame).to eq(Reports::DemographicsMetricsS3Report::DEFAULT_TIME_FRAME)
       end
     end
 
     context 'with invalid parameters' do
       it 'raises error for invalid days_back' do
-        expect { described_class.new(run_date, 95, receiver, time_frame) }
+        expect { Reports::DemographicsMetricsS3Report.new(run_date, 95, receiver, time_frame) }
           .to raise_error(ArgumentError, /days_back_for_time_period must be between 0 and 90/)
       end
 
       it 'raises error for invalid receiver' do
-        expect { described_class.new(run_date, days_back, :external, time_frame) }
+        expect { Reports::DemographicsMetricsS3Report.new(run_date, days_back, :external, time_frame) }
           .to raise_error(ArgumentError, /report_receiver must be :internal or :both/)
       end
 
       it 'raises error for invalid time_frame' do
-        expect { described_class.new(run_date, days_back, receiver, 'weekly') }
+        expect { Reports::DemographicsMetricsS3Report.new(run_date, days_back, receiver, 'weekly') }
           .to raise_error(ArgumentError, /time_frame must be quarterly, monthly, or daily/)
       end
     end
@@ -236,9 +236,9 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
     context 'with missing service provider' do
       before do
         # Remove issuer1 from metadata
-        allow_any_instance_of(described_class).to receive(:get_service_provider_info)
+        allow_any_instance_of(Reports::DemographicsMetricsS3Report).to receive(:get_service_provider_info)
           .with(issuer1).and_return(nil)
-        allow_any_instance_of(described_class).to receive(:get_service_provider_info)
+        allow_any_instance_of(Reports::DemographicsMetricsS3Report).to receive(:get_service_provider_info)
           .with(issuer2).and_return(sp_metadata[issuer2])
       end
 
@@ -375,7 +375,7 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
 
     context 'with email recipient handling' do
       it 'sends to internal emails only when receiver is :internal' do
-        job = described_class.new(run_date, days_back, :internal, time_frame)
+        job = Reports::DemographicsMetricsS3Report.new(run_date, days_back, :internal, time_frame)
 
         # Both issuers should use internal emails when job receiver is :internal
         expect(ReportMailer).to receive(:tables_report).with(
@@ -389,7 +389,7 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
       end
 
       it 'sends to partner emails with internal BCC when receiver is :both' do
-        job = described_class.new(run_date, days_back, :both, time_frame)
+        job = Reports::DemographicsMetricsS3Report.new(run_date, days_back, :both, time_frame)
 
         # First issuer (SSA)
         expect(ReportMailer).to receive(:tables_report).with(
@@ -423,7 +423,7 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
           double(deliver_now: true),
         )
 
-        job = described_class.new(run_date, days_back, :both, time_frame)
+        job = Reports::DemographicsMetricsS3Report.new(run_date, days_back, :both, time_frame)
         job.perform
       end
     end
@@ -480,21 +480,21 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
         expect(job.send(:report_time_range_label)).to eq('Q22026')
 
         # Q4 2025
-        q4_job = described_class.new(
+        q4_job = Reports::DemographicsMetricsS3Report.new(
           Time.zone.parse('2026-01-04'), 5, :internal, 'quarterly'
         )
         expect(q4_job.send(:report_time_range_label)).to eq('Q42025')
       end
 
       it 'formats monthly labels correctly' do
-        monthly_job = described_class.new(
+        monthly_job = Reports::DemographicsMetricsS3Report.new(
           Time.zone.parse('2026-05-04'), 5, :internal, 'monthly'
         )
         expect(monthly_job.send(:report_time_range_label)).to eq('Apr2026')
       end
 
       it 'formats daily labels correctly' do
-        daily_job = described_class.new(
+        daily_job = Reports::DemographicsMetricsS3Report.new(
           Time.zone.parse('2026-05-04'), 1, :internal, 'daily'
         )
         expect(daily_job.send(:report_time_range_label)).to eq('May032026')
@@ -506,21 +506,21 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
         expect(job.send(:report_time_range_label_email_subject)).to eq('Q2 CY 2026')
 
         # Q4 2025
-        q4_job = described_class.new(
+        q4_job = Reports::DemographicsMetricsS3Report.new(
           Time.zone.parse('2026-01-04'), 5, :internal, 'quarterly'
         )
         expect(q4_job.send(:report_time_range_label_email_subject)).to eq('Q4 CY 2025')
       end
 
       it 'formats monthly labels with spaces' do
-        monthly_job = described_class.new(
+        monthly_job = Reports::DemographicsMetricsS3Report.new(
           Time.zone.parse('2026-05-04'), 5, :internal, 'monthly'
         )
         expect(monthly_job.send(:report_time_range_label_email_subject)).to eq('Apr 2026')
       end
 
       it 'formats daily labels with spaces' do
-        daily_job = described_class.new(
+        daily_job = Reports::DemographicsMetricsS3Report.new(
           Time.zone.parse('2026-05-04'), 1, :internal, 'daily'
         )
         expect(daily_job.send(:report_time_range_label_email_subject)).to eq('May 3 2026')
@@ -535,7 +535,7 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
       end
 
       it 'calculates correct monthly range' do
-        monthly_job = described_class.new(
+        monthly_job = Reports::DemographicsMetricsS3Report.new(
           Time.zone.parse('2026-05-04'), 5, :internal, 'monthly'
         )
         range = monthly_job.send(:report_time_range)

--- a/spec/jobs/reports/demographics_metrics_s3_report_spec.rb
+++ b/spec/jobs/reports/demographics_metrics_s3_report_spec.rb
@@ -236,9 +236,11 @@ RSpec.describe Reports::DemographicsMetricsS3Report do
     context 'with missing service provider' do
       before do
         # Remove issuer1 from metadata
-        allow_any_instance_of(Reports::DemographicsMetricsS3Report).to receive(:get_service_provider_info)
+        allow_any_instance_of(Reports::DemographicsMetricsS3Report)
+          .to receive(:get_service_provider_info)
           .with(issuer1).and_return(nil)
-        allow_any_instance_of(Reports::DemographicsMetricsS3Report).to receive(:get_service_provider_info)
+        allow_any_instance_of(Reports::DemographicsMetricsS3Report)
+          .to receive(:get_service_provider_info)
           .with(issuer2).and_return(sp_metadata[issuer2])
       end
 

--- a/spec/jobs/reports/fraud_metrics_lg99_s3_report_spec.rb
+++ b/spec/jobs/reports/fraud_metrics_lg99_s3_report_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
   end
 
   subject(:report) do
-    described_class.new(
+    FraudMetricsLg99ReportS3.new(
       time_range: time_range,
       bucket_name: bucket_name,
       custom_s3_path: custom_s3_path,
@@ -65,7 +65,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
     context 'when neither report_date nor custom_s3_path is provided' do
       it 'raises an ArgumentError' do
         expect do
-          described_class.new(time_range: time_range, bucket_name: bucket_name)
+          FraudMetricsLg99ReportS3.new(time_range: time_range, bucket_name: bucket_name)
         end.to raise_error(
           ArgumentError,
           /report_date.*custom_s3_path|custom_s3_path.*report_date/,
@@ -98,7 +98,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
       end
 
       it 'derives the correct custom_s3_path from report_date' do
-        report_with_date = described_class.new(
+        report_with_date = FraudMetricsLg99ReportS3.new(
           time_range: time_range,
           bucket_name: bucket_name,
           env: 'sliang',

--- a/spec/jobs/reports/fraud_metrics_lg99_s3_report_spec.rb
+++ b/spec/jobs/reports/fraud_metrics_lg99_s3_report_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
   end
 
   subject(:report) do
-    FraudMetricsLg99ReportS3.new(
+    Reports::FraudMetricsLg99ReportS3.new(
       time_range: time_range,
       bucket_name: bucket_name,
       custom_s3_path: custom_s3_path,
@@ -65,7 +65,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
     context 'when neither report_date nor custom_s3_path is provided' do
       it 'raises an ArgumentError' do
         expect do
-          FraudMetricsLg99ReportS3.new(time_range: time_range, bucket_name: bucket_name)
+          Reports::FraudMetricsLg99ReportS3.new(time_range: time_range, bucket_name: bucket_name)
         end.to raise_error(
           ArgumentError,
           /report_date.*custom_s3_path|custom_s3_path.*report_date/,
@@ -98,7 +98,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
       end
 
       it 'derives the correct custom_s3_path from report_date' do
-        report_with_date = FraudMetricsLg99ReportS3.new(
+        report_with_date = Reports::FraudMetricsLg99ReportS3.new(
           time_range: time_range,
           bucket_name: bucket_name,
           env: 'sliang',

--- a/spec/jobs/reports/fraud_metrics_lg99_s3_report_spec.rb
+++ b/spec/jobs/reports/fraud_metrics_lg99_s3_report_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
   end
 
   subject(:report) do
-    Reports::FraudMetricsLg99ReportS3.new(
+    Reporting::FraudMetricsLg99ReportS3.new(
       time_range: time_range,
       bucket_name: bucket_name,
       custom_s3_path: custom_s3_path,
@@ -65,7 +65,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
     context 'when neither report_date nor custom_s3_path is provided' do
       it 'raises an ArgumentError' do
         expect do
-          Reports::FraudMetricsLg99ReportS3.new(time_range: time_range, bucket_name: bucket_name)
+          Reporting::FraudMetricsLg99ReportS3.new(time_range: time_range, bucket_name: bucket_name)
         end.to raise_error(
           ArgumentError,
           /report_date.*custom_s3_path|custom_s3_path.*report_date/,
@@ -98,7 +98,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
       end
 
       it 'derives the correct custom_s3_path from report_date' do
-        report_with_date = Reports::FraudMetricsLg99ReportS3.new(
+        report_with_date = Reporting::FraudMetricsLg99ReportS3.new(
           time_range: time_range,
           bucket_name: bucket_name,
           env: 'sliang',

--- a/spec/jobs/reports/monthly_sp_verification_report_spec.rb
+++ b/spec/jobs/reports/monthly_sp_verification_report_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reports::MonthlySpVerificationReport do
 
   let(:report_date)     { (Time.zone.today.beginning_of_month - 1.day).end_of_day }
   let(:report_receiver) { :internal }
-  let(:report) { MonthlySpVerificationReport.new(report_date, report_receiver) }
+  let(:report) { Reports::MonthlySpVerificationReport.new(report_date, report_receiver) }
   let(:agency_abbreviation) { 'Test_agency' }
 
   let(:base_config) do

--- a/spec/jobs/reports/monthly_sp_verification_report_spec.rb
+++ b/spec/jobs/reports/monthly_sp_verification_report_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reports::MonthlySpVerificationReport do
 
   let(:report_date)     { (Time.zone.today.beginning_of_month - 1.day).end_of_day }
   let(:report_receiver) { :internal }
-  let(:report) { described_class.new(report_date, report_receiver) }
+  let(:report) { MonthlySpVerificationReport.new(report_date, report_receiver) }
   let(:agency_abbreviation) { 'Test_agency' }
 
   let(:base_config) do

--- a/spec/jobs/reports/quarterly_account_stats_spec.rb
+++ b/spec/jobs/reports/quarterly_account_stats_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'csv'
 
 RSpec.describe Reports::QuarterlyAccountStats do
-  subject(:report) { QuarterlyAccountStats.new }
+  subject(:report) { Reports::QuarterlyAccountStats.new }
 
   describe '#perform' do
     let(:end_date) { Time.zone.today }

--- a/spec/jobs/reports/quarterly_account_stats_spec.rb
+++ b/spec/jobs/reports/quarterly_account_stats_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'csv'
 
 RSpec.describe Reports::QuarterlyAccountStats do
-  subject(:report) { described_class.new }
+  subject(:report) { QuarterlyAccountStats.new }
 
   describe '#perform' do
     let(:end_date) { Time.zone.today }

--- a/spec/jobs/reports/sp_active_users_report_spec.rb
+++ b/spec/jobs/reports/sp_active_users_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::SpActiveUsersReport do
-  subject { described_class.new }
+  subject { SpActiveUsersReport.new }
 
   let(:issuer) { 'foo' }
   let(:issuer2) { 'foo2' }

--- a/spec/jobs/reports/sp_active_users_report_spec.rb
+++ b/spec/jobs/reports/sp_active_users_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::SpActiveUsersReport do
-  subject { SpActiveUsersReport.new }
+  subject { Reports::SpActiveUsersReport.new }
 
   let(:issuer) { 'foo' }
   let(:issuer2) { 'foo2' }

--- a/spec/jobs/reports/sp_fraud_metrics_report_spec.rb
+++ b/spec/jobs/reports/sp_fraud_metrics_report_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
   let(:time_range)  { report_date.all_month }
   let(:report_receiver) { :internal }
 
-  subject(:report) { described_class.new(report_date, report_receiver) }
+  subject(:report) { SpFraudMetricsReport.new(report_date, report_receiver) }
 
   let(:agency_abbreviation) { 'Test_Agency' }
   let(:report_name) { "#{agency_abbreviation.downcase}_fraud_metrics_report" }
@@ -81,7 +81,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
 
   context 'when recipient is :both and partner emails exist' do
     let(:report_date) { Date.new(2025, 10, 1).prev_day } # 2025-09-30
-    subject(:report) { described_class.new(report_date, :both) }
+    subject(:report) { SpFraudMetricsReport.new(report_date, :both) }
 
     it 'sends a report to partner as TO and internal as BCC' do
       expect(ReportMailer).to receive(:tables_report).once.with(
@@ -100,7 +100,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
   context 'recipient is :both but partner emails are empty' do
     let(:report_receiver) { :both }
     let(:report_date) { Date.new(2025, 9, 30).in_time_zone('UTC').end_of_day }
-    subject(:report) { described_class.new(report_date, report_receiver) }
+    subject(:report) { SpFraudMetricsReport.new(report_date, report_receiver) }
 
     let(:sp_fraud_metrics_config) do
       [
@@ -134,7 +134,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
   context 'recipient is internal but internal emails are empty' do
     let(:report_receiver) { :internal }
     let(:report_date) { Date.new(2025, 9, 30).in_time_zone('UTC').end_of_day }
-    subject(:report) { described_class.new(report_date, report_receiver) }
+    subject(:report) { SpFraudMetricsReport.new(report_date, report_receiver) }
 
     let(:sp_fraud_metrics_config) do
       [
@@ -161,7 +161,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
   context 'when queued from the first of the month' do
     let(:report_receiver) { :both }
     let(:report_date) { Date.new(2021, 3, 1).prev_day.end_of_day }
-    subject(:report) { described_class.new(report_date, report_receiver) }
+    subject(:report) { SpFraudMetricsReport.new(report_date, report_receiver) }
 
     it 'sends partner emails in TO and internal emails in BCC for month-end' do
       expect(ReportMailer).to receive(:tables_report).once.with(
@@ -179,7 +179,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
 
   context 'recipient is internal and internal emails exist' do
     let(:report_date) { Date.new(2025, 9, 27).prev_day } # 2025-09-26
-    subject(:report) { described_class.new(report_date, :internal) }
+    subject(:report) { SpFraudMetricsReport.new(report_date, :internal) }
 
     it 'sends a report to internal only' do
       expect(ReportMailer).to receive(:tables_report).once.with(

--- a/spec/jobs/reports/sp_fraud_metrics_report_spec.rb
+++ b/spec/jobs/reports/sp_fraud_metrics_report_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
   let(:time_range)  { report_date.all_month }
   let(:report_receiver) { :internal }
 
-  subject(:report) { SpFraudMetricsReport.new(report_date, report_receiver) }
+  subject(:report) { Reports::SpFraudMetricsReport.new(report_date, report_receiver) }
 
   let(:agency_abbreviation) { 'Test_Agency' }
   let(:report_name) { "#{agency_abbreviation.downcase}_fraud_metrics_report" }
@@ -81,7 +81,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
 
   context 'when recipient is :both and partner emails exist' do
     let(:report_date) { Date.new(2025, 10, 1).prev_day } # 2025-09-30
-    subject(:report) { SpFraudMetricsReport.new(report_date, :both) }
+    subject(:report) { Reports::SpFraudMetricsReport.new(report_date, :both) }
 
     it 'sends a report to partner as TO and internal as BCC' do
       expect(ReportMailer).to receive(:tables_report).once.with(
@@ -100,7 +100,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
   context 'recipient is :both but partner emails are empty' do
     let(:report_receiver) { :both }
     let(:report_date) { Date.new(2025, 9, 30).in_time_zone('UTC').end_of_day }
-    subject(:report) { SpFraudMetricsReport.new(report_date, report_receiver) }
+    subject(:report) { Reports::SpFraudMetricsReport.new(report_date, report_receiver) }
 
     let(:sp_fraud_metrics_config) do
       [
@@ -134,7 +134,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
   context 'recipient is internal but internal emails are empty' do
     let(:report_receiver) { :internal }
     let(:report_date) { Date.new(2025, 9, 30).in_time_zone('UTC').end_of_day }
-    subject(:report) { SpFraudMetricsReport.new(report_date, report_receiver) }
+    subject(:report) { Reports::SpFraudMetricsReport.new(report_date, report_receiver) }
 
     let(:sp_fraud_metrics_config) do
       [
@@ -161,7 +161,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
   context 'when queued from the first of the month' do
     let(:report_receiver) { :both }
     let(:report_date) { Date.new(2021, 3, 1).prev_day.end_of_day }
-    subject(:report) { SpFraudMetricsReport.new(report_date, report_receiver) }
+    subject(:report) { Reports::SpFraudMetricsReport.new(report_date, report_receiver) }
 
     it 'sends partner emails in TO and internal emails in BCC for month-end' do
       expect(ReportMailer).to receive(:tables_report).once.with(
@@ -179,7 +179,7 @@ RSpec.describe Reports::SpFraudMetricsReport do
 
   context 'recipient is internal and internal emails exist' do
     let(:report_date) { Date.new(2025, 9, 27).prev_day } # 2025-09-26
-    subject(:report) { SpFraudMetricsReport.new(report_date, :internal) }
+    subject(:report) { Reports::SpFraudMetricsReport.new(report_date, :internal) }
 
     it 'sends a report to internal only' do
       expect(ReportMailer).to receive(:tables_report).once.with(

--- a/spec/jobs/reports/sp_issuer_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_issuer_user_counts_report_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Reports::SpIssuerUserCountsReport do
     }
   end
 
-  subject { SpIssuerUserCountsReport.new }
+  subject { Reports::SpIssuerUserCountsReport.new }
 
   let(:reports) do
     [

--- a/spec/jobs/reports/sp_issuer_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_issuer_user_counts_report_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Reports::SpIssuerUserCountsReport do
     }
   end
 
-  subject { described_class.new }
+  subject { SpIssuerUserCountsReport.new }
 
   let(:reports) do
     [

--- a/spec/jobs/reports/sp_registration_funnel_report_spec.rb
+++ b/spec/jobs/reports/sp_registration_funnel_report_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Reports::SpRegistrationFunnelReport do
   let(:report_date)     { Date.new(2021, 3, 2).in_time_zone('UTC').end_of_day }
   let(:report_receiver) { :internal }
-  subject(:report) { SpRegistrationFunnelReport.new(report_date, report_receiver) }
+  subject(:report) { Reports::SpRegistrationFunnelReport.new(report_date, report_receiver) }
   let(:agency_abbreviation) { 'Test_agency' }
   let(:report_name)         { "#{agency_abbreviation.downcase}_registration_funnel_report" }
 
@@ -75,7 +75,7 @@ RSpec.describe Reports::SpRegistrationFunnelReport do
   context 'recipient is :both but partner emails are empty' do
     let(:report_receiver) { :both }
     let(:report_date)     { Date.new(2025, 10, 20).prev_day } # 2025-10-19
-    subject(:report) { SpRegistrationFunnelReport.new(report_date, report_receiver) }
+    subject(:report) { Reports::SpRegistrationFunnelReport.new(report_date, report_receiver) }
 
     let(:partner_emails)  { [] }
     let(:internal_emails) { ['mock_internal@example.com'] }
@@ -102,7 +102,7 @@ RSpec.describe Reports::SpRegistrationFunnelReport do
   context 'recipient is :internal but internal emails are empty' do
     let(:report_receiver) { :internal }
     let(:report_date)     { Date.new(2021, 3, 2).in_time_zone('UTC').end_of_day }
-    subject(:report) { SpRegistrationFunnelReport.new(report_date, report_receiver) }
+    subject(:report) { Reports::SpRegistrationFunnelReport.new(report_date, report_receiver) }
 
     let(:internal_emails) { [] }
     let(:partner_emails)  { ['mock_partner@example.com'] }
@@ -164,7 +164,7 @@ RSpec.describe Reports::SpRegistrationFunnelReport do
 
   context 'begining of the week, it sends out the report to the internal and partner' do
     let(:report_date) { Date.new(2025, 10, 20).prev_day } # 2025-10-19
-    subject(:report) { SpRegistrationFunnelReport.new(report_date, :both) }
+    subject(:report) { Reports::SpRegistrationFunnelReport.new(report_date, :both) }
 
     let(:partner_emails)  { ['mock_partner@example.com'] }
     let(:internal_emails) { ['mock_internal@example.com'] }

--- a/spec/jobs/reports/sp_registration_funnel_report_spec.rb
+++ b/spec/jobs/reports/sp_registration_funnel_report_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Reports::SpRegistrationFunnelReport do
   let(:report_date)     { Date.new(2021, 3, 2).in_time_zone('UTC').end_of_day }
   let(:report_receiver) { :internal }
-  subject(:report) { described_class.new(report_date, report_receiver) }
+  subject(:report) { SpRegistrationFunnelReport.new(report_date, report_receiver) }
   let(:agency_abbreviation) { 'Test_agency' }
   let(:report_name)         { "#{agency_abbreviation.downcase}_registration_funnel_report" }
 
@@ -75,7 +75,7 @@ RSpec.describe Reports::SpRegistrationFunnelReport do
   context 'recipient is :both but partner emails are empty' do
     let(:report_receiver) { :both }
     let(:report_date)     { Date.new(2025, 10, 20).prev_day } # 2025-10-19
-    subject(:report) { described_class.new(report_date, report_receiver) }
+    subject(:report) { SpRegistrationFunnelReport.new(report_date, report_receiver) }
 
     let(:partner_emails)  { [] }
     let(:internal_emails) { ['mock_internal@example.com'] }
@@ -102,7 +102,7 @@ RSpec.describe Reports::SpRegistrationFunnelReport do
   context 'recipient is :internal but internal emails are empty' do
     let(:report_receiver) { :internal }
     let(:report_date)     { Date.new(2021, 3, 2).in_time_zone('UTC').end_of_day }
-    subject(:report) { described_class.new(report_date, report_receiver) }
+    subject(:report) { SpRegistrationFunnelReport.new(report_date, report_receiver) }
 
     let(:internal_emails) { [] }
     let(:partner_emails)  { ['mock_partner@example.com'] }
@@ -164,7 +164,7 @@ RSpec.describe Reports::SpRegistrationFunnelReport do
 
   context 'begining of the week, it sends out the report to the internal and partner' do
     let(:report_date) { Date.new(2025, 10, 20).prev_day } # 2025-10-19
-    subject(:report) { described_class.new(report_date, :both) }
+    subject(:report) { SpRegistrationFunnelReport.new(report_date, :both) }
 
     let(:partner_emails)  { ['mock_partner@example.com'] }
     let(:internal_emails) { ['mock_internal@example.com'] }

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::SpUserCountsReport do
-  subject { described_class.new }
+  subject { SpUserCountsReport.new }
 
   let(:issuer) { 'foo' }
   let(:app_id) { 'app_id' }

--- a/spec/jobs/reports/sp_user_counts_report_spec.rb
+++ b/spec/jobs/reports/sp_user_counts_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::SpUserCountsReport do
-  subject { SpUserCountsReport.new }
+  subject { Reports::SpUserCountsReport.new }
 
   let(:issuer) { 'foo' }
   let(:app_id) { 'app_id' }

--- a/spec/jobs/reports/sp_verification_demographics_report_spec.rb
+++ b/spec/jobs/reports/sp_verification_demographics_report_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reports::SpVerificationDemographicsReport do
   let(:report_receiver) { :internal }
   let(:time_range) { report_date.all_quarter }
 
-  subject(:report) { described_class.new(report_date, report_receiver) }
+  subject(:report) { SpVerificationDemographicsReport.new(report_date, report_receiver) }
 
   let(:job_report_name) { "#{agency_abbreviation.downcase}_verification_demographics_report" }
   let(:s3_report_bucket_prefix) { 'reports-bucket' }
@@ -120,7 +120,7 @@ RSpec.describe Reports::SpVerificationDemographicsReport do
   context 'beginning of the quarter sends to internal + partner when receiver is :both' do
     let(:report_date) { Date.new(2025, 7, 1).prev_day } # 2025-06-30
     let(:report_receiver) { :both }
-    subject(:report) { described_class.new(report_date, report_receiver) }
+    subject(:report) { SpVerificationDemographicsReport.new(report_date, report_receiver) }
 
     it 'sends partner in TO and internal in BCC' do
       expect(ReportMailer).to receive(:tables_report).once.with(
@@ -139,7 +139,7 @@ RSpec.describe Reports::SpVerificationDemographicsReport do
   context 'any other day sends to internal when receiver is :internal' do
     let(:report_date) { Date.new(2025, 9, 27).prev_day } # 2025-09-26
     let(:report_receiver) { :internal }
-    subject(:report) { described_class.new(report_date, report_receiver) }
+    subject(:report) { SpVerificationDemographicsReport.new(report_date, report_receiver) }
 
     it 'sends only to internal emails' do
       expect(ReportMailer).to receive(:tables_report).once.with(
@@ -158,7 +158,7 @@ RSpec.describe Reports::SpVerificationDemographicsReport do
   context 'recipient is :both but partner emails are empty' do
     let(:report_receiver) { :both }
     let(:report_date) { Date.new(2025, 7, 1).prev_day } # 2025-06-30
-    subject(:report) { described_class.new(report_date, report_receiver) }
+    subject(:report) { SpVerificationDemographicsReport.new(report_date, report_receiver) }
 
     let(:partner_emails) { [] }
 

--- a/spec/jobs/reports/sp_verification_demographics_report_spec.rb
+++ b/spec/jobs/reports/sp_verification_demographics_report_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reports::SpVerificationDemographicsReport do
   let(:report_receiver) { :internal }
   let(:time_range) { report_date.all_quarter }
 
-  subject(:report) { SpVerificationDemographicsReport.new(report_date, report_receiver) }
+  subject(:report) { Reports::SpVerificationDemographicsReport.new(report_date, report_receiver) }
 
   let(:job_report_name) { "#{agency_abbreviation.downcase}_verification_demographics_report" }
   let(:s3_report_bucket_prefix) { 'reports-bucket' }
@@ -120,7 +120,7 @@ RSpec.describe Reports::SpVerificationDemographicsReport do
   context 'beginning of the quarter sends to internal + partner when receiver is :both' do
     let(:report_date) { Date.new(2025, 7, 1).prev_day } # 2025-06-30
     let(:report_receiver) { :both }
-    subject(:report) { SpVerificationDemographicsReport.new(report_date, report_receiver) }
+    subject(:report) { Reports::SpVerificationDemographicsReport.new(report_date, report_receiver) }
 
     it 'sends partner in TO and internal in BCC' do
       expect(ReportMailer).to receive(:tables_report).once.with(
@@ -139,7 +139,7 @@ RSpec.describe Reports::SpVerificationDemographicsReport do
   context 'any other day sends to internal when receiver is :internal' do
     let(:report_date) { Date.new(2025, 9, 27).prev_day } # 2025-09-26
     let(:report_receiver) { :internal }
-    subject(:report) { SpVerificationDemographicsReport.new(report_date, report_receiver) }
+    subject(:report) { Reports::SpVerificationDemographicsReport.new(report_date, report_receiver) }
 
     it 'sends only to internal emails' do
       expect(ReportMailer).to receive(:tables_report).once.with(
@@ -158,7 +158,7 @@ RSpec.describe Reports::SpVerificationDemographicsReport do
   context 'recipient is :both but partner emails are empty' do
     let(:report_receiver) { :both }
     let(:report_date) { Date.new(2025, 7, 1).prev_day } # 2025-06-30
-    subject(:report) { SpVerificationDemographicsReport.new(report_date, report_receiver) }
+    subject(:report) { Reports::SpVerificationDemographicsReport.new(report_date, report_receiver) }
 
     let(:partner_emails) { [] }
 

--- a/spec/jobs/reports/sp_verification_report_spec.rb
+++ b/spec/jobs/reports/sp_verification_report_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe Reports::SpVerificationReport do
     allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
 
     # Prevent real AWS calls
-    allow_any_instance_of(Reports::SpVerificationReport).to receive(:bucket_name).and_return('test-bucket')
-    allow_any_instance_of(Reports::SpVerificationReport).to receive(:upload_file_to_s3_bucket).and_return(true)
+    allow_any_instance_of(Reports::SpVerificationReport)
+      .to receive(:bucket_name).and_return('test-bucket')
+    allow_any_instance_of(Reports::SpVerificationReport)
+      .to receive(:upload_file_to_s3_bucket).and_return(true)
 
     # No-op mailer
     allow(ReportMailer).to receive_message_chain(:tables_report, :deliver_now).and_return(true)

--- a/spec/jobs/reports/sp_verification_report_spec.rb
+++ b/spec/jobs/reports/sp_verification_report_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Reports::SpVerificationReport do
     allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
 
     # Prevent real AWS calls
-    allow_any_instance_of(SpVerificationReport).to receive(:bucket_name).and_return('test-bucket')
-    allow_any_instance_of(SpVerificationReport).to receive(:upload_file_to_s3_bucket).and_return(true)
+    allow_any_instance_of(Reports::SpVerificationReport).to receive(:bucket_name).and_return('test-bucket')
+    allow_any_instance_of(Reports::SpVerificationReport).to receive(:upload_file_to_s3_bucket).and_return(true)
 
     # No-op mailer
     allow(ReportMailer).to receive_message_chain(:tables_report, :deliver_now).and_return(true)
@@ -74,7 +74,7 @@ RSpec.describe Reports::SpVerificationReport do
 
       # Expect uploads (one per emailable report)
       emailable_reports.each do |r|
-        expect_any_instance_of(SpVerificationReport).to receive(:upload_to_s3).with(
+        expect_any_instance_of(Reports::SpVerificationReport).to receive(:upload_to_s3).with(
           r.table,
           report_name: r.filename,
         )
@@ -90,7 +90,7 @@ RSpec.describe Reports::SpVerificationReport do
         attachment_format: :csv,
       ).and_call_original
 
-      SpVerificationReport.new.perform(report_date, :both)
+      Reports::SpVerificationReport.new.perform(report_date, :both)
     end
 
     it 'emails only internal when receiver=:internal' do
@@ -114,7 +114,7 @@ RSpec.describe Reports::SpVerificationReport do
         attachment_format: :csv,
       ).and_call_original
 
-      SpVerificationReport.new.perform(report_date, :internal)
+      Reports::SpVerificationReport.new.perform(report_date, :internal)
     end
 
     context 'when no emails are configured for the chosen receiver' do
@@ -125,14 +125,14 @@ RSpec.describe Reports::SpVerificationReport do
         # Ensure we do NOT instantiate the builder or call mailer
         expect(ReportMailer).not_to receive(:tables_report)
 
-        SpVerificationReport.new.perform(report_date, :internal)
+        Reports::SpVerificationReport.new.perform(report_date, :internal)
       end
     end
   end
 
   describe '#previous_week_range' do
     it 'returns the sunday..saturday range for the previous week based on report_date' do
-      job = SpVerificationReport.new(report_date, :internal)
+      job = Reports::SpVerificationReport.new(report_date, :internal)
       range = job.previous_week_range
 
       expect(range).to be_a(Range)

--- a/spec/jobs/reports/sp_verification_report_spec.rb
+++ b/spec/jobs/reports/sp_verification_report_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Reports::SpVerificationReport do
     allow(IdentityConfig.store).to receive(:s3_reports_enabled).and_return(true)
 
     # Prevent real AWS calls
-    allow_any_instance_of(described_class).to receive(:bucket_name).and_return('test-bucket')
-    allow_any_instance_of(described_class).to receive(:upload_file_to_s3_bucket).and_return(true)
+    allow_any_instance_of(SpVerificationReport).to receive(:bucket_name).and_return('test-bucket')
+    allow_any_instance_of(SpVerificationReport).to receive(:upload_file_to_s3_bucket).and_return(true)
 
     # No-op mailer
     allow(ReportMailer).to receive_message_chain(:tables_report, :deliver_now).and_return(true)
@@ -74,7 +74,7 @@ RSpec.describe Reports::SpVerificationReport do
 
       # Expect uploads (one per emailable report)
       emailable_reports.each do |r|
-        expect_any_instance_of(described_class).to receive(:upload_to_s3).with(
+        expect_any_instance_of(SpVerificationReport).to receive(:upload_to_s3).with(
           r.table,
           report_name: r.filename,
         )
@@ -90,7 +90,7 @@ RSpec.describe Reports::SpVerificationReport do
         attachment_format: :csv,
       ).and_call_original
 
-      described_class.new.perform(report_date, :both)
+      SpVerificationReport.new.perform(report_date, :both)
     end
 
     it 'emails only internal when receiver=:internal' do
@@ -114,7 +114,7 @@ RSpec.describe Reports::SpVerificationReport do
         attachment_format: :csv,
       ).and_call_original
 
-      described_class.new.perform(report_date, :internal)
+      SpVerificationReport.new.perform(report_date, :internal)
     end
 
     context 'when no emails are configured for the chosen receiver' do
@@ -125,14 +125,14 @@ RSpec.describe Reports::SpVerificationReport do
         # Ensure we do NOT instantiate the builder or call mailer
         expect(ReportMailer).not_to receive(:tables_report)
 
-        described_class.new.perform(report_date, :internal)
+        SpVerificationReport.new.perform(report_date, :internal)
       end
     end
   end
 
   describe '#previous_week_range' do
     it 'returns the sunday..saturday range for the previous week based on report_date' do
-      job = described_class.new(report_date, :internal)
+      job = SpVerificationReport.new(report_date, :internal)
       range = job.previous_week_range
 
       expect(range).to be_a(Range)

--- a/spec/jobs/reports/total_monthly_auths_report_spec.rb
+++ b/spec/jobs/reports/total_monthly_auths_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::TotalMonthlyAuthsReport do
-  subject { described_class.new }
+  subject { TotalMonthlyAuthsReport.new }
 
   let(:issuer) { 'foo' }
   let(:app_id) { 'app_id' }

--- a/spec/jobs/reports/total_monthly_auths_report_spec.rb
+++ b/spec/jobs/reports/total_monthly_auths_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Reports::TotalMonthlyAuthsReport do
-  subject { TotalMonthlyAuthsReport.new }
+  subject { Reports::TotalMonthlyAuthsReport.new }
 
   let(:issuer) { 'foo' }
   let(:app_id) { 'app_id' }

--- a/spec/jobs/reports/verification_failures_report_spec.rb
+++ b/spec/jobs/reports/verification_failures_report_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Reports::VerificationFailuresReport do
   let(:uuid2) { 'foo2' }
   let(:now) { Time.zone.now.beginning_of_day }
 
-  subject { described_class.new }
+  subject { VerificationFailuresReport.new }
 
   it 'is does not send out an email with nothing configured' do
     expect(UserMailer).to_not receive(:verification_errors_report)

--- a/spec/jobs/reports/verification_failures_report_spec.rb
+++ b/spec/jobs/reports/verification_failures_report_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Reports::VerificationFailuresReport do
   let(:uuid2) { 'foo2' }
   let(:now) { Time.zone.now.beginning_of_day }
 
-  subject { VerificationFailuresReport.new }
+  subject { Reports::VerificationFailuresReport.new }
 
   it 'is does not send out an email with nothing configured' do
     expect(UserMailer).to_not receive(:verification_errors_report)

--- a/spec/lib/reporting/api_transaction_count_report_spec.rb
+++ b/spec/lib/reporting/api_transaction_count_report_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Reporting::ApiTransactionCountReport do
     ]
   end
 
-  subject(:report) { described_class.new(time_range:) }
+  subject(:report) { Reporting::ApiTransactionCountReport.new(time_range:) }
 
   before do
     allow(report).to receive(:true_id_table).and_return([10, mock_results])

--- a/spec/lib/reporting/authentication_report_spec.rb
+++ b/spec/lib/reporting/authentication_report_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Reporting::AuthenticationReport do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) { described_class.new(issuers: [issuer], time_range:, **opts) }
+    let(:subject) { Reporting::AuthenticationReport.new(issuers: [issuer], time_range:, **opts) }
     let(:default_args) do
       {
         num_threads: 5,

--- a/spec/lib/reporting/cloudwatch_query_time_slice_spec.rb
+++ b/spec/lib/reporting/cloudwatch_query_time_slice_spec.rb
@@ -4,31 +4,31 @@ require 'reporting/cloudwatch_query_time_slice'
 RSpec.describe Reporting::CloudwatchQueryTimeSlice do
   describe '#self.parse_duration' do
     it 'parses min as minutes' do
-      expect(described_class.parse_duration('1111min')).to eq(1111.minutes)
+      expect(Reporting::CloudwatchQueryTimeSlice.parse_duration('1111min')).to eq(1111.minutes)
     end
 
     it 'parses h as hours' do
-      expect(described_class.parse_duration('2h')).to eq(2.hours)
+      expect(Reporting::CloudwatchQueryTimeSlice.parse_duration('2h')).to eq(2.hours)
     end
 
     it 'parses d as days' do
-      expect(described_class.parse_duration('3d')).to eq(3.days)
+      expect(Reporting::CloudwatchQueryTimeSlice.parse_duration('3d')).to eq(3.days)
     end
 
     it 'parses w as weeks' do
-      expect(described_class.parse_duration('4w')).to eq(4.weeks)
+      expect(Reporting::CloudwatchQueryTimeSlice.parse_duration('4w')).to eq(4.weeks)
     end
 
     it 'parses mon as months' do
-      expect(described_class.parse_duration('5mon')).to eq(5.months)
+      expect(Reporting::CloudwatchQueryTimeSlice.parse_duration('5mon')).to eq(5.months)
     end
 
     it 'parses y as years' do
-      expect(described_class.parse_duration('6y')).to eq(6.years)
+      expect(Reporting::CloudwatchQueryTimeSlice.parse_duration('6y')).to eq(6.years)
     end
 
     it 'is nil for unknown' do
-      expect(described_class.parse_duration('7x')).to be_nil
+      expect(Reporting::CloudwatchQueryTimeSlice.parse_duration('7x')).to be_nil
     end
   end
 end

--- a/spec/lib/reporting/demographics_metrics_s3_report_spec.rb
+++ b/spec/lib/reporting/demographics_metrics_s3_report_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Reporting::DemographicsMetricsS3Report do
   let(:s3_helper) { instance_double(JobHelpers::S3Helper) }
 
   let(:report_reader) do
-    described_class.new(
+    Reporting::DemographicsMetricsS3Report.new(
       bucket_name: bucket_name,
       custom_s3_path: custom_s3_path,
       agency_abbreviation: agency_abbreviation,
@@ -31,7 +31,7 @@ RSpec.describe Reporting::DemographicsMetricsS3Report do
     end
 
     it 'allows nil agency_abbreviation' do
-      reader = described_class.new(
+      reader = Reporting::DemographicsMetricsS3Report.new(
         bucket_name: bucket_name,
         custom_s3_path: custom_s3_path,
         agency_abbreviation: nil,

--- a/spec/lib/reporting/drop_off_report_spec.rb
+++ b/spec/lib/reporting/drop_off_report_spec.rb
@@ -151,7 +151,9 @@ RSpec.describe Reporting::DropOffReport do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) { described_class.new(issuers: Array(issuer), time_range:, **opts) }
+    let(:subject) {
+      Reporting::DropOffReport.new(issuers: Array(issuer), time_range:, **opts)
+    }
     let(:default_args) do
       {
         num_threads: 5,

--- a/spec/lib/reporting/drop_off_report_spec.rb
+++ b/spec/lib/reporting/drop_off_report_spec.rb
@@ -151,9 +151,9 @@ RSpec.describe Reporting::DropOffReport do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) {
+    let(:subject) do
       Reporting::DropOffReport.new(issuers: Array(issuer), time_range:, **opts)
-    }
+    end
     let(:default_args) do
       {
         num_threads: 5,

--- a/spec/lib/reporting/fraud_metrics_lg99_report_s3_spec.rb
+++ b/spec/lib/reporting/fraud_metrics_lg99_report_s3_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
   end
 
   subject(:report) do
-    described_class.new(
+    Reporting::FraudMetricsLg99ReportS3.new(
       time_range: time_range,
       bucket_name: bucket_name,
       custom_s3_path: custom_s3_path,
@@ -65,7 +65,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
     context 'when neither report_date nor custom_s3_path is provided' do
       it 'raises an ArgumentError' do
         expect do
-          described_class.new(time_range: time_range, bucket_name: bucket_name)
+          Reporting::FraudMetricsLg99ReportS3.new(time_range: time_range, bucket_name: bucket_name)
         end.to raise_error(
           ArgumentError,
           /report_date.*custom_s3_path|custom_s3_path.*report_date/,
@@ -98,7 +98,7 @@ RSpec.describe Reporting::FraudMetricsLg99ReportS3 do
       end
 
       it 'derives the correct custom_s3_path from report_date' do
-        report_with_date = described_class.new(
+        report_with_date = Reporting::FraudMetricsLg99ReportS3.new(
           time_range: time_range,
           bucket_name: bucket_name,
           env: 'sliang',

--- a/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/fraud_metrics_lg99_report_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Reporting::FraudMetricsLg99Report do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) { described_class.new(time_range:, **opts) }
+    let(:subject) { Reporting::FraudMetricsLg99Report.new(time_range:, **opts) }
     let(:default_args) do
       {
         num_threads: 1,

--- a/spec/lib/reporting/identity_verification_outcomes_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_outcomes_report_spec.rb
@@ -203,7 +203,9 @@ RSpec.describe Reporting::IdentityVerificationOutcomesReport do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) { described_class.new(issuers: [issuer], time_range:, **opts) }
+    let(:subject) {
+      Reporting::IdentityVerificationOutcomesReport.new(issuers: [issuer], time_range:, **opts)
+    }
     let(:default_args) do
       {
         num_threads: 5,

--- a/spec/lib/reporting/identity_verification_outcomes_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_outcomes_report_spec.rb
@@ -203,9 +203,9 @@ RSpec.describe Reporting::IdentityVerificationOutcomesReport do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) {
+    let(:subject) do
       Reporting::IdentityVerificationOutcomesReport.new(issuers: [issuer], time_range:, **opts)
-    }
+    end
     let(:default_args) do
       {
         num_threads: 5,

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -548,9 +548,9 @@ RSpec.describe Reporting::IdentityVerificationReport do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) {
+    let(:subject) do
       Reporting::IdentityVerificationReport.new(issuers: Array(issuer), time_range:, **opts)
-    }
+    end
     let(:default_args) do
       {
         num_threads: 5,

--- a/spec/lib/reporting/identity_verification_report_spec.rb
+++ b/spec/lib/reporting/identity_verification_report_spec.rb
@@ -548,7 +548,9 @@ RSpec.describe Reporting::IdentityVerificationReport do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) { described_class.new(issuers: Array(issuer), time_range:, **opts) }
+    let(:subject) {
+      Reporting::IdentityVerificationReport.new(issuers: Array(issuer), time_range:, **opts)
+    }
     let(:default_args) do
       {
         num_threads: 5,

--- a/spec/lib/reporting/mfa_report_spec.rb
+++ b/spec/lib/reporting/mfa_report_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Reporting::MfaReport do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) { described_class.new(issuers: [issuer], time_range:, **opts) }
+    let(:subject) { Reporting::MfaReport.new(issuers: [issuer], time_range:, **opts) }
     let(:default_args) do
       {
         num_threads: 10,

--- a/spec/lib/reporting/monthly_idv_report_spec.rb
+++ b/spec/lib/reporting/monthly_idv_report_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Reporting::MonthlyIdvReport do
   let(:parallel) { true }
 
   subject(:idv_report) do
-    described_class.new(end_date: end_date, parallel: parallel)
+    Reporting::MonthlyIdvReport.new(end_date: end_date, parallel: parallel)
   end
 
   describe '#as_csv' do

--- a/spec/lib/reporting/protocols_report_spec.rb
+++ b/spec/lib/reporting/protocols_report_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Reporting::ProtocolsReport do
 
   describe '#cloudwatch_client' do
     let(:opts) { {} }
-    let(:subject) { described_class.new(issuers: nil, time_range:, **opts) }
+    let(:subject) { Reporting::ProtocolsReport.new(issuers: nil, time_range:, **opts) }
     let(:default_args) do
       {
         num_threads: 10,

--- a/spec/lib/reporting/sp_fraud_metrics_lg99_report_spec.rb
+++ b/spec/lib/reporting/sp_fraud_metrics_lg99_report_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Reporting::SpFraudMetricsLg99Report do
   end
 
   subject(:report) do
-    described_class.new(
+    Reporting::SpFraudMetricsLg99Report.new(
       issuers: [issuer],
       time_range:,
       agency_abbreviation: agency_abbreviation,
@@ -191,7 +191,7 @@ RSpec.describe Reporting::SpFraudMetricsLg99Report do
     let(:opts) { {} }
 
     subject(:report_with_opts) do
-      described_class.new(
+      Reporting::SpFraudMetricsLg99Report.new(
         issuers: [issuer],
         time_range:,
         agency_abbreviation: agency_abbreviation,

--- a/spec/lib/reporting/sp_idv_weekly_dropoff_report_spec.rb
+++ b/spec/lib/reporting/sp_idv_weekly_dropoff_report_spec.rb
@@ -182,7 +182,9 @@ RSpec.describe Reporting::SpIdvWeeklyDropoffReport do
     stub_multiple_cloudwatch_logs(*cloudwatch_results)
   end
 
-  subject(:report) { described_class.new(issuers:, agency_abbreviation:, time_range:) }
+  subject(:report) {
+    Reporting::SpIdvWeeklyDropoffReport.new(issuers:, agency_abbreviation:, time_range:)
+  }
 
   describe '#as_csv' do
     it 'queries cloudwatch and formats a report' do

--- a/spec/lib/reporting/sp_idv_weekly_dropoff_report_spec.rb
+++ b/spec/lib/reporting/sp_idv_weekly_dropoff_report_spec.rb
@@ -182,9 +182,9 @@ RSpec.describe Reporting::SpIdvWeeklyDropoffReport do
     stub_multiple_cloudwatch_logs(*cloudwatch_results)
   end
 
-  subject(:report) {
+  subject(:report) do
     Reporting::SpIdvWeeklyDropoffReport.new(issuers:, agency_abbreviation:, time_range:)
-  }
+  end
 
   describe '#as_csv' do
     it 'queries cloudwatch and formats a report' do

--- a/spec/lib/reporting/sp_registration_funnel_report_spec.rb
+++ b/spec/lib/reporting/sp_registration_funnel_report_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Reporting::SpRegistrationFunnelReport do
   end
 
   subject(:report) do
-    described_class.new(
+    Reporting::SpRegistrationFunnelReport.new(
       issuers: issuers,
       time_range: time_range,
       agency_abbreviation: agency,
@@ -129,7 +129,7 @@ RSpec.describe Reporting::SpRegistrationFunnelReport do
   describe '#cloudwatch_client' do
     let(:opts) { {} }
     let(:subject) do
-      described_class.new(
+      Reporting::SpRegistrationFunnelReport.new(
         issuers: issuers,
         time_range: time_range,
         agency_abbreviation: agency,

--- a/spec/lib/reporting/sp_verification_demographics_report_spec.rb
+++ b/spec/lib/reporting/sp_verification_demographics_report_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Reporting::SpVerificationDemographicsReport do
   describe '#cloudwatch_client' do
     let(:opts) { {} }
     let(:subject) do
-      described_class.new(
+      Reporting::SpVerificationDemographicsReport.new(
         issuers: [issuer], agency_abbreviation: agency_abbreviation, time_range:,
         **opts
       )

--- a/spec/lib/reporting/sp_verification_report_spec.rb
+++ b/spec/lib/reporting/sp_verification_report_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Reporting::SpVerificationReport do
   end
 
   subject(:report) do
-    described_class.new(
+    Reporting::SpVerificationReport.new(
       time_range: time_range,
       issuers: issuers,
       agency_abbreviation: agency_abbreviation,


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[Team Data Issue 438](https://gitlab.login.gov/lg-teams/Team-Data/reporting/-/issues/438)



## 🛠 Summary of changes

This PR replaces #12862. The changes in this PR include replacing all the instances of `described_class` with the report specific classes in `spec/jobs/reports`.

Will close #12862 once this PR gets merged into main.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
