### PR TITLE
LG-17659 point agreement privacy link to privacy act statement

### DIFF
--- a/app/views/idv/agreement/show.html.erb
+++ b/app/views/idv/agreement/show.html.erb
@@ -36,7 +36,7 @@
     <%= new_tab_link_to(
           t('doc_auth.instructions.learn_more'),
           policy_redirect_url(
-            policy: :security_and_privacy_practices,
+            policy: :privacy_act_statement,
             flow: :idv,
             step: :agreement,
             location: :consent,

--- a/spec/views/idv/agreement/show.html.erb_spec.rb
+++ b/spec/views/idv/agreement/show.html.erb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'idv/agreement/show' do
     expect(rendered).to have_link(
       t('doc_auth.instructions.learn_more'),
       href: policy_redirect_url(
-        policy: :security_and_privacy_practices,
+        policy: :privacy_act_statement,
         flow: :idv,
         step: :agreement,
         location: :consent,


### PR DESCRIPTION
changelog: Internal, Identity Verification, update privacy link on agreement page to privacy act statement

## 🎫 Ticket

Link to the relevant ticket:
[LG-17659](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17659)

## 🛠 Summary of changes
Legal wants the "Learn more about our privacy and security measures" link on the agreement screen

## 📜 Testing Plan

- [ ] navigate to http://localhost:3000/en/verify/agreement
- [ ] click "Learn more about our privacy and security measures", confirm it lands on https://www.login.gov/policy/our-privacy-act-statement/

## 👀 Screenshots
<img width="644" height="909" alt="Screenshot 2026-06-11 at 6 09 27 PM" src="https://github.com/user-attachments/assets/b1041470-8333-4e5a-8201-811f33e02c33" />

[LG-17659]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17659