### PR TITLE
LG-17475: Add tmx to proofing agent

### DIFF
--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -2,58 +2,61 @@
 
 module Idv
   class EnterDobSsnController < ApplicationController
-    include Idv::AvailabilityConcern
+    include AvailabilityConcern
     include IdvStepConcern
-    include Idv::StepIndicatorConcern
-    include Idv::ProofingAgentConcern
+    include StepIndicatorConcern
+    include ProofingAgentConcern
+    include Steps::ThreatMetrixStepHelper
+    include ThreatMetrixConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_verification_needed
     before_action :move_agent_proofed_user_pii_to_idv_session
+    before_action :override_csp_for_threat_metrix,
+                  if: -> {
+                    FeatureManagement.proofing_agent_device_profiling_collecting_enabled?
+                  }
 
     def new
       @dob_ssn_form = Idv::DobSsnForm.new(idv_session.applicant)
       analytics.idv_proofing_agent_user_confirmation_visited(**proofing_agent_analytics)
+
+      render :new, locals: threatmetrix_view_variables
     end
 
     def create
       @dob_ssn_form = Idv::DobSsnForm.new(idv_session.applicant)
 
       form_response = @dob_ssn_form.submit(
-        ssn: normalized_ssn,
-        dob: parse_form_date,
+        ssn: dob_ssn_params[:ssn],
+        dob: dob_ssn_params[:dob],
       )
+      idv_session.proofing_agent_match = form_response.success?
 
       analytics.idv_proofing_agent_user_confirmation_submitted(
         **proofing_agent_analytics,
         success: form_response.success?,
-        dob_match: dob_match?,
-        ssn_match: ssn_match?,
-        dob_and_ssn_match: verify_dob_ssn_matches_applicant_pii?,
+        dob_match: @dob_ssn_form.dob_match?,
+        ssn_match: @dob_ssn_form.ssn_match?,
+        dob_and_ssn_match: @dob_ssn_form.ssn_match? && @dob_ssn_form.dob_match?,
       )
 
       if form_response.success?
-        return redirect_to idv_enter_password_url if verify_dob_ssn_matches_applicant_pii?
-        flash.now[:error] = t('idv.failure.dob_ssn.warning')
+        if FeatureManagement.proofing_agent_device_profiling_collecting_enabled?
+          ::ProofingAgentThreatMetrixJob.perform_now(**tmx_job_attrs)
+        end
+        return redirect_to idv_enter_password_url
       else
-        flash.now[:error] = form_response.first_error_message
+        flash.now[:error] = t('idv.failure.dob_ssn.warning')
       end
 
-      render :new
+      render :new, locals: threatmetrix_view_variables
     end
 
     private
 
     def dob_ssn_params
       params.require(:doc_auth).permit(:ssn, dob: [:month, :day, :year])
-    end
-
-    def normalized_ssn
-      SsnFormatter.normalize(dob_ssn_params[:ssn])
-    end
-
-    def parse_form_date
-      MemorableDateComponent.extract_date_param(dob_ssn_params[:dob])
     end
 
     def move_agent_proofed_user_pii_to_idv_session
@@ -69,19 +72,6 @@ module Idv
       end
     end
 
-    def dob_match?
-      idv_session.applicant[:dob] == parse_form_date
-    end
-
-    def ssn_match?
-      idv_session.applicant[:ssn] == normalized_ssn
-    end
-
-    def verify_dob_ssn_matches_applicant_pii?
-      idv_session.proofing_agent_match = ssn_match? && dob_match?
-      idv_session.proofing_agent_match
-    end
-
     def confirm_verification_needed
       redirect_to account_url unless verification_needed?
     end
@@ -89,6 +79,18 @@ module Idv
     def verification_needed?
       IdentityConfig.store.idv_proofing_agent_enabled &&
         current_user.proofing_agent_pending?
+    end
+
+    def tmx_job_attrs
+      {
+        user_id: current_user.id,
+        applicant_pii: idv_session.applicant,
+        request_ip: request&.ip,
+        threatmetrix_session_id: idv_session.threatmetrix_session_id,
+        timer: JobHelpers::Timer.new,
+        current_sp:,
+        workflow: :proofing_agent,
+      }
     end
   end
 end

--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -47,7 +47,7 @@ module Idv
         end
         return redirect_to idv_enter_password_url
       else
-        flash.now[:error] = t('idv.failure.dob_ssn.warning')
+        flash.now[:error] = form_response.first_error_message
       end
 
       render :new, locals: threatmetrix_view_variables

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -204,11 +204,6 @@ module Idv
       end
     end
 
-    def remove_agent_proofed_profile_pending_status_if_needed
-      # move this to user.rb probably
-      current_user.pending_agent_proofed_session&.update!(pending_agent_proofed_user_at: nil)
-    end
-
     def handle_request_enroll_exception(err)
       analytics.idv_in_person_usps_request_enroll_exception(
         context: context,

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -13,6 +13,7 @@ module Idv
     before_action :confirm_step_allowed
     before_action :confirm_no_profile_yet
     before_action :confirm_current_password, only: [:create]
+    before_action :save_proofing_agent_threatmetrix_status, only: [:new]
 
     helper_method :step_indicator_step
 
@@ -238,6 +239,18 @@ module Idv
 
     def attempt_events
       user_session['idv/attempts'] || []
+    end
+
+    def save_proofing_agent_threatmetrix_status
+      return unless FeatureManagement.proofing_agent_device_profiling_collecting_enabled?
+      return if idv_session.threatmetrix_review_status.present?
+      return if idv_session.hybrid_mobile_threatmetrix_review_status.present?
+
+      device_profile = DeviceProfilingResult.for_user(
+        user_id: current_user.id,
+        type: DeviceProfilingResult::PROFILING_TYPES[:proofing_agent],
+      ).order(created_at: :desc).first
+      idv_session.threatmetrix_review_status = device_profile.review_status
     end
   end
 end

--- a/app/forms/idv/dob_ssn_form.rb
+++ b/app/forms/idv/dob_ssn_form.rb
@@ -5,19 +5,21 @@ module Idv
     include ActiveModel::Model
     include FormDobSsnValidator
 
-    attr_accessor :ssn, :dob
+    validate :dob_ssn_matches_applicant_pii
+
+    attr_accessor :applicant, :ssn, :dob
 
     def self.model_name
       ActiveModel::Name.new(self, nil, 'doc_auth')
     end
 
-    def initialize(pii)
-      @pii = pii
+    def initialize(applicant)
+      @applicant = applicant
     end
 
     def submit(ssn:, dob:)
-      @ssn = ssn
-      @dob = dob
+      @ssn = SsnFormatter.normalize(ssn) if ssn.present?
+      @dob = MemorableDateComponent.extract_date_param(dob) if dob.present?
 
       FormResponse.new(
         success: valid?,
@@ -32,6 +34,19 @@ module Idv
           ],
         },
       )
+    end
+
+    def dob_ssn_matches_applicant_pii
+      errors.add(:ssn, 'SSN mismatch', type: :mismatch) unless ssn_match?
+      errors.add(:dob, 'Date of Birth mismatch', type: :mismatch) unless dob_match?
+    end
+
+    def dob_match?
+      applicant[:dob] == dob
+    end
+
+    def ssn_match?
+      applicant[:ssn] == ssn
     end
   end
 end

--- a/app/forms/idv/dob_ssn_form.rb
+++ b/app/forms/idv/dob_ssn_form.rb
@@ -37,8 +37,9 @@ module Idv
     end
 
     def dob_ssn_matches_applicant_pii
-      errors.add(:ssn, 'SSN mismatch', type: :mismatch) unless ssn_match?
-      errors.add(:dob, 'Date of Birth mismatch', type: :mismatch) unless dob_match?
+      unless ssn_match? && dob_match?
+        errors.add(:mismatch, I18n.t('idv.failure.dob_ssn.warning'), type: :mismatch)
+      end
     end
 
     def dob_match?

--- a/app/jobs/proofing_agent_threat_metrix_job.rb
+++ b/app/jobs/proofing_agent_threat_metrix_job.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class ProofingAgentThreatMetrixJob < ApplicationJob
+  def perform(
+    user_id:,
+    applicant_pii:,
+    request_ip:,
+    threatmetrix_session_id:,
+    timer:,
+    current_sp:,
+    workflow:
+  )
+    user = User.find_by(id: user_id)
+
+    device_profiling_result = nil
+    if !FeatureManagement.proofing_agent_device_profiling_collecting_enabled?
+      device_profiling_result = threatmetrix_plugin.threatmetrix_disabled_result
+    end
+
+    device_profiling_result ||= threatmetrix_plugin.call(
+      applicant_pii:,
+      request_ip:,
+      threatmetrix_session_id:,
+      timer:,
+      current_sp:,
+      workflow:,
+      user_email: user&.last_sign_in_email_address&.email,
+      user_uuid: user&.uuid,
+      ddp_policy: IdentityConfig.store.lexisnexis_threatmetrix_policy,
+    )
+
+    store_device_profiling_result(user_id, device_profiling_result)
+    analytics(user).idv_proofing_agent_tmx_result(**device_profiling_result.to_h)
+  end
+
+  def analytics(user)
+    Analytics.new(user: user, request: nil, session: {}, sp: nil)
+  end
+
+  private
+
+  def threatmetrix_plugin
+    @threatmetrix_plugin ||= Proofing::Resolution::Plugins::ThreatMetrixPlugin.new
+  end
+
+  def store_device_profiling_result(user_id, result)
+    return unless user_id.present?
+    return unless IdentityConfig.store.proofing_agent_device_profiling == :enabled
+
+    device_profiling_result = DeviceProfilingResult.find_or_create_by(
+      user_id:,
+      profiling_type: DeviceProfilingResult::PROFILING_TYPES[:proofing_agent],
+    )
+    device_profiling_result.update(
+      client: result.client,
+      review_status: result.review_status,
+      transaction_id: result.transaction_id,
+    )
+  end
+end

--- a/app/models/device_profiling_result.rb
+++ b/app/models/device_profiling_result.rb
@@ -5,6 +5,7 @@ class DeviceProfilingResult < ApplicationRecord
 
   PROFILING_TYPES = {
     account_creation: 'ACCOUNT_CREATION',
+    proofing_agent: 'PROOFING_AGENT',
   }.freeze
 
   def self.find_or_create_by(user_id:, profiling_type:)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -148,6 +148,8 @@ class Profile < ApplicationRecord
       activated_at:,
     )
 
+    remove_agent_proofed_pending_status_if_needed
+
     track_facial_match_reproof if is_facial_match_upgrade
     send_push_notifications if is_reproof
   end
@@ -214,6 +216,10 @@ class Profile < ApplicationRecord
         activate(reason_deactivated: :password_reset) if activated_at.present?
       end
     end
+  end
+
+  def remove_agent_proofed_pending_status_if_needed
+    user.pending_agent_proofed_session&.update!(pending_agent_proofed_user_at: nil)
   end
 
   def deactivate(reason)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5510,6 +5510,46 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Boolean] success Check whether threatmetrix succeeded properly.
+  # @param [String] transaction_id Vendor-specific transaction ID for the request.
+  # @param [String, nil] client Client user was directed from when creating account
+  # @param [array<String>, nil] errors error response from api call
+  # @param [String, nil] exception Error exception from api call
+  # @param [Boolean] timed_out set whether api call timed out
+  # @param [String] review_status TMX decision on the user
+  # @param [String] account_lex_id LexID associated with the response.
+  # @param [String] session_id Session ID associated with response
+  # @param [Hash] response_body total response body for api call
+  # Result when threatmetrix is completed for proofing agent and result
+  def idv_proofing_agent_tmx_result(
+    client:,
+    success:,
+    errors:,
+    exception:,
+    timed_out:,
+    transaction_id:,
+    review_status:,
+    account_lex_id:,
+    session_id:,
+    response_body:,
+    **extra
+  )
+    track_event(
+      :idv_proofing_agent_tmx_result,
+      client:,
+      success:,
+      errors:,
+      exception:,
+      timed_out:,
+      transaction_id:,
+      review_status:,
+      account_lex_id:,
+      session_id:,
+      response_body:,
+      **extra,
+    )
+  end
+
   # @param [Boolean] success Whether the user confirmed the proofing agent results
   # @param [Boolean] dob_match the user's date of birth matched the proofing agent's results
   # @param [Boolean] ssn_match the user's SSN matched the proofing agent's results

--- a/app/services/idv/steps/threat_metrix_step_helper.rb
+++ b/app/services/idv/steps/threat_metrix_step_helper.rb
@@ -4,7 +4,7 @@ module Idv
   module Steps
     module ThreatMetrixStepHelper
       include ThreatMetrixHelper
-      def threatmetrix_view_variables(updating_ssn)
+      def threatmetrix_view_variables(updating_ssn = false)
         session_id = generate_threatmetrix_session_id(updating_ssn)
 
         {

--- a/app/views/idv/enter_dob_ssn/new.html.erb
+++ b/app/views/idv/enter_dob_ssn/new.html.erb
@@ -18,6 +18,15 @@
   <% end %>
 </p>
 
+<% if FeatureManagement.proofing_agent_device_profiling_collecting_enabled? %>
+  <%= render partial: 'shared/threat_metrix_profiling',
+             locals: {
+               threatmetrix_session_id:,
+               threatmetrix_javascript_urls:,
+               threatmetrix_iframe_url:,
+             } %>
+<% end %>
+
 <% if IdentityConfig.store.proofer_mock_fallback %>
   <div class="usa-alert usa-alert--info margin-bottom-4" role="status">
     <div class="usa-alert__body">

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -404,6 +404,7 @@ proof_address_max_attempts: 5
 proof_ssn_max_attempt_window_in_minutes: 60
 proof_ssn_max_attempts: 10
 proofer_mock_fallback: true
+proofing_agent_device_profiling: enabled
 proofing_device_hybrid_profiling: disabled
 proofing_device_profiling: enabled
 protocols_report_config: '[]'

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -138,6 +138,18 @@ class FeatureManagement
     end
   end
 
+  # Whether we collect device profiling as part of the proofing_agent idv process
+  def self.proofing_agent_device_profiling_collecting_enabled?
+    return false unless proofing_device_profiling_decisioning_enabled?
+
+    case IdentityConfig.store.proofing_agent_device_profiling
+    when :enabled, :collect_only then true
+    when :disabled then false
+    else
+      raise 'Invalid value for proofing_agent_device_profiling'
+    end
+  end
+
   # Whether we collect device profiling on the hybrid flow
   def self.proofing_device_hybrid_profiling_collecting_enabled?
     case IdentityConfig.store.proofing_device_hybrid_profiling

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -424,6 +424,11 @@ module IdentityConfig
     config.add(:proof_ssn_max_attempts, type: :integer)
     config.add(:proofer_mock_fallback, type: :boolean)
     config.add(
+      :proofing_agent_device_profiling,
+      type: :symbol,
+      enum: [:disabled, :collect_only, :enabled],
+    )
+    config.add(
       :proofing_device_hybrid_profiling,
       type: :symbol,
       enum: [:disabled, :collect_only, :enabled],

--- a/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
+++ b/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Idv::EnterDobSsnController do
-  let(:proofing_agent_enabled) { true }
+  let(:idv_proofing_agent_enabled) { true }
   let(:success) { true }
   let(:pii) do
     {
@@ -33,6 +33,8 @@ RSpec.describe Idv::EnterDobSsnController do
   let(:resolved_authn_context_result) do
     Component::Parser.new(acr_values: Saml::Idp::Constants::IAL_AUTH_ONLY_ACR).parse
   end
+  let(:proofing_agent_device_profiling) { :disabled }
+  let(:tmx_session_id) { nil }
 
   before do
     stub_sign_in(user)
@@ -41,8 +43,14 @@ RSpec.describe Idv::EnterDobSsnController do
     resolver_mock = instance_double(AuthnContextResolver)
     allow(resolver_mock).to receive(:result).and_return(resolved_authn_context_result)
     allow(AuthnContextResolver).to receive(:new).and_return(resolver_mock)
-    allow(IdentityConfig.store).to receive(:idv_proofing_agent_enabled)
-      .and_return(proofing_agent_enabled)
+    allow(IdentityConfig.store).to receive_messages(
+      {
+        idv_proofing_agent_enabled:,
+        proofing_agent_device_profiling:,
+        lexisnexis_threatmetrix_org_id: 'org1',
+      },
+    )
+    allow(controller.idv_session).to receive(:threatmetrix_session_id).and_return(tmx_session_id)
   end
 
   describe 'before_actions' do
@@ -52,6 +60,7 @@ RSpec.describe Idv::EnterDobSsnController do
         :confirm_two_factor_authenticated,
         :confirm_verification_needed,
         :move_agent_proofed_user_pii_to_idv_session,
+        :override_csp_for_threat_metrix,
       )
     end
 
@@ -61,10 +70,10 @@ RSpec.describe Idv::EnterDobSsnController do
   end
 
   describe '#new' do
-    before { get :new }
+    let(:response) { get :new }
 
     context 'proofing agent feature is disabled' do
-      let(:proofing_agent_enabled) { false }
+      let(:idv_proofing_agent_enabled) { false }
 
       it 'redirects to the account page' do
         expect(response).to redirect_to(account_url)
@@ -80,6 +89,8 @@ RSpec.describe Idv::EnterDobSsnController do
     end
 
     context 'user has proofing agent pending pii' do
+      before { get :new }
+
       it 'moves agent proofed user pii to idv_session applicant' do
         expect(subject.idv_session.applicant).to eq(pii.stringify_keys)
       end
@@ -106,19 +117,67 @@ RSpec.describe Idv::EnterDobSsnController do
         )
       end
     end
+
+    context 'with threatmetrix disabled' do
+      let(:proofing_agent_device_profiling) { :disabled }
+
+      it 'does not override CSPs for ThreatMetrix' do
+        expect(controller).not_to receive(:override_csp_for_threat_metrix)
+
+        response
+      end
+    end
+
+    context 'with threatmetrix enabled' do
+      let(:proofing_agent_device_profiling) { :enabled }
+      let(:tmx_session_id) { '1234' }
+
+      before do
+        allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_mock_enabled)
+          .and_return(false)
+      end
+
+      it 'renders new valid request' do
+        tmx_url = 'https://h.online-metrix.net/fp'
+        expect(controller).to receive(:render).with(
+          :new,
+          locals: hash_including(
+            threatmetrix_session_id: tmx_session_id,
+            threatmetrix_javascript_urls:
+              ["#{tmx_url}/tags.js?org_id=org1&session_id=#{tmx_session_id}"],
+            threatmetrix_iframe_url:
+              "#{tmx_url}/tags?org_id=org1&session_id=#{tmx_session_id}",
+          ),
+        ).and_call_original
+
+        response
+      end
+
+      it 'overrides CSPs for ThreatMetrix' do
+        expect(controller).to receive(:override_csp_for_threat_metrix)
+
+        response
+      end
+    end
   end
 
   describe '#create' do
-    before { get :new }
+    let(:ssn) { pii[:ssn] }
+    let(:year) { '1990' }
+    let(:dob) {  { year:, month: '01', day: '01' } }
+    let(:params) do
+      {
+        doc_auth: {
+          ssn:,
+          dob:,
+        },
+      }
+    end
 
     context 'user typed dob and ssn matches idv_session.applicant dob and ssn' do
       it 'redirects to enter password step' do
-        post :create, params: {
-          doc_auth: {
-            ssn: pii[:ssn],
-            dob: { year: '1990', month: '01', day: '01' },
-          },
-        }
+        post :create, params: params
+
         expect(response).to redirect_to(idv_enter_password_url)
         expect(@analytics).to have_logged_event(
           :idv_proofing_agent_user_confirmation_submitted,
@@ -133,26 +192,41 @@ RSpec.describe Idv::EnterDobSsnController do
     end
 
     context 'user typed ssn does not match idv_session.applicant ssn' do
+      let(:ssn) { '000000000' }
+
       it 'renders new' do
-        post :create, params: {
-          doc_auth: {
-            ssn: '000000000',
-            dob: { year: '1990', month: '01', day: '01' },
-          },
-        }
+        post :create, params: params
+
         expect(response).to render_template(:new)
       end
     end
 
     context 'user typed dob does not match idv_session.applicant dob' do
+      let(:year) { '2000' }
+
       it 'renders new' do
-        post :create, params: {
-          doc_auth: {
-            ssn: pii[:ssn],
-            dob: { year: '2000', month: '06', day: '15' },
-          },
-        }
+        post :create, params: params
+
         expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when proofing agent threatmetrix is not enabled' do
+      it 'does not save a threatmetrix result' do
+        expect { put :create, params: params }.not_to change { DeviceProfilingResult.count }
+      end
+    end
+
+    context 'when proofing agent threatmetrix is enabled' do
+      let(:tmx_session_id) { 'test-tmx-session-id-1234' }
+      let(:proofing_agent_device_profiling) { :enabled }
+
+      it 'saves the threatmetrix result to db' do
+        expect { put :create, params: params }.to change { DeviceProfilingResult.count }
+
+        result = DeviceProfilingResult.last
+        expect(result.review_status).to eq('pass')
+        expect(result.transaction_id).to eq('ddp-mock-transaction-id-123')
       end
     end
   end

--- a/spec/forms/idv/dob_ssn_form_spec.rb
+++ b/spec/forms/idv/dob_ssn_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Idv::DobSsnForm do
-  let(:ssn) { '111-11-1111' }
+  let(:ssn) { '111111111' }
   let(:dob) { '1990-01-01' }
   let(:pii) do
     {
@@ -15,8 +15,7 @@ RSpec.describe Idv::DobSsnForm do
   describe '#submit' do
     context 'when the form is valid' do
       it 'returns a successful form response' do
-        result = subject.submit(ssn: '111111111', dob: '1990-01-01')
-
+        result = subject.submit(ssn: '111-11-1111', dob: { year: '1990', month: '01', day: '01' })
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(true)
         expect(result.errors).to be_empty

--- a/spec/forms/idv/dob_ssn_form_spec.rb
+++ b/spec/forms/idv/dob_ssn_form_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe Idv::DobSsnForm do
         expect(result.errors).to include(:ssn, :dob)
       end
     end
+
+    context 'when the ssn and dob do not match' do
+      it 'returns a successful form response' do
+        result = subject.submit(ssn: '111-22-3333', dob: { year: '2000', month: '01', day: '01' })
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(result.errors).to include(:mismatch)
+      end
+    end
   end
 
   describe 'presence validations' do

--- a/spec/jobs/proofing_agent_threat_metrix_job_spec.rb
+++ b/spec/jobs/proofing_agent_threat_metrix_job_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProofingAgentThreatMetrixJob, type: :job do
+  let(:user) { create(:user, :fully_registered) }
+  let(:request_ip) { Faker::Internet.ip_v4_address }
+  let(:current_sp) { create(:service_provider) }
+  let(:threatmetrix_session_id) { SecureRandom.uuid }
+  let(:proofing_device_profiling) { :enabled }
+  let(:proofing_agent_device_profiling) { :collect_only }
+  let(:lexisnexis_threatmetrix_mock_enabled) { false }
+  let(:threatmetrix_response) { LexisNexisFixtures.threatmetrix_success_response_json }
+  let(:threatmetrix_stub) { stub_threatmetrix_request(threatmetrix_response) }
+  let(:job_analytics) { FakeAnalytics.new }
+  let(:applicant_pii) do
+    {
+      ssn: '123456789',
+      dob: '1990-01-01',
+    }
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive_messages(
+      {
+        lexisnexis_threatmetrix_mock_enabled:,
+        proofing_device_profiling:,
+        proofing_agent_device_profiling:,
+        lexisnexis_threatmetrix_base_url: 'https://www.example.com',
+      },
+    )
+    allow(instance).to receive(:analytics).and_return(job_analytics)
+  end
+
+  describe '#perform' do
+    let(:instance) { ProofingAgentThreatMetrixJob.new }
+
+    subject(:perform) do
+      instance.perform(
+        user_id: user.id,
+        applicant_pii:,
+        request_ip:,
+        threatmetrix_session_id:,
+        current_sp:,
+        timer: JobHelpers::Timer.new,
+        workflow: :proofing_agent,
+      )
+    end
+
+    context 'Threat Metrix Proofing Agent analysis passes' do
+      let(:threatmetrix_response) { LexisNexisFixtures.threatmetrix_success_response_json }
+      let(:proofing_agent_device_profiling) { :enabled }
+
+      it 'logs a successful result' do
+        threatmetrix_stub
+
+        perform
+
+        expect(job_analytics).to have_logged_event(
+          :idv_proofing_agent_tmx_result,
+          hash_including(
+            success: true,
+            review_status: 'pass',
+          ),
+        )
+      end
+
+      it 'creates a DeviceProfilingResult' do
+        threatmetrix_stub
+
+        perform
+        result = DeviceProfilingResult.find_by(
+          user_id: user.id,
+          profiling_type: DeviceProfilingResult::PROFILING_TYPES[:proofing_agent],
+        )
+        expect(result).to be_truthy
+        expect(result.user_id).to eq(user.id)
+      end
+    end
+
+    context 'with an error response result' do
+      let(:threatmetrix_response) { LexisNexisFixtures.threatmetrix_failure_response_json }
+
+      it 'stores an unsuccessful result' do
+        threatmetrix_stub
+
+        perform
+
+        expect(job_analytics).to have_logged_event(
+          :idv_proofing_agent_tmx_result,
+          hash_including(
+            success: false,
+            review_status: 'reject',
+          ),
+        )
+      end
+    end
+
+    context 'with threatmetrix disabled' do
+      let(:proofing_agent_device_profiling) { :disabled }
+
+      it 'does not make a request to threatmetrix' do
+        threatmetrix_stub
+
+        perform
+
+        expect(threatmetrix_stub).to_not have_been_requested
+        expect(job_analytics).to have_logged_event(
+          :idv_proofing_agent_tmx_result,
+          hash_including(
+            success: true,
+            client: 'tmx_disabled',
+            review_status: 'pass',
+          ),
+        )
+      end
+    end
+
+    context 'without a threatmetrix session ID' do
+      let(:threatmetrix_session_id) { nil }
+      let(:ipp_enrollment_in_progress) { false }
+      let(:threatmetrix_response) { LexisNexisFixtures.threatmetrix_failure_response_json }
+
+      it 'does not make a request to threatmetrix' do
+        threatmetrix_stub
+
+        perform
+
+        expect(threatmetrix_stub).to_not have_been_requested
+        expect(job_analytics).to have_logged_event(
+          :idv_proofing_agent_tmx_result,
+          hash_including(
+            success: false,
+            client: 'tmx_session_id_missing',
+            review_status: 'reject',
+          ),
+        )
+      end
+    end
+  end
+
+  def stub_threatmetrix_request(threatmetrix_response)
+    stub_request(
+      :post,
+      'https://www.example.com/api/session-query',
+    ).to_return(body: threatmetrix_response)
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17475](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17475)

## 🛠 Summary of changes

When enabled, makes a ThreatMetrix check when activating a profile created via a proofing agent.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Create an un-verified User and sign out
- [ ] Create an agent proofed document capture session for that user in rails console:
```
u = User.find_with_email(EMAIL)
d = DocumentCaptureSession.create(user: u, doc_auth_vendor: Idp::Constants::Vendors::PROOFING_AGENT, requested_at: Time.zone.now)
pii = Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE
agent_proofing_result = { pii: pii, success: true }
d.store_agent_proofed_user(agent_proofing_result)
```
- [ ] Log back in and enter the Date of Birth and SSN (If using MOCK_IDV_APPLICANT_WITH_PHONE dob is 1938-10-6 and ssn is 900661234), and
- [ ] Choose `Reject` from the `Mock device profiling behavior` dropdown, then Continue
<img width="459" height="65" alt="reject" src="https://github.com/user-attachments/assets/d7e9d817-c62a-4f99-a01a-0c458940533e" />

- [ ] Enter password and Continue - verify that 'please call' email is sent 
- [ ] Save personal key and Continue - verify that user lands on the `please call` screen


[LG-17475]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17475