### PR TITLE
GL-Reporting-637

### DIFF
--- a/lib/reporting/api_transaction_count_report.rb
+++ b/lib/reporting/api_transaction_count_report.rb
@@ -282,9 +282,15 @@ module Reporting
 
     def instant_verify_query
       <<~QUERY
-        fields @timestamp, @message
+        fields @timestamp, @message, id
+        | filter name in ['IdV: doc auth verify proofing results']
         | fields jsonParse(@message) as message
-        | filter name='IdV: doc auth verify proofing results' and message.properties.event_properties.proofing_results.context.stages.resolution.vendor_name='lexisnexis:instant_verify'
+        | unnest message.properties.event_properties into event_properties
+        | unnest event_properties.proofing_results into proofing_results
+        | unnest proofing_results.context into context
+        | unnest context.stages into stages
+        | unnest stages.resolution into resolution
+        | filter resolution.vendor_name like /lexisnexis/
         | display id
         | limit 10000
       QUERY
@@ -367,9 +373,9 @@ module Reporting
 
     def ln_phonefinder_query
       <<~QUERY
-        fields @timestamp, @message
+        fields @timestamp, @message, id
         | filter name = 'IdV: phone confirmation vendor'
-        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder"
+        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder" or properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder_ddp"
         | display id
         | limit 10000
       QUERY


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[637: Update API Transaction Report: LN Phone Finder, Instant Verify](https://gitlab.login.gov/lg-teams/Team-Data/reporting/-/issues/637)


## 🛠 Summary of changes

The query in IDP for instantverify appears to not have the jsonParse of the message and doesn't unnest the parsed message. This issue is needs to be corrected in order to circumvent the 200 key limit  error that we know exists in CW. Also,`lexisnexis:phone_finder_ddp` needs to be added to the LN_phone_finder query. For InstantVerify `lexisnexis:instant_verify_ddp` needs to be added into the search.

## 👀 Screenshots




<details>
<summary>After: Looking at May 24, 2026 timeframe in both CW and Prod</summary>
<img width="1319" height="711" alt="Screenshot 2026-06-05 at 3 47 40 PM" src="https://github.com/user-attachments/assets/b1fe9d53-698a-49f0-a2d4-1766b328689f" />

<img />
</details>
