### PR TITLE
Deploy RC 585 to Production

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -501,7 +501,7 @@ GEM
       uri (>= 0.11.1)
     net-http-persistent (4.0.8)
       connection_pool (>= 2.2.4, < 4)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/components/flash_component.rb
+++ b/app/components/flash_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FlashComponent < BaseComponent
-  VALID_FLASH_TYPES = %w[error info success warning other notice alert].freeze
+  VALID_FLASH_TYPES = %w[error info success warning other notice alert session_timed_out].freeze
 
   attr_reader :flash
 
@@ -20,6 +20,8 @@ class FlashComponent < BaseComponent
   def alert_type(flash_type)
     case flash_type
     when 'notice'
+      :info
+    when 'session_timed_out'
       :info
     when 'alert'
       :error

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -9,6 +9,7 @@ class AccountsController < ApplicationController
 
   def show
     analytics.account_visit
+    delete_session_timeout_flash_if_present
     session[:account_redirect_path] = account_path
     cacher = Pii::Cacher.new(current_user, user_session)
     @presenter = AccountShowPresenter.new(
@@ -42,5 +43,9 @@ class AccountsController < ApplicationController
 
   def confirm_user_is_not_suspended
     redirect_to user_please_call_url if current_user.suspended?
+  end
+
+  def delete_session_timeout_flash_if_present
+    flash.delete(:session_timed_out)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,16 +30,16 @@ class ApplicationController < ActionController::Base
   helper_method :decorated_sp_session, :current_sp, :user_fully_authenticated?
 
   prepend_before_action :add_new_relic_trace_attributes
-  prepend_before_action :session_expires_at
+  prepend_before_action :set_session_start_value_if_nil
+  prepend_before_action :show_flash_with_redirect_if_session_timeout
   prepend_before_action :set_locale
   before_action :disable_caching
   before_action :cache_issuer_in_cookie
   after_action :store_web_locale_in_session
 
-  def session_expires_at
+  def set_session_start_value_if_nil
     return if @skip_session_expiration || @skip_session_load
     session[:session_started_at] = Time.zone.now if session[:session_started_at].nil?
-    redirect_with_flash_if_timeout
   end
 
   # for lograge
@@ -190,13 +190,12 @@ class ApplicationController < ActionController::Base
                           end
   end
 
-  def redirect_with_flash_if_timeout
+  def show_flash_with_redirect_if_session_timeout
     return unless params[:timeout]
 
     if params[:timeout] == 'session'
-      analytics.session_timed_out
-      attempts_api_tracker.session_timeout
-      flash[:info] = t(
+      log_session_timeout
+      flash[:session_timed_out] = t(
         'notices.session_timedout',
         app_name: APP_NAME,
         minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes.to_i,
@@ -213,6 +212,11 @@ class ApplicationController < ActionController::Base
     rescue ActionController::UrlGenerationError # Binary data in parameters throw on redirect
       head :bad_request
     end
+  end
+
+  def log_session_timeout
+    analytics.session_timed_out
+    attempts_api_tracker.session_timeout
   end
 
   def permitted_timeout_params

--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -2,58 +2,61 @@
 
 module Idv
   class EnterDobSsnController < ApplicationController
-    include Idv::AvailabilityConcern
+    include AvailabilityConcern
     include IdvStepConcern
-    include Idv::StepIndicatorConcern
-    include Idv::ProofingAgentConcern
+    include StepIndicatorConcern
+    include ProofingAgentConcern
+    include Steps::ThreatMetrixStepHelper
+    include ThreatMetrixConcern
 
     before_action :confirm_two_factor_authenticated
     before_action :confirm_verification_needed
     before_action :move_agent_proofed_user_pii_to_idv_session
+    before_action :override_csp_for_threat_metrix,
+                  if: -> {
+                    FeatureManagement.proofing_agent_device_profiling_collecting_enabled?
+                  }
 
     def new
       @dob_ssn_form = Idv::DobSsnForm.new(idv_session.applicant)
       analytics.idv_proofing_agent_user_confirmation_visited(**proofing_agent_analytics)
+
+      render :new, locals: threatmetrix_view_variables
     end
 
     def create
       @dob_ssn_form = Idv::DobSsnForm.new(idv_session.applicant)
 
       form_response = @dob_ssn_form.submit(
-        ssn: normalized_ssn,
-        dob: parse_form_date,
+        ssn: dob_ssn_params[:ssn],
+        dob: dob_ssn_params[:dob],
       )
+      idv_session.proofing_agent_match = form_response.success?
 
       analytics.idv_proofing_agent_user_confirmation_submitted(
         **proofing_agent_analytics,
         success: form_response.success?,
-        dob_match: dob_match?,
-        ssn_match: ssn_match?,
-        dob_and_ssn_match: verify_dob_ssn_matches_applicant_pii?,
+        dob_match: @dob_ssn_form.dob_match?,
+        ssn_match: @dob_ssn_form.ssn_match?,
+        dob_and_ssn_match: @dob_ssn_form.ssn_match? && @dob_ssn_form.dob_match?,
       )
 
       if form_response.success?
-        return redirect_to idv_enter_password_url if verify_dob_ssn_matches_applicant_pii?
-        flash.now[:error] = t('idv.failure.dob_ssn.warning')
+        if FeatureManagement.proofing_agent_device_profiling_collecting_enabled?
+          ::ProofingAgentThreatMetrixJob.perform_now(**tmx_job_attrs)
+        end
+        return redirect_to idv_enter_password_url
       else
         flash.now[:error] = form_response.first_error_message
       end
 
-      render :new
+      render :new, locals: threatmetrix_view_variables
     end
 
     private
 
     def dob_ssn_params
       params.require(:doc_auth).permit(:ssn, dob: [:month, :day, :year])
-    end
-
-    def normalized_ssn
-      SsnFormatter.normalize(dob_ssn_params[:ssn])
-    end
-
-    def parse_form_date
-      MemorableDateComponent.extract_date_param(dob_ssn_params[:dob])
     end
 
     def move_agent_proofed_user_pii_to_idv_session
@@ -69,19 +72,6 @@ module Idv
       end
     end
 
-    def dob_match?
-      idv_session.applicant[:dob] == parse_form_date
-    end
-
-    def ssn_match?
-      idv_session.applicant[:ssn] == normalized_ssn
-    end
-
-    def verify_dob_ssn_matches_applicant_pii?
-      idv_session.proofing_agent_match = ssn_match? && dob_match?
-      idv_session.proofing_agent_match
-    end
-
     def confirm_verification_needed
       redirect_to account_url unless verification_needed?
     end
@@ -89,6 +79,18 @@ module Idv
     def verification_needed?
       IdentityConfig.store.idv_proofing_agent_enabled &&
         current_user.proofing_agent_pending?
+    end
+
+    def tmx_job_attrs
+      {
+        user_id: current_user.id,
+        applicant_pii: idv_session.applicant,
+        request_ip: request&.ip,
+        threatmetrix_session_id: idv_session.threatmetrix_session_id,
+        timer: JobHelpers::Timer.new,
+        current_sp:,
+        workflow: :proofing_agent,
+      }
     end
   end
 end

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -13,6 +13,7 @@ module Idv
     before_action :confirm_step_allowed
     before_action :confirm_no_profile_yet
     before_action :confirm_current_password, only: [:create]
+    before_action :save_proofing_agent_threatmetrix_status, only: [:new]
 
     helper_method :step_indicator_step
 
@@ -203,11 +204,6 @@ module Idv
       end
     end
 
-    def remove_agent_proofed_profile_pending_status_if_needed
-      # move this to user.rb probably
-      current_user.pending_agent_proofed_session&.update!(pending_agent_proofed_user_at: nil)
-    end
-
     def handle_request_enroll_exception(err)
       analytics.idv_in_person_usps_request_enroll_exception(
         context: context,
@@ -238,6 +234,18 @@ module Idv
 
     def attempt_events
       user_session['idv/attempts'] || []
+    end
+
+    def save_proofing_agent_threatmetrix_status
+      return unless FeatureManagement.proofing_agent_device_profiling_collecting_enabled?
+      return if idv_session.threatmetrix_review_status.present?
+      return if idv_session.hybrid_mobile_threatmetrix_review_status.present?
+
+      device_profile = DeviceProfilingResult.for_user(
+        user_id: current_user.id,
+        type: DeviceProfilingResult::PROFILING_TYPES[:proofing_agent],
+      ).order(created_at: :desc).first
+      idv_session.threatmetrix_review_status = device_profile.review_status
     end
   end
 end

--- a/app/forms/idv/dob_ssn_form.rb
+++ b/app/forms/idv/dob_ssn_form.rb
@@ -5,19 +5,21 @@ module Idv
     include ActiveModel::Model
     include FormDobSsnValidator
 
-    attr_accessor :ssn, :dob
+    validate :dob_ssn_matches_applicant_pii
+
+    attr_accessor :applicant, :ssn, :dob
 
     def self.model_name
       ActiveModel::Name.new(self, nil, 'doc_auth')
     end
 
-    def initialize(pii)
-      @pii = pii
+    def initialize(applicant)
+      @applicant = applicant
     end
 
     def submit(ssn:, dob:)
-      @ssn = ssn
-      @dob = dob
+      @ssn = SsnFormatter.normalize(ssn) if ssn.present?
+      @dob = MemorableDateComponent.extract_date_param(dob) if dob.present?
 
       FormResponse.new(
         success: valid?,
@@ -32,6 +34,20 @@ module Idv
           ],
         },
       )
+    end
+
+    def dob_ssn_matches_applicant_pii
+      unless ssn_match? && dob_match?
+        errors.add(:mismatch, I18n.t('idv.failure.dob_ssn.warning'), type: :mismatch)
+      end
+    end
+
+    def dob_match?
+      applicant[:dob] == dob
+    end
+
+    def ssn_match?
+      applicant[:ssn] == ssn
     end
   end
 end

--- a/app/javascript/packs/session-expire-session.ts
+++ b/app/javascript/packs/session-expire-session.ts
@@ -16,6 +16,9 @@ const timeoutURL = warningEl?.dataset.timeoutUrl!;
 let sessionExpiration = new Date(Date.now() + sessionTimeout);
 let redirectTimeout: ReturnType<typeof setTimeout>;
 
+/*
+This function handles session management when user is fully signed-in to account (i.e. password created and MFA method(s) added)
+*/
 function scheduleRedirect() {
   clearTimeout(redirectTimeout);
   redirectTimeout = setTimeout(() => forceRedirect(timeoutURL), sessionTimeout);

--- a/app/javascript/packs/session-timeout-ping.ts
+++ b/app/javascript/packs/session-timeout-ping.ts
@@ -21,6 +21,7 @@ const countdownEls: NodeListOf<CountdownElement> = modal.querySelectorAll('lg-co
 function success({ isLive, timeout }: SessionStatus) {
   if (!isLive) {
     if (timeoutURL) {
+      // Handles redirect when user is partially signed-in to account (i.e. password not yet created and/or MFA method(s) not yet added)
       forceRedirect(timeoutURL);
     }
     return;

--- a/app/jobs/proofing_agent_threat_metrix_job.rb
+++ b/app/jobs/proofing_agent_threat_metrix_job.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class ProofingAgentThreatMetrixJob < ApplicationJob
+  def perform(
+    user_id:,
+    applicant_pii:,
+    request_ip:,
+    threatmetrix_session_id:,
+    timer:,
+    current_sp:,
+    workflow:
+  )
+    user = User.find_by(id: user_id)
+
+    device_profiling_result = nil
+    if !FeatureManagement.proofing_agent_device_profiling_collecting_enabled?
+      device_profiling_result = threatmetrix_plugin.threatmetrix_disabled_result
+    end
+
+    device_profiling_result ||= threatmetrix_plugin.call(
+      applicant_pii:,
+      request_ip:,
+      threatmetrix_session_id:,
+      timer:,
+      current_sp:,
+      workflow:,
+      user_email: user&.last_sign_in_email_address&.email,
+      user_uuid: user&.uuid,
+      ddp_policy: IdentityConfig.store.lexisnexis_threatmetrix_policy,
+    )
+
+    store_device_profiling_result(user_id, device_profiling_result)
+    analytics(user).idv_proofing_agent_tmx_result(**device_profiling_result.to_h)
+  end
+
+  def analytics(user)
+    Analytics.new(user: user, request: nil, session: {}, sp: nil)
+  end
+
+  private
+
+  def threatmetrix_plugin
+    @threatmetrix_plugin ||= Proofing::Resolution::Plugins::ThreatMetrixPlugin.new
+  end
+
+  def store_device_profiling_result(user_id, result)
+    return unless user_id.present?
+    return unless IdentityConfig.store.proofing_agent_device_profiling == :enabled
+
+    device_profiling_result = DeviceProfilingResult.find_or_create_by(
+      user_id:,
+      profiling_type: DeviceProfilingResult::PROFILING_TYPES[:proofing_agent],
+    )
+    device_profiling_result.update(
+      client: result.client,
+      review_status: result.review_status,
+      transaction_id: result.transaction_id,
+    )
+  end
+end

--- a/app/models/device_profiling_result.rb
+++ b/app/models/device_profiling_result.rb
@@ -5,6 +5,7 @@ class DeviceProfilingResult < ApplicationRecord
 
   PROFILING_TYPES = {
     account_creation: 'ACCOUNT_CREATION',
+    proofing_agent: 'PROOFING_AGENT',
   }.freeze
 
   def self.find_or_create_by(user_id:, profiling_type:)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -148,6 +148,8 @@ class Profile < ApplicationRecord
       activated_at:,
     )
 
+    remove_agent_proofed_pending_status_if_needed
+
     track_facial_match_reproof if is_facial_match_upgrade
     send_push_notifications if is_reproof
   end
@@ -214,6 +216,10 @@ class Profile < ApplicationRecord
         activate(reason_deactivated: :password_reset) if activated_at.present?
       end
     end
+  end
+
+  def remove_agent_proofed_pending_status_if_needed
+    user.pending_agent_proofed_session&.update!(pending_agent_proofed_user_at: nil)
   end
 
   def deactivate(reason)

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5510,6 +5510,46 @@ module AnalyticsEvents
     )
   end
 
+  # @param [Boolean] success Check whether threatmetrix succeeded properly.
+  # @param [String] transaction_id Vendor-specific transaction ID for the request.
+  # @param [String, nil] client Client user was directed from when creating account
+  # @param [array<String>, nil] errors error response from api call
+  # @param [String, nil] exception Error exception from api call
+  # @param [Boolean] timed_out set whether api call timed out
+  # @param [String] review_status TMX decision on the user
+  # @param [String] account_lex_id LexID associated with the response.
+  # @param [String] session_id Session ID associated with response
+  # @param [Hash] response_body total response body for api call
+  # Result when threatmetrix is completed for proofing agent and result
+  def idv_proofing_agent_tmx_result(
+    client:,
+    success:,
+    errors:,
+    exception:,
+    timed_out:,
+    transaction_id:,
+    review_status:,
+    account_lex_id:,
+    session_id:,
+    response_body:,
+    **extra
+  )
+    track_event(
+      :idv_proofing_agent_tmx_result,
+      client:,
+      success:,
+      errors:,
+      exception:,
+      timed_out:,
+      transaction_id:,
+      review_status:,
+      account_lex_id:,
+      session_id:,
+      response_body:,
+      **extra,
+    )
+  end
+
   # @param [Boolean] success Whether the user confirmed the proofing agent results
   # @param [Boolean] dob_match the user's date of birth matched the proofing agent's results
   # @param [Boolean] ssn_match the user's SSN matched the proofing agent's results

--- a/app/services/idv/steps/threat_metrix_step_helper.rb
+++ b/app/services/idv/steps/threat_metrix_step_helper.rb
@@ -4,7 +4,7 @@ module Idv
   module Steps
     module ThreatMetrixStepHelper
       include ThreatMetrixHelper
-      def threatmetrix_view_variables(updating_ssn)
+      def threatmetrix_view_variables(updating_ssn = false)
         session_id = generate_threatmetrix_session_id(updating_ssn)
 
         {

--- a/app/views/idv/enter_dob_ssn/new.html.erb
+++ b/app/views/idv/enter_dob_ssn/new.html.erb
@@ -18,6 +18,15 @@
   <% end %>
 </p>
 
+<% if FeatureManagement.proofing_agent_device_profiling_collecting_enabled? %>
+  <%= render partial: 'shared/threat_metrix_profiling',
+             locals: {
+               threatmetrix_session_id:,
+               threatmetrix_javascript_urls:,
+               threatmetrix_iframe_url:,
+             } %>
+<% end %>
+
 <% if IdentityConfig.store.proofer_mock_fallback %>
   <div class="usa-alert usa-alert--info margin-bottom-4" role="status">
     <div class="usa-alert__body">

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -404,6 +404,7 @@ proof_address_max_attempts: 5
 proof_ssn_max_attempt_window_in_minutes: 60
 proof_ssn_max_attempts: 10
 proofer_mock_fallback: true
+proofing_agent_device_profiling: enabled
 proofing_device_hybrid_profiling: disabled
 proofing_device_profiling: enabled
 protocols_report_config: '[]'

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -138,6 +138,18 @@ class FeatureManagement
     end
   end
 
+  # Whether we collect device profiling as part of the proofing_agent idv process
+  def self.proofing_agent_device_profiling_collecting_enabled?
+    return false unless proofing_device_profiling_decisioning_enabled?
+
+    case IdentityConfig.store.proofing_agent_device_profiling
+    when :enabled, :collect_only then true
+    when :disabled then false
+    else
+      raise 'Invalid value for proofing_agent_device_profiling'
+    end
+  end
+
   # Whether we collect device profiling on the hybrid flow
   def self.proofing_device_hybrid_profiling_collecting_enabled?
     case IdentityConfig.store.proofing_device_hybrid_profiling

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -424,6 +424,11 @@ module IdentityConfig
     config.add(:proof_ssn_max_attempts, type: :integer)
     config.add(:proofer_mock_fallback, type: :boolean)
     config.add(
+      :proofing_agent_device_profiling,
+      type: :symbol,
+      enum: [:disabled, :collect_only, :enabled],
+    )
+    config.add(
       :proofing_device_hybrid_profiling,
       type: :symbol,
       enum: [:disabled, :collect_only, :enabled],

--- a/lib/reporting/api_transaction_count_report.rb
+++ b/lib/reporting/api_transaction_count_report.rb
@@ -282,9 +282,15 @@ module Reporting
 
     def instant_verify_query
       <<~QUERY
-        fields @timestamp, @message
+        fields @timestamp, @message, id
+        | filter name in ['IdV: doc auth verify proofing results']
         | fields jsonParse(@message) as message
-        | filter name='IdV: doc auth verify proofing results' and message.properties.event_properties.proofing_results.context.stages.resolution.vendor_name='lexisnexis:instant_verify'
+        | unnest message.properties.event_properties into event_properties
+        | unnest event_properties.proofing_results into proofing_results
+        | unnest proofing_results.context into context
+        | unnest context.stages into stages
+        | unnest stages.resolution into resolution
+        | filter resolution.vendor_name like /lexisnexis/
         | display id
         | limit 10000
       QUERY
@@ -367,9 +373,9 @@ module Reporting
 
     def ln_phonefinder_query
       <<~QUERY
-        fields @timestamp, @message
+        fields @timestamp, @message, id
         | filter name = 'IdV: phone confirmation vendor'
-        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder"
+        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder" or properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder_ddp"
         | display id
         | limit 10000
       QUERY

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe AccountsController do
       end
     end
 
+    context 'when session_timed_out flash is present' do
+      it 'deletes the flash message' do
+        flash[:session_timed_out] = 'Your session has timed out'
+
+        get :show
+
+        expect(flash[:session_timed_out]).to be_nil
+      end
+    end
+
     describe 'pii fetching' do
       let(:pii_cacher) { Pii::Cacher.new(user, {}) }
       let(:active_profile) { create(:profile, :active) }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -360,39 +360,38 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe '#session_expires_at' do
+  describe '#set_session_start_value_if_nil' do
     before { routes.draw { get 'index' => 'anonymous#index' } }
     after { Rails.application.reload_routes! }
 
     controller do
-      prepend_before_action :session_expires_at
+      prepend_before_action :set_session_start_value_if_nil
 
       def index
         render plain: 'Hello'
       end
     end
 
-    context 'when URL contains the host parameter' do
-      it 'does not redirect to the host' do
-        get :index, params: { timeout: true, host: 'www.monfresh.com' }
+    context 'when session start value is nil' do
+      it 'sets the session start value to the current time' do
+        freeze_time do
+          session[:session_started_at] = nil
 
-        expect(response.header['Location']).to_not match 'www.monfresh.com'
+          get :index
+
+          expect(session[:session_started_at]).to eq(Time.zone.now)
+        end
       end
     end
 
-    context 'when URL does not contain the timeout parameter' do
-      it 'does not redirect anywhere' do
-        get :index, params: { host: 'www.monfresh.com' }
+    context 'when session start value is not nil' do
+      it 'does not change the session start value' do
+        original_time = 1.hour.ago
+        session[:session_started_at] = original_time
 
-        expect(response).to_not be_redirect
-      end
-    end
+        get :index
 
-    context 'when URL contains the request_id parameter' do
-      it 'preserves the request_id parameter' do
-        get :index, params: { timeout: true, request_id: '123' }
-
-        expect(response.header['Location']).to match '123'
+        expect(session[:session_started_at]).to eq(original_time)
       end
     end
   end
@@ -411,11 +410,12 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe '#redirect_with_flash_if_timeout' do
+  describe '#show_flash_with_redirect_if_session_timeout' do
     before { routes.draw { get 'index' => 'anonymous#index' } }
     after { Rails.application.reload_routes! }
 
     controller do
+      prepend_before_action :show_flash_with_redirect_if_session_timeout
       def index
         render plain: 'Hello'
       end
@@ -436,7 +436,7 @@ RSpec.describe ApplicationController do
       it 'displays flash message for session timeout' do
         get :index, params: { timeout: 'session', request_id: '123' }
 
-        expect(flash[:info]).to eq t(
+        expect(flash[:session_timed_out]).to eq t(
           'notices.session_timedout',
           app_name: APP_NAME,
           minutes: IdentityConfig.store.session_timeout_in_seconds.seconds.in_minutes.to_i,

--- a/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
+++ b/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Idv::EnterDobSsnController do
-  let(:proofing_agent_enabled) { true }
+  let(:idv_proofing_agent_enabled) { true }
   let(:success) { true }
   let(:pii) do
     {
@@ -33,6 +33,8 @@ RSpec.describe Idv::EnterDobSsnController do
   let(:resolved_authn_context_result) do
     Component::Parser.new(acr_values: Saml::Idp::Constants::IAL_AUTH_ONLY_ACR).parse
   end
+  let(:proofing_agent_device_profiling) { :disabled }
+  let(:tmx_session_id) { nil }
 
   before do
     stub_sign_in(user)
@@ -41,8 +43,14 @@ RSpec.describe Idv::EnterDobSsnController do
     resolver_mock = instance_double(AuthnContextResolver)
     allow(resolver_mock).to receive(:result).and_return(resolved_authn_context_result)
     allow(AuthnContextResolver).to receive(:new).and_return(resolver_mock)
-    allow(IdentityConfig.store).to receive(:idv_proofing_agent_enabled)
-      .and_return(proofing_agent_enabled)
+    allow(IdentityConfig.store).to receive_messages(
+      {
+        idv_proofing_agent_enabled:,
+        proofing_agent_device_profiling:,
+        lexisnexis_threatmetrix_org_id: 'org1',
+      },
+    )
+    allow(controller.idv_session).to receive(:threatmetrix_session_id).and_return(tmx_session_id)
   end
 
   describe 'before_actions' do
@@ -52,6 +60,7 @@ RSpec.describe Idv::EnterDobSsnController do
         :confirm_two_factor_authenticated,
         :confirm_verification_needed,
         :move_agent_proofed_user_pii_to_idv_session,
+        :override_csp_for_threat_metrix,
       )
     end
 
@@ -61,10 +70,10 @@ RSpec.describe Idv::EnterDobSsnController do
   end
 
   describe '#new' do
-    before { get :new }
+    let(:response) { get :new }
 
     context 'proofing agent feature is disabled' do
-      let(:proofing_agent_enabled) { false }
+      let(:idv_proofing_agent_enabled) { false }
 
       it 'redirects to the account page' do
         expect(response).to redirect_to(account_url)
@@ -80,6 +89,8 @@ RSpec.describe Idv::EnterDobSsnController do
     end
 
     context 'user has proofing agent pending pii' do
+      before { get :new }
+
       it 'moves agent proofed user pii to idv_session applicant' do
         expect(subject.idv_session.applicant).to eq(pii.stringify_keys)
       end
@@ -106,19 +117,67 @@ RSpec.describe Idv::EnterDobSsnController do
         )
       end
     end
+
+    context 'with threatmetrix disabled' do
+      let(:proofing_agent_device_profiling) { :disabled }
+
+      it 'does not override CSPs for ThreatMetrix' do
+        expect(controller).not_to receive(:override_csp_for_threat_metrix)
+
+        response
+      end
+    end
+
+    context 'with threatmetrix enabled' do
+      let(:proofing_agent_device_profiling) { :enabled }
+      let(:tmx_session_id) { '1234' }
+
+      before do
+        allow(IdentityConfig.store).to receive(:lexisnexis_threatmetrix_mock_enabled)
+          .and_return(false)
+      end
+
+      it 'renders new valid request' do
+        tmx_url = 'https://h.online-metrix.net/fp'
+        expect(controller).to receive(:render).with(
+          :new,
+          locals: hash_including(
+            threatmetrix_session_id: tmx_session_id,
+            threatmetrix_javascript_urls:
+              ["#{tmx_url}/tags.js?org_id=org1&session_id=#{tmx_session_id}"],
+            threatmetrix_iframe_url:
+              "#{tmx_url}/tags?org_id=org1&session_id=#{tmx_session_id}",
+          ),
+        ).and_call_original
+
+        response
+      end
+
+      it 'overrides CSPs for ThreatMetrix' do
+        expect(controller).to receive(:override_csp_for_threat_metrix)
+
+        response
+      end
+    end
   end
 
   describe '#create' do
-    before { get :new }
+    let(:ssn) { pii[:ssn] }
+    let(:year) { '1990' }
+    let(:dob) {  { year:, month: '01', day: '01' } }
+    let(:params) do
+      {
+        doc_auth: {
+          ssn:,
+          dob:,
+        },
+      }
+    end
 
     context 'user typed dob and ssn matches idv_session.applicant dob and ssn' do
       it 'redirects to enter password step' do
-        post :create, params: {
-          doc_auth: {
-            ssn: pii[:ssn],
-            dob: { year: '1990', month: '01', day: '01' },
-          },
-        }
+        post :create, params: params
+
         expect(response).to redirect_to(idv_enter_password_url)
         expect(@analytics).to have_logged_event(
           :idv_proofing_agent_user_confirmation_submitted,
@@ -133,26 +192,41 @@ RSpec.describe Idv::EnterDobSsnController do
     end
 
     context 'user typed ssn does not match idv_session.applicant ssn' do
+      let(:ssn) { '000000000' }
+
       it 'renders new' do
-        post :create, params: {
-          doc_auth: {
-            ssn: '000000000',
-            dob: { year: '1990', month: '01', day: '01' },
-          },
-        }
+        post :create, params: params
+
         expect(response).to render_template(:new)
       end
     end
 
     context 'user typed dob does not match idv_session.applicant dob' do
+      let(:year) { '2000' }
+
       it 'renders new' do
-        post :create, params: {
-          doc_auth: {
-            ssn: pii[:ssn],
-            dob: { year: '2000', month: '06', day: '15' },
-          },
-        }
+        post :create, params: params
+
         expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when proofing agent threatmetrix is not enabled' do
+      it 'does not save a threatmetrix result' do
+        expect { put :create, params: params }.not_to change { DeviceProfilingResult.count }
+      end
+    end
+
+    context 'when proofing agent threatmetrix is enabled' do
+      let(:tmx_session_id) { 'test-tmx-session-id-1234' }
+      let(:proofing_agent_device_profiling) { :enabled }
+
+      it 'saves the threatmetrix result to db' do
+        expect { put :create, params: params }.to change { DeviceProfilingResult.count }
+
+        result = DeviceProfilingResult.last
+        expect(result.review_status).to eq('pass')
+        expect(result.transaction_id).to eq('ddp-mock-transaction-id-123')
       end
     end
   end

--- a/spec/forms/idv/dob_ssn_form_spec.rb
+++ b/spec/forms/idv/dob_ssn_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Idv::DobSsnForm do
-  let(:ssn) { '111-11-1111' }
+  let(:ssn) { '111111111' }
   let(:dob) { '1990-01-01' }
   let(:pii) do
     {
@@ -15,8 +15,7 @@ RSpec.describe Idv::DobSsnForm do
   describe '#submit' do
     context 'when the form is valid' do
       it 'returns a successful form response' do
-        result = subject.submit(ssn: '111111111', dob: '1990-01-01')
-
+        result = subject.submit(ssn: '111-11-1111', dob: { year: '1990', month: '01', day: '01' })
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(true)
         expect(result.errors).to be_empty
@@ -30,6 +29,15 @@ RSpec.describe Idv::DobSsnForm do
         expect(result).to be_kind_of(FormResponse)
         expect(result.success?).to eq(false)
         expect(result.errors).to include(:ssn, :dob)
+      end
+    end
+
+    context 'when the ssn and dob do not match' do
+      it 'returns a successful form response' do
+        result = subject.submit(ssn: '111-22-3333', dob: { year: '2000', month: '01', day: '01' })
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(result.errors).to include(:mismatch)
       end
     end
   end

--- a/spec/jobs/proofing_agent_threat_metrix_job_spec.rb
+++ b/spec/jobs/proofing_agent_threat_metrix_job_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ProofingAgentThreatMetrixJob, type: :job do
+  let(:user) { create(:user, :fully_registered) }
+  let(:request_ip) { Faker::Internet.ip_v4_address }
+  let(:current_sp) { create(:service_provider) }
+  let(:threatmetrix_session_id) { SecureRandom.uuid }
+  let(:proofing_device_profiling) { :enabled }
+  let(:proofing_agent_device_profiling) { :collect_only }
+  let(:lexisnexis_threatmetrix_mock_enabled) { false }
+  let(:threatmetrix_response) { LexisNexisFixtures.threatmetrix_success_response_json }
+  let(:threatmetrix_stub) { stub_threatmetrix_request(threatmetrix_response) }
+  let(:job_analytics) { FakeAnalytics.new }
+  let(:applicant_pii) do
+    {
+      ssn: '123456789',
+      dob: '1990-01-01',
+    }
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive_messages(
+      {
+        lexisnexis_threatmetrix_mock_enabled:,
+        proofing_device_profiling:,
+        proofing_agent_device_profiling:,
+        lexisnexis_threatmetrix_base_url: 'https://www.example.com',
+      },
+    )
+    allow(instance).to receive(:analytics).and_return(job_analytics)
+  end
+
+  describe '#perform' do
+    let(:instance) { ProofingAgentThreatMetrixJob.new }
+
+    subject(:perform) do
+      instance.perform(
+        user_id: user.id,
+        applicant_pii:,
+        request_ip:,
+        threatmetrix_session_id:,
+        current_sp:,
+        timer: JobHelpers::Timer.new,
+        workflow: :proofing_agent,
+      )
+    end
+
+    context 'Threat Metrix Proofing Agent analysis passes' do
+      let(:threatmetrix_response) { LexisNexisFixtures.threatmetrix_success_response_json }
+      let(:proofing_agent_device_profiling) { :enabled }
+
+      it 'logs a successful result' do
+        threatmetrix_stub
+
+        perform
+
+        expect(job_analytics).to have_logged_event(
+          :idv_proofing_agent_tmx_result,
+          hash_including(
+            success: true,
+            review_status: 'pass',
+          ),
+        )
+      end
+
+      it 'creates a DeviceProfilingResult' do
+        threatmetrix_stub
+
+        perform
+        result = DeviceProfilingResult.find_by(
+          user_id: user.id,
+          profiling_type: DeviceProfilingResult::PROFILING_TYPES[:proofing_agent],
+        )
+        expect(result).to be_truthy
+        expect(result.user_id).to eq(user.id)
+      end
+    end
+
+    context 'with an error response result' do
+      let(:threatmetrix_response) { LexisNexisFixtures.threatmetrix_failure_response_json }
+
+      it 'stores an unsuccessful result' do
+        threatmetrix_stub
+
+        perform
+
+        expect(job_analytics).to have_logged_event(
+          :idv_proofing_agent_tmx_result,
+          hash_including(
+            success: false,
+            review_status: 'reject',
+          ),
+        )
+      end
+    end
+
+    context 'with threatmetrix disabled' do
+      let(:proofing_agent_device_profiling) { :disabled }
+
+      it 'does not make a request to threatmetrix' do
+        threatmetrix_stub
+
+        perform
+
+        expect(threatmetrix_stub).to_not have_been_requested
+        expect(job_analytics).to have_logged_event(
+          :idv_proofing_agent_tmx_result,
+          hash_including(
+            success: true,
+            client: 'tmx_disabled',
+            review_status: 'pass',
+          ),
+        )
+      end
+    end
+
+    context 'without a threatmetrix session ID' do
+      let(:threatmetrix_session_id) { nil }
+      let(:ipp_enrollment_in_progress) { false }
+      let(:threatmetrix_response) { LexisNexisFixtures.threatmetrix_failure_response_json }
+
+      it 'does not make a request to threatmetrix' do
+        threatmetrix_stub
+
+        perform
+
+        expect(threatmetrix_stub).to_not have_been_requested
+        expect(job_analytics).to have_logged_event(
+          :idv_proofing_agent_tmx_result,
+          hash_including(
+            success: false,
+            client: 'tmx_session_id_missing',
+            review_status: 'reject',
+          ),
+        )
+      end
+    end
+  end
+
+  def stub_threatmetrix_request(threatmetrix_response)
+    stub_request(
+      :post,
+      'https://www.example.com/api/session-query',
+    ).to_return(body: threatmetrix_response)
+  end
+end


### PR DESCRIPTION
## Bug Fixes
- Session Timeout: Delete session timeout flash message after sign-in ([#13183](https://github.com/18F/identity-idp/pull/13183))

## Internal
- Reporting: Fixed instantverify and ln phonefinder queries to use jsonParse and unest to get full data and get lexisnexis ddp  ([#13212](https://github.com/18F/identity-idp/pull/13212))
- dependency audit: Upgrade net-imap ([#13208](https://github.com/18F/identity-idp/pull/13208))

## Upcoming Features
- Proofing Agent: ThreatMetrix check when activating profile. ([#13206](https://github.com/18F/identity-idp/pull/13206))
