### PR TITLE
Support running devenv on aarch64-linux

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -8,6 +8,15 @@
 
 let
   pkgs-unstable = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; config.allowUnfree = true; };
+  # google-chrome has no aarch64-linux build; fall back to chromium there.
+  chromeBrowser =
+    if pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isAarch64
+    then pkgs-unstable.chromium
+    else pkgs-unstable.google-chrome;
+  chromeBinary =
+    if pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isAarch64
+    then "${chromeBrowser}/bin/chromium"
+    else "${chromeBrowser}/bin/google-chrome-stable";
 in
 {
   packages = with pkgs; [
@@ -21,7 +30,7 @@ in
     libyaml
     openssl
     pkgs-unstable.chromedriver
-    pkgs-unstable.google-chrome
+    chromeBrowser
     ssm-session-manager-plugin
     yubikey-manager
     zlib
@@ -69,7 +78,7 @@ in
   env = {
     AWS_VAULT_KEYCHAIN_NAME = "login";
     AWS_VAULT_PROMPT = "ykman";
-    NIX_GOOGLE_CHROME = "${pkgs-unstable.google-chrome}/bin/google-chrome-stable";
+    NIX_GOOGLE_CHROME = chromeBinary;
   };
 
   git-hooks.hooks = {

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,6 +6,20 @@ require 'extensions/capybara/node/simple'
 # temporary fix for local development feature tests
 # remove when we get a new working version of Chromedriver
 
+# When a chromedriver binary is already on PATH (e.g. provided by devenv/Nix),
+# point Selenium at it explicitly. Otherwise Selenium falls back to its bundled
+# `selenium-manager` helper to locate a driver. selenium-manager ships a macOS
+# universal binary (x86_64 + arm64) but only an x86_64 build for Linux, so on
+# aarch64-linux it cannot execute and raises `NoSuchDriverError`. On platforms
+# where chromedriver is not on PATH (typical macOS/CI), this returns nil and
+# Selenium behaves as before.
+def chromedriver_service
+  path = ENV['CHROMEDRIVER_PATH'].presence || `command -v chromedriver 2>/dev/null`.strip.presence
+  return nil if path.nil?
+
+  Selenium::WebDriver::Service.chrome(path: path)
+end
+
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.binary = ENV['NIX_GOOGLE_CHROME'] if ENV.key?('NIX_GOOGLE_CHROME')
@@ -18,7 +32,8 @@ Capybara.register_driver :headless_chrome do |app|
 
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,
-                                 options: options
+                                 options: options,
+                                 service: chromedriver_service
 end
 Capybara.javascript_driver = :headless_chrome
 
@@ -40,7 +55,8 @@ Capybara.register_driver(:headless_chrome_mobile) do |app|
 
   Capybara::Selenium::Driver.new app,
                                  browser: :chrome,
-                                 options: options
+                                 options: options,
+                                 service: chromedriver_service
 end
 
 Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
## 🛠 Summary of changes

Enable the IdP's devenv-based development environment to build and run on
**aarch64-linux** (e.g. Linux dev containers / sandboxes), in addition to the
macOS and x86_64-linux environments already supported. Two small,
platform-conditional changes; neither affects macOS or x86_64-linux behavior.

### 1. Use chromium on aarch64-linux in `devenv.nix`

**Why:** `devenv.nix` pulls in `google-chrome`, which has **no aarch64-linux
build**. On ARM Linux, `devenv shell` / `devenv up` fails to even evaluate with
`Package google-chrome ... is not available on the requested hostPlatform`,
blocking the whole environment. macOS (aarch64-darwin) and x86_64-linux still
have `google-chrome`, so the fix must not change their behavior.

**How:** Select the browser by host platform — `chromium` on aarch64-linux,
`google-chrome` everywhere else. `chromium` is supported on ARM Linux and its
bundled `chromedriver` version matches. `NIX_GOOGLE_CHROME` (consumed by
`spec/support/capybara.rb`) is pointed at the platform-appropriate binary.

### 2. Point Capybara at chromedriver on PATH (`spec/support/capybara.rb`)

**Why:** On aarch64-linux, feature specs fail with
`Selenium::WebDriver::Error::NoSuchDriverError: Unable to obtain chromedriver`.
Selenium falls back to its bundled `selenium-manager` to locate a driver, but
selenium-manager ships only an **x86_64** build for Linux (its macOS binary is
a universal x86_64+arm64 binary, which is why macOS is unaffected), so it
cannot execute on ARM Linux.

**How:** When a `chromedriver` binary is available (on PATH, or via
`CHROMEDRIVER_PATH`), pass an explicit `Selenium::WebDriver::Service.chrome` to
the Capybara Chrome drivers, bypassing selenium-manager. When no chromedriver
is found (typical macOS/CI), the helper returns `nil` and Selenium behaves
exactly as before — so macOS and x86_64-linux are unaffected.

## 📜 Testing Plan

### Verify no regression on existing platforms (macOS / x86_64-linux)
- [x] On macOS, `devenv shell` and `devenv up` still evaluate and start
  services (google-chrome still selected).
- [x] Feature specs that use the headless Chrome driver still run on macOS
  (selenium-manager path unchanged when chromedriver is not on PATH).

### Verify the fix on aarch64-linux
- [x] On an aarch64-linux host, `devenv up -d` and `devenv shell` succeed
  (previously failed to evaluate due to google-chrome).
- [x] A unit/service/controller spec run passes, e.g.
  `RAILS_ENV=test bundle exec rspec spec/forms/idv/state_id_form_spec.rb`.
- [x] A feature spec runs in the browser without `NoSuchDriverError`, e.g.
  `CAPYBARA_WAIT_TIME_SECONDS=10 RAILS_ENV=test bundle exec rspec spec/features/idv/cancel_spec.rb`.