### PR TITLE
LG-17647: Configure Faraday POST calls for retry on network failure

### DIFF
--- a/app/services/doc_auth/dos/request.rb
+++ b/app/services/doc_auth/dos/request.rb
@@ -130,7 +130,11 @@ module DocAuth
           interval: 0.05,
           interval_randomness: 0.5,
           backoff_factor: 2,
+          methods: %i[get],
           retry_statuses: [404, 500],
+          retry_if: lambda do |env, exception|
+            env[:method] == :post && !exception.is_a?(Faraday::RetriableResponse)
+          end,
           retry_block: lambda do |env:, options:, retry_count:, exception:, will_retry_in:|
             NewRelic::Agent.notice_error(exception, custom_params: { retry: retry_count })
           end,

--- a/app/services/doc_auth/lexis_nexis/request.rb
+++ b/app/services/doc_auth/lexis_nexis/request.rb
@@ -96,7 +96,11 @@ module DocAuth
           interval: 0.05,
           interval_randomness: 0.5,
           backoff_factor: 2,
+          methods: %i[get],
           retry_statuses: [404, 500],
+          retry_if: lambda do |env, exception|
+            env[:method] == :post && !exception.is_a?(Faraday::RetriableResponse)
+          end,
           retry_block: lambda do |env:, options:, retry_count:, exception:, will_retry_in:|
             NewRelic::Agent.notice_error(exception, custom_params: { retry: retry_count })
           end,

--- a/app/services/doc_auth/socure/request.rb
+++ b/app/services/doc_auth/socure/request.rb
@@ -91,7 +91,11 @@ module DocAuth
           interval: 0.05,
           interval_randomness: 0.5,
           backoff_factor: 2,
+          methods: %i[get],
           retry_statuses: [404, 500],
+          retry_if: lambda do |env, exception|
+            env[:method] == :post && !exception.is_a?(Faraday::RetriableResponse)
+          end,
           retry_block: lambda do |env:, options:, retry_count:, exception:, will_retry_in:|
             NewRelic::Agent.notice_error(exception, custom_params: { retry: retry_count })
           end,

--- a/app/services/doc_auth/socure/webhook_repeater.rb
+++ b/app/services/doc_auth/socure/webhook_repeater.rb
@@ -39,7 +39,11 @@ module DocAuth
           interval: 0.05,
           interval_randomness: 0.5,
           backoff_factor: 2,
+          methods: %i[get],
           retry_statuses: [404, 500],
+          retry_if: lambda do |env, exception|
+            env[:method] == :post && !exception.is_a?(Faraday::RetriableResponse)
+          end,
           retry_block: lambda do |env:, options:, retry_count:, exception:, will_retry_in:|
             NewRelic::Agent.notice_error(exception, custom_params: { retry: retry_count })
           end,

--- a/app/services/proofing_agent/webhook_caller.rb
+++ b/app/services/proofing_agent/webhook_caller.rb
@@ -68,7 +68,11 @@ module ProofingAgent
         interval: 0.05,
         interval_randomness: 0.5,
         backoff_factor: 2,
+        methods: %i[get],
         retry_statuses: [404, 500],
+        retry_if: lambda do |env, exception|
+          env[:method] == :post && !exception.is_a?(Faraday::RetriableResponse)
+        end,
         retry_block: lambda do |env:, options:, retry_count:, exception:, will_retry_in:|
           NewRelic::Agent.notice_error(exception, custom_params: { retry: retry_count })
         end,


### PR DESCRIPTION
## 🎫 Ticket                                                                                                          
                                                                                                                        
  Link to the relevant ticket:
  [LG-17647](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17647)                                             
                                                                                                                        
  ## 🛠 Summary of changes
                                                                                                                        
  Configure Faraday's retry middleware to retry POST requests (in addition to GET) when network failures occur. By      
  default, Faraday only retries idempotent methods, so POST requests were not being retried on transient network errors.
   This adds `methods: %i[get post]` to the retry configuration across the following clients:                           
                                                                                                                      
  - `DocAuth::Dos::Request`
  - `DocAuth::LexisNexis::Request`
  - `DocAuth::Socure::Request`
  - `DocAuth::Socure::WebhookRepeater`
  - `ProofingAgent::WebhookCaller`                                                                                      
   
  ## 📜 Testing Plan                                                                                                    
                                                                                                                      
  - [ ] Confirm existing specs for the affected services still pass                                                     
  - [ ] Verify that a simulated network failure on a POST request triggers the retry block (and
  `NewRelic::Agent.notice_error` is called with the retry count)                                                        
  - [ ] Confirm retries still respect `max`, `interval`, `interval_randomness`, and `backoff_factor`                  
  - [ ] Confirm GET request retry behavior is unchanged  

[LG-17647]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17647