### PR TITLE
LG-17610 only call proofing vendors after id validation passes

### DIFF
--- a/app/jobs/proofing_agent_job.rb
+++ b/app/jobs/proofing_agent_job.rb
@@ -167,91 +167,100 @@ class ProofingAgentJob < ApplicationJob
       end
     end
 
-    re_encrypted_arguments = Encryption::Encryptors::BackgroundProofingArgEncryptor.new.encrypt(
-      { applicant_pii: }.to_json,
-    )
+    # Only call the proofing vendors once the ID has been validated (AAMVA or DoS/MRZ).
+    # If the relevant source check was unsuccessful, skip resolution entirely so we
+    # don't spend on the resolution/phone vendors or log their events.
+    source_check_succeeded = aamva_result&.success? || mrz_result&.success?
 
-    resolution_result = call_resolution_proofing_job(
-      timer:,
-      result_id: SecureRandom.uuid,
-      encrypted_arguments: re_encrypted_arguments,
-      trace_id:,
-      user_id: user.id,
-      service_provider_issuer:,
-      proofing_vendor:,
-    )
+    resolution_result = nil
 
-    if resolution_result&.dig(:context, :stages, :resolution, :success) == true
-      proofing_components[:residential_resolution_check] = resolution_result&.dig(
-        :context, :stages, :residential_address, :vendor_name
+    if source_check_succeeded
+      re_encrypted_arguments = Encryption::Encryptors::BackgroundProofingArgEncryptor.new.encrypt(
+        { applicant_pii: }.to_json,
       )
-      proofing_components[:resolution_check] = resolution_result&.dig(
-        :context, :stages, :resolution, :vendor_name
+
+      resolution_result = call_resolution_proofing_job(
+        timer:,
+        result_id: SecureRandom.uuid,
+        encrypted_arguments: re_encrypted_arguments,
+        trace_id:,
+        user_id: user.id,
+        service_provider_issuer:,
+        proofing_vendor:,
       )
-    end
 
-    if resolution_result&.dig(:context, :stages, :phone_precheck, :success) == true
-      proofing_components[:address_check] = resolution_result&.dig(
-        :context, :stages, :phone_precheck, :vendor_name
-      )
-    end
+      if resolution_result&.dig(:context, :stages, :resolution, :success) == true
+        proofing_components[:residential_resolution_check] = resolution_result&.dig(
+          :context, :stages, :residential_address, :vendor_name
+        )
+        proofing_components[:resolution_check] = resolution_result&.dig(
+          :context, :stages, :resolution, :vendor_name
+        )
+      end
 
-    analytics.idv_doc_auth_verify_proofing_results(
-      **{
-        success: resolution_result&.dig(:context, :stages, :resolution, :success),
-        proofing_agent:,
-        proofing_components: proofing_components.dup,
-        analytics_id: 'Doc Auth',
-        address_edited: false,
-        address_line2_present: false,
-        errors: resolution_result&.dig(:errors),
-        last_name_spaced: applicant_pii&.dig(:last_name)&.include?(' '),
-        opted_in_to_in_person_proofing: false,
-        proofing_results: resolution_result.to_h,
-        ssn_is_unique: resolution_result&.dig(:ssn_is_unique),
-        step: 'Proofing Agent Job',
-        flow_path: 'Proofing Agent',
-      }.to_h.merge(
-        pii_like_keypaths: [
-          [:proofing_results, :biographical_info],
-          [:proofing_results, :errors, :zipcode],
-          [:proofing_results, :errors, :ssn],
-          [:proofing_results, :biographical_info, :identity_doc_address_state],
-          [:proofing_results, :biographical_info, :state_id_jurisdiction],
-          [:proofing_results, :context, :stages, :resolution, :errors, :zipcode],
-          [:proofing_results, :biographical_info, :same_address_as_id],
-          [:proofing_results, :biographical_info, :phone],
-          [:proofing_results, :context, :stages, :resolution, :errors, :ssn],
-          [:errors, :zipcode],
-          [:errors, :ssn],
-        ],
-      ),
-    )
+      if resolution_result&.dig(:context, :stages, :phone_precheck, :success) == true
+        proofing_components[:address_check] = resolution_result&.dig(
+          :context, :stages, :phone_precheck, :vendor_name
+        )
+      end
 
-    if resolution_result.dig(:context, :stages, :phone_precheck).present?
-      phone_precheck_body = resolution_result&.dig(:context, :stages, :phone_precheck)
-      phone_info = resolution_result&.dig(:biographical_info, :phone)
-
-      analytics.idv_phone_confirmation_vendor_submitted(
+      analytics.idv_doc_auth_verify_proofing_results(
         **{
-          success: phone_precheck_body&.dig(:success),
-          vendor: phone_precheck_body&.dig(:vendor_name),
-          area_code: phone_info&.dig(:area_code),
-          country_code: phone_info&.dig(:country_code),
-          phone_fingerprint: phone_info&.dig(:phone_fingerprint),
-          new_phone_added: true,
-          hybrid_handoff_phone_used: false,
-          manual_review: false,
-          errors: phone_precheck_body&.dig(:errors),
-          reason_codes: phone_precheck_body&.dig(:reason_codes),
+          success: resolution_result&.dig(:context, :stages, :resolution, :success),
           proofing_agent:,
           proofing_components: proofing_components.dup,
+          analytics_id: 'Doc Auth',
+          address_edited: false,
+          address_line2_present: false,
+          errors: resolution_result&.dig(:errors),
+          last_name_spaced: applicant_pii&.dig(:last_name)&.include?(' '),
+          opted_in_to_in_person_proofing: false,
+          proofing_results: resolution_result.to_h,
+          ssn_is_unique: resolution_result&.dig(:ssn_is_unique),
+          step: 'Proofing Agent Job',
+          flow_path: 'Proofing Agent',
         }.to_h.merge(
           pii_like_keypaths: [
-            [:errors, :phone],
+            [:proofing_results, :biographical_info],
+            [:proofing_results, :errors, :zipcode],
+            [:proofing_results, :errors, :ssn],
+            [:proofing_results, :biographical_info, :identity_doc_address_state],
+            [:proofing_results, :biographical_info, :state_id_jurisdiction],
+            [:proofing_results, :context, :stages, :resolution, :errors, :zipcode],
+            [:proofing_results, :biographical_info, :same_address_as_id],
+            [:proofing_results, :biographical_info, :phone],
+            [:proofing_results, :context, :stages, :resolution, :errors, :ssn],
+            [:errors, :zipcode],
+            [:errors, :ssn],
           ],
         ),
       )
+
+      if resolution_result&.dig(:context, :stages, :phone_precheck).present?
+        phone_precheck_body = resolution_result&.dig(:context, :stages, :phone_precheck)
+        phone_info = resolution_result&.dig(:biographical_info, :phone)
+
+        analytics.idv_phone_confirmation_vendor_submitted(
+          **{
+            success: phone_precheck_body&.dig(:success),
+            vendor: phone_precheck_body&.dig(:vendor_name),
+            area_code: phone_info&.dig(:area_code),
+            country_code: phone_info&.dig(:country_code),
+            phone_fingerprint: phone_info&.dig(:phone_fingerprint),
+            new_phone_added: true,
+            hybrid_handoff_phone_used: false,
+            manual_review: false,
+            errors: phone_precheck_body&.dig(:errors),
+            reason_codes: phone_precheck_body&.dig(:reason_codes),
+            proofing_agent:,
+            proofing_components: proofing_components.dup,
+          }.to_h.merge(
+            pii_like_keypaths: [
+              [:errors, :phone],
+            ],
+          ),
+        )
+      end
     end
 
     ProofingAgent::ProofingResult.new(

--- a/app/services/proofing_agent/proofing_result.rb
+++ b/app/services/proofing_agent/proofing_result.rb
@@ -57,7 +57,7 @@ module ProofingAgent
     end
 
     def phone_precheck_attempted?
-      resolution_result.dig(:context, :stages, :phone_precheck).present?
+      resolution_result&.dig(:context, :stages, :phone_precheck).present?
     end
 
     private
@@ -76,7 +76,7 @@ module ProofingAgent
     end
 
     def phone_precheck_passed?
-      resolution_result[:phone_precheck_passed]
+      resolution_result&.dig(:phone_precheck_passed)
     end
 
     def aamva_success?

--- a/spec/jobs/proofing_agent_job_spec.rb
+++ b/spec/jobs/proofing_agent_job_spec.rb
@@ -424,6 +424,21 @@ RSpec.describe ProofingAgentJob, type: :job do
           analytics_attributes: an_instance_of(Hash),
         )
       end
+
+      it 'does not call ResolutionProofingJob' do
+        expect(ResolutionProofingJob).not_to receive(:perform_now)
+        perform
+      end
+
+      it 'does not log idv_doc_auth_verify_proofing_results' do
+        perform
+        expect(@analytics).not_to have_logged_event('IdV: doc auth verify proofing results')
+      end
+
+      it 'does not log idv_phone_confirmation_vendor_submitted' do
+        perform
+        expect(@analytics).not_to have_logged_event('IdV: phone confirmation vendor')
+      end
     end
 
     context 'when phone check fails' do
@@ -513,6 +528,21 @@ RSpec.describe ProofingAgentJob, type: :job do
           correlation_id: correlation_id,
           analytics_attributes: an_instance_of(Hash),
         )
+      end
+
+      it 'does not call ResolutionProofingJob' do
+        expect(ResolutionProofingJob).not_to receive(:perform_now)
+        perform
+      end
+
+      it 'does not log idv_doc_auth_verify_proofing_results' do
+        perform
+        expect(@analytics).not_to have_logged_event('IdV: doc auth verify proofing results')
+      end
+
+      it 'does not log idv_phone_confirmation_vendor_submitted' do
+        perform
+        expect(@analytics).not_to have_logged_event('IdV: phone confirmation vendor')
       end
     end
 

--- a/spec/services/proofing_agent/proofing_result_spec.rb
+++ b/spec/services/proofing_agent/proofing_result_spec.rb
@@ -272,4 +272,14 @@ RSpec.describe ProofingAgent::ProofingResult do
       )
     end
   end
+
+  context 'when resolution_result is nil' do
+    let(:resolution_result) { nil }
+
+    it 'does not raise and returns a failure reason' do
+      expect { subject.combined_result }.not_to raise_error
+      expect(subject.combined_result[:success]).to be false
+      expect(subject.combined_result[:reason]).to eq('phone_check_fail')
+    end
+  end
 end


### PR DESCRIPTION
changelog: Internal, Identity verification, Skip proofing resolution when AAMVA or DoS validation fails

## 🎫 Ticket

Link to the relevant ticket:
[LG-17610](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17610)

## 🛠 Summary of changes

ProofingAgentJob was calling the resolution proofing job and logging the doc-auth / phone vendor events even when AAMVA or DoS/MRZ came back unsuccessful. Now that work is gated on a successful source check, so we don't hit the proofing vendors or log those events for users who already failed ID validation.

Also nil-guarded the `resolution_result` reads in ProofingResult so a skipped resolution doesn't blow up. The job diff looks big but it's mostly re-indenting the existing block into the new conditional.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] On an AAMVA failure, confirm the resolution job doesn't run and the doc-auth / phone vendor events aren't logged
- [ ] Same on a DoS/MRZ failure
- [ ] On a successful AAMVA or MRZ check, confirm resolution still runs and both events still fire
- [ ] `bundle exec rspec spec/jobs/proofing_agent_job_spec.rb spec/services/proofing_agent/proofing_result_spec.rb`


[LG-17610]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17610