### PR TITLE
Lg 17666 check for card support in api requests

### DIFF
--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -13,7 +13,9 @@ module Idv
     def set_passport_requested
       if passport_chosen?
         unless document_capture_session.passport_requested?
-          document_capture_session.request_passport!
+          document_capture_session.request_passport!(
+            passport_cards_supported: passport_cards_supported?,
+          )
         end
       else
         document_capture_session.request_state_id!
@@ -61,8 +63,11 @@ module Idv
     end
 
     def passports_enabled?
-      IdentityConfig.store.doc_auth_passports_enabled ||
-        (FeatureManagement.doc_auth_passport_cards_enabled? && in_passport_cards_allowed_bucket?)
+      IdentityConfig.store.doc_auth_passports_enabled || passport_cards_supported?
+    end
+
+    def passport_cards_supported?
+      FeatureManagement.doc_auth_passport_cards_enabled? && in_passport_cards_allowed_bucket?
     end
 
     def in_passport_cards_allowed_bucket?

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -206,6 +206,7 @@ module Idv
           liveness_checking_required: liveness_checking_required,
           document_type_requested: document_type_requested,
           passport_requested: document_capture_session.passport_requested?,
+          passport_cards_supported: document_capture_session.passport_cards_supported?,
         }
         post_images_args[:user_email] = user_email if ddp_client?
         doc_auth_client.post_images(**post_images_args)
@@ -262,8 +263,7 @@ module Idv
 
     def validate_mrz(client_response)
       id_type = client_response.pii_from_doc.document_type_received
-
-      unless id_type == 'passport'
+      unless in_supported_passport_types?(id_type)
         return DocAuth::Response.new(
           success: false,
           errors: { passport: "Cannot validate MRZ for id type: #{id_type}" },
@@ -292,6 +292,14 @@ module Idv
 
       response.extra.merge!(extra_attributes)
       response
+    end
+
+    def in_supported_passport_types?(id_type)
+      return true if id_type == Idp::Constants::DocumentTypes::PASSPORT
+      if document_capture_session.passport_cards_supported?
+        return id_type == Idp::Constants::DocumentTypes::PASSPORT_CARD
+      end
+      false
     end
 
     def doc_side_classification(client_response)

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -263,7 +263,7 @@ module Idv
 
     def validate_mrz(client_response)
       id_type = client_response.pii_from_doc.document_type_received
-      unless in_supported_passport_types?(id_type)
+      unless document_capture_session.in_supported_passport_types?(id_type)
         return DocAuth::Response.new(
           success: false,
           errors: { passport: "Cannot validate MRZ for id type: #{id_type}" },
@@ -292,14 +292,6 @@ module Idv
 
       response.extra.merge!(extra_attributes)
       response
-    end
-
-    def in_supported_passport_types?(id_type)
-      return true if id_type == Idp::Constants::DocumentTypes::PASSPORT
-      if document_capture_session.passport_cards_supported?
-        return id_type == Idp::Constants::DocumentTypes::PASSPORT_CARD
-      end
-      false
     end
 
     def doc_side_classification(client_response)

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -323,7 +323,7 @@ class SocureDocvResultsJob < ApplicationJob
 
   def validate_mrz(doc_pii_response)
     id_type = doc_pii_response.extra[:document_type_received]
-    unless in_supported_passport_types?(id_type)
+    unless document_capture_session.in_supported_passport_types?(id_type)
       return unless document_capture_session.passport_requested?
     end
 
@@ -349,14 +349,6 @@ class SocureDocvResultsJob < ApplicationJob
     )
 
     response
-  end
-
-  def in_supported_passport_types?(id_type)
-    return true if id_type == Idp::Constants::DocumentTypes::PASSPORT
-    if document_capture_session.passport_cards_supported?
-      return id_type == Idp::Constants::DocumentTypes::PASSPORT_CARD
-    end
-    false
   end
 
   def document_type_requested

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -323,7 +323,7 @@ class SocureDocvResultsJob < ApplicationJob
 
   def validate_mrz(doc_pii_response)
     id_type = doc_pii_response.extra[:document_type_received]
-    unless id_type == 'passport'
+    unless in_supported_passport_types?(id_type)
       return unless document_capture_session.passport_requested?
     end
 
@@ -349,6 +349,14 @@ class SocureDocvResultsJob < ApplicationJob
     )
 
     response
+  end
+
+  def in_supported_passport_types?(id_type)
+    return true if id_type == Idp::Constants::DocumentTypes::PASSPORT
+    if document_capture_session.passport_cards_supported?
+      return id_type == Idp::Constants::DocumentTypes::PASSPORT_CARD
+    end
+    false
   end
 
   def document_type_requested

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -177,7 +177,7 @@ class DocumentCaptureSession < ApplicationRecord
   end
 
   def passport_cards_supported?
-    passport_cards_supported
+    !!passport_cards_supported
   end
 
   def in_supported_passport_types?(id_type)

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -176,11 +176,16 @@ class DocumentCaptureSession < ApplicationRecord
     document_type_requested == Idp::Constants::DocumentTypes::PASSPORT
   end
 
-  def request_passport!
+  def passport_cards_supported?
+    passport_cards_supported
+  end
+
+  def request_passport!(passport_cards_supported: false)
     attrs = {
       passport_status: nil,
       document_type_requested: Idp::Constants::DocumentTypes::PASSPORT,
       doc_auth_vendor: nil,
+      passport_cards_supported: passport_cards_supported,
     }.merge(clear_socure_attributes)
 
     update!(attrs) if !passport_requested?

--- a/app/models/document_capture_session.rb
+++ b/app/models/document_capture_session.rb
@@ -180,12 +180,19 @@ class DocumentCaptureSession < ApplicationRecord
     passport_cards_supported
   end
 
+  def in_supported_passport_types?(id_type)
+    return true if id_type == Idp::Constants::DocumentTypes::PASSPORT
+    return id_type == Idp::Constants::DocumentTypes::PASSPORT_CARD if passport_cards_supported?
+
+    false
+  end
+
   def request_passport!(passport_cards_supported: false)
     attrs = {
       passport_status: nil,
       document_type_requested: Idp::Constants::DocumentTypes::PASSPORT,
       doc_auth_vendor: nil,
-      passport_cards_supported: passport_cards_supported,
+      passport_cards_supported:,
     }.merge(clear_socure_attributes)
 
     update!(attrs) if !passport_requested?

--- a/app/services/doc_auth/document_classifications.rb
+++ b/app/services/doc_auth/document_classifications.rb
@@ -2,14 +2,24 @@
 
 module DocAuth::DocumentClassifications
   PASSPORT = 'Passport'
+  PASSPORT_CARD = 'PassportCard'
+  PASSPORT_CARD_SPACED = 'Passport Card'
   IDENTIFICATION_CARD = 'Identification Card'
   DRIVERS_LICENSE = 'Drivers License'
 
-  ALL_CLASSIFICATIONS = [PASSPORT, IDENTIFICATION_CARD, DRIVERS_LICENSE].freeze
+  ALL_CLASSIFICATIONS = [
+    PASSPORT,
+    PASSPORT_CARD,
+    PASSPORT_CARD_SPACED,
+    IDENTIFICATION_CARD,
+    DRIVERS_LICENSE,
+  ].freeze
   STATE_ID_CLASSIFICATIONS = [IDENTIFICATION_CARD, DRIVERS_LICENSE].freeze
 
   CLASSIFICATION_TO_DOCUMENT_TYPE = {
     PASSPORT => Idp::Constants::DocumentTypes::PASSPORT,
+    PASSPORT_CARD => Idp::Constants::DocumentTypes::PASSPORT_CARD,
+    PASSPORT_CARD_SPACED => Idp::Constants::DocumentTypes::PASSPORT_CARD,
     DRIVERS_LICENSE => Idp::Constants::DocumentTypes::DRIVERS_LICENSE,
     IDENTIFICATION_CARD => Idp::Constants::DocumentTypes::IDENTIFICATION_CARD,
   }.freeze

--- a/app/services/doc_auth/lexis_nexis/ddp_client.rb
+++ b/app/services/doc_auth/lexis_nexis/ddp_client.rb
@@ -16,6 +16,7 @@ module DocAuth
       def post_images(
         document_type_requested: nil,
         passport_requested: false,
+        passport_cards_supported: false,
         liveness_checking_required: false,
         front_image: nil,
         back_image: nil,
@@ -36,6 +37,7 @@ module DocAuth
           document_type_requested:,
           liveness_checking_required:,
           passport_requested:,
+          passport_cards_supported:,
           uuid_prefix:,
           uuid: user_uuid,
           email: user_email,

--- a/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
+++ b/app/services/doc_auth/lexis_nexis/lexis_nexis_client.rb
@@ -21,7 +21,8 @@ module DocAuth
         user_uuid: nil,
         uuid_prefix: nil,
         liveness_checking_required: false,
-        passport_requested: false
+        passport_requested: false,
+        passport_cards_supported: false
       )
         Requests::TrueIdRequest.new(
           config: config,
@@ -36,6 +37,7 @@ module DocAuth
           liveness_checking_required: liveness_checking_required,
           document_type_requested: document_type_requested,
           passport_requested: passport_requested,
+          passport_cards_supported: passport_cards_supported,
         ).fetch
       end
     end

--- a/app/services/doc_auth/lexis_nexis/requests/ddp/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/ddp/true_id_request.rb
@@ -27,6 +27,7 @@ module DocAuth
             LexisNexis::Responses::Ddp::TrueIdResponse.new(
               http_response:,
               passport_requested: applicant[:passport_requested],
+              passport_cards_supported: applicant[:passport_cards_supported],
               config:,
               liveness_checking_enabled: liveness_checking_required?,
               request_context: request_context,

--- a/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
+++ b/app/services/doc_auth/lexis_nexis/requests/true_id_request.rb
@@ -5,7 +5,8 @@ module DocAuth
     module Requests
       class TrueIdRequest < DocAuth::LexisNexis::Request
         attr_reader :front_image, :back_image, :passport_image, :selfie_image,
-                    :liveness_checking_required, :document_type_requested, :passport_requested
+                    :liveness_checking_required, :document_type_requested, :passport_requested,
+                    :passport_cards_supported
 
         def initialize(
           config:,
@@ -19,7 +20,8 @@ module DocAuth
           image_source: nil,
           images_cropped: false,
           liveness_checking_required: false,
-          passport_requested: false
+          passport_requested: false,
+          passport_cards_supported: false
         )
           super(config: config, user_uuid: user_uuid, uuid_prefix: uuid_prefix)
           @front_image = front_image
@@ -32,6 +34,7 @@ module DocAuth
           @liveness_checking_required = liveness_checking_required
           @document_type_requested = document_type_requested
           @passport_requested = passport_requested
+          @passport_cards_supported = passport_cards_supported
         end
 
         def request_context
@@ -74,6 +77,7 @@ module DocAuth
             config:,
             liveness_checking_enabled: liveness_checking_required,
             request_context:,
+            passport_cards_supported:,
           )
         end
 

--- a/app/services/doc_auth/lexis_nexis/responses/ddp/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/ddp/true_id_response.rb
@@ -46,7 +46,7 @@ module DocAuth
           # vendor (document and selfie if requested)
           # Will be further implemented in future tickets
           def successful_result?
-            return false if passport_card_detected? && !passport_cards_supported?
+            return false if passport_card_detected? && !passport_cards_supported
 
             doc_auth_success? &&
               (@liveness_checking_enabled ? selfie_passed? : true)
@@ -59,7 +59,7 @@ module DocAuth
           def error_messages
             return {} if successful_result?
 
-            if passport_card_detected? && !passport_cards_supported?
+            if passport_card_detected? && !passport_cards_supported
               { passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') }
             elsif id_type.present? && !expected_document_type_received?
               { unexpected_id_type: true, expected_id_type: expected_id_type }

--- a/app/services/doc_auth/lexis_nexis/responses/ddp/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/ddp/true_id_response.rb
@@ -10,13 +10,15 @@ module DocAuth
           include DocAuth::LexisNexis::DocPiiReader
           include DocAuth::ClassificationConcern
 
-          attr_reader :config, :http_response, :passport_requested
+          attr_reader :config, :http_response, :passport_requested, :passport_cards_supported
 
           def initialize(http_response:, config:, passport_requested: false,
-                         liveness_checking_enabled: false, request_context: {}, request: nil)
+                         passport_cards_supported: false, liveness_checking_enabled: false,
+                         request_context: {}, request: nil)
             @config = config
             @http_response = http_response
             @passport_requested = passport_requested
+            @passport_cards_supported = passport_cards_supported
             @request_context = request_context
             @request = request
             @liveness_checking_enabled = liveness_checking_enabled
@@ -44,7 +46,7 @@ module DocAuth
           # vendor (document and selfie if requested)
           # Will be further implemented in future tickets
           def successful_result?
-            return false if passport_card_detected?
+            return false if passport_card_detected? && !passport_cards_supported?
 
             doc_auth_success? &&
               (@liveness_checking_enabled ? selfie_passed? : true)
@@ -57,7 +59,7 @@ module DocAuth
           def error_messages
             return {} if successful_result?
 
-            if passport_card_detected?
+            if passport_card_detected? && !passport_cards_supported?
               { passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') }
             elsif id_type.present? && !expected_document_type_received?
               { unexpected_id_type: true, expected_id_type: expected_id_type }
@@ -153,14 +155,6 @@ module DocAuth
 
           def policy
             @policy ||= @request&.policy
-          end
-
-          def expected_document_type_received?
-            expected_id_types = passport_requested ?
-              Idp::Constants::DocumentTypes::SUPPORTED_PASSPORT_TYPES :
-              Idp::Constants::DocumentTypes::SUPPORTED_STATE_ID_TYPES
-
-            expected_id_types.include?(id_type)
           end
 
           def id_type

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -44,7 +44,7 @@ module DocAuth
         ## returns full check success status, considering all checks:
         #    vendor (document and selfie if requested)
         def successful_result?
-          return false if passport_card_detected? && !passport_cards_supported?
+          return false if passport_card_detected? && !passport_cards_supported
 
           doc_auth_success? &&
             (@liveness_checking_enabled ? selfie_passed? : true)
@@ -61,7 +61,7 @@ module DocAuth
         def error_messages
           return {} if successful_result?
 
-          if passport_card_detected? && !passport_cards_supported?
+          if passport_card_detected? && !passport_cards_supported
             { passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') }
           elsif id_type.present? && !expected_document_type_received?
             { unexpected_id_type: true, expected_id_type: expected_id_type }

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -10,13 +10,15 @@ module DocAuth
         include ClassificationConcern
         include SelfieConcern
 
-        attr_reader :config, :http_response, :passport_requested
+        attr_reader :config, :http_response, :passport_requested, :passport_cards_supported
 
         def initialize(http_response:, config:, passport_requested: false,
-                       liveness_checking_enabled: false, request_context: {})
+                       passport_cards_supported: false, liveness_checking_enabled: false,
+                       request_context: {})
           @config = config
           @http_response = http_response
           @passport_requested = passport_requested
+          @passport_cards_supported = passport_cards_supported
           @request_context = request_context
           @liveness_checking_enabled = liveness_checking_enabled
           @pii_from_doc = read_pii
@@ -42,7 +44,7 @@ module DocAuth
         ## returns full check success status, considering all checks:
         #    vendor (document and selfie if requested)
         def successful_result?
-          return false if passport_card_detected?
+          return false if passport_card_detected? && !passport_cards_supported?
 
           doc_auth_success? &&
             (@liveness_checking_enabled ? selfie_passed? : true)
@@ -59,7 +61,7 @@ module DocAuth
         def error_messages
           return {} if successful_result?
 
-          if passport_card_detected?
+          if passport_card_detected? && !passport_cards_supported?
             { passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') }
           elsif id_type.present? && !expected_document_type_received?
             { unexpected_id_type: true, expected_id_type: expected_id_type }
@@ -126,14 +128,6 @@ module DocAuth
 
         def request_id
           @request_id ||= parsed_response_body.dig(:Status, :RequestId)
-        end
-
-        def expected_document_type_received?
-          expected_id_types = passport_requested ?
-            Idp::Constants::DocumentTypes::SUPPORTED_PASSPORT_TYPES :
-            Idp::Constants::DocumentTypes::SUPPORTED_STATE_ID_TYPES
-
-          expected_id_types.include?(id_type)
         end
 
         def id_type

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response_concern.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response_concern.rb
@@ -56,7 +56,7 @@ module DocAuth
         end
 
         def passport_card_detected?
-          doc_issue_type == 'Passport Card'
+          Idp::Constants::DocumentTypes::PASSPORT_CARD_RESPONSES.include?(doc_issue_type)
         end
 
         def expected_document_type_received?

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response_concern.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response_concern.rb
@@ -59,6 +59,17 @@ module DocAuth
           doc_issue_type == 'Passport Card'
         end
 
+        def expected_document_type_received?
+          expected_id_types = passport_requested ?
+            Idp::Constants::DocumentTypes::SUPPORTED_PASSPORT_TYPES :
+            Idp::Constants::DocumentTypes::SUPPORTED_STATE_ID_TYPES
+
+          if passport_cards_supported?
+            expected_id_types += [Idp::Constants::DocumentTypes::PASSPORT_CARD]
+          end
+          expected_id_types.include?(id_type)
+        end
+
         def response_info
           @response_info ||= create_response_info
         end

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response_concern.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response_concern.rb
@@ -64,7 +64,7 @@ module DocAuth
             Idp::Constants::DocumentTypes::SUPPORTED_PASSPORT_TYPES :
             Idp::Constants::DocumentTypes::SUPPORTED_STATE_ID_TYPES
 
-          if passport_cards_supported?
+          if passport_cards_supported
             expected_id_types += [Idp::Constants::DocumentTypes::PASSPORT_CARD]
           end
           expected_id_types.include?(id_type)

--- a/app/services/doc_auth/mock/doc_auth_mock_client.rb
+++ b/app/services/doc_auth/mock/doc_auth_mock_client.rb
@@ -65,7 +65,8 @@ module DocAuth
         user_uuid: nil,
         uuid_prefix: nil,
         liveness_checking_required: false,
-        passport_requested: false
+        passport_requested: false,
+        passport_cards_supported: false
       )
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
 
@@ -89,11 +90,12 @@ module DocAuth
           selfie_required: liveness_checking_required,
           passport_submittal: passport_image.present?,
           passport_requested:,
+          passport_cards_supported:,
         )
       end
 
       def get_results(instance_id:, selfie_required: false, passport_submittal: false,
-                      passport_requested: false)
+                      passport_requested: false, passport_cards_supported: false)
         return mocked_response_for_method(__method__) if method_mocked?(__method__)
         last_image = passport_submittal ?
                        self.class.last_uploaded_passport_image : self.class.last_uploaded_back_image
@@ -111,6 +113,7 @@ module DocAuth
           selfie_required:,
           passport_submittal:,
           passport_requested:,
+          passport_cards_supported:,
         )
       end
       # rubocop:enable Lint/UnusedMethodArgument

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -8,15 +8,16 @@ module DocAuth
       include DocAuth::Mock::YmlLoaderConcern
 
       attr_reader :uploaded_file, :config, :selfie_required, :passport_submittal,
-                  :passport_requested
+                  :passport_requested, :passport_cards_supported
 
       def initialize(uploaded_file, config, selfie_required: false, passport_submittal: false,
-                     passport_requested: false)
+                     passport_requested: false, passport_cards_supported: false)
         @uploaded_file = uploaded_file.to_s
         @config = config
         @selfie_required = selfie_required
         @passport_submittal = passport_submittal
         @passport_requested = passport_requested
+        @passport_cards_supported = passport_cards_supported
         super(
           success: success?,
           errors:,
@@ -248,6 +249,9 @@ module DocAuth
           Idp::Constants::DocumentTypes::SUPPORTED_PASSPORT_TYPES :
           Idp::Constants::DocumentTypes::SUPPORTED_STATE_ID_TYPES
 
+        if passport_cards_supported?
+          expected_id_types += [Idp::Constants::DocumentTypes::PASSPORT_CARD]
+        end
         expected_id_types.include?(id_type)
       end
 

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -249,7 +249,7 @@ module DocAuth
           Idp::Constants::DocumentTypes::SUPPORTED_PASSPORT_TYPES :
           Idp::Constants::DocumentTypes::SUPPORTED_STATE_ID_TYPES
 
-        if passport_cards_supported?
+        if passport_cards_supported
           expected_id_types += [Idp::Constants::DocumentTypes::PASSPORT_CARD]
         end
         expected_id_types.include?(id_type)

--- a/db/primary_migrate/20260618151409_add_passport_cards_supported_to_document_capture_session.rb
+++ b/db/primary_migrate/20260618151409_add_passport_cards_supported_to_document_capture_session.rb
@@ -1,0 +1,6 @@
+class AddPassportCardsSupportedToDocumentCaptureSession < ActiveRecord::Migration[8.0]
+  def change
+    add_column :document_capture_sessions, :passport_cards_supported, :boolean, default: false,
+                                                                                null: false
+  end
+end

--- a/db/primary_migrate/20260618151409_add_passport_cards_supported_to_document_capture_session.rb
+++ b/db/primary_migrate/20260618151409_add_passport_cards_supported_to_document_capture_session.rb
@@ -1,7 +1,6 @@
 class AddPassportCardsSupportedToDocumentCaptureSession < ActiveRecord::Migration[8.0]
   def change
     add_column :document_capture_sessions, :passport_cards_supported, :boolean, default: false,
-                                                                                null: false,
                                                                                 comment: 'sensitive=false'
   end
 end

--- a/db/primary_migrate/20260618151409_add_passport_cards_supported_to_document_capture_session.rb
+++ b/db/primary_migrate/20260618151409_add_passport_cards_supported_to_document_capture_session.rb
@@ -1,6 +1,7 @@
 class AddPassportCardsSupportedToDocumentCaptureSession < ActiveRecord::Migration[8.0]
   def change
     add_column :document_capture_sessions, :passport_cards_supported, :boolean, default: false,
-                                                                                null: false
+                                                                                null: false,
+                                                                                comment: 'sensitive=false'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -219,7 +219,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_18_151409) do
     t.string "hybrid_mobile_request_ip", comment: "sensitive=false"
     t.integer "document_type_requested", comment: "sensitive=false"
     t.datetime "pending_agent_proofed_user_at", comment: "sensitive=false"
-    t.boolean "passport_cards_supported", default: false, null: false
+    t.boolean "passport_cards_supported", default: false, null: false, comment: "sensitive=false"
     t.index ["passport_status"], name: "idx_document_capture_sessions_on_passport_status_null_doc_type", where: "((document_type_requested IS NULL) AND (passport_status IS NOT NULL))"
     t.index ["result_id"], name: "index_document_capture_sessions_on_result_id"
     t.index ["socure_docv_transaction_token"], name: "index_socure_docv_transaction_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_29_170050) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_18_151409) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -219,6 +219,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_29_170050) do
     t.string "hybrid_mobile_request_ip", comment: "sensitive=false"
     t.integer "document_type_requested", comment: "sensitive=false"
     t.datetime "pending_agent_proofed_user_at", comment: "sensitive=false"
+    t.boolean "passport_cards_supported", default: false, null: false
     t.index ["passport_status"], name: "idx_document_capture_sessions_on_passport_status_null_doc_type", where: "((document_type_requested IS NULL) AND (passport_status IS NOT NULL))"
     t.index ["result_id"], name: "index_document_capture_sessions_on_result_id"
     t.index ["socure_docv_transaction_token"], name: "index_socure_docv_transaction_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -219,7 +219,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_18_151409) do
     t.string "hybrid_mobile_request_ip", comment: "sensitive=false"
     t.integer "document_type_requested", comment: "sensitive=false"
     t.datetime "pending_agent_proofed_user_at", comment: "sensitive=false"
-    t.boolean "passport_cards_supported", default: false, null: false, comment: "sensitive=false"
+    t.boolean "passport_cards_supported", default: false, comment: "sensitive=false"
     t.index ["passport_status"], name: "idx_document_capture_sessions_on_passport_status_null_doc_type", where: "((document_type_requested IS NULL) AND (passport_status IS NOT NULL))"
     t.index ["result_id"], name: "index_document_capture_sessions_on_result_id"
     t.index ["socure_docv_transaction_token"], name: "index_socure_docv_transaction_token", unique: true

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -32,6 +32,7 @@ module Idp
       STATE_ID_CARD = 'state_id_card'
       IDENTIFICATION_CARD = 'identification_card'
 
+      PASSPORT_CARD_RESPONSES = ['Passport Card', 'PassportCard'].freeze
       SUPPORTED_PASSPORT_TYPES = [PASSPORT].freeze
       SUPPORTED_STATE_ID_TYPES = [DRIVERS_LICENSE, STATE_ID_CARD, IDENTIFICATION_CARD].freeze
       SUPPORTED_ID_TYPES = [*SUPPORTED_PASSPORT_TYPES, *SUPPORTED_STATE_ID_TYPES].freeze

--- a/spec/controllers/concerns/idv/choose_id_type_concern_spec.rb
+++ b/spec/controllers/concerns/idv/choose_id_type_concern_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe Idv::ChooseIdTypeConcern, :controller do
   end
 
   describe '#set_passport_requested' do
+    context 'when chosen_id_type is passport and passport cards supported' do
+      let(:document_type_chosen) { 'passport' }
+      before do
+        allow(IdentityConfig.store).to receive(:doc_auth_passport_cards_enabled)
+          .and_return(true)
+        ab_test = AbTests::DOC_AUTH_PASSPORT_CARDS_ALLOWED.dup
+        allow(ab_test).to receive(:bucket).and_return(:doc_auth_passport_cards_allowed)
+        stub_const(
+          'AbTests::DOC_AUTH_PASSPORT_CARDS_ALLOWED',
+          ab_test,
+        )
+        allow(controller).to receive(:params).and_return(parameters)
+        subject.set_passport_requested
+      end
+
+      it 'expect the document capture session to show passport cards supported' do
+        expect(document_capture_session.passport_cards_supported?).to be true
+      end
+    end
+
     context 'when chosen_id_type is "passport"' do
       let(:document_type_chosen) { 'passport' }
 

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -609,6 +609,7 @@ RSpec.describe Idv::ImageUploadsController do
               liveness_checking_required: true,
               images_cropped: false,
               passport_requested: false,
+              passport_cards_supported: false,
             ).and_call_original
 
           action
@@ -632,6 +633,7 @@ RSpec.describe Idv::ImageUploadsController do
             liveness_checking_required: false,
             images_cropped: false,
             passport_requested: false,
+            passport_cards_supported: false,
           ).and_call_original
 
         action
@@ -1677,6 +1679,7 @@ RSpec.describe Idv::ImageUploadsController do
             liveness_checking_required: true,
             images_cropped: false,
             passport_requested: false,
+            passport_cards_supported: false,
           ).and_call_original
 
         action
@@ -1703,6 +1706,7 @@ RSpec.describe Idv::ImageUploadsController do
             liveness_checking_required: false,
             images_cropped: false,
             passport_requested: false,
+            passport_cards_supported: false,
           ).and_call_original
 
         action

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -960,8 +960,7 @@ RSpec.describe SocureDocvResultsJob do
                     expect(document_capture_session_result.doc_auth_success).to eq(false)
                     expect(document_capture_session_result.selfie_status).to eq(:not_processed)
                     expect(document_capture_session_result.aamva_status).to eq(:not_processed)
-                    expect(document_capture_session_result.errors)
-                      .to eq({ unaccepted_id_type: true })
+                    expect(document_capture_session_result.errors[:unexpected_id_type]).to eq(true)
                     expect(@analytics).to have_logged_event(
                       :idv_socure_verification_data_requested,
                       hash_including(

--- a/spec/models/document_capture_session_spec.rb
+++ b/spec/models/document_capture_session_spec.rb
@@ -574,6 +574,29 @@ RSpec.describe DocumentCaptureSession do
         doc_auth_vendor: nil,
         socure_docv_capture_app_url: nil,
         socure_docv_transaction_token: nil,
+        passport_cards_supported: false,
+      )
+
+      expect(record.passport_requested?).to eq(true)
+      expect(record.state_id_requested?).to eq(false)
+    end
+
+    it 'sets the correct attributes for a requested passport with passport card supported' do
+      record = build(
+        :document_capture_session,
+        socure_docv_capture_app_url: 'hello',
+        socure_docv_transaction_token: 'world',
+      )
+
+      record.request_passport!(passport_cards_supported: true)
+
+      expect(record).to have_attributes(
+        passport_status: nil,
+        document_type_requested: Idp::Constants::DocumentTypes::PASSPORT,
+        doc_auth_vendor: nil,
+        socure_docv_capture_app_url: nil,
+        socure_docv_transaction_token: nil,
+        passport_cards_supported: true,
       )
 
       expect(record.passport_requested?).to eq(true)

--- a/spec/services/doc_auth/lexis_nexis/responses/ddp/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/ddp/true_id_response_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::Ddp::TrueIdResponse do
   end
 
   let(:passport_requested) { false }
+  let(:passport_cards_supported) { false }
   let(:front_image) { 'front_image_data' }
   let(:back_image) { 'back_image_data' }
   let(:selfie_image) { 'selfie_image_data' }
@@ -70,6 +71,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::Ddp::TrueIdResponse do
       request:,
       passport_requested:,
       liveness_checking_enabled: liveness_checking_required,
+      passport_cards_supported:,
     )
   end
 
@@ -356,6 +358,15 @@ RSpec.describe DocAuth::LexisNexis::Responses::Ddp::TrueIdResponse do
 
       it 'is not a successful result' do
         expect(response.success?).to eq(false)
+      end
+    end
+
+    context 'when the received document type is a passport card and passport cards are supported' do
+      let(:passport_cards_supported) { true }
+      let(:ddp_response_body) { LexisNexisFixtures.ddp_true_id_passport_card_response_success }
+
+      it 'is a successful result' do
+        expect(response.success?).to eq(true)
       end
     end
   end

--- a/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/true_id_response_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
   # rubocop:enable Layout/LineLength
 
   let(:passport_requested) { false }
+  let(:passport_cards_supported) { false }
   let(:config) do
     DocAuth::LexisNexis::Config.new
   end
@@ -401,6 +402,7 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         config:,
         liveness_checking_enabled:,
         request_context:,
+        passport_cards_supported:,
       )
     end
 
@@ -419,6 +421,22 @@ RSpec.describe DocAuth::LexisNexis::Responses::TrueIdResponse do
         expect(response.error_messages[:passport_card]).to eq(
           I18n.t('doc_auth.errors.doc.doc_type_check'),
         )
+      end
+    end
+
+    context 'when passport cards are supported' do
+      let(:passport_cards_supported) { true }
+      let(:passport_requested) { true }
+      it 'is a successful result' do
+        expect(response.successful_result?).to eq(true)
+      end
+
+      it 'records the document_type_received as passport_card' do
+        expect(response.pii_from_doc.document_type_received).to eq('passport_card')
+      end
+
+      it 'does not have error messages' do
+        expect(response.error_messages[:passport_card]).to eq(nil)
       end
     end
   end


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-17666](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17666)

## 🛠 Summary of changes
Updated dcs to have attribute to hold if passport cards are supported for requests further in the process.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - ensure specs pass


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17666]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17666