### PR TITLE
Fix DDP IV missing additional verification attrs

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer.rb
@@ -46,7 +46,8 @@ module Proofing
             return if parsed_response.product_list.blank?
 
             product = parsed_response.product_list.first
-            return unless product['ProductType'] == 'Verify'
+            return unless product['ProductType'] == 'Verification' ||
+                          product['ProductType'] == 'Verify'
 
             product
           end

--- a/spec/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer_spec.rb
@@ -129,19 +129,100 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::InstantVerifyProofer do
             LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json
           end
 
-          it 'returns a result that identifies attribute as needing verification' do
-            stub_request(
-              :post,
-              proofing_verification_request.url,
-            ).to_return(
-              body: LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json,
-              status: 200,
-            )
+          context 'response ProductType is "Verification"' do
+            let(:response_body) do
+              result = JSON.parse(
+                LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json,
+              )
+              result.dig(
+                'integration_hub_results',
+                'test_org_id:test-policy',
+                'Execute Instant Verify',
+                'tps_vendor_raw_response',
+                'Products',
+              ).first['ProductType'] = 'Verification'
 
-            result = subject.proof(proofing_applicant)
+              result.to_json
+            end
 
-            expect(result.failed_result_can_pass_with_additional_verification?).to eq(true)
-            expect(result.attributes_requiring_additional_verification).to eq([:dob])
+            it 'returns a result that identifies attribute as needing verification' do
+              stub_request(
+                :post,
+                proofing_verification_request.url,
+              ).to_return(
+                body: response_body,
+                status: 200,
+              )
+
+              result = subject.proof(proofing_applicant)
+
+              expect(result.failed_result_can_pass_with_additional_verification?).to eq(true)
+              expect(result.attributes_requiring_additional_verification).to eq([:dob])
+            end
+          end
+
+          context 'response ProductType is "Verify"' do
+            let(:response_body) do
+              result = JSON.parse(
+                LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json,
+              )
+              result.dig(
+                'integration_hub_results',
+                'test_org_id:test-policy',
+                'Execute Instant Verify',
+                'tps_vendor_raw_response',
+                'Products',
+              ).first['ProductType'] = 'Verify'
+
+              result.to_json
+            end
+
+            it 'returns a result that identifies attribute as needing verification' do
+              stub_request(
+                :post,
+                proofing_verification_request.url,
+              ).to_return(
+                body: response_body,
+                status: 200,
+              )
+
+              result = subject.proof(proofing_applicant)
+
+              expect(result.failed_result_can_pass_with_additional_verification?).to eq(true)
+              expect(result.attributes_requiring_additional_verification).to eq([:dob])
+            end
+          end
+
+          context 'response ProductType is not "Verify" or "Verification"' do
+            let(:response_body) do
+              result = JSON.parse(
+                LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json,
+              )
+              result.dig(
+                'integration_hub_results',
+                'test_org_id:test-policy',
+                'Execute Instant Verify',
+                'tps_vendor_raw_response',
+                'Products',
+              ).first['ProductType'] = 'UKNOWN'
+
+              result.to_json
+            end
+
+            it 'returns a result that does not identify attributes as needing verification' do
+              stub_request(
+                :post,
+                proofing_verification_request.url,
+              ).to_return(
+                body: response_body,
+                status: 200,
+              )
+
+              result = subject.proof(proofing_applicant)
+
+              expect(result.failed_result_can_pass_with_additional_verification?).to eq(false)
+              expect(result.attributes_requiring_additional_verification).to eq([])
+            end
           end
         end
 


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Joan-88](https://gitlab.login.gov/lg-teams/joan/joan/-/issues/88)

## 🛠 Summary of changes

DDP Instant Verify `attributes_requiring_additional_verification` response property is always an empty array due to a mismatch on the Lexis Nexis response `ProductType`. This makes it so that users cannot pass verification with additional verification coverage with AAMVA (get-to-yes feature).