### PR TITLE
allow devenv test to fail while we figure out a better way

### DIFF
--- a/.gitlab-ci-devenv.yml
+++ b/.gitlab-ci-devenv.yml
@@ -1,5 +1,6 @@
 devenv-test:
   image: $ECR_REGISTRY/github/cachix/devenv/devenv:v1.8.1
+  allow_failure: true
   before_script:
     # Set up a local cache directory for Nix
     - export CACHEDIR="$(pwd)/.nix-cache"

--- a/.gitlab-ci-devenv.yml
+++ b/.gitlab-ci-devenv.yml
@@ -1,6 +1,6 @@
 devenv-test:
   image: $ECR_REGISTRY/github/cachix/devenv/devenv:v1.8.1
-  allow_failure: true
+  allow_failure: true # XXXAllow this to fail until we can figure out better caching, or why we can't increase the timeout.
   before_script:
     # Set up a local cache directory for Nix
     - export CACHEDIR="$(pwd)/.nix-cache"


### PR DESCRIPTION
## 🛠 Summary of changes

Allow the devenv test to fail and not break the build.

Currently, the devenv test job is taking too long and is timing out.  We are making the completion of this job optional until we can figure out a better way to do this.  @akrito has some ideas, but I can't remember what they are.
