### PR TITLE
Add prompt=create support to send users directly to the account creation page (SAML and OIDC)

### DIFF
--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -75,7 +75,11 @@ module OpenidConnect
     end
 
     def redirect_to_sign_in
-      redirect_to new_user_session_url
+      if @authorize_form.prompt == 'create' && session[:sp].present?
+        redirect_to sign_up_email_url
+      else
+        redirect_to new_user_session_url
+      end
     end
 
     def redirect_to_reauthenticate

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -119,7 +119,11 @@ class SamlIdpController < ApplicationController
   private
 
   def redirect_to_sign_in
-    redirect_to new_user_session_url
+    if params[:prompt] == 'create' && session[:sp].present?
+      redirect_to sign_up_email_url
+    else
+      redirect_to new_user_session_url
+    end
   end
 
   def redirect_to_reauthenticate

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -57,7 +57,7 @@ class OpenidConnectAuthorizeForm
   validates :nonce, presence: true, length: { minimum: RANDOM_VALUE_MINIMUM_LENGTH }
 
   validates :response_type, inclusion: { in: %w[code] }
-  validates :prompt, presence: true, inclusion: { in: %w[login select_account] }
+  validates :prompt, presence: true, inclusion: { in: %w[login select_account create] }
   validates :code_challenge_method, inclusion: { in: %w[S256] }, if: :code_challenge
 
   validate :validate_acr_values
@@ -207,6 +207,7 @@ class OpenidConnectAuthorizeForm
 
   def validate_prompt
     return if prompt == 'select_account'
+    return if prompt == 'create'
     return if prompt == 'login' && service_provider&.allow_prompt_login
     errors.add(
       :prompt, t('openid_connect.authorization.errors.prompt_invalid'),

--- a/app/presenters/openid_connect_configuration_presenter.rb
+++ b/app/presenters/openid_connect_configuration_presenter.rb
@@ -8,6 +8,7 @@ class OpenidConnectConfigurationPresenter
       acr_values_supported: Saml::Idp::Constants::VALID_AUTHN_CONTEXTS,
       claims_supported: claims_supported,
       grant_types_supported: %w[authorization_code],
+      prompt_values_supported: %w[login select_account create],
       response_types_supported: %w[code],
       scopes_supported: OpenidConnectAttributeScoper::VALID_SCOPES,
       subject_types_supported: %w[pairwise],

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1297,6 +1297,18 @@ RSpec.describe OpenidConnect::AuthorizationController do
             vtr: nil,
           )
         end
+
+        context 'when the SP requests the account creation flow with prompt=create' do
+          let(:prompt) { 'create' }
+
+          it 'redirects to account creation with the request_id in the session' do
+            action
+            sp_request_id = ServiceProviderRequestProxy.last.uuid
+
+            expect(response).to redirect_to sign_up_email_url
+            expect(controller.session[:sp][:request_id]).to eq(sp_request_id)
+          end
+        end
       end
     end
 

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2318,6 +2318,17 @@ RSpec.describe SamlIdpController do
         expect(session[:sp][:request_id]).to eq sp_request_id
       end
 
+      it 'redirects to account creation when prompt=create' do
+        get :auth, params: {
+          SAMLRequest: CGI.unescape(saml_request(saml_settings)),
+          path_year: path_year,
+          prompt: 'create',
+        }
+        sp_request_id = ServiceProviderRequestProxy.last.uuid
+        expect(response).to redirect_to sign_up_email_path
+        expect(session[:sp][:request_id]).to eq sp_request_id
+      end
+
       it 'logs SAML Auth Request but does not log SAML Auth' do
         stub_analytics
 

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -100,6 +100,26 @@ RSpec.feature 'IAL1 Single Sign On' do
     end
   end
 
+  context 'when the SP requests the account creation flow', email: true do
+    it 'sends the user straight to account creation and back to the SP when complete' do
+      email = 'test@test.com'
+
+      visit saml_authn_request_url(params: { prompt: 'create' })
+
+      expect(page).to have_current_path(sign_up_email_path)
+
+      submit_form_with_valid_email(email)
+      click_confirmation_link_in_email(email)
+      submit_form_with_valid_password
+      set_up_2fa_with_valid_phone
+      skip_second_mfa_prompt
+      click_agree_and_continue
+
+      expect(page).to have_current_path complete_saml_path
+      expect(page.get_rack_session.keys).to include('sp')
+    end
+  end
+
   context 'fully signed up user authenticates new sp' do
     let(:user) { create(:user, :fully_registered) }
     let(:saml_authn_request) { saml_authn_request_url }

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'IAL2 Single Sign On' do
   include IdvStepHelper
   include DocAuthHelper
 
-  def saml_ial2_request_url
+  def saml_ial2_request_url(params: {})
     saml_authn_request_url(
       overrides: {
         issuer: 'saml_sp_ial2',
@@ -15,6 +15,7 @@ RSpec.feature 'IAL2 Single Sign On' do
           "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
         ],
       },
+      params: params,
     )
   end
 
@@ -63,6 +64,12 @@ RSpec.feature 'IAL2 Single Sign On' do
 
       expect(page).to have_current_path(new_user_session_path)
       expect(page).to have_content(sp_content)
+    end
+
+    it 'sends the user straight to account creation when the SP requests it' do
+      visit saml_ial2_request_url(params: { prompt: 'create' })
+
+      expect(page).to have_current_path(sign_up_email_path)
     end
 
     it 'shows user the start page with a link back to the SP' do

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -285,9 +285,14 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
 
-    context 'when prompt is not select_account or login' do
+    context 'when prompt is not select_account, login, or create' do
       let(:prompt) { 'aaa' }
       it { expect(valid?).to eq(false) }
+    end
+
+    context 'when prompt is create' do
+      let(:prompt) { 'create' }
+      it { expect(valid?).to eq(true) }
     end
 
     context 'when prompt is not given' do

--- a/spec/presenters/openid_connect_configuration_presenter_spec.rb
+++ b/spec/presenters/openid_connect_configuration_presenter_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe OpenidConnectConfigurationPresenter do
         expect(configuration[:service_documentation]).to eq('https://developers.login.gov/')
         expect(configuration[:response_types_supported]).to eq(%w[code])
         expect(configuration[:grant_types_supported]).to eq(%w[authorization_code])
+        expect(configuration[:prompt_values_supported]).to eq(%w[login select_account create])
         expect(configuration[:acr_values_supported])
           .to match_array(Saml::Idp::Constants::VALID_AUTHN_CONTEXTS)
         expect(configuration[:subject_types_supported]).to eq(%w[pairwise])


### PR DESCRIPTION
Service providers can now send users directly to the Login.gov account creation page instead of the sign-in page by including prompt=create on the authorization request. After the account is created, the user is returned to the service provider exactly as a normal sign-in would.

This uses the OIDC standard [Initiating User Registration via OpenID Connect 1.0](https://openid.net/specs/openid-connect-prompt-create-1_0.html) `prompt=create`. The same `prompt=create` query parameter is honored for SAML as well, so both protocols share one consistent trigger.

Changes:
- SAML and OIDC: unauthenticated requests with `prompt=create` redirect to the account creation page (only when an SP request is present in the session; behavior is otherwise unchanged).
- OIDC: create added to the accepted prompt values, and advertised via prompt_values_supported in the discovery metadata.
- Tests: unit coverage for both controllers and the OIDC form/discovery metadata, plus IAL1 (full create-account → return-to-SP round trip) and IAL2 (direct landing) feature specs.
