### PR TITLE
Update doc escrow for all service providers when historical_attempts_api_enabled

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -389,7 +389,7 @@ module Idv
       return {} unless doc_escrow_enabled?
 
       return @doc_escrow_images if defined?(@doc_escrow_images)
-      @doc_escrow_images = images_metadata.attempts_file_data(issuer: service_provider.issuer)
+      @doc_escrow_images = images_metadata.attempts_file_data
       @doc_escrow_images
     end
 

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -124,7 +124,7 @@ class SocureDocvResultsJob < ApplicationJob
   )
     image_data = {}
 
-    if socure_doc_escrow_enabled? &&
+    if doc_escrow_enabled? &&
        docv_result_response.instance_of?(DocAuth::Socure::Responses::DocvResultResponse)
 
       job_data = {
@@ -291,12 +291,12 @@ class SocureDocvResultsJob < ApplicationJob
     @sp ||= ServiceProvider.find_by(issuer: document_capture_session.issuer)
   end
 
-  def socure_doc_escrow_enabled?
+  def doc_escrow_enabled?
     FeatureManagement.doc_escrow_enabled?(sp)
   end
 
   def doc_escrow_name
-    "#{sp.issuer}/#{SecureRandom.uuid}"
+    "encrypted_images/#{SecureRandom.uuid}"
   end
 
   def doc_escrow_key

--- a/app/jobs/socure_docv_results_job.rb
+++ b/app/jobs/socure_docv_results_job.rb
@@ -292,7 +292,7 @@ class SocureDocvResultsJob < ApplicationJob
   end
 
   def socure_doc_escrow_enabled?
-    sp&.attempts_api_enabled? && IdentityConfig.store.socure_doc_escrow_enabled
+    FeatureManagement.doc_escrow_enabled?(sp)
   end
 
   def doc_escrow_name

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -11,21 +11,15 @@ module EncryptedDocStorage
       @s3_enabled = s3_enabled
     end
 
-    def write(issuer:, image: nil)
-      raise if issuer.blank?
-
+    def write(issuer: nil, image: nil)
       if image.blank?
         return Result.new(name: nil, encryption_key: nil)
       end
 
-      name = "#{issuer}/#{SecureRandom.uuid}"
+      name = "encrypted_images/#{SecureRandom.uuid}"
       encryption_key = SecureRandom.bytes(32)
 
-      write_with_data(
-        image:,
-        encryption_key:,
-        name:,
-      )
+      write_with_data(image:, encryption_key:, name:)
 
       Result.new(
         name:,

--- a/app/services/encrypted_doc_storage/doc_writer.rb
+++ b/app/services/encrypted_doc_storage/doc_writer.rb
@@ -11,7 +11,7 @@ module EncryptedDocStorage
       @s3_enabled = s3_enabled
     end
 
-    def write(issuer: nil, image: nil)
+    def write(image: nil)
       if image.blank?
         return Result.new(name: nil, encryption_key: nil)
       end

--- a/app/services/idv/idv_images.rb
+++ b/app/services/idv/idv_images.rb
@@ -18,9 +18,9 @@ module Idv
       @errors = {}
     end
 
-    def attempts_file_data(issuer:)
+    def attempts_file_data
       images.each_with_object({}) do |image, obj|
-        result = write_image(issuer:, image: image.bytes)
+        result = write_image(image: image.bytes)
         obj[image.attempts_tracker_file_id_key] = result.name
         obj[image.attempts_tracker_encryption_key] = result.encryption_key
       end
@@ -82,8 +82,8 @@ module Idv
 
     private
 
-    def write_image(issuer:, image:)
-      encrypted_document_storage_writer.write(issuer:, image:)
+    def write_image(image:)
+      encrypted_document_storage_writer.write(image:)
     end
 
     def write_image_with_data(image, encryption_key:, name:)

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -493,7 +493,6 @@ sign_in_user_id_per_ip_attempt_window_in_minutes: 720
 sign_in_user_id_per_ip_attempt_window_max_minutes: 43_200
 sign_in_user_id_per_ip_max_attempts: 50
 skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:dev", "urn:gov:gsa:SAML:2.0.profiles:sp:sso:int"]'
-socure_doc_escrow_enabled: false
 socure_docv_document_request_endpoint: ''
 socure_docv_enabled: false
 socure_docv_images_request_endpoint: ''

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -198,7 +198,7 @@ class FeatureManagement
   def self.doc_escrow_enabled?(service_provider)
     IdentityConfig.store.doc_escrow_enabled && (
       IdentityConfig.store.historical_attempts_api_enabled ||
-      service_provider&.attempts_api_enabled?
+      !!service_provider&.attempts_api_enabled?
     )
   end
 

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -197,8 +197,8 @@ class FeatureManagement
 
   def self.doc_escrow_enabled?(service_provider)
     IdentityConfig.store.doc_escrow_enabled && (
-      service_provider&.attempts_api_enabled? ||
-        IdentityConfig.store.historical_attempts_api_enabled
+      IdentityConfig.store.historical_attempts_api_enabled ||
+      service_provider&.attempts_api_enabled?
     )
   end
 

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -196,7 +196,10 @@ class FeatureManagement
   end
 
   def self.doc_escrow_enabled?(service_provider)
-    IdentityConfig.store.doc_escrow_enabled && service_provider&.attempts_api_enabled?
+    IdentityConfig.store.doc_escrow_enabled && (
+      service_provider&.attempts_api_enabled? ||
+        IdentityConfig.store.historical_attempts_api_enabled
+    )
   end
 
   def self.idv_proofing_agent_enabled?

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -524,7 +524,6 @@ module IdentityConfig
     config.add(:sign_in_recaptcha_score_threshold, type: :float)
     config.add(:sign_in_password_compromised_percent_tested, type: :integer)
     config.add(:skip_encryption_allowed_list, type: :json)
-    config.add(:socure_doc_escrow_enabled, type: :boolean)
     config.add(:socure_docv_document_request_endpoint, type: :string)
     config.add(:socure_docv_enabled, type: :boolean)
     config.add(:socure_docv_images_request_endpoint, type: :string)

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Idv::ImageUploadsController do
           let(:attempts_api_enabled_for_sp) { true }
           before do
             expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-            expect(writer).to receive(:write).with(issuer: sp.issuer, image: nil).and_call_original
+            expect(writer).to receive(:write).with(image: nil).and_call_original
             allow(writer).to receive(:write).and_return result
           end
 

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -509,7 +509,6 @@ RSpec.describe Idv::ApiImageUploadForm do
               form.send(:images).each do |image|
                 # testing that the storage is happening
                 expect(writer).to receive(:write).with(
-                  issuer: service_provider.issuer,
                   image: image.bytes,
                 ).exactly(1).time
               end
@@ -735,7 +734,6 @@ RSpec.describe Idv::ApiImageUploadForm do
                 form.send(:images).each do |image|
                   # testing that the storage is happening
                   expect(writer).to receive(:write).with(
-                    issuer: service_provider.issuer,
                     image: image.bytes,
                   ).exactly(1).time
                 end
@@ -935,7 +933,6 @@ RSpec.describe Idv::ApiImageUploadForm do
             form.send(:images).each do |image|
               # testing that the storage is happening
               expect(writer).to receive(:write).with(
-                issuer: service_provider.issuer,
                 image: image.bytes,
               ).exactly(1).time.and_return(result)
             end
@@ -1018,7 +1015,6 @@ RSpec.describe Idv::ApiImageUploadForm do
             form.send(:images).each do |image|
               # testing that the storage is happening
               expect(writer).to receive(:write).with(
-                issuer: service_provider.issuer,
                 image: image.bytes,
               ).exactly(1).time
             end

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SocureDocvResultsJob do
   let(:document_metadata_type) { 'Drivers License' }
   let(:reason_codes) { %w[I831 R810] }
   let(:writer) { EncryptedDocStorage::DocWriter.new }
-  let(:socure_doc_escrow_enabled) { false }
+  let(:historical_attempts_api_enabled) { false }
   let(:selfie) { false }
   let(:mrz_response) { 'YES' }
   let(:aamva_at_doc_auth_enabled) { false }
@@ -92,13 +92,14 @@ RSpec.describe SocureDocvResultsJob do
 
     rate_limiter.increment!
 
-    enable_attempts_api if socure_doc_escrow_enabled
+    enable_attempts_api if historical_attempts_api_enabled
   end
 
   def enable_attempts_api
     allow(IdentityConfig.store).to receive_messages(
-      socure_doc_escrow_enabled:,
-      attempts_api_enabled: socure_doc_escrow_enabled,
+      historical_attempts_api_enabled:,
+      attempts_api_enabled: historical_attempts_api_enabled,
+      doc_escrow_enabled: historical_attempts_api_enabled,
       allowed_attempts_providers: [{ 'issuer' => sp.issuer }],
     )
     allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
@@ -279,7 +280,7 @@ RSpec.describe SocureDocvResultsJob do
       end
 
       context 'when document escrow is enabled' do
-        let(:socure_doc_escrow_enabled) { true }
+        let(:historical_attempts_api_enabled) { true }
 
         context 'we get a 200-http response from the image endpoint' do
           before do
@@ -314,7 +315,7 @@ RSpec.describe SocureDocvResultsJob do
         end
 
         context 'when we get a non-200 HTTP response back from the image endpoint' do
-          let(:socure_doc_escrow_enabled) { true }
+          let(:historical_attempts_api_enabled) { true }
 
           %w[400 403 404 500].each do |http_status|
             context "Socure returns HTTP #{http_status} with an error body" do
@@ -410,7 +411,7 @@ RSpec.describe SocureDocvResultsJob do
           end
 
           context 'document escrow is enabled' do
-            let(:socure_doc_escrow_enabled) { true }
+            let(:historical_attempts_api_enabled) { true }
 
             before do
               expect(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
@@ -460,7 +461,7 @@ RSpec.describe SocureDocvResultsJob do
           context 'and the socure result response is a failure' do
             let(:decision_value) { 'failed' }
             context 'doc escrow is enabled' do
-              let(:socure_doc_escrow_enabled) { true }
+              let(:historical_attempts_api_enabled) { true }
 
               it 'stores the images via doc escrow' do
                 expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
@@ -814,8 +815,8 @@ RSpec.describe SocureDocvResultsJob do
                   perform
                 end
 
-                context 'when socure_doc_escrow_enabled is true' do
-                  let(:socure_doc_escrow_enabled) { true }
+                context 'when historical_attempts_api_enabled is true' do
+                  let(:historical_attempts_api_enabled) { true }
 
                   it 'tracks the attempt with mrz data' do
                     expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
@@ -1182,7 +1183,7 @@ RSpec.describe SocureDocvResultsJob do
         end
 
         context 'doc escrow is enabled' do
-          let(:socure_doc_escrow_enabled) { true }
+          let(:historical_attempts_api_enabled) { true }
 
           it 'stores the images via doc escrow' do
             expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
@@ -1230,8 +1231,8 @@ RSpec.describe SocureDocvResultsJob do
           )
         end
 
-        context 'doc escrow is enabled' do
-          let(:socure_doc_escrow_enabled) { true }
+        context 'historic attempts data is enabled' do
+          let(:historical_attempts_api_enabled) { true }
 
           it 'stores the images via doc escrow' do
             expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
@@ -1266,7 +1267,7 @@ RSpec.describe SocureDocvResultsJob do
         end
 
         context 'when doc escrow is disabled' do
-          let(:socure_doc_escrow_enabled) { false }
+          let(:historical_attempts_api_enabled) { false }
 
           before do
             allow(attempts_api_tracker).to receive(:idv_document_upload_submitted)
@@ -1308,7 +1309,7 @@ RSpec.describe SocureDocvResultsJob do
         end
 
         context 'doc escrow is enabled' do
-          let(:socure_doc_escrow_enabled) { true }
+          let(:historical_attempts_api_enabled) { true }
 
           it 'tracks the attempt and stores the images via doc escrow' do
             expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
@@ -1438,7 +1439,7 @@ RSpec.describe SocureDocvResultsJob do
           end
 
           context 'doc escrow is enabled' do
-            let(:socure_doc_escrow_enabled) { true }
+            let(:historical_attempts_api_enabled) { true }
             it 'tracks the attempt and stores the images via doc escrow' do
               expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                 success: false,

--- a/spec/jobs/socure_docv_results_job_spec.rb
+++ b/spec/jobs/socure_docv_results_job_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe SocureDocvResultsJob do
   let(:job) { described_class.new }
   let(:user) { create(:user) }
   let(:attempts_api_tracker) { AttemptsApiTrackingHelper::FakeAttemptsTracker.new }
+  let(:attempts_api_enabled) { true }
+  let(:doc_escrow_enabled) { false }
   let(:fraud_opt_tracker) { AttemptsApiTrackingHelper::FakeAttemptsTracker.new }
   let(:sp) { create(:service_provider, app_id: 'Test123') }
   let(:socure_docv_transaction_token) { 'abcd' }
@@ -92,18 +94,24 @@ RSpec.describe SocureDocvResultsJob do
 
     rate_limiter.increment!
 
-    enable_attempts_api if historical_attempts_api_enabled
+    doc_escrow_setup
   end
 
-  def enable_attempts_api
+  def doc_escrow_setup
+    if attempts_api_enabled
+      allowed_attempts_providers = [{ 'issuer' => sp.issuer }]
+    end
     allow(IdentityConfig.store).to receive_messages(
       historical_attempts_api_enabled:,
-      attempts_api_enabled: historical_attempts_api_enabled,
-      doc_escrow_enabled: historical_attempts_api_enabled,
-      allowed_attempts_providers: [{ 'issuer' => sp.issuer }],
+      attempts_api_enabled:,
+      doc_escrow_enabled:,
+      allowed_attempts_providers:,
     )
-    allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
-    allow(writer).to receive(:write_with_data)
+
+    if doc_escrow_enabled
+      allow(EncryptedDocStorage::DocWriter).to receive(:new).and_return(writer)
+      allow(writer).to receive(:write_with_data)
+    end
   end
 
   describe '#perform' do
@@ -280,6 +288,7 @@ RSpec.describe SocureDocvResultsJob do
       end
 
       context 'when document escrow is enabled' do
+        let(:doc_escrow_enabled) { true }
         let(:historical_attempts_api_enabled) { true }
 
         context 'we get a 200-http response from the image endpoint' do
@@ -411,6 +420,7 @@ RSpec.describe SocureDocvResultsJob do
           end
 
           context 'document escrow is enabled' do
+            let(:doc_escrow_enabled) { true }
             let(:historical_attempts_api_enabled) { true }
 
             before do
@@ -461,6 +471,7 @@ RSpec.describe SocureDocvResultsJob do
           context 'and the socure result response is a failure' do
             let(:decision_value) { 'failed' }
             context 'doc escrow is enabled' do
+              let(:doc_escrow_enabled) { true }
               let(:historical_attempts_api_enabled) { true }
 
               it 'stores the images via doc escrow' do
@@ -816,6 +827,7 @@ RSpec.describe SocureDocvResultsJob do
                 end
 
                 context 'when historical_attempts_api_enabled is true' do
+                  let(:doc_escrow_enabled) { true }
                   let(:historical_attempts_api_enabled) { true }
 
                   it 'tracks the attempt with mrz data' do
@@ -1183,6 +1195,7 @@ RSpec.describe SocureDocvResultsJob do
         end
 
         context 'doc escrow is enabled' do
+          let(:doc_escrow_enabled) { true }
           let(:historical_attempts_api_enabled) { true }
 
           it 'stores the images via doc escrow' do
@@ -1232,6 +1245,7 @@ RSpec.describe SocureDocvResultsJob do
         end
 
         context 'historic attempts data is enabled' do
+          let(:doc_escrow_enabled) { true }
           let(:historical_attempts_api_enabled) { true }
 
           it 'stores the images via doc escrow' do
@@ -1267,7 +1281,7 @@ RSpec.describe SocureDocvResultsJob do
         end
 
         context 'when doc escrow is disabled' do
-          let(:historical_attempts_api_enabled) { false }
+          let(:doc_escrow) { false }
 
           before do
             allow(attempts_api_tracker).to receive(:idv_document_upload_submitted)
@@ -1309,6 +1323,7 @@ RSpec.describe SocureDocvResultsJob do
         end
 
         context 'doc escrow is enabled' do
+          let(:doc_escrow_enabled) { true }
           let(:historical_attempts_api_enabled) { true }
 
           it 'tracks the attempt and stores the images via doc escrow' do

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -525,4 +525,66 @@ RSpec.describe 'FeatureManagement' do
       end
     end
   end
+
+  describe '#doc_escrow_enabled?' do
+    let(:service_provider) { create(:service_provider) }
+    let(:attempts_api_enabled) { false }
+    let(:doc_escrow_enabled) { false }
+    let(:historical_attempts_api_enabled) { false }
+
+    before do
+      allow(IdentityConfig.store).to receive(:doc_escrow_enabled).and_return(doc_escrow_enabled)
+      allow(IdentityConfig.store).to receive(:attempts_api_enabled).and_return(attempts_api_enabled)
+      allow(IdentityConfig.store).to receive(:historical_attempts_api_enabled).and_return(
+        historical_attempts_api_enabled,
+      )
+    end
+    context 'when enabled' do
+      let(:doc_escrow_enabled) { true }
+
+      describe 'when historic attempts api is not enabled' do
+        describe 'when no service provider is passed in' do
+          it 'disables the feature' do
+            expect(FeatureManagement.doc_escrow_enabled?(nil)).to eq(false)
+          end
+        end
+
+        describe 'when the service provider is not on the allowlist' do
+          it 'disables the feature' do
+            expect(FeatureManagement.doc_escrow_enabled?(service_provider)).to eq(false)
+          end
+
+          describe 'when the service_provider passed in is on the allowlist' do
+            let(:attempts_api_enabled) { true }
+            before do
+              allow(IdentityConfig.store).to receive(:allowed_attempts_providers).and_return(
+                [{ 'issuer' => service_provider.issuer }],
+              )
+            end
+
+            it 'enables the feature' do
+              expect(FeatureManagement.doc_escrow_enabled?(service_provider)).to eq(true)
+            end
+          end
+        end
+      end
+
+      describe 'when historic attempts api is enabled' do
+        let(:historical_attempts_api_enabled) { true }
+        it 'enables the feature' do
+          expect(FeatureManagement.doc_escrow_enabled?(service_provider)).to eq(true)
+        end
+      end
+    end
+
+    context 'when disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:doc_escrow_enabled).and_return(false)
+      end
+
+      it 'disables the feature' do
+        expect(FeatureManagement.doc_escrow_enabled?(nil)).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
   subject { EncryptedDocStorage::DocWriter.new }
   describe '#write' do
     it 'encrypts the document and writes it to storage' do
-      result = subject.write(issuer:, image:)
+      result = subject.write(image:)
 
       key = Base64.strict_decode64(result.encryption_key)
       aes_cipher = Encryption::AesCipherV2.new
@@ -25,13 +25,11 @@ RSpec.describe EncryptedDocStorage::DocWriter do
 
     context 'when two images are written with the same writer object' do
       it 'each image has a different key' do
-        result = subject.write(issuer:, image:)
-        result1 = subject.write(issuer:, image:)
+        result = subject.write(image:)
+        result1 = subject.write(image:)
 
         expect(result.name).not_to eq(result1.name)
         expect(result.encryption_key).not_to eq(result1.encryption_key)
-        expect(result.name).to start_with(issuer)
-        expect(result1.name).to start_with(issuer)
       end
     end
 
@@ -39,7 +37,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
       expect_any_instance_of(EncryptedDocStorage::LocalStorage).to receive(:write_image).once
       expect_any_instance_of(EncryptedDocStorage::S3Storage).to_not receive(:write_image)
 
-      subject.write(issuer:, image:)
+      subject.write(image:)
     end
 
     context 'when S3Storage is initalized' do
@@ -51,15 +49,15 @@ RSpec.describe EncryptedDocStorage::DocWriter do
         expect_any_instance_of(EncryptedDocStorage::S3Storage).to receive(:write_image).once
         expect_any_instance_of(EncryptedDocStorage::LocalStorage).not_to receive(:write_image)
 
-        result = subject.write(issuer:, image:)
-        expect(result.name).to start_with(issuer)
+        result = subject.write(image:)
+        expect(result.name).to start_with('encrypted_images')
       end
     end
 
     context 'when an image is not passed in' do
       context 'when the image value is nil' do
         it 'returns a blank Result object' do
-          result = subject.write(issuer:, image: nil)
+          result = subject.write(image: nil)
 
           expect(result.name).to be nil
           expect(result.encryption_key).to be nil
@@ -68,7 +66,7 @@ RSpec.describe EncryptedDocStorage::DocWriter do
 
       context 'when the image value is an empty string' do
         it 'returns a blank Result object' do
-          result = subject.write(issuer:, image: '')
+          result = subject.write(image: '')
 
           expect(result.name).to be nil
           expect(result.encryption_key).to be nil

--- a/spec/services/encrypted_doc_storage/doc_writer_spec.rb
+++ b/spec/services/encrypted_doc_storage/doc_writer_spec.rb
@@ -28,6 +28,9 @@ RSpec.describe EncryptedDocStorage::DocWriter do
         result = subject.write(image:)
         result1 = subject.write(image:)
 
+        File.delete(file_path(result.name))
+        File.delete(file_path(result1.name))
+
         expect(result.name).not_to eq(result1.name)
         expect(result.encryption_key).not_to eq(result1.encryption_key)
       end

--- a/spec/services/idv/idv_images_spec.rb
+++ b/spec/services/idv/idv_images_spec.rb
@@ -59,11 +59,11 @@ RSpec.describe Idv::IdvImages do
       expect(EncryptedDocStorage::DocWriter).to receive(:new).with(s3_enabled: false)
       expect(writer).to receive(:write).exactly(2).times
 
-      subject.attempts_file_data(issuer: issuer)
+      subject.attempts_file_data
     end
 
     it 'returns a hash of objects' do
-      expect(subject.attempts_file_data(issuer: issuer)).to be_a_kind_of(Hash)
+      expect(subject.attempts_file_data).to be_a_kind_of(Hash)
     end
 
     context 'when s3 storage is turned on' do
@@ -73,7 +73,7 @@ RSpec.describe Idv::IdvImages do
         expect(EncryptedDocStorage::DocWriter).to receive(:new).with(s3_enabled: true)
         expect(writer).to receive(:write).exactly(2).times
 
-        subject.attempts_file_data(issuer: issuer)
+        subject.attempts_file_data
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 114](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/issues/114)

## 🛠 Summary of changes
This change:
- Removes `socure_doc_escrow_enabled` feature flag
- Updates FeatureManagement.doc_escrow_enabled? method to enable doc escrow when historical_attempts_api_enabled feature flag is set
- Adds specs for the method
- Replaces `issuer` prefix from the doc escrow file directory with `encrypted_images`


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
