### PR TITLE
LG-17478: Update source_check for passport-proofed user

### DIFF
--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4675,6 +4675,14 @@ module AnalyticsEvents
   end
   # rubocop:enable Naming/VariableName,Naming/MethodParameterName,IdentityIdp/AnalyticsEventNameLinter
 
+  # Tracks if a user's passport source_check was corrected
+  def idv_passport_source_check_corrected(**extra)
+    track_event(
+      :idv_passport_source_check_corrected,
+      **extra,
+    )
+  end
+
   # Tracks if a user clicks the 'acknowledge' checkbox during personal
   # key creation
   # @param [Hash,nil] proofing_components User's current proofing components

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -12,6 +12,7 @@ module Pii
 
     def save(user_password, profile = user.active_profile)
       decrypted_pii = profile.decrypt_pii(user_password) if profile
+      correct_passport_source_check(profile) if profile
       save_decrypted_pii(decrypted_pii, profile.id) if decrypted_pii
       rotate_fingerprints_if_stale(profile, decrypted_pii)
       decrypted_pii
@@ -43,6 +44,23 @@ module Pii
     end
 
     private
+
+    # When initially enabled, proofing against a passport recorded the source_check incorrectly.
+    # This was fixed in https://github.com/18F/identity-idp/pull/13039.
+    # Presently we only have one valid source to verify a passport, so we can force the correction.
+    def correct_passport_source_check(profile)
+      # The fix was deployed in April 2026 - only correct profiles created before May 1, 2026
+      return if profile.created_at > DateTime.new(2026, 5, 1)
+
+      proofing_components = profile.proofing_components
+      if proofing_components.present? &&
+         proofing_components['document_type'] == 'passport' &&
+         proofing_components['source_check'] != 'dos:passport'
+        proofing_components['source_check'] = 'dos:passport'
+        profile.proofing_components = proofing_components
+        profile.save!
+      end
+    end
 
     def rotate_fingerprints_if_stale(profile, pii)
       return unless profile.present? && pii.present?

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -50,7 +50,7 @@ module Pii
     # Presently we only have one valid source to verify a passport, so we can force the correction.
     def correct_passport_source_check(profile)
       # The fix was deployed in April 2026 - only correct profiles created before May 1, 2026
-      return if profile.created_at > DateTime.new(2026, 5, 1)
+      return if profile.created_at > Time.zone.local(2026, 5, 1)
 
       proofing_components = profile.proofing_components
       if proofing_components.present? &&

--- a/app/services/pii/cacher.rb
+++ b/app/services/pii/cacher.rb
@@ -59,6 +59,7 @@ module Pii
         proofing_components['source_check'] = 'dos:passport'
         profile.proofing_components = proofing_components
         profile.save!
+        analytics&.idv_passport_source_check_corrected
       end
     end
 

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -36,7 +36,11 @@ RSpec.describe Pii::Cacher do
     profile
   end
 
-  subject { described_class.new(user, user_session) }
+  subject { described_class.new(user, user_session, analytics: @analytics) }
+
+  before do
+    stub_analytics
+  end
 
   describe '#save' do
     it 'writes decrypted PII to user_session for multiple profiles' do
@@ -58,10 +62,6 @@ RSpec.describe Pii::Cacher do
     end
 
     context 'when the original signature was based on an unnormalized SSN' do
-      before do
-        stub_analytics
-      end
-
       let(:ssn) { '123-45-6789' }
 
       it 'updates the ssn_signature based on the normalized form' do
@@ -138,6 +138,7 @@ RSpec.describe Pii::Cacher do
         subject.save(password, profile)
 
         expect(profile.reload.proofing_components['source_check']).to eq('dos:passport')
+        expect(@analytics).to have_logged_event(:idv_passport_source_check_corrected)
       end
 
       it 'does not correct the source_check for a passport created after May 1, 2026' do
@@ -152,6 +153,7 @@ RSpec.describe Pii::Cacher do
         subject.save(password, profile)
 
         expect(profile.reload.proofing_components['source_check']).to eq('incorrect:source')
+        expect(@analytics).to_not have_logged_event(:idv_passport_source_check_corrected)
       end
     end
   end

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -126,12 +126,13 @@ RSpec.describe Pii::Cacher do
     end
 
     context 'when the source_check for a passport is incorrect' do
-      it 'corrects the source_check for a passport' do
-        profile = create(:profile, :active, :verified, user: user)
+      it 'corrects the source_check for a passport created before May 1, 2026' do
+        profile = active_profile
         profile.proofing_components = {
           'document_type' => 'passport',
           'source_check' => 'incorrect:source',
         }
+        profile.created_at = DateTime.new(2026, 4, 30)
         profile.save!
 
         subject.save(password, profile)
@@ -140,7 +141,7 @@ RSpec.describe Pii::Cacher do
       end
 
       it 'does not correct the source_check for a passport created after May 1, 2026' do
-        profile = create(:profile, :active, :verified, user: user)
+        profile = active_profile
         profile.proofing_components = {
           'document_type' => 'passport',
           'source_check' => 'incorrect:source',

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Pii::Cacher do
           'document_type' => 'passport',
           'source_check' => 'incorrect:source',
         }
-        profile.created_at = DateTime.new(2026, 4, 30)
+        profile.created_at = Time.zone.local(2026, 4, 30)
         profile.save!
 
         subject.save(password, profile)
@@ -146,7 +146,7 @@ RSpec.describe Pii::Cacher do
           'document_type' => 'passport',
           'source_check' => 'incorrect:source',
         }
-        profile.created_at = DateTime.new(2026, 5, 2)
+        profile.created_at = Time.zone.local(2026, 5, 2)
         profile.save!
 
         subject.save(password, profile)

--- a/spec/services/pii/cacher_spec.rb
+++ b/spec/services/pii/cacher_spec.rb
@@ -124,6 +124,35 @@ RSpec.describe Pii::Cacher do
         subject.save('incorrect password', active_profile)
       end.to raise_error(Encryption::EncryptionError)
     end
+
+    context 'when the source_check for a passport is incorrect' do
+      it 'corrects the source_check for a passport' do
+        profile = create(:profile, :active, :verified, user: user)
+        profile.proofing_components = {
+          'document_type' => 'passport',
+          'source_check' => 'incorrect:source',
+        }
+        profile.save!
+
+        subject.save(password, profile)
+
+        expect(profile.reload.proofing_components['source_check']).to eq('dos:passport')
+      end
+
+      it 'does not correct the source_check for a passport created after May 1, 2026' do
+        profile = create(:profile, :active, :verified, user: user)
+        profile.proofing_components = {
+          'document_type' => 'passport',
+          'source_check' => 'incorrect:source',
+        }
+        profile.created_at = DateTime.new(2026, 5, 2)
+        profile.save!
+
+        subject.save(password, profile)
+
+        expect(profile.reload.proofing_components['source_check']).to eq('incorrect:source')
+      end
+    end
   end
 
   describe '#fetch' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17478](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17478)

## 🛠 Summary of changes

Upon logging in, we check the proofing components and update the source_check, if necessary.

We only check profiles created prior to May 1, 2026, since the fix for this was deployed to production in mid-April (RC 568)

[skip changelog]

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17478]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17478