### PR TITLE
changelog: User-Facing Improvements, force users to change pwned pas…

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -4,6 +4,7 @@ class AccountsController < ApplicationController
   include RememberDeviceConcern
   before_action :confirm_two_factor_authenticated
   before_action :confirm_user_is_not_suspended
+  before_action :confirm_password_change_not_required
 
   layout 'account_side_nav'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -607,4 +607,10 @@ class ApplicationController < ActionController::Base
 
     redirect_to user_please_call_url
   end
+
+  def confirm_password_change_not_required
+    return unless session[:redirect_to_change_password]
+
+    redirect_to manage_password_url
+  end
 end

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -27,6 +27,7 @@ module OpenidConnect
     before_action :redirect_to_reauthenticate, only: :index, if: :remember_device_expired_for_sp?
     before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: [:index]
     before_action :confirm_user_is_not_suspended, only: :index
+    before_action :confirm_password_change_not_required, only: :index
 
     def index
       if resolved_authn_context_result.identity_proofing?

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -32,6 +32,7 @@ class SamlIdpController < ApplicationController
   before_action :redirect_to_reauthenticate, only: :auth, if: :remember_device_expired_for_sp?
   before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: :auth
   before_action :confirm_user_is_not_suspended, only: :auth
+  before_action :confirm_password_change_not_required, only: :auth
 
   def auth
     capture_analytics

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -98,8 +98,6 @@ module Users
       if @update_user_password_form.personal_key.present?
         user_session[:personal_key] = @update_user_password_form.personal_key
         manage_personal_key_url
-      elsif required_password_change?
-        after_sign_in_path_for(current_user)
       else
         account_path
       end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -59,16 +59,12 @@ module Users
       # that the user remains authenticated.
       bypass_sign_in current_user
 
-      flash[:info] = t('notices.password_changed')
-      if @update_user_password_form.personal_key.present?
-        user_session[:personal_key] = @update_user_password_form.personal_key
-        redirect_to manage_personal_key_url
-      elsif required_password_change?
-        session.delete(:redirect_to_change_password)
-        redirect_to after_sign_in_path_for(current_user)
-      else
-        redirect_to account_path
-      end
+      # Clear the flag for required password change if it was set.
+      session.delete(:redirect_to_change_password) if required_password_change?
+
+      flash[:success] = t('notices.password_changed')
+
+      redirect_to post_update_user_password_path
     end
 
     def handle_invalid_password
@@ -96,6 +92,17 @@ module Users
 
     def user_password_params
       params.require(:update_user_password_form).permit(:password, :password_confirmation)
+    end
+
+    def post_update_user_password_path
+      if @update_user_password_form.personal_key.present?
+        user_session[:personal_key] = @update_user_password_form.personal_key
+        manage_personal_key_url
+      elsif required_password_change?
+        after_sign_in_path_for(current_user)
+      else
+        account_path
+      end
     end
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -317,9 +317,12 @@ module Users
                 !ab_test_eligible? ||
                 compromised_password_check_current?
 
-      is_pwned = PwnedPasswords::LookupPassword.call(auth_params[:password])
-      track_pwned_password if is_pwned
-      update_user_password_compromised_checked_at
+      if PwnedPasswords::LookupPassword.call(auth_params[:password])
+        track_pwned_password
+        session[:redirect_to_change_password] = true
+      else
+        update_user_password_compromised_checked_at
+      end
     end
 
     def compromised_password_check_current?

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe AccountsController do
         :before,
         :confirm_user_is_not_suspended,
       )
+      expect(subject).to have_actions(
+        :before,
+        :confirm_password_change_not_required,
+      )
     end
   end
 
@@ -161,6 +165,18 @@ RSpec.describe AccountsController do
         get :show
 
         expect(response).to redirect_to(user_please_call_url)
+      end
+    end
+
+    context 'when a password change is required' do
+      it 'redirects to the manage password page' do
+        user = create(:user, :fully_registered)
+
+        sign_in user
+        session[:redirect_to_change_password] = true
+        get :show
+
+        expect(response).to redirect_to(manage_password_url)
       end
     end
 

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1411,6 +1411,23 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
       end
     end
+    context 'password change is required' do
+      let(:user) { create(:user, :fully_registered) }
+      let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
+      let(:sign_in_flow) { :sign_in }
+
+      before do
+        stub_sign_in user
+        session[:sign_in_flow] = sign_in_flow
+        session[:sign_in_page_visited_at] = Time.zone.now.to_s
+        session[:redirect_to_change_password] = true
+      end
+
+      it 'redirects to the manage password page' do
+        action
+        expect(response).to redirect_to(manage_password_url)
+      end
+    end
   end
 end
 # rubocop:enable Layout/LineLength

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2114,6 +2114,25 @@ RSpec.describe SamlIdpController do
       end
     end
 
+    context 'password change is required' do
+      let(:user) { create(:user, :fully_registered) }
+      let(:acr_values) do
+        Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF +
+          ' ' +
+          Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF
+      end
+
+      before do
+        sign_in(user)
+        session[:redirect_to_change_password] = true
+      end
+
+      it 'redirects to the manage password page' do
+        saml_get_auth(saml_settings)
+        expect(response).to redirect_to(manage_password_url)
+      end
+    end
+
     describe 'NameID format' do
       let(:user) { create(:user, :fully_registered) }
       let(:subject_element) { xmldoc.subject_nodeset[0] }

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Users::PasswordsController do
           required_password_change: false,
         )
         expect(response).to redirect_to account_url
-        expect(flash[:info]).to eq t('notices.password_changed')
+        expect(flash[:success]).to eq t('notices.password_changed')
         expect(controller.user_session[:personal_key]).to be_nil
       end
 
@@ -164,7 +164,30 @@ RSpec.describe Users::PasswordsController do
             required_password_change: true,
           )
           expect(response).to redirect_to account_url
-          expect(flash[:info]).to eq t('notices.password_changed')
+          expect(flash[:success]).to eq t('notices.password_changed')
+        end
+
+        it 'clears the redirect_to_change_password session flag' do
+          patch :update, params: { update_user_password_form: params }
+
+          expect(session[:redirect_to_change_password]).to be_nil
+        end
+
+        context 'and the user has a proofed profile' do
+          let(:user) { create(:user) }
+
+          before do
+            create(:profile, :active, :verified, user: user, pii: { first_name: 'Jane' })
+            Pii::Cacher.new(user, controller.user_session)
+              .save_decrypted_pii({ first_name: 'Jane' }, user.active_profile.id)
+          end
+
+          it 'redirects to the personal key page and clears the flag' do
+            patch :update, params: { update_user_password_form: params }
+
+            expect(response).to redirect_to manage_personal_key_url
+            expect(session[:redirect_to_change_password]).to be_nil
+          end
         end
 
         it 'sends email notifying user of password change' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -577,12 +577,29 @@ RSpec.describe Users::SessionsController, devise: true do
           allow(Analytics).to receive(:new).and_return(analytics)
           reload_ab_tests
         end
-        it 'updates user attribute password_compromised_checked_at' do
+        it 'does not update user attribute password_compromised_checked_at' do
           expect(user.password_compromised_checked_at).to be_falsey
           freeze_time do
             post :create, params: { user: { email: user.email, password: user.password } }
-            expect(user.reload.password_compromised_checked_at).to eq Time.zone.now
+            expect(user.reload.password_compromised_checked_at).to be_falsey
           end
+        end
+
+        it 'sets the redirect_to_change_password session flag' do
+          post :create, params: { user: { email: user.email, password: user.password } }
+          expect(session[:redirect_to_change_password]).to eq true
+        end
+
+        it 'forces the check again on a subsequent login since the timestamp is not set' do
+          post :create, params: { user: { email: user.email, password: user.password } }
+          expect(session[:redirect_to_change_password]).to eq true
+          expect(user.reload.password_compromised_checked_at).to be_falsey
+
+          sign_out :user
+          session.delete(:redirect_to_change_password)
+
+          post :create, params: { user: { email: user.email, password: user.password } }
+          expect(session[:redirect_to_change_password]).to eq true
         end
 
         it 'posts an analytics event when password is compromised' do
@@ -608,6 +625,11 @@ RSpec.describe Users::SessionsController, devise: true do
             post :create, params: { user: { email: user.email, password: user.password } }
             expect(user.reload.password_compromised_checked_at).to eq Time.zone.now
           end
+        end
+
+        it 'does not set the redirect_to_change_password session flag' do
+          post :create, params: { user: { email: user.email, password: user.password } }
+          expect(session[:redirect_to_change_password]).to be_nil
         end
       end
     end

--- a/spec/features/users/password_compromised_spec.rb
+++ b/spec/features/users/password_compromised_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.feature 'Forced password change when password is compromised' do
+  include SamlAuthHelper
+
+  let(:user) { user_with_2fa }
+
+  before do
+    allow(FeatureManagement).to receive(:check_password_enabled?).and_return(true)
+    allow(IdentityConfig.store)
+      .to receive(:sign_in_password_compromised_percent_tested)
+      .and_return(100)
+    allow(PwnedPasswords::LookupPassword).to receive(:call).and_return(true)
+    reload_ab_tests
+  end
+
+  after { reload_ab_tests }
+
+  scenario 'user is forced to the manage password page after signing in' do
+    sign_in_live_with_2fa(user)
+
+    expect(page).to have_current_path(manage_password_path)
+  end
+
+  scenario 'user cannot navigate away to the account page until they change it' do
+    sign_in_live_with_2fa(user)
+    expect(page).to have_current_path(manage_password_path)
+
+    visit account_path
+
+    expect(page).to have_current_path(manage_password_path)
+  end
+
+  scenario 'user can reach the account page after changing the password' do
+    sign_in_live_with_2fa(user)
+    expect(page).to have_current_path(manage_password_path)
+
+    allow(PwnedPasswords::LookupPassword).to receive(:call).and_return(false)
+
+    new_password = 'a fresh uncompromised password'
+    fill_in t('forms.passwords.edit.labels.password'), with: new_password
+    fill_in t('components.password_confirmation.confirm_label'), with: new_password
+    click_button t('forms.passwords.edit.buttons.submit')
+
+    visit account_path
+
+    expect(page).to have_current_path(account_path)
+  end
+end


### PR DESCRIPTION
…swords, change from just logging to forcing users to change passwords when found in pwned password set

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket

Link to the relevant ticket:
[LG-17569](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17569)



## 🛠 Summary of changes

In the app/controllers/users/sessions_controller.rb behind the gate conditions:
```      
                return if !FeatureManagement.check_password_enabled? ||
                !ab_test_eligible? ||
                compromised_password_check_current?
```
We check if the user's current password is found in a Pwned passwords set. 
Currently we can only collect analytics when a user's password is found to be a pwned. 
These changes will force the user to change their password once authenticated if password is found to be pwned.

Changes affect the login flow from Login.gov and from SPs on both SAML and OIDC routes. 

### app/controllers/users/sessions_controller.rb
- If pwned set the redirect_to_change_password flag to require the redirect to change password after 2FA.
- Currently the password_compromised_checked_at time_stamp on every check and use this time stamp to skip the password check next time if less than 30 days have passed. This leaves a gap in case the user abandons the password change and comes back for example tomorrow and authenticates. We would not check again for 30 days. 
With this change we will only update this time stamp if we confirm that the password is not pwned otherwise we do not. 

### app/controllers/users/passwords_controller.rb
- When the user redirected here to change password remove the redirect_to_change_password flag (basically has been consumed)

### app/controllers/application_controller.rb
- add method to enforce redirect if password change required


### Enforce change password redirect
- app/controllers/accounts_controller.rb
- app/controllers/saml_idp_controller.rb
- app/controllers/openid_connect/authorization_controller.rb

### New Feature Spec
- spec/features/users/password_compromised_spec.rb

### Updated Specs
- spec/controllers/users/passwords_controller_spec.rb
- spec/controllers/users/sessions_controller_spec.rb
- spec/controllers/accounts_controller_spec.rb
- spec/controllers/saml_idp_controller_spec.rb


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.
Testing in Katherine Sandbox environment. 
- [ ] Step 1 Create or reuse existing user for example daniel.mage+070126@gsa.gov
- [ ] Step 2 In the katherine console change the password of this user to a known pwned password
```
# WRITE: BE CAREFUL: This script is intended to be run in a sandbox environment. 
aws-vault exec sandbox-power -- \
    ./bin/ssm-instance --document rails-w --any asg-katherine-idp

user = EmailAddress.find_with_email('daniel.mage+070126@gsa.gov')&.user

user.update!(password: '3.1415926535', password_confirmation: '3.1415926535')

user.update!(password_compromised_checked_at: 90.days.ago)
```
- [x] Step 3 Use the testing app[Katherine SAMAL](https://katherine-identity-saml-sinatra.app.cloud.gov/)
- [x] Step 4 Go through the sign-in flow. Do you see the change password page?
- [x] Step 5 Once logged in but before you change your password, try to navigate to the accounts page, you should be redirected back.
- [x] Step 6 Finish changing password you should be taken to the accounts page, there will be a green notification that you have successfully updated your password and a link to continue to the SP where you started. 

## 👀 Screenshots

https://github.com/user-attachments/assets/f574a3b9-4121-4227-8bc3-3b69f161fef7
<!--



If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17569]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17569