### PR TITLE
User registration initiated on auth request

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -246,7 +246,7 @@ module SamlIdpAuthConcern
   end
 
   def request_url
-    url = URI(api_saml_auth_url(path_year: params[:path_year]))
+    url = URI(api_saml_auth_url(path_year: params[:path_year], prompt: params[:prompt]))
 
     query_params = request.query_parameters
     unless query_params['SAMLRequest']

--- a/app/controllers/openid_connect/authorization_controller.rb
+++ b/app/controllers/openid_connect/authorization_controller.rb
@@ -22,7 +22,7 @@ module OpenidConnect
     before_action :handle_banned_user
     before_action :handle_duplicate_profile_user, only: :index
     before_action :bump_auth_count, only: :index
-    before_action :redirect_to_sign_in, only: :index, unless: :user_signed_in?
+    before_action :redirect_to_sign_in_or_create, only: :index, unless: :user_signed_in?
     before_action :confirm_two_factor_authenticated, only: :index
     before_action :redirect_to_reauthenticate, only: :index, if: :remember_device_expired_for_sp?
     before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: [:index]
@@ -74,8 +74,12 @@ module OpenidConnect
       true
     end
 
-    def redirect_to_sign_in
-      redirect_to new_user_session_url
+    def redirect_to_sign_in_or_create
+      if @authorize_form.initiate_user_registration?
+        redirect_to sign_up_email_url
+      else
+        redirect_to new_user_session_url
+      end
     end
 
     def redirect_to_reauthenticate

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -27,7 +27,7 @@ class SamlIdpController < ApplicationController
   before_action :handle_banned_user
   before_action :handle_duplicate_profile_user, only: :auth
   before_action :bump_auth_count, only: :auth
-  before_action :redirect_to_sign_in, only: :auth, unless: :user_signed_in?
+  before_action :redirect_to_sign_in_or_create, only: :auth, unless: :user_signed_in?
   before_action :confirm_two_factor_authenticated, only: :auth
   before_action :redirect_to_reauthenticate, only: :auth, if: :remember_device_expired_for_sp?
   before_action :prompt_for_password_if_ial2_request_and_pii_locked, only: :auth
@@ -118,8 +118,12 @@ class SamlIdpController < ApplicationController
 
   private
 
-  def redirect_to_sign_in
-    redirect_to new_user_session_url
+  def redirect_to_sign_in_or_create
+    if params[:prompt] == 'create' && saml_request_service_provider&.create_prompt_allowed?
+      redirect_to sign_up_email_url
+    else
+      redirect_to new_user_session_url
+    end
   end
 
   def redirect_to_reauthenticate

--- a/app/controllers/saml_idp_controller.rb
+++ b/app/controllers/saml_idp_controller.rb
@@ -119,11 +119,17 @@ class SamlIdpController < ApplicationController
   private
 
   def redirect_to_sign_in_or_create
-    if params[:prompt] == 'create' && saml_request_service_provider&.create_prompt_allowed?
+    # Using query params &prompt=create to trigger user registration
+    # from authentication in order to mirror standard OIDC behavior
+    if params[:prompt] == 'create' && create_prompt_allowed?
       redirect_to sign_up_email_url
     else
       redirect_to new_user_session_url
     end
+  end
+
+  def create_prompt_allowed?
+    saml_request_service_provider&.create_prompt_allowed?
   end
 
   def redirect_to_reauthenticate
@@ -158,6 +164,8 @@ class SamlIdpController < ApplicationController
       matching_cert_serial:,
       requested_nameid_format: saml_request.name_id_format,
       unknown_authn_contexts:,
+      prompt: params[:prompt],
+      allow_prompt_create: create_prompt_allowed?,
     )
 
     if result.success? && saml_request.signed?
@@ -189,6 +197,8 @@ class SamlIdpController < ApplicationController
       matching_cert_serial:,
       unknown_authn_contexts:,
       user_fully_authenticated: user_fully_authenticated?,
+      prompt: params[:prompt],
+      allow_prompt_create: create_prompt_allowed?,
     )
   end
 

--- a/app/controllers/saml_post_controller.rb
+++ b/app/controllers/saml_post_controller.rb
@@ -11,7 +11,7 @@ class SamlPostController < ApplicationController
       return
     end
 
-    form_params = params.permit(:SAMLRequest, :RelayState, :SigAlg, :Signature)
+    form_params = params.permit(:SAMLRequest, :RelayState, :SigAlg, :Signature, :prompt)
 
     render 'shared/saml_post_form', locals: { action_url: action_url, form_params: form_params },
                                     layout: false

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -251,6 +251,7 @@ class OpenidConnectAuthorizeForm
       client_id: client_id,
       prompt: prompt,
       allow_prompt_login: service_provider&.allow_prompt_login,
+      allow_prompt_create: service_provider&.create_prompt_allowed?,
       redirect_uri: result_uri,
       scope: scope&.sort&.join(' '),
       acr_values: acr_values&.sort&.join(' '),

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -145,6 +145,10 @@ class OpenidConnectAuthorizeForm
       Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF
   end
 
+  def initiate_user_registration?
+    prompt == 'create'
+  end
+
   private
 
   attr_reader :identity, :success

--- a/app/forms/openid_connect_authorize_form.rb
+++ b/app/forms/openid_connect_authorize_form.rb
@@ -57,7 +57,7 @@ class OpenidConnectAuthorizeForm
   validates :nonce, presence: true, length: { minimum: RANDOM_VALUE_MINIMUM_LENGTH }
 
   validates :response_type, inclusion: { in: %w[code] }
-  validates :prompt, presence: true, inclusion: { in: %w[login select_account] }
+  validates :prompt, presence: true, inclusion: { in: %w[create login select_account] }
   validates :code_challenge_method, inclusion: { in: %w[S256] }, if: :code_challenge
 
   validate :validate_acr_values
@@ -208,6 +208,8 @@ class OpenidConnectAuthorizeForm
   def validate_prompt
     return if prompt == 'select_account'
     return if prompt == 'login' && service_provider&.allow_prompt_login
+    return if prompt == 'create' && service_provider&.create_prompt_allowed?
+
     errors.add(
       :prompt, t('openid_connect.authorization.errors.prompt_invalid'),
       type: :prompt_invalid

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -94,6 +94,10 @@ class ServiceProvider < ApplicationRecord
     end
   end
 
+  def create_prompt_allowed?
+    IdentityConfig.store.allowed_create_prompt_providers.include?(issuer)
+  end
+
   def logo_url
     LogoUrl.new(logo, remote_logo_key).url
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -7364,8 +7364,9 @@ module AnalyticsEvents
   # Tracks when openid authorization request is made
   # @param [Boolean] success Whether form validations were succcessful
   # @param [Hash] error_details Details for errors that occurred in unsuccessful submission
-  # @param [String] prompt OIDC prompt parameter
+  # @param ['create','login','select_account'] prompt OIDC prompt parameter
   # @param [Boolean] allow_prompt_login Whether service provider is configured to allow prompt=login
+  # @param [Boolean] allow_prompt_create if service provider is configured to allow prompt=create
   # @param [Boolean] code_challenge_present Whether code challenge is present
   # @param [Boolean, nil] service_provider_pkce Whether service provider is configured with PKCE
   # @param [String, nil] referer Request referer
@@ -7379,6 +7380,7 @@ module AnalyticsEvents
     success:,
     prompt:,
     allow_prompt_login:,
+    allow_prompt_create:,
     code_challenge_present:,
     service_provider_pkce:,
     referer:,
@@ -7397,6 +7399,7 @@ module AnalyticsEvents
       error_details:,
       prompt:,
       allow_prompt_login:,
+      allow_prompt_create:,
       code_challenge_present:,
       service_provider_pkce:,
       referer:,
@@ -8223,6 +8226,8 @@ module AnalyticsEvents
   # @param [Boolean] finish_profile
   # @param [String] requested_ial
   # @param [Boolean] request_signed
+  # @param [Boolean] allow_prompt_create If service provider is configured to allow prompt=create
+  # @param ['create', nil] prompt
   # @param [String] matching_cert_serial matches the request certificate in a successful, signed
   #   request
   # @param [Hash] cert_error_details Details for errors that occurred because of an invalid
@@ -8241,9 +8246,11 @@ module AnalyticsEvents
     requested_ial:,
     request_signed:,
     matching_cert_serial:,
+    allow_prompt_create:,
     error_details: nil,
     cert_error_details: nil,
     unknown_authn_contexts: nil,
+    prompt: nil,
     **extra
   )
     track_event(
@@ -8263,6 +8270,8 @@ module AnalyticsEvents
       matching_cert_serial:,
       cert_error_details:,
       unknown_authn_contexts:,
+      prompt:,
+      allow_prompt_create:,
       **extra,
     )
   end
@@ -8277,6 +8286,8 @@ module AnalyticsEvents
   # @param [String] matching_cert_serial
   # @param [String] unknown_authn_contexts space separated list of unknown contexts
   # @param [Boolean] user_fully_authenticated
+  # @param [Boolean] allow_prompt_create If service provider is configured to allow prompt=create
+  # @param ['create', nil] prompt
   # An external request for SAML Authentication was received
   def saml_auth_request(
     requested_ial:,
@@ -8289,6 +8300,8 @@ module AnalyticsEvents
     matching_cert_serial:,
     unknown_authn_contexts:,
     user_fully_authenticated:,
+    allow_prompt_create:,
+    prompt: nil,
     **extra
   )
     track_event(
@@ -8303,6 +8316,8 @@ module AnalyticsEvents
       matching_cert_serial:,
       unknown_authn_contexts:,
       user_fully_authenticated:,
+      prompt:,
+      allow_prompt_create:,
       **extra,
     )
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -43,7 +43,7 @@ agent_proofed_user_time_validity_hours: 1
 all_redirect_uris_cache_duration_minutes: 2
 allowed_attempts_providers: '[]'
 allowed_client_id_in_risc_service_providers: '[]'
-allowed_create_login_providers: '[]'
+allowed_create_prompt_providers: '[]'
 allowed_ialmax_providers: '[]'
 allowed_verified_within_providers: '[]'
 api_transaction_count_report_config: '[]'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -43,6 +43,7 @@ agent_proofed_user_time_validity_hours: 1
 all_redirect_uris_cache_duration_minutes: 2
 allowed_attempts_providers: '[]'
 allowed_client_id_in_risc_service_providers: '[]'
+allowed_create_login_providers: '[]'
 allowed_ialmax_providers: '[]'
 allowed_verified_within_providers: '[]'
 api_transaction_count_report_config: '[]'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -59,7 +59,7 @@ module IdentityConfig
     config.add(:agent_proofed_user_time_validity_hours, type: :integer)
     config.add(:all_redirect_uris_cache_duration_minutes, type: :integer)
     config.add(:allowed_attempts_providers, type: :json)
-    config.add(:allowed_create_login_providers, type: :json)
+    config.add(:allowed_create_prompt_providers, type: :json)
     config.add(:allowed_client_id_in_risc_service_providers, type: :json)
     config.add(:allowed_ialmax_providers, type: :json)
     config.add(:allowed_verified_within_providers, type: :json)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -59,6 +59,7 @@ module IdentityConfig
     config.add(:agent_proofed_user_time_validity_hours, type: :integer)
     config.add(:all_redirect_uris_cache_duration_minutes, type: :integer)
     config.add(:allowed_attempts_providers, type: :json)
+    config.add(:allowed_create_login_providers, type: :json)
     config.add(:allowed_client_id_in_risc_service_providers, type: :json)
     config.add(:allowed_ialmax_providers, type: :json)
     config.add(:allowed_verified_within_providers, type: :json)

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1326,6 +1326,41 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
       end
     end
+
+    context 'with prompt=create' do
+      let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
+      let(:prompt) { 'create' }
+
+      context 'sp is not on the allowlist for prompt=create' do
+        it 'redirects back to the sp with errors' do
+          action
+          expect(controller).to render_template('openid_connect/shared/redirect_js')
+          uri = URI(assigns(:oidc_redirect_uri))
+          resp_params = CGI.parse(uri.query)
+
+          expect(uri.to_s).to start_with(params[:redirect_uri])
+          expect(resp_params['error']).to eq ['invalid_request']
+          expect(resp_params['error_description']).to eq(
+            [
+              'Prompt No valid prompt values found. Please see our documentation at https://developers.login.gov/support/#oidc-no-prompt',
+            ],
+          )
+        end
+      end
+
+      context 'sp is on the allowist for prompt=create' do
+        before do
+          allow(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
+            .and_return([client_id])
+        end
+
+        it 'redirects to the create view' do
+          action
+
+          expect(response).to redirect_to(sign_up_email_url)
+        end
+      end
+    end
   end
 end
 # rubocop:enable Layout/LineLength

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
               client_id: client_id,
               prompt: 'select_account',
               allow_prompt_login: true,
+              allow_prompt_create: false,
               unauthorized_scope: true,
               user_fully_authenticated: true,
               acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
@@ -228,6 +229,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 client_id: client_id,
                 prompt: 'select_account',
                 allow_prompt_login: true,
+                allow_prompt_create: false,
                 unauthorized_scope: false,
                 user_fully_authenticated: true,
                 acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
@@ -619,6 +621,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                   client_id: client_id,
                   prompt: 'select_account',
                   allow_prompt_login: true,
+                  allow_prompt_create: false,
                   unauthorized_scope: false,
                   user_fully_authenticated: true,
                   acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
@@ -727,6 +730,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                   client_id: client_id,
                   prompt: 'select_account',
                   allow_prompt_login: true,
+                  allow_prompt_create: false,
                   unauthorized_scope: false,
                   user_fully_authenticated: true,
                   acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
@@ -806,6 +810,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                   client_id: client_id,
                   prompt: 'select_account',
                   allow_prompt_login: true,
+                  allow_prompt_create: false,
                   unauthorized_scope: false,
                   user_fully_authenticated: true,
                   acr_values: 'http://idmanagement.gov/ns/assurance/ial/0',
@@ -929,6 +934,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             client_id: client_id,
             prompt: '',
             allow_prompt_login: true,
+            allow_prompt_create: false,
             unauthorized_scope: true,
             error_details: hash_including(:prompt),
             user_fully_authenticated: true,
@@ -990,6 +996,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
               client_id:,
               prompt:,
               allow_prompt_login: true,
+              allow_prompt_create: false,
               unauthorized_scope: false,
               error_details: hash_including(:acr_values),
               user_fully_authenticated: true,
@@ -1030,6 +1037,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
                 client_id:,
                 prompt:,
                 allow_prompt_login: true,
+                allow_prompt_create: false,
                 unauthorized_scope: false,
                 user_fully_authenticated: true,
                 acr_values: known_value,
@@ -1276,6 +1284,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
             client_id: client_id,
             prompt: 'select_account',
             allow_prompt_login: true,
+            allow_prompt_create: false,
             unauthorized_scope: true,
             user_fully_authenticated: false,
             acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
@@ -1330,6 +1339,10 @@ RSpec.describe OpenidConnect::AuthorizationController do
     context 'with prompt=create' do
       let(:acr_values) { Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF }
       let(:prompt) { 'create' }
+      let(:now) { Time.zone.now }
+      let(:user) { create(:user) }
+
+      before { stub_analytics }
 
       context 'sp is not on the allowlist for prompt=create' do
         it 'redirects back to the sp with errors' do
@@ -1346,6 +1359,25 @@ RSpec.describe OpenidConnect::AuthorizationController do
             ],
           )
         end
+
+        it 'tracks the prompt value' do
+          action
+
+          expect(@analytics).to have_logged_event(
+            'OpenID Connect: authorization request',
+            success: false,
+            client_id: client_id,
+            prompt: 'create',
+            allow_prompt_login: true,
+            allow_prompt_create: false,
+            unauthorized_scope: true,
+            user_fully_authenticated: false,
+            acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+            code_challenge_present: false,
+            scope: 'openid',
+            error_details: { prompt: { prompt_invalid: true } },
+          )
+        end
       end
 
       context 'sp is on the allowlist for prompt=create' do
@@ -1358,6 +1390,24 @@ RSpec.describe OpenidConnect::AuthorizationController do
           action
 
           expect(response).to redirect_to(sign_up_email_url)
+        end
+
+        it 'tracks the prompt value' do
+          action
+
+          expect(@analytics).to have_logged_event(
+            'OpenID Connect: authorization request',
+            success: true,
+            client_id: client_id,
+            prompt: 'create',
+            allow_prompt_login: true,
+            allow_prompt_create: true,
+            unauthorized_scope: true,
+            user_fully_authenticated: false,
+            acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+            code_challenge_present: false,
+            scope: 'openid',
+          )
         end
       end
     end

--- a/spec/controllers/openid_connect/authorization_controller_spec.rb
+++ b/spec/controllers/openid_connect/authorization_controller_spec.rb
@@ -1348,7 +1348,7 @@ RSpec.describe OpenidConnect::AuthorizationController do
         end
       end
 
-      context 'sp is on the allowist for prompt=create' do
+      context 'sp is on the allowlist for prompt=create' do
         before do
           allow(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
             .and_return([client_id])

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -790,6 +790,7 @@ RSpec.describe SamlIdpController do
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
             user_fully_authenticated: true,
+            allow_prompt_create: false,
           }
         )
         expect(@analytics).to have_logged_event(
@@ -806,6 +807,7 @@ RSpec.describe SamlIdpController do
             finish_profile: false,
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
+            allow_prompt_create: false,
           ),
         )
         expect(@analytics).to have_logged_event(
@@ -982,6 +984,7 @@ RSpec.describe SamlIdpController do
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
             user_fully_authenticated: true,
+            allow_prompt_create: false,
           }
         )
         expect(@analytics).to have_logged_event(
@@ -998,6 +1001,7 @@ RSpec.describe SamlIdpController do
             finish_profile: false,
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
+            allow_prompt_create: false,
           ),
         )
         expect(@analytics).to have_logged_event(
@@ -1286,6 +1290,7 @@ RSpec.describe SamlIdpController do
             matching_cert_serial: saml_test_sp_cert_serial,
             force_authn: true,
             user_fully_authenticated: false,
+            allow_prompt_create: false,
           }
         )
       end
@@ -2318,6 +2323,27 @@ RSpec.describe SamlIdpController do
         expect(session[:sp][:request_id]).to eq sp_request_id
       end
 
+      it 'logs SAML Auth Request' do
+        stub_analytics
+
+        saml_get_auth(saml_settings, prompt: 'create')
+
+        expect(@analytics).to have_logged_event(
+          'SAML Auth Request', {
+            authn_context: request_authn_contexts,
+            requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+            service_provider: 'http://localhost:3000',
+            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            request_signed: true,
+            matching_cert_serial: saml_test_sp_cert_serial,
+            force_authn: false,
+            user_fully_authenticated: false,
+            allow_prompt_create: false,
+            prompt: 'create',
+          }
+        )
+      end
+
       context 'when prompt=create is passed as a query params' do
         context 'when sp is not on allowlist' do
           it 'redirects the user to the new user session path' do
@@ -2339,6 +2365,27 @@ RSpec.describe SamlIdpController do
             expect(response).to redirect_to sign_up_email_path
             expect(session[:sp][:request_id]).to eq sp_request_id
           end
+
+          it 'logs SAML Auth Request' do
+            stub_analytics
+
+            saml_get_auth(saml_settings, prompt: 'create')
+
+            expect(@analytics).to have_logged_event(
+              'SAML Auth Request', {
+                authn_context: request_authn_contexts,
+                requested_ial: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+                service_provider: 'http://localhost:3000',
+                requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+                request_signed: true,
+                matching_cert_serial: saml_test_sp_cert_serial,
+                force_authn: false,
+                user_fully_authenticated: false,
+                allow_prompt_create: true,
+                prompt: 'create',
+              }
+            )
+          end
         end
       end
 
@@ -2357,6 +2404,7 @@ RSpec.describe SamlIdpController do
             matching_cert_serial: saml_test_sp_cert_serial,
             force_authn: false,
             user_fully_authenticated: false,
+            allow_prompt_create: false,
           }
         )
       end
@@ -2819,6 +2867,7 @@ RSpec.describe SamlIdpController do
             force_authn: false,
             request_signed: false,
             user_fully_authenticated: true,
+            allow_prompt_create: false,
           }
         )
         expect(@analytics).to have_logged_event(
@@ -2836,6 +2885,7 @@ RSpec.describe SamlIdpController do
             endpoint: "/api/saml/auth#{path_year}",
             idv: true,
             finish_profile: false,
+            allow_prompt_create: false,
             request_signed: false,
           ),
         )
@@ -2874,6 +2924,7 @@ RSpec.describe SamlIdpController do
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
             user_fully_authenticated: true,
+            allow_prompt_create: false,
           }
         )
         expect(@analytics).to have_logged_event(
@@ -2890,6 +2941,7 @@ RSpec.describe SamlIdpController do
             finish_profile: false,
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
+            allow_prompt_create: false,
           ),
         )
         expect(@analytics).to have_logged_event(
@@ -2928,6 +2980,7 @@ RSpec.describe SamlIdpController do
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
             user_fully_authenticated: true,
+            allow_prompt_create: false,
           }
         )
         expect(@analytics).to have_logged_event(
@@ -2944,6 +2997,7 @@ RSpec.describe SamlIdpController do
             finish_profile: true,
             request_signed: true,
             matching_cert_serial: saml_test_sp_cert_serial,
+            allow_prompt_create: false,
           ),
         )
         expect(@analytics).to have_logged_event(

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2318,6 +2318,30 @@ RSpec.describe SamlIdpController do
         expect(session[:sp][:request_id]).to eq sp_request_id
       end
 
+      context 'when prompt=create is passed as a query params' do
+        context 'when sp is not on allowlist' do
+          it 'redirects the user to the new user session path' do
+            saml_get_auth(saml_settings, prompt: 'create')
+            sp_request_id = ServiceProviderRequestProxy.last.uuid
+            expect(response).to redirect_to new_user_session_path
+            expect(session[:sp][:request_id]).to eq sp_request_id
+          end
+        end
+
+        context 'when sp is on allowlist' do
+          before do
+            allow(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
+              .and_return(['http://localhost:3000'])
+          end
+          it 'redirects the user to the sign up email path' do
+            saml_get_auth(saml_settings, prompt: 'create')
+            sp_request_id = ServiceProviderRequestProxy.last.uuid
+            expect(response).to redirect_to sign_up_email_path
+            expect(session[:sp][:request_id]).to eq sp_request_id
+          end
+        end
+      end
+
       it 'logs SAML Auth Request but does not log SAML Auth' do
         stub_analytics
 

--- a/spec/controllers/saml_post_controller_spec.rb
+++ b/spec/controllers/saml_post_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SamlPostController do
     let(:sig_alg) { 'aes256' }
     let(:signature) { 'xyz789' }
     let(:path_year) { SamlAuthHelper::PATH_YEAR }
+    let(:prompt) { 'create' }
 
     it 'renders the appropriate form' do
       post :auth, params: {
@@ -18,7 +19,8 @@ RSpec.describe SamlPostController do
         'RelayState' => relay_state,
         'SigAlg' => sig_alg,
         'Signature' => signature,
-        path_year: path_year,
+        path_year:,
+        prompt:,
       }
 
       expect(response.body).to match(form_action_regex)
@@ -26,10 +28,11 @@ RSpec.describe SamlPostController do
       expect(response.body).to match(hidden_field_tag('RelayState', relay_state))
       expect(response.body).to match(hidden_field_tag('SigAlg', sig_alg))
       expect(response.body).to match(hidden_field_tag('Signature', signature))
+      expect(response.body).to match(hidden_field_tag('prompt', prompt))
     end
 
     it 'does not render extra parameters' do
-      post :auth, params: { 'Foo' => 'bar', path_year: path_year }
+      post :auth, params: { 'Foo' => 'bar', path_year: }
 
       expect(response.body).not_to match(hidden_field_tag('Foo', 'bar'))
     end

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature 'IAL1 Single Sign On' do
 
     context 'when the sp requests user registration flow' do
       before do
-        expect(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
+        allow(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
           .and_return(['http://localhost:3000'])
       end
 

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -100,11 +100,12 @@ RSpec.feature 'IAL1 Single Sign On' do
       expect(page).to have_current_path(test_saml_decode_assertion_path)
     end
 
-    context 'when the sp request user registration flow' do
+    context 'when the sp requests user registration flow' do
       before do
         expect(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
           .and_return(['http://localhost:3000'])
       end
+
       it 'sends the user to the account creation view initially' do
         visit saml_authn_request_url(params: { prompt: 'create' })
 

--- a/spec/features/saml/ial1_sso_spec.rb
+++ b/spec/features/saml/ial1_sso_spec.rb
@@ -4,8 +4,9 @@ RSpec.feature 'IAL1 Single Sign On' do
   include SamlAuthHelper
 
   context 'First time registration', email: true do
+    let(:email) { 'test@test.com' }
+
     it 'takes user to agency handoff page when sign up flow complete' do
-      email = 'test@test.com'
       request_url = saml_authn_request_url
 
       perform_in_browser(:one) do
@@ -97,6 +98,29 @@ RSpec.feature 'IAL1 Single Sign On' do
       click_agree_and_continue
 
       expect(page).to have_current_path(test_saml_decode_assertion_path)
+    end
+
+    context 'when the sp request user registration flow' do
+      before do
+        expect(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
+          .and_return(['http://localhost:3000'])
+      end
+      it 'sends the user to the account creation view initially' do
+        visit saml_authn_request_url(params: { prompt: 'create' })
+
+        expect(page).to have_current_path(sign_up_email_path)
+
+        submit_form_with_valid_email(email)
+        click_confirmation_link_in_email(email)
+
+        submit_form_with_valid_password
+        set_up_2fa_with_valid_phone
+        skip_second_mfa_prompt
+        click_agree_and_continue
+
+        expect(page).to have_current_path complete_saml_path
+        expect(page.get_rack_session.keys).to include('sp')
+      end
     end
   end
 

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'IAL2 Single Sign On' do
   include IdvStepHelper
   include DocAuthHelper
 
-  def saml_ial2_request_url
+  def saml_ial2_request_url(params: {})
     saml_authn_request_url(
       overrides: {
         issuer: 'saml_sp_ial2',
@@ -15,6 +15,7 @@ RSpec.feature 'IAL2 Single Sign On' do
           "#{Saml::Idp::Constants::REQUESTED_ATTRIBUTES_CLASSREF}phone",
         ],
       },
+      params:,
     )
   end
 
@@ -63,6 +64,14 @@ RSpec.feature 'IAL2 Single Sign On' do
 
       expect(page).to have_current_path(new_user_session_path)
       expect(page).to have_content(sp_content)
+    end
+
+    context 'when prompt=create is passed in a params' do
+      it 'send the user to account creation' do
+        visit saml_ial2_request_url(params: { prompt: 'create' })
+
+        expect(page).to have_current_path(sign_up_email_path)
+      end
     end
 
     it 'shows user the start page with a link back to the SP' do

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -66,8 +66,13 @@ RSpec.feature 'IAL2 Single Sign On' do
       expect(page).to have_content(sp_content)
     end
 
-    context 'when prompt=create is passed in a params' do
-      it 'send the user to account creation' do
+    context 'when the sp requests user registration flow' do
+      before do
+        allow(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
+          .and_return(['http://localhost:3000'])
+      end
+
+      it 'sends the user to account creation' do
         visit saml_ial2_request_url(params: { prompt: 'create' })
 
         expect(page).to have_current_path(sign_up_email_path)

--- a/spec/features/saml/ial2_sso_spec.rb
+++ b/spec/features/saml/ial2_sso_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'IAL2 Single Sign On' do
     context 'when the sp requests user registration flow' do
       before do
         allow(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
-          .and_return(['http://localhost:3000'])
+          .and_return(['saml_sp_ial2'])
       end
 
       it 'sends the user to account creation' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -507,14 +507,19 @@ RSpec.feature 'saml api' do
       click_submit_default_twice
 
       expect(fake_analytics.events['SAML Auth Request']).to eq(
-        [{ authn_context: request_authn_contexts,
-           requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
-           service_provider: 'http://localhost:3000',
-           requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-           force_authn: false,
-           matching_cert_serial: saml_test_sp_cert_serial,
-           request_signed: true,
-           user_fully_authenticated: false }],
+        [
+          {
+            authn_context: request_authn_contexts,
+            requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
+            service_provider: 'http://localhost:3000',
+            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            force_authn: false,
+            matching_cert_serial: saml_test_sp_cert_serial,
+            request_signed: true,
+            user_fully_authenticated: false,
+            allow_prompt_create: false,
+          },
+        ],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
 
@@ -560,6 +565,7 @@ RSpec.feature 'saml api' do
             matching_cert_serial: saml_test_sp_cert_serial,
             request_signed: true,
             user_fully_authenticated: false,
+            allow_prompt_create: false,
           },
         ],
       )
@@ -584,14 +590,19 @@ RSpec.feature 'saml api' do
       click_submit_default_twice
 
       expect(fake_analytics.events['SAML Auth Request']).to eq(
-        [{ authn_context: request_authn_contexts,
-           requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
-           service_provider: 'http://localhost:3000',
-           requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-           force_authn: false,
-           matching_cert_serial: saml_test_sp_cert_serial,
-           request_signed: true,
-           user_fully_authenticated: false }],
+        [
+          {
+            authn_context: request_authn_contexts,
+            requested_ial: 'http://idmanagement.gov/ns/assurance/ial/1',
+            service_provider: 'http://localhost:3000',
+            requested_aal_authn_context: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
+            force_authn: false,
+            matching_cert_serial: saml_test_sp_cert_serial,
+            request_signed: true,
+            user_fully_authenticated: false,
+            allow_prompt_create: false,
+          },
+        ],
       )
       expect(fake_analytics.events['SAML Auth'].count).to eq 2
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -794,10 +794,10 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
 
-    context 'when prompt is "create"' do
-      let(:prompt) { 'create' }
+    context 'when prompt is "select_account"' do
+      let(:prompt) { 'select_account' }
       it 'returns false' do
-        expect(form.initiate_user_registration?).to be true
+        expect(form.initiate_user_registration?).to be false
       end
     end
   end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
           client_id: client_id,
           prompt: 'select_account',
           allow_prompt_login: true,
+          allow_prompt_create: false,
           redirect_uri: nil,
           unauthorized_scope: true,
           acr_values:,
@@ -68,6 +69,7 @@ RSpec.describe OpenidConnectAuthorizeForm do
             client_id: client_id,
             prompt: 'select_account',
             allow_prompt_login: true,
+            allow_prompt_create: false,
             redirect_uri: "#{redirect_uri}?error=invalid_request&error_description=" \
                           "Response+type+is+not+included+in+the+list&state=#{state}",
             unauthorized_scope: true,

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -785,4 +785,20 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
   end
+
+  describe '#initiate_user_registration?' do
+    context 'when prompt is "create"' do
+      let(:prompt) { 'create' }
+      it 'returns true' do
+        expect(form.initiate_user_registration?).to be true
+      end
+    end
+
+    context 'when prompt is "create"' do
+      let(:prompt) { 'create' }
+      it 'returns false' do
+        expect(form.initiate_user_registration?).to be true
+      end
+    end
+  end
 end

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -285,38 +285,61 @@ RSpec.describe OpenidConnectAuthorizeForm do
       end
     end
 
-    context 'when prompt is not select_account or login' do
-      let(:prompt) { 'aaa' }
-      it { expect(valid?).to eq(false) }
-    end
-
-    context 'when prompt is not given' do
-      let(:prompt) { nil }
-
-      it { expect(valid?).to eq(true) }
-    end
-
-    context 'when prompt is login and allowed by sp' do
-      let(:prompt) { 'login' }
-      before do
-        allow_any_instance_of(ServiceProvider).to receive(:allow_prompt_login).and_return true
+    context 'prompt' do
+      context 'when prompt is select_account' do
+        it { expect(valid?).to eq(true) }
       end
 
-      it { expect(valid?).to eq(true) }
-    end
-
-    context 'when prompt is login but not allowed by sp' do
-      let(:prompt) { 'login' }
-      before do
-        allow_any_instance_of(ServiceProvider).to receive(:allow_prompt_login).and_return false
+      context 'when prompt is a random string' do
+        let(:prompt) { 'aaa' }
+        it { expect(valid?).to eq(false) }
       end
 
-      it { expect(valid?).to eq(false) }
-    end
+      context 'when prompt is not given' do
+        let(:prompt) { nil }
 
-    context 'when prompt is blank' do
-      let(:prompt) { '' }
-      it { expect(valid?).to eq(false) }
+        it { expect(valid?).to eq(true) }
+      end
+
+      context 'when prompt is an empty string' do
+        let(:prompt) { '' }
+        it { expect(valid?).to eq(false) }
+      end
+
+      context 'when prompt is login' do
+        let(:prompt) { 'login' }
+
+        context 'when prompt=login is not allowed by sp' do
+          before do
+            allow_any_instance_of(ServiceProvider).to receive(:allow_prompt_login).and_return false
+          end
+
+          it { expect(valid?).to eq(false) }
+        end
+
+        context 'when prompt=login is allowed by sp' do
+          before do
+            allow_any_instance_of(ServiceProvider).to receive(:allow_prompt_login).and_return true
+          end
+
+          it { expect(valid?).to eq(true) }
+        end
+      end
+
+      context 'when prompt is create' do
+        let(:prompt) { 'create' }
+
+        it { expect(valid?).to eq false }
+
+        context 'when prompt=create is allowed by sp' do
+          before do
+            allow(IdentityConfig.store).to receive(:allowed_create_prompt_providers)
+              .and_return([client_id])
+          end
+
+          it { expect(valid?).to eq(true) }
+        end
+      end
     end
 
     context 'when scope does not contain valid scopes' do

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -157,6 +157,26 @@ RSpec.describe ServiceProvider do
     end
   end
 
+  describe '#create_prompt_allowed?' do
+    context 'when the sp is not on the allowlist for the "create" prompt' do
+      it 'returns false' do
+        expect(service_provider.create_prompt_allowed?).to be(false)
+      end
+    end
+
+    context 'when the sp is on the allowlist for the "create" prompt' do
+      before do
+        allow(IdentityConfig.store).to receive(:allowed_create_prompt_providers).and_return(
+          ['an-issuer', service_provider.issuer],
+        )
+      end
+
+      it 'returns true' do
+        expect(service_provider.create_prompt_allowed?).to be(true)
+      end
+    end
+  end
+
   describe '#attempts_public_key' do
     context 'when the sp is configured to use the attempts api' do
       context 'when there is no public key set in the configuration' do

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -111,9 +111,10 @@ module SamlAuthHelper
     page.driver.post remote_logout_request_url
   end
 
-  def saml_get_auth(settings)
+  def saml_get_auth(settings, prompt: nil)
     # GET redirect binding Authn Request
-    get :auth, params: { SAMLRequest: CGI.unescape(saml_request(settings)), path_year: PATH_YEAR }
+    params = { SAMLRequest: CGI.unescape(saml_request(settings)), path_year: PATH_YEAR, prompt: }
+    get :auth, params: params.compact
   end
 
   def saml_post_auth(saml_request)


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 116](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/work_items/116)

SBAR: https://docs.google.com/document/d/1zCkmiEe7fHV_hKosveVz5ed6ozpxluhoDFsw-2jjADY/edit?tab=t.0

## 🛠 Summary of changes
This change updates our SAML and OIDC implementations to support  the OIDC extension `prompt=create`, which supports user registration on initial auth request. This is a high-priority ask from leadership.

This change:
- Adds an allowlist so we can control what service providers (SP) use, this feature
- Updates valid prompt list for OIDC to include `create`
- Adds a method on the SP to determine if the SP is on the allowlist
- Supports the query param for both OIDC and SAML (GET and POST)
- Updates OIDC analytics to include a `allow_prompt_create` attribute
- Updates SAML analytics to include the prompt value, if it exists, and the allow_prompt_create` attribute
- Updates and adds specs

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
