### PR TITLE
OIDC: Return auth_time behind feature flag

### DIFF
--- a/app/models/service_provider_identity.rb
+++ b/app/models/service_provider_identity.rb
@@ -63,7 +63,7 @@ class ServiceProviderIdentity < ApplicationRecord
   end
 
   def happened_at
-    last_authenticated_at.in_time_zone('UTC')
+    last_authenticated_at&.in_time_zone('UTC')
   end
 
   def verified_single_email_attribute?

--- a/app/presenters/openid_connect_configuration_presenter.rb
+++ b/app/presenters/openid_connect_configuration_presenter.rb
@@ -41,6 +41,6 @@ class OpenidConnectConfigurationPresenter
   end
 
   def claims_supported
-    %w[iss sub] + OpenidConnectAttributeScoper::CLAIMS
+    OpenidConnectAttributeScoper::UNSCOPED_CLAIMS + OpenidConnectAttributeScoper::CLAIMS
   end
 end

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -26,7 +26,7 @@ class OpenidConnectUserInfoPresenter
     info[:verified_at] = verified_at if scoper.verified_at_requested?
     info[:ial] = authn_context_resolver.asserted_ial_acr
     info[:aal] = requested_aal_value
-    info[:auth_time] = auth_time if FeatureManagement.openid_connect_auth_time_enabled?
+    info[:auth_time] = auth_time if FeatureManagement.auth_time_attribute_enabled?
 
     scoper.filter(info)
   end
@@ -182,7 +182,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def auth_time
-    identity.happened_at.to_i if identity.last_authenticated_at.present?
+    (identity.happened_at || Time.zone.now).to_i
   end
 
   def out_of_band_session_accessor

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -26,6 +26,7 @@ class OpenidConnectUserInfoPresenter
     info[:verified_at] = verified_at if scoper.verified_at_requested?
     info[:ial] = authn_context_resolver.asserted_ial_acr
     info[:aal] = requested_aal_value
+    info[:auth_time] = auth_time if FeatureManagement.openid_connect_auth_time_enabled?
 
     scoper.filter(info)
   end
@@ -178,6 +179,10 @@ class OpenidConnectUserInfoPresenter
     return if identity&.service_provider_record&.ial.to_i < 2
 
     active_profile&.verified_at&.to_i
+  end
+
+  def auth_time
+    identity.happened_at.to_i if identity.last_authenticated_at.present?
   end
 
   def out_of_band_session_accessor

--- a/app/services/openid_connect_attribute_scoper.rb
+++ b/app/services/openid_connect_attribute_scoper.rb
@@ -62,6 +62,7 @@ class OpenidConnectAttributeScoper
   end.with_indifferent_access.freeze
 
   CLAIMS = ATTRIBUTE_SCOPES_MAP.keys.freeze
+  UNSCOPED_CLAIMS = %w[auth_time iss sub].freeze
 
   attr_reader :scopes
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -360,7 +360,7 @@ mx_timeout: 3
 new_device_alert_delay_in_minutes: 5
 new_device_alert_window_start_in_minutes: 480
 newrelic_license_key: ''
-openid_connect_auth_time_enabled: false
+auth_time_attribute_enabled: false
 openid_connect_authorization_code_expiration_seconds: 300
 openid_connect_content_security_form_action_enabled: false
 openid_connect_redirect: client_side_js

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -55,6 +55,7 @@ attempts_api_signing_enabled: false
 attempts_api_signing_key: ''
 attribute_encryption_key:
 attribute_encryption_key_queue: '[]'
+auth_time_attribute_enabled: false
 available_locales: 'en,es,fr,zh'
 aws_http_retry_limit: 2
 aws_http_retry_max_delay: 1
@@ -360,7 +361,6 @@ mx_timeout: 3
 new_device_alert_delay_in_minutes: 5
 new_device_alert_window_start_in_minutes: 480
 newrelic_license_key: ''
-auth_time_attribute_enabled: false
 openid_connect_authorization_code_expiration_seconds: 300
 openid_connect_content_security_form_action_enabled: false
 openid_connect_redirect: client_side_js

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -360,6 +360,7 @@ mx_timeout: 3
 new_device_alert_delay_in_minutes: 5
 new_device_alert_window_start_in_minutes: 480
 newrelic_license_key: ''
+openid_connect_auth_time_enabled: false
 openid_connect_authorization_code_expiration_seconds: 300
 openid_connect_content_security_form_action_enabled: false
 openid_connect_redirect: client_side_js

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -114,6 +114,10 @@ class FeatureManagement
     !Rails.env.test? && IdentityConfig.store.log_to_stdout
   end
 
+  def self.openid_connect_auth_time_enabled?
+    IdentityConfig.store.openid_connect_auth_time_enabled
+  end
+
   def self.phone_recaptcha_enabled?
     IdentityConfig.store.phone_recaptcha_score_threshold.positive? && recaptcha_enabled?
   end

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -114,8 +114,8 @@ class FeatureManagement
     !Rails.env.test? && IdentityConfig.store.log_to_stdout
   end
 
-  def self.openid_connect_auth_time_enabled?
-    IdentityConfig.store.openid_connect_auth_time_enabled
+  def self.auth_time_attribute_enabled?
+    IdentityConfig.store.auth_time_attribute_enabled
   end
 
   def self.phone_recaptcha_enabled?

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -72,6 +72,7 @@ module IdentityConfig
     config.add(:attempts_api_signing_enabled, type: :boolean)
     config.add(:attribute_encryption_key, type: :string)
     config.add(:attribute_encryption_key_queue, type: :json)
+    config.add(:auth_time_attribute_enabled, type: :boolean)
     config.add(:available_locales, type: :comma_separated_string_list)
     config.add(:aws_http_retry_limit, type: :integer)
     config.add(:aws_http_retry_max_delay, type: :integer)
@@ -371,7 +372,6 @@ module IdentityConfig
     config.add(:new_device_alert_delay_in_minutes, type: :integer)
     config.add(:new_device_alert_window_start_in_minutes, type: :integer, allow_nil: true)
     config.add(:newrelic_license_key, type: :string)
-    config.add(:openid_connect_auth_time_enabled, type: :boolean)
     config.add(:openid_connect_authorization_code_expiration_seconds, type: :integer)
     config.add(:openid_connect_content_security_form_action_enabled, type: :boolean)
     config.add(

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -371,13 +371,14 @@ module IdentityConfig
     config.add(:new_device_alert_delay_in_minutes, type: :integer)
     config.add(:new_device_alert_window_start_in_minutes, type: :integer, allow_nil: true)
     config.add(:newrelic_license_key, type: :string)
+    config.add(:openid_connect_auth_time_enabled, type: :boolean)
+    config.add(:openid_connect_authorization_code_expiration_seconds, type: :integer)
+    config.add(:openid_connect_content_security_form_action_enabled, type: :boolean)
     config.add(
       :openid_connect_redirect,
       type: :string,
       enum: ['server_side', 'client_side_js'],
     )
-    config.add(:openid_connect_authorization_code_expiration_seconds, type: :integer)
-    config.add(:openid_connect_content_security_form_action_enabled, type: :boolean)
     config.add(:otp_delivery_blocklist_findtime, type: :integer)
     config.add(:otp_delivery_blocklist_maxretry, type: :integer)
     config.add(:otp_expiration_warning_seconds, type: :integer)

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -695,7 +695,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
 
     it 'updates auth_time to the current authentication timestamp for existing identities' do
       now = Time.zone.parse('2026-06-01 12:00:00 UTC')
-      allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
       ServiceProviderIdentity.create!(
         user: user,
         service_provider: client_id,
@@ -714,7 +713,6 @@ RSpec.describe OpenidConnectAuthorizeForm do
         identity = user.identities.find_by(service_provider: client_id)
 
         expect(identity.last_authenticated_at.to_i).to eq(now.to_i)
-        expect(OpenidConnectUserInfoPresenter.new(identity).user_info[:auth_time]).to eq(now.to_i)
       end
     end
 

--- a/spec/forms/openid_connect_authorize_form_spec.rb
+++ b/spec/forms/openid_connect_authorize_form_spec.rb
@@ -693,6 +693,31 @@ RSpec.describe OpenidConnectAuthorizeForm do
     let(:user) { create(:user) }
     let(:rails_session_id) { SecureRandom.hex }
 
+    it 'updates auth_time to the current authentication timestamp for existing identities' do
+      now = Time.zone.parse('2026-06-01 12:00:00 UTC')
+      allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
+      ServiceProviderIdentity.create!(
+        user: user,
+        service_provider: client_id,
+        service_provider_record: form.service_provider,
+        last_authenticated_at: 1.week.ago,
+      )
+
+      travel_to(now) do
+        form.link_identity_to_service_provider(
+          current_user: user,
+          ial: 1,
+          rails_session_id: rails_session_id,
+          email_address_id: 4,
+        )
+
+        identity = user.identities.find_by(service_provider: client_id)
+
+        expect(identity.last_authenticated_at.to_i).to eq(now.to_i)
+        expect(OpenidConnectUserInfoPresenter.new(identity).user_info[:auth_time]).to eq(now.to_i)
+      end
+    end
+
     context 'with PKCE' do
       let(:code_challenge) { 'abcdef' }
       let(:code_challenge_method) { 'S256' }

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -81,12 +81,12 @@ RSpec.describe 'FeatureManagement' do
     end
   end
 
-  describe '#openid_connect_auth_time_enabled?' do
-    subject(:enabled) { FeatureManagement.openid_connect_auth_time_enabled? }
+  describe '#auth_time_attribute_enabled?' do
+    subject(:enabled) { FeatureManagement.auth_time_attribute_enabled? }
 
     context 'when enabled' do
       before do
-        allow(IdentityConfig.store).to receive(:openid_connect_auth_time_enabled).and_return(true)
+        allow(IdentityConfig.store).to receive(:auth_time_attribute_enabled).and_return(true)
       end
 
       it { expect(enabled).to eq(true) }
@@ -94,7 +94,7 @@ RSpec.describe 'FeatureManagement' do
 
     context 'when disabled' do
       before do
-        allow(IdentityConfig.store).to receive(:openid_connect_auth_time_enabled).and_return(false)
+        allow(IdentityConfig.store).to receive(:auth_time_attribute_enabled).and_return(false)
       end
 
       it { expect(enabled).to eq(false) }

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -81,6 +81,26 @@ RSpec.describe 'FeatureManagement' do
     end
   end
 
+  describe '#openid_connect_auth_time_enabled?' do
+    subject(:enabled) { FeatureManagement.openid_connect_auth_time_enabled? }
+
+    context 'when enabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:openid_connect_auth_time_enabled).and_return(true)
+      end
+
+      it { expect(enabled).to eq(true) }
+    end
+
+    context 'when disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:openid_connect_auth_time_enabled).and_return(false)
+      end
+
+      it { expect(enabled).to eq(false) }
+    end
+  end
+
   describe '#use_dashboard_service_providers?' do
     context 'when enabled' do
       before do

--- a/spec/models/service_provider_identity_spec.rb
+++ b/spec/models/service_provider_identity_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe ServiceProviderIdentity do
     end
   end
 
+  describe '#happened_at' do
+    context 'when last_authenticated_at is present' do
+      it 'returns last_authenticated_at in UTC' do
+        identity.last_authenticated_at = Time.zone.parse('2026-06-01 12:00:00 UTC')
+
+        expect(identity.happened_at).to eq(identity.last_authenticated_at.in_time_zone('UTC'))
+      end
+    end
+
+    context 'when last_authenticated_at is missing' do
+      it 'returns nil' do
+        identity.last_authenticated_at = nil
+
+        expect(identity.happened_at).to be_nil
+      end
+    end
+  end
+
   describe 'uuid validations' do
     it 'uses a DB constraint to enforce presence' do
       identity = create(:service_provider_identity)

--- a/spec/presenters/openid_connect_configuration_presenter_spec.rb
+++ b/spec/presenters/openid_connect_configuration_presenter_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe OpenidConnectConfigurationPresenter do
         expect(configuration[:token_endpoint_auth_methods_supported]).to eq(%w[private_key_jwt])
         expect(configuration[:token_endpoint_auth_signing_alg_values_supported]).to eq(%w[RS256])
 
-        claims = %w[iss sub] + OpenidConnectAttributeScoper::CLAIMS
+        claims = OpenidConnectAttributeScoper::UNSCOPED_CLAIMS +
+                 OpenidConnectAttributeScoper::CLAIMS
         expect(configuration[:claims_supported]).to match_array(claims)
       end
     end

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
   let(:vtr) { nil }
   let(:requested_aal_value) { nil }
   let(:acr_values) { Saml::Idp::Constants::IAL_VERIFIED_ACR }
+  let(:last_authenticated_at) { Time.zone.parse('2026-05-29 12:00:00 UTC') }
   let(:locale) { 'en' }
   let(:identity) do
     build(
@@ -24,6 +25,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
       vtr: vtr,
       acr_values: acr_values,
       requested_aal_value: requested_aal_value,
+      last_authenticated_at: last_authenticated_at,
     )
   end
 
@@ -64,6 +66,34 @@ RSpec.describe OpenidConnectUserInfoPresenter do
     end
 
     subject(:user_info) { presenter.user_info }
+
+    context 'when OIDC auth_time is enabled' do
+      before do
+        allow(FeatureManagement).to receive(:openid_connect_auth_time_enabled?).and_return(true)
+      end
+
+      it 'includes auth_time from the identity authentication timestamp' do
+        expect(user_info[:auth_time]).to eq(last_authenticated_at.to_i)
+      end
+
+      context 'without an identity authentication timestamp' do
+        let(:last_authenticated_at) { nil }
+
+        it 'includes a null auth_time' do
+          expect(user_info[:auth_time]).to be_nil
+        end
+      end
+    end
+
+    context 'when OIDC auth_time is disabled' do
+      before do
+        allow(FeatureManagement).to receive(:openid_connect_auth_time_enabled?).and_return(false)
+      end
+
+      it 'does not include auth_time' do
+        expect(user_info).to_not have_key(:auth_time)
+      end
+    end
 
     context 'with a vtr parameter' do
       let(:acr_values) { nil }

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe OpenidConnectUserInfoPresenter do
 
     subject(:user_info) { presenter.user_info }
 
-    context 'when OIDC auth_time is enabled' do
+    context 'when auth_time attribute is enabled' do
       before do
-        allow(FeatureManagement).to receive(:openid_connect_auth_time_enabled?).and_return(true)
+        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
       end
 
       it 'includes auth_time from the identity authentication timestamp' do
@@ -78,16 +78,19 @@ RSpec.describe OpenidConnectUserInfoPresenter do
 
       context 'without an identity authentication timestamp' do
         let(:last_authenticated_at) { nil }
+        let(:now) { Time.zone.parse('2026-06-01 12:00:00 UTC') }
 
-        it 'includes a null auth_time' do
-          expect(user_info[:auth_time]).to be_nil
+        it 'falls back to the current time' do
+          travel_to(now) do
+            expect(user_info[:auth_time]).to eq(now.to_i)
+          end
         end
       end
     end
 
-    context 'when OIDC auth_time is disabled' do
+    context 'when auth_time attribute is disabled' do
       before do
-        allow(FeatureManagement).to receive(:openid_connect_auth_time_enabled?).and_return(false)
+        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(false)
       end
 
       it 'does not include auth_time' do

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe IdTokenBuilder do
 
   let(:code) { SecureRandom.hex }
   let(:user) { create(:user) }
+  let(:last_authenticated_at) { Time.zone.parse('2026-05-29 12:00:00 UTC') }
   let(:identity) do
     build(
       :service_provider_identity,
@@ -16,6 +17,7 @@ RSpec.describe IdTokenBuilder do
       # https://www.pingidentity.com/content/developer/en/resources/openid-connect-developers-guide.html
       access_token: 'dNZX1hEZ9wBCzNL40Upu646bdzQA',
       user: user,
+      last_authenticated_at: last_authenticated_at,
     )
   end
 
@@ -163,6 +165,26 @@ RSpec.describe IdTokenBuilder do
 
     it 'sets the not-before to now' do
       expect(decoded_payload[:nbf]).to eq(now.to_i)
+    end
+
+    context 'when OIDC auth_time is enabled' do
+      before do
+        allow(FeatureManagement).to receive(:openid_connect_auth_time_enabled?).and_return(true)
+      end
+
+      it 'sets auth_time to the authentication timestamp' do
+        expect(decoded_payload[:auth_time]).to eq(last_authenticated_at.to_i)
+      end
+    end
+
+    context 'when OIDC auth_time is disabled' do
+      before do
+        allow(FeatureManagement).to receive(:openid_connect_auth_time_enabled?).and_return(false)
+      end
+
+      it 'does not include auth_time' do
+        expect(decoded_payload).to_not have_key(:auth_time)
+      end
     end
 
     it 'sets the access token hash correctly' do

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -167,9 +167,9 @@ RSpec.describe IdTokenBuilder do
       expect(decoded_payload[:nbf]).to eq(now.to_i)
     end
 
-    context 'when OIDC auth_time is enabled' do
+    context 'when auth_time attribute is enabled' do
       before do
-        allow(FeatureManagement).to receive(:openid_connect_auth_time_enabled?).and_return(true)
+        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
       end
 
       it 'sets auth_time to the authentication timestamp' do
@@ -177,9 +177,9 @@ RSpec.describe IdTokenBuilder do
       end
     end
 
-    context 'when OIDC auth_time is disabled' do
+    context 'when auth_time attribute is disabled' do
       before do
-        allow(FeatureManagement).to receive(:openid_connect_auth_time_enabled?).and_return(false)
+        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(false)
       end
 
       it 'does not include auth_time' do


### PR DESCRIPTION
## Summary

- Add a manual feature flag, `openid_connect_auth_time_enabled`, defaulting to `false`
- Return OIDC `auth_time` from `OpenidConnectUserInfoPresenter` when the flag is enabled
- Derive `auth_time` from `ServiceProviderIdentity#happened_at`, which wraps `last_authenticated_at` in UTC
- Advertise `auth_time` in OIDC discovery metadata by grouping it with unscoped claims (`iss`, `sub`)

## Why

NIST 800-63C-4 section 4.7 requires the IdP to provide relying parties with information about the user's latest authentication event. `IdentityLinker` already updates `last_authenticated_at` for each SP transaction, and the identity object is available in the OIDC presenter path, so this uses the existing timestamp rather than introducing a new dependency on 2FA session event state.

## Notes

`claims_supported` changed from:

```ruby
%w[iss sub] + OpenidConnectAttributeScoper::CLAIMS
```

to:

```ruby
OpenidConnectAttributeScoper::UNSCOPED_CLAIMS + OpenidConnectAttributeScoper::CLAIMS
```

This keeps `iss` and `sub` advertised, adds `auth_time`, and avoids adding `auth_time` to `ATTRIBUTE_SCOPES_MAP`, since it is not scope-controlled like email/address/profile attributes.

## Testing

- Targeted RSpec: `117 examples, 0 failures`
- Targeted RuboCop: `9 files inspected, no offenses detected`
