### PR TITLE
LG-17716: add  awaiting binding user search response

### DIFF
--- a/app/controllers/api/proofing_agent/proofing_agent_controller.rb
+++ b/app/controllers/api/proofing_agent/proofing_agent_controller.rb
@@ -24,7 +24,8 @@ module Api
         response_body = {
           email_account_found: user.present?,
           ssn_profile_found: ssn_active_profiles.any?,
-          profiles: active_profiles,
+          profiles: active_profiles_info,
+          email_account_awaiting_binding: !!user&.proofing_agent_user_awaiting_binding?,
         }
 
         analytics.idv_proofing_agent_account_check_requested(
@@ -252,15 +253,16 @@ module Api
       end
 
       def active_profiles
-        @active_profiles ||= begin
-          profiles = ssn_active_profiles | [user_active_profile].compact
-          profiles.map do |profile|
-            {
-              email_match: profile.user_id == user&.id,
-              ssn_match: ssn_active_profiles.any? { |ssn_profile| ssn_profile.id == profile.id },
-              idv_level: Profile::PROOFING_AGENT_IDV_LEVELS[profile.idv_level],
-            }
-          end
+        @active_profiles ||= ssn_active_profiles | [user_active_profile].compact
+      end
+
+      def active_profiles_info
+        active_profiles.map do |profile|
+          {
+            email_match: profile.user_id == user&.id,
+            ssn_match: ssn_active_profiles.any? { |ssn_profile| ssn_profile.id == profile.id },
+            idv_level: Profile::PROOFING_AGENT_IDV_LEVELS[profile.idv_level],
+          }
         end
       end
 
@@ -288,7 +290,7 @@ module Api
       end
 
       def user_has_enhanced_profile?
-        [user_active_profile, *ssn_active_profiles].compact.any? do |profile|
+        active_profiles.compact.any? do |profile|
           profile.enhanced?
         end
       end

--- a/app/controllers/api/proofing_agent/proofing_agent_controller.rb
+++ b/app/controllers/api/proofing_agent/proofing_agent_controller.rb
@@ -290,7 +290,7 @@ module Api
       end
 
       def user_has_enhanced_profile?
-        active_profiles.compact.any? do |profile|
+        active_profiles.any? do |profile|
           profile.enhanced?
         end
       end

--- a/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
+++ b/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
@@ -286,6 +286,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               expect(body['email_account_found']).to eq(false)
               expect(body['ssn_profile_found']).to eq(false)
               expect(body['profiles']).to eq([])
+              expect(body['email_account_awaiting_binding']).to eq(false)
               expect(@analytics).to have_logged_event(
                 :idv_proofing_agent_account_check_requested,
                 response_body: a_hash_including(
@@ -312,6 +313,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               body = JSON.parse(response.body)
               expect(body['email_account_found']).to eq(false)
               expect(body['ssn_profile_found']).to eq(true)
+              expect(body['email_account_awaiting_binding']).to eq(false)
               expect(body['profiles'].length).to eq(1)
               expect(body['profiles']).to include(
                 a_hash_including(
@@ -324,6 +326,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
                 :idv_proofing_agent_account_check_requested,
                 response_body: a_hash_including(
                   email_account_found: false,
+                  email_account_awaiting_binding: false,
                   ssn_profile_found: true,
                   profiles: include(
                     a_hash_including(
@@ -354,10 +357,12 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(false)
             expect(body['profiles'].length).to eq(0)
+            expect(body['email_account_awaiting_binding']).to eq(false)
             expect(@analytics).to have_logged_event(
               :idv_proofing_agent_account_check_requested,
               response_body: a_hash_including(
                 email_account_found: true,
+                email_account_awaiting_binding: false,
                 ssn_profile_found: false,
                 profiles: [],
               ),
@@ -415,6 +420,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             body = JSON.parse(response.body)
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(true)
+            expect(body['email_account_awaiting_binding']).to eq(false)
             expect(body['profiles'].length).to eq(3)
             expect(body['profiles']).to include(
               a_hash_including(
@@ -437,6 +443,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               :idv_proofing_agent_account_check_requested,
               response_body: a_hash_including(
                 email_account_found: true,
+                email_account_awaiting_binding: false,
                 ssn_profile_found: true,
                 profiles: include(
                   a_hash_including(
@@ -503,6 +510,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             body = JSON.parse(response.body)
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(true)
+            expect(body['email_account_awaiting_binding']).to eq(false)
             expect(body['profiles'].length).to eq(2)
             expect(body['profiles']).to include(
               a_hash_including(
@@ -521,6 +529,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               response_body: a_hash_including(
                 email_account_found: true,
                 ssn_profile_found: true,
+                email_account_awaiting_binding: false,
                 profiles: include(
                   a_hash_including(
                     email_match: true,
@@ -531,6 +540,72 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
                     email_match: false,
                     ssn_match: true,
                     idv_level: 'enhanced',
+                  ),
+                ),
+              ),
+              proofing_agent: proofing_agent_analytics_hash,
+              issuer:,
+            )
+          end
+        end
+
+        context 'when the user is awaiting binding' do
+          let(:session) do
+            create(
+              :document_capture_session,
+              user:,
+              issuer:,
+              doc_auth_vendor: Idp::Constants::Vendors::PROOFING_AGENT,
+              pending_agent_proofed_user_at: Time.zone.now,
+              result_id: SecureRandom.uuid,
+            )
+          end
+
+          let(:successful_proofing_result) do
+            Idv::ProofingAgent::AgentProofedUser.new(
+              id: SecureRandom.uuid,
+              success: true,
+              reason: nil,
+              transaction_id: session.uuid,
+            )
+          end
+
+          before do
+            allow(EncryptedRedisStructStorage).to receive(:load).with(session.result_id, type: Idv::ProofingAgent::AgentProofedUser).and_return(successful_proofing_result)
+          end
+
+          it 'awaiting binding is true' do
+            create(
+              :profile,
+              :active,
+              user:,
+              ssn_signature: Pii::Fingerprinter.fingerprint(SsnFormatter.normalize(ssn)),
+              idv_level: 1,
+            )
+            action
+            body = JSON.parse(response.body)
+            expect(body['email_account_found']).to eq(true)
+            expect(body['ssn_profile_found']).to eq(true)
+            expect(body['email_account_awaiting_binding']).to eq(true)
+            expect(body['profiles'].length).to eq(1)
+            expect(body['profiles']).to include(
+              a_hash_including(
+                'email_match' => true,
+                'ssn_match' => true,
+                'idv_level' => 'basic',
+              ),
+            )
+            expect(@analytics).to have_logged_event(
+              :idv_proofing_agent_account_check_requested,
+              response_body: a_hash_including(
+                email_account_found: true,
+                email_account_awaiting_binding: true,
+                ssn_profile_found: true,
+                profiles: include(
+                  a_hash_including(
+                    email_match: true,
+                    ssn_match: true,
+                    idv_level: 'basic',
                   ),
                 ),
               ),
@@ -2102,12 +2177,16 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
         end
 
         context 'when there is a successful proofing result' do
-          before do
-            session = DocumentCaptureSession.create!(
+          let(:session) do
+            create(
+              :document_capture_session,
               uuid: transaction_id,
               user_id: user.id,
               issuer:,
             )
+          end
+
+          before do
             allow(session)
               .to receive(:load_agent_proofed_user)
               .and_return(successful_proofing_result)

--- a/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
+++ b/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
@@ -555,9 +555,9 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               :document_capture_session,
               user:,
               issuer:,
+              result_id: SecureRandom.uuid,
               doc_auth_vendor: Idp::Constants::Vendors::PROOFING_AGENT,
               pending_agent_proofed_user_at: Time.zone.now,
-              result_id: SecureRandom.uuid,
             )
           end
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-17716](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17716)

## 🛠 Summary of changes
Added awaiting binding to the response body for user search


## 📜 Testing Plan
- [ ] agent proof a user successfully (do not bind account)
- [ ] send a user search api request and verify the body contains `email_account_awaiting_binding: true`

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17716]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17716