### PR TITLE
LG-17650: Build mechanism to fully support deprecating personal keys as an MFA method

### DIFF
--- a/app/decorators/mfa_context.rb
+++ b/app/decorators/mfa_context.rb
@@ -95,8 +95,7 @@ class MfaContext
       webauthn_configurations.to_a.count(&:mfa_enabled?) +
       (backup_code_configurations.any? ? 1 : 0) +
       piv_cac_configurations.to_a.count(&:mfa_enabled?) +
-      auth_app_configurations.to_a.count(&:mfa_enabled?) +
-      personal_key_method_count
+      auth_app_configurations.to_a.count(&:mfa_enabled?)
   end
 
   # returns a hash showing the count for each enabled 2FA configuration,
@@ -118,11 +117,6 @@ class MfaContext
   end
 
   private
-
-  def personal_key_method_count
-    return 0 if IdentityConfig.store.personal_key_retired
-    (personal_key_configuration.mfa_enabled? ? 1 : 0)
-  end
 
   def enabled_two_factor_configuration_names
     two_factor_configurations.select(&:mfa_enabled?).map(&:friendly_name)

--- a/app/presenters/two_factor_login_options_presenter.rb
+++ b/app/presenters/two_factor_login_options_presenter.rb
@@ -73,11 +73,9 @@ class TwoFactorLoginOptionsPresenter < TwoFactorAuthCode::GenericDeliveryPresent
       configurations = mfa.phishing_resistant_configurations
     else
       configurations = mfa.two_factor_configurations
-      # for now, we include the personal key since that's our current behavior,
-      # but there are designs to remove personal key from the option list and
-      # make it a link with some additional text to call it out as a special
-      # case.
-      if TwoFactorAuthentication::PersonalKeyPolicy.new(user).enabled?
+
+      if TwoFactorAuthentication::PersonalKeyPolicy.new(user).enabled? &&
+         IdentityConfig.store.personal_key_as_mfa_active
         configurations << mfa.personal_key_configuration
       end
     end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -382,7 +382,7 @@ outbound_connection_check_url: 'https://checkip.amazonaws.com'
 participate_in_dap: false
 password_max_attempts: 3
 password_pepper:
-personal_key_retired: true
+personal_key_as_mfa_active: true
 phone_carrier_registration_blocklist_array: '[]'
 phone_confirmation_max_attempt_window_in_minutes: 1_440
 phone_confirmation_max_attempts: 20

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -397,7 +397,7 @@ module IdentityConfig
     config.add(:participate_in_dap, type: :boolean)
     config.add(:password_max_attempts, type: :integer)
     config.add(:password_pepper, type: :string)
-    config.add(:personal_key_retired, type: :boolean)
+    config.add(:personal_key_as_mfa_active, type: :boolean)
     config.add(:phone_carrier_registration_blocklist_array, type: :json)
     config.add(:phone_confirmation_max_attempt_window_in_minutes, type: :integer)
     config.add(:phone_confirmation_max_attempts, type: :integer)

--- a/spec/decorators/mfa_context_spec.rb
+++ b/spec/decorators/mfa_context_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe MfaContext do
     end
 
     context 'with a phone and a personal key' do
-      it 'returns 2' do
+      it 'returns 1' do
         user = create(:user, :with_phone, :with_personal_key)
         subject = described_class.new(user.reload)
 

--- a/spec/presenters/two_factor_login_options_presenter_spec.rb
+++ b/spec/presenters/two_factor_login_options_presenter_spec.rb
@@ -279,6 +279,22 @@ RSpec.describe TwoFactorLoginOptionsPresenter do
         end
       end
     end
+
+    context 'deprecating personal keys' do
+      it 'does not show the personal key option when set to false' do
+        allow(IdentityConfig.store).to receive(:personal_key_as_mfa_active).and_return(false)
+        expect(options_classes).to eq(
+          [
+            TwoFactorAuthentication::SignInPhoneSelectionPresenter,
+            TwoFactorAuthentication::SignInPhoneSelectionPresenter,
+            TwoFactorAuthentication::SignInWebauthnSelectionPresenter,
+            TwoFactorAuthentication::SignInBackupCodeSelectionPresenter,
+            TwoFactorAuthentication::SignInPivCacSelectionPresenter,
+            TwoFactorAuthentication::SignInAuthAppSelectionPresenter,
+          ],
+        )
+      end
+    end
   end
 
   describe '#restricted_options_warning_text' do


### PR DESCRIPTION
## 🎫 Ticket

[LG-17650: Deprecating Personal Key as an MFA method: Part 2 - deactivate personal key as MFA](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17650)

## 🛠 Summary of changes

This pull request makes it so that when we are ready to disable personal keys as an authentication method, we can do so by changing the new value of `personal_key_as_mfa_active` to `false`. This value starts as `true` because we still provide the option for users to use personal key as an MFA option until we want to switch it off.

This pull request also removes the `personal_key_retired` config which was present to not allow personal key to be counted as an enabled MFA method if personal key was retired. 

This is part of a two-part plan to deprecate its use as an authentication method. Personal keys generated during the identity verification process arse **not** affected by these changes.

## 📜 Testing Plan

This test requires using an account with a personal key added as an MFA method. To do so, you need to add the method via the rails console. To do so:
1. Create an account with at least 1 authentication method
2. Open the console using `rails c`
3. Use `User.find_with_email('example@example.com').profiles.delete_all` to delete all profiles from the account. 
**At this point, personal key will be available as an authentication method** 

**To test**:
- [ ] Change value of `personal_key_as_mfa_active` to `false`
- [ ] Follow steps to log into account
- [ ] Once presented with MFA authentication, select "Choose another authentication method"
- [ ] Once on "Choose another authentication method" screen, note that the personal key option is **not** present
