### PR TITLE
LG-17673 combine address line 1 and 2 for USPS streetAddress

### DIFF
--- a/app/services/usps_in_person_proofing/applicant.rb
+++ b/app/services/usps_in_person_proofing/applicant.rb
@@ -14,6 +14,8 @@ module UspsInPersonProofing
     :unique_id, :first_name, :last_name, :address, :city, :state, :zip_code,
     :email, :document_type, :document_number, :document_expiration_date, keyword_init: true
   ) do
+    STREET_ADDRESS_MAX_LENGTH = 255
+
     def self.from_usps_applicant_and_enrollment(applicant, enrollment)
       id_expiration = Time.zone.parse(applicant&.id_expiration || '')
       document_expiration_date =
@@ -22,11 +24,13 @@ module UspsInPersonProofing
           (id_expiration + offset).to_i
         end
 
+      street_address = [applicant.address1, applicant.address2].select(&:present?).join(' ')
+
       self.new(
         unique_id: enrollment.unique_id,
         first_name: transliterate(applicant.first_name),
         last_name: transliterate(applicant.last_name),
-        address: transliterate(applicant.address1),
+        address: transliterate(street_address)[0, STREET_ADDRESS_MAX_LENGTH],
         city: transliterate(applicant.city),
         state: applicant.state,
         zip_code: applicant.zipcode,

--- a/spec/features/idv/in_person/usps_opt_in_ipp_applicant_expanded_payload_spec.rb
+++ b/spec/features/idv/in_person/usps_opt_in_ipp_applicant_expanded_payload_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe 'In Person Proofing: opt in ipp applicant expanded payload', js: 
               'uniqueID' => InPersonEnrollment.first.unique_id,
               'firstName' => InPersonHelper::GOOD_FIRST_NAME,
               'lastName' => InPersonHelper::GOOD_LAST_NAME,
-              'streetAddress' => InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1,
+              'streetAddress' =>
+                "#{InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1} " \
+                "#{InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2}",
               'city' => InPersonHelper::GOOD_IDENTITY_DOC_CITY,
               'state' => InPersonHelper::GOOD_STATE_ABBR,
               'zipCode' => InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE,
@@ -116,7 +118,9 @@ RSpec.describe 'In Person Proofing: opt in ipp applicant expanded payload', js: 
               'uniqueID' => InPersonEnrollment.first.unique_id,
               'firstName' => InPersonHelper::GOOD_FIRST_NAME,
               'lastName' => InPersonHelper::GOOD_LAST_NAME,
-              'streetAddress' => InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1,
+              'streetAddress' =>
+                "#{InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1} " \
+                "#{InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2}",
               'city' => InPersonHelper::GOOD_IDENTITY_DOC_CITY,
               'state' => InPersonHelper::GOOD_STATE_ABBR,
               'zipCode' => InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE,

--- a/spec/services/usps_in_person_proofing/applicant_spec.rb
+++ b/spec/services/usps_in_person_proofing/applicant_spec.rb
@@ -103,6 +103,58 @@ RSpec.describe UspsInPersonProofing::Applicant do
       end
     end
 
+    context 'when the applicant has a second address line' do
+      let(:applicant) do
+        Pii::UspsApplicant.new(
+          **applicant_pii.merge(address1: '123 Main St', address2: 'Apt 4'),
+        )
+      end
+
+      it 'joins both lines into the address with a space' do
+        expect(
+          described_class.from_usps_applicant_and_enrollment(
+            applicant,
+            enrollment,
+          ).address,
+        ).to eq('123 Main St Apt 4')
+      end
+    end
+
+    context 'when the second address line is blank' do
+      let(:applicant) do
+        Pii::UspsApplicant.new(
+          **applicant_pii.merge(address1: '123 Main St', address2: ''),
+        )
+      end
+
+      it 'uses only the first line with no trailing space' do
+        expect(
+          described_class.from_usps_applicant_and_enrollment(
+            applicant,
+            enrollment,
+          ).address,
+        ).to eq('123 Main St')
+      end
+    end
+
+    context 'when the combined address exceeds 255 characters' do
+      let(:applicant) do
+        Pii::UspsApplicant.new(
+          **applicant_pii.merge(address1: 'A' * 200, address2: 'B' * 200),
+        )
+      end
+
+      it 'truncates the address to 255 characters' do
+        address = described_class.from_usps_applicant_and_enrollment(
+          applicant,
+          enrollment,
+        ).address
+
+        expect(address.length).to eq(255)
+        expect(address).to eq(('A' * 200) + ' ' + ('B' * 54))
+      end
+    end
+
     context 'with an offset to the expiration time', timezone: 'UTC' do
       context 'with an offset of zero' do
         it 'shows the previous date if interpreted in US timezone' do


### PR DESCRIPTION
changelog: Bug Fixes, In-person proofing, Include second address line in the address sent to USPS

## 🎫 Ticket

Link to the relevant ticket:
[LG-17673](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17673)



## 🛠 Summary of changes

When building the USPS in-person enrollment payload we were only sending address1, so anyone whose profile had a second address line (apartment, unit, etc.) lost it before the request went out. from_usps_applicant_and_enrollment now joins address1 and address2 with a space into the single streetAddress field and truncates the result to USPS's 255-char max. When there's no second line the behavior is unchanged.

📜 Testing Plan

- [ ] Enroll a user whose address has a second line (e.g. **123 Main St / Apt 4**) and confirm the USPS request streetAddress is _**123 Main St Apt 4**_
- [ ] Enroll a user with no second address line and confirm streetAddress is just the first line, no trailing space
- [ ] With a combined address over 255 characters, confirm it's cut to 255 in the outgoing request

[LG-17673]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17673