### PR TITLE
Add SAML auth instant support

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -193,15 +193,24 @@ module SamlIdpAuthConcern
   end
 
   def saml_response
-    encode_response(
-      current_user,
+    encode_response(current_user, saml_response_options)
+  end
+
+  def saml_response_options
+    {
       name_id_format: name_id_format,
       authn_context_classref: response_authn_context,
       reference_id: active_identity.session_uuid,
       encryption: encryption_opts,
       signature: saml_response_signature_options,
       signed_response_message: saml_request_service_provider&.signed_response_message_requested,
-    )
+    }.tap do |options|
+      options[:authn_instant] = saml_authn_instant if FeatureManagement.auth_time_attribute_enabled?
+    end
+  end
+
+  def saml_authn_instant
+    active_identity&.happened_at || Time.zone.now
   end
 
   def encryption_opts

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2427,9 +2427,14 @@ RSpec.describe SamlIdpController do
       let(:status) { xmldoc.status[0] }
       let(:status_code) { xmldoc.status_code[0] }
       let(:user) { create(:user, :fully_registered) }
+      let(:authn_at) { nil }
 
       before do
-        generate_saml_response(user, saml_settings)
+        if authn_at
+          travel_to(authn_at) { generate_saml_response(user, saml_settings) }
+        else
+          generate_saml_response(user, saml_settings)
+        end
       end
 
       it 'returns a valid xml document' do
@@ -2739,6 +2744,20 @@ RSpec.describe SamlIdpController do
 
         it 'has an AuthnInstant attribute' do
           expect(subject.attributes['AuthnInstant'].value).to_not be_nil
+        end
+
+        context 'when authentication timestamp support is enabled' do
+          let(:authn_at) { Time.zone.parse('2026-07-08 12:34:56 UTC') }
+
+          before do
+            allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
+          end
+
+          it 'uses the identity authentication timestamp for AuthnInstant' do
+            authn_instant = Time.zone.parse(subject.attributes['AuthnInstant'].value)
+
+            expect(authn_instant).to be_within(1.second).of(authn_at)
+          end
         end
 
         it 'has a SessionIndex attribute' do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -171,6 +171,27 @@ RSpec.feature 'saml api' do
         expect(user.last_identity.last_authenticated_at).to be_present
       end
 
+      context 'when auth_time_attribute_enabled is enabled' do
+        before do
+          allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
+        end
+
+        it 'refreshes the identity last authenticated time during SAML login' do
+          stale_authn_at = 1.week.ago
+          now = Time.zone.parse('2026-07-08 12:34:56 UTC')
+          identity = user.identities.find_by(service_provider: sp.issuer)
+          identity.update!(last_authenticated_at: stale_authn_at)
+
+          travel_to(now) do
+            visit_saml_authn_request_url
+
+            identity.reload
+
+            expect(identity.last_authenticated_at).to be_within(1.second).of(now)
+          end
+        end
+      end
+
       it 'disables cache' do
         expect(page.response_headers['Pragma']).to eq 'no-cache'
       end


### PR DESCRIPTION
## Summary of changes

- Adds SAML AuthnInstant support behind the shared auth_time_attribute_enabled feature flag.
- Uses the latest linked service provider identity authentication timestamp, with a current-time fallback.
- Adds focused SAML response option coverage and keeps the SAML login regression focused on refreshing last_authenticated_at.

## Testing Plan

- [x] bin/rspec spec/controllers/saml_idp_controller_spec.rb:9 spec/features/saml/saml_spec.rb:179 spec/lib/feature_management_spec.rb:106 spec/services/identity_linker_spec.rb:30
- [x] bin/bundle exec rubocop app/controllers/concerns/saml_idp_auth_concern.rb app/models/service_provider_identity.rb app/services/identity_linker.rb lib/feature_management.rb lib/identity_config.rb spec/controllers/saml_idp_controller_spec.rb spec/features/saml/saml_spec.rb spec/lib/feature_management_spec.rb spec/services/identity_linker_spec.rb spec/support/saml_response_doc.rb