### PR TITLE
Add OIDC state to IdV failure to proof redirects

### DIFF
--- a/app/services/sp_return_url_resolver.rb
+++ b/app/services/sp_return_url_resolver.rb
@@ -17,7 +17,11 @@ class SpReturnUrlResolver
   end
 
   def failure_to_proof_url
-    service_provider.failure_to_proof_url.presence || return_to_sp_url
+    url = service_provider.failure_to_proof_url.presence
+    return return_to_sp_url if url.blank?
+    return url if oidc_state.blank? || !FeatureManagement.idv_failure_to_proof_oidc_state_enabled?
+
+    UriService.add_params(url, state: oidc_state) || url
   end
 
   def homepage_url

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -229,6 +229,7 @@ idv_attempt_window_in_hours: 6
 idv_available: true
 idv_contact_phone_number: (844) 555-5555
 idv_doc_auth_mdl_enabled_percent: 0
+idv_failure_to_proof_oidc_state_enabled: false
 idv_gpo_verification_enabled: true
 idv_max_attempts: 5
 idv_min_age_years: 13

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -199,6 +199,10 @@ class FeatureManagement
       outage_status.phone_finder_outage?
   end
 
+  def self.idv_failure_to_proof_oidc_state_enabled?
+    IdentityConfig.store.idv_failure_to_proof_oidc_state_enabled
+  end
+
   def self.doc_escrow_enabled?(service_provider)
     IdentityConfig.store.doc_escrow_enabled && (
       IdentityConfig.store.historical_attempts_api_enabled ||

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -243,6 +243,7 @@ module IdentityConfig
     config.add(:idv_available, type: :boolean)
     config.add(:idv_contact_phone_number, type: :string)
     config.add(:idv_doc_auth_mdl_enabled_percent, type: :integer)
+    config.add(:idv_failure_to_proof_oidc_state_enabled, type: :boolean)
     config.add(:idv_gpo_verification_enabled, type: :boolean)
     config.add(:idv_max_attempts, type: :integer)
     config.add(:idv_min_age_years, type: :integer)

--- a/spec/controllers/redirect/return_to_sp_controller_spec.rb
+++ b/spec/controllers/redirect/return_to_sp_controller_spec.rb
@@ -102,6 +102,26 @@ RSpec.describe Redirect::ReturnToSpController do
           redirect_url: 'https://sp.gov/failure_to_proof',
         )
       end
+
+      it 'redirects to the SP with OIDC state from the request url' do
+        current_sp.failure_to_proof_url = 'https://sp.gov/failure_to_proof'
+        redirect_uri = 'https://sp.gov/result'
+        state = '123abc'
+        sp_request_url = UriService.add_params(
+          'https://example.gov/authorize', state: state, redirect_uri: redirect_uri
+        )
+        session[:sp] = { request_url: sp_request_url }
+        allow(FeatureManagement).to receive(:idv_failure_to_proof_oidc_state_enabled?)
+          .and_return(true)
+
+        get 'failure_to_proof'
+
+        expect(response).to redirect_to('https://sp.gov/failure_to_proof?state=123abc')
+        expect(@analytics).to have_logged_event(
+          'Return to SP: Failed to proof',
+          redirect_url: 'https://sp.gov/failure_to_proof?state=123abc',
+        )
+      end
     end
 
     context 'with step or location parameters' do

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -607,4 +607,29 @@ RSpec.describe 'FeatureManagement' do
       end
     end
   end
+
+  describe '#idv_failure_to_proof_oidc_state_enabled?' do
+    let(:enabled) { nil }
+
+    before do
+      allow(IdentityConfig.store).to receive(:idv_failure_to_proof_oidc_state_enabled)
+        .and_return(enabled)
+    end
+
+    context 'when idv_failure_to_proof_oidc_state_enabled is true' do
+      let(:enabled) { true }
+
+      it 'returns true' do
+        expect(FeatureManagement.idv_failure_to_proof_oidc_state_enabled?).to be(true)
+      end
+    end
+
+    context 'when idv_failure_to_proof_oidc_state_enabled is false' do
+      let(:enabled) { false }
+
+      it 'returns false' do
+        expect(FeatureManagement.idv_failure_to_proof_oidc_state_enabled?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/services/sp_return_url_resolver_spec.rb
+++ b/spec/services/sp_return_url_resolver_spec.rb
@@ -93,6 +93,57 @@ RSpec.describe SpReturnUrlResolver do
       expect(failure_to_proof_url).to eq(configured_failure_to_proof_url)
     end
 
+    it 'does not add the OIDC state when the feature flag is disabled' do
+      configured_failure_to_proof_url = 'https://sp.gov/failure_to_proof'
+      state = '1234abcd'
+      sp = build(
+        :service_provider,
+        failure_to_proof_url: configured_failure_to_proof_url,
+      )
+      allow(FeatureManagement).to receive(:idv_failure_to_proof_oidc_state_enabled?)
+        .and_return(false)
+
+      resolver = described_class.new(service_provider: sp, oidc_state: state)
+      failure_to_proof_url = resolver.failure_to_proof_url
+
+      expect(failure_to_proof_url).to eq(configured_failure_to_proof_url)
+    end
+
+    it 'adds the OIDC state to a registered failure to proof url' do
+      configured_failure_to_proof_url = 'https://sp.gov/failure_to_proof'
+      state = '1234abcd'
+      sp = build(
+        :service_provider,
+        failure_to_proof_url: configured_failure_to_proof_url,
+      )
+      allow(FeatureManagement).to receive(:idv_failure_to_proof_oidc_state_enabled?)
+        .and_return(true)
+
+      resolver = described_class.new(service_provider: sp, oidc_state: state)
+      failure_to_proof_url = resolver.failure_to_proof_url
+
+      expect(failure_to_proof_url).to eq("#{configured_failure_to_proof_url}?state=#{state}")
+    end
+
+    it 'preserves existing params when adding OIDC state to a registered failure to proof url' do
+      configured_failure_to_proof_url = 'https://sp.gov/failure_to_proof?source=idv'
+      state = '1234abcd'
+      sp = build(
+        :service_provider,
+        failure_to_proof_url: configured_failure_to_proof_url,
+      )
+      allow(FeatureManagement).to receive(:idv_failure_to_proof_oidc_state_enabled?)
+        .and_return(true)
+
+      resolver = described_class.new(service_provider: sp, oidc_state: state)
+      failure_to_proof_url = resolver.failure_to_proof_url
+
+      expect(UriService.params(failure_to_proof_url)).to eq(
+        'source' => 'idv',
+        'state' => state,
+      )
+    end
+
     it 'returns the return to sp url if no failure to proof url is registered' do
       configured_return_to_sp_url = 'https://sp.gov/return_to_sp'
       sp = build(


### PR DESCRIPTION
## Summary
- Add feature-flagged support for appending the original OIDC `state` parameter to configured IdV failure-to-proof redirects.
- Add `idv_failure_to_proof_oidc_state_enabled`, defaulting to `false`.
- Cover enabled and disabled resolver behavior, controller state propagation, feature flag plumbing, and config registration.

## Testing
- `rbenv exec bundle exec rspec spec/lib/identity_config_spec.rb spec/services/sp_return_url_resolver_spec.rb spec/controllers/redirect/return_to_sp_controller_spec.rb spec/lib/feature_management_spec.rb`
- `rbenv exec bundle exec rubocop app/services/sp_return_url_resolver.rb lib/feature_management.rb lib/identity_config.rb spec/controllers/redirect/return_to_sp_controller_spec.rb spec/lib/feature_management_spec.rb spec/services/sp_return_url_resolver_spec.rb`
- `make lint_yaml` in a clean temporary worktree at commit `3f3e33edbf`
