### PR TITLE
Add null check for emails on users at sign up completion

### DIFF
--- a/app/services/displayable_pii_formatter.rb
+++ b/app/services/displayable_pii_formatter.rb
@@ -39,7 +39,7 @@ class DisplayablePiiFormatter
 
   def email
     current_user.confirmed_email_addresses.find_by(id: selected_email_id)&.email ||
-      current_user.last_sign_in_email_address.email
+      current_user.last_sign_in_email_address&.email
   end
 
   def all_emails


### PR DESCRIPTION
This is a quick bandaid to reduce 500s on the `sign_up/completed` page when users arrive with no confirmed email address.  
- [New Relic errors can be viewed here](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&begin=1783496541232&end=1783539741232&filters=selectedInstance%20IN%20%28%29&state=42f3a19c-c48f-1b94-d381-d78f0409309f)
- [Ticket for further remediation of this issue](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17728?atlOrigin=eyJpIjoiNTJhNjQ1NTE4YjQwNGJmNjhkMDFhZjdhZGEyZjQwYTIiLCJwIjoiaiJ9)

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
