### PR TITLE
fixing occurences when user has mulitple emails at sign up

### DIFF
--- a/app/forms/register_user_email_form.rb
+++ b/app/forms/register_user_email_form.rb
@@ -166,7 +166,8 @@ class RegisterUserEmailForm
         email_already_registered: false,
       )
     else
-      SendSignUpEmailConfirmation.new(existing_user).call(request_id: request_id)
+      SendSignUpEmailConfirmation.new(existing_user, email_address: email_address_record)
+        .call(request_id: request_id)
     end
   end
 

--- a/app/services/send_sign_up_email_confirmation.rb
+++ b/app/services/send_sign_up_email_confirmation.rb
@@ -3,8 +3,9 @@
 class SendSignUpEmailConfirmation
   attr_reader :user
 
-  def initialize(user)
+  def initialize(user, email_address: nil)
     @user = user
+    @email_address = email_address
   end
 
   def call(request_id: nil)
@@ -29,10 +30,7 @@ class SendSignUpEmailConfirmation
   end
 
   def email_address
-    @email_address ||= begin
-      handle_multiple_email_address_error if user.email_addresses.count > 1
-      user.email_addresses.take
-    end
+    @email_address ||= user.email_addresses.order('confirmed_at ASC NULLS FIRST').take
   end
 
   def valid_confirmation_token_exists?
@@ -58,9 +56,5 @@ class SendSignUpEmailConfirmation
       user: user,
       email_address: email_address,
     ).suspended_create_account.deliver_now_or_later
-  end
-
-  def handle_multiple_email_address_error
-    raise 'sign up user has multiple email address records'
   end
 end

--- a/spec/forms/register_user_email_form_spec.rb
+++ b/spec/forms/register_user_email_form_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe RegisterUserEmailForm do
       it 'sends confirmation instructions to existing user' do
         expect(send_sign_up_email_confirmation).to receive(:call)
         expect(SendSignUpEmailConfirmation).to receive(:new)
-          .with(existing_user)
+          .with(existing_user, email_address: existing_user.email_addresses.take)
           .and_return(send_sign_up_email_confirmation)
 
         result = subject.submit(params).to_h

--- a/spec/services/send_sign_up_email_confirmation_spec.rb
+++ b/spec/services/send_sign_up_email_confirmation_spec.rb
@@ -40,6 +40,28 @@ RSpec.describe SendSignUpEmailConfirmation do
       expect(email_address.confirmed_at).to eq(nil)
     end
 
+    context 'when the user has multiple unconfirmed email address records' do
+      let!(:second_email_address) do
+        create(:email_address, user: user, confirmed_at: nil, email: 'second@example.com')
+      end
+
+      subject { described_class.new(user, email_address: second_email_address) }
+
+      it 'does not raise and confirms the passed-in email address record' do
+        expect { subject.call(request_id: request_id) }.to_not raise_error
+
+        expect(second_email_address.reload.confirmation_token).to eq(confirmation_token)
+        expect(second_email_address.confirmation_sent_at).to be_within(5.seconds).of(Time.zone.now)
+
+        expect_delivered_email_count(1)
+        expect_delivered_email(
+          to: [second_email_address.email],
+          subject: t('user_mailer.email_confirmation_instructions.subject'),
+          body: [request_id],
+        )
+      end
+    end
+
     context 'when the user already has a confirmation token' do
       let(:email_address) do
         invalid_confirmation_sent_at =


### PR DESCRIPTION
Potential fix for users seeing 500 error when they start the sign up process, abandon without confirming their email address, then restart with the same address.  

[New Relic Errors](https://one.newrelic.com/nr1-core/errors-inbox/entity-inbox/MTM3NjM3MHxBUE18QVBQTElDQVRJT058NTIxMzY4NTg?account=1376370&begin=1783496419195&end=1783539619195&filters=selectedInstance%20IN%20%28%29&state=7a26fc10-32d7-6432-45e6-3ca47640c832)

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
