### PR TITLE
Fix component previews

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -172,7 +172,10 @@ module Identity
       require 'lookbook'
 
       config.view_component.previews.controller = 'ComponentPreviewController'
-      config.view_component.previews.paths = [Rails.root.join('spec', 'components', 'previews').to_s]
+      config.view_component.previews.paths = [Rails.root.join(
+        'spec', 'components',
+        'previews'
+      ).to_s]
       config.view_component.previews.default_layout = 'component_preview'
       config.lookbook.auto_refresh = false
       config.lookbook.project_name = "#{APP_NAME} Component Previews"

--- a/config/application.rb
+++ b/config/application.rb
@@ -167,13 +167,13 @@ module Identity
       config.middleware.delete Rack::Attack
     end
 
-    config.view_component.show_previews = Identity::Hostdata.config.component_previews_enabled
+    config.view_component.previews.enabled = Identity::Hostdata.config.component_previews_enabled
     if Identity::Hostdata.config.component_previews_enabled
       require 'lookbook'
 
-      config.view_component.preview_controller = 'ComponentPreviewController'
-      config.view_component.preview_paths = [Rails.root.join('spec', 'components', 'previews')]
-      config.view_component.default_preview_layout = 'component_preview'
+      config.view_component.previews.controller = 'ComponentPreviewController'
+      config.view_component.previews.paths = [Rails.root.join('spec', 'components', 'previews').to_s]
+      config.view_component.previews.default_layout = 'component_preview'
       config.lookbook.auto_refresh = false
       config.lookbook.project_name = "#{APP_NAME} Component Previews"
       config.lookbook.ui_theme = 'blue'


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
https://gitlab.login.gov/lg-teams/FIE/developer-docs/-/work_items/23

## 🛠 Summary of changes
ViewComponent introduced [breaking changes in v4.0.0](https://github.com/ViewComponent/view_component/releases/tag/v4.0.0). This change addresses these and makes our component previews functional again.

## 📜 Testing Plan

- [ ] visit `/components` in a test environment that has `component_previews_enabled` set to `true`
- [ ] observe that you can see our design system components again

## 👀 Screenshots

<details>
<summary>Before:</summary>
<img width="1288" height="291" alt="image" src="https://github.com/user-attachments/assets/00ef65be-4c4a-4838-9507-1fc59562478b" />
</details>

<details>
<summary>After:</summary>
<img width="1291" height="386" alt="image" src="https://github.com/user-attachments/assets/634ddefe-c839-4548-a963-f6fa4a14f59a" />
</details>

