### PR TITLE
LG-17736 ssa binding page fix

### DIFF
--- a/app/controllers/concerns/idv_session_concern.rb
+++ b/app/controllers/concerns/idv_session_concern.rb
@@ -49,6 +49,10 @@ module IdvSessionConcern
   def redirect_unless_sp_requested_verification
     return if !IdentityConfig.store.idv_sp_required
     return if idv_session_user.profiles.any?
+    # agent proofed users have no sp session on the way in (the success email is
+    # a plain sign in link), so nothing here asks for identity proofing on their
+    # behalf and they would otherwise be sent to the account page
+    return if idv_session_user.proofing_agent_user_awaiting_binding?
     return if resolved_authn_context_result.identity_proofing?
 
     redirect_to account_url

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -234,7 +234,8 @@ module Idv
     end
 
     def save_proofing_agent_threatmetrix_status
-      return unless FeatureManagement.proofing_agent_device_profiling_collecting_enabled?
+      # results are only stored when device profiling is :enabled, not :collect_only
+      return unless IdentityConfig.store.proofing_agent_device_profiling == :enabled
       return if idv_session.threatmetrix_review_status.present?
       return if idv_session.hybrid_mobile_threatmetrix_review_status.present?
 
@@ -242,7 +243,9 @@ module Idv
         user_id: current_user.id,
         type: DeviceProfilingResult::PROFILING_TYPES[:proofing_agent],
       ).order(created_at: :desc).first
-      idv_session.threatmetrix_review_status = device_profile.review_status
+      # collect_only collects the result but never stores a row, so there may
+      # not be one to read here
+      idv_session.threatmetrix_review_status = device_profile&.review_status
     end
   end
 end

--- a/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
+++ b/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
@@ -73,6 +73,20 @@ RSpec.describe Idv::EnterDobSsnController do
   describe '#new' do
     let(:response) { get :new }
 
+    context 'when idv_sp_required is enabled' do
+      # agent proofed users come in from a plain sign in link with no sp
+      # session, so nothing asks for identity proofing on their behalf
+      let(:idv_sp_required) { true }
+
+      before do
+        allow(IdentityConfig.store).to receive(:idv_sp_required).and_return(idv_sp_required)
+      end
+
+      it 'renders the binding page instead of the account page' do
+        expect(response).to render_template(:new)
+      end
+    end
+
     context 'proofing agent feature is disabled' do
       let(:idv_proofing_agent_enabled) { false }
 

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1251,6 +1251,25 @@ RSpec.describe Idv::EnterPasswordController do
 
         expect(document_capture_session.reload.pending_agent_proofed_user_at).to be_nil
       end
+
+      context 'when proofing agent device profiling is collect_only' do
+        # collect_only collects the tmx result but never stores a
+        # DeviceProfilingResult, so this step has no row to read
+        let(:threatmetrix_result) { nil }
+
+        before do
+          allow(IdentityConfig.store).to receive(:proofing_agent_device_profiling)
+            .and_return(:collect_only)
+          allow(IdentityConfig.store).to receive(:proofing_device_profiling)
+            .and_return(:enabled)
+        end
+
+        it 'renders without a stored device profiling result' do
+          get :new
+
+          expect(response).to render_template :new
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17736](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17736)

## 🛠 Summary of changes

Agent proofed users were landing on /account instead of the binding page. The binding email is
a plain sign in link, so they show up with no sp session and no profile yet, and the sp-required
guard sent them to the account page. idv_sp_required is false in dev/test and true in staging,
so it never showed up locally.

Also fixed a nil crash on the password screen. The tmx job only writes a DeviceProfilingResult
when device profiling is :enabled, but that step read one under :collect_only too and called
.review_status on nil.

This is half the staging fix. The dob/ssn 500 is the missing acr_values, which [Amir has in
LG-17737](https://github.com/18F/identity-idp/pull/13275). His needs this one to land first, the guard redirects to /account before his
before_action ever runs.

## 📜 Testing Plan

- [ ] With idv_sp_required on, sign in as a user awaiting binding and confirm you get the
      binding page, not /account
- [ ] With device profiling on :collect_only, submit matching DOB/SSN and confirm the password
      screen renders instead of 500ing
- [ ] On :enabled, confirm the review status still gets picked up and the flow finishes
- [ ] Confirm a normal user with no profile and an SP not asking for proofing still gets /account

[LG-17736]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17736