### PR TITLE
LG-17689: self assert id type on in-person proofing

### DIFF
--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -51,8 +51,11 @@ module Idv
     end
 
     def extra_analytics_attributes(params)
-      { birth_year: params.dig(:dob, :year),
-        document_zip_code: params.dig(:identity_doc_zipcode)&.slice(0, 5) }
+      {
+        birth_year: params.dig(:dob, :year),
+        document_zip_code: params.dig(:identity_doc_zipcode)&.slice(0, 5),
+        asserted_id_type: params.dig(:asserted_id_type),
+      }
     end
   end
 end

--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -8,7 +8,7 @@ module Idv
     ATTRIBUTES = %i[first_name last_name dob identity_doc_address1 identity_doc_address2
                     identity_doc_city identity_doc_zipcode state_id_jurisdiction
                     identity_doc_address_state state_id_number same_address_as_id
-                    id_expiration].freeze
+                    id_expiration asserted_id_type].freeze
 
     attr_accessor(*ATTRIBUTES)
 

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3472,6 +3472,7 @@ module AnalyticsEvents
   # @param [Boolean] opted_in_to_in_person_proofing User opted into in person proofing
   # @param [String] birth_year Birth year from document
   # @param [String] document_zip_code ZIP code from document
+  # @param [String] asserted_id_type Type of ID asserted by the user
   # @param [Boolean] skip_hybrid_handoff Whether skipped hybrid handoff A/B test is active
   # User submitted state id
   def idv_in_person_proofing_state_id_submitted(
@@ -3481,6 +3482,7 @@ module AnalyticsEvents
     analytics_id:,
     birth_year:,
     document_zip_code:,
+    asserted_id_type:,
     skip_hybrid_handoff: nil,
     error_details: nil,
     opted_in_to_in_person_proofing: nil,
@@ -3495,6 +3497,7 @@ module AnalyticsEvents
       error_details:,
       birth_year:,
       document_zip_code:,
+      asserted_id_type:,
       skip_hybrid_handoff:,
       opted_in_to_in_person_proofing:,
       **extra,

--- a/app/services/pii/usps_applicant.rb
+++ b/app/services/pii/usps_applicant.rb
@@ -3,7 +3,7 @@
 module Pii
   UspsApplicant = RedactedStruct.new(
     :first_name, :last_name, :address1, :address2, :city, :state, :zipcode,
-    :current_address_same_as_id, :id_number, :id_expiration, keyword_init: true
+    :current_address_same_as_id, :id_number, :id_expiration, :document_type, keyword_init: true
   ) do
     def self.from_idv_applicant(applicant)
       new(
@@ -17,6 +17,7 @@ module Pii
         id_expiration: applicant['state_id_expiration'],
         id_number: applicant['state_id_number'],
         current_address_same_as_id: applicant['same_address_as_id'],
+        document_type: applicant['asserted_id_type'],
       )
     end
 

--- a/app/services/pii/usps_applicant.rb
+++ b/app/services/pii/usps_applicant.rb
@@ -2,8 +2,21 @@
 
 module Pii
   UspsApplicant = RedactedStruct.new(
-    :first_name, :last_name, :address1, :address2, :city, :state, :zipcode,
-    :current_address_same_as_id, :id_number, :id_expiration, :document_type, keyword_init: true
+    :first_name,
+    :last_name,
+    :address1,
+    :address2,
+    :city,
+    :state,
+    :zipcode,
+    :current_address_same_as_id,
+    :id_number,
+    :id_expiration,
+    :document_type,
+    allowed_members: [
+      :document_type,
+    ],
+    keyword_init: true,
   ) do
     def self.from_idv_applicant(applicant)
       new(

--- a/app/services/usps_in_person_proofing/applicant.rb
+++ b/app/services/usps_in_person_proofing/applicant.rb
@@ -10,9 +10,23 @@ module UspsInPersonProofing
     InPersonEnrollment::DOCUMENT_TYPE_PASSPORT_BOOK => 4,
     Idp::Constants::DocumentTypes::PASSPORT_CARD => 8,
   }.freeze
+
   Applicant = RedactedStruct.new(
-    :unique_id, :first_name, :last_name, :address, :city, :state, :zip_code,
-    :email, :document_type, :document_number, :document_expiration_date, keyword_init: true
+    :unique_id,
+    :first_name,
+    :last_name,
+    :address,
+    :city,
+    :state,
+    :zip_code,
+    :email,
+    :document_type,
+    :document_number,
+    :document_expiration_date,
+    allowed_members: [
+      :document_type,
+    ],
+    keyword_init: true,
   ) do
     def self.from_usps_applicant_and_enrollment(applicant, enrollment)
       id_expiration = Time.zone.parse(applicant&.id_expiration || '')

--- a/app/services/usps_in_person_proofing/applicant.rb
+++ b/app/services/usps_in_person_proofing/applicant.rb
@@ -33,7 +33,7 @@ module UspsInPersonProofing
         email: IdentityConfig.store.usps_ipp_enrollment_status_update_email_address.presence,
         document_number: applicant.id_number,
         document_expiration_date:,
-        document_type: USPS_DOCUMENT_TYPE_MAPPINGS[enrollment.document_type],
+        document_type: USPS_DOCUMENT_TYPE_MAPPINGS[applicant.document_type],
       )
     end
 

--- a/app/services/usps_in_person_proofing/applicant.rb
+++ b/app/services/usps_in_person_proofing/applicant.rb
@@ -47,7 +47,9 @@ module UspsInPersonProofing
         email: IdentityConfig.store.usps_ipp_enrollment_status_update_email_address.presence,
         document_number: applicant.id_number,
         document_expiration_date:,
-        document_type: USPS_DOCUMENT_TYPE_MAPPINGS[applicant.document_type],
+        document_type: USPS_DOCUMENT_TYPE_MAPPINGS[
+          applicant.document_type.presence || enrollment.document_type,
+        ],
       )
     end
 

--- a/app/validators/idv/form_state_id_validator.rb
+++ b/app/validators/idv/form_state_id_validator.rb
@@ -15,6 +15,7 @@ module Idv
                 :state_id_number,
                 :id_expiration,
                 :same_address_as_id,
+                :asserted_id_type,
                 presence: true
 
       validates_with UspsInPersonProofing::TransliterableValidator,

--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -142,6 +142,30 @@
   </div>
 
   <div class="margin-bottom-4">
+    <%= render ValidatedFieldComponent.new(
+          as: :radio_buttons,
+          checked: pii[:asserted_id_type],
+          collection: [
+            [
+              t('in_person_proofing.form.state_id.id_type_drivers_license'),
+              Idp::Constants::DocumentTypes::DRIVERS_LICENSE,
+            ],
+            [
+              t('in_person_proofing.form.state_id.id_type_state_id'),
+              Idp::Constants::DocumentTypes::STATE_ID_CARD,
+            ],
+          ],
+          form: f,
+          label: t('in_person_proofing.form.state_id.id_type'),
+          legend_html: { class: 'h2' },
+          name: :asserted_id_type,
+          required: true,
+          wrapper: :uswds_radio_buttons,
+        )
+    %>
+  </div>
+
+  <div class="margin-bottom-4">
     <%= render MemorableDateComponent.new(
           content_tag: 'memorable-date',
           name: :id_expiration,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1381,6 +1381,9 @@ in_person_proofing.form.state_id.errors.unsupported_chars: 'Our system cannot re
 in_person_proofing.form.state_id.expiration_date: Expiration date
 in_person_proofing.form.state_id.expiration_date_hint: 'Example: 4 28 2028'
 in_person_proofing.form.state_id.first_name: First name
+in_person_proofing.form.state_id.id_type: ID type
+in_person_proofing.form.state_id.id_type_drivers_license: "State Driver’s license"
+in_person_proofing.form.state_id.id_type_state_id: "State Non-Driver’s Identification Card"
 in_person_proofing.form.state_id.identity_doc_address_state: State
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- Select -'
 in_person_proofing.form.state_id.last_name: Last name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1382,7 +1382,7 @@ in_person_proofing.form.state_id.expiration_date: Expiration date
 in_person_proofing.form.state_id.expiration_date_hint: 'Example: 4 28 2028'
 in_person_proofing.form.state_id.first_name: First name
 in_person_proofing.form.state_id.id_type: ID type
-in_person_proofing.form.state_id.id_type_drivers_license: 'State Driver’s license'
+in_person_proofing.form.state_id.id_type_drivers_license: 'State Driver’s License'
 in_person_proofing.form.state_id.id_type_state_id: 'State Non-Driver’s Identification Card'
 in_person_proofing.form.state_id.identity_doc_address_state: State
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- Select -'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1382,8 +1382,8 @@ in_person_proofing.form.state_id.expiration_date: Expiration date
 in_person_proofing.form.state_id.expiration_date_hint: 'Example: 4 28 2028'
 in_person_proofing.form.state_id.first_name: First name
 in_person_proofing.form.state_id.id_type: ID type
-in_person_proofing.form.state_id.id_type_drivers_license: "State Driver’s license"
-in_person_proofing.form.state_id.id_type_state_id: "State Non-Driver’s Identification Card"
+in_person_proofing.form.state_id.id_type_drivers_license: 'State Driver’s license'
+in_person_proofing.form.state_id.id_type_state_id: 'State Non-Driver’s Identification Card'
 in_person_proofing.form.state_id.identity_doc_address_state: State
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- Select -'
 in_person_proofing.form.state_id.last_name: Last name

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1392,6 +1392,9 @@ in_person_proofing.form.state_id.errors.unsupported_chars: 'Nuestro sistema no p
 in_person_proofing.form.state_id.expiration_date: Fecha de vencimiento
 in_person_proofing.form.state_id.expiration_date_hint: 'Ejemplo: 4 28 2028'
 in_person_proofing.form.state_id.first_name: Nombre
+in_person_proofing.form.state_id.id_type: Tipo de identificación
+in_person_proofing.form.state_id.id_type_drivers_license: Licencia de conducir
+in_person_proofing.form.state_id.id_type_state_id: Tarjeta de identificación estatal
 in_person_proofing.form.state_id.identity_doc_address_state: Estado
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- Seleccione -'
 in_person_proofing.form.state_id.last_name: Apellido

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1381,6 +1381,9 @@ in_person_proofing.form.state_id.errors.unsupported_chars: 'Notre système ne pa
 in_person_proofing.form.state_id.expiration_date: Date d’expiration
 in_person_proofing.form.state_id.expiration_date_hint: 'Exemple : 4 28 2028'
 in_person_proofing.form.state_id.first_name: Prénom
+in_person_proofing.form.state_id.id_type: "Type d’identification"
+in_person_proofing.form.state_id.id_type_drivers_license: "Permis de conduire"
+in_person_proofing.form.state_id.id_type_state_id: "Carte d’identité d’un État"
 in_person_proofing.form.state_id.identity_doc_address_state: État
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- Sélectionnez -'
 in_person_proofing.form.state_id.last_name: Nom de famille

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1381,9 +1381,9 @@ in_person_proofing.form.state_id.errors.unsupported_chars: 'Notre système ne pa
 in_person_proofing.form.state_id.expiration_date: Date d’expiration
 in_person_proofing.form.state_id.expiration_date_hint: 'Exemple : 4 28 2028'
 in_person_proofing.form.state_id.first_name: Prénom
-in_person_proofing.form.state_id.id_type: "Type d’identification"
-in_person_proofing.form.state_id.id_type_drivers_license: "Permis de conduire"
-in_person_proofing.form.state_id.id_type_state_id: "Carte d’identité d’un État"
+in_person_proofing.form.state_id.id_type: 'Type d’identification'
+in_person_proofing.form.state_id.id_type_drivers_license: 'Permis de conduire'
+in_person_proofing.form.state_id.id_type_state_id: 'Carte d’identité d’un État'
 in_person_proofing.form.state_id.identity_doc_address_state: État
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- Sélectionnez -'
 in_person_proofing.form.state_id.last_name: Nom de famille

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1394,6 +1394,9 @@ in_person_proofing.form.state_id.errors.unsupported_chars: 我们的系统无法
 in_person_proofing.form.state_id.expiration_date: 过期日期
 in_person_proofing.form.state_id.expiration_date_hint: 举例：4 28 2028
 in_person_proofing.form.state_id.first_name: 名
+in_person_proofing.form.state_id.id_type: 身份证类型
+in_person_proofing.form.state_id.id_type_drivers_license: 的驾照
+in_person_proofing.form.state_id.id_type_state_id: 州颁发的非驾照 ID 卡
 in_person_proofing.form.state_id.identity_doc_address_state: 州
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- 选择 -'
 in_person_proofing.form.state_id.last_name: 姓

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -204,6 +204,7 @@ RSpec.describe Idv::InPerson::StateIdController do
           step: 'state_id',
           birth_year: dob[:year],
           document_zip_code: identity_doc_zipcode&.slice(0, 5),
+          asserted_id_type:,
           opted_in_to_in_person_proofing: true,
         }
       end

--- a/spec/controllers/idv/in_person/state_id_controller_spec.rb
+++ b/spec/controllers/idv/in_person/state_id_controller_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe Idv::InPerson::StateIdController do
     let(:identity_doc_city) { InPersonHelper::GOOD_IDENTITY_DOC_CITY }
     let(:identity_doc_address_state) { InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS_STATE }
     let(:identity_doc_zipcode) { InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE }
+    let(:asserted_id_type) { Idp::Constants::DocumentTypes::DRIVERS_LICENSE }
 
     let(:params) do
       {
@@ -179,6 +180,7 @@ RSpec.describe Idv::InPerson::StateIdController do
           identity_doc_zipcode:,
           dob:,
           id_expiration:,
+          asserted_id_type:,
         },
       }
     end
@@ -452,6 +454,7 @@ RSpec.describe Idv::InPerson::StateIdController do
           identity_doc_zipcode: InPersonHelper::GOOD_IDENTITY_DOC_ZIPCODE,
           dob: { month: '1', day: '1', year: '1980' },
           id_expiration: { month: '12', day: '31', year: '2030' },
+          asserted_id_type: Idp::Constants::DocumentTypes::DRIVERS_LICENSE,
         },
       }
     end

--- a/spec/features/idv/analytics_spec.rb
+++ b/spec/features/idv/analytics_spec.rb
@@ -623,7 +623,7 @@ RSpec.feature 'Analytics Regression', :js do
         step: 'state_id', flow_path: 'standard', analytics_id: 'In Person Proofing', opted_in_to_in_person_proofing: boolean
       },
       'IdV: in person proofing state_id submitted' => {
-        success: true, flow_path: 'standard', step: 'state_id', analytics_id: 'In Person Proofing', birth_year: '1938', document_zip_code: '12345', proofing_components: { document_check: 'usps' }, opted_in_to_in_person_proofing: boolean
+        success: true, flow_path: 'standard', step: 'state_id', analytics_id: 'In Person Proofing', birth_year: '1938', document_zip_code: '12345', asserted_id_type: 'drivers_license', proofing_components: { document_check: 'usps' }, opted_in_to_in_person_proofing: boolean
       },
       'IdV: in person proofing address visited' => {
         step: 'address', flow_path: 'standard', analytics_id: 'In Person Proofing', proofing_components: { document_check: 'usps', source_check: 'StateIdMock' }, opted_in_to_in_person_proofing: boolean

--- a/spec/features/idv/in_person/usps_opt_in_ipp_applicant_expanded_payload_spec.rb
+++ b/spec/features/idv/in_person/usps_opt_in_ipp_applicant_expanded_payload_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe 'In Person Proofing: opt in ipp applicant expanded payload', js: 
   let(:ipp_service_provider) { create(:service_provider, :active, :in_person_proofing_enabled) }
   let(:user) { user_with_2fa }
   let(:usps_expected_document_type) do
-    UspsInPersonProofing::USPS_DOCUMENT_TYPE_MAPPINGS[InPersonEnrollment::DOCUMENT_TYPE_STATE_ID]
+    UspsInPersonProofing::USPS_DOCUMENT_TYPE_MAPPINGS[
+      Idp::Constants::DocumentTypes::DRIVERS_LICENSE,
+    ]
   end
   let(:usps_expected_expiration_date) do
     Time.zone.parse(InPersonHelper::GOOD_STATE_ID_EXPIRATION).to_i

--- a/spec/forms/idv/state_id_form_spec.rb
+++ b/spec/forms/idv/state_id_form_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Idv::StateIdForm do
   let(:first_name) { Faker::Name.first_name }
   let(:dob) { valid_dob }
   let(:id_expiration) { valid_exp }
+  let(:asserted_id_type) { 'drivers_license' }
   let(:params) do
     {
       first_name:,
@@ -52,6 +53,7 @@ RSpec.describe Idv::StateIdForm do
       state_id_jurisdiction: 'AL',
       state_id_number: Faker::IdNumber.valid,
       id_expiration:,
+      asserted_id_type:,
     }
   end
   let(:invalid_char) { '1' }
@@ -153,6 +155,18 @@ RSpec.describe Idv::StateIdForm do
         expect(result.success?).to eq(false)
         expect(subject.errors.empty?).to be(false)
         expect(subject.errors[:same_address_as_id]).to eq [
+          I18n.t('errors.messages.missing_field'),
+        ]
+      end
+    end
+
+    context 'when the asserted_id_type field is missing' do
+      let(:asserted_id_type) { nil }
+
+      it 'returns an error' do
+        expect(result.success?).to eq(false)
+        expect(subject.errors.empty?).to be(false)
+        expect(subject.errors[:asserted_id_type]).to eq [
           I18n.t('errors.messages.missing_field'),
         ]
       end

--- a/spec/forms/idv/state_id_form_spec.rb
+++ b/spec/forms/idv/state_id_form_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Idv::StateIdForm do
   let(:first_name) { Faker::Name.first_name }
   let(:dob) { valid_dob }
   let(:id_expiration) { valid_exp }
-  let(:asserted_id_type) { 'drivers_license' }
+  let(:asserted_id_type) { Idp::Constants::DocumentTypes::DRIVERS_LICENSE }
   let(:params) do
     {
       first_name:,
@@ -66,30 +66,32 @@ RSpec.describe Idv::StateIdForm do
   let(:expired_params) { params.merge(id_expiration: expired_exp) }
   let(:name_error_params) { params.merge(first_name: Faker::Name.first_name + invalid_char) }
   let(:pii) { nil }
+
   describe '#submit' do
     let(:result) { subject.submit(params) }
 
     context 'when the form is valid' do
-      let(:form_response) do
+      let(:expected_extra) do
+        {
+          birth_year: valid_dob[:year],
+          document_zip_code: params[:identity_doc_zipcode].slice(0, 5),
+          asserted_id_type:,
+        }
+      end
+      let(:expected_form_response) do
         FormResponse.new(
           success: true,
           errors: {},
-          extra: { birth_year: valid_dob[:year],
-                   document_zip_code: params[:identity_doc_zipcode].slice(0, 5) },
+          extra: expected_extra,
         )
       end
 
       it 'returns a successful form response' do
-        expect(result).to eq(form_response)
+        expect(result).to eq(expected_form_response)
       end
 
       it 'logs extra analytics attributes' do
-        expect(result.extra).to eq(
-          {
-            birth_year: valid_dob[:year],
-            document_zip_code: params[:identity_doc_zipcode].slice(0, 5),
-          },
-        )
+        expect(result.extra).to eq(expected_extra)
       end
     end
 

--- a/spec/services/pii/usps_applicant_spec.rb
+++ b/spec/services/pii/usps_applicant_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Pii::UspsApplicant do
         'state_id_number' => Faker::Number.number(digits: 9),
         'state_id_expiration' => Faker::Date.in_date_period(year: 2030).strftime('%Y-%m-%d'),
         'same_address_as_id' => false,
+        'asserted_id_type' => Idp::Constants::DocumentTypes::DRIVERS_LICENSE,
       }
     end
 
@@ -29,6 +30,7 @@ RSpec.describe Pii::UspsApplicant do
         id_number: idv_applicant['state_id_number'],
         id_expiration: idv_applicant['state_id_expiration'],
         current_address_same_as_id: idv_applicant['same_address_as_id'],
+        document_type: idv_applicant['asserted_id_type'],
       )
     end
   end

--- a/spec/services/usps_in_person_proofing/applicant_spec.rb
+++ b/spec/services/usps_in_person_proofing/applicant_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe UspsInPersonProofing::Applicant do
   let(:document_expiration_date_in_epoch) do
     Time.zone.parse(document_expiration_date).to_i
   end
-  let(:document_type) { InPersonEnrollment::DOCUMENT_TYPE_STATE_ID }
+  let(:enrollment_document_type) { InPersonEnrollment::DOCUMENT_TYPE_STATE_ID }
+  let(:applicant_document_type) { Idp::Constants::DocumentTypes::DRIVERS_LICENSE }
   let(:usps_expected_document_type) do
-    UspsInPersonProofing::USPS_DOCUMENT_TYPE_MAPPINGS[document_type]
+    UspsInPersonProofing::USPS_DOCUMENT_TYPE_MAPPINGS[applicant_document_type]
   end
   let(:applicant_pii) do
     {
@@ -20,10 +21,11 @@ RSpec.describe UspsInPersonProofing::Applicant do
       zipcode: Faker::Address.zip_code,
       id_number: Faker::Number.number(digits: 9),
       id_expiration: document_expiration_date,
+      document_type: applicant_document_type,
     }
   end
   let(:applicant) { Pii::UspsApplicant.new(**applicant_pii) }
-  let(:enrollment) { build('in_person_enrollment', document_type: document_type) }
+  let(:enrollment) { build('in_person_enrollment', document_type: enrollment_document_type) }
   let(:email) { Faker::Internet.email(name: 'noreply') }
 
   before do
@@ -69,13 +71,15 @@ RSpec.describe UspsInPersonProofing::Applicant do
     end
 
     context 'from_usps_applicant_and_enrollment w state_id' do
-      let(:document_type) { InPersonEnrollment::DOCUMENT_TYPE_STATE_ID }
+      let(:enrollment_document_type) { InPersonEnrollment::DOCUMENT_TYPE_STATE_ID }
+      let(:applicant_document_type) { Idp::Constants::DocumentTypes::STATE_ID_CARD }
 
       it_behaves_like 'when values contains transliterable characters'
     end
 
     context 'from_usps_applicant_and_enrollment w passport book' do
-      let(:document_type) { InPersonEnrollment::DOCUMENT_TYPE_PASSPORT_BOOK }
+      let(:enrollment_document_type) { InPersonEnrollment::DOCUMENT_TYPE_PASSPORT_BOOK }
+      let(:applicant_document_type) { Idp::Constants::DocumentTypes::PASSPORT }
 
       it_behaves_like 'when values contains transliterable characters'
     end

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -46,6 +46,7 @@ module InPersonHelper
     select GOOD_STATE_ID_JURISDICTION,
            from: t('in_person_proofing.form.state_id.state_id_jurisdiction')
     fill_in t('in_person_proofing.form.state_id.state_id_number'), with: GOOD_STATE_ID_NUMBER
+    choose t('in_person_proofing.form.state_id.id_type_drivers_license')
     fill_in_memorable_date('identity_doc[id_expiration]', GOOD_STATE_ID_EXPIRATION)
     fill_in t('in_person_proofing.form.state_id.address1'), with: GOOD_IDENTITY_DOC_ADDRESS1
     fill_in t('in_person_proofing.form.state_id.address2'), with: GOOD_IDENTITY_DOC_ADDRESS2


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17689](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17689)

## 🛠 Summary of changes

Adds an additional field on the In Person State ID form for the user to specify if they are using a driver's license or some other state issued ID.

## 📜 Testing Plan

- [ ] Add a `puts` to the UspsInPersonProofing::EnrollmentHelper at line 119:
```
117      def create_usps_enrollment(enrollment, applicant_pii, is_enhanced_ipp)
118        applicant = create_enrollment_applicant(applicant_pii, enrollment)
119        puts "\n#{'-'*10}document_type: #{applicant.document_type}\n"  # <= Add this line
```
- [ ] Go through IdV, choosing In Person
- [ ] When filling out the state ID form, verify that the ID Type field is present and required
- [ ] Continue through the flow until you enter your password
- [ ] Verify that the puts statement shows the correct document_type:

| ID Type chosen | document_type |
|---|---|
| State Driver's License | 1 |
| State Non-Driver’s Identification Card | 2 |

## 👀 Screenshots

<details>
<summary>Screenshots showing blank error in all languages</summary>

| en | es | fr | zh |
|---|---|---|---|
|<img width="677" height="1506" alt="lg-17689-en" src="https://github.com/user-attachments/assets/43bb81c8-259c-42f4-98a0-e83ec5fa310d" />|<img width="677" height="1506" alt="lg-17689-es" src="https://github.com/user-attachments/assets/e6986ee6-d0e5-4ec8-a698-29f48a352321" />|<img width="677" height="1506" alt="lg-17689-fr" src="https://github.com/user-attachments/assets/c72c46f6-5ec5-4e3f-a2cf-807d815ec570" />|<img width="677" height="1506" alt="lg-17689-zh" src="https://github.com/user-attachments/assets/22c7274c-db77-46a1-aca3-542d54afe2d0" />|

</details>



[LG-17689]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17689