### PR TITLE
LG-15879: Refactor use of selfie_check_performed?

### DIFF
--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -49,7 +49,7 @@ module Idv
         idv_session.doc_auth_vendor = document_capture_session.doc_auth_vendor
         idv_session.pii_from_doc = stored_result.pii_from_doc
         idv_session.aamva_verified_attributes = stored_result.aamva_verified_attributes
-        idv_session.selfie_check_performed = stored_result.selfie_check_performed?
+        idv_session.selfie_check_performed = stored_result.selfie_check_passed?
         idv_session.source_check_vendor = stored_result.source_check_vendor
       end
 
@@ -64,7 +64,7 @@ module Idv
     def selfie_requirement_met?
       !resolved_authn_context_result.facial_match? ||
         mdl_received? ||
-        stored_result.selfie_check_performed?
+        stored_result.selfie_check_passed?
     end
 
     def mrz_requirement_met?

--- a/app/services/doc_auth/response.rb
+++ b/app/services/doc_auth/response.rb
@@ -83,6 +83,10 @@ module DocAuth
       false
     end
 
+    def selfie_check_passed?
+      false
+    end
+
     def doc_auth_success?
       # to be implemented by concrete subclass
       false

--- a/app/services/doc_auth/selfie_concern.rb
+++ b/app/services/doc_auth/selfie_concern.rb
@@ -27,6 +27,10 @@ module DocAuth
       SELFIE_PERFORMED_STATUSES.include?(selfie_status)
     end
 
+    def selfie_check_passed?
+      selfie_status == :success
+    end
+
     private
 
     SELFIE_PERFORMED_STATUSES = %i[success fail].freeze

--- a/spec/controllers/concerns/idv/document_capture_concern_spec.rb
+++ b/spec/controllers/concerns/idv/document_capture_concern_spec.rb
@@ -254,8 +254,8 @@ RSpec.describe Idv::DocumentCaptureConcern, :controller do
           context 'selfie check fail' do
             let(:selfie_status) { :fail }
 
-            it 'returns true' do
-              expect(controller.selfie_requirement_met?).to eq(true)
+            it 'returns false' do
+              expect(controller.selfie_requirement_met?).to eq(false)
             end
           end
         end

--- a/spec/controllers/idv/link_sent_controller_spec.rb
+++ b/spec/controllers/idv/link_sent_controller_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Idv::LinkSentController do
         allow(load_result).to receive(:attention_with_barcode?).and_return(false)
 
         allow(load_result).to receive(:success?).and_return(load_result_success)
-        allow(load_result).to receive(:selfie_check_performed?).and_return(false)
+        allow(load_result).to receive(:selfie_check_passed?).and_return(false)
         allow(load_result).to receive(:errors).and_return({ message: 'an error message' })
         allow(load_result).to receive(:aamva_verified_attributes)
           .and_return(aamva_verified_attributes)

--- a/spec/services/doc_auth/selfie_concern_spec.rb
+++ b/spec/services/doc_auth/selfie_concern_spec.rb
@@ -40,6 +40,37 @@ RSpec.describe DocAuth::SelfieConcern do
     end
   end
 
+  describe '#selfie_check_passed?' do
+    subject do
+      selfie_status_value = selfie_status
+      Class.new do
+        include DocAuth::SelfieConcern
+        define_method(:selfie_status) { selfie_status_value }
+      end.new
+    end
+
+    context 'when the selfie check succeeded' do
+      let(:selfie_status) { :success }
+      it 'returns true' do
+        expect(subject.selfie_check_passed?).to eq(true)
+      end
+    end
+
+    context 'when the selfie check failed' do
+      let(:selfie_status) { :fail }
+      it 'returns false' do
+        expect(subject.selfie_check_passed?).to eq(false)
+      end
+    end
+
+    context 'when the selfie check was not processed' do
+      let(:selfie_status) { :not_processed }
+      it 'returns false' do
+        expect(subject.selfie_check_passed?).to eq(false)
+      end
+    end
+  end
+
   describe '#selfie_quality_good?' do
     context 'no error message' do
       it 'returns true' do


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-15879](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-15879)

## 🛠 Summary of changes

Introduces a `selfie_check_passed?` predicate and uses it in place of
`selfie_check_performed?` where we actually care about whether the selfie check
*succeeded* rather than merely whether it *ran*.

- Add `DocAuth::SelfieConcern#selfie_check_passed?`, which returns `true` only
  when `selfie_status == :success`. This differs from `selfie_check_performed?`,
  which returns `true` for both `:success` and `:fail` statuses.
- Add a default `selfie_check_passed?` (returns `false`) to `DocAuth::Response`
  so all response types respond to the method.
- Update `Idv::DocumentCaptureConcern` to use `selfie_check_passed?`:
  - When setting `idv_session.selfie_check_performed` from the stored result.
  - In `selfie_requirement_met?`, so the selfie requirement is only satisfied
    when the check actually passed.
- Add spec coverage for `#selfie_check_passed?` (`:success`, `:fail`,
  `:not_processed`) and update the link-sent controller spec stub accordingly.

## 📜 Testing Plan

- [ ] `bundle exec rspec spec/services/doc_auth/selfie_concern_spec.rb`
- [ ] `bundle exec rspec spec/controllers/idv/link_sent_controller_spec.rb`
- [ ] Complete a facial-match / selfie IdV flow with a passing selfie and confirm the selfie requirement is met.
- [ ] Complete a flow with a failing selfie and confirm the selfie requirement is **not** met.

[LG-15879]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-15879