### PR TITLE
Implement Users Report API endpoint

### DIFF
--- a/app/controllers/api/users_report/reports_controller.rb
+++ b/app/controllers/api/users_report/reports_controller.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module Api
+  module UsersReport
+    class ReportsController < ApplicationController
+      include RenderConditionConcern
+
+      check_or_render_not_found -> { IdentityConfig.store.users_report_api_enabled }
+
+      prepend_before_action :skip_session_load
+      prepend_before_action :skip_session_expiration
+
+      skip_before_action :verify_authenticity_token
+      # Report config is resolved first so that server misconfiguration (an issuer
+      # mapping to zero or multiple report configs) surfaces as a 500 and takes
+      # precedence over authentication and validation failures.
+      before_action :resolve_report_config
+      before_action :authenticate_client
+      before_action :validate_hourstamp
+
+      rescue_from ::UsersReport::ReportConfigResolver::ConfigurationError,
+                  with: :render_server_error
+
+      def show
+        csv_body = s3_client.get_object(bucket: bucket_name, key: report_key).body.read
+
+        track_request(success: true, status: 200)
+
+        send_data(
+          csv_body,
+          filename: "#{report_name}_#{hourstamp}.csv",
+          type: 'text/csv',
+          disposition: 'attachment',
+        )
+      rescue Aws::S3::Errors::NoSuchKey
+        track_request(success: false, status: 404, failure_type: :not_found)
+        render json: { error: 'CSV file is not available' }, status: :not_found
+      rescue Aws::S3::Errors::ServiceError => e
+        render_server_error(e)
+      end
+
+      private
+
+      def resolve_report_config
+        # A missing/malformed Authorization header has no issuer to resolve
+        return if header_issuer.blank?
+
+        report_config
+      end
+
+      def authenticate_client
+        return if request_token.valid?
+
+        track_request(success: false, status: 401, failure_type: :authorization)
+        render json: { error: 'Unauthorized' }, status: :unauthorized
+      end
+
+      def validate_hourstamp
+        return if parsed_hour.present?
+
+        track_request(success: false, status: 400, failure_type: :bad_request)
+        render json: { error: 'hourstamp must be formatted as YYYYMMDDHH in UTC' },
+               status: :bad_request
+      end
+
+      def parsed_hour
+        return @parsed_hour if defined?(@parsed_hour)
+
+        @parsed_hour = begin
+          value = params[:hourstamp].to_s
+          if /\A\d{10}\z/.match?(value)
+            Time.use_zone('UTC') do
+              parsed = Time.zone.strptime(value, '%Y%m%d%H')
+              parsed if parsed.strftime('%Y%m%d%H') == value
+            end
+          end
+        rescue ArgumentError
+          nil
+        end
+      end
+
+      def hourstamp
+        @hourstamp ||= params[:hourstamp]
+      end
+
+      def request_token
+        @request_token ||= ::UsersReport::RequestTokenValidator.new(request.authorization)
+      end
+
+      def s3_client
+        @s3_client ||= JobHelpers::S3Helper.new.s3_client
+      end
+
+      def bucket_name
+        @bucket_name ||= Identity::Hostdata.bucket_name(IdentityConfig.store.s3_report_bucket_prefix)
+      end
+
+      def report_key
+        time = parsed_hour
+        "#{Identity::Hostdata.env}/#{report_name}/#{time.year}/#{time.strftime('%F.%H')}.csv"
+      end
+
+      def report_name
+        @report_name ||=
+          "#{report_config.fetch('agency_abbreviation').downcase}_proofing_events_by_uuid"
+      end
+
+      def report_config
+        @report_config ||=
+          ::UsersReport::ReportConfigResolver.new(header_issuer).report_config
+      end
+
+      def header_issuer
+        return @header_issuer if defined?(@header_issuer)
+
+        @header_issuer =
+          case request.authorization.to_s.split(' ', 3)
+          in ['Bearer', String => issuer, String]
+            issuer
+          else
+            nil
+          end
+      end
+
+      def render_server_error(exception)
+        NewRelic::Agent.notice_error(exception)
+        track_request(success: false, status: 500, failure_type: :server_error)
+        render json: { error: 'An unexpected error was encountered' },
+               status: :internal_server_error
+      end
+
+      def track_request(success:, status:, failure_type: nil)
+        analytics.users_report_api_requested(
+          issuer: header_issuer,
+          hourstamp:,
+          agency_abbreviation: @report_config&.dig('agency_abbreviation'),
+          success:,
+          status:,
+          failure_type:,
+        )
+      end
+    end
+  end
+end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -335,6 +335,33 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String, nil] issuer
+  # @param [String, nil] hourstamp
+  # @param [String, nil] agency_abbreviation
+  # @param [Boolean] success
+  # @param [Integer] status
+  # @param [Symbol, nil] failure_type
+  def users_report_api_requested(
+    issuer:,
+    hourstamp:,
+    agency_abbreviation:,
+    success:,
+    status:,
+    failure_type: nil,
+    **extra
+  )
+    track_event(
+      :users_report_api_requested,
+      issuer:,
+      hourstamp:,
+      agency_abbreviation:,
+      success:,
+      status:,
+      failure_type:,
+      **extra,
+    )
+  end
+
   # @identity.idp.previous_event_name TOTP: User Disabled
   # Tracks when a user deletes their auth app from account
   # @param [Boolean] success

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -9042,6 +9042,33 @@ module AnalyticsEvents
     track_event(:user_suspension_confirmed)
   end
 
+  # @param [String, nil] issuer
+  # @param [String, nil] hourstamp
+  # @param [String, nil] agency_abbreviation
+  # @param [Boolean] success
+  # @param [Integer] status
+  # @param [Symbol, nil] failure_type
+  def users_report_api_requested(
+    issuer:,
+    hourstamp:,
+    agency_abbreviation:,
+    success:,
+    status:,
+    failure_type: nil,
+    **extra
+  )
+    track_event(
+      :users_report_api_requested,
+      issuer:,
+      hourstamp:,
+      agency_abbreviation:,
+      success:,
+      status:,
+      failure_type:,
+      **extra,
+    )
+  end
+
   # Tracks when USPS in-person proofing enrollment is created
   # @param [String] enrollment_code
   # @param [Integer] enrollment_id

--- a/app/services/users_report/report_config_resolver.rb
+++ b/app/services/users_report/report_config_resolver.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module UsersReport
+  class ReportConfigResolver
+    class ConfigurationError < StandardError; end
+
+    def initialize(issuer)
+      @issuer = issuer
+    end
+
+    # @raise [ConfigurationError] if the issuer maps to zero or more than one config
+    def report_config
+      raise ConfigurationError, 'Issuer is blank' if @issuer.blank?
+
+      matches = IdentityConfig.store.sp_proofing_events_by_uuid_report_configs.select do |config|
+        Array(config['issuers']).include?(@issuer)
+      end
+
+      unless matches.one?
+        raise ConfigurationError,
+              "Expected exactly one report config for the issuer, found #{matches.length}"
+      end
+
+      matches.first
+    end
+
+    def agency_abbreviation
+      report_config['agency_abbreviation']
+    rescue ConfigurationError
+      nil
+    end
+  end
+end

--- a/app/services/users_report/request_token_validator.rb
+++ b/app/services/users_report/request_token_validator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module UsersReport
+  class RequestTokenValidator < Api::RequestTokenValidator
+    private
+
+    def config_data_exists
+      return if config_data_exists?
+
+      errors.add(
+        :issuer,
+        :not_authorized,
+        message: 'Issuer is not authorized to use Users Report API',
+      )
+    end
+
+    def config
+      IdentityConfig.store.users_report_api_config
+    end
+
+    def config_data
+      return nil if agency_abbreviation.nil?
+
+      @config_data ||= config.find do |report_api_config|
+        report_api_config['agency_abbreviation'] == agency_abbreviation
+      end
+    end
+
+    def agency_abbreviation
+      @agency_abbreviation ||= ReportConfigResolver.new(issuer).agency_abbreviation
+    end
+  end
+end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -524,6 +524,8 @@ test_ssn_allowed_list: ''
 totp_code_interval: 30
 unauthorized_scope_enabled: false
 update_cancel_account_reset_path: false
+users_report_api_config: '[]'
+users_report_api_enabled: false
 use_dashboard_service_providers: false
 use_kms: false
 use_vot_in_sp_requests: true

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -546,6 +546,8 @@ update_cancel_account_reset_path: false
 use_dashboard_service_providers: false
 use_kms: false
 use_vot_in_sp_requests: true
+users_report_api_config: '[]'
+users_report_api_enabled: false
 usps_auth_token_refresh_job_enabled: false
 usps_confirmation_max_days: 30
 usps_confirmation_max_days_contiguous_states: 21

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       get '/status' => 'events#status', as: :status
     end
     get '/attempts-certs' => 'attempts_certs#index', as: :attempts_certs
+    get '/users_report/:hourstamp' => 'users_report/reports#show'
 
     namespace :proofing_agent do
       post '/search_user' => 'proofing_agent#search_user'

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -551,6 +551,8 @@ module IdentityConfig
     config.add(:totp_code_interval, type: :integer)
     config.add(:unauthorized_scope_enabled, type: :boolean)
     config.add(:update_cancel_account_reset_path, type: :boolean)
+    config.add(:users_report_api_config, type: :json)
+    config.add(:users_report_api_enabled, type: :boolean)
     config.add(:use_dashboard_service_providers, type: :boolean)
     config.add(:use_kms, type: :boolean)
     config.add(:use_vot_in_sp_requests, type: :boolean)

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -574,6 +574,8 @@ module IdentityConfig
     config.add(:ui_test_bucket_params_enabled, type: :boolean)
     config.add(:unauthorized_scope_enabled, type: :boolean)
     config.add(:update_cancel_account_reset_path, type: :boolean)
+    config.add(:users_report_api_config, type: :json)
+    config.add(:users_report_api_enabled, type: :boolean)
     config.add(:use_dashboard_service_providers, type: :boolean)
     config.add(:use_kms, type: :boolean)
     config.add(:use_vot_in_sp_requests, type: :boolean)

--- a/spec/controllers/api/users_report/reports_controller_spec.rb
+++ b/spec/controllers/api/users_report/reports_controller_spec.rb
@@ -1,0 +1,343 @@
+require 'rails_helper'
+
+RSpec.describe Api::UsersReport::ReportsController do
+  include Rails.application.routes.url_helpers
+
+  let(:enabled) { false }
+  let(:sp) { create(:service_provider) }
+  let(:issuer) { sp.issuer }
+  let(:token) { 'a-shared-secret' }
+  let(:salt) { SecureRandom.hex(32) }
+  let(:cost) { IdentityConfig.store.scrypt_cost }
+  let(:auth_header) { "Bearer #{issuer} #{token}" }
+  let(:hourstamp) { '2024120915' }
+  let(:s3_report_bucket_prefix) { 'reports-bucket' }
+  let(:s3_bucket_name) { 'reports-bucket-test' }
+  let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
+  let(:csv_body) { "uuid,issuer\n123,#{issuer}\n" }
+  let(:agency_abbreviation) { 'ABC' }
+  let(:expected_key) do
+    "test/#{agency_abbreviation.downcase}_proofing_events_by_uuid/2024/2024-12-09.15.csv"
+  end
+
+  let(:hashed_token) do
+    scrypt_salt = cost + OpenSSL::Digest::SHA256.hexdigest(salt)
+    scrypted = SCrypt::Engine.hash_secret token, scrypt_salt, 32
+    SCrypt::Password.new(scrypted).digest
+  end
+
+  let(:users_report_api_config) do
+    [
+      {
+        'agency_abbreviation' => agency_abbreviation,
+        'tokens' => [{ 'value' => hashed_token, 'salt' => salt, 'cost' => cost }],
+      },
+    ]
+  end
+
+  let(:report_configs) do
+    [
+      {
+        'issuers' => [issuer, 'urn:example:second-issuer'],
+        'agency_abbreviation' => agency_abbreviation,
+        'emails' => ['test@example.com'],
+      },
+    ]
+  end
+
+  before do
+    stub_analytics
+    allow(IdentityConfig.store).to receive(:users_report_api_enabled).and_return(enabled)
+    allow(IdentityConfig.store).to receive(:users_report_api_config).and_return(
+      users_report_api_config,
+    )
+    allow(IdentityConfig.store).to receive(:sp_proofing_events_by_uuid_report_configs).and_return(
+      report_configs,
+    )
+    allow(IdentityConfig.store).to receive(:s3_report_bucket_prefix).and_return(
+      s3_report_bucket_prefix,
+    )
+    allow(Identity::Hostdata).to receive(:env).and_return('test')
+    allow(Identity::Hostdata).to receive(:bucket_name).with(s3_report_bucket_prefix).and_return(
+      s3_bucket_name,
+    )
+    allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+
+    request.headers['Authorization'] = auth_header
+  end
+
+  describe '#show' do
+    let(:action) { get :show, params: { hourstamp: hourstamp } }
+
+    context 'when the Users Report API is not enabled' do
+      it 'returns 404 not found' do
+        expect(action.status).to eq(404)
+      end
+    end
+
+    context 'when the Users Report API is enabled' do
+      let(:enabled) { true }
+
+      context 'with no Authorization header' do
+        let(:auth_header) { nil }
+
+        it 'returns a 401' do
+          expect(action.status).to eq(401)
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            hourstamp:,
+            success: false,
+            status: 401,
+            failure_type: :authorization,
+          )
+        end
+      end
+
+      context 'when Authorization header is an empty string' do
+        let(:auth_header) { '' }
+
+        it 'returns a 401' do
+          expect(action.status).to eq(401)
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            hourstamp:,
+            success: false,
+            status: 401,
+            failure_type: :authorization,
+          )
+        end
+      end
+
+      context 'without a Bearer token Authorization header' do
+        let(:auth_header) { "#{issuer} #{token}" }
+
+        it 'returns a 401' do
+          expect(action.status).to eq(401)
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            hourstamp:,
+            success: false,
+            status: 401,
+            failure_type: :authorization,
+          )
+        end
+      end
+
+      context 'with an unknown issuer' do
+        let(:issuer) { 'unknown-issuer' }
+
+        it 'returns a 401' do
+          expect(action.status).to eq(401)
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            issuer:,
+            hourstamp:,
+            agency_abbreviation: agency_abbreviation,
+            success: false,
+            status: 401,
+            failure_type: :authorization,
+          )
+        end
+      end
+
+      context 'with an invalid token' do
+        let(:auth_header) { "Bearer #{issuer} not-shared-secret" }
+
+        it 'returns a 401' do
+          expect(action.status).to eq(401)
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            issuer:,
+            hourstamp:,
+            agency_abbreviation: agency_abbreviation,
+            success: false,
+            status: 401,
+            failure_type: :authorization,
+          )
+        end
+      end
+
+      context 'with a malformed hourstamp' do
+        let(:hourstamp) { '2024-12-09-15' }
+
+        it 'returns a 400 with a JSON error body' do
+          expect(action.status).to eq(400)
+          expect(response.media_type).to eq('application/json')
+          expect(JSON.parse(response.body)).to have_key('error')
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            issuer:,
+            hourstamp:,
+            agency_abbreviation: agency_abbreviation,
+            success: false,
+            status: 400,
+            failure_type: :bad_request,
+          )
+        end
+      end
+
+      context 'with an invalid UTC hourstamp' do
+        let(:hourstamp) { '2024130925' }
+
+        it 'returns a 400 with a JSON error body' do
+          expect(action.status).to eq(400)
+          expect(response.media_type).to eq('application/json')
+          expect(JSON.parse(response.body)).to have_key('error')
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            issuer:,
+            hourstamp:,
+            agency_abbreviation: agency_abbreviation,
+            success: false,
+            status: 400,
+            failure_type: :bad_request,
+          )
+        end
+      end
+
+      context 'when no report config matches the issuer' do
+        let(:report_configs) do
+          [
+            {
+              'issuers' => ['urn:example:different-issuer'],
+              'agency_abbreviation' => agency_abbreviation,
+              'emails' => ['test@example.com'],
+            },
+          ]
+        end
+
+        it 'returns a 500' do
+          expect(action.status).to eq(500)
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            issuer:,
+            hourstamp:,
+            success: false,
+            status: 500,
+            failure_type: :server_error,
+          )
+        end
+      end
+
+      context 'when multiple report configs match the issuer' do
+        let(:report_configs) do
+          [
+            {
+              'issuers' => [issuer],
+              'agency_abbreviation' => 'ABC',
+              'emails' => ['test@example.com'],
+            },
+            {
+              'issuers' => [issuer, 'urn:example:other'],
+              'agency_abbreviation' => 'DEF',
+              'emails' => ['test@example.com'],
+            },
+          ]
+        end
+
+        it 'returns a 500' do
+          expect(action.status).to eq(500)
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            issuer:,
+            hourstamp:,
+            success: false,
+            status: 500,
+            failure_type: :server_error,
+          )
+        end
+
+        context 'and the token is also invalid' do
+          let(:auth_header) { "Bearer #{issuer} not-shared-secret" }
+
+          it 'returns a 500 because server misconfiguration takes precedence' do
+            expect(action.status).to eq(500)
+            expect(@analytics).to have_logged_event(
+              :users_report_api_requested,
+              issuer:,
+              hourstamp:,
+              success: false,
+              status: 500,
+              failure_type: :server_error,
+            )
+          end
+        end
+      end
+
+      context 'when the CSV file is not available' do
+        before do
+          s3_client.stub_responses(
+            :get_object,
+            lambda do |_context|
+              raise Aws::S3::Errors::NoSuchKey.new(nil, nil)
+            end,
+          )
+        end
+
+        it 'returns a 404' do
+          expect(action.status).to eq(404)
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            issuer:,
+            hourstamp:,
+            agency_abbreviation: agency_abbreviation,
+            success: false,
+            status: 404,
+            failure_type: :not_found,
+          )
+        end
+      end
+
+      context 'when the CSV file is available' do
+        before do
+          s3_client.stub_responses(
+            :get_object,
+            { body: StringIO.new(csv_body) },
+          )
+        end
+
+        it 'returns a 200 with the csv body and attachment headers' do
+          expect(action.status).to eq(200)
+          expect(response.media_type).to eq('text/csv')
+          expect(response.body).to eq(csv_body)
+          expect(response.headers['Content-Disposition']).to include('attachment;')
+          expect(response.headers['Content-Disposition']).to include('filename=')
+          expect(response.headers['Content-Disposition']).to include(
+            'abc_proofing_events_by_uuid_2024120915.csv',
+          )
+          expect(@analytics).to have_logged_event(
+            :users_report_api_requested,
+            issuer:,
+            hourstamp:,
+            agency_abbreviation: agency_abbreviation,
+            success: true,
+            status: 200,
+          )
+        end
+
+        it 'looks up the stored file for the exact requested hourstamp' do
+          action
+
+          expect(s3_client.api_requests).to include(
+            a_hash_including(
+              operation_name: :get_object,
+              params: hash_including(bucket: s3_bucket_name, key: expected_key),
+            ),
+          )
+        end
+
+        it 'matches the report config using the raw header issuer' do
+          report_configs.first['issuers'] = [issuer]
+          action
+
+          expect(s3_client.api_requests).to include(
+            a_hash_including(
+              operation_name: :get_object,
+              params: hash_including(bucket: s3_bucket_name, key: expected_key),
+            ),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/users_report/report_config_resolver_spec.rb
+++ b/spec/services/users_report/report_config_resolver_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe UsersReport::ReportConfigResolver do
+  let(:issuer) { 'urn:gov:gsa:openidconnect:sp:example' }
+  let(:agency_abbreviation) { 'ABC' }
+
+  let(:report_configs) do
+    [
+      {
+        'issuers' => [issuer, 'urn:gov:gsa:openidconnect:sp:example:mobile'],
+        'agency_abbreviation' => agency_abbreviation,
+        'emails' => ['test@example.com'],
+      },
+    ]
+  end
+
+  before do
+    allow(IdentityConfig.store).to receive(:sp_proofing_events_by_uuid_report_configs).and_return(
+      report_configs,
+    )
+  end
+
+  subject(:resolver) { described_class.new(issuer) }
+
+  describe '#report_config' do
+    context 'with exactly one matching report config' do
+      it 'returns the matched config' do
+        expect(resolver.report_config).to eq(report_configs.first)
+      end
+    end
+
+    context 'with no matching report config' do
+      let(:report_configs) do
+        [
+          {
+            'issuers' => ['urn:gov:gsa:openidconnect:sp:other'],
+            'agency_abbreviation' => agency_abbreviation,
+            'emails' => ['test@example.com'],
+          },
+        ]
+      end
+
+      it 'raises a ConfigurationError' do
+        expect { resolver.report_config }.to raise_error(
+          UsersReport::ReportConfigResolver::ConfigurationError,
+        )
+      end
+    end
+
+    context 'with multiple matching report configs' do
+      let(:report_configs) do
+        [
+          {
+            'issuers' => [issuer],
+            'agency_abbreviation' => 'ABC',
+            'emails' => ['test@example.com'],
+          },
+          {
+            'issuers' => [issuer, 'urn:gov:gsa:openidconnect:sp:other'],
+            'agency_abbreviation' => 'DEF',
+            'emails' => ['test@example.com'],
+          },
+        ]
+      end
+
+      it 'raises a ConfigurationError' do
+        expect { resolver.report_config }.to raise_error(
+          UsersReport::ReportConfigResolver::ConfigurationError,
+        )
+      end
+    end
+
+    context 'with a blank issuer' do
+      let(:issuer) { nil }
+
+      it 'raises a ConfigurationError' do
+        expect { resolver.report_config }.to raise_error(
+          UsersReport::ReportConfigResolver::ConfigurationError,
+        )
+      end
+    end
+  end
+
+  describe '#agency_abbreviation' do
+    context 'with exactly one matching report config' do
+      it 'returns the agency abbreviation for that config' do
+        expect(resolver.agency_abbreviation).to eq(agency_abbreviation)
+      end
+    end
+
+    context 'with no unique matching report config' do
+      let(:report_configs) { [] }
+
+      it 'returns nil' do
+        expect(resolver.agency_abbreviation).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/users_report/request_token_validator_spec.rb
+++ b/spec/services/users_report/request_token_validator_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe UsersReport::RequestTokenValidator do
+  let(:sp) { create(:service_provider) }
+  let(:issuer) { sp.issuer }
+  let(:agency_abbreviation) { 'ABC' }
+  let(:token) { 'a-shared-secret' }
+  let(:salt) { SecureRandom.hex(32) }
+  let(:cost) { IdentityConfig.store.scrypt_cost }
+
+  let(:hashed_token) do
+    scrypt_salt = cost + OpenSSL::Digest::SHA256.hexdigest(salt)
+    scrypted = SCrypt::Engine.hash_secret token, scrypt_salt, 32
+    SCrypt::Password.new(scrypted).digest
+  end
+
+  let(:auth_header) { "Bearer #{issuer} #{token}" }
+
+  before do
+    allow(IdentityConfig.store).to receive(:users_report_api_config).and_return(
+      [
+        {
+          'agency_abbreviation' => agency_abbreviation,
+          'tokens' => [
+            {
+              'value' => hashed_token,
+              'salt' => salt,
+              'cost' => cost,
+            },
+          ],
+        },
+      ],
+    )
+    allow(IdentityConfig.store).to receive(:sp_proofing_events_by_uuid_report_configs).and_return(
+      [
+        {
+          'issuers' => [sp.issuer],
+          'agency_abbreviation' => agency_abbreviation,
+          'emails' => ['test@example.com'],
+        },
+      ],
+    )
+  end
+
+  subject { UsersReport::RequestTokenValidator.new(auth_header) }
+
+  describe 'validations' do
+    context 'with a valid auth header' do
+      it 'returns true' do
+        expect(subject.valid?).to be true
+      end
+    end
+
+    context 'with no auth header' do
+      let(:auth_header) { nil }
+
+      it 'returns false' do
+        expect(subject.valid?).to be false
+      end
+    end
+
+    context 'with an empty string for auth header' do
+      let(:auth_header) { '' }
+
+      it 'returns false' do
+        expect(subject.valid?).to be false
+      end
+    end
+
+    context 'without a Bearer token' do
+      let(:auth_header) { "#{sp.issuer} #{token}" }
+
+      it 'returns false' do
+        expect(subject.valid?).to be false
+      end
+    end
+
+    context 'without a valid issuer' do
+      context 'with an unknown issuer' do
+        let(:issuer) { 'unknown-issuer' }
+
+        it 'returns false' do
+          expect(subject.valid?).to be false
+        end
+      end
+
+      context 'with an issuer associated with an unauthorized sp' do
+        let(:unauthorized_sp) { create(:service_provider) }
+        let(:issuer) { unauthorized_sp.issuer }
+
+        it 'returns false' do
+          expect(subject.valid?).to be false
+        end
+      end
+
+      context 'with an issuer that is not in a report config' do
+        before do
+          allow(IdentityConfig.store)
+            .to receive(:sp_proofing_events_by_uuid_report_configs)
+            .and_return(
+              [
+                {
+                  'issuers' => ['urn:example:other-issuer'],
+                  'agency_abbreviation' => agency_abbreviation,
+                  'emails' => ['test@example.com'],
+                },
+              ],
+            )
+        end
+
+        it 'returns false' do
+          expect(subject.valid?).to be false
+        end
+      end
+    end
+
+    context 'without a token' do
+      let(:token) { nil }
+
+      it 'returns false' do
+        expect(subject.valid?).to be false
+      end
+    end
+
+    context 'with an invalid token' do
+      let(:auth_header) { "Bearer #{issuer} not-shared-secret" }
+
+      it 'returns false' do
+        expect(subject.valid?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

Ticket in GitLab to be added under Team Data.

## 🛠 Summary of changes

Adds a new API endpoint to access SP-scoped, hourly-generated, non-PII user activity reports stored in S3 as CSVs.

[Technical Spec for Partners](https://docs.google.com/document/d/1Fs-eIAYtKssPEJ73LqFl1cn0GKxDiSONJ_kEhKKpAbM/edit?tab=t.0#heading=h.iv19dj1nlpzp)

The endpoint is protected with a Bearer token at the app (IdP) level, and will enforce mutual TLS at the network (API Gateway) level.

## 🤖 Generative AI Use
An LLM coding agent was used to assist with this PR.

- [X] I've read and reviewed all AI-generated code in this PR.
- [X] I understand all the code in this PR.
- [X] I can debug this code in production if needed.
