### PR TITLE
Add analytic events for historic attempts

### DIFF
--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -14,24 +14,22 @@ module Idv
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)
     end
 
+    def send_historic_events?
+      return false, :idv_not_requested unless idv_requested?
+      return false, :no_user_proofing_event if existing_user_proofing_event.blank?
+      return false, :already_sent if existing_user_proofing_event.already_sent_to_sp?(current_sp.id)
+
+      return true, nil
+    end
+
     private
 
-    def ial2_requested?
+    def idv_requested?
       resolved_authn_context_result.identity_proofing_or_ialmax? && current_user.identity_verified?
     end
 
-    def historical_events_need_be_sent?
-      return false unless historical_events_enabled?
-      return false unless current_sp&.attempts_api_enabled?
-      return false if existing_user_proofing_event.blank?
-
-      return !existing_user_proofing_event.already_sent_to_sp?(current_sp.id)
-    end
-
     def historical_events_enabled?
-      return false unless IdentityConfig.store.historical_attempts_api_enabled
-
-      ial2_requested?
+      IdentityConfig.store.historical_attempts_api_enabled
     end
 
     def existing_user_proofing_event

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -9,15 +9,17 @@ module Idv
       # we always need to cache events if the feature is enabled
       # in case we have to re-encrypt them
       return unless IdentityConfig.store.historical_attempts_api_enabled
-      return unless current_user.active_profile.present?
+      return unless profile.present?
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)
     end
 
     def send_historic_events?
       return false, :idv_not_requested unless idv_requested?
+      return false, :no_active_profile if profile.blank?
       return false, :no_user_proofing_event if existing_user_proofing_event.blank?
       return false, :already_sent if existing_user_proofing_event.already_sent_to_sp?(current_sp.id)
+      return false, :no_encryped_file_reference if profile.encrypted_attempts_file_reference.blank?
 
       return true, nil
     end
@@ -32,8 +34,12 @@ module Idv
       IdentityConfig.store.historical_attempts_api_enabled
     end
 
+    def profile
+      @profile ||= current_user.active_profile
+    end
+
     def existing_user_proofing_event
-      @existing_user_proofing_event ||= current_user.active_profile.user_proofing_event
+      @existing_user_proofing_event ||= profile.user_proofing_event
     end
   end
 end

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -16,10 +16,9 @@ module Idv
 
     def send_historic_events?
       return false, :idv_not_requested unless idv_requested?
-      return false, :no_active_profile if profile.blank?
       return false, :no_user_proofing_event if existing_user_proofing_event.blank?
       return false, :already_sent if existing_user_proofing_event.already_sent_to_sp?(current_sp.id)
-      return false, :no_encryped_file_reference if profile.encrypted_attempts_file_reference.blank?
+      return false, :no_encrypted_file_reference if profile.encrypted_attempts_file_reference.blank?
 
       return true, nil
     end

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -216,6 +216,7 @@ module Idv
 
     def record_user_proofing_events
       return unless historical_events_enabled?
+      return unless idv_requested?
 
       current_user.active_profile.create_user_proofing_event(
         attempt_events:,

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -223,6 +223,7 @@ module Idv
         personal_key: idv_session.personal_key,
         sent_to_sp: attempts_api_enabled_for_session?,
       )
+      analytics.historic_event_data_saved
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)
 

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -235,7 +235,8 @@ module Idv
         personal_key: idv_session.personal_key,
         sent_to_sp: attempts_api_enabled_for_session?,
       )
-      analytics.historic_event_data_saved
+
+      analytics.historic_event_data_saved(profile_id: current_user.active_profile.id)
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)
 

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -227,6 +227,7 @@ module Idv
 
     def record_user_proofing_events
       return unless historical_events_enabled?
+      return unless idv_requested?
 
       current_user.active_profile.create_user_proofing_event(
         attempt_events:,

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -234,6 +234,7 @@ module Idv
         personal_key: idv_session.personal_key,
         sent_to_sp: attempts_api_enabled_for_session?,
       )
+      analytics.historic_event_data_saved
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)
 

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -25,7 +25,7 @@ module SignUp
       update_verified_attributes
       send_in_person_completion_survey
       notify_user_of_connected_sp
-      send_historical_events if historical_events_need_be_sent?
+      send_historical_events
       if selected_email_id_for_linked_identity.nil?
         user_session[:selected_email_id_for_linked_identity] = current_user
           .last_sign_in_email_address.id
@@ -142,11 +142,19 @@ module SignUp
     end
 
     def send_historical_events
-      historical_attempts = AttemptsApi::Cacher.new(current_user, user_session).fetch
+      return unless historical_events_enabled?
+      return unless current_sp&.attempts_api_enabled?
 
-      AttemptsApi::Tracker.write_existing_user_events(historical_attempts:, sp: current_sp)
+      send, msg = send_historic_events?
+      if send
+        historical_attempts = AttemptsApi::Cacher.new(current_user, user_session).fetch
 
-      existing_user_proofing_event.add_sp_sent(current_sp.id)
+        AttemptsApi::Tracker.write_existing_user_events(historical_attempts:, sp: current_sp)
+
+        existing_user_proofing_event.add_sp_sent(current_sp.id)
+      end
+
+      analytics.historic_event_data_released(success: send, exception: msg)
     end
 
     def pii

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -154,7 +154,11 @@ module SignUp
         existing_user_proofing_event.add_sp_sent(current_sp.id)
       end
 
-      analytics.historic_event_data_released(success: send, exception: msg)
+      analytics.historic_event_data_released(
+        success: send,
+        exception: msg,
+        profile_id: current_user.active_profile&.id,
+      )
     end
 
     def pii

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -145,8 +145,8 @@ module SignUp
       return unless historical_events_enabled?
       return unless current_sp&.attempts_api_enabled?
 
-      send, msg = send_historic_events?
-      if send
+      will_send_events, msg = send_historic_events?
+      if will_send_events
         historical_attempts = AttemptsApi::Cacher.new(current_user, user_session).fetch
 
         AttemptsApi::Tracker.write_existing_user_events(historical_attempts:, sp: current_sp)
@@ -155,7 +155,7 @@ module SignUp
       end
 
       analytics.historic_event_data_released(
-        success: send,
+        success: will_send_events,
         exception: msg,
         profile_id: current_user.active_profile&.id,
       )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -606,6 +606,7 @@ class User < ApplicationRecord
 
   def delete_attempt_events
     return unless IdentityConfig.store.historical_attempts_api_enabled
+    analytics.historic_event_data_destroyed
 
     attempt_data_handler.delete_all_user_attempt_data(user_uuid: uuid)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -606,9 +606,9 @@ class User < ApplicationRecord
 
   def delete_attempt_events
     return unless IdentityConfig.store.historical_attempts_api_enabled
-    analytics.historic_event_data_destroyed
 
     attempt_data_handler.delete_all_user_attempt_data(user_uuid: uuid)
+    analytics.historic_event_data_destroyed
   end
 
   def attempt_data_handler

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -854,6 +854,18 @@ module AnalyticsEvents
     )
   end
 
+  # Historic Attempt data was saved when a user completed the IdV process
+  def historic_event_data_saved
+    track_event(:historic_event_data_saved)
+  end
+
+  # @param [Boolean] success Whether the historic attempt data was released
+  # @param [:idv_not_requested, :no_user_proofing_event, :already_sent, nil] exception
+  # Historic data was potentially sent when a user accessed an Attempts Api Consumer App
+  def historic_event_data_released(success:, exception: nil, **extra)
+    track_event(:historic_event_data_released, success:, exception:, **extra)
+  end
+
   # User visited sign-in URL from the "You've been successfully verified email" CTA button
   # @param issuer [String] the ServiceProvider.issuer
   # @param campaign_id [String] the email campaign ID

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -854,9 +854,10 @@ module AnalyticsEvents
     )
   end
 
-  # Historic Attempt data was saved when a user completed the IdV process
-  def historic_event_data_saved
-    track_event(:historic_event_data_saved)
+  # Historic Attempt data was destroyed when a user deleted their account
+  # It deletes ALL historic data, not just the most recent active profile
+  def historic_event_data_destroyed
+    track_event(:historic_event_data_destroyed)
   end
 
   # @param [Boolean] success Whether the historic attempt data was released

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -860,10 +860,23 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether the historic attempt data was released
-  # @param [:idv_not_requested, :no_user_proofing_event, :already_sent, nil] exception
+  # @param [:idv_not_requested, :no_active_profile, :no_user_proofing_event, :already_sent, nil] exception
+  # @param [Number,nil] profile_id ID of the active profile associated with attempts data
   # Historic data was potentially sent when a user accessed an Attempts Api Consumer App
-  def historic_event_data_released(success:, exception: nil, **extra)
-    track_event(:historic_event_data_released, success:, exception:, **extra)
+  def historic_event_data_released(success:, exception: nil, profile_id: nil, **extra)
+    track_event(
+      :historic_event_data_released,
+      success:,
+      exception:,
+      profile_id:,
+      **extra,
+    )
+  end
+
+  # @param [Number] profile_id ID of the active profile associated with attempts data
+  # Historic Attempt data was saved when a user completed the IdV process
+  def historic_event_data_saved(profile_id:, **extra)
+    track_event(:historic_event_data_saved, profile_id:, **extra)
   end
 
   # User visited sign-in URL from the "You've been successfully verified email" CTA button

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -860,12 +860,12 @@ module AnalyticsEvents
     track_event(:historic_event_data_destroyed)
   end
 
+  # Historic data was potentially sent when a user accessed an Attempts Api Consumer App
   # @param [Boolean] success Whether the historic attempt data was released
   # rubocop:disable Layout/LineLength
   # @param [:idv_not_requested, :no_user_proofing_event, :already_sent, :no_encrypted_file_reference nil] exception
   # rubocop:enable Layout/LineLength
   # @param [Integer,nil] profile_id ID of the active profile associated with attempts data
-  # Historic data was potentially sent when a user accessed an Attempts Api Consumer App
   def historic_event_data_released(success:, exception: nil, profile_id: nil, **extra)
     track_event(
       :historic_event_data_released,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -861,8 +861,10 @@ module AnalyticsEvents
   end
 
   # @param [Boolean] success Whether the historic attempt data was released
-  # @param [:idv_not_requested, :no_active_profile, :no_user_proofing_event, :already_sent, nil] exception
-  # @param [Number,nil] profile_id ID of the active profile associated with attempts data
+  # rubocop:disable Layout/LineLength
+  # @param [:idv_not_requested, :no_user_proofing_event, :already_sent, :no_encrypted_file_reference nil] exception
+  # rubocop:enable Layout/LineLength
+  # @param [Integer,nil] profile_id ID of the active profile associated with attempts data
   # Historic data was potentially sent when a user accessed an Attempts Api Consumer App
   def historic_event_data_released(success:, exception: nil, profile_id: nil, **extra)
     track_event(
@@ -874,7 +876,7 @@ module AnalyticsEvents
     )
   end
 
-  # @param [Number] profile_id ID of the active profile associated with attempts data
+  # @param [Integer] profile_id ID of the active profile associated with attempts data
   # Historic Attempt data was saved when a user completed the IdV process
   def historic_event_data_saved(profile_id:, **extra)
     track_event(:historic_event_data_saved, profile_id:, **extra)

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -182,6 +182,7 @@ module AttemptsApi
     end
 
     def should_track?(event_type)
+      # Historical Attempts feature requires the Attempts API to be enabled globally
       return false unless IdentityConfig.store.attempts_api_enabled
 
       should_send_event? || should_log_history?(event_type)

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
   let(:encrypted_existing_events) do
     pii_encryptor.encrypt(idv_attempts.to_json, user_uuid: user.uuid)
   end
+  let(:acr_values) { Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF }
 
   controller ApplicationController do
     include Idv::HistoricalAttemptsConcern
@@ -28,9 +29,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       current_sp: sp,
       current_user: user,
       sp_from_sp_session: sp,
-      sp_session: {
-        acr_values: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-      },
+      sp_session: { acr_values: },
       user_session: { 'idv/attempts' => idv_attempts },
     )
     allow(IdentityConfig.store).to receive_messages(
@@ -39,9 +38,11 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       historical_attempts_api_enabled: true,
     )
 
-    allow(user.active_profile).to receive(:decrypt_user_proofing_events).and_return(
-      idv_attempts.to_json,
-    )
+    if user.active_profile.present?
+      allow(user.active_profile).to receive(:decrypt_user_proofing_events).and_return(
+        idv_attempts.to_json,
+      )
+    end
   end
 
   describe '#cache_user_proofing_events' do
@@ -70,7 +71,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       context 'user does not have an active profile' do
         let(:user) { create(:user, :fully_registered, password:, profiles: []) }
         it 'does not attempt to decrypt events' do
-          expect(user.active_profile).to_not receive(:decrypt_user_proofing_events)
+          expect(AttemptsApi::Cacher).to_not receive(:save)
 
           controller.cache_user_proofing_events(password:)
         end
@@ -122,6 +123,43 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
           it 'does not raise an error' do
             expect { controller.cache_user_proofing_events(password:) }.to_not raise_error
+          end
+        end
+      end
+    end
+  end
+
+  describe '#historical_events_need_to_be_sent' do
+    context 'the request is not an idv request' do
+      let(:acr_values) { Saml::Idp::Constants::IAL_AUTH_ONLY_ACR }
+      it 'returns false with a message' do
+        expect(controller.send_historic_events?).to eq([false, :idv_not_requested])
+      end
+    end
+
+    context 'when the request is an idv request' do
+      context 'when user proofing event does not exist' do
+        it 'returns false with a message' do
+          expect(controller.send_historic_events?).to eq([false, :no_user_proofing_event])
+        end
+      end
+
+      context 'when user proofing event exists' do
+        let(:service_provider_ids_sent) { [] }
+        before do
+          user.active_profile.build_user_proofing_event(service_provider_ids_sent:)
+        end
+
+        context 'when historic data have not been released to the service provider' do
+          it 'returns true with no message' do
+            expect(controller.send_historic_events?).to eq([true, nil])
+          end
+        end
+
+        context 'The events have already been released to the service provider' do
+          let(:service_provider_ids_sent) { [sp.id] }
+          it 'returns false with a message' do
+            expect(controller.send_historic_events?).to eq([false, :already_sent])
           end
         end
       end

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
     end
   end
 
-  describe '#historical_events_need_to_be_sent' do
+  describe '#send_historic_events?' do
     context 'the request is not an idv request' do
       let(:acr_values) { Saml::Idp::Constants::IAL_AUTH_ONLY_ACR }
       it 'returns false with a message' do

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1173,6 +1173,12 @@ RSpec.describe Idv::EnterPasswordController do
               expect(event.profile_id).to eq(user.profiles.last.id)
             end
 
+            it 'tracks an analytic event' do
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+              expect(@analytics).to have_logged_event(:historic_event_data_saved)
+            end
+
             it 'caches user proofing events' do
               put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
               data = controller.user_session[:encrypted_proofing_events]
@@ -1197,6 +1203,8 @@ RSpec.describe Idv::EnterPasswordController do
 
           it 'does not create a UserProofingEvent for the profile' do
             put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(@analytics).to_not have_logged_event(:historic_event_data_saved)
             expect(UserProofingEvent.count).to eq(0)
           end
         end
@@ -1207,6 +1215,8 @@ RSpec.describe Idv::EnterPasswordController do
 
         it 'does not create a UserProofingEvent for the profile' do
           put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+          expect(@analytics).to_not have_logged_event(:historic_event_data_saved)
           expect(UserProofingEvent.count).to eq(0)
         end
       end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1229,7 +1229,10 @@ RSpec.describe Idv::EnterPasswordController do
             it 'tracks an analytic event' do
               put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
-              expect(@analytics).to have_logged_event(:historic_event_data_saved)
+              expect(@analytics).to have_logged_event(
+                :historic_event_data_saved,
+                profile_id: user.profiles.last.id,
+              )
             end
 
             it 'caches user proofing events' do

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1226,6 +1226,12 @@ RSpec.describe Idv::EnterPasswordController do
               expect(event.profile_id).to eq(user.profiles.last.id)
             end
 
+            it 'tracks an analytic event' do
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+              expect(@analytics).to have_logged_event(:historic_event_data_saved)
+            end
+
             it 'caches user proofing events' do
               put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
               data = controller.user_session[:encrypted_proofing_events]
@@ -1250,6 +1256,8 @@ RSpec.describe Idv::EnterPasswordController do
 
           it 'does not create a UserProofingEvent for the profile' do
             put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(@analytics).to_not have_logged_event(:historic_event_data_saved)
             expect(UserProofingEvent.count).to eq(0)
           end
         end
@@ -1260,6 +1268,8 @@ RSpec.describe Idv::EnterPasswordController do
 
         it 'does not create a UserProofingEvent for the profile' do
           put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+          expect(@analytics).to_not have_logged_event(:historic_event_data_saved)
           expect(UserProofingEvent.count).to eq(0)
         end
       end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -232,6 +232,7 @@ RSpec.describe SignUp::CompletionsController do
           needs_completion_screen_reason: :new_sp,
           in_account_creation_flow: true,
         )
+        expect(@analytics).to_not have_logged_event(:historic_event_data_released)
       end
 
       it 'updates verified attributes' do
@@ -366,6 +367,7 @@ RSpec.describe SignUp::CompletionsController do
           in_person_proofing_status: 'passed',
           doc_auth_result: 'Passed',
         )
+        expect(@analytics).to_not have_logged_event(:historic_event_data_released)
       end
 
       it 'updates verified attributes' do
@@ -459,6 +461,12 @@ RSpec.describe SignUp::CompletionsController do
                   sp: current_sp,
                 )
                 expect(proofing_event.service_provider_ids_sent).to include(current_sp.id)
+              end
+
+              it 'tracks analytics' do
+                patch :update
+
+                expect(@analytics).to have_logged_event(:historic_event_data_released)
               end
             end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -447,26 +447,72 @@ RSpec.describe SignUp::CompletionsController do
                 create(
                   :user_proofing_event,
                   :existing,
-                  profile_id: profile.id,
+                  profile_id: user.active_profile.id,
                 )
               end
 
-              it 'updates the associated user proofing event' do
-                expect(proofing_event.service_provider_ids_sent).to_not include(current_sp.id)
-                patch :update
+              context 'there is no user proofing event' do
+                it 'tracks analytics' do
+                  patch :update
 
-                proofing_event.reload
-                expect(AttemptsApi::Tracker).to have_received(:write_existing_user_events).with(
-                  historical_attempts: JSON.parse(idv_attempts),
-                  sp: current_sp,
-                )
-                expect(proofing_event.service_provider_ids_sent).to include(current_sp.id)
+                  expect(@analytics).to have_logged_event(
+                    :historic_event_data_released,
+                    success: false,
+                    exception: :no_user_proofing_event,
+                    profile_id: profile.id,
+                  )
+                end
               end
 
-              it 'tracks analytics' do
-                patch :update
+              context 'there is a user proofing event' do
+                let!(:proofing_event) do
+                  create(
+                    :user_proofing_event,
+                    :existing,
+                    profile_id: user.active_profile.id,
+                  )
+                end
 
-                expect(@analytics).to have_logged_event(:historic_event_data_released)
+                context 'the profile does not have an encrypted_attempts_file_reference' do
+                  it 'tracks analytics' do
+                    patch :update
+
+                    expect(@analytics).to have_logged_event(
+                      :historic_event_data_released,
+                      success: false,
+                      exception: :no_encryped_file_reference,
+                      profile_id: profile.id,
+                    )
+                  end
+                end
+
+                context 'the profile has an encrypted_attempts_file_reference' do
+                  before do
+                    user.active_profile.update(encrypted_attempts_file_reference: 'file-reference')
+                  end
+
+                  it 'updates the associated user proofing event' do
+                    expect(proofing_event.service_provider_ids_sent).to_not include(current_sp.id)
+                    patch :update
+
+                    proofing_event.reload
+                    expect(AttemptsApi::Tracker).to have_received(:write_existing_user_events).with(
+                      historical_attempts: JSON.parse(idv_attempts),
+                      sp: current_sp,
+                    )
+                    expect(proofing_event.service_provider_ids_sent).to include(current_sp.id)
+                  end
+
+                  it 'tracks analytics' do
+                    patch :update
+
+                    expect(@analytics).to have_logged_event(
+                      :historic_event_data_released,
+                      success: true,
+                      profile_id: profile.id,
+                    )
+                  end
+                end
               end
             end
 

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -480,7 +480,7 @@ RSpec.describe SignUp::CompletionsController do
                     expect(@analytics).to have_logged_event(
                       :historic_event_data_released,
                       success: false,
-                      exception: :no_encryped_file_reference,
+                      exception: :no_encrypted_file_reference,
                       profile_id: profile.id,
                     )
                   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2189,12 +2189,18 @@ RSpec.describe User do
 
       describe 'historical_attempts_api_enabled is true' do
         let(:historical_attempts_api_enabled) { true }
+        before { allow(user.analytics).to receive(:historic_event_data_destroyed) }
 
         it 'deletes the event bundle' do
           expect(user_proofing_event.decrypt_events(password:)).to eq(attempt_events.to_json)
           user.destroy
 
           expect(user_proofing_event.decrypt_events(password:)).to be nil
+        end
+
+        it 'tracks an analytics event' do
+          user.destroy
+          expect(user.analytics).to have_received(:historic_event_data_destroyed)
         end
         describe 'when a user has multiple profiles with data' do
           let(:profile1) do
@@ -2219,6 +2225,11 @@ RSpec.describe User do
 
             expect(user_proofing_event.decrypt_events(password:)).to be nil
             expect(deactivated_user_proofing_event.decrypt_events(password:)).to be nil
+          end
+
+          it 'only tracks one analytic event' do
+            user.destroy
+            expect(user.analytics).to have_received(:historic_event_data_destroyed).once
           end
         end
       end


### PR DESCRIPTION
## Ticket
[Secure Protocols 125](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/work_items/125)

## 🛠 Summary of changes
This change: 
- adds three events:
  - `historic_event_data_saved`
  - `historic_event_data_released`
  - `historic_event_data_deleted`
- adds specs for all those events
- adds some specific failure cases for the released event
- updates some code that indicates `ial2` when it means `idv` generally

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
