### PR TITLE
Send additional reCAPTCHA fields

### DIFF
--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -36,6 +36,7 @@ module Users
         user: current_user,
         analytics: analytics,
         request_ip: request.remote_ip,
+        request_user_agent: request.user_agent,
       )
       result = @new_phone_form.submit(new_phone_form_params)
       analytics.multi_factor_auth_phone_setup(**result)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -144,7 +144,7 @@ module Users
     end
 
     def recaptcha_form_args
-      args = { analytics: }
+      args = { analytics:, user_agent: request.user_agent, user_ip_address: request.remote_ip }
       if IdentityConfig.store.recaptcha_mock_validator
         args.merge(
           form_class: RecaptchaMockForm,

--- a/app/forms/new_phone_form.rb
+++ b/app/forms/new_phone_form.rb
@@ -30,13 +30,20 @@ class NewPhoneForm
 
   alias_method :setup_voice_preference?, :setup_voice_preference
 
-  def initialize(user:, analytics: nil, setup_voice_preference: false, request_ip: nil)
+  def initialize(
+    user:,
+    analytics: nil,
+    setup_voice_preference: false,
+    request_ip: nil,
+    request_user_agent: nil
+  )
     @user = user
     @analytics = analytics
     @otp_delivery_preference = user.otp_delivery_preference
     @otp_make_default_number = false
     @setup_voice_preference = setup_voice_preference
     @request_ip = request_ip
+    @request_user_agent = request_user_agent
   end
 
   def submit(params)
@@ -183,7 +190,7 @@ class NewPhoneForm
   end
 
   def recaptcha_form_args
-    args = { analytics: }
+    args = { analytics:, user_agent: @request_user_agent, user_ip_address: @request_ip }
     if IdentityConfig.store.recaptcha_mock_validator
       args.merge(form_class: RecaptchaMockForm, score: recaptcha_mock_score)
     else

--- a/app/forms/recaptcha_enterprise_form.rb
+++ b/app/forms/recaptcha_enterprise_form.rb
@@ -10,7 +10,9 @@ class RecaptchaEnterpriseForm
               :recaptcha_token,
               :score_threshold,
               :analytics,
-              :extra_analytics_properties
+              :extra_analytics_properties,
+              :user_agent,
+              :user_ip_address
 
   validate :validate_token_exists
   validate :validate_recaptcha_result
@@ -19,12 +21,16 @@ class RecaptchaEnterpriseForm
     recaptcha_action: nil,
     score_threshold: 0.0,
     analytics: nil,
-    extra_analytics_properties: {}
+    extra_analytics_properties: {},
+    user_agent: nil,
+    user_ip_address: nil
   )
     @score_threshold = score_threshold
     @analytics = analytics
     @recaptcha_action = recaptcha_action
     @extra_analytics_properties = extra_analytics_properties
+    @user_agent = user_agent
+    @user_ip_address = user_ip_address
   end
 
   def exempt?
@@ -54,7 +60,12 @@ class RecaptchaEnterpriseForm
   end
 
   def recaptcha_result
-    RecaptchaService.new.create_assessment(recaptcha_token:, recaptcha_action:)
+    RecaptchaService.new.create_assessment(
+      recaptcha_token:,
+      recaptcha_action:,
+      user_agent:,
+      user_ip_address:,
+    )
   end
 
   def faraday

--- a/app/services/recaptcha_service.rb
+++ b/app/services/recaptcha_service.rb
@@ -32,14 +32,20 @@ class RecaptchaService
     end
   end
 
-  def create_assessment(recaptcha_token:, recaptcha_action:)
+  def create_assessment(recaptcha_token:, recaptcha_action:, user_agent: nil, user_ip_address: nil)
+    event = {
+      site_key: IdentityConfig.store.recaptcha_site_key,
+      token: recaptcha_token,
+    }
+    if FeatureManagement.recaptcha_enterprise_additional_context_enabled?
+      event[:user_agent] = user_agent if user_agent.present?
+      event[:user_ip_address] = user_ip_address if user_ip_address.present?
+    end
+
     request = {
       parent: "projects/#{IdentityConfig.store.recaptcha_enterprise_project_id}",
       assessment: {
-        event: {
-          site_key: IdentityConfig.store.recaptcha_site_key,
-          token: recaptcha_token,
-        },
+        event:,
       },
     }
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -422,6 +422,7 @@ rails_mailer_previews_enabled: false
 raise_on_component_validation_error: true
 raise_on_missing_title: false
 reauthn_window: 1200
+recaptcha_enterprise_additional_context_enabled: false
 recaptcha_enterprise_api_key: ''
 recaptcha_enterprise_project_id: ''
 recaptcha_mock_validator: true

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -132,6 +132,10 @@ class FeatureManagement
       IdentityConfig.store.recaptcha_enterprise_project_id.present?
   end
 
+  def self.recaptcha_enterprise_additional_context_enabled?
+    IdentityConfig.store.recaptcha_enterprise_additional_context_enabled
+  end
+
   # Whether we collect device profiling as part of the account creation process
   def self.account_creation_device_profiling_collecting_enabled?
     case IdentityConfig.store.account_creation_device_profiling

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -453,6 +453,7 @@ module IdentityConfig
     config.add(:raise_on_component_validation_error, type: :boolean)
     config.add(:raise_on_missing_title, type: :boolean)
     config.add(:reauthn_window, type: :integer)
+    config.add(:recaptcha_enterprise_additional_context_enabled, type: :boolean)
     config.add(:recaptcha_enterprise_api_key, type: :string)
     config.add(:recaptcha_enterprise_project_id, type: :string)
     config.add(:recaptcha_mock_validator, type: :boolean)

--- a/spec/forms/new_phone_form_spec.rb
+++ b/spec/forms/new_phone_form_spec.rb
@@ -601,6 +601,19 @@ RSpec.describe NewPhoneForm do
         allow(form).to receive(:recaptcha_form).and_return(recaptcha_form)
       end
 
+      context 'with request context' do
+        let(:request_ip) { '203.0.113.10' }
+        let(:request_user_agent) { 'Example/1.0' }
+        subject(:form) { NewPhoneForm.new(user:, request_ip:, request_user_agent:) }
+
+        it 'forwards the user agent and ip to the recaptcha form args' do
+          expect(form.send(:recaptcha_form_args)).to include(
+            user_agent: request_user_agent,
+            user_ip_address: request_ip,
+          )
+        end
+      end
+
       context 'with valid recaptcha result' do
         let(:recaptcha_form_response) { FormResponse.new(success: true) }
 

--- a/spec/forms/recaptcha_enterprise_form_spec.rb
+++ b/spec/forms/recaptcha_enterprise_form_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe RecaptchaEnterpriseForm do
   let(:analytics) { FakeAnalytics.new }
   let(:extra_analytics_properties) { {} }
   let(:recaptcha_action) { 'example_action' }
+  let(:user_agent) { 'Example/1.0' }
+  let(:user_ip_address) { '127.0.0.1' }
 
   subject(:form) do
     described_class.new(
@@ -12,6 +14,8 @@ RSpec.describe RecaptchaEnterpriseForm do
       score_threshold:,
       analytics:,
       extra_analytics_properties:,
+      user_agent:,
+      user_ip_address:,
     )
   end
 
@@ -102,7 +106,7 @@ RSpec.describe RecaptchaEnterpriseForm do
       before do
         allow(RecaptchaService).to receive(:new).and_return(recaptcha_service)
         allow(recaptcha_service).to receive(:create_assessment)
-          .with(recaptcha_token: token, recaptcha_action:)
+          .with(recaptcha_token: token, recaptcha_action:, user_agent:, user_ip_address:)
           .and_return(RecaptchaService::RecaptchaResult.new(success: false, reasons: ['EXPIRED']))
       end
 
@@ -146,7 +150,7 @@ RSpec.describe RecaptchaEnterpriseForm do
       before do
         allow(RecaptchaService).to receive(:new).and_return(recaptcha_service)
         allow(recaptcha_service).to receive(:create_assessment)
-          .with(recaptcha_token: token, recaptcha_action:)
+          .with(recaptcha_token: token, recaptcha_action:, user_agent:, user_ip_address:)
           .and_return(RecaptchaService::RecaptchaResult.new(
             success: true,
             reasons: [risk_analysis_reason],
@@ -225,7 +229,7 @@ RSpec.describe RecaptchaEnterpriseForm do
       before do
         allow(RecaptchaService).to receive(:new).and_return(recaptcha_service)
         allow(recaptcha_service).to receive(:create_assessment)
-          .with(recaptcha_token: token, recaptcha_action:)
+          .with(recaptcha_token: token, recaptcha_action:, user_agent:, user_ip_address:)
           .and_return(RecaptchaService::RecaptchaResult.new(
             success: true,
             reasons: ['LOW_CONFIDENCE'],

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -487,6 +487,27 @@ RSpec.describe 'FeatureManagement' do
     end
   end
 
+  describe '.recaptcha_enterprise_additional_context_enabled?' do
+    let(:recaptcha_enterprise_additional_context_enabled) { false }
+
+    subject(:recaptcha_enterprise_additional_context_enabled?) do
+      FeatureManagement.recaptcha_enterprise_additional_context_enabled?
+    end
+
+    before do
+      allow(IdentityConfig.store).to receive(:recaptcha_enterprise_additional_context_enabled)
+        .and_return(recaptcha_enterprise_additional_context_enabled)
+    end
+
+    it { is_expected.to eq(false) }
+
+    context 'when enabled in config' do
+      let(:recaptcha_enterprise_additional_context_enabled) { true }
+
+      it { is_expected.to eq(true) }
+    end
+  end
+
   describe '#idv_available?' do
     let(:idv_available) { true }
     let(:vendor_status_lexisnexis_instant_verify) { :operational }

--- a/spec/services/recaptcha_service_spec.rb
+++ b/spec/services/recaptcha_service_spec.rb
@@ -6,8 +6,15 @@ RSpec.describe RecaptchaService do
   describe '#create_assessment' do
     let(:recaptcha_token) { 'TOKEN' }
     let(:recaptcha_action) { 'ACTION' }
+    let(:user_agent) { 'Example/1.0' }
+    let(:user_ip_address) { '127.0.0.1' }
     subject(:create_assessment) do
-      RecaptchaService.new.create_assessment(recaptcha_token:, recaptcha_action:)
+      RecaptchaService.new.create_assessment(
+        recaptcha_token:,
+        recaptcha_action:,
+        user_agent:,
+        user_ip_address:,
+      )
     end
     let(:recaptcha_client) { instance_double('Google::Cloud::RecaptchaEnterprise::RecaptchaEnterpriseService::Client') }
     let(:recaptcha_assessment) { instance_double('Google::Cloud::RecaptchaEnterprise::Assessment') }
@@ -78,6 +85,77 @@ RSpec.describe RecaptchaService do
           expect(result.assessment_id).to eq('ASSESSMENT_ID')
           expect(result.score).to eq(0.1)
           expect(result.reasons).to eq('AUTOMATION')
+        end
+
+        it 'includes the user agent and user ip address in the assessment event' do
+          allow(FeatureManagement).to receive(:recaptcha_enterprise_additional_context_enabled?)
+            .and_return(true)
+
+          expect(recaptcha_client).to receive(:create_assessment) do |request|
+            event = request[:assessment][:event]
+            expect(event[:user_agent]).to eq(user_agent)
+            expect(event[:user_ip_address]).to eq(user_ip_address)
+            recaptcha_assessment
+          end
+
+          create_assessment
+        end
+
+        context 'when additional context is enabled' do
+          before do
+            allow(FeatureManagement).to receive(:recaptcha_enterprise_additional_context_enabled?)
+              .and_return(true)
+          end
+
+          context 'when the user agent and user ip address are not provided' do
+            subject(:create_assessment) do
+              RecaptchaService.new.create_assessment(recaptcha_token:, recaptcha_action:)
+            end
+
+            it 'omits them from the assessment event' do
+              expect(recaptcha_client).to receive(:create_assessment) do |request|
+                event = request[:assessment][:event]
+                expect(event).not_to have_key(:user_agent)
+                expect(event).not_to have_key(:user_ip_address)
+                recaptcha_assessment
+              end
+
+              create_assessment
+            end
+          end
+
+          context 'when the user agent and user ip address are blank' do
+            let(:user_agent) { '' }
+            let(:user_ip_address) { '' }
+
+            it 'omits them from the assessment event' do
+              expect(recaptcha_client).to receive(:create_assessment) do |request|
+                event = request[:assessment][:event]
+                expect(event).not_to have_key(:user_agent)
+                expect(event).not_to have_key(:user_ip_address)
+                recaptcha_assessment
+              end
+
+              create_assessment
+            end
+          end
+        end
+
+        context 'when additional context is disabled' do
+          before do
+            allow(FeatureManagement).to receive(:recaptcha_enterprise_additional_context_enabled?)
+              .and_return(false)
+          end
+
+          it 'omits the user agent and user ip address from the assessment event' do
+            expect(recaptcha_client).to receive(:create_assessment) do |request|
+              event = request[:assessment][:event]
+              expect(event.keys).to contain_exactly(:site_key, :token)
+              recaptcha_assessment
+            end
+
+            create_assessment
+          end
         end
       end
     end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->


## 🛠 Summary of changes

Adds the Google-recommended `userAgent` and `userIpAddress` values to reCAPTCHA
Enterprise assessments, behind a config flag (default off). These server-side
signals help Google's risk model detect advanced/automated abuse.
Applied to the two flows that use reCAPTCHA today: **sign-in** and **add-new-phone**.

JA3/JA4 (the other two values Google recommends) are intentionally **out of scope** 

## Why

Previously our assessment payload sent only `site_key` and `token`. Google's docs
recommend also passing `userAgent` and `userIpAddress` to improve detection against
"advanced attack patterns and human-led abuse." Both values are already available
server-side (`request.user_agent` / `request.remote_ip`) and are read from the request
rather than trusted from the client, so they can meaningfully corroborate the token.

## Changes

**New config flag (default `false`, preserves current behavior everywhere):**
- `lib/identity_config.rb` — register `recaptcha_enterprise_additional_context_enabled` (boolean)
- `config/application.yml.default` — default `false`
- `lib/feature_management.rb` — add `recaptcha_enterprise_additional_context_enabled?` helper,
  matching how other reCAPTCHA flags are centralized

**Assessment payload:**
- `app/services/recaptcha_service.rb` — `create_assessment` now accepts optional
  `user_agent:` / `user_ip_address:`. When the flag is on, each is added to the event
  **only if present** (non-nil, non-blank). When the flag is off, the event is equal to
  the original `{ site_key, token }` — no behavior change.

**Plumbing (thread request context down to the service):**
- `app/forms/recaptcha_enterprise_form.rb` — accepts and forwards the two values
- `app/controllers/users/sessions_controller.rb` — supplies `request.user_agent` /
  `request.remote_ip` (sign-in)
- `app/controllers/users/phone_setup_controller.rb` + `app/forms/new_phone_form.rb` —
  supply the same (add-phone)
- The wrapper forms (`SignInRecaptchaForm`, `PhoneRecaptchaForm`) required no changes;
  values flow through their existing `**form_args` passthrough.

**Tests:**
- `spec/services/recaptcha_service_spec.rb` — flag on + present → included; flag on +
  blank/absent → omitted; flag off → payload unchanged (`{ site_key, token }`)
- `spec/lib/feature_management_spec.rb` — coverage for the new helper (default off / enabled)
- `spec/forms/recaptcha_enterprise_form_spec.rb`, `spec/forms/new_phone_form_spec.rb` —
  updated for the new forwarded args

## Design decisions

- **Config-gated, single chokepoint.** The enrichment is gated in `RecaptchaService` (via the
  `FeatureManagement` helper), so when the flag is off the off-path is identical to
  prior behavior. Controllers/forms still pass the values regardless; they're simply dropped at
  the service when disabled — one authoritative gate.
- **Presence guard, no truncation.** Empty/nil values are never sent (`.present?`). We forward the
  raw UA string rather than a parsed/normalized one, since Google expects the raw header and
  parsing would lose signal. No length cap added (Google handles limits
  server-side).
- **Read server-side, not from the client.** Using `request.*` (not form fields) is deliberate —
  a client-supplied UA/IP could be spoofed to match a replayed token, defeating the purpose.
- **Two flows only.** Sign-in and add-phone are the only reCAPTCHA entry points today. The shared
  service/form layer means future callers can opt in by passing the values, but none do implicitly.

## Rollout

Additive and reversible. Flag defaults to `false`, so merging changes nothing until
`recaptcha_enterprise_additional_context_enabled` is enabled per environment.

## Follow-ups (not in this PR)

- JA3/JA4 fingerprinting (requires infra/TLS-layer work) — tracked separately

## NIST Compliance
- [Leveraging other risk-based or adaptive authentication techniques such as use of IP address or browser metadata is ALLOWED](https://github.com/usnistgov/800-63-3/blob/nist-pages/sp800-63b/sec5_authenticators.md#522-rate-limiting-throttling)


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [x] Step 1 Specs and local testing
- [ ] Step 2 Sandbox Testing
- [ ] Step 3 Turn on feature toggle when we are ready to observe

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
