### PR TITLE
[LG-17362] update french translation for connected services in account nav

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -124,7 +124,7 @@ account.navigation.add_phone_number: Ajouter un numéro de téléphone
 account.navigation.add_platform_authenticator: Ajouter le déverrouillage facial ou tactile
 account.navigation.add_security_key: Ajouter une clé de sécurité
 account.navigation.close: Fermer
-account.navigation.connected_services: Vos comptes connectés
+account.navigation.connected_services: Vos services connectés
 account.navigation.customer_support: Service client
 account.navigation.delete_account: Supprimer le compte
 account.navigation.edit_password: Modifier le mot de passe


### PR DESCRIPTION
changelog: Bug Fixes, Fix missing translation, Update account to service in account navigation

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17362](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17362)



## 🛠 Summary of changes

Previous work missed an updated translation in French when we were updating `connected accounts` to `connected services`.



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 : Sign into any type of user account at any level
- [ ] Step 2: View the sidebar nav at `/accounts` when selecting French as a the language



<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17362]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17362