### PR TITLE
LG-17750 update idv min age

### DIFF
--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -175,7 +175,7 @@ class SocureErrorPresenter
       t('doc_auth.info.review_passport')
     else
       if remapped_error(error_code) == 'underage' # special handling because it says 'Login.gov'
-        I18n.t('doc_auth.errors.underage', app_name: APP_NAME)
+        I18n.t('doc_auth.errors.underage', app_name: APP_NAME, min_age: IdentityConfig.store.idv_min_age_years)
       else
         # i18n-tasks-use t('doc_auth.errors.unreadable_id')
         # i18n-tasks-use t('doc_auth.errors.unaccepted_id_type')

--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -175,7 +175,11 @@ class SocureErrorPresenter
       t('doc_auth.info.review_passport')
     else
       if remapped_error(error_code) == 'underage' # special handling because it says 'Login.gov'
-        I18n.t('doc_auth.errors.underage', app_name: APP_NAME, min_age: IdentityConfig.store.idv_min_age_years)
+        I18n.t(
+          'doc_auth.errors.underage',
+          app_name: APP_NAME,
+          min_age: IdentityConfig.store.idv_min_age_years,
+        )
       else
         # i18n-tasks-use t('doc_auth.errors.unreadable_id')
         # i18n-tasks-use t('doc_auth.errors.unaccepted_id_type')

--- a/app/validators/idv/form_dob_ssn_validator.rb
+++ b/app/validators/idv/form_dob_ssn_validator.rb
@@ -15,6 +15,7 @@ module Idv
                        I18n.t(
                          'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
                          app_name: APP_NAME,
+                         min_age: IdentityConfig.store.idv_min_age_years,
                        )
                      end
       # rubocop:enable Layout/LineLength

--- a/app/validators/idv/form_state_id_validator.rb
+++ b/app/validators/idv/form_state_id_validator.rb
@@ -46,6 +46,7 @@ module Idv
                        I18n.t(
                          'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
                          app_name: APP_NAME,
+                         min_age: IdentityConfig.store.idv_min_age_years,
                        )
                      end
       # rubocop:enable Layout/LineLength

--- a/app/validators/idv/in_person/form_passport_validator.rb
+++ b/app/validators/idv/in_person/form_passport_validator.rb
@@ -42,6 +42,7 @@ module Idv::InPerson::FormPassportValidator
                      I18n.t(
                        'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
                        app_name: APP_NAME,
+                       min_age: IdentityConfig.store.idv_min_age_years,
                      )
                    end
     # rubocop:enable Layout/LineLength

--- a/app/views/idv/in_person/passport/show.html.erb
+++ b/app/views/idv/in_person/passport/show.html.erb
@@ -63,10 +63,11 @@
             },
             range_errors: [
               {
-                max: Time.zone.today - 13.years,
+                max: Time.zone.today - IdentityConfig.store.idv_min_age_years.years,
                 message: t(
                   'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
                   app_name: APP_NAME,
+                  min_age: IdentityConfig.store.idv_min_age_years,
                 ),
               },
             ],

--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -76,10 +76,11 @@
         },
         range_errors: [
           {
-            max: Time.zone.today - 13.years,
+            max: Time.zone.today - IdentityConfig.store.idv_min_age_years.years,
             message: t(
               'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
               app_name: APP_NAME,
+              min_age: IdentityConfig.store.idv_min_age_years,
             ),
           },
         ],

--- a/app/views/shared/_dob_field.html.erb
+++ b/app/views/shared/_dob_field.html.erb
@@ -17,10 +17,11 @@ locals:
       },
       range_errors: [
         {
-          max: Time.zone.today - 13.years,
+          max: Time.zone.today - IdentityConfig.store.idv_min_age_years.years,
           message: t(
             'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
             app_name: APP_NAME,
+            min_age: IdentityConfig.store.idv_min_age_years,
           ),
         },
       ],

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -231,7 +231,7 @@ idv_contact_phone_number: (844) 555-5555
 idv_doc_auth_mdl_enabled_percent: 0
 idv_gpo_verification_enabled: true
 idv_max_attempts: 5
-idv_min_age_years: 13
+idv_min_age_years: 18
 idv_phone_confirmation_manual_review_validity_hours: 0
 idv_phone_precheck_percent: 0
 idv_phone_verification_dual_vendor_check_ddp_lexis_nexis_percent: 0

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -586,7 +586,7 @@ doc_auth.errors.sharpness.top_msg: We couldn’t read your ID. Your photo may be
 doc_auth.errors.sharpness.top_msg_plural: We couldn’t read your ID. Your photos may be too blurry or dark. Try taking new pictures in a bright area.
 doc_auth.errors.state_id_verification: The information on your ID could not be verified with your state. You may need to verify your ID in person, or you can try again with a different ID.
 doc_auth.errors.unaccepted_id_type: We do not accept passports, military IDs, paper IDs or temporary IDs. You may only use a driver’s license or an ID issued by a U.S. state or territory.
-doc_auth.errors.underage: You must be at least 13 years old to use %{app_name}. If you are 13 or older, try again and make sure your date of birth is in focus.
+doc_auth.errors.underage: You must be at least %{min_age} years old to use %{app_name}. If you are %{min_age} or older, try again and make sure your date of birth is in focus.
 doc_auth.errors.unreadable_id: Take your photos in a well-lit area without shadows or glare. Make sure that everything on your ID is in focus and that the card fills the frame.
 doc_auth.errors.upload_error: Sorry, something went wrong on our end.
 doc_auth.errors.verify_drivers_license_heading: We couldn’t verify your driver’s license or state ID
@@ -1406,7 +1406,7 @@ in_person_proofing.form.state_id.identity_doc_address_state: State
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- Select -'
 in_person_proofing.form.state_id.last_name: Last name
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.missing_month_day_year: Enter a date of birth
-in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: You must be over 13 years of age to use %{app_name}
+in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: You must be over %{min_age} years of age to use %{app_name}
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_overflow: Enter a date that is in the past
 in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired: You cannot use an expired ID.
 in_person_proofing.form.state_id.same_address_as_id: Do you currently live at the address listed on your state‑issued ID?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -597,7 +597,7 @@ doc_auth.errors.sharpness.top_msg: No pudimos leer su identificación. Es posibl
 doc_auth.errors.sharpness.top_msg_plural: No pudimos leer su identificación. Es posible que sus fotos estén demasiado borrosas u oscuras. Intente tomar nuevas fotos en un lugar iluminado.
 doc_auth.errors.state_id_verification: La información de su identificación no pudo ser verificada con su estado. Es posible que necesite verificar su identificación en persona, o puede volver a intentarlo con una identificación diferente.
 doc_auth.errors.unaccepted_id_type: No aceptamos pasaportes, identificaciones militares, ni identificaciones impresas o temporales. Solo puede usar una licencia de conducir o una identificación emitida por un estado o territorio de los EE. UU.
-doc_auth.errors.underage: Debe tener al menos 13 años para usar %{app_name}. Si tiene 13 años o más, vuelva a intentarlo y verifique que su fecha de nacimiento se vea nítida.
+doc_auth.errors.underage: Debe tener al menos %{min_age} años para usar %{app_name}. Si tiene %{min_age} años o más, vuelva a intentarlo y verifique que su fecha de nacimiento se vea nítida.
 doc_auth.errors.unreadable_id: Tome sus fotografías en un lugar bien iluminado sin sombras ni reflejos. Revise que la información en su identificación se vea nítida y que la tarjeta llene el marco.
 doc_auth.errors.upload_error: Lo sentimos, algo no funcionó bien.
 doc_auth.errors.verify_drivers_license_heading: No pudimos verificar su licencia de conducir o su identificación estatal
@@ -1417,7 +1417,7 @@ in_person_proofing.form.state_id.identity_doc_address_state: Estado
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- Seleccione -'
 in_person_proofing.form.state_id.last_name: Apellido
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.missing_month_day_year: Ingrese una fecha de nacimiento
-in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: Debe ser mayor de 13 años para usar %{app_name}
+in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: Debe ser mayor de %{min_age} años para usar %{app_name}
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_overflow: Ingrese una fecha ya transcurrida
 in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired: No puede usar una identificación vencida.
 in_person_proofing.form.state_id.same_address_as_id: '¿Vive actualmente en la dirección que figura en su identificación emitida por el estado?'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -586,7 +586,7 @@ doc_auth.errors.sharpness.top_msg: Nous n’avons pas pu lire votre pièce d’i
 doc_auth.errors.sharpness.top_msg_plural: Nous n’avons pas pu lire votre pièce d’identité. Il se peut que vos photos soient trop floues ou trop sombres. Essayez de prendre de nouvelles photos dans un endroit bien éclairé.
 doc_auth.errors.state_id_verification: Les informations figurant sur votre pièce d’identité n’ont pas pu être vérifiées auprès de votre État. Vous devrez peut-être faire vérifier votre pièce d’identité en personne, ou vous pouvez réessayer avec une autre pièce d’identité.
 doc_auth.errors.unaccepted_id_type: Nous n’acceptons pas de passeports, de cartes d’identité militaires, de pièces d’identité papier ou provisoires. Vous pouvez uniquement utiliser un permis de conduire ou une pièce d’identité délivré par un État ou un territoire des États-Unis.
-doc_auth.errors.underage: Vous devez être âgé de 13 ans au moins pour utiliser %{app_name}. Si vous avez 13 ans ou plus, réessayez et assurez-vous que votre date de naissance est bien visible.
+doc_auth.errors.underage: Vous devez être âgé de %{min_age} ans au moins pour utiliser %{app_name}. Si vous avez %{min_age} ans ou plus, réessayez et assurez-vous que votre date de naissance est bien visible.
 doc_auth.errors.unreadable_id: Prenez vos photos dans un endroit bien éclairé sans ombre ou reflet. Veillez à ce que tous les renseignements figurant sur votre pièce d’identité soient nets et que l’ensemble de la pièce soit visible à l’intérieur du cadre.
 doc_auth.errors.upload_error: Désolé, il y a eu un problème de notre côté.
 doc_auth.errors.verify_drivers_license_heading: Nous n’avons pas pu vérifier votre permis de conduire ou carte d’identité d’un État
@@ -1406,7 +1406,7 @@ in_person_proofing.form.state_id.identity_doc_address_state: État
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- Sélectionnez -'
 in_person_proofing.form.state_id.last_name: Nom de famille
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.missing_month_day_year: Saisissez une date de naissance
-in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: Vous devez avoir plus de 13 ans pour utiliser %{app_name}
+in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: Vous devez avoir plus de %{min_age} ans pour utiliser %{app_name}
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_overflow: Saisissez une date dans le passé
 in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired: Vous ne pouvez pas utiliser une pièce d’identité expirée.
 in_person_proofing.form.state_id.same_address_as_id: Vivez-vous actuellement à l’adresse indiquée sur votre pièce d’identité émise par l’État ?

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -597,7 +597,7 @@ doc_auth.errors.sharpness.top_msg: 我们无法读取你的身份证件。你的
 doc_auth.errors.sharpness.top_msg_plural: 我们无法读取你的身份证件。你的照片可能太模糊或太暗。尝试在明亮的地方重拍一张。
 doc_auth.errors.state_id_verification: 您的身份证件上的信息无法通过您所在州的验证。您可能需要亲自验证身份证件，或者您可以尝试使用其他身份证件。
 doc_auth.errors.unaccepted_id_type: 我们不接受护照、军人身份证件、纸质身份证件或临时身份证件。你只能使用驾驶执照或美国州或领地颁发的身份证件。
-doc_auth.errors.underage: 你必须年满 13 岁才能使用 %{app_name}。如果你年满 13 岁，请重试并确保你的出生日期对焦。
+doc_auth.errors.underage: 你必须年满 %{min_age} 岁才能使用 %{app_name}。如果你年满 %{min_age} 岁，请重试并确保你的出生日期对焦。
 doc_auth.errors.unreadable_id: 请在光线充足而且没有阴影或眩光的地方拍照。确保你身份证件上的所有内容都清晰对焦，并且身份卡填满画面。
 doc_auth.errors.upload_error: 抱歉，我们这边出错了。
 doc_auth.errors.verify_drivers_license_heading: 我们无法验证你的驾照或州 ID。
@@ -1420,7 +1420,7 @@ in_person_proofing.form.state_id.identity_doc_address_state: 州
 in_person_proofing.form.state_id.identity_doc_address_state_prompt: '- 选择 -'
 in_person_proofing.form.state_id.last_name: 姓
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.missing_month_day_year: 输入生日
-in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: 你年龄必须超过 13 岁才能使用 %{app_name}
+in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: 你年龄必须超过 %{min_age} 岁才能使用 %{app_name}
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_overflow: 输入过去的一个日期
 in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired: 你不能使用过期 ID。
 in_person_proofing.form.state_id.same_address_as_id: 你目前所住地址是州政府颁发的身份证件上所列地址吗？

--- a/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
+++ b/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
@@ -138,7 +138,9 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
   let(:passport_card_type) { Idp::Constants::DocumentTypes::PASSPORT_CARD }
   let(:first_name) { 'FirstName' }
   let(:last_name) { 'LastName' }
-  let(:dob) { (Time.zone.today - 14.years).strftime('%Y-%m-%d') }
+  let(:dob) do
+    (Time.zone.today - (IdentityConfig.store.idv_min_age_years + 1).years).strftime('%Y-%m-%d')
+  end
   let(:document_number) { '123' }
   let(:jurisdiction) { 'MD' }
   let(:address1) { '123 Main' }

--- a/spec/features/idv/steps/in_person/state_id_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_spec.rb
@@ -91,11 +91,13 @@ RSpec.describe 'state id controller enabled', :js do
 
       buffer_to_avoid_test_flakiness = 2.days
 
-      less_than_13_years_ago = Time.zone.now - (13.years - buffer_to_avoid_test_flakiness)
+      less_than_min_age_years_ago = Time.zone.now - (
+        IdentityConfig.store.idv_min_age_years.years - buffer_to_avoid_test_flakiness
+      )
       dob = [
-        less_than_13_years_ago.year,
-        less_than_13_years_ago.month,
-        less_than_13_years_ago.day,
+        less_than_min_age_years_ago.year,
+        less_than_min_age_years_ago.month,
+        less_than_min_age_years_ago.day,
       ].join('-')
 
       fill_in_memorable_date('identity_doc[dob]', dob)
@@ -105,14 +107,17 @@ RSpec.describe 'state id controller enabled', :js do
         t(
           'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
           app_name: APP_NAME,
+          min_age: IdentityConfig.store.idv_min_age_years,
         ),
       )
 
-      thirteenish_years_ago = Time.zone.now - (13.years + buffer_to_avoid_test_flakiness)
+      older_than_min_age_years_ago = Time.zone.now - (
+        IdentityConfig.store.idv_min_age_years.years + buffer_to_avoid_test_flakiness
+      )
       dob = [
-        thirteenish_years_ago.year,
-        thirteenish_years_ago.month,
-        thirteenish_years_ago.day,
+        older_than_min_age_years_ago.year,
+        older_than_min_age_years_ago.month,
+        older_than_min_age_years_ago.day,
       ].join('-')
 
       fill_in_memorable_date('identity_doc[dob]', dob)
@@ -122,6 +127,7 @@ RSpec.describe 'state id controller enabled', :js do
         t(
           'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
           app_name: APP_NAME,
+          min_age: IdentityConfig.store.idv_min_age_years,
         ),
       )
     end

--- a/spec/forms/idv/in_person/passport_form_spec.rb
+++ b/spec/forms/idv/in_person/passport_form_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe Idv::InPerson::PassportForm do
             I18n.t(
               'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
               app_name: APP_NAME,
+              min_age: IdentityConfig.store.idv_min_age_years,
             ),
           ]
         end

--- a/spec/forms/idv/state_id_form_spec.rb
+++ b/spec/forms/idv/state_id_form_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe Idv::StateIdForm do
             I18n.t(
               'in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age',
               app_name: APP_NAME,
+              min_age: IdentityConfig.store.idv_min_age_years,
             ),
           ]
         end

--- a/spec/presenters/socure_error_presenter_spec.rb
+++ b/spec/presenters/socure_error_presenter_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe SocureErrorPresenter do
 
       it 'returns the underage message with app name' do
         expect(presenter.body_text).to eq(
-          I18n.t('doc_auth.errors.underage', app_name: APP_NAME),
+          I18n.t('doc_auth.errors.underage', app_name: APP_NAME, min_age: IdentityConfig.store.idv_min_age_years),
         )
       end
     end

--- a/spec/presenters/socure_error_presenter_spec.rb
+++ b/spec/presenters/socure_error_presenter_spec.rb
@@ -217,7 +217,11 @@ RSpec.describe SocureErrorPresenter do
 
       it 'returns the underage message with app name' do
         expect(presenter.body_text).to eq(
-          I18n.t('doc_auth.errors.underage', app_name: APP_NAME, min_age: IdentityConfig.store.idv_min_age_years),
+          I18n.t(
+            'doc_auth.errors.underage',
+            app_name: APP_NAME,
+            min_age: IdentityConfig.store.idv_min_age_years,
+          ),
         )
       end
     end

--- a/spec/services/pii/passport_spec.rb
+++ b/spec/services/pii/passport_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Pii::Passport do
       middle_name: Faker::Name.middle_name,
       last_name: Faker::Name.last_name,
       name_suffix: Faker::Name.suffix,
-      dob: Faker::Date.between(from: 90.years.ago, to: 13.years.ago).strftime('%Y-%m-%d'),
+      dob: Faker::Date.between(
+        from: 90.years.ago,
+        to: IdentityConfig.store.idv_min_age_years.years.ago,
+      ).strftime('%Y-%m-%d'),
       sex: Faker::Gender.short_binary_type,
       birth_place: Faker::Address.city,
       passport_expiration: Faker::Date.between(from: 1.day.after, to: 2.years.after)

--- a/spec/services/pii/state_id_spec.rb
+++ b/spec/services/pii/state_id_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe Pii::StateId do
       city: Faker::Address.city,
       state: Faker::Address.state_abbr,
       zipcode: Faker::Address.zip_code,
-      dob: Faker::Date.between(from: 90.years.ago, to: 13.years.ago).strftime('%Y-%m-%d'),
+      dob: Faker::Date.between(
+        from: 90.years.ago,
+        to: IdentityConfig.store.idv_min_age_years.years.ago,
+      ).strftime('%Y-%m-%d'),
       sex: Faker::Gender.short_binary_type,
       height: 72,
       weight: nil,


### PR DESCRIPTION
changelog: User-Facing Improvements, Identity Verification, raise minimum age requirement to 18

## 🎫 Ticket

Link to the relevant ticket:
[LG-17750](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17750)


## 🛠 Summary of changes

Raises the IdV minimum age from 13 to 18 via `idv_min_age_years`.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] DOB under 18 -> "Your birthday does not meet the minimum age requirement."
- [ ] DOB at 18 passes through to SSN
- [ ] IPP state ID: DOB under 18 -> "You must be over 18 years of age to use Login.gov"
- [ ] Socure: under 18 -> underage copy (needs R845, not reproducible locally)


## 👀 Screenshots
<img width="1512" height="795" alt="LG-17750-ipp-state-id-under18-full" src="https://github.com/user-attachments/assets/a157d921-97a4-4965-914f-b1e270fce117" />

[LG-17750]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17750