### PR TITLE
LG-17734 proofing completion confirmation text

### DIFF
--- a/app/controllers/idv/by_mail/enter_code_controller.rb
+++ b/app/controllers/idv/by_mail/enter_code_controller.rb
@@ -119,6 +119,7 @@ module Idv
 
           UserAlerts::AlertUserAboutAccountVerified.call(
             profile: current_user.active_profile,
+            phone: nil,
           )
           flash[:success] = t('account.index.verification.success')
         end

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -156,6 +156,7 @@ module Idv
         create_user_event(:account_verified)
         UserAlerts::AlertUserAboutAccountVerified.call(
           profile: idv_session.profile,
+          phone: proofing_completion_phone_number,
         )
         attempts_api_tracker.idv_enrollment_complete(reproof:)
         fraud_ops_tracker.idv_enrollment_complete(reproof:)
@@ -172,6 +173,16 @@ module Idv
 
     def password
       params.fetch(:user, {})[:password].presence
+    end
+
+    def proofing_completion_phone_number
+      if idv_session.address_verification_mechanism == 'phone'
+        idv_session.user_phone_confirmation_session&.phone
+      elsif idv_session.phone_for_mobile_flow.present?
+        idv_session.phone_for_mobile_flow
+      else
+        current_user.default_phone_configuration&.formatted_phone
+      end
     end
 
     def confirm_no_profile_yet

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -499,7 +499,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       end
 
       # send SMS and email
-      send_account_verified_sms_notification(enrollment)
+      send_account_verified_sms_notification(enrollment: enrollment)
       send_verified_email(enrollment:, visited_location_name: response['proofingPostOffice'])
       analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
         **email_analytics_attributes(enrollment),
@@ -688,7 +688,7 @@ class GetUspsProofingResultsJob < ApplicationJob
     end
   end
 
-  def send_account_verified_sms_notification(enrollment)
+  def send_account_verified_sms_notification(enrollment:)
     phone = MfaContext.new(enrollment.user).phone_configuration&.phone
     return if phone.blank?
 

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -22,6 +22,7 @@ class GetUspsProofingResultsJob < ApplicationJob
   queue_as :long_running
 
   include IppHelper
+  include LocaleHelper
 
   def perform(_now)
     return unless job_can_run?
@@ -692,12 +693,14 @@ class GetUspsProofingResultsJob < ApplicationJob
     phone = MfaContext.new(enrollment.user).phone_configuration&.phone
     return if phone.blank?
 
-    Telephony.send_proofing_completion_confirmation(
-      to: phone,
-      country_code: Phonelib.parse(phone).country,
-      sp_or_app_name: enrollment.profile&.initiating_service_provider&.friendly_name.presence ||
-        APP_NAME,
-    )
+    with_user_locale(enrollment.user) do
+      Telephony.send_proofing_completion_confirmation(
+        to: phone,
+        country_code: Phonelib.parse(phone).country,
+        sp_or_app_name: enrollment.profile&.initiating_service_provider&.friendly_name.presence ||
+          APP_NAME,
+      )
+    end
   end
 
   def notification_delivery_params(enrollment)

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -499,7 +499,7 @@ class GetUspsProofingResultsJob < ApplicationJob
       end
 
       # send SMS and email
-      send_enrollment_status_sms_notification(enrollment: enrollment)
+      send_account_verified_sms_notification(enrollment)
       send_verified_email(enrollment:, visited_location_name: response['proofingPostOffice'])
       analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
         **email_analytics_attributes(enrollment),
@@ -686,6 +686,18 @@ class GetUspsProofingResultsJob < ApplicationJob
         **notification_delivery_params(enrollment),
       ).perform_later(enrollment.id)
     end
+  end
+
+  def send_account_verified_sms_notification(enrollment)
+    phone = MfaContext.new(enrollment.user).phone_configuration&.phone
+    return if phone.blank?
+
+    Telephony.send_proofing_completion_confirmation(
+      to: phone,
+      country_code: Phonelib.parse(phone).country,
+      sp_or_app_name: enrollment.profile&.initiating_service_provider&.friendly_name.presence ||
+        APP_NAME,
+    )
   end
 
   def notification_delivery_params(enrollment)

--- a/app/jobs/get_usps_proofing_results_job.rb
+++ b/app/jobs/get_usps_proofing_results_job.rb
@@ -500,8 +500,9 @@ class GetUspsProofingResultsJob < ApplicationJob
       end
 
       # send SMS and email
-      send_account_verified_sms_notification(enrollment: enrollment)
+      send_enrollment_status_sms_notification(enrollment: enrollment)
       send_verified_email(enrollment:, visited_location_name: response['proofingPostOffice'])
+      send_account_verified_sms_notification(enrollment: enrollment)
       analytics(user: enrollment.user).idv_in_person_usps_proofing_results_job_email_initiated(
         **email_analytics_attributes(enrollment),
         email_type: 'Success',

--- a/app/mailers/user_sms_text_mailer.rb
+++ b/app/mailers/user_sms_text_mailer.rb
@@ -27,6 +27,12 @@ class UserSmsTextMailer < ActionMailer::Base
     mail_to
   end
 
+  def proofing_completion_confirmation
+    @proof_date = I18n.l(Time.current, format: :sms_date)
+    @sp_or_app_name = 'Sample SAML Sinatra SP'
+    mail_to
+  end
+
   def doc_auth_link
     @link = url_for(idv_hybrid_mobile_entry_url) + "?document-capture-session=#{SecureRandom.uuid}"
     @sp_or_app_name = 'Sample SAML Sinatra SP'

--- a/app/services/user_alerts/alert_user_about_account_verified.rb
+++ b/app/services/user_alerts/alert_user_about_account_verified.rb
@@ -2,12 +2,21 @@
 
 module UserAlerts
   class AlertUserAboutAccountVerified
-    def self.call(profile:)
+    def self.call(profile:, phone: nil)
       user = profile.user
       user.confirmed_email_addresses.each do |email_address|
         UserMailer.with(user: user, email_address: email_address).account_verified(
           profile: profile,
         ).deliver_now_or_later
+      end
+
+      if profile.enhanced?
+        Telephony.send_proofing_completion_confirmation(
+          to: phone,
+          country_code: Phonelib.parse(phone).country,
+          sp_or_app_name: profile.initiating_service_provider&.friendly_name.presence ||
+            APP_NAME,
+        )
       end
     end
   end

--- a/app/services/user_alerts/alert_user_about_account_verified.rb
+++ b/app/services/user_alerts/alert_user_about_account_verified.rb
@@ -10,7 +10,7 @@ module UserAlerts
         ).deliver_now_or_later
       end
 
-      if profile.enhanced?
+      if profile.enhanced? && phone.present?
         Telephony.send_proofing_completion_confirmation(
           to: phone,
           country_code: Phonelib.parse(phone).country,

--- a/app/services/user_alerts/alert_user_about_account_verified.rb
+++ b/app/services/user_alerts/alert_user_about_account_verified.rb
@@ -2,6 +2,8 @@
 
 module UserAlerts
   class AlertUserAboutAccountVerified
+    extend LocaleHelper
+
     def self.call(profile:, phone: nil)
       user = profile.user
       user.confirmed_email_addresses.each do |email_address|
@@ -11,12 +13,14 @@ module UserAlerts
       end
 
       if profile.enhanced? && phone.present?
-        Telephony.send_proofing_completion_confirmation(
-          to: phone,
-          country_code: Phonelib.parse(phone).country,
-          sp_or_app_name: profile.initiating_service_provider&.friendly_name.presence ||
-            APP_NAME,
-        )
+        with_user_locale(user) do
+          Telephony.send_proofing_completion_confirmation(
+            to: phone,
+            country_code: Phonelib.parse(phone).country,
+            sp_or_app_name: profile.initiating_service_provider&.friendly_name.presence ||
+              APP_NAME,
+          )
+        end
       end
     end
   end

--- a/app/views/user_sms_text_mailer/proofing_completion_confirmation.text.erb
+++ b/app/views/user_sms_text_mailer/proofing_completion_confirmation.text.erb
@@ -1,0 +1,1 @@
+<%= t('telephony.proofing_completion_confirmation.sms', app_name: APP_NAME, proof_date: @proof_date, sp_or_app_name: @sp_or_app_name, contact_url: MarketingSite.contact_url) %>

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -62,3 +62,8 @@ en:
       sms: A new personal key has been issued for your %{app_name} account. If this wasn't you, reset your password.
     personal_key_sign_in_notice:
       sms: Your personal key was just used to sign into your %{app_name} account. If this wasn't you, reset your password.
+    proofing_completion_confirmation:
+      sms: |-
+        %{app_name} Identity verified on %{proof_date} for ${sp_or_app_name}.
+
+        Not you? Sign in, update your password and authentication methods, report fraud: @%{contact_url}

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -64,6 +64,6 @@ en:
       sms: Your personal key was just used to sign into your %{app_name} account. If this wasn't you, reset your password.
     proofing_completion_confirmation:
       sms: |-
-        %{app_name} Identity verified on %{proof_date} for %{sp_or_app_name}.
+        %{app_name}: Identity verified on %{proof_date} for %{sp_or_app_name}.
 
         Not you? Sign in, update your password and authentication methods, report fraud: @%{contact_url}

--- a/config/locales/telephony/en.yml
+++ b/config/locales/telephony/en.yml
@@ -64,6 +64,6 @@ en:
       sms: Your personal key was just used to sign into your %{app_name} account. If this wasn't you, reset your password.
     proofing_completion_confirmation:
       sms: |-
-        %{app_name} Identity verified on %{proof_date} for ${sp_or_app_name}.
+        %{app_name} Identity verified on %{proof_date} for %{sp_or_app_name}.
 
         Not you? Sign in, update your password and authentication methods, report fraud: @%{contact_url}

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -60,6 +60,6 @@ es:
       sms: Su clave personal acaba de se usada para iniciar sesión en su cuenta de %{app_name}. Si no fue usted, restablezca su contraseña.
     proofing_completion_confirmation:
       sms: |-
-        %{app_name} Identidad verificada el %{proof_date} para ${sp_or_app_name}.
+        %{app_name} Identidad verificada el %{proof_date} para %{sp_or_app_name}.
 
         ¿No es usted? Inicie sesión, actualice su contraseña y sus métodos de autenticación, y reporte cualquier fraude en: @%{contact_url}

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -58,3 +58,8 @@ es:
       sms: Se emitió una nueva clave personal para su cuenta de %{app_name}. Si no fue usted, restablezca su contraseña.
     personal_key_sign_in_notice:
       sms: Su clave personal acaba de se usada para iniciar sesión en su cuenta de %{app_name}. Si no fue usted, restablezca su contraseña.
+    proofing_completion_confirmation:
+      sms: |-
+        %{app_name} Identidad verificada el %{proof_date} para ${sp_or_app_name}.
+
+        ¿No es usted? Inicie sesión, actualice su contraseña y sus métodos de autenticación, y reporte cualquier fraude en: @%{contact_url}

--- a/config/locales/telephony/es.yml
+++ b/config/locales/telephony/es.yml
@@ -60,6 +60,6 @@ es:
       sms: Su clave personal acaba de se usada para iniciar sesión en su cuenta de %{app_name}. Si no fue usted, restablezca su contraseña.
     proofing_completion_confirmation:
       sms: |-
-        %{app_name} Identidad verificada el %{proof_date} para %{sp_or_app_name}.
+        %{app_name}: Identidad verificada el %{proof_date} para %{sp_or_app_name}.
 
         ¿No es usted? Inicie sesión, actualice su contraseña y sus métodos de autenticación, y reporte cualquier fraude en: @%{contact_url}

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -60,6 +60,6 @@ fr:
       sms: Votre clé personnelle vient d’être utilisée pour vous connecter à votre compte %{app_name}. Si cela ne vient pas de vous, réinitialisez votre mot de passe.
     proofing_completion_confirmation:
       sms: |-
-        %{app_name} Identité vérifiée le %{proof_date} pour ${sp_or_app_name}.
+        %{app_name} Identité vérifiée le %{proof_date} pour %{sp_or_app_name}.
 
         Ce n'est pas vous ? Connectez-vous, mettez à jour votre mot de passe et vos méthodes d'authentification, ou signalez une fraude: @%{contact_url}

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -58,3 +58,8 @@ fr:
       sms: Une nouvelle clé personnelle a été émise pour votre compte %{app_name}. Si cela ne vient pas de vous, réinitialisez votre mot de passe.
     personal_key_sign_in_notice:
       sms: Votre clé personnelle vient d’être utilisée pour vous connecter à votre compte %{app_name}. Si cela ne vient pas de vous, réinitialisez votre mot de passe.
+    proofing_completion_confirmation:
+      sms: |-
+        %{app_name} Identité vérifiée le %{proof_date} pour ${sp_or_app_name}.
+
+        Ce n'est pas vous ? Connectez-vous, mettez à jour votre mot de passe et vos méthodes d'authentification, ou signalez une fraude: @%{contact_url}

--- a/config/locales/telephony/fr.yml
+++ b/config/locales/telephony/fr.yml
@@ -60,6 +60,6 @@ fr:
       sms: Votre clé personnelle vient d’être utilisée pour vous connecter à votre compte %{app_name}. Si cela ne vient pas de vous, réinitialisez votre mot de passe.
     proofing_completion_confirmation:
       sms: |-
-        %{app_name} Identité vérifiée le %{proof_date} pour %{sp_or_app_name}.
+        %{app_name}: Identité vérifiée le %{proof_date} pour %{sp_or_app_name}.
 
         Ce n'est pas vous ? Connectez-vous, mettez à jour votre mot de passe et vos méthodes d'authentification, ou signalez une fraude: @%{contact_url}

--- a/config/locales/telephony/zh.yml
+++ b/config/locales/telephony/zh.yml
@@ -59,3 +59,8 @@ zh:
       sms: 已给你的 %{app_name} 账户发放了一个新个人密钥。如果不是你，请重设你的密码。
     personal_key_sign_in_notice:
       sms: 你的个人密钥刚被用来登录你的 %{app_name} 账户。如果不是你，请重设你的密码。
+    proofing_completion_confirmation:
+      sms: |-
+        %{app_name} 已于 %{proof_date} 为 ${sp_or_app_name}.
+
+        不是您本人？请登录、更新密码及验证方式，或举报欺诈行为: @%{contact_url}

--- a/config/locales/telephony/zh.yml
+++ b/config/locales/telephony/zh.yml
@@ -61,6 +61,6 @@ zh:
       sms: 你的个人密钥刚被用来登录你的 %{app_name} 账户。如果不是你，请重设你的密码。
     proofing_completion_confirmation:
       sms: |-
-        %{app_name} 已于 %{proof_date} 为 %{sp_or_app_name}.
+        %{app_name}: 已于 %{proof_date} 为 %{sp_or_app_name}.
 
         不是您本人？请登录、更新密码及验证方式，或举报欺诈行为: @%{contact_url}

--- a/config/locales/telephony/zh.yml
+++ b/config/locales/telephony/zh.yml
@@ -61,6 +61,6 @@ zh:
       sms: 你的个人密钥刚被用来登录你的 %{app_name} 账户。如果不是你，请重设你的密码。
     proofing_completion_confirmation:
       sms: |-
-        %{app_name} 已于 %{proof_date} 为 ${sp_or_app_name}.
+        %{app_name} 已于 %{proof_date} 为 %{sp_or_app_name}.
 
         不是您本人？请登录、更新密码及验证方式，或举报欺诈行为: @%{contact_url}

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -322,7 +322,10 @@ class ActionAccount
             fraud_ops_tracker(profile:).idv_enrollment_complete(reproof:)
             UserEventCreator.new(current_user: user)
               .create_out_of_band_user_event(:account_verified)
-            UserAlerts::AlertUserAboutAccountVerified.call(profile: profile)
+            UserAlerts::AlertUserAboutAccountVerified.call(
+              profile: profile,
+              phone: MfaContext.new(user).phone_configuration&.phone,
+            )
 
             log_texts << log_text[:profile_activated]
           else

--- a/lib/telephony.rb
+++ b/lib/telephony.rb
@@ -88,6 +88,7 @@ module Telephony
                  :send_account_reset_cancellation_notice,
                  :send_dupe_profile_sign_in_attempted_notice,
                  :send_dupe_profile_created_notice,
+                 :send_proofing_completion_confirmation,
                  :send_notification
 
   # @param [String] phone_number phone number in E.164 format

--- a/lib/telephony/alert_sender.rb
+++ b/lib/telephony/alert_sender.rb
@@ -79,6 +79,20 @@ module Telephony
       response
     end
 
+    def send_proofing_completion_confirmation(to:, country_code:, sp_or_app_name:)
+      proof_date = I18n.l(Time.current, format: :sms_date)
+      message = I18n.t(
+        'telephony.proofing_completion_confirmation.sms',
+        app_name: APP_NAME,
+        proof_date: proof_date,
+        sp_or_app_name: sp_or_app_name,
+        contact_url: MarketingSite.contact_url,
+      )
+      response = adapter.deliver(message: message, to: to, country_code: country_code)
+      log_response(response, context: __method__.to_s.gsub(/^send_/, ''))
+      response
+    end
+
     def send_raw_message(to:, message:, country_code:)
       response = adapter.deliver(message: message, to: to, country_code: country_code)
       log_response(response, context: __method__.to_s.gsub(/^send_/, ''))

--- a/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
+++ b/spec/controllers/idv/by_mail/enter_code_controller_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe Idv::ByMail::EnterCodeController do
 
         expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
           profile: user.active_profile,
+          phone: nil,
         )
       end
 

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -423,14 +423,67 @@ RSpec.describe Idv::EnterPasswordController do
         expect(profile).to be_active
       end
 
-      it 'dispatches account verified alert' do
-        allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+      context 'dispatches account verified alert' do
+        let(:user_phone_confirmation_session) do
+          Idv::PhoneConfirmationSession.new(
+            code: '123456',
+            phone: '+1 202-555-1212',
+            delivery_method: :sms,
+            user: user,
+            sent_at: Time.zone.now,
+          )
+        end
 
-        put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+        before do
+          subject.idv_session.user_phone_confirmation_session = user_phone_confirmation_session
+        end
 
-        expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
-          profile: user.reload.active_profile,
-        )
+        it 'dispatches account verified alert with the phone confirmation session phone' do
+          allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+          put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+          expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+            profile: user.reload.active_profile,
+            phone: user_phone_confirmation_session.phone,
+          )
+        end
+
+        context 'when the user completed verification via the hybrid/mobile flow' do
+          before do
+            subject.idv_session.address_verification_mechanism = nil
+            subject.idv_session.phone_for_mobile_flow = '+1 202-555-5555'
+          end
+
+          it 'dispatches account verified alert with the mobile flow phone' do
+            allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+              profile: user.reload.active_profile,
+              phone: subject.idv_session.phone_for_mobile_flow,
+            )
+          end
+        end
+
+        context 'when there is no phone confirmation session or mobile flow phone' do
+          before do
+            subject.idv_session.address_verification_mechanism = nil
+            subject.idv_session.phone_for_mobile_flow = nil
+          end
+
+          it 'dispatches account verified alert with the default phone configuration phone' do
+            allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+              profile: user.reload.active_profile,
+              phone: user.default_phone_configuration.formatted_phone,
+            )
+          end
+        end
       end
 
       it 'tracks the idv_enrollment_complete event' do
@@ -1223,6 +1276,16 @@ RSpec.describe Idv::EnterPasswordController do
         )
       end
 
+      let(:user_phone_confirmation_session) do
+        Idv::PhoneConfirmationSession.new(
+          code: '123456',
+          phone: '+1 202-555-1212',
+          delivery_method: :sms,
+          user: user,
+          sent_at: Time.zone.now,
+        )
+      end
+
       before do
         document_capture_session.store_agent_proofed_user(
           { pii: applicant, success: true, service_provider_issuer: sp.issuer },
@@ -1231,6 +1294,7 @@ RSpec.describe Idv::EnterPasswordController do
         subject.idv_session.proofing_agent_match = true
         subject.idv_session.vendor_phone_confirmation = true
         subject.idv_session.user_phone_confirmation = true
+        subject.idv_session.user_phone_confirmation_session = user_phone_confirmation_session
         session[:sp] = { issuer: sp.issuer }
       end
 

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -2057,6 +2057,12 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                       )
                     end
 
+                    it 'sends a proofing sms notification for post office and ref' do
+                      expect(send_proofing_notification_job).to have_received(
+                        :perform_later,
+                      ).with(enrollment.id)
+                    end
+
                     it 'sends an account verified sms notification' do
                       expect(Telephony).to have_received(
                         :send_proofing_completion_confirmation,

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -2106,6 +2106,65 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                     end
                   end
 
+                  context 'sends a message that respects the user locale preference' do
+                    let(:phone_number) { enrollment.user.default_phone_configuration.phone }
+
+                    before do
+                      stub_request_proofing_results(status_code: 200, body: response_body)
+                      allow(analytics).to receive(
+                        :idv_in_person_usps_proofing_results_job_enrollment_updated,
+                      )
+                      allow(analytics).to receive(
+                        :idv_in_person_usps_proofing_results_job_email_initiated,
+                      )
+                      allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
+                      allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
+                    end
+
+                    it 'handles English language preference' do
+                      enrollment.user.update!(email_language: 'en')
+
+                      subject.perform(current_time)
+
+                      last_message = Telephony::Test::Message.messages.last
+                      expect(last_message.to).to eq(phone_number)
+                      expect(last_message.body).to eq(expected_sms_body('en'))
+                    end
+
+                    it 'handles French language preference' do
+                      enrollment.user.update!(email_language: 'fr')
+
+                      subject.perform(current_time)
+
+                      last_message = Telephony::Test::Message.messages.last
+                      expect(last_message.to).to eq(phone_number)
+                      expect(last_message.body).to eq(expected_sms_body('fr'))
+                    end
+
+                    it 'handles Spanish language preference' do
+                      enrollment.user.update!(email_language: 'es')
+
+                      subject.perform(current_time)
+
+                      last_message = Telephony::Test::Message.messages.last
+                      expect(last_message.to).to eq(phone_number)
+                      expect(last_message.body).to eq(expected_sms_body('es'))
+                    end
+
+                    def expected_sms_body(locale)
+                      I18n.with_locale(locale) do
+                        I18n.t(
+                          'telephony.proofing_completion_confirmation.sms',
+                          app_name: APP_NAME,
+                          proof_date: I18n.l(current_time, format: :sms_date, locale: locale),
+                          sp_or_app_name: APP_NAME,
+                          contact_url: MarketingSite.contact_url,
+                          locale: locale,
+                        )
+                      end
+                    end
+                  end
+
                   context 'when proofing passed and the user has no phone configuration' do
                     let(:enrollment) do
                       create(

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -2004,6 +2004,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                       )
                       allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
                       allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
+                      allow(Telephony).to receive(:send_proofing_completion_confirmation)
                       subject.perform(current_time)
                     end
 
@@ -2056,10 +2057,16 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                       )
                     end
 
-                    it 'sends a proofing sms notification' do
-                      expect(send_proofing_notification_job).to have_received(
-                        :perform_later,
-                      ).with(enrollment.id)
+                    it 'sends an account verified sms notification' do
+                      expect(Telephony).to have_received(
+                        :send_proofing_completion_confirmation,
+                      ).with(
+                        to: enrollment.user.default_phone_configuration.phone,
+                        country_code: Phonelib.parse(
+                          enrollment.user.default_phone_configuration.phone,
+                        ).country,
+                        sp_or_app_name: APP_NAME,
+                      )
                     end
 
                     it 'sends the in person verified email with a delay' do
@@ -2232,6 +2239,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                       )
                       allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
                       allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
+                      allow(Telephony).to receive(:send_proofing_completion_confirmation)
                       subject.perform(current_time)
                     end
 
@@ -2284,10 +2292,16 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                       )
                     end
 
-                    it 'sends a proofing sms notification' do
-                      expect(send_proofing_notification_job).to have_received(
-                        :perform_later,
-                      ).with(enrollment.id)
+                    it 'sends an account verified sms notification' do
+                      expect(Telephony).to have_received(
+                        :send_proofing_completion_confirmation,
+                      ).with(
+                        to: enrollment.user.default_phone_configuration.phone,
+                        country_code: Phonelib.parse(
+                          enrollment.user.default_phone_configuration.phone,
+                        ).country,
+                        sp_or_app_name: APP_NAME,
+                      )
                     end
 
                     it 'sends the in person verified email with delay' do
@@ -2338,6 +2352,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                       )
                       allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
                       allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
+                      allow(Telephony).to receive(:send_proofing_completion_confirmation)
                       subject.perform(current_time)
                     end
 
@@ -2390,10 +2405,16 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                       )
                     end
 
-                    it 'sends a proofing sms notification' do
-                      expect(send_proofing_notification_job).to have_received(
-                        :perform_later,
-                      ).with(enrollment.id)
+                    it 'sends an account verified sms notification' do
+                      expect(Telephony).to have_received(
+                        :send_proofing_completion_confirmation,
+                      ).with(
+                        to: enrollment.user.default_phone_configuration.phone,
+                        country_code: Phonelib.parse(
+                          enrollment.user.default_phone_configuration.phone,
+                        ).country,
+                        sp_or_app_name: APP_NAME,
+                      )
                     end
 
                     it 'sends the in person verified email' do
@@ -2445,6 +2466,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                       )
                       allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
                       allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
+                      allow(Telephony).to receive(:send_proofing_completion_confirmation)
                       subject.perform(current_time)
                     end
 
@@ -2497,10 +2519,16 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                       )
                     end
 
-                    it 'sends a proofing sms notification' do
-                      expect(send_proofing_notification_job).to have_received(
-                        :perform_later,
-                      ).with(enrollment.id)
+                    it 'sends an account verified sms notification' do
+                      expect(Telephony).to have_received(
+                        :send_proofing_completion_confirmation,
+                      ).with(
+                        to: enrollment.user.default_phone_configuration.phone,
+                        country_code: Phonelib.parse(
+                          enrollment.user.default_phone_configuration.phone,
+                        ).country,
+                        sp_or_app_name: APP_NAME,
+                      )
                     end
 
                     it 'sends the in person verified email' do

--- a/spec/jobs/get_usps_proofing_results_job_spec.rb
+++ b/spec/jobs/get_usps_proofing_results_job_spec.rb
@@ -2106,6 +2106,41 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                     end
                   end
 
+                  context 'when proofing passed and the user has no phone configuration' do
+                    let(:enrollment) do
+                      create(
+                        :in_person_enrollment,
+                        :pending,
+                        :with_notification_phone_configuration,
+                        user: create(:user),
+                      )
+                    end
+
+                    before do
+                      stub_request_proofing_results(status_code: 200, body: response_body)
+                      allow(analytics).to receive(
+                        :idv_in_person_usps_proofing_results_job_enrollment_updated,
+                      )
+                      allow(analytics).to receive(
+                        :idv_in_person_usps_proofing_results_job_email_initiated,
+                      )
+                      allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
+                      allow(attempts_api_tracker).to receive(:idv_enrollment_complete)
+                      allow(Telephony).to receive(:send_proofing_completion_confirmation)
+                      subject.perform(current_time)
+                    end
+
+                    it 'does not send an account verified sms notification' do
+                      expect(Telephony).not_to have_received(
+                        :send_proofing_completion_confirmation,
+                      )
+                    end
+
+                    it "still activates the enrollment's profile" do
+                      expect(enrollment.reload.profile).to have_attributes(active: true)
+                    end
+                  end
+
                   context 'when proofing passed with an unsupported id type' do
                     before do
                       response_body[:primaryIdType] = 'Unsupported'
@@ -2847,6 +2882,7 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                     :idv_in_person_usps_proofing_results_job_email_initiated,
                   )
                   allow(user_mailer).to receive(:in_person_verified).and_return(mail_deliverer)
+                  allow(Telephony).to receive(:send_proofing_completion_confirmation)
                   subject.perform(current_time)
                 end
 
@@ -2854,6 +2890,18 @@ RSpec.describe GetUspsProofingResultsJob, freeze_time: true do
                   expect(send_proofing_notification_job).not_to have_received(
                     :perform_later,
                   ).with(enrollment.id)
+                end
+
+                it 'still sends the account verified sms notification' do
+                  expect(Telephony).to have_received(
+                    :send_proofing_completion_confirmation,
+                  ).with(
+                    to: enrollment.user.default_phone_configuration.phone,
+                    country_code: Phonelib.parse(
+                      enrollment.user.default_phone_configuration.phone,
+                    ).country,
+                    sp_or_app_name: APP_NAME,
+                  )
                 end
               end
             end

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -254,6 +254,7 @@ RSpec.describe ActionAccount do
       it 'Pass a user that has a pending review', aggregate_failures: true do
         expect(UserAlerts::AlertUserAboutAccountVerified).to receive(:call).with(
           profile: user.pending_profile,
+          phone: MfaContext.new(user).phone_configuration&.phone,
         )
         expect(attempts_api_tracker).to receive(:idv_enrollment_complete).with(reproof: false)
 

--- a/spec/mailers/previews/user_sms_text_mailer_preview.rb
+++ b/spec/mailers/previews/user_sms_text_mailer_preview.rb
@@ -10,5 +10,6 @@ class UserSmsTextMailerPreview < ActionMailer::Preview
            :duplicate_profile_sign_in_attempted,
            :personal_key_regeneration_notice,
            :personal_key_sign_in_notice,
+           :proofing_completion_confirmation,
            to: UserSmsTextMailer
 end

--- a/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
@@ -136,5 +136,66 @@ RSpec.describe UserAlerts::AlertUserAboutAccountVerified do
         end
       end
     end
+
+    context 'when the profile is enhanced and the user has a locale preference' do
+      let(:phone) { '+1 202-555-1234' }
+      let(:profile) do
+        create(
+          :profile,
+          :active,
+          idv_level: :unsupervised_with_selfie,
+          initiating_service_provider: service_provider,
+        )
+      end
+
+      it 'sends the sms respecting the English locale preference' do
+        user.update!(email_language: 'en')
+
+        freeze_time do
+          described_class.call(profile: profile, phone: phone)
+
+          last_message = Telephony::Test::Message.messages.last
+          expect(last_message.to).to eq(phone)
+          expect(last_message.body).to eq(expected_sms_body('en'))
+        end
+      end
+
+      it 'sends the sms respecting the French locale preference' do
+        user.update!(email_language: 'fr')
+
+        freeze_time do
+          described_class.call(profile: profile, phone: phone)
+
+          last_message = Telephony::Test::Message.messages.last
+          expect(last_message.to).to eq(phone)
+          expect(last_message.body).to eq(expected_sms_body('fr'))
+        end
+      end
+
+      it 'sends the sms respecting the Spanish locale preference' do
+        user.update!(email_language: 'es')
+
+        freeze_time do
+          described_class.call(profile: profile, phone: phone)
+
+          last_message = Telephony::Test::Message.messages.last
+          expect(last_message.to).to eq(phone)
+          expect(last_message.body).to eq(expected_sms_body('es'))
+        end
+      end
+
+      def expected_sms_body(locale)
+        I18n.with_locale(locale) do
+          I18n.t(
+            'telephony.proofing_completion_confirmation.sms',
+            app_name: APP_NAME,
+            proof_date: I18n.l(Time.zone.now, format: :sms_date, locale: locale),
+            sp_or_app_name: service_provider.friendly_name,
+            contact_url: MarketingSite.contact_url,
+            locale: locale,
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
@@ -118,6 +118,14 @@ RSpec.describe UserAlerts::AlertUserAboutAccountVerified do
             )
           end
         end
+
+        context 'when no phone is given' do
+          it 'does not send an SMS message' do
+            described_class.call(profile: profile)
+
+            expect(Telephony).to_not have_received(:send_proofing_completion_confirmation)
+          end
+        end
       end
 
       context 'when the profile is not enhanced' do

--- a/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
+++ b/spec/services/user_alerts/alert_user_about_account_verified_spec.rb
@@ -77,5 +77,56 @@ RSpec.describe UserAlerts::AlertUserAboutAccountVerified do
         )
       end
     end
+
+    context 'sending a proofing completed SMS message' do
+      let(:phone) { '+1 202-555-1234' }
+
+      before do
+        allow(Telephony).to receive(:send_proofing_completion_confirmation)
+      end
+
+      context 'when the profile is enhanced' do
+        let(:profile) do
+          create(
+            :profile,
+            :active,
+            idv_level: :unsupervised_with_selfie,
+            initiating_service_provider: service_provider,
+          )
+        end
+
+        it 'sends an SMS proofing completion confirmation to the given phone' do
+          described_class.call(profile: profile, phone: phone)
+
+          expect(Telephony).to have_received(:send_proofing_completion_confirmation).with(
+            to: phone,
+            country_code: Phonelib.parse(phone).country,
+            sp_or_app_name: service_provider.friendly_name,
+          )
+        end
+
+        context 'when no service provider initiated the proofing event' do
+          let(:service_provider) { nil }
+
+          it 'falls back to the app name' do
+            described_class.call(profile: profile, phone: phone)
+
+            expect(Telephony).to have_received(:send_proofing_completion_confirmation).with(
+              to: phone,
+              country_code: Phonelib.parse(phone).country,
+              sp_or_app_name: APP_NAME,
+            )
+          end
+        end
+      end
+
+      context 'when the profile is not enhanced' do
+        it 'does not send an SMS message' do
+          described_class.call(profile: profile, phone: phone)
+
+          expect(Telephony).to_not have_received(:send_proofing_completion_confirmation)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17734](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17734)



## 🛠 Summary of changes

Users who complete proofing now receive a text confirming that they have completed the process.



## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Proof through IAL2 locally (Use identity-oidc-sinatra and check selfie preferred, or do in person proofing)
- [ ] Check `localhost:3000/test/telephony` to see if you receive a text saying "Identity verified on [proof date] for [partner agency]
- [ ] Go through proofing with a legacy unsupervised profile (proofing without selfie)
- [ ] Verify that you did not receive a text.



## 👀 Screenshots

TBD

[LG-17734]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17734