### PR TITLE
Use IdP auth time for SAML AuthnInstant

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -210,7 +210,7 @@ module SamlIdpAuthConcern
   end
 
   def saml_authn_instant
-    active_identity&.happened_at || Time.zone.now
+    auth_methods_session.last_authentication_event_at || Time.zone.now
   end
 
   def encryption_opts

--- a/app/services/auth_methods_session.rb
+++ b/app/services/auth_methods_session.rb
@@ -30,6 +30,14 @@ class AuthMethodsSession
     end
   end
 
+  def last_authentication_event_at
+    auth_event = last_2fa_auth_event
+    return unless auth_event
+
+    timestamp = auth_event[:at]
+    timestamp.is_a?(String) ? Time.zone.parse(timestamp) : timestamp&.in_time_zone
+  end
+
   def reauthenticate_at
     last_2fa_auth_event_at = last_2fa_auth_event&.[](:at)
     if last_2fa_auth_event_at

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2427,13 +2427,20 @@ RSpec.describe SamlIdpController do
       let(:status) { xmldoc.status[0] }
       let(:status_code) { xmldoc.status_code[0] }
       let(:user) { create(:user, :fully_registered) }
-      let(:authn_at) { nil }
+      let(:response_at) { nil }
+      let(:auth_events) { nil }
+      let(:auth_time_attribute_enabled) { false }
 
       before do
-        if authn_at
-          travel_to(authn_at) { generate_saml_response(user, saml_settings) }
+        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?)
+          .and_return(auth_time_attribute_enabled)
+
+        if response_at
+          travel_to(response_at) do
+            generate_saml_response(user, saml_settings, auth_events: auth_events)
+          end
         else
-          generate_saml_response(user, saml_settings)
+          generate_saml_response(user, saml_settings, auth_events: auth_events)
         end
       end
 
@@ -2747,16 +2754,32 @@ RSpec.describe SamlIdpController do
         end
 
         context 'when authentication timestamp support is enabled' do
-          let(:authn_at) { Time.zone.parse('2026-07-08 12:34:56 UTC') }
-
-          before do
-            allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
+          let(:auth_time_attribute_enabled) { true }
+          let(:idp_authn_at) { Time.zone.parse('2026-07-08 12:04:56 UTC') }
+          let(:response_at) { Time.zone.parse('2026-07-08 12:34:56 UTC') }
+          let(:auth_events) do
+            [
+              {
+                auth_method: TwoFactorAuthenticatable::AuthMethod::SMS,
+                at: idp_authn_at,
+              },
+            ]
           end
 
-          it 'uses the identity authentication timestamp for AuthnInstant' do
+          it 'uses the IdP authentication timestamp for AuthnInstant' do
             authn_instant = Time.zone.parse(subject.attributes['AuthnInstant'].value)
 
-            expect(authn_instant).to be_within(1.second).of(authn_at)
+            expect(authn_instant).to be_within(1.second).of(idp_authn_at)
+          end
+
+          context 'when the IdP authentication timestamp is missing' do
+            let(:auth_events) { nil }
+
+            it 'falls back to the response time for AuthnInstant' do
+              authn_instant = Time.zone.parse(subject.attributes['AuthnInstant'].value)
+
+              expect(authn_instant).to be_within(1.second).of(response_at)
+            end
           end
         end
 

--- a/spec/services/auth_methods_session_spec.rb
+++ b/spec/services/auth_methods_session_spec.rb
@@ -158,6 +158,69 @@ RSpec.describe AuthMethodsSession do
     end
   end
 
+  describe '#last_authentication_event_at' do
+    subject(:last_authentication_event_at) { auth_methods_session.last_authentication_event_at }
+
+    context 'no auth events' do
+      it { expect(last_authentication_event_at).to be_nil }
+    end
+
+    context 'with only a remember device auth event' do
+      let(:user_session) do
+        {
+          auth_events: [
+            {
+              auth_method: TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE,
+              at: Time.zone.now,
+            },
+          ],
+        }
+      end
+
+      it { expect(last_authentication_event_at).to be_nil }
+    end
+
+    context 'with a non-remember device auth event followed by a remember device auth event' do
+      let(:auth_event_at) { 3.minutes.ago }
+      let(:user_session) do
+        {
+          auth_events: [
+            {
+              auth_method: TwoFactorAuthenticatable::AuthMethod::SMS,
+              at: auth_event_at,
+            },
+            {
+              auth_method: TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE,
+              at: Time.zone.now,
+            },
+          ],
+        }
+      end
+
+      it 'returns the non-remember device auth event timestamp' do
+        expect(last_authentication_event_at).to eq(auth_event_at)
+      end
+    end
+
+    context 'with a serialized timestamp' do
+      let(:auth_event_at) { 3.minutes.ago }
+      let(:user_session) do
+        {
+          auth_events: [
+            {
+              auth_method: TwoFactorAuthenticatable::AuthMethod::SMS,
+              at: auth_event_at.iso8601,
+            },
+          ],
+        }
+      end
+
+      it 'returns the timestamp in the current time zone' do
+        expect(last_authentication_event_at).to eq(auth_event_at)
+      end
+    end
+  end
+
   describe '#reauthenticate_at' do
     subject(:reauthenticate_at) { auth_methods_session.reauthenticate_at }
 

--- a/spec/support/saml_auth_helper.rb
+++ b/spec/support/saml_auth_helper.rb
@@ -164,10 +164,11 @@ module SamlAuthHelper
   ##################################################################################################
 
   # generates a SAML response and returns a parsed Nokogiri XML document
-  def generate_saml_response(user, settings = saml_settings, link: true)
+  def generate_saml_response(user, settings = saml_settings, link: true, auth_events: nil)
     # user needs to be signed in in order to generate an assertion
     link_user_to_identity(user, link, settings)
     sign_in(user)
+    set_saml_auth_events(auth_events) if auth_events
     saml_get_auth(settings)
   end
 
@@ -192,6 +193,14 @@ module SamlAuthHelper
   end
 
   private
+
+  def set_saml_auth_events(auth_events)
+    request.env['warden'].session(:user)[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
+    request.env['warden'].session(:user)[:auth_events] = auth_events
+    session['warden.user.user.session'] ||= {}.with_indifferent_access
+    session['warden.user.user.session'][TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
+    session['warden.user.user.session'][:auth_events] = auth_events
+  end
 
   def link_user_to_identity(user, link, settings)
     return unless link


### PR DESCRIPTION
changelog: Upcoming Features, Authentication, Use IdP authentication time for SAML authentication timestamp

## 🎫 Ticket

https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/work_items/111

## 🛠 Summary of changes

Updates the SAML `AuthnInstant` to represent the latest actual Login.gov authentication event instead of the service provider linking transaction time.

Remember-device events are excluded because they do not represent a new authentication. If no qualifying authentication timestamp is available, the response falls back to the current time.

## 📜 Testing Plan

- [ ] Enable `auth_time_attribute_enabled`, complete a SAML sign-in, and confirm `AuthnInstant` matches the Login.gov authentication time.
- [ ] Start another SAML sign-in using the existing Login.gov session and confirm `AuthnInstant` does not advance without a new authentication, including when remember device is used.
- [ ] Disable `auth_time_attribute_enabled` and confirm the existing SAML response behavior is unchanged.