### PR TITLE
Use IdP auth time for OIDC auth_time

### DIFF
--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -182,7 +182,7 @@ class OpenidConnectUserInfoPresenter
   end
 
   def auth_time
-    (identity.happened_at || Time.zone.now).to_i
+    (out_of_band_session_accessor&.authentication_event_at || Time.zone.now).to_i
   end
 
   def out_of_band_session_accessor

--- a/app/services/out_of_band_session_accessor.rb
+++ b/app/services/out_of_band_session_accessor.rb
@@ -49,6 +49,11 @@ class OutOfBandSessionAccessor
     X509::Attributes.new_from_json(session_data.dig('warden.user.user.session', :decrypted_x509))
   end
 
+  def authentication_event_at
+    user_session = session_data['warden.user.user.session'] || {}
+    AuthMethodsSession.new(user_session:).last_authentication_event_at
+  end
+
   def destroy
     session_store.send(
       :delete_session,

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -70,6 +70,58 @@ RSpec.describe OpenidConnect::TokenController do
 
         expect(@analytics).to_not have_logged_event(:sp_integration_errors_present)
       end
+
+      context 'when auth_time is enabled' do
+        let(:authentication_event_at) { Time.zone.parse('2026-07-01 12:00:00 UTC') }
+        let(:remember_device_at) { Time.zone.parse('2026-07-01 12:30:00 UTC') }
+        let(:federation_at) { Time.zone.parse('2026-07-01 13:00:00 UTC') }
+        let(:stale_identity_timestamp) { 1.week.before(authentication_event_at) }
+
+        before do
+          allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
+          identity.update!(last_authenticated_at: stale_identity_timestamp)
+
+          travel_to(federation_at) do
+            IdentityLinker.new(user, service_provider).link_identity(
+              acr_values: Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
+              ial: 1,
+              rails_session_id: identity.rails_session_id,
+            )
+          end
+          identity.reload
+
+          write_out_of_band_user_session(
+            session_uuid: identity.rails_session_id,
+            user_session: {
+              auth_events: [
+                {
+                  auth_method: TwoFactorAuthenticatable::AuthMethod::SMS,
+                  at: authentication_event_at,
+                },
+                {
+                  auth_method: TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE,
+                  at: remember_device_at,
+                },
+              ],
+            },
+          )
+        end
+
+        it 'returns the latest IdP authentication event instead of the federation time' do
+          travel_to(federation_at) { action }
+
+          json = JSON.parse(response.body).with_indifferent_access
+          payload = JWT.decode(
+            json[:id_token],
+            Rails.application.config.oidc_public_key,
+            true,
+            algorithm: 'RS256',
+          ).first.with_indifferent_access
+
+          expect(identity.last_authenticated_at.to_i).to eq(federation_at.to_i)
+          expect(payload[:auth_time]).to eq(authentication_event_at.to_i)
+        end
+      end
     end
 
     context 'with invalid params' do

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -179,6 +179,38 @@ RSpec.describe OpenidConnect::UserInfoController do
         expect(request.session.to_h).to eq(session_hash)
       end
 
+      context 'when auth_time is enabled' do
+        let(:authentication_event_at) { Time.zone.parse('2026-07-01 12:00:00 UTC') }
+        let(:remember_device_at) { Time.zone.parse('2026-07-01 12:30:00 UTC') }
+        let(:federation_at) { Time.zone.parse('2026-07-01 13:00:00 UTC') }
+
+        before do
+          allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
+          identity.update!(last_authenticated_at: federation_at)
+          write_out_of_band_user_session(
+            session_uuid: identity.rails_session_id,
+            user_session: {
+              auth_events: [
+                {
+                  auth_method: TwoFactorAuthenticatable::AuthMethod::SMS,
+                  at: authentication_event_at,
+                },
+                {
+                  auth_method: TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE,
+                  at: remember_device_at,
+                },
+              ],
+            },
+          )
+        end
+
+        it 'returns the latest IdP authentication event instead of the identity timestamp' do
+          action
+
+          expect(json_response[:auth_time]).to eq(authentication_event_at.to_i)
+        end
+      end
+
       context 'with session expiring after validation and before render' do
         before do
           allow_any_instance_of(AccessTokenVerifier).to receive(:submit).and_wrap_original do |impl|

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe OpenidConnectUserInfoPresenter do
   let(:requested_aal_value) { nil }
   let(:acr_values) { Saml::Idp::Constants::IAL_VERIFIED_ACR }
   let(:last_authenticated_at) { Time.zone.parse('2026-05-29 12:00:00 UTC') }
+  let(:authentication_event_at) { Time.zone.parse('2026-05-30 12:00:00 UTC') }
+  let(:session_accessor) { OutOfBandSessionAccessor.new(rails_session_id) }
   let(:locale) { 'en' }
   let(:identity) do
     build(
@@ -37,7 +39,7 @@ RSpec.describe OpenidConnectUserInfoPresenter do
     stub_analytics
   end
 
-  subject(:presenter) { OpenidConnectUserInfoPresenter.new(identity) }
+  subject(:presenter) { OpenidConnectUserInfoPresenter.new(identity, session_accessor:) }
 
   describe '#user_info' do
     let(:pii) do
@@ -70,14 +72,16 @@ RSpec.describe OpenidConnectUserInfoPresenter do
     context 'when auth_time attribute is enabled' do
       before do
         allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
+        allow(session_accessor).to receive(:authentication_event_at)
+          .and_return(authentication_event_at)
       end
 
-      it 'includes auth_time from the identity authentication timestamp' do
-        expect(user_info[:auth_time]).to eq(last_authenticated_at.to_i)
+      it 'includes auth_time from the session authentication event timestamp' do
+        expect(user_info[:auth_time]).to eq(authentication_event_at.to_i)
       end
 
-      context 'without an identity authentication timestamp' do
-        let(:last_authenticated_at) { nil }
+      context 'without an authentication event timestamp' do
+        let(:authentication_event_at) { nil }
         let(:now) { Time.zone.parse('2026-06-01 12:00:00 UTC') }
 
         it 'falls back to the current time' do

--- a/spec/services/id_token_builder_spec.rb
+++ b/spec/services/id_token_builder_spec.rb
@@ -167,26 +167,6 @@ RSpec.describe IdTokenBuilder do
       expect(decoded_payload[:nbf]).to eq(now.to_i)
     end
 
-    context 'when auth_time attribute is enabled' do
-      before do
-        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
-      end
-
-      it 'sets auth_time to the authentication timestamp' do
-        expect(decoded_payload[:auth_time]).to eq(last_authenticated_at.to_i)
-      end
-    end
-
-    context 'when auth_time attribute is disabled' do
-      before do
-        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(false)
-      end
-
-      it 'does not include auth_time' do
-        expect(decoded_payload).to_not have_key(:auth_time)
-      end
-    end
-
     it 'sets the access token hash correctly' do
       # this is a known value from an example developer guide
       # https://developer.pingidentity.com/en/resources/openid-connect-developers-guide.html

--- a/spec/services/out_of_band_session_accessor_spec.rb
+++ b/spec/services/out_of_band_session_accessor_spec.rb
@@ -62,6 +62,29 @@ RSpec.describe OutOfBandSessionAccessor do
     end
   end
 
+  describe '#authentication_event_at' do
+    it 'loads the latest non-remember-device authentication event from the session' do
+      authentication_event_at = Time.zone.parse('2026-07-01 12:00:00')
+      write_out_of_band_user_session(
+        session_uuid:,
+        user_session: {
+          auth_events: [
+            {
+              auth_method: TwoFactorAuthenticatable::AuthMethod::SMS,
+              at: authentication_event_at,
+            },
+            {
+              auth_method: TwoFactorAuthenticatable::AuthMethod::REMEMBER_DEVICE,
+              at: Time.zone.now,
+            },
+          ],
+        },
+      )
+
+      expect(store.authentication_event_at).to eq(authentication_event_at)
+    end
+  end
+
   describe '#destroy' do
     it 'destroys the session' do
       writer_instance.put_pii(

--- a/spec/support/out_of_band_session_helper.rb
+++ b/spec/support/out_of_band_session_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module OutOfBandSessionHelper
+  PLACEHOLDER_REQUEST = ActionDispatch::TestRequest.create.freeze
+
+  def write_out_of_band_user_session(session_uuid:, user_session:, expiration: 5.minutes)
+    session_store = Rails.application.config.session_store.new(
+      {},
+      Rails.application.config.session_options,
+    )
+    session_data = { 'warden.user.user.session' => user_session }
+
+    session_store.send(
+      :write_session,
+      PLACEHOLDER_REQUEST,
+      Rack::Session::SessionId.new(session_uuid),
+      session_data,
+      expire_after: expiration.to_i,
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include OutOfBandSessionHelper
+end


### PR DESCRIPTION
changelog: Upcoming Features, Authentication, Use IdP authentication time for OIDC authentication timestamp

## 🎫 Ticket

https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/work_items/101

## 🛠 Summary of changes

Updates the OIDC `auth_time` claim to represent the latest actual Login.gov authentication event instead of the service provider linking transaction time. The corrected timestamp is returned in both the ID token and user-info response.

Remember-device events are excluded because they do not represent a new authentication. If no qualifying authentication timestamp is available, the response falls back to the current time.

## 📜 Testing Plan

- [ ] Enable `auth_time_attribute_enabled`, complete an OIDC sign-in, and confirm `auth_time` in the ID token and user-info response matches the Login.gov authentication time.
- [ ] Start another OIDC sign-in using the existing Login.gov session and confirm `auth_time` does not advance without a new authentication, including when remember device is used.
- [ ] Disable `auth_time_attribute_enabled` and confirm `auth_time` is not included in the OIDC responses.