### PR TITLE
LG-17771 fix run-on text in in-person state id alert

### DIFF
--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -24,8 +24,9 @@
       text_tag: 'div',
     ) do %>
   <strong><%= t('in_person_proofing.body.state_id.alert_message') %></strong>
-  <br/>
-  <%= t('in_person_proofing.body.state_id.alert_text') %>
+  <%# alert_text holds two separate strings separated by a blank line. Rendered bare, HTML %>
+  <%# collapses the break and the second one runs on to the end of the first. %>
+  <%= simple_format(t('in_person_proofing.body.state_id.alert_text'), {}, sanitize: true) %>
 <% end %>
 <%= simple_form_for form,
                     as: 'identity_doc', # Renaming form as a workaround for aggressive browser autofill assumptions


### PR DESCRIPTION
changelog: Bug Fixes, Identity Verification, fix run-on text in the in-person state ID alert


## 🎫 Ticket

Link to the relevant ticket:
[LG-17771](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17771)

## 🛠 Summary of changes

The alert on the in-person proofing state ID page content contained two paragraphs separated by a blank line. This cause the HTML to  collapse the line break and the second sentence ran on directly from the end of the first.

## 📜 Testing Plan

- [ ] Start identity verification and choose the in-person proofing flow
- [ ] Navigate to the state ID information page /`verify/in_person/state_id`
- [ ] Confirm the alert renders the bolded alert message, followed by the alert text as two distinct paragraphs (no run-on between them)
- [ ] Confirm no stray markup renders in the alert


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="1459" height="812" alt="LG-17771-before" src="https://github.com/user-attachments/assets/94e4b6ba-7da9-42b6-9e40-0266c9565199" />

</details>

<details>
<summary>After:</summary>
<img width="1459" height="812" alt="LG-17771-after" src="https://github.com/user-attachments/assets/b3cc69c6-40d4-4017-ba5a-ad7e8299051d" />

</details>


[LG-17771]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17771