### PR TITLE
LG-17801: display passport document number on verify info show

### DIFF
--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -59,7 +59,9 @@ locals:
       </div>
       <div>
         <dt class="display-inline"> <%= t('idv.form.id_number') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @pii[:state_id_number] %> </dd>
+        <dd class="display-inline margin-left-0">
+          <%= @pii[:state_id_number] || @pii[:document_number] %>
+        </dd>
       </div>
     </dl>
   </div>

--- a/lib/idp/constants.rb
+++ b/lib/idp/constants.rb
@@ -283,7 +283,7 @@ module Idp
       issuing_country_code: 'USA',
       passport_issued: (DateTime.new.utc - 1.year).to_s,
       nationality_code: 'USA',
-      document_number: nil,
+      document_number: '000000',
     ).freeze
     def self.mock_idv_applicant_with_passport
       MOCK_IDV_APPLICANT_WITH_PASSPORT.dup

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -698,6 +698,19 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
 
             fill_out_ssn_form_ok
             click_idv_continue
+
+            expect(page).to have_current_path(idv_address_path)
+
+            expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+            expect(page).not_to have_content(t('forms.example'))
+            fill_in 'idv_form_address1', with: '123 Main St'
+            fill_in 'idv_form_city', with: 'Nowhere'
+            select 'Virginia', from: 'idv_form_state'
+            fill_in 'idv_form_zipcode', with: '66044'
+
+            click_idv_continue
+
+            expect(page).to have_current_path(idv_verify_info_path)
           end
         end
 
@@ -768,6 +781,19 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
 
               fill_out_ssn_form_ok
               click_idv_continue
+
+              expect(page).to have_current_path(idv_address_path)
+
+              expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+              expect(page).not_to have_content(t('forms.example'))
+              fill_in 'idv_form_address1', with: '123 Main St'
+              fill_in 'idv_form_city', with: 'Nowhere'
+              select 'Virginia', from: 'idv_form_state'
+              fill_in 'idv_form_zipcode', with: '66044'
+
+              click_idv_continue
+
+              expect(page).to have_current_path(idv_verify_info_path)
             end
           end
         end
@@ -974,6 +1000,19 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
 
               fill_out_ssn_form_ok
               click_idv_continue
+
+              expect(page).to have_current_path(idv_address_path)
+
+              expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+              expect(page).not_to have_content(t('forms.example'))
+              fill_in 'idv_form_address1', with: '123 Main St'
+              fill_in 'idv_form_city', with: 'Nowhere'
+              select 'Virginia', from: 'idv_form_state'
+              fill_in 'idv_form_zipcode', with: '66044'
+
+              click_idv_continue
+
+              expect(page).to have_current_path(idv_verify_info_path)
             end
           end
 

--- a/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
+++ b/spec/features/idv/hybrid_mobile/hybrid_socure_mobile_spec.rb
@@ -358,6 +358,19 @@ RSpec.describe 'Hybrid Flow' do
           )
           fill_out_ssn_form_ok
           click_idv_continue
+
+          expect(page).to have_current_path(idv_address_path)
+
+          expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+          expect(page).not_to have_content(t('forms.example'))
+          fill_in 'idv_form_address1', with: '123 Main St'
+          fill_in 'idv_form_city', with: 'Nowhere'
+          select 'Virginia', from: 'idv_form_state'
+          fill_in 'idv_form_zipcode', with: '66044'
+
+          click_idv_continue
+
+          expect(page).to have_current_path(idv_verify_info_path)
         end
       end
 
@@ -503,6 +516,19 @@ RSpec.describe 'Hybrid Flow' do
             )
             fill_out_ssn_form_ok
             click_idv_continue
+
+            expect(page).to have_current_path(idv_address_path)
+
+            expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+            expect(page).not_to have_content(t('forms.example'))
+            fill_in 'idv_form_address1', with: '123 Main St'
+            fill_in 'idv_form_city', with: 'Nowhere'
+            select 'Virginia', from: 'idv_form_state'
+            fill_in 'idv_form_zipcode', with: '66044'
+
+            click_idv_continue
+
+            expect(page).to have_current_path(idv_verify_info_path)
           end
         end
 
@@ -708,6 +734,19 @@ RSpec.describe 'Hybrid Flow' do
           )
           fill_out_ssn_form_ok
           click_idv_continue
+
+          expect(page).to have_current_path(idv_address_path)
+
+          expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+          expect(page).not_to have_content(t('forms.example'))
+          fill_in 'idv_form_address1', with: '123 Main St'
+          fill_in 'idv_form_city', with: 'Nowhere'
+          select 'Virginia', from: 'idv_form_state'
+          fill_in 'idv_form_zipcode', with: '66044'
+
+          click_idv_continue
+
+          expect(page).to have_current_path(idv_verify_info_path)
         end
       end
 
@@ -853,6 +892,19 @@ RSpec.describe 'Hybrid Flow' do
             )
             fill_out_ssn_form_ok
             click_idv_continue
+
+            expect(page).to have_current_path(idv_address_path)
+
+            expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_info'))
+            expect(page).not_to have_content(t('forms.example'))
+            fill_in 'idv_form_address1', with: '123 Main St'
+            fill_in 'idv_form_city', with: 'Nowhere'
+            select 'Virginia', from: 'idv_form_state'
+            fill_in 'idv_form_zipcode', with: '66044'
+
+            click_idv_continue
+
+            expect(page).to have_current_path(idv_verify_info_path)
           end
         end
 
@@ -1313,7 +1365,7 @@ RSpec.describe 'Hybrid Flow' do
 
     context 'selfie is required' do
       let(:facial_match_required) { true }
-      context 'passport is submitted' do
+      context 'state id is submitted' do
         before do
           allow(IdentityConfig.store).to receive_messages(
             doc_auth_max_attempts: 6,


### PR DESCRIPTION
changelog: Bug Fixes, Document Authentication, Display passport document number on verify info

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-17801](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17801)

## 🛠 Summary of changes
Display document number on verify info page

## 📜 Testing Plan
1. Complete Doc Auth with Passport
2. Complete SSN
3. Verify ID Number is displayed on Verify Info page


## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>
<img width="515" height="690" alt="Screenshot 2026-07-31 at 4 50 41 PM" src="https://github.com/user-attachments/assets/b2f201dc-a66d-479c-9977-2d4a815f3a06" />
</details>

<details>
<summary>After:</summary>
<img width="518" height="738" alt="Screenshot 2026-07-31 at 4 47 44 PM" src="https://github.com/user-attachments/assets/a776682f-73d4-491d-96f3-d09e37416307" />
</details>


[LG-17801]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17801