### PR TITLE
Rename ial2 to idv when only identity verification is implied

### DIFF
--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -61,7 +61,7 @@ module SignUp
         current_sp: current_sp,
         decrypted_pii: pii,
         requested_attributes: decorated_sp_session.requested_attributes.map(&:to_sym),
-        ial2_requested: ial2_requested?,
+        idv_requested: idv_requested?,
         completion_context: needs_completion_screen_reason,
         selected_email_id: selected_email_id_for_linked_identity,
       )
@@ -71,7 +71,7 @@ module SignUp
       resolved_authn_context_result.identity_proofing?
     end
 
-    def ial2_requested?
+    def idv_requested?
       resolved_authn_context_result.identity_proofing_or_ialmax? && current_user.identity_verified?
     end
 

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -7,7 +7,7 @@ class CompletionsPresenter
   attr_reader :current_user, :current_sp, :decrypted_pii, :requested_attributes,
               :completion_context, :selected_email_id
 
-  SORTED_IAL2_ATTRIBUTE_MAPPING = [
+  SORTED_IDV_ATTRIBUTE_MAPPING = [
     [[:email], :email],
     [[:all_emails], :all_emails],
     [%i[given_name family_name], :full_name],
@@ -20,7 +20,7 @@ class CompletionsPresenter
     [[:verified_at], :verified_at],
   ].freeze
 
-  SORTED_IAL1_ATTRIBUTE_MAPPING = [
+  SORTED_AUTH_ONLY_ATTRIBUTE_MAPPING = [
     [[:email], :email],
     [[:all_emails], :all_emails],
     [[:x509_subject], :x509_subject],
@@ -33,7 +33,7 @@ class CompletionsPresenter
     current_sp:,
     decrypted_pii:,
     requested_attributes:,
-    ial2_requested:,
+    idv_requested:,
     completion_context:,
     selected_email_id:
   )
@@ -41,13 +41,13 @@ class CompletionsPresenter
     @current_sp = current_sp
     @decrypted_pii = decrypted_pii
     @requested_attributes = requested_attributes
-    @ial2_requested = ial2_requested
+    @idv_requested = idv_requested
     @completion_context = completion_context
     @selected_email_id = selected_email_id
   end
 
-  def ial2_requested?
-    @ial2_requested
+  def idv_requested?
+    @idv_requested
   end
 
   def sp_name
@@ -55,7 +55,7 @@ class CompletionsPresenter
   end
 
   def heading
-    if ial2_requested?
+    if idv_requested?
       if consent_has_expired?
         I18n.t('titles.sign_up.completion_consent_expired_ial2')
       elsif reverified_after_consent?
@@ -64,7 +64,7 @@ class CompletionsPresenter
           sp: sp_name,
         )
       else
-        I18n.t('titles.sign_up.completion_ial2', sp: sp_name)
+        I18n.t('titles.sign_up.completion_idv', sp: sp_name)
       end
     elsif first_time_signing_in?
       I18n.t('titles.sign_up.completion_first_sign_in', sp: sp_name)
@@ -89,7 +89,7 @@ class CompletionsPresenter
         ],
         ' ',
       )
-    elsif ial2_requested? && reverified_after_consent?
+    elsif idv_requested? && reverified_after_consent?
       t(
         'help_text.requested_attributes.ial2_reverified_consent_info_html',
         sp_html: content_tag(:strong, sp_name),
@@ -128,10 +128,10 @@ class CompletionsPresenter
   end
 
   def displayable_attribute_keys
-    sorted_attribute_mapping = if ial2_requested?
-                                 SORTED_IAL2_ATTRIBUTE_MAPPING
+    sorted_attribute_mapping = if idv_requested?
+                                 SORTED_IDV_ATTRIBUTE_MAPPING
                                else
-                                 SORTED_IAL1_ATTRIBUTE_MAPPING
+                                 SORTED_AUTH_ONLY_ATTRIBUTE_MAPPING
                                end
 
     sorted_attributes = sorted_attribute_mapping.map do |raw_attribute, display_attribute|

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -57,7 +57,7 @@ class CompletionsPresenter
   def heading
     if idv_requested?
       if consent_has_expired?
-        I18n.t('titles.sign_up.completion_consent_expired_ial2')
+        I18n.t('titles.sign_up.completion_consent_expired_idv')
       elsif reverified_after_consent?
         I18n.t(
           'titles.sign_up.completion_reverified_consent',
@@ -69,7 +69,7 @@ class CompletionsPresenter
     elsif first_time_signing_in?
       I18n.t('titles.sign_up.completion_first_sign_in', sp: sp_name)
     elsif consent_has_expired?
-      I18n.t('titles.sign_up.completion_consent_expired_ial1')
+      I18n.t('titles.sign_up.completion_consent_expired_auth_only')
     elsif completion_context == :new_attributes
       I18n.t('titles.sign_up.completion_new_attributes', sp: sp_name)
     else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1794,7 +1794,7 @@ titles.sign_in: Sign in
 titles.sign_up.completion_consent_expired_ial1: It’s been a year since you gave us consent to share your information
 titles.sign_up.completion_consent_expired_ial2: It’s been a year since you gave us consent to share your verified identity
 titles.sign_up.completion_first_sign_in: Continue to %{sp}
-titles.sign_up.completion_ial2: Connect your verified information to %{sp}
+titles.sign_up.completion_idv: Connect your verified information to %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} is requesting new information'
 titles.sign_up.completion_new_sp: You are now signing in for the first time
 titles.sign_up.completion_reverified_consent: Share your updated information with %{sp}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1791,8 +1791,8 @@ titles.revoke_consent: Revoke Consent
 titles.rules_of_use: Rules of Use
 titles.select_email: Select your preferred email
 titles.sign_in: Sign in
-titles.sign_up.completion_consent_expired_ial1: It’s been a year since you gave us consent to share your information
-titles.sign_up.completion_consent_expired_ial2: It’s been a year since you gave us consent to share your verified identity
+titles.sign_up.completion_consent_expired_auth_only: It’s been a year since you gave us consent to share your information
+titles.sign_up.completion_consent_expired_idv: It’s been a year since you gave us consent to share your verified identity
 titles.sign_up.completion_first_sign_in: Continue to %{sp}
 titles.sign_up.completion_idv: Connect your verified information to %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} is requesting new information'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1803,8 +1803,8 @@ titles.revoke_consent: Revocar consentimiento
 titles.rules_of_use: Reglas de uso
 titles.select_email: Seleccione el correo electrónico que prefiera
 titles.sign_in: Iniciar sesión
-titles.sign_up.completion_consent_expired_ial1: Hace un año que nos dio su consentimiento para divulgar su información
-titles.sign_up.completion_consent_expired_ial2: Hace un año que nos dio su consentimiento para divulgar su identidad verificada
+titles.sign_up.completion_consent_expired_auth_only: Hace un año que nos dio su consentimiento para divulgar su información
+titles.sign_up.completion_consent_expired_idv: Hace un año que nos dio su consentimiento para divulgar su identidad verificada
 titles.sign_up.completion_first_sign_in: Continuar con %{sp}
 titles.sign_up.completion_idv: Conecte su información verificada a %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} está solicitando nueva información'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1806,7 +1806,7 @@ titles.sign_in: Iniciar sesión
 titles.sign_up.completion_consent_expired_ial1: Hace un año que nos dio su consentimiento para divulgar su información
 titles.sign_up.completion_consent_expired_ial2: Hace un año que nos dio su consentimiento para divulgar su identidad verificada
 titles.sign_up.completion_first_sign_in: Continuar con %{sp}
-titles.sign_up.completion_ial2: Conecte su información verificada a %{sp}
+titles.sign_up.completion_idv: Conecte su información verificada a %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} está solicitando nueva información'
 titles.sign_up.completion_new_sp: Está iniciando sesión por primera vez
 titles.sign_up.completion_reverified_consent: Comunique su información actualizada a %{sp}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1792,8 +1792,8 @@ titles.revoke_consent: Révoquer le consentement
 titles.rules_of_use: Règles d’utilisation
 titles.select_email: Sélectionner l’adresse e-mail de votre choix
 titles.sign_in: Se connecter
-titles.sign_up.completion_consent_expired_ial1: Cela fait un an que vous nous avez donné votre consentement pour partager vos informations
-titles.sign_up.completion_consent_expired_ial2: Cela fait un an que vous nous avez donné votre consentement pour partager votre identité vérifiée
+titles.sign_up.completion_consent_expired_auth_only: Cela fait un an que vous nous avez donné votre consentement pour partager vos informations
+titles.sign_up.completion_consent_expired_idv: Cela fait un an que vous nous avez donné votre consentement pour partager votre identité vérifiée
 titles.sign_up.completion_first_sign_in: Continuer vers %{sp}
 titles.sign_up.completion_idv: Connecter vos informations vérifiées à %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} demande de nouvelles informations'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1795,7 +1795,7 @@ titles.sign_in: Se connecter
 titles.sign_up.completion_consent_expired_ial1: Cela fait un an que vous nous avez donné votre consentement pour partager vos informations
 titles.sign_up.completion_consent_expired_ial2: Cela fait un an que vous nous avez donné votre consentement pour partager votre identité vérifiée
 titles.sign_up.completion_first_sign_in: Continuer vers %{sp}
-titles.sign_up.completion_ial2: Connecter vos informations vérifiées à %{sp}
+titles.sign_up.completion_idv: Connecter vos informations vérifiées à %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} demande de nouvelles informations'
 titles.sign_up.completion_new_sp: Vous vous connectez pour la première fois
 titles.sign_up.completion_reverified_consent: Partager vos informations mises à jour avec %{sp}

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1805,8 +1805,8 @@ titles.revoke_consent: 撤销同意
 titles.rules_of_use: 使用规则
 titles.select_email: 选择你想用的电邮
 titles.sign_in: 登录
-titles.sign_up.completion_consent_expired_ial1: 从你上次授权我们分享你的信息已经一年了。
-titles.sign_up.completion_consent_expired_ial2: 从你上次授权我们分享你验证过的身份已经一年了。
+titles.sign_up.completion_consent_expired_auth_only: 从你上次授权我们分享你的信息已经一年了。
+titles.sign_up.completion_consent_expired_idv: 从你上次授权我们分享你验证过的身份已经一年了。
 titles.sign_up.completion_first_sign_in: 继续到 %{sp}
 titles.sign_up.completion_idv: 连接你验证过的信息到 %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} 在要求新信息'

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1808,7 +1808,7 @@ titles.sign_in: 登录
 titles.sign_up.completion_consent_expired_ial1: 从你上次授权我们分享你的信息已经一年了。
 titles.sign_up.completion_consent_expired_ial2: 从你上次授权我们分享你验证过的身份已经一年了。
 titles.sign_up.completion_first_sign_in: 继续到 %{sp}
-titles.sign_up.completion_ial2: 连接你验证过的信息到 %{sp}
+titles.sign_up.completion_idv: 连接你验证过的信息到 %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} 在要求新信息'
 titles.sign_up.completion_new_sp: 你现在正在首次登入
 titles.sign_up.completion_reverified_consent: 与 %{sp}分享你更新后的信息

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SignUp::CompletionsController do
         expect(response).to redirect_to account_url
       end
 
-      context 'IAL1' do
+      context 'auth only' do
         let(:user) { create(:user, :fully_registered, email: temporary_email) }
 
         before do
@@ -50,12 +50,12 @@ RSpec.describe SignUp::CompletionsController do
           )
         end
 
-        it 'creates a presenter object that is not requesting ial2' do
-          expect(assigns(:presenter).ial2_requested?).to eq false
+        it 'creates a presenter object that is not requesting idv' do
+          expect(assigns(:presenter).idv_requested?).to eq false
         end
       end
 
-      context 'IAL2' do
+      context 'identity verification' do
         let(:user) do
           create(:user, :fully_registered, profiles: [create(:profile, :verified, :active)])
         end
@@ -87,8 +87,8 @@ RSpec.describe SignUp::CompletionsController do
           )
         end
 
-        it 'creates a presenter object that is requesting ial2' do
-          expect(assigns(:presenter).ial2_requested?).to eq true
+        it 'creates a presenter object that is requesting idv' do
+          expect(assigns(:presenter).idv_requested?).to eq true
         end
 
         context 'user is not identity verified' do
@@ -134,15 +134,15 @@ RSpec.describe SignUp::CompletionsController do
         end
 
         context 'verified user' do
-          it 'creates a presenter object that is requesting ial2' do
-            expect(assigns(:presenter).ial2_requested?).to eq true
+          it 'creates a presenter object that is requesting idv' do
+            expect(assigns(:presenter).idv_requested?).to eq true
           end
         end
 
         context 'unverified user' do
           let(:user) { create(:user) }
-          it 'creates a presenter object that is requesting ial2' do
-            expect(assigns(:presenter).ial2_requested?).to eq false
+          it 'creates a presenter object that is requesting idv' do
+            expect(assigns(:presenter).idv_requested?).to eq false
           end
         end
       end
@@ -210,7 +210,7 @@ RSpec.describe SignUp::CompletionsController do
       allow(IdentityLinker).to receive(:new).and_return(@linker)
     end
 
-    context 'IAL1' do
+    context 'auth only' do
       let(:user) { create(:user, :fully_registered) }
       it 'tracks analytics' do
         stub_sign_in(user)
@@ -331,7 +331,7 @@ RSpec.describe SignUp::CompletionsController do
       end
     end
 
-    context 'IAL2' do
+    context 'identity verification' do
       it 'tracks analytics' do
         DisposableEmailDomain.create(name: 'temporary.com')
         user = create(

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -715,7 +715,7 @@ RSpec.describe 'OpenID Connect' do
       client_id: client_id,
       handoff_page_steps: proc do
         click_button t('webauthn_platform_recommended.skip')
-        expect(page).to have_content(t('titles.sign_up.completion_consent_expired_ial1'))
+        expect(page).to have_content(t('titles.sign_up.completion_consent_expired_auth_only'))
         expect(page).to_not have_content(t('titles.sign_up.completion_new_sp'))
 
         click_agree_and_continue
@@ -740,7 +740,7 @@ RSpec.describe 'OpenID Connect' do
       handoff_page_steps: proc do
         click_button t('webauthn_platform_recommended.skip')
         expect(page).to have_content(t('titles.sign_up.completion_new_sp'))
-        expect(page).to_not have_content(t('titles.sign_up.completion_consent_expired_ial1'))
+        expect(page).to_not have_content(t('titles.sign_up.completion_consent_expired_auth_only'))
 
         click_agree_and_continue
       end,

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CompletionsPresenter do
       :verified_at
     ]
   end
-  let(:ial2_requested) { false }
+  let(:idv_requested) { false }
   let(:completion_context) { :new_sp }
 
   subject(:presenter) do
@@ -46,23 +46,23 @@ RSpec.describe CompletionsPresenter do
       current_sp:,
       decrypted_pii:,
       requested_attributes:,
-      ial2_requested:,
+      idv_requested:,
       completion_context:,
       selected_email_id:,
     )
   end
 
   describe '#heading' do
-    context 'ial2 sign in' do
-      let(:ial2_requested) { true }
+    context 'idv sign in' do
+      let(:idv_requested) { true }
 
-      it 'renders the ial2 message' do
+      it 'renders the idv message' do
         expect(presenter.heading).to eq(
-          I18n.t('titles.sign_up.completion_ial2', sp: current_sp.friendly_name),
+          I18n.t('titles.sign_up.completion_idv', sp: current_sp.friendly_name),
         )
       end
 
-      context 'renders the ial2 consent message if consent expired' do
+      context 'renders the idv consent message if consent expired' do
         let(:identities) do
           [
             build(
@@ -90,7 +90,7 @@ RSpec.describe CompletionsPresenter do
       end
     end
 
-    context 'consent has expired since the last sign in with ial1' do
+    context 'consent has expired since the last sign in with auth only' do
       let(:identities) do
         [
           build(
@@ -192,8 +192,8 @@ RSpec.describe CompletionsPresenter do
       end
     end
 
-    describe 'ial2' do
-      let(:ial2_requested) { true }
+    describe 'idv' do
+      let(:idv_requested) { true }
 
       context 'consent has expired since the last sign in' do
         let(:identities) do
@@ -238,7 +238,7 @@ RSpec.describe CompletionsPresenter do
         end
         let(:completion_context) { :reverified_after_consent }
 
-        it 'renders the reverified IAL2 consent intro message' do
+        it 'renders the reverified IDV consent intro message' do
           expect(presenter.intro).to eq(
             t(
               'help_text.requested_attributes.ial2_reverified_consent_info_html',
@@ -253,7 +253,7 @@ RSpec.describe CompletionsPresenter do
   describe '#pii' do
     subject(:pii) { presenter.pii }
 
-    context 'ial1' do
+    context 'auth only' do
       context 'with a subset of attributes requested' do
         let(:requested_attributes) { [:email] }
 
@@ -291,8 +291,8 @@ RSpec.describe CompletionsPresenter do
       end
     end
 
-    context 'ial2' do
-      let(:ial2_requested) { true }
+    context 'idv' do
+      let(:idv_requested) { true }
 
       context 'with a subset of attributes requested' do
         let(:requested_attributes) { [:email, :given_name, :phone] }

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe CompletionsPresenter do
 
         it 'renders the expired consent message' do
           expect(presenter.heading).to eq(
-            I18n.t('titles.sign_up.completion_consent_expired_ial2'),
+            I18n.t('titles.sign_up.completion_consent_expired_idv'),
           )
         end
       end
@@ -104,7 +104,7 @@ RSpec.describe CompletionsPresenter do
 
       it 'renders the expired consent message' do
         expect(presenter.heading).to eq(
-          I18n.t('titles.sign_up.completion_consent_expired_ial1'),
+          I18n.t('titles.sign_up.completion_consent_expired_auth_only'),
         )
       end
     end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -201,7 +201,7 @@ module IdvHelper
     expect(user.identity_verified?).to be(true)
     expect(page).to have_current_path sign_up_completed_path
     expect(page).to have_content t(
-      'titles.sign_up.completion_ial2',
+      'titles.sign_up.completion_idv',
       sp: 'Test SP',
     )
   end

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -21,7 +21,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       acknowledge_and_confirm_personal_key
 
       expect(page).to have_content t(
-        'titles.sign_up.completion_ial2',
+        'titles.sign_up.completion_idv',
         sp: 'Test SP',
       )
       expect_csp_headers_to_be_present if sp == :oidc
@@ -51,7 +51,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       acknowledge_and_confirm_personal_key
 
       expect(page).to have_content t(
-        'titles.sign_up.completion_ial2',
+        'titles.sign_up.completion_idv',
         sp: 'Test SP',
       )
       expect_csp_headers_to_be_present if sp == :oidc

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
   let(:selected_email_id) { user.email_addresses.first.id }
   let(:decrypted_pii) { {} }
   let(:requested_attributes) { [:email] }
-  let(:ial2_requested) { false }
+  let(:idv_requested) { false }
   let(:completion_context) { :new_sp }
 
   let(:view_context) { ActionController::Base.new.view_context }
@@ -25,7 +25,7 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
       current_sp: service_provider,
       decrypted_pii:,
       requested_attributes:,
-      ial2_requested:,
+      idv_requested:,
       completion_context:,
       selected_email_id:,
     )
@@ -86,8 +86,8 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
     end
   end
 
-  context 'ial2' do
-    let(:ial2_requested) { true }
+  context 'idv' do
+    let(:idv_requested) { true }
     let(:requested_attributes) { [:email, :social_security_number, :verified_at] }
     let(:decrypted_pii) do
       {


### PR DESCRIPTION
The code uses ial2 to mean identity-verified.
This refactor converts such usages to just idv.

changelog: Internal, Refactoring, Use idv when only identity verification is implied

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
