### PR TITLE
[LG-17625] Update duplicate account content for clarity

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文（简体）
 account.email_language.updated: Your email language preference has been updated.
-account.emails.confirmed_html: You have confirmed your email address. Go to <a href="%{url}">your connected services</a> to update the email you share with connected agencies.
+account.emails.confirmed_html: You have confirmed your email address. Go to <a href="%{url}">your connected services</a> to update the email you share with connected services.
 account.forget_all_browsers.longer_description: Once you choose to ‘forget all browsers,’ we’ll need additional information to know that it’s actually you signing in to your account. We’ll ask for a multi-factor authentication method (such as text/SMS code or a security key) each time you want to access your account.
 account.index.auth_app_add: Add app
 account.index.auth_app_disabled: not enabled
@@ -756,7 +756,7 @@ doc_auth.tips.document_capture_selfie_text3: Keep your expression neutral
 doc_auth.tips.document_capture_selfie_text4: Make sure your whole face is visible within the green circle
 duplicate_profiles_detected.accounts_list.heading: Accounts with the same verified information
 duplicate_profiles_detected.cant_access: 'I can’t access an account'
-duplicate_profiles_detected.connected_acct_html: '<strong> Connected agencies: </strong> %{count}'
+duplicate_profiles_detected.connected_acct_html: '<strong> Connected services: </strong> %{count}'
 duplicate_profiles_detected.created_at_html: '<strong> Created: </strong> %{timestamp_html}'
 duplicate_profiles_detected.delete_duplicates.details_html: Sign into the account you are going to delete at <a href="https://secure.login.gov">https://secure.login.gov</a>. Here’s %{link_html}
 duplicate_profiles_detected.delete_duplicates.details2_html: If you want, you may %{link_html} to the account you’re keeping after deleting the duplicate account.
@@ -767,11 +767,11 @@ duplicate_profiles_detected.dont_recognize_account: I don’t recognize an accou
 duplicate_profiles_detected.duplicate: Duplicate
 duplicate_profiles_detected.get_help: Get Help
 duplicate_profiles_detected.heading: We found other accounts that may be yours
-duplicate_profiles_detected.intro_html: 'The %{sp_name} requires that you only have one %{app_name} account with a verified identity. You need to delete %{link_html} before signing into %{sp_name}. Here’s what to do:'
+duplicate_profiles_detected.intro_html: 'Some services require that you only have one %{app_name} account with a verified identity. You need to delete %{link_html} before signing into %{sp_name}. Here’s what to do:'
 duplicate_profiles_detected.intro.link: duplicate accounts
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> Last login: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: Never logged in to
-duplicate_profiles_detected.select_an_account.details_html: 'Keep the account that’s connected to the most services. Go to %{link_html} page to view connected agencies by selecting “Your connected services” in the left menu.'
+duplicate_profiles_detected.select_an_account.details_html: 'Keep the account that’s connected to the most services. Go to %{link_html} page to view connected services by selecting “Your connected services” in the left menu.'
 duplicate_profiles_detected.select_an_account.details.link: Your account
 duplicate_profiles_detected.select_an_account.heading: Choose an account to keep
 duplicate_profiles_detected.sign_back_in.details: Go back to the %{app_name} website and sign in using the one %{app_name} account you kept.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -58,7 +58,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文（简体）
 account.email_language.updated: Se actualizó su preferencia de idioma del correo electrónico.
-account.emails.confirmed_html: Has confirmado tu dirección de correo electrónico. Ve a <a href="%{url}">tus servicios conectados</a> para actualizar el correo electrónico que compartes con las agencias conectadas.
+account.emails.confirmed_html: Has confirmado tu dirección de correo electrónico. Ve a <a href="%{url}">tus servicios conectados</a> para actualizar el correo electrónico que compartes con las servicios conectadas.
 account.forget_all_browsers.longer_description: Una vez que elija “Olvidar todos los navegadores”, necesitaremos más información para saber que realmente es usted quien está iniciando sesión en su cuenta. Le pediremos un método de autenticación multifactor (como código de texto o de SMS, o una clave de seguridad) cada vez que desee acceder a su cuenta.
 account.index.auth_app_add: Agregar aplicación
 account.index.auth_app_disabled: no habilitada
@@ -767,7 +767,7 @@ doc_auth.tips.document_capture_selfie_text3: Mantenga una expresión neutral
 doc_auth.tips.document_capture_selfie_text4: Revise que se vea su rostro completo dentro del círculo verde.
 duplicate_profiles_detected.accounts_list.heading: Cuentas con la misma información verificada
 duplicate_profiles_detected.cant_access: 'No puedo acceder a una cuenta'
-duplicate_profiles_detected.connected_acct_html: '<strong> Agencias conectadas: </strong> %{count}'
+duplicate_profiles_detected.connected_acct_html: '<strong> Servicios conectadas: </strong> %{count}'
 duplicate_profiles_detected.created_at_html: '<strong> Creado: </strong> %{timestamp_html}'
 duplicate_profiles_detected.delete_duplicates.details_html: Inicia sesión en la cuenta que va a eliminar en <a href="https://secure.login.gov">https://secure.login.gov</a>. Así es %{link_html}
 duplicate_profiles_detected.delete_duplicates.details2_html: Si lo desea, %{link_html} a la cuenta que conservará después de eliminar la cuenta duplicada.
@@ -778,11 +778,11 @@ duplicate_profiles_detected.dont_recognize_account: No reconozco una de estas cu
 duplicate_profiles_detected.duplicate: Duplicada
 duplicate_profiles_detected.get_help: Obtener ayuda
 duplicate_profiles_detected.heading: Encontramos otras cuentas que pueden ser suyas
-duplicate_profiles_detected.intro_html: '%{sp_name} requiere que usted tenga sólo una cuenta de %{app_name} con una identidad verificada. Debe eliminar %{link_html} antes de iniciar sesión en %{sp_name}. Esto es lo que debe hacer:'
+duplicate_profiles_detected.intro_html: 'Algunas servicios requieren que usted tenga únicamente una cuenta de %{app_name} con una identidad verificada. Debe eliminar %{link_html} antes de iniciar sesión en %{sp_name}. Esto es lo que debe hacer:'
 duplicate_profiles_detected.intro.link: las cuentas duplicativas
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> Último inicio de sesión: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: Nunca he iniciado sesión en
-duplicate_profiles_detected.select_an_account.details_html: 'Conserva la cuenta que esté conectada a la mayor cantidad de servicios. Ve a la página %{link_html} para ver las agencias conectadas seleccionando “Tus servicios conectados” en el menú de la izquierda.'
+duplicate_profiles_detected.select_an_account.details_html: 'Conserva la cuenta que esté conectada a la mayor cantidad de servicios. Ve a la página %{link_html} para ver las servicios conectadas seleccionando “Tus servicios conectados” en el menú de la izquierda.'
 duplicate_profiles_detected.select_an_account.details.link: «Su cuenta»
 duplicate_profiles_detected.select_an_account.heading: Elija la cuenta que desea conservar.
 duplicate_profiles_detected.sign_back_in.details: Vuelva al sitio web de %{app_name} e inicie sesión usando la cuenta de %{app_name} que conservó.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -58,7 +58,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文（简体）
 account.email_language.updated: Votre langue de préférence pour les e-mails a été mise à jour.
-account.emails.confirmed_html: Vous avez confirmé votre adresse e-mail. Rendez-vous sur <a href="%{url}">vos services connectés</a> pour actualiser l’adresse e-mail que vous communiquez aux organismes connectés.
+account.emails.confirmed_html: Vous avez confirmé votre adresse e-mail. Rendez-vous sur <a href="%{url}">vos services connectés</a> pour actualiser l’adresse e-mail que vous communiquez aux services connectés.
 account.forget_all_browsers.longer_description: Une fois que vous aurez choisi d’« oublier tous les navigateurs », nous aurons besoin d’informations supplémentaires pour savoir que c’est bien vous qui vous connectez à votre compte. Nous vous demanderons une méthode d’authentification multi-facteurs (comme un code SMS/texto ou une clé de sécurité) chaque fois que vous souhaiterez accéder à votre compte.
 account.index.auth_app_add: Ajouter une appli
 account.index.auth_app_disabled: non activé
@@ -756,7 +756,7 @@ doc_auth.tips.document_capture_selfie_text3: Gardez une expression neutre
 doc_auth.tips.document_capture_selfie_text4: Assurez-vous que l’ensemble de votre visage est visible dans le cercle vert
 duplicate_profiles_detected.accounts_list.heading: Comptes ayant les mêmes informations vérifiées
 duplicate_profiles_detected.cant_access: 'Je ne peux pas accéder à un compte'
-duplicate_profiles_detected.connected_acct_html: '<strong> Agences connectées: </strong> %{count}'
+duplicate_profiles_detected.connected_acct_html: '<strong> Services connectés: </strong> %{count}'
 duplicate_profiles_detected.created_at_html: '<strong> Créé: </strong> %{timestamp_html}'
 duplicate_profiles_detected.delete_duplicates.details_html: Connectez-vous au compte que vous souhaitez supprimer sur <a href="https://secure.login.gov">https://secure.login.gov</a> . Voici %{link_html}
 duplicate_profiles_detected.delete_duplicates.details2_html: 'Si vous le souhaitez, vous pouvez ajouter %{link_html} au compte que vous conservez après avoir supprimé le compte en double.'
@@ -767,11 +767,11 @@ duplicate_profiles_detected.dont_recognize_account: Je ne reconnais pas l’un d
 duplicate_profiles_detected.duplicate: En double
 duplicate_profiles_detected.get_help: Obtenir de l’aide
 duplicate_profiles_detected.heading: Nous avons trouvé d’autres comptes susceptibles de vous appartenir
-duplicate_profiles_detected.intro_html: 'L’%{sp_name} exige que vous ne disposiez que d’un seul et unique compte %{app_name} avec une identité vérifiée. Vous devez supprimer les %{link_html} avant de vous connecter à l’%{sp_name}. Voici la marche à suivre :'
+duplicate_profiles_detected.intro_html: 'Certaines services exigent que vous ne disposiez que d’un seul compte %{app_name} avec une identité vérifiée. Vous devez supprimer les %{link_html} avant de vous connecter à l’%{sp_name}. Voici la marche à suivre :'
 duplicate_profiles_detected.intro.link: comptes en double
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> Dernière connexion : </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: 'Jamais connecté à'
-duplicate_profiles_detected.select_an_account.details_html: 'Conservez le compte connecté au plus grand nombre de services. Rendez-vous sur la page %{link_html} pour consulter les agences connectées en sélectionnant «Vos services connectés» dans le menu de gauche.'
+duplicate_profiles_detected.select_an_account.details_html: 'Conservez le compte connecté au plus grand nombre de services. Rendez-vous sur la page %{link_html} pour consulter les services connectées en sélectionnant «Vos services connectés» dans le menu de gauche.'
 duplicate_profiles_detected.select_an_account.details.link: '«Votre compte»'
 duplicate_profiles_detected.select_an_account.heading: Choisir le compte que vous voulez conserver
 duplicate_profiles_detected.sign_back_in.details: Retournez sur le site web de %{app_name} et connectez-vous à l’aide du compte %{app_name} que vous avez conservé.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -767,7 +767,7 @@ doc_auth.tips.document_capture_selfie_text3: 保持中性表情
 doc_auth.tips.document_capture_selfie_text4: 确保您整个面孔都可以在绿色圆圈里看到
 duplicate_profiles_detected.accounts_list.heading: 以下账户具有相同的已验证信息
 duplicate_profiles_detected.cant_access: '我无法访问某个帐户'
-duplicate_profiles_detected.connected_acct_html: '<strong> 关联机构: </strong> %{count}'
+duplicate_profiles_detected.connected_acct_html: '<strong> 互联服务: </strong> %{count}'
 duplicate_profiles_detected.created_at_html: '<strong> 创建: </strong> %{timestamp_html}'
 duplicate_profiles_detected.delete_duplicates.details_html: 请登录您打算删除的账户：<a href="https://secure.login.gov">https://secure.login.gov/zh</a>。以下是%{link_html}。
 duplicate_profiles_detected.delete_duplicates.details2_html: 如果您愿意，可以在%{link_html}，将该电子邮件地址添加到您保留的账户中。
@@ -778,7 +778,7 @@ duplicate_profiles_detected.dont_recognize_account: 我不认识上边的一个�
 duplicate_profiles_detected.duplicate: 重复
 duplicate_profiles_detected.get_help: 获取帮助
 duplicate_profiles_detected.heading: 我们发现了其他可能属于你的帐户
-duplicate_profiles_detected.intro_html: '%{sp_name} 要求您仅持有一个已验证身份的 %{app_name} 账户。在登录 %{sp_name} 之前，您需要%{link_html}。具体操作如下：'
+duplicate_profiles_detected.intro_html: '某些服务要求您仅拥有一个已验证身份的 %{app_name} 账户。在登录 %{sp_name} 之前，您需要%{link_html}。具体操作如下：'
 duplicate_profiles_detected.intro.link: 删除重复账户
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> 上次登录: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: 从未登录过

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -782,7 +782,7 @@ duplicate_profiles_detected.intro_html: '某些服务要求您仅拥有一个已
 duplicate_profiles_detected.intro.link: 删除重复账户
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> 上次登录: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: 从未登录过
-duplicate_profiles_detected.select_an_account.details_html: '保留关联服务最多的帐户。前往 %{link_html} 页面，在左侧菜单中选择”您的关联服务”，即可查看已关联的机构。'
+duplicate_profiles_detected.select_an_account.details_html: '保留关联服务最多的帐户。前往 %{link_html} 页面，在左侧菜单中选择“您的关联服务”，即可查看已关联的机构。'
 duplicate_profiles_detected.select_an_account.details.link: 您的账户
 duplicate_profiles_detected.select_an_account.heading: 选择要保留的帐户
 duplicate_profiles_detected.sign_back_in.details: 返回 %{app_name} 网站，使用你保留的那个 %{app_name} 帐户登录。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -782,7 +782,7 @@ duplicate_profiles_detected.intro_html: '某些服务要求您仅拥有一个已
 duplicate_profiles_detected.intro.link: 删除重复账户
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> 上次登录: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: 从未登录过
-duplicate_profiles_detected.select_an_account.details_html: '保留关联服务最多的帐户。前往 %{link_html} 页面，在左侧菜单中选择"您的关联服务"，即可查看已关联的机构。'
+duplicate_profiles_detected.select_an_account.details_html: '保留关联服务最多的帐户。前往 %{link_html} 页面，在左侧菜单中选择”您的关联服务”，即可查看已关联的机构。'
 duplicate_profiles_detected.select_an_account.details.link: 您的账户
 duplicate_profiles_detected.select_an_account.heading: 选择要保留的帐户
 duplicate_profiles_detected.sign_back_in.details: 返回 %{app_name} 网站，使用你保留的那个 %{app_name} 帐户登录。

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -782,7 +782,7 @@ duplicate_profiles_detected.intro_html: '某些服务要求您仅拥有一个已
 duplicate_profiles_detected.intro.link: 删除重复账户
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> 上次登录: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: 从未登录过
-duplicate_profiles_detected.select_an_account.details_html: '保留关联服务最多的帐户。前往 %{link_html} 页面，在左侧菜单中选择“您的关联服务”，即可查看已关联的机构。'
+duplicate_profiles_detected.select_an_account.details_html: '保留关联服务最多的帐户。前往 %{link_html} 页面，在左侧菜单中选择"您的关联服务"，即可查看已关联的机构。'
 duplicate_profiles_detected.select_an_account.details.link: 您的账户
 duplicate_profiles_detected.select_an_account.heading: 选择要保留的帐户
 duplicate_profiles_detected.sign_back_in.details: 返回 %{app_name} 网站，使用你保留的那个 %{app_name} 帐户登录。


### PR DESCRIPTION
changelog: User-Facing Improvements, Duplicate Accounts, Updating language for clarity regarding service provider requirements

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17625](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17625)



## 🛠 Summary of changes
- Content updates for service provider requirements on the duplicate accounts page

Note: There is one less translation for zh because it was already correct

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17625]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17625