### PR TITLE
Add Identity Proofing flag to User Registration analytics event

### DIFF
--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -24,7 +24,7 @@ module SignUp
 
       result = @register_user_email_form.submit(permitted_params.merge(request_id:))
 
-      analytics.user_registration_email(**result, identity_proofing: ial2_requested?)
+      analytics.user_registration_email(**result, idv_requested: idv_requested?)
       attempts_api_tracker.user_registration_email_submitted(
         email: permitted_params[:email].presence,
         success: result.success?,

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -24,7 +24,7 @@ module SignUp
 
       result = @register_user_email_form.submit(permitted_params.merge(request_id:))
 
-      analytics.user_registration_email(**result)
+      analytics.user_registration_email(**result, identity_proofing: ial2_requested?)
       attempts_api_tracker.user_registration_email_submitted(
         email: permitted_params[:email].presence,
         success: result.success?,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -8911,7 +8911,7 @@ module AnalyticsEvents
   # @param [Boolean] email_already_exists Whether an account with the email address already exists
   # @param [String] domain_name Domain name of email address submitted
   # @param [String] email_language Preferred language for email communication
-  # @param [Boolean] identity_proofing Whether the resolved authn context requires identity proofing
+  # @param [Boolean] idv_requested Whether the resolved authn context requires identity proofing
   def user_registration_email(
     success:,
     rate_limited:,
@@ -8919,7 +8919,7 @@ module AnalyticsEvents
     email_already_exists:,
     domain_name:,
     email_language:,
-    identity_proofing:,
+    idv_requested:,
     error_details: nil,
     **extra
   )
@@ -8932,7 +8932,7 @@ module AnalyticsEvents
       email_already_exists:,
       domain_name:,
       email_language:,
-      identity_proofing:,
+      idv_requested:,
       **extra,
     )
   end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -8911,7 +8911,7 @@ module AnalyticsEvents
   # @param [Boolean] email_already_exists Whether an account with the email address already exists
   # @param [String] domain_name Domain name of email address submitted
   # @param [String] email_language Preferred language for email communication
-  # @param [Boolean] identity_proofing Whether the resolved authn context requires identity proofing (IdV),
+  # @param [Boolean] identity_proofing Whether the resolved authn context requires identity proofing,
   # from ApplicationHelper#ial2_requested?.
   def user_registration_email(
     success:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -8911,8 +8911,7 @@ module AnalyticsEvents
   # @param [Boolean] email_already_exists Whether an account with the email address already exists
   # @param [String] domain_name Domain name of email address submitted
   # @param [String] email_language Preferred language for email communication
-  # @param [Boolean] identity_proofing Whether the resolved authn context requires identity proofing,
-  # from ApplicationHelper#ial2_requested?.
+  # @param [Boolean] identity_proofing Whether the resolved authn context requires identity proofing
   def user_registration_email(
     success:,
     rate_limited:,

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -8911,6 +8911,8 @@ module AnalyticsEvents
   # @param [Boolean] email_already_exists Whether an account with the email address already exists
   # @param [String] domain_name Domain name of email address submitted
   # @param [String] email_language Preferred language for email communication
+  # @param [Boolean] identity_proofing Whether the resolved authn context requires identity proofing (IdV),
+  # from ApplicationHelper#ial2_requested?.
   def user_registration_email(
     success:,
     rate_limited:,
@@ -8918,6 +8920,7 @@ module AnalyticsEvents
     email_already_exists:,
     domain_name:,
     email_language:,
+    identity_proofing:,
     error_details: nil,
     **extra
   )
@@ -8930,6 +8933,7 @@ module AnalyticsEvents
       email_already_exists:,
       domain_name:,
       email_language:,
+      identity_proofing:,
       **extra,
     )
   end

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -89,9 +89,59 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
           user_id: user.uuid,
           domain_name: 'example.com',
           email_language:,
+          identity_proofing: false,
         )
 
         expect(subject).to have_received(:create_user_event).with(:account_created, user)
+      end
+
+      context 'when the SP requests identity proofing (IAL2)' do
+        before do
+          subject.session[:sp] = {
+            issuer: create(:service_provider).issuer,
+            acr_values: Saml::Idp::Constants::IAL2_AUTHN_CONTEXT_CLASSREF,
+          }
+        end
+
+        it 'logs identity_proofing as true' do
+          post :create, params: params
+
+          expect(@analytics).to have_logged_event(
+            'User Registration: Email Submitted',
+            hash_including(identity_proofing: true),
+          )
+        end
+      end
+
+      context 'when the SP requests authentication only (IAL1)' do
+        before do
+          subject.session[:sp] = {
+            issuer: create(:service_provider).issuer,
+            acr_values: Saml::Idp::Constants::IAL1_AUTHN_CONTEXT_CLASSREF,
+          }
+        end
+
+        it 'logs identity_proofing as false' do
+          post :create, params: params
+
+          expect(@analytics).to have_logged_event(
+            'User Registration: Email Submitted',
+            hash_including(identity_proofing: false),
+          )
+        end
+      end
+
+      context 'when there is no associated service provider request' do
+        it 'logs identity_proofing as false' do
+          expect(subject.session[:sp]).to be_blank
+
+          post :create, params: params
+
+          expect(@analytics).to have_logged_event(
+            'User Registration: Email Submitted',
+            hash_including(identity_proofing: false),
+          )
+        end
       end
 
       it 'sets the users preferred email locale and sends an email in that locale' do
@@ -145,6 +195,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
           user_id: existing_user.uuid,
           domain_name: 'example.com',
           email_language:,
+          identity_proofing: false,
         )
       end
     end
@@ -170,6 +221,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
           user_id: 'anonymous-uuid',
           domain_name: 'invalid',
           email_language:,
+          identity_proofing: false,
         )
       end
 

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -89,13 +89,13 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
           user_id: user.uuid,
           domain_name: 'example.com',
           email_language:,
-          identity_proofing: false,
+          idv_requested: false,
         )
 
         expect(subject).to have_received(:create_user_event).with(:account_created, user)
       end
 
-      context 'when the SP requests identity proofing (IAL2)' do
+      context 'when the SP requests IDV' do
         before do
           subject.session[:sp] = {
             issuer: create(:service_provider).issuer,
@@ -103,17 +103,17 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
           }
         end
 
-        it 'logs identity_proofing as true' do
+        it 'logs idv_requested as true' do
           post :create, params: params
 
           expect(@analytics).to have_logged_event(
             'User Registration: Email Submitted',
-            hash_including(identity_proofing: true),
+            hash_including(idv_requested: true),
           )
         end
       end
 
-      context 'when the SP requests authentication only (IAL1)' do
+      context 'when the SP requests authentication only' do
         before do
           subject.session[:sp] = {
             issuer: create(:service_provider).issuer,
@@ -121,25 +121,25 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
           }
         end
 
-        it 'logs identity_proofing as false' do
+        it 'logs idv_requested as false' do
           post :create, params: params
 
           expect(@analytics).to have_logged_event(
             'User Registration: Email Submitted',
-            hash_including(identity_proofing: false),
+            hash_including(idv_requested: false),
           )
         end
       end
 
       context 'when there is no associated service provider request' do
-        it 'logs identity_proofing as false' do
+        it 'logs idv_requested as false' do
           expect(subject.session[:sp]).to be_blank
 
           post :create, params: params
 
           expect(@analytics).to have_logged_event(
             'User Registration: Email Submitted',
-            hash_including(identity_proofing: false),
+            hash_including(idv_requested: false),
           )
         end
       end
@@ -195,7 +195,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
           user_id: existing_user.uuid,
           domain_name: 'example.com',
           email_language:,
-          identity_proofing: false,
+          idv_requested: false,
         )
       end
     end
@@ -221,7 +221,7 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
           user_id: 'anonymous-uuid',
           domain_name: 'invalid',
           email_language:,
-          identity_proofing: false,
+          idv_requested: false,
         )
       end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -60,4 +60,25 @@ RSpec.describe ApplicationHelper do
       expect(helper.view_flow.get(:title)).to eq(title)
     end
   end
+
+  describe '#idv_requested?' do
+    subject(:idv_requested?) { helper.idv_requested? }
+
+    before do
+      allow(helper).to receive(:resolved_authn_context_result)
+        .and_return(double(identity_proofing?: identity_proofing))
+    end
+
+    context 'when the resolved authn context requires identity proofing' do
+      let(:identity_proofing) { true }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the resolved authn context does not require identity proofing' do
+      let(:identity_proofing) { false }
+
+      it { is_expected.to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
changelog: Internal, User Registration Funnel, add ID proofing flag to user registration event

## 🎫 Ticket

Link to the relevant ticket:
[LG-17540](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17540)


## 🛠 Summary of changes

We need to create two account creation funnels: one for auth-only users and one for identity verification users. 

In the current state of the `user_registration_email` analytics event (i.e. when a user submits an email to start the account creation flow) we don't have a way of differentiating between auth-only vs IDV from an analytics logging perspective, so I am adding that flag here.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Spin up the IDP and Sinatra app locally `make run`
- [ ] Tail + filter the event log
```
tail -f log/events.log | jq -c 'select(.name == "User Registration: Email Submitted") | {name, ial2_requested: .properties.event_properties.ial2_requested, success: .properties.event_properties.success, user_id: .properties.user_id}
```
- [ ] In a browser, create an account directly on Login.gov (no SP), expecting `identity_proofing` to show false in the log
```
{"name":"User Registration: Email Submitted","identity_proofing":false,"success":true,"email_already_exists":false,"user_id":"d13ea4fa-c0fe-4c51-90fa-4a751bf8aa02"}
```
- [ ] In a browser, in the Sinatra app with "Level of Service" at "Authentication Only", create an account. Expect `identity_proofing` to show false in the log:
```
{"name":"User Registration: Email Submitted","identity_proofing":false,"success":true,"email_already_exists":false,"user_id":"2ffb695b-51a0-4bc2-b5c4-a798ecfbf9cd"}
```
- [ ] In a browser, in the Sinatra app with "Level of Service" at "Identity-verified", create an account. Expect `identity_proofing` to show true in the log:
```
{"name":"User Registration: Email Submitted","identity_proofing":true,"success":true,"email_already_exists":false,"user_id":"af2fba49-eab7-4ae1-b544-fb11d7ddea09"}
```


## 👀 Screenshots
<img width="942" height="229" alt="image" src="https://github.com/user-attachments/assets/26fc9c84-ee87-4902-ab0f-11ea8d27a273" />


[LG-17237]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17237

[LG-17540]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17540