### PR TITLE
LG-17770: Remove feature flag and experiment `sign_in_recaptcha_percent_tested`

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -124,7 +124,6 @@ module Users
 
       @recaptcha_form ||= SignInRecaptchaForm.new(
         existing_device: existing_device,
-        ab_test_bucket: ab_test_bucket(:RECAPTCHA_SIGN_IN, user: user_from_params),
         **recaptcha_form_args,
       )
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -209,7 +209,6 @@ module Users
         user_id: current_user.id,
         email: auth_params[:email],
       )
-      user_session[:captcha_validation_performed_at_sign_in] = captcha_validation_performed?
       user_session[:platform_authenticator_available] =
         params[:platform_authenticator_available] == 'true'
       check_password_compromised

--- a/app/forms/sign_in_recaptcha_form.rb
+++ b/app/forms/sign_in_recaptcha_form.rb
@@ -5,8 +5,7 @@ class SignInRecaptchaForm
 
   RECAPTCHA_ACTION = 'sign_in'
 
-  attr_reader :form_class, :form_args, :recaptcha_token, :ab_test_bucket,
-              :assessment_id
+  attr_reader :form_class, :form_args, :recaptcha_token, :assessment_id
 
   attr_writer :existing_device
 
@@ -14,12 +13,10 @@ class SignInRecaptchaForm
 
   def initialize(
     existing_device:,
-    ab_test_bucket:,
     form_class:,
     **form_args
   )
     @existing_device = existing_device
-    @ab_test_bucket = ab_test_bucket
     @form_class = form_class
     @form_args = form_args
   end
@@ -33,7 +30,6 @@ class SignInRecaptchaForm
 
   def exempt?
     IdentityConfig.store.sign_in_recaptcha_score_threshold.zero? ||
-      ab_test_bucket != :sign_in_recaptcha ||
       @existing_device
   end
 

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -492,7 +492,6 @@ short_term_phone_otp_max_attempts: 2
 show_user_attribute_deprecation_warnings: false
 sign_in_password_compromised_percent_tested: 0
 sign_in_recaptcha_annotation_enabled: false
-sign_in_recaptcha_percent_tested: 0
 sign_in_recaptcha_score_threshold: 0.0
 sign_in_user_id_per_ip_attempt_window_exponential_factor: 1.1
 sign_in_user_id_per_ip_attempt_window_in_minutes: 720
@@ -618,7 +617,6 @@ development:
   secret_key_base: development_secret_key_base
   session_encryption_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   sign_in_recaptcha_annotation_enabled: true
-  sign_in_recaptcha_percent_tested: 100
   sign_in_recaptcha_score_threshold: 0.3
   skip_encryption_allowed_list: '["urn:gov:gsa:SAML:2.0.profiles:sp:sso:localhost"]'
   socure_idplus_base_url: 'https://sandbox.socure.us'

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -95,25 +95,6 @@ module AbTests
     document_capture_session_uuid_discriminator(service_provider:, session:, user:, user_session:)
   end.freeze
 
-  RECAPTCHA_SIGN_IN = AbTest.new(
-    experiment_name: 'reCAPTCHA at Sign-In',
-    should_log: [
-      'Email and Password Authentication',
-      'IdV: doc auth verify proofing results',
-      'reCAPTCHA verify result received',
-      :idv_enter_password_submitted,
-    ].to_set,
-    buckets: { sign_in_recaptcha: IdentityConfig.store.sign_in_recaptcha_percent_tested },
-  ) do |user:, user_session:, **|
-    if user_session&.[](:captcha_validation_performed_at_sign_in) == false
-      nil
-    elsif user
-      user.uuid
-    else
-      SecureRandom.alphanumeric(8)
-    end
-  end.freeze
-
   ACCOUNT_CREATION_TMX_PROCESSED = AbTest.new(
     experiment_name: 'Account Creation Threat Metrix Processed',
     should_log: [

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -526,7 +526,6 @@ module IdentityConfig
     config.add(:sign_in_user_id_per_ip_attempt_window_max_minutes, type: :integer)
     config.add(:sign_in_user_id_per_ip_max_attempts, type: :integer)
     config.add(:sign_in_recaptcha_annotation_enabled, type: :boolean)
-    config.add(:sign_in_recaptcha_percent_tested, type: :integer)
     config.add(:sign_in_recaptcha_score_threshold, type: :float)
     config.add(:sign_in_password_compromised_percent_tested, type: :integer)
     config.add(:skip_encryption_allowed_list, type: :json)

--- a/spec/config/initializers/ab_tests_spec.rb
+++ b/spec/config/initializers/ab_tests_spec.rb
@@ -529,67 +529,6 @@ RSpec.describe AbTests do
     it_behaves_like 'an A/B test that uses document_capture_session_uuid as a discriminator'
   end
 
-  describe 'RECAPTCHA_SIGN_IN' do
-    let(:user) { nil }
-    let(:user_session) { {} }
-
-    subject(:bucket) do
-      AbTests::RECAPTCHA_SIGN_IN.bucket(
-        request: nil,
-        service_provider: nil,
-        session: nil,
-        user:,
-        user_session:,
-      )
-    end
-
-    context 'when A/B test is disabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:sign_in_recaptcha_percent_tested).and_return(0)
-        reload_ab_tests
-      end
-
-      context 'when it would otherwise assign a bucket' do
-        let(:user) { build(:user) }
-
-        it 'does not return a bucket' do
-          expect(bucket).to be_nil
-        end
-      end
-    end
-
-    context 'when A/B test is enabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:sign_in_recaptcha_percent_tested).and_return(100)
-        reload_ab_tests
-      end
-
-      context 'with no associated user' do
-        let(:user) { nil }
-
-        it 'returns a bucket' do
-          expect(bucket).not_to be_nil
-        end
-      end
-
-      context 'with an associated user' do
-        let(:user) { build(:user) }
-
-        it 'returns a bucket' do
-          expect(bucket).not_to be_nil
-        end
-
-        context 'with user session indicating recaptcha was not performed at sign-in' do
-          let(:user_session) { { captcha_validation_performed_at_sign_in: false } }
-
-          it 'does not return a bucket' do
-            expect(bucket).to be_nil
-          end
-        end
-      end
-    end
-  end
-
   describe 'PROOFING_VENDOR' do
     let(:ab_test) { :PROOFING_VENDOR }
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -371,8 +371,6 @@ RSpec.describe Users::SessionsController, devise: true do
         allow(FeatureManagement).to receive(:sign_in_recaptcha_enabled?).and_return(true)
         allow(IdentityConfig.store).to receive(:recaptcha_mock_validator).and_return(true)
         allow(IdentityConfig.store).to receive(:sign_in_recaptcha_score_threshold).and_return(0.2)
-        allow(controller).to receive(:ab_test_bucket).with(:RECAPTCHA_SIGN_IN, kind_of(Hash))
-          .and_return(:sign_in_recaptcha)
       end
 
       it 'stores the reCAPTCHA assessment id in the session' do

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -935,7 +935,6 @@ RSpec.feature 'Sign in' do
       allow(FeatureManagement).to receive(:sign_in_recaptcha_enabled?).and_return(true)
       allow(IdentityConfig.store).to receive(:recaptcha_mock_validator).and_return(true)
       allow(IdentityConfig.store).to receive(:sign_in_recaptcha_score_threshold).and_return(0.2)
-      allow(IdentityConfig.store).to receive(:sign_in_recaptcha_percent_tested).and_return(100)
       reload_ab_tests
     end
 

--- a/spec/forms/sign_in_recaptcha_form_spec.rb
+++ b/spec/forms/sign_in_recaptcha_form_spec.rb
@@ -6,13 +6,11 @@ RSpec.describe SignInRecaptchaForm do
   let(:score_threshold_config) { 0.2 }
   let(:analytics) { FakeAnalytics.new }
   let(:existing_device) { false }
-  let(:ab_test_bucket) { :sign_in_recaptcha }
   let(:recaptcha_token) { 'token' }
   let(:score) { 1.0 }
   subject(:form) do
     described_class.new(
       existing_device:,
-      ab_test_bucket:,
       form_class: RecaptchaMockForm,
       analytics:,
       score:,
@@ -44,7 +42,6 @@ RSpec.describe SignInRecaptchaForm do
     subject(:form) do
       described_class.new(
         existing_device:,
-        ab_test_bucket:,
         analytics:,
         form_class: RecaptchaEnterpriseForm,
       )
@@ -66,12 +63,6 @@ RSpec.describe SignInRecaptchaForm do
     subject(:exempt?) { form.exempt? }
 
     it { is_expected.to eq(false) }
-
-    context 'when not part of a/b test' do
-      let(:ab_test_bucket) { nil }
-
-      it { is_expected.to eq(true) }
-    end
 
     context 'score threshold configured at zero' do
       let(:score_threshold_config) { 0.0 }
@@ -102,14 +93,6 @@ RSpec.describe SignInRecaptchaForm do
 
       context 'existing device for user' do
         let(:existing_device) { true }
-
-        it 'is successful' do
-          expect(response.to_h).to eq(success: true)
-        end
-      end
-
-      context 'when not part of a/b test' do
-        let(:ab_test_bucket) { nil }
 
         it 'is successful' do
           expect(response.to_h).to eq(success: true)

--- a/spec/jobs/reports/ab_tests_report_spec.rb
+++ b/spec/jobs/reports/ab_tests_report_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe Reports::AbTestsReport do
   end
   let(:ab_tests) do
     {
-      RECAPTCHA_SIGN_IN: AbTest.new(
-        experiment_name: 'reCAPTCHA at Sign-In',
+      REPORTED_EXPERIMENT: AbTest.new(
+        experiment_name: 'Account Creation Threat Metrix Processed',
         persist: true,
         max_participants: 10_000,
-        buckets: { sign_in_recaptcha: tested_percent },
+        buckets: { account_creation_tmx_processed: tested_percent },
         report: { email:, queries: },
       ),
       UNREPORTED_EXPERIMENT: AbTest.new(
@@ -63,7 +63,7 @@ RSpec.describe Reports::AbTestsReport do
 
     before do
       allow(Reporting::AbTestsReport).to receive(:new).with(
-        ab_test: ab_tests[:RECAPTCHA_SIGN_IN],
+        ab_test: ab_tests[:REPORTED_EXPERIMENT],
         time_range: report_date.yesterday..report_date,
       ).and_return(report)
 
@@ -73,9 +73,9 @@ RSpec.describe Reports::AbTestsReport do
     it 'emails the table report with csv' do
       expect(ReportMailer).to receive(:tables_report).with(
         to: email,
-        subject: "A/B Tests Report - reCAPTCHA at Sign-In - #{report_date}",
+        subject: "A/B Tests Report - Account Creation Threat Metrix Processed - #{report_date}",
         message: [
-          "A/B Tests Report - reCAPTCHA at Sign-In - #{report_date}",
+          "A/B Tests Report - Account Creation Threat Metrix Processed - #{report_date}",
           'Total participants: 0 (of 10,000 maximum)',
         ],
         reports: emailable_reports,


### PR DESCRIPTION
## 🎫 Ticket
[LG-17770: Remove feature flag and experiment - sign_in_recaptcha_percent_tested](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-177)

## 🛠 Summary of changes
This PR removes the `sign_in_recaptcha_percent_tested` flag and code related to that A/B test

## 📜 Testing Plan
On this test branch, sign in with an existing account. There should be no regressions that appear during the sign in process.