### PR TITLE
Rename ial2 to idv in RegistrationsController and ApplicationHelper

### DIFF
--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -2,11 +2,11 @@
 
 module SignUp
   class RegistrationsController < ApplicationController
-    include ApplicationHelper # for ial2_requested?
+    include ApplicationHelper # for idv_requested?
 
     before_action :confirm_two_factor_authenticated, only: [:destroy_confirm]
     before_action :require_no_authentication
-    before_action :redirect_if_ial2_and_idv_unavailable
+    before_action :redirect_if_idv_requested_and_unavailable
 
     CREATE_ACCOUNT = 'create_account'
 
@@ -66,8 +66,8 @@ module SignUp
       sp_session[:request_id]
     end
 
-    def redirect_if_ial2_and_idv_unavailable
-      if ial2_requested? && !FeatureManagement.idv_available?
+    def redirect_if_idv_requested_and_unavailable
+      if idv_requested? && !FeatureManagement.idv_available?
         redirect_to idv_unavailable_path(from: CREATE_ACCOUNT)
       end
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
     )
   end
 
-  def ial2_requested?
+  def idv_requested?
     resolved_authn_context_result.identity_proofing?
   end
 

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
       before do
         allow(IdentityConfig.store).to receive(:idv_available).and_return(false)
       end
-      it 'redirects to idv vendor outage page when ial2 requested' do
-        allow(controller).to receive(:ial2_requested?).and_return(true)
+      it 'redirects to idv vendor outage page when idv requested' do
+        allow(controller).to receive(:idv_requested?).and_return(true)
         get :new
         expect(response).to redirect_to(
           idv_unavailable_path(from: SignUp::RegistrationsController::CREATE_ACCOUNT),


### PR DESCRIPTION
* changelog: Internal, Refactoring, rename ial2 to idv in RegistrationsController and ApplicationHelper

## 🛠 Summary of changes
The `RegistrationController` and `ApplicationHelper` code use ial2 to mean identity-verified.
This refactor converts such usages to idv.