### PR TITLE
changelog: post-release housekeeping for @18f/identity-build-sass 3.2.0 and @18f/identity-stylelint-config 6.0.0

### DIFF
--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## 3.2.0
 
 - Fix typecheck error due to updated arguments in `fileURLToPath` from `node:url`

--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 3.2.0
 
 - Fix typecheck error due to updated arguments in `fileURLToPath` from `node:url`
 

--- a/app/javascript/packages/stylelint-config/CHANGELOG.md
+++ b/app/javascript/packages/stylelint-config/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 6.0.0
 
 ### Breaking Changes
 

--- a/app/javascript/packages/stylelint-config/CHANGELOG.md
+++ b/app/javascript/packages/stylelint-config/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## 6.0.0
 
 ### Breaking Changes


### PR DESCRIPTION
## Summary

- Mark `@18f/identity-build-sass` 3.2.0 and `@18f/identity-stylelint-config` 6.0.0 as released in their respective `CHANGELOG.md` files (previously under `## Unreleased`).
- Restore an empty `## Unreleased` header at the top of each changelog to collect future changes.

Both packages have been published to npm at the versions above.

## Test plan

- [ ] CI passes