### PR TITLE
[bug] 1558/FraudOps bug

### DIFF
--- a/app/services/fraud_ops/tracker.rb
+++ b/app/services/fraud_ops/tracker.rb
@@ -45,6 +45,15 @@ module FraudOps
 
     private
 
+    def agency_uuid(event_type: nil) # rubocop:disable Lint/UnusedMethodArgument
+      return nil unless user&.id && sp
+
+      uuid = AgencyIdentityLinker.for(user: user, service_provider: sp, skip_create: true)&.uuid
+      return uuid if uuid
+
+      AgencyIdentityLinker.for(user: user, service_provider: sp, skip_create: true)&.uuid
+    end
+
     def extra_attributes(event_type: nil)
       {
         agency_uuid: agency_uuid(event_type:),

--- a/app/services/fraud_ops/tracker.rb
+++ b/app/services/fraud_ops/tracker.rb
@@ -48,9 +48,8 @@ module FraudOps
     def agency_uuid(event_type: nil) # rubocop:disable Lint/UnusedMethodArgument
       return nil unless user&.id && sp
 
-      uuid = AgencyIdentityLinker.for(user: user, service_provider: sp, skip_create: true)&.uuid
-      return uuid if uuid
-
+      AgencyIdentityLinker.for(user: user, service_provider: sp, skip_create: false).uuid
+    rescue ActiveRecord::RecordNotUnique
       AgencyIdentityLinker.for(user: user, service_provider: sp, skip_create: true)&.uuid
     end
 

--- a/spec/services/fraud_ops/tracker_spec.rb
+++ b/spec/services/fraud_ops/tracker_spec.rb
@@ -78,6 +78,60 @@ RSpec.describe FraudOps::Tracker do
     end
   end
 
+  describe 'agency_uuid' do
+    let(:redis_wrapper) { instance_double(FraudOps::RedisClient) }
+
+    before do
+      allow(FraudOps::RedisClient).to receive(:new).and_return(redis_wrapper)
+      allow(redis_wrapper).to receive(:write_event)
+    end
+
+    def tracked_agency_uuid
+      tracker.login_email_and_password_auth(email: user.email, success: true)
+
+      expect(redis_wrapper).to have_received(:write_event) do |**args|
+        payload = JSON.parse(JWE.decrypt(args[:jwe], fraud_ops_private_key))
+        return payload.dig('events').values.first['agency_uuid']
+      end
+    end
+
+    it 'does not create an AgencyIdentity when looking up the uuid' do
+      expect do
+        tracker.login_email_and_password_auth(email: user.email, success: true)
+      end.not_to change(AgencyIdentity, :count)
+    end
+
+    it 'includes the existing AgencyIdentity uuid in the event' do
+      agency_identity = AgencyIdentityLinker.for(
+        user: user, service_provider: sp, skip_create: false
+      )
+
+      expect(tracked_agency_uuid).to eq(agency_identity.uuid)
+    end
+
+    it 'retries the lookup once when the first lookup returns nil' do
+      agency_identity = AgencyIdentityLinker.for(
+        user: user, service_provider: sp, skip_create: false
+      )
+
+      first_lookup = true
+      allow(AgencyIdentityLinker).to receive(:for).and_wrap_original do |original, **kwargs|
+        next original.call(**kwargs) unless first_lookup
+
+        first_lookup = false
+        nil
+      end
+
+      expect(tracked_agency_uuid).to eq(agency_identity.uuid)
+    end
+
+    it 'sends a nil agency_uuid when both lookups return nil' do
+      allow(AgencyIdentityLinker).to receive(:for).and_return(nil)
+
+      expect(tracked_agency_uuid).to be_nil
+    end
+  end
+
   describe 'error handling' do
     it 'returns nil and logs a warning when an error occurs' do
       allow(IdentityConfig.store).to receive(:fraud_ops_public_key).and_return('')

--- a/spec/services/fraud_ops/tracker_spec.rb
+++ b/spec/services/fraud_ops/tracker_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe FraudOps::Tracker do
 
     it 'includes the existing AgencyIdentity uuid in the event' do
       agency_identity = AgencyIdentityLinker.for(
-        user: user, service_provider: sp, skip_create: false
+        user: user, service_provider: sp, skip_create: false,
       )
 
       expect(tracked_agency_uuid).to eq(agency_identity.uuid)
@@ -111,7 +111,7 @@ RSpec.describe FraudOps::Tracker do
 
     it 'falls back to a lookup when creation races with a duplicate' do
       agency_identity = AgencyIdentityLinker.for(
-        user: user, service_provider: sp, skip_create: false
+        user: user, service_provider: sp, skip_create: false,
       )
 
       raised = false
@@ -127,10 +127,10 @@ RSpec.describe FraudOps::Tracker do
 
     it 'sends a nil agency_uuid when the fallback lookup returns nil' do
       allow(AgencyIdentityLinker).to receive(:for).with(
-        user: user, service_provider: sp, skip_create: false
+        user: user, service_provider: sp, skip_create: false,
       ).and_raise(ActiveRecord::RecordNotUnique)
       allow(AgencyIdentityLinker).to receive(:for).with(
-        user: user, service_provider: sp, skip_create: true
+        user: user, service_provider: sp, skip_create: true,
       ).and_return(nil)
 
       expect(tracked_agency_uuid).to be_nil

--- a/spec/services/fraud_ops/tracker_spec.rb
+++ b/spec/services/fraud_ops/tracker_spec.rb
@@ -95,10 +95,10 @@ RSpec.describe FraudOps::Tracker do
       end
     end
 
-    it 'does not create an AgencyIdentity when looking up the uuid' do
+    it 'creates and includes the AgencyIdentity uuid in the event' do
       expect do
-        tracker.login_email_and_password_auth(email: user.email, success: true)
-      end.not_to change(AgencyIdentity, :count)
+        expect(tracked_agency_uuid).to be_present
+      end.to change(AgencyIdentity, :count).by(1)
     end
 
     it 'includes the existing AgencyIdentity uuid in the event' do
@@ -109,24 +109,29 @@ RSpec.describe FraudOps::Tracker do
       expect(tracked_agency_uuid).to eq(agency_identity.uuid)
     end
 
-    it 'retries the lookup once when the first lookup returns nil' do
+    it 'falls back to a lookup when creation races with a duplicate' do
       agency_identity = AgencyIdentityLinker.for(
         user: user, service_provider: sp, skip_create: false
       )
 
-      first_lookup = true
+      raised = false
       allow(AgencyIdentityLinker).to receive(:for).and_wrap_original do |original, **kwargs|
-        next original.call(**kwargs) unless first_lookup
+        next original.call(**kwargs) if raised || kwargs[:skip_create]
 
-        first_lookup = false
-        nil
+        raised = true
+        raise ActiveRecord::RecordNotUnique
       end
 
       expect(tracked_agency_uuid).to eq(agency_identity.uuid)
     end
 
-    it 'sends a nil agency_uuid when both lookups return nil' do
-      allow(AgencyIdentityLinker).to receive(:for).and_return(nil)
+    it 'sends a nil agency_uuid when the fallback lookup returns nil' do
+      allow(AgencyIdentityLinker).to receive(:for).with(
+        user: user, service_provider: sp, skip_create: false
+      ).and_raise(ActiveRecord::RecordNotUnique)
+      allow(AgencyIdentityLinker).to receive(:for).with(
+        user: user, service_provider: sp, skip_create: true
+      ).and_return(nil)
 
       expect(tracked_agency_uuid).to be_nil
     end


### PR DESCRIPTION
changelog: Internal, Tracking, FraudOps Tracker race condition bug


## 🎫 Ticket

Link to the relevant ticket:
[Gitlab 1558](https://gitlab.login.gov/lg-teams/Team-Data/data-warehouse-ag/-/work_items/1558)
-->


## 🛠 Summary of changes

The FraudOps::Tracker implements the agency_uuid method twice. Occasionally a race condition happens where both calls attempt to create the record.

This fix is to rescue on the recordUniqueness validation error and to read the value again. 
finally, will just return nil if creation takes too long.


