### PR TITLE
Deploy RC 599 to Production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,7 @@ variables:
   ECR_REGISTRY: '${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com'
   SECURE_ANALYZERS_PREFIX: "$ECR_REGISTRY/gitlab/security-products"
   IDP_CI_SHA: 'sha256:787f58c3d7e0899d7a622202aa21a9ead24a3fc160d1b158160429bdcc33e4fe'
+  KUBECTL_CI_SHA: 'sha256:96a7d245a74d461925a56e3024d2f027c2a7a822b3e9e0117ec558db42de9c35'
   PKI_IMAGE_TAG: 'main'
   DASHBOARD_IMAGE_TAG: 'main'
   APPLICATION_MANIFEST: dockerfiles/application.yaml
@@ -480,7 +481,8 @@ trigger_devops:
 
 .deploy:
   image:
-    name: dtzar/helm-kubectl:latest
+    name: ${ECR_REGISTRY}/docker-hub/alpine/kubectl@${KUBECTL_CI_SHA}
+    entrypoint: ['']
   script:
     - kubectl config get-contexts
     - export CONTEXT=$(kubectl config get-contexts | grep reviewapp | awk '{print $1}' | head -1)
@@ -488,7 +490,6 @@ trigger_devops:
     - export SANITIZED_BRANCH_NAME=$(echo "$CI_COMMIT_REF_NAME" | tr '/' '-' | tr -c '[:alnum:]-_' '-' | sed 's/-*$//')
     - echo "${CI_COMMIT_REF_NAME}"
     - echo "${SANITIZED_BRANCH_NAME}"
-    #TODO put in kustomize based deploy
     # Dynamically populate review environment settings
     - sed -i "s|{{ENVIRONMENT}}|${CI_ENVIRONMENT_SLUG}|g" ${APPLICATION_MANIFEST}
     - sed -i "s|{{SANITIZED_BRANCH_NAME}}|${SANITIZED_BRANCH_NAME}|g" ${APPLICATION_MANIFEST}
@@ -538,7 +539,8 @@ stop-review-app:
     - kubectl delete application "$CI_ENVIRONMENT_SLUG-db" -n argocd
   stage: review
   image:
-    name: dtzar/helm-kubectl:latest
+    name: ${ECR_REGISTRY}/docker-hub/alpine/kubectl@${KUBECTL_CI_SHA}
+    entrypoint: ['']
   needs:
     - job: review-app
   environment:

--- a/app/assets/stylesheets/components/_full-screen.scss
+++ b/app/assets/stylesheets/components/_full-screen.scss
@@ -11,7 +11,7 @@
 }
 
 .full-screen__close-button {
-  background-color: rgba(color('base-darkest'), 0.7);
+  background-color: rgb(color('base-darkest'), 0.7);
   border-radius: 0;
   position: absolute;
   right: 0;

--- a/app/assets/stylesheets/design-system-waiting-room.scss
+++ b/app/assets/stylesheets/design-system-waiting-room.scss
@@ -22,7 +22,7 @@ ul {
 // basscss-utility-typography
 // ------------------------------------------------
 .break-word {
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 .display-list-item {
   display: list-item;

--- a/app/controllers/concerns/idv/historical_attempts_concern.rb
+++ b/app/controllers/concerns/idv/historical_attempts_concern.rb
@@ -9,33 +9,36 @@ module Idv
       # we always need to cache events if the feature is enabled
       # in case we have to re-encrypt them
       return unless IdentityConfig.store.historical_attempts_api_enabled
-      return unless current_user.active_profile.present?
+      return unless profile.present?
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)
     end
 
+    def send_historic_events?
+      return false, :idv_not_requested unless idv_requested?
+      return false, :no_user_proofing_event if existing_user_proofing_event.blank?
+      return false, :already_sent if existing_user_proofing_event.already_sent_to_sp?(current_sp.id)
+      return false, :no_encrypted_file_reference if profile.encrypted_attempts_file_reference.blank?
+
+      return true, nil
+    end
+
     private
 
-    def ial2_requested?
+    def idv_requested?
       resolved_authn_context_result.identity_proofing_or_ialmax? && current_user.identity_verified?
     end
 
-    def historical_events_need_be_sent?
-      return false unless historical_events_enabled?
-      return false unless current_sp&.attempts_api_enabled?
-      return false if existing_user_proofing_event.blank?
-
-      return !existing_user_proofing_event.already_sent_to_sp?(current_sp.id)
+    def historical_events_enabled?
+      IdentityConfig.store.historical_attempts_api_enabled
     end
 
-    def historical_events_enabled?
-      return false unless IdentityConfig.store.historical_attempts_api_enabled
-
-      ial2_requested?
+    def profile
+      @profile ||= current_user.active_profile
     end
 
     def existing_user_proofing_event
-      @existing_user_proofing_event ||= current_user.active_profile.user_proofing_event
+      @existing_user_proofing_event ||= profile.user_proofing_event
     end
   end
 end

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -227,6 +227,7 @@ module Idv
 
     def record_user_proofing_events
       return unless historical_events_enabled?
+      return unless idv_requested?
 
       current_user.active_profile.create_user_proofing_event(
         attempt_events:,
@@ -234,6 +235,8 @@ module Idv
         personal_key: idv_session.personal_key,
         sent_to_sp: attempts_api_enabled_for_session?,
       )
+
+      analytics.historic_event_data_saved(profile_id: current_user.active_profile.id)
 
       AttemptsApi::Cacher.new(current_user, user_session).save(password:)
 

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -25,7 +25,7 @@ module SignUp
       update_verified_attributes
       send_in_person_completion_survey
       notify_user_of_connected_sp
-      send_historical_events if historical_events_need_be_sent?
+      send_historical_events
       if selected_email_id_for_linked_identity.nil?
         user_session[:selected_email_id_for_linked_identity] = current_user
           .last_sign_in_email_address.id
@@ -142,11 +142,23 @@ module SignUp
     end
 
     def send_historical_events
-      historical_attempts = AttemptsApi::Cacher.new(current_user, user_session).fetch
+      return unless historical_events_enabled?
+      return unless current_sp&.attempts_api_enabled?
 
-      AttemptsApi::Tracker.write_existing_user_events(historical_attempts:, sp: current_sp)
+      will_send_events, msg = send_historic_events?
+      if will_send_events
+        historical_attempts = AttemptsApi::Cacher.new(current_user, user_session).fetch
 
-      existing_user_proofing_event.add_sp_sent(current_sp.id)
+        AttemptsApi::Tracker.write_existing_user_events(historical_attempts:, sp: current_sp)
+
+        existing_user_proofing_event.add_sp_sent(current_sp.id)
+      end
+
+      analytics.historic_event_data_released(
+        success: will_send_events,
+        exception: msg,
+        profile_id: current_user.active_profile&.id,
+      )
     end
 
     def pii

--- a/app/controllers/sign_up/completions_controller.rb
+++ b/app/controllers/sign_up/completions_controller.rb
@@ -61,7 +61,7 @@ module SignUp
         current_sp: current_sp,
         decrypted_pii: pii,
         requested_attributes: decorated_sp_session.requested_attributes.map(&:to_sym),
-        ial2_requested: ial2_requested?,
+        idv_requested: idv_requested?,
         completion_context: needs_completion_screen_reason,
         selected_email_id: selected_email_id_for_linked_identity,
       )
@@ -71,7 +71,7 @@ module SignUp
       resolved_authn_context_result.identity_proofing?
     end
 
-    def ial2_requested?
+    def idv_requested?
       resolved_authn_context_result.identity_proofing_or_ialmax? && current_user.identity_verified?
     end
 

--- a/app/controllers/sign_up/registrations_controller.rb
+++ b/app/controllers/sign_up/registrations_controller.rb
@@ -2,11 +2,11 @@
 
 module SignUp
   class RegistrationsController < ApplicationController
-    include ApplicationHelper # for ial2_requested?
+    include ApplicationHelper # for idv_requested?
 
     before_action :confirm_two_factor_authenticated, only: [:destroy_confirm]
     before_action :require_no_authentication
-    before_action :redirect_if_ial2_and_idv_unavailable
+    before_action :redirect_if_idv_requested_and_unavailable
 
     CREATE_ACCOUNT = 'create_account'
 
@@ -66,8 +66,8 @@ module SignUp
       sp_session[:request_id]
     end
 
-    def redirect_if_ial2_and_idv_unavailable
-      if ial2_requested? && !FeatureManagement.idv_available?
+    def redirect_if_idv_requested_and_unavailable
+      if idv_requested? && !FeatureManagement.idv_available?
         redirect_to idv_unavailable_path(from: CREATE_ACCOUNT)
       end
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,7 @@ module ApplicationHelper
     )
   end
 
-  def ial2_requested?
+  def idv_requested?
     resolved_authn_context_result.identity_proofing?
   end
 

--- a/app/javascript/packages/build-sass/cli.js
+++ b/app/javascript/packages/build-sass/cli.js
@@ -46,10 +46,15 @@ const options = { outDir, loadPaths, sassCompiler, optimize: isProduction };
  * @param {() => void} callback Callback to invoke.
  */
 function watchOnce(paths, callback) {
-  const watcher = watch(paths).once('change', () => {
+  const watcher = watch(paths, { ignoreInitial: true });
+  const onEvent = () => {
+    watcher.off('change', onEvent);
+    watcher.off('add', onEvent);
+    watcher.off('unlink', onEvent);
     watcher.close();
     callback();
-  });
+  };
+  watcher.on('change', onEvent).on('add', onEvent).on('unlink', onEvent);
 }
 
 /**

--- a/app/javascript/packages/build-sass/package.json
+++ b/app/javascript/packages/build-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-build-sass",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": false,
   "description": "Stylesheet compilation utility with reasonable defaults and fast performance.",
   "type": "module",
@@ -31,10 +31,10 @@
   "homepage": "https://github.com/18f/identity-idp",
   "dependencies": {
     "@aduth/is-dependency": "^1.0.0",
-    "browserslist": "^4.22.3",
-    "chokidar": "^3.6.0",
-    "lightningcss": "^1.23.0",
-    "sass-embedded": "^1.70.0"
+    "browserslist": "^4.28.7",
+    "chokidar": "^5.0.0",
+    "lightningcss": "^1.33.0",
+    "sass-embedded": "^1.100.0"
   },
   "sideEffects": false
 }

--- a/app/javascript/packages/stylelint-config/package.json
+++ b/app/javascript/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-stylelint-config",
-  "version": "5.0.0-beta.1",
+  "version": "6.0.0",
   "private": false,
   "description": "Stylelint shareable configuration for Login.gov CSS/SASS standards",
   "exports": {
@@ -20,12 +20,12 @@
   },
   "homepage": "https://github.com/18f/identity-idp",
   "dependencies": {
-    "stylelint-config-standard-scss": "^13.1.0",
-    "stylelint-prettier": "^5.0.0"
+    "stylelint-config-standard-scss": "^17.0.0",
+    "stylelint-prettier": "^5.0.3"
   },
   "peerDependencies": {
     "prettier": ">=3.0.0",
-    "stylelint": ">=16.0.2"
+    "stylelint": "^17.0.0"
   },
   "sideEffects": false
 }

--- a/app/jobs/reports/monthly_key_metrics_s3_report.rb
+++ b/app/jobs/reports/monthly_key_metrics_s3_report.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'reporting/monthly_key_metrics_idv_s3_report'
+
+module Reports
+  # S3-backed variant of MonthlyKeyMetricsReport.
+  #
+  # Identical to MonthlyKeyMetricsReport except the two CloudWatch-derived tables
+  # (condensed IDV + proofing rate) are no longer generated in-app. Instead they are
+  # generated in reporting-rails from Redshift, uploaded to S3, and read back here.
+  #
+  # If either S3 file is missing or stale, the ENTIRE report is aborted (we do not
+  # send a partial Key Metrics email).
+  class MonthlyKeyMetricsS3Report < BaseReport
+    REPORT_NAME = 'MonthlyKeyMetricsIdvS3Report'
+
+    # The two IDV files are expected to have been uploaded by reporting-rails within
+    # a few days of the report date.
+    MAX_FILE_AGE_DAYS = 5
+
+    attr_reader :report_date
+
+    def initialize(report_date = nil, *args, **rest)
+      @report_date = report_date
+      super(report_date, *args, **rest)
+    end
+
+    def perform(date = Time.zone.yesterday.end_of_day)
+      @report_date ||= date
+
+      email_addresses = emails.select(&:present?)
+      if email_addresses.empty?
+        Rails.logger.warn 'No email addresses received - Monthly Key Metrics S3 Report NOT SENT'
+        return false
+      end
+
+      # Abort the whole report if the S3-backed IDV files are missing or stale.
+      # We do not send a partial Key Metrics email.
+      unless idv_s3_reports_available?
+        Rails.logger.error(
+          "#{REPORT_NAME}: IDV S3 reports unavailable or stale - Monthly Key Metrics " \
+          "S3 Report NOT SENT",
+        )
+        return false
+      end
+
+      Rails.logger.info "Generating Monthly Key Metrics Reports (and pulling IDV tables from S3)" \
+        " for date: #{report_date.to_date}"
+      reports.each do |report|
+        upload_to_s3(report.table, report_name: report.filename)
+      end
+
+      ReportMailer.tables_report(
+        to: email_addresses,
+        subject: "Monthly Key Metrics Report NEW - #{date.to_date}",
+        reports: reports,
+        message: preamble,
+        attachment_format: :xlsx,
+      ).deliver_now
+    end
+
+    # @return [String]
+    def preamble(env: Identity::Hostdata.env || 'local')
+      ERB.new(<<~ERB).result(binding).html_safe # rubocop:disable Rails/OutputSafety
+        <% if env != 'prod' %>
+          <div class="usa-alert usa-alert--info usa-alert--email">
+            <div class="usa-alert__body">
+              <%#
+                NOTE: our AlertComponent doesn't support heading content like this uses,
+                so for a one-off outside the Rails pipeline it was easier to inline the HTML here.
+              %>
+              <h2 class="usa-alert__heading">
+                Non-Production Report
+              </h2>
+              <p class="usa-alert__text">
+                This was generated in the <strong><%= env %></strong> environment.
+              </p>
+            </div>
+          </div>
+        <% end %>
+        <p>
+          For more information on how each of these metrics are calculated, take a look at our
+          <a href="https://handbook.login.gov/articles/monthly-key-metrics-explainer.html">
+          Monthly Key Metrics Report Explainer document</a>.
+        </p>
+      ERB
+    end
+
+    # Same ordering as original MonthlyKeyMetricsReport, but the two CloudWatch-derived tables
+    # (monthly_idv + proofing_rate) now come from the S3 reader
+    def reports
+      @reports ||= begin
+        report_builders = [
+          ['active_users_count',
+           -> { active_users_count_report.active_users_count_emailable_report }],
+          ['total_user_count', -> { total_user_count_report.total_user_count_emailable_report }],
+          ['condensed_idv (S3)', -> { idv_s3_report.condensed_idv_emailable_report }],
+          ['proofing_rate (S3)', -> { idv_s3_report.proofing_rate_emailable_report }],
+          ['account_deletion_rate',
+           -> { account_deletion_rate_report.account_deletion_emailable_report }],
+          ['account_reuse', -> { account_reuse_report.account_reuse_emailable_report }],
+          ['agency_and_sp', -> { agency_and_sp_report.agency_and_sp_emailable_report }],
+          ['active_users_count (APG)',
+           -> { active_users_count_report.active_users_count_apg_emailable_report }],
+        ]
+
+        report_builders.each_with_index.map do |(label, builder), index|
+          Rails.logger.info(
+            "#{REPORT_NAME}: generating report #{index + 1}/#{report_builders.size}: #{label}",
+          )
+          builder.call
+        end
+      end
+    end
+
+    def emails
+      emails = [*IdentityConfig.store.team_daily_reports_emails]
+      if report_date.next_day.day == 1
+        emails += IdentityConfig.store.team_all_login_emails
+      end
+      emails
+    end
+
+    # Database-backed reports (unchanged from MonthlyKeyMetricsReport)
+
+    def account_reuse_report
+      @account_reuse_report ||= Reporting::AccountReuseReport.new(report_date)
+    end
+
+    def account_deletion_rate_report
+      @account_deletion_rate_report ||= Reporting::AccountDeletionRateReport.new(report_date)
+    end
+
+    def total_user_count_report
+      @total_user_count_report ||= Reporting::TotalUserCountReport.new(report_date)
+    end
+
+    def active_users_count_report
+      @active_users_count_report ||= Reporting::ActiveUsersCountReport.new(report_date)
+    end
+
+    def agency_and_sp_report
+      @agency_and_sp_report ||= Reporting::AgencyAndSpReport.new(report_date)
+    end
+
+    def idv_s3_report
+      @idv_s3_report ||= Reporting::MonthlyKeyMetricsIdvS3Report.new(
+        bucket_name: data_warehouse_bucket_name,
+        custom_s3_path: idv_s3_path,
+      )
+    end
+
+    # S3-backed IDV reports
+
+    # Builds the S3 key prefix so that the reader appending "_<filename>.csv"
+    # reproduces the key reporting-rails wrote in #paths_for:
+    #   <base>idp/MonthlyKeyMetricsIdvS3Report/<YYYY>/<MM>/<YYYYMMDD>_monthly_<filename>.csv
+    def idv_s3_path
+      report_day = report_date.to_date
+      date_prefix = report_day.strftime('%Y%m%d')
+      year = report_day.strftime('%Y')
+      month = report_day.strftime('%m')
+
+      base_path = generate_base_s3_path(directory: 'idp')
+
+      "#{base_path}#{REPORT_NAME}/#{year}/#{month}/#{date_prefix}_monthly"
+    end
+
+    def idv_s3_reports_available?
+      bucket = data_warehouse_bucket_name
+      if bucket.blank?
+        Rails.logger.error "#{REPORT_NAME}: data warehouse bucket name is blank"
+        return false
+      end
+
+      cutoff_time = MAX_FILE_AGE_DAYS.days.ago
+
+      idv_s3_report.csv_file_names.all? do |file_name|
+        begin
+          last_modified = idv_s3_report.get_file_last_modified(file_name)
+
+          if last_modified <= cutoff_time
+            Rails.logger.error(
+              "#{REPORT_NAME}: IDV S3 report '#{file_name}' is stale " \
+              "(last modified #{last_modified}, cutoff #{cutoff_time}) - " \
+              "key: #{idv_s3_path}_#{file_name}.csv",
+            )
+            next false
+          end
+
+          Rails.logger.info(
+            "#{REPORT_NAME}: IDV S3 report '#{file_name}' found and fresh " \
+            "(age #{((Time.zone.now - last_modified) / 1.day).round(2)} days, " \
+            "last modified #{last_modified}) - key: #{idv_s3_path}_#{file_name}.csv",
+          )
+
+          true
+        rescue Aws::S3::Errors::NoSuchKey
+          Rails.logger.error(
+            "#{REPORT_NAME}: IDV S3 report '#{file_name}' not found - " \
+            "key: #{idv_s3_path}_#{file_name}.csv, bucket: #{bucket}",
+          )
+          false
+        end
+      end
+    end
+
+    def upload_to_s3(report_body, report_name: nil)
+      _latest, path = generate_s3_paths(REPORT_NAME, 'csv', subname: report_name, now: report_date)
+
+      if bucket_name.present?
+        upload_file_to_s3_bucket(
+          path: path,
+          body: csv_file(report_body),
+          content_type: 'text/csv',
+          bucket: bucket_name,
+        )
+      end
+    end
+
+    def csv_file(report_array)
+      CSV.generate do |csv|
+        report_array.each do |row|
+          csv << row
+        end
+      end
+    end
+
+    def data_warehouse_bucket_name
+      bucket_prefix = IdentityConfig.store.s3_data_warehouse_replica_bucket_prefix
+      aws_account_id = Identity::Hostdata.aws_account_id
+      aws_region = Identity::Hostdata.aws_region
+      "#{bucket_prefix}-#{aws_account_id}-#{aws_region}"
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -608,6 +608,7 @@ class User < ApplicationRecord
     return unless IdentityConfig.store.historical_attempts_api_enabled
 
     attempt_data_handler.delete_all_user_attempt_data(user_uuid: uuid)
+    analytics.historic_event_data_destroyed
   end
 
   def attempt_data_handler

--- a/app/presenters/completions_presenter.rb
+++ b/app/presenters/completions_presenter.rb
@@ -7,7 +7,7 @@ class CompletionsPresenter
   attr_reader :current_user, :current_sp, :decrypted_pii, :requested_attributes,
               :completion_context, :selected_email_id
 
-  SORTED_IAL2_ATTRIBUTE_MAPPING = [
+  SORTED_IDV_ATTRIBUTE_MAPPING = [
     [[:email], :email],
     [[:all_emails], :all_emails],
     [%i[given_name family_name], :full_name],
@@ -20,7 +20,7 @@ class CompletionsPresenter
     [[:verified_at], :verified_at],
   ].freeze
 
-  SORTED_IAL1_ATTRIBUTE_MAPPING = [
+  SORTED_AUTH_ONLY_ATTRIBUTE_MAPPING = [
     [[:email], :email],
     [[:all_emails], :all_emails],
     [[:x509_subject], :x509_subject],
@@ -33,7 +33,7 @@ class CompletionsPresenter
     current_sp:,
     decrypted_pii:,
     requested_attributes:,
-    ial2_requested:,
+    idv_requested:,
     completion_context:,
     selected_email_id:
   )
@@ -41,13 +41,13 @@ class CompletionsPresenter
     @current_sp = current_sp
     @decrypted_pii = decrypted_pii
     @requested_attributes = requested_attributes
-    @ial2_requested = ial2_requested
+    @idv_requested = idv_requested
     @completion_context = completion_context
     @selected_email_id = selected_email_id
   end
 
-  def ial2_requested?
-    @ial2_requested
+  def idv_requested?
+    @idv_requested
   end
 
   def sp_name
@@ -55,21 +55,21 @@ class CompletionsPresenter
   end
 
   def heading
-    if ial2_requested?
+    if idv_requested?
       if consent_has_expired?
-        I18n.t('titles.sign_up.completion_consent_expired_ial2')
+        I18n.t('titles.sign_up.completion_consent_expired_idv')
       elsif reverified_after_consent?
         I18n.t(
           'titles.sign_up.completion_reverified_consent',
           sp: sp_name,
         )
       else
-        I18n.t('titles.sign_up.completion_ial2', sp: sp_name)
+        I18n.t('titles.sign_up.completion_idv', sp: sp_name)
       end
     elsif first_time_signing_in?
       I18n.t('titles.sign_up.completion_first_sign_in', sp: sp_name)
     elsif consent_has_expired?
-      I18n.t('titles.sign_up.completion_consent_expired_ial1')
+      I18n.t('titles.sign_up.completion_consent_expired_auth_only')
     elsif completion_context == :new_attributes
       I18n.t('titles.sign_up.completion_new_attributes', sp: sp_name)
     else
@@ -89,7 +89,7 @@ class CompletionsPresenter
         ],
         ' ',
       )
-    elsif ial2_requested? && reverified_after_consent?
+    elsif idv_requested? && reverified_after_consent?
       t(
         'help_text.requested_attributes.ial2_reverified_consent_info_html',
         sp_html: content_tag(:strong, sp_name),
@@ -128,10 +128,10 @@ class CompletionsPresenter
   end
 
   def displayable_attribute_keys
-    sorted_attribute_mapping = if ial2_requested?
-                                 SORTED_IAL2_ATTRIBUTE_MAPPING
+    sorted_attribute_mapping = if idv_requested?
+                                 SORTED_IDV_ATTRIBUTE_MAPPING
                                else
-                                 SORTED_IAL1_ATTRIBUTE_MAPPING
+                                 SORTED_AUTH_ONLY_ATTRIBUTE_MAPPING
                                end
 
     sorted_attributes = sorted_attribute_mapping.map do |raw_attribute, display_attribute|

--- a/app/presenters/idv/in_person/verification_results_email_presenter.rb
+++ b/app/presenters/idv/in_person/verification_results_email_presenter.rb
@@ -40,11 +40,17 @@ module Idv
       end
 
       def show_cta?
-        !service_provider || service_provider_homepage_url.present?
+        return true unless service_provider
+
+        service_provider_homepage_url.present? || service_provider_post_idv_follow_up_url.present?
       end
 
       def sign_in_url
-        service_provider_homepage_url || root_url
+        service_provider_post_idv_follow_up_url || service_provider_homepage_url || root_url
+      end
+
+      def service_provider_post_idv_follow_up_url
+        sp_return_url_resolver.post_idv_follow_up_url if service_provider
       end
 
       def service_provider_homepage_url

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -854,6 +854,34 @@ module AnalyticsEvents
     )
   end
 
+  # Historic Attempt data was destroyed when a user deleted their account
+  # It deletes ALL historic data, not just the most recent active profile
+  def historic_event_data_destroyed
+    track_event(:historic_event_data_destroyed)
+  end
+
+  # Historic data was potentially sent when a user accessed an Attempts Api Consumer App
+  # @param [Boolean] success Whether the historic attempt data was released
+  # rubocop:disable Layout/LineLength
+  # @param [:idv_not_requested, :no_user_proofing_event, :already_sent, :no_encrypted_file_reference nil] exception
+  # rubocop:enable Layout/LineLength
+  # @param [Integer,nil] profile_id ID of the active profile associated with attempts data
+  def historic_event_data_released(success:, exception: nil, profile_id: nil, **extra)
+    track_event(
+      :historic_event_data_released,
+      success:,
+      exception:,
+      profile_id:,
+      **extra,
+    )
+  end
+
+  # @param [Integer] profile_id ID of the active profile associated with attempts data
+  # Historic Attempt data was saved when a user completed the IdV process
+  def historic_event_data_saved(profile_id:, **extra)
+    track_event(:historic_event_data_saved, profile_id:, **extra)
+  end
+
   # User visited sign-in URL from the "You've been successfully verified email" CTA button
   # @param issuer [String] the ServiceProvider.issuer
   # @param campaign_id [String] the email campaign ID

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -182,6 +182,7 @@ module AttemptsApi
     end
 
     def should_track?(event_type)
+      # Historical Attempts feature requires the Attempts API to be enabled globally
       return false unless IdentityConfig.store.attempts_api_enabled
 
       should_send_event? || should_log_history?(event_type)

--- a/app/views/user_mailer/in_person_verified.html.erb
+++ b/app/views/user_mailer/in_person_verified.html.erb
@@ -6,15 +6,13 @@
       class: 'float-center padding-bottom-4',
     ) %>
 <h1><%= message.subject %></h1>
+<p><%= t('user_mailer.in_person_verified.greeting') %></p>
 <p>
-  <%= t('user_mailer.in_person_verified.greeting') %><br>
   <%= t(
         'user_mailer.in_person_verified.intro',
         location: @presenter.visited_location_name,
         date: @presenter.formatted_verified_date,
       ) %>
-</p>
-<p>
   <% if @presenter.service_provider.present? %>
     <% if @presenter.show_cta? %>
       <%= t('user_mailer.in_person_verified.next_sign_in.with_sp.with_cta', sp_name: @presenter.service_provider.friendly_name) %>

--- a/config/initializers/job_configurations.rb
+++ b/config/initializers/job_configurations.rb
@@ -13,6 +13,7 @@ cron_monthly = '30 0 1 * *' # monthly, 0:30 UTC to not overlap with jobs running
 cron_monthly_5am = '0 5 1 * *' # monthly, 5 AM UTC to not overlap with jobs running at 0000
 s3_cron_24h = '0 6 * * *' # 6am UTC is 1am EST/2am EDT
 cron_1st_of_month_12pm = '0 12 1 * *' # 1st of month 12 pm
+cron_24h_6am = '0 6 * * *' # Daily 6am UTC
 
 if defined?(Rails::Console)
   Rails.logger.info 'job_configurations: console detected, skipping schedule'
@@ -230,6 +231,12 @@ else
       monthly_key_metrics_report: {
         class: 'Reports::MonthlyKeyMetricsReport',
         cron: cron_24h,
+        args: -> { [Time.zone.yesterday.end_of_day] },
+      },
+      monthly_key_metrics_s3_report: {
+        class: 'Reports::MonthlyKeyMetricsS3Report',
+        cron: cron_24h_6am, # reporting rails scheduled a little after midnight
+        # 6am seems like more than enough time for a ~midnight report to finish in reporting-rails
         args: -> { [Time.zone.yesterday.end_of_day] },
       },
       # Send previous week's authentication reports to partners

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1791,10 +1791,10 @@ titles.revoke_consent: Revoke Consent
 titles.rules_of_use: Rules of Use
 titles.select_email: Select your preferred email
 titles.sign_in: Sign in
-titles.sign_up.completion_consent_expired_ial1: It’s been a year since you gave us consent to share your information
-titles.sign_up.completion_consent_expired_ial2: It’s been a year since you gave us consent to share your verified identity
+titles.sign_up.completion_consent_expired_auth_only: It’s been a year since you gave us consent to share your information
+titles.sign_up.completion_consent_expired_idv: It’s been a year since you gave us consent to share your verified identity
 titles.sign_up.completion_first_sign_in: Continue to %{sp}
-titles.sign_up.completion_ial2: Connect your verified information to %{sp}
+titles.sign_up.completion_idv: Connect your verified information to %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} is requesting new information'
 titles.sign_up.completion_new_sp: You are now signing in for the first time
 titles.sign_up.completion_reverified_consent: Share your updated information with %{sp}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2104,9 +2104,9 @@ user_mailer.in_person_ready_to_verify_reminder.subject.other: Verify your identi
 user_mailer.in_person_ready_to_verify.subject: You’re ready to verify your identity with %{app_name} in person
 user_mailer.in_person_verified.greeting: Hello,
 user_mailer.in_person_verified.intro: You successfully verified your identity at the %{location} Post Office on %{date}.
-user_mailer.in_person_verified.next_sign_in.with_sp.with_cta: Next, click the button or copy the link below to access %{sp_name} and sign in.
-user_mailer.in_person_verified.next_sign_in.with_sp.without_cta: You can now sign in from %{sp_name}’s website.
-user_mailer.in_person_verified.next_sign_in.without_sp: Next, click the button or copy the link below to sign in to %{app_name}.
+user_mailer.in_person_verified.next_sign_in.with_sp.with_cta: Sign in and connect your verified information with %{sp_name}.
+user_mailer.in_person_verified.next_sign_in.with_sp.without_cta: Sign in from %{sp_name}’s website to connect your verified information.
+user_mailer.in_person_verified.next_sign_in.without_sp: Sign in to %{app_name}.
 user_mailer.in_person_verified.sign_in: Sign in
 user_mailer.in_person_verified.subject: You successfully verified your identity with %{app_name}
 user_mailer.in_person_verified.warning_contact_us_html: If you did not attempt to verify your identity in person, please sign in to <a href="%{reset_password_url}">reset your password</a>. To report this, <a href="%{contact_us_url}">contact %{app_name} support</a>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文（简体）
 account.email_language.updated: Your email language preference has been updated.
-account.emails.confirmed_html: You have confirmed your email address. Go to <a href="%{url}">your connected services</a> to update the email you share with connected agencies.
+account.emails.confirmed_html: You have confirmed your email address. Go to <a href="%{url}">your connected services</a> to update the email you share with connected services.
 account.forget_all_browsers.longer_description: Once you choose to ‘forget all browsers,’ we’ll need additional information to know that it’s actually you signing in to your account. We’ll ask for a multi-factor authentication method (such as text/SMS code or a security key) each time you want to access your account.
 account.index.auth_app_add: Add app
 account.index.auth_app_disabled: not enabled
@@ -756,7 +756,7 @@ doc_auth.tips.document_capture_selfie_text3: Keep your expression neutral
 doc_auth.tips.document_capture_selfie_text4: Make sure your whole face is visible within the green circle
 duplicate_profiles_detected.accounts_list.heading: Accounts with the same verified information
 duplicate_profiles_detected.cant_access: 'I can’t access an account'
-duplicate_profiles_detected.connected_acct_html: '<strong> Connected agencies: </strong> %{count}'
+duplicate_profiles_detected.connected_acct_html: '<strong> Connected services: </strong> %{count}'
 duplicate_profiles_detected.created_at_html: '<strong> Created: </strong> %{timestamp_html}'
 duplicate_profiles_detected.delete_duplicates.details_html: Sign into the account you are going to delete at <a href="https://secure.login.gov">https://secure.login.gov</a>. Here’s %{link_html}
 duplicate_profiles_detected.delete_duplicates.details2_html: If you want, you may %{link_html} to the account you’re keeping after deleting the duplicate account.
@@ -767,11 +767,11 @@ duplicate_profiles_detected.dont_recognize_account: I don’t recognize an accou
 duplicate_profiles_detected.duplicate: Duplicate
 duplicate_profiles_detected.get_help: Get Help
 duplicate_profiles_detected.heading: We found other accounts that may be yours
-duplicate_profiles_detected.intro_html: 'The %{sp_name} requires that you only have one %{app_name} account with a verified identity. You need to delete %{link_html} before signing into %{sp_name}. Here’s what to do:'
+duplicate_profiles_detected.intro_html: 'Some services require that you only have one %{app_name} account with a verified identity. You need to delete %{link_html} before signing into %{sp_name}. Here’s what to do:'
 duplicate_profiles_detected.intro.link: duplicate accounts
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> Last login: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: Never logged in to
-duplicate_profiles_detected.select_an_account.details_html: 'Keep the account that’s connected to the most services. Go to %{link_html} page to view connected agencies by selecting “Your connected services” in the left menu.'
+duplicate_profiles_detected.select_an_account.details_html: 'Keep the account that’s connected to the most services. Go to %{link_html} page to view connected services by selecting “Your connected services” in the left menu.'
 duplicate_profiles_detected.select_an_account.details.link: Your account
 duplicate_profiles_detected.select_an_account.heading: Choose an account to keep
 duplicate_profiles_detected.sign_back_in.details: Go back to the %{app_name} website and sign in using the one %{app_name} account you kept.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1803,10 +1803,10 @@ titles.revoke_consent: Revocar consentimiento
 titles.rules_of_use: Reglas de uso
 titles.select_email: Seleccione el correo electrónico que prefiera
 titles.sign_in: Iniciar sesión
-titles.sign_up.completion_consent_expired_ial1: Hace un año que nos dio su consentimiento para divulgar su información
-titles.sign_up.completion_consent_expired_ial2: Hace un año que nos dio su consentimiento para divulgar su identidad verificada
+titles.sign_up.completion_consent_expired_auth_only: Hace un año que nos dio su consentimiento para divulgar su información
+titles.sign_up.completion_consent_expired_idv: Hace un año que nos dio su consentimiento para divulgar su identidad verificada
 titles.sign_up.completion_first_sign_in: Continuar con %{sp}
-titles.sign_up.completion_ial2: Conecte su información verificada a %{sp}
+titles.sign_up.completion_idv: Conecte su información verificada a %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} está solicitando nueva información'
 titles.sign_up.completion_new_sp: Está iniciando sesión por primera vez
 titles.sign_up.completion_reverified_consent: Comunique su información actualizada a %{sp}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -58,7 +58,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文（简体）
 account.email_language.updated: Se actualizó su preferencia de idioma del correo electrónico.
-account.emails.confirmed_html: Has confirmado tu dirección de correo electrónico. Ve a <a href="%{url}">tus servicios conectados</a> para actualizar el correo electrónico que compartes con las agencias conectadas.
+account.emails.confirmed_html: Has confirmado tu dirección de correo electrónico. Ve a <a href="%{url}">tus servicios conectados</a> para actualizar el correo electrónico que compartes con las servicios conectadas.
 account.forget_all_browsers.longer_description: Una vez que elija “Olvidar todos los navegadores”, necesitaremos más información para saber que realmente es usted quien está iniciando sesión en su cuenta. Le pediremos un método de autenticación multifactor (como código de texto o de SMS, o una clave de seguridad) cada vez que desee acceder a su cuenta.
 account.index.auth_app_add: Agregar aplicación
 account.index.auth_app_disabled: no habilitada
@@ -767,7 +767,7 @@ doc_auth.tips.document_capture_selfie_text3: Mantenga una expresión neutral
 doc_auth.tips.document_capture_selfie_text4: Revise que se vea su rostro completo dentro del círculo verde.
 duplicate_profiles_detected.accounts_list.heading: Cuentas con la misma información verificada
 duplicate_profiles_detected.cant_access: 'No puedo acceder a una cuenta'
-duplicate_profiles_detected.connected_acct_html: '<strong> Agencias conectadas: </strong> %{count}'
+duplicate_profiles_detected.connected_acct_html: '<strong> Servicios conectadas: </strong> %{count}'
 duplicate_profiles_detected.created_at_html: '<strong> Creado: </strong> %{timestamp_html}'
 duplicate_profiles_detected.delete_duplicates.details_html: Inicia sesión en la cuenta que va a eliminar en <a href="https://secure.login.gov">https://secure.login.gov</a>. Así es %{link_html}
 duplicate_profiles_detected.delete_duplicates.details2_html: Si lo desea, %{link_html} a la cuenta que conservará después de eliminar la cuenta duplicada.
@@ -778,11 +778,11 @@ duplicate_profiles_detected.dont_recognize_account: No reconozco una de estas cu
 duplicate_profiles_detected.duplicate: Duplicada
 duplicate_profiles_detected.get_help: Obtener ayuda
 duplicate_profiles_detected.heading: Encontramos otras cuentas que pueden ser suyas
-duplicate_profiles_detected.intro_html: '%{sp_name} requiere que usted tenga sólo una cuenta de %{app_name} con una identidad verificada. Debe eliminar %{link_html} antes de iniciar sesión en %{sp_name}. Esto es lo que debe hacer:'
+duplicate_profiles_detected.intro_html: 'Algunas servicios requieren que usted tenga únicamente una cuenta de %{app_name} con una identidad verificada. Debe eliminar %{link_html} antes de iniciar sesión en %{sp_name}. Esto es lo que debe hacer:'
 duplicate_profiles_detected.intro.link: las cuentas duplicativas
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> Último inicio de sesión: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: Nunca he iniciado sesión en
-duplicate_profiles_detected.select_an_account.details_html: 'Conserva la cuenta que esté conectada a la mayor cantidad de servicios. Ve a la página %{link_html} para ver las agencias conectadas seleccionando “Tus servicios conectados” en el menú de la izquierda.'
+duplicate_profiles_detected.select_an_account.details_html: 'Conserva la cuenta que esté conectada a la mayor cantidad de servicios. Ve a la página %{link_html} para ver las servicios conectadas seleccionando “Tus servicios conectados” en el menú de la izquierda.'
 duplicate_profiles_detected.select_an_account.details.link: «Su cuenta»
 duplicate_profiles_detected.select_an_account.heading: Elija la cuenta que desea conservar.
 duplicate_profiles_detected.sign_back_in.details: Vuelva al sitio web de %{app_name} e inicie sesión usando la cuenta de %{app_name} que conservó.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2116,9 +2116,9 @@ user_mailer.in_person_ready_to_verify_reminder.subject.other: Verifique su ident
 user_mailer.in_person_ready_to_verify.subject: Está listo para verificar su identidad con %{app_name} en persona
 user_mailer.in_person_verified.greeting: 'Hola:'
 user_mailer.in_person_verified.intro: El %{date}, verificó correctamente su identidad en la oficina de correos de %{location}.
-user_mailer.in_person_verified.next_sign_in.with_sp.with_cta: A continuación, haga clic en el botón o copie el vínculo siguiente para acceder a %{sp_name} e iniciar sesión.
-user_mailer.in_person_verified.next_sign_in.with_sp.without_cta: Ya puede iniciar la sesión en el sitio web de %{sp_name}.
-user_mailer.in_person_verified.next_sign_in.without_sp: Luego, haga clic en el botón o copie el vínculo siguiente para iniciar sesión en %{app_name}.
+user_mailer.in_person_verified.next_sign_in.with_sp.with_cta: Inicie sesión y conecte su información verificada con %{sp_name}.
+user_mailer.in_person_verified.next_sign_in.with_sp.without_cta: Inicie sesión desde el sitio web de %{sp_name} para conectar su información verificada.
+user_mailer.in_person_verified.next_sign_in.without_sp: Inicie sesión en %{app_name}.
 user_mailer.in_person_verified.sign_in: Iniciar sesión
 user_mailer.in_person_verified.subject: Logró verificar su identidad con %{app_name}
 user_mailer.in_person_verified.warning_contact_us_html: Si usted no intentó verificar su identidad en persona, inicie sesión en <a href="%{reset_password_url}"> para restablecer su contraseña</a>. Para informar de esto, <a href="%{contact_us_url}">contacte con el servicio de asistencia de %{app_name}</a>.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -58,7 +58,7 @@ account.email_language.name.es: Español
 account.email_language.name.fr: Français
 account.email_language.name.zh: 中文（简体）
 account.email_language.updated: Votre langue de préférence pour les e-mails a été mise à jour.
-account.emails.confirmed_html: Vous avez confirmé votre adresse e-mail. Rendez-vous sur <a href="%{url}">vos services connectés</a> pour actualiser l’adresse e-mail que vous communiquez aux organismes connectés.
+account.emails.confirmed_html: Vous avez confirmé votre adresse e-mail. Rendez-vous sur <a href="%{url}">vos services connectés</a> pour actualiser l’adresse e-mail que vous communiquez aux services connectés.
 account.forget_all_browsers.longer_description: Une fois que vous aurez choisi d’« oublier tous les navigateurs », nous aurons besoin d’informations supplémentaires pour savoir que c’est bien vous qui vous connectez à votre compte. Nous vous demanderons une méthode d’authentification multi-facteurs (comme un code SMS/texto ou une clé de sécurité) chaque fois que vous souhaiterez accéder à votre compte.
 account.index.auth_app_add: Ajouter une appli
 account.index.auth_app_disabled: non activé
@@ -756,7 +756,7 @@ doc_auth.tips.document_capture_selfie_text3: Gardez une expression neutre
 doc_auth.tips.document_capture_selfie_text4: Assurez-vous que l’ensemble de votre visage est visible dans le cercle vert
 duplicate_profiles_detected.accounts_list.heading: Comptes ayant les mêmes informations vérifiées
 duplicate_profiles_detected.cant_access: 'Je ne peux pas accéder à un compte'
-duplicate_profiles_detected.connected_acct_html: '<strong> Agences connectées: </strong> %{count}'
+duplicate_profiles_detected.connected_acct_html: '<strong> Services connectés: </strong> %{count}'
 duplicate_profiles_detected.created_at_html: '<strong> Créé: </strong> %{timestamp_html}'
 duplicate_profiles_detected.delete_duplicates.details_html: Connectez-vous au compte que vous souhaitez supprimer sur <a href="https://secure.login.gov">https://secure.login.gov</a> . Voici %{link_html}
 duplicate_profiles_detected.delete_duplicates.details2_html: 'Si vous le souhaitez, vous pouvez ajouter %{link_html} au compte que vous conservez après avoir supprimé le compte en double.'
@@ -767,11 +767,11 @@ duplicate_profiles_detected.dont_recognize_account: Je ne reconnais pas l’un d
 duplicate_profiles_detected.duplicate: En double
 duplicate_profiles_detected.get_help: Obtenir de l’aide
 duplicate_profiles_detected.heading: Nous avons trouvé d’autres comptes susceptibles de vous appartenir
-duplicate_profiles_detected.intro_html: 'L’%{sp_name} exige que vous ne disposiez que d’un seul et unique compte %{app_name} avec une identité vérifiée. Vous devez supprimer les %{link_html} avant de vous connecter à l’%{sp_name}. Voici la marche à suivre :'
+duplicate_profiles_detected.intro_html: 'Certaines services exigent que vous ne disposiez que d’un seul compte %{app_name} avec une identité vérifiée. Vous devez supprimer les %{link_html} avant de vous connecter à l’%{sp_name}. Voici la marche à suivre :'
 duplicate_profiles_detected.intro.link: comptes en double
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> Dernière connexion : </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: 'Jamais connecté à'
-duplicate_profiles_detected.select_an_account.details_html: 'Conservez le compte connecté au plus grand nombre de services. Rendez-vous sur la page %{link_html} pour consulter les agences connectées en sélectionnant «Vos services connectés» dans le menu de gauche.'
+duplicate_profiles_detected.select_an_account.details_html: 'Conservez le compte connecté au plus grand nombre de services. Rendez-vous sur la page %{link_html} pour consulter les services connectées en sélectionnant «Vos services connectés» dans le menu de gauche.'
 duplicate_profiles_detected.select_an_account.details.link: '«Votre compte»'
 duplicate_profiles_detected.select_an_account.heading: Choisir le compte que vous voulez conserver
 duplicate_profiles_detected.sign_back_in.details: Retournez sur le site web de %{app_name} et connectez-vous à l’aide du compte %{app_name} que vous avez conservé.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1792,10 +1792,10 @@ titles.revoke_consent: Révoquer le consentement
 titles.rules_of_use: Règles d’utilisation
 titles.select_email: Sélectionner l’adresse e-mail de votre choix
 titles.sign_in: Se connecter
-titles.sign_up.completion_consent_expired_ial1: Cela fait un an que vous nous avez donné votre consentement pour partager vos informations
-titles.sign_up.completion_consent_expired_ial2: Cela fait un an que vous nous avez donné votre consentement pour partager votre identité vérifiée
+titles.sign_up.completion_consent_expired_auth_only: Cela fait un an que vous nous avez donné votre consentement pour partager vos informations
+titles.sign_up.completion_consent_expired_idv: Cela fait un an que vous nous avez donné votre consentement pour partager votre identité vérifiée
 titles.sign_up.completion_first_sign_in: Continuer vers %{sp}
-titles.sign_up.completion_ial2: Connecter vos informations vérifiées à %{sp}
+titles.sign_up.completion_idv: Connecter vos informations vérifiées à %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} demande de nouvelles informations'
 titles.sign_up.completion_new_sp: Vous vous connectez pour la première fois
 titles.sign_up.completion_reverified_consent: Partager vos informations mises à jour avec %{sp}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2105,9 +2105,9 @@ user_mailer.in_person_ready_to_verify_reminder.subject.other: Vérifiez votre id
 user_mailer.in_person_ready_to_verify.subject: Vous êtes prêt à vérifier votre identité avec %{app_name} en personne
 user_mailer.in_person_verified.greeting: Bonjour,
 user_mailer.in_person_verified.intro: Vous avez réussi à vérifier votre identité au bureau de poste de %{location} le %{date}.
-user_mailer.in_person_verified.next_sign_in.with_sp.with_cta: Maintenant, cliquez sur le bouton ou copiez le lien ci-dessous pour accéder à %{sp_name} et vous connecter.
-user_mailer.in_person_verified.next_sign_in.with_sp.without_cta: Vous pouvez désormais vous connecter depuis le site Web de %{sp_name}.
-user_mailer.in_person_verified.next_sign_in.without_sp: Maintenant, cliquez sur le bouton ou copiez le lien ci-dessous pour vous connecter à %{app_name}.
+user_mailer.in_person_verified.next_sign_in.with_sp.with_cta: Connectez-vous et associez vos informations vérifiées à %{sp_name}.
+user_mailer.in_person_verified.next_sign_in.with_sp.without_cta: Connectez-vous depuis le site Web de %{sp_name} pour associer vos informations vérifiées.
+user_mailer.in_person_verified.next_sign_in.without_sp: Connectez-vous à %{app_name}.
 user_mailer.in_person_verified.sign_in: Se connecter
 user_mailer.in_person_verified.subject: Vous avez réussi à vérifier votre identité avec %{app_name}
 user_mailer.in_person_verified.warning_contact_us_html: Si vous n’avez pas essayé de confirmer votre identité en personne, veuillez vous connecter pour <a href="%{reset_password_url}">réinitialiser votre mot de passe</a>. Pour signaler ce problème, <a href="%{contact_us_url}">contactez l’assistance de %{app_name}</a>.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1805,10 +1805,10 @@ titles.revoke_consent: 撤销同意
 titles.rules_of_use: 使用规则
 titles.select_email: 选择你想用的电邮
 titles.sign_in: 登录
-titles.sign_up.completion_consent_expired_ial1: 从你上次授权我们分享你的信息已经一年了。
-titles.sign_up.completion_consent_expired_ial2: 从你上次授权我们分享你验证过的身份已经一年了。
+titles.sign_up.completion_consent_expired_auth_only: 从你上次授权我们分享你的信息已经一年了。
+titles.sign_up.completion_consent_expired_idv: 从你上次授权我们分享你验证过的身份已经一年了。
 titles.sign_up.completion_first_sign_in: 继续到 %{sp}
-titles.sign_up.completion_ial2: 连接你验证过的信息到 %{sp}
+titles.sign_up.completion_idv: 连接你验证过的信息到 %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} 在要求新信息'
 titles.sign_up.completion_new_sp: 你现在正在首次登入
 titles.sign_up.completion_reverified_consent: 与 %{sp}分享你更新后的信息

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -767,7 +767,7 @@ doc_auth.tips.document_capture_selfie_text3: 保持中性表情
 doc_auth.tips.document_capture_selfie_text4: 确保您整个面孔都可以在绿色圆圈里看到
 duplicate_profiles_detected.accounts_list.heading: 以下账户具有相同的已验证信息
 duplicate_profiles_detected.cant_access: '我无法访问某个帐户'
-duplicate_profiles_detected.connected_acct_html: '<strong> 关联机构: </strong> %{count}'
+duplicate_profiles_detected.connected_acct_html: '<strong> 互联服务: </strong> %{count}'
 duplicate_profiles_detected.created_at_html: '<strong> 创建: </strong> %{timestamp_html}'
 duplicate_profiles_detected.delete_duplicates.details_html: 请登录您打算删除的账户：<a href="https://secure.login.gov">https://secure.login.gov/zh</a>。以下是%{link_html}。
 duplicate_profiles_detected.delete_duplicates.details2_html: 如果您愿意，可以在%{link_html}，将该电子邮件地址添加到您保留的账户中。
@@ -778,7 +778,7 @@ duplicate_profiles_detected.dont_recognize_account: 我不认识上边的一个�
 duplicate_profiles_detected.duplicate: 重复
 duplicate_profiles_detected.get_help: 获取帮助
 duplicate_profiles_detected.heading: 我们发现了其他可能属于你的帐户
-duplicate_profiles_detected.intro_html: '%{sp_name} 要求您仅持有一个已验证身份的 %{app_name} 账户。在登录 %{sp_name} 之前，您需要%{link_html}。具体操作如下：'
+duplicate_profiles_detected.intro_html: '某些服务要求您仅拥有一个已验证身份的 %{app_name} 账户。在登录 %{sp_name} 之前，您需要%{link_html}。具体操作如下：'
 duplicate_profiles_detected.intro.link: 删除重复账户
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> 上次登录: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: 从未登录过

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -2118,9 +2118,9 @@ user_mailer.in_person_ready_to_verify_reminder.subject.other: 过%{count} 天去
 user_mailer.in_person_ready_to_verify.subject: 你可以在 %{app_name} 亲身验证身份了
 user_mailer.in_person_verified.greeting: 你好，
 user_mailer.in_person_verified.intro: 你于 %{date}在 %{location} 邮局成功地验证了身份。
-user_mailer.in_person_verified.next_sign_in.with_sp.with_cta: 接下来请点击按钮或复制下面的连接来访问 %{sp_name} 并登录。
-user_mailer.in_person_verified.next_sign_in.with_sp.without_cta: 你现在可以从 %{sp_name} 的网站登录。
-user_mailer.in_person_verified.next_sign_in.without_sp: 接下来请点击按钮或复制下面的连接来登录 %{app_name}。
+user_mailer.in_person_verified.next_sign_in.with_sp.with_cta: 登录并将你的已验证信息与 %{sp_name} 关联。
+user_mailer.in_person_verified.next_sign_in.with_sp.without_cta: 从 %{sp_name} 的网站登录，以关联你的已验证信息。
+user_mailer.in_person_verified.next_sign_in.without_sp: 登录 %{app_name}。
 user_mailer.in_person_verified.sign_in: 登录
 user_mailer.in_person_verified.subject: 你在 %{app_name} 成功地验证了身份
 user_mailer.in_person_verified.warning_contact_us_html: 如果你没有试图亲身验证身份，请登入 <a href="%{reset_password_url}"> 重设密码</a>。要报告这件事，<a href="%{contact_us_url}">联系 %{app_name} 支持 %{app_name}</a>。

--- a/lib/reporting/monthly_key_metrics_idv_s3_report.rb
+++ b/lib/reporting/monthly_key_metrics_idv_s3_report.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module Reporting
+  # Reads the pre-generated IDV key-metrics CSV reports (condensed IDV + proofing rate)
+  # that reporting-rails generates from Redshift and uploads to S3, and presents them
+  # as emailable reports so the Monthly Key Metrics email matches what the in-app
+  # CloudWatch-based reports used to produce (99.9% similar in prod testing 6/26 and 5/26)
+  class MonthlyKeyMetricsIdvS3Report
+    attr_reader :bucket_name, :s3_path
+
+    CONDENSED_IDV_FILENAME = 'condensed_idv'
+    PROOFING_RATE_FILENAME = 'proofing_rate_metrics'
+
+    CSV_FILE_NAMES = [
+      CONDENSED_IDV_FILENAME,
+      PROOFING_RATE_FILENAME,
+    ].freeze
+
+    # @param [String] bucket_name the S3 bucket name
+    # @param [String] custom_s3_path S3 key prefix for the reports
+    def initialize(bucket_name:, custom_s3_path:)
+      @bucket_name = bucket_name
+      @s3_path = custom_s3_path
+    end
+
+    def as_emailable_reports
+      [
+        condensed_idv_emailable_report,
+        proofing_rate_emailable_report,
+      ]
+    end
+
+    # Mirrors Reporting::MonthlyIdvReport#monthly_idv_report_emailable_report
+    def condensed_idv_emailable_report
+      Reporting::EmailableReport.new(
+        title: 'Proofing Rate Metrics',
+        subtitle: 'Condensed (NEW)', # (NEW) was in original formatting
+        float_as_percent: true,
+        precision: 2,
+        table: condensed_idv_table,
+        filename: CONDENSED_IDV_FILENAME,
+      )
+    end
+
+    # Mirrors Reporting::ProofingRateReport#proofing_rate_emailable_report
+    def proofing_rate_emailable_report
+      Reporting::EmailableReport.new(
+        subtitle: 'Detail',
+        float_as_percent: true,
+        precision: 2,
+        table: proofing_rate_table,
+        filename: PROOFING_RATE_FILENAME,
+      )
+    end
+
+    def condensed_idv_table
+      csv_data_for(CONDENSED_IDV_FILENAME)
+    end
+
+    def proofing_rate_table
+      csv_data_for(PROOFING_RATE_FILENAME)
+    end
+
+    def csv_file_names
+      CSV_FILE_NAMES
+    end
+
+    # @param [String] report_name one of CSV_FILE_NAMES
+    def csv_data_for(report_name)
+      @csv_cache ||= {}
+      @csv_cache[report_name] ||= begin
+        body = fetch_csv_from_s3(report_name)
+        CSV.parse(body).map { |row| row.map { |cell| coerce_cell(cell) } }
+      end
+    end
+
+    # Get the last modified time for a specific file
+    # @return [Time] last modified time
+    # @raise [Aws::S3::Errors::NoSuchKey] if the file doesn't exist
+    def get_file_last_modified(report_name)
+      key = "#{s3_path}_#{report_name}.csv"
+      resp = s3_helper.s3_client.head_object(bucket: bucket_name, key: key)
+      resp.last_modified
+    end
+
+    private
+
+    # CSV stores everything as strings. The original EmailableReport received real
+    # Integers and Floats. Recreate that so:
+    #   - integer-looking cells (counts) -> Integer
+    #   - decimal-looking cells (rates) -> Float (so float_as_percent kicks in)
+    #   - everything else (labels, dates) -> left as the original String
+    def coerce_cell(cell)
+      return cell unless cell.is_a?(String)
+
+      stripped = cell.strip
+      return cell if stripped.empty?
+
+      if stripped.match?(/\A-?\d+\z/)
+        Integer(stripped)
+      elsif stripped.match?(/\A-?\d*\.\d+\z/)
+        Float(stripped)
+      else
+        cell
+      end
+    rescue ArgumentError
+      cell
+    end
+
+    # Builds the full S3 object key for the given CSV report name and fetches it.
+    # Key format: "<s3_path>_<report_name>.csv"
+    # @return [String] raw CSV body
+    def fetch_csv_from_s3(report_name)
+      key = "#{s3_path}_#{report_name}.csv"
+      resp = s3_helper.s3_client.get_object(bucket: bucket_name, key: key)
+      resp.body.read
+
+      # Shouldn't fail, already verified file exists in job
+    rescue Aws::S3::Errors::NoSuchKey => e
+      Rails.logger.error "Unexpected failure reading CSV file from S3: #{key} - #{e}"
+      raise
+    end
+
+    def s3_helper
+      @s3_helper ||= JobHelpers::S3Helper.new
+    end
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "react-test-renderer": "^17.0.2",
         "sinon": "^16.0.0",
         "sinon-chai": "^3.7.0",
-        "stylelint": "^16.2.1",
+        "stylelint": "^17.14.1",
         "svgo": "^3.2.0",
         "swr": "^2.0.0",
         "typescript": "^5.7.2",
@@ -126,20 +126,81 @@
     },
     "app/javascript/packages/build-sass": {
       "name": "@18f/identity-build-sass",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@aduth/is-dependency": "^1.0.0",
-        "browserslist": "^4.22.3",
-        "chokidar": "^3.6.0",
-        "lightningcss": "^1.23.0",
-        "sass-embedded": "^1.70.0"
+        "browserslist": "^4.28.7",
+        "chokidar": "^5.0.0",
+        "lightningcss": "^1.33.0",
+        "sass-embedded": "^1.100.0"
       },
       "bin": {
         "build-sass": "cli.js"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "app/javascript/packages/build-sass/node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "app/javascript/packages/build-sass/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "app/javascript/packages/build-sass/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "app/javascript/packages/captcha-submit-button": {
@@ -388,15 +449,15 @@
     },
     "app/javascript/packages/stylelint-config": {
       "name": "@18f/identity-stylelint-config",
-      "version": "5.0.0-beta.1",
+      "version": "6.0.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "stylelint-config-standard-scss": "^13.1.0",
-        "stylelint-prettier": "^5.0.0"
+        "stylelint-config-standard-scss": "^17.0.0",
+        "stylelint-prettier": "^5.0.3"
       },
       "peerDependencies": {
         "prettier": ">=3.0.0",
-        "stylelint": ">=16.0.2"
+        "stylelint": "^17.0.0"
       }
     },
     "app/javascript/packages/submit-button": {
@@ -2392,9 +2453,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
-      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
+      "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bundled-es-modules/cookie": {
@@ -2444,42 +2505,61 @@
         "node": ">=6"
       }
     },
-    "node_modules/@cacheable/memoize": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cacheable/memoize/-/memoize-2.0.1.tgz",
-      "integrity": "sha512-WBLH37SynkCa39S6IrTSMQF3Wdv4/51WxuU5TuCNEqZcLgLGHme8NUxRTcDIO8ZZFXlslWbh9BD3DllixgPg6Q==",
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
       "license": "MIT",
       "dependencies": {
-        "@cacheable/utils": "^2.0.1"
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
       }
     },
-    "node_modules/@cacheable/memory": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.1.tgz",
-      "integrity": "sha512-Ufc7iQnRKFC8gjZVGOTOsMwM/vZtmsw3LafvctVXPm835ElgK3DpMe1U5i9sd6OieSkyJhXbAT2Q2FosXBBbAQ==",
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
       "license": "MIT",
       "dependencies": {
-        "@cacheable/memoize": "^2.0.1",
-        "@cacheable/utils": "^2.0.1",
-        "@keyv/bigmap": "^1.0.0",
-        "hookified": "^1.12.0",
-        "keyv": "^5.5.1"
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@cacheable/memory/node_modules/keyv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.2.tgz",
-      "integrity": "sha512-TXcFHbmm/z7MGd1u9ASiCSfTS+ei6Z8B3a5JHzx3oPa/o7QzWVtPRpc4KGER5RR469IC+/nfg4U5YLIuDUua2g==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/@cacheable/utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.0.1.tgz",
-      "integrity": "sha512-sxHjO6wKn4/0wHCFYbh6tljj+ciP9BKgyBi09NLsor3sN+nu/Rt3FwLw6bYp7bp8usHpmcwUozrB/u4RuSw/eg==",
-      "license": "MIT"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
@@ -2557,6 +2637,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2573,12 +2654,37 @@
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2594,33 +2700,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@csstools/media-query-list-parser": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
-      "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/selector-specificity": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.1.tgz",
+      "integrity": "sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==",
       "funding": [
         {
           "type": "github",
@@ -2633,10 +2716,32 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "postcss-selector-parser": "^7.0.0"
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2646,16 +2751,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@dual-bundle/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -3135,18 +3230,6 @@
         "jsep": "^0.4.0||^1.0.0"
       }
     },
-    "node_modules/@keyv/bigmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.0.1.tgz",
-      "integrity": "sha512-dZ7TMshK6brpuGPPRoq4pHNzNH4KTWaxVPB7KEnPErlgJpc+jG1Oyx3sw6nBFiZ0OCKwC1zU6skMEG7H421f9g==",
-      "license": "MIT",
-      "dependencies": {
-        "hookified": "^1.12.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -3524,6 +3607,294 @@
         "node": ">=14"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3855,6 +4226,18 @@
       "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -4981,6 +5364,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -5048,6 +5432,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5439,9 +5824,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -5474,6 +5859,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5551,12 +5937,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-builder": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
-      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
-      "license": "MIT/X11"
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5580,22 +5960,22 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.0.1.tgz",
-      "integrity": "sha512-MSKxcybpxB5kcWKpj+1tPBm2os4qKKGxDovsZmLhZmWIDYp8EgtC45C5zk1fLe1IC9PpI4ZE4eyryQH0N10PKA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
       "license": "MIT",
       "dependencies": {
-        "@cacheable/memoize": "^2.0.1",
-        "@cacheable/memory": "^2.0.1",
-        "@cacheable/utils": "^2.0.1",
-        "hookified": "^1.12.0",
-        "keyv": "^5.5.1"
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.2.tgz",
-      "integrity": "sha512-TXcFHbmm/z7MGd1u9ASiCSfTS+ei6Z8B3a5JHzx3oPa/o7QzWVtPRpc4KGER5RR469IC+/nfg4U5YLIuDUua2g==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -5688,9 +6068,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5772,7 +6152,9 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -5915,6 +6297,12 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorjs.io": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
+      "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -6119,12 +6507,12 @@
       }
     },
     "node_modules/css-functions-list": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12 || >=16"
+        "node": ">=12"
       }
     },
     "node_modules/css-select": {
@@ -6157,13 +6545,13 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -6578,6 +6966,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
@@ -6719,9 +7108,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.400",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.400.tgz",
+      "integrity": "sha512-96EWDNjM59SYflgeV5Ylsf4EMiq1a25YjCnJH7cxn/AF2H3pILRweaUnoLax0yKHWdpOzY6JKEu45e8irqZIHA==",
       "license": "ISC"
     },
     "node_modules/element-closest": {
@@ -8046,6 +8435,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8110,6 +8500,18 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-func-name": {
@@ -8317,6 +8719,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
@@ -8337,6 +8740,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -8346,6 +8750,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8488,6 +8893,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -8518,9 +8935,9 @@
       "license": "MIT"
     },
     "node_modules/hookified": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.1.tgz",
-      "integrity": "sha512-xnKGl+iMIlhrZmGHB729MqlmPoWBznctSQTYCpFKqNsCgimJQmithcW0xSQMMFzYnV2iKUh25alswn6epgxS0Q==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
@@ -8537,12 +8954,12 @@
       }
     },
     "node_modules/html-tags": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
-      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=20.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8605,9 +9022,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
-      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -8707,6 +9124,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -8848,6 +9275,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -9777,9 +10205,9 @@
       "license": "MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
-      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -9792,22 +10220,43 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.30.1",
-        "lightningcss-darwin-x64": "1.30.1",
-        "lightningcss-freebsd-x64": "1.30.1",
-        "lightningcss-linux-arm-gnueabihf": "1.30.1",
-        "lightningcss-linux-arm64-gnu": "1.30.1",
-        "lightningcss-linux-arm64-musl": "1.30.1",
-        "lightningcss-linux-x64-gnu": "1.30.1",
-        "lightningcss-linux-x64-musl": "1.30.1",
-        "lightningcss-win32-arm64-msvc": "1.30.1",
-        "lightningcss-win32-x64-msvc": "1.30.1"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
-      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -9825,9 +10274,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
-      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -9845,9 +10294,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
-      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -9865,9 +10314,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
-      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -9885,9 +10334,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
-      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -9905,9 +10354,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
-      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -9925,9 +10374,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
-      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -9945,9 +10394,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
-      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -9965,9 +10414,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
-      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -9985,9 +10434,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
-      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -10251,9 +10700,9 @@
       }
     },
     "node_modules/mathml-tag-names": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
-      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -10261,18 +10710,18 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
     "node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10678,6 +11127,13 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -10748,10 +11204,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "license": "MIT"
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -11300,6 +11759,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11556,9 +12016,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -11701,6 +12161,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "license": "MIT"
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -11842,6 +12320,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -12266,45 +12745,88 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sass": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
+      "integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
     "node_modules/sass-embedded": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.70.0.tgz",
-      "integrity": "sha512-1sVSh5MlSdktkwC2zG9WuaVR6j7AlDxadPmZBN0wP4GhznMQTvpwNIAFhAqgjwJYhwdWFOKEdIHSQK4V8K434Q==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.100.0.tgz",
+      "integrity": "sha512-Ut8wlQSk19tm7jMK6mz6cF1+e+E7tUnW2tM02zQDPnOTcVbV8qCQG8UWxZkkNlY50+hV3hqP24OOkUlMz8xBpw==",
       "license": "MIT",
       "dependencies": {
-        "@bufbuild/protobuf": "^1.0.0",
-        "buffer-builder": "^0.2.0",
-        "immutable": "^4.0.0",
+        "@bufbuild/protobuf": "^2.5.0",
+        "colorjs.io": "^0.5.0",
+        "immutable": "^5.1.5",
         "rxjs": "^7.4.0",
         "supports-color": "^8.1.1",
+        "sync-child-process": "^1.0.2",
         "varint": "^6.0.0"
+      },
+      "bin": {
+        "sass": "dist/bin/sass.js"
       },
       "engines": {
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.70.0",
-        "sass-embedded-android-arm64": "1.70.0",
-        "sass-embedded-android-ia32": "1.70.0",
-        "sass-embedded-android-x64": "1.70.0",
-        "sass-embedded-darwin-arm64": "1.70.0",
-        "sass-embedded-darwin-x64": "1.70.0",
-        "sass-embedded-linux-arm": "1.70.0",
-        "sass-embedded-linux-arm64": "1.70.0",
-        "sass-embedded-linux-ia32": "1.70.0",
-        "sass-embedded-linux-musl-arm": "1.70.0",
-        "sass-embedded-linux-musl-arm64": "1.70.0",
-        "sass-embedded-linux-musl-ia32": "1.70.0",
-        "sass-embedded-linux-musl-x64": "1.70.0",
-        "sass-embedded-linux-x64": "1.70.0",
-        "sass-embedded-win32-ia32": "1.70.0",
-        "sass-embedded-win32-x64": "1.70.0"
+        "sass-embedded-all-unknown": "1.100.0",
+        "sass-embedded-android-arm": "1.100.0",
+        "sass-embedded-android-arm64": "1.100.0",
+        "sass-embedded-android-riscv64": "1.100.0",
+        "sass-embedded-android-x64": "1.100.0",
+        "sass-embedded-darwin-arm64": "1.100.0",
+        "sass-embedded-darwin-x64": "1.100.0",
+        "sass-embedded-linux-arm": "1.100.0",
+        "sass-embedded-linux-arm64": "1.100.0",
+        "sass-embedded-linux-musl-arm": "1.100.0",
+        "sass-embedded-linux-musl-arm64": "1.100.0",
+        "sass-embedded-linux-musl-riscv64": "1.100.0",
+        "sass-embedded-linux-musl-x64": "1.100.0",
+        "sass-embedded-linux-riscv64": "1.100.0",
+        "sass-embedded-linux-x64": "1.100.0",
+        "sass-embedded-unknown-all": "1.100.0",
+        "sass-embedded-win32-arm64": "1.100.0",
+        "sass-embedded-win32-x64": "1.100.0"
+      }
+    },
+    "node_modules/sass-embedded-all-unknown": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.100.0.tgz",
+      "integrity": "sha512-auFtXY/kwYILmSVjtBDwyj0axcLbYYiffOKWoaXHnI5bsYwiRbBh3EneR1rpbX2ZIZCrwX93i5pxKLTZF/662Q==",
+      "cpu": [
+        "!arm",
+        "!arm64",
+        "!riscv64",
+        "!x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "sass": "1.100.0"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.70.0.tgz",
-      "integrity": "sha512-Vog4Z+tsDYGv7m9sZisr/P6KvqDioCMu0cinexdnXhHXReo+X6CFe79yv/zA/Xfq5HtAAmFjGD6CO/nTjoydtw==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.100.0.tgz",
+      "integrity": "sha512-70f3HgX2pFNmzpGQ86n5e6QfWn2fP4QUQGfFQK0P1XH73ZLIzLo2YqygrGKGKeeqtc5eU2Wl1/xQzhzuKnO4kw==",
       "cpu": [
         "arm"
       ],
@@ -12313,17 +12835,14 @@
       "os": [
         "android"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.70.0.tgz",
-      "integrity": "sha512-vMr7fruLUv/VvF7CPVF1z7Bc28a8K9Ps5nyN3UatOj+irxN1LbZIbeQua6neX2eFUsXvcg7hLZwvV3+T96Fhrw==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.100.0.tgz",
+      "integrity": "sha512-W+Ru9JwTnfU0UX3jSZcbqFdtKFMcYdfFwytc57h2DgnqCOIiAqI2E06mABZBZC+r3LwXCBuS5GbXAGeVgvVDkA==",
       "cpu": [
         "arm64"
       ],
@@ -12332,36 +12851,30 @@
       "os": [
         "android"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-android-ia32": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.70.0.tgz",
-      "integrity": "sha512-RWEJ7sBGBCd101oSBPuePPU8yXb1iB/ME4sRhgI5xjjyIsldiuvX48saW25u1ZqCo2AVA0BTXfWpNJnhKB3b4Q==",
+    "node_modules/sass-embedded-android-riscv64": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.100.0.tgz",
+      "integrity": "sha512-icU3o0V/uCSytSpf+tX5Lf51BvyQEbLzDUJfUi9etSauYBGHpPKkdtdZH0si4v98phq11Kl8rSV1SggksxF1Hg==",
       "cpu": [
-        "ia32"
+        "riscv64"
       ],
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.70.0.tgz",
-      "integrity": "sha512-u+ijV6AQR/84kjjGb3mp0aibPiXkFKqfmHxqYBMN7h2xV7EM70Yz054nVifaBr8nfC0E8aT/DurSI4nkkQ6Uvg==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.100.0.tgz",
+      "integrity": "sha512-mevF9VQk6gEYByy8+jusaHGmd7Usb2ytX/DsEOd0JtOGCtcf1kh575xJ6OUBDIcJ15uLnbau/0iy1eP6WVBvWA==",
       "cpu": [
         "x64"
       ],
@@ -12370,17 +12883,14 @@
       "os": [
         "android"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.70.0.tgz",
-      "integrity": "sha512-qMs08h0nwRA1B/Ieakcg/Y6lcCEnuBnPTNEkFkBlnfj3PFVPTb50wQvDr9JLpcjXWznlBxyFrz1nZM+pXDix7Q==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.100.0.tgz",
+      "integrity": "sha512-1PVlYi61POo93IT/FfrG1mc1tAHxeSTyUALF2aOFmXGWjVXr3bQzEQiBGCOvQbj/ix+5hNyXFXcEMEyKvtUJJA==",
       "cpu": [
         "arm64"
       ],
@@ -12389,17 +12899,14 @@
       "os": [
         "darwin"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.70.0.tgz",
-      "integrity": "sha512-Vf8UQY3IBmsaz9L5DeJDjn19N//1n3rTquH69x29zPCd3zF2gnay38atxIZ+6h7VsZT3C6evm0y58JUJDWN1CA==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.100.0.tgz",
+      "integrity": "sha512-x97o3JnGyImZNCIVs9wQHJUE5QCvmVIKaH1cwrz/5dK7OT1FpeNiW+u9TUomP9hG6Ekjd8EL8NBHpxTfIhdjmg==",
       "cpu": [
         "x64"
       ],
@@ -12408,17 +12915,14 @@
       "os": [
         "darwin"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.70.0.tgz",
-      "integrity": "sha512-U9e+k0XHwubeSIwsBYTNrTVH+0zF/ErSfuHfgTfuvlcKlhoGtFgAb7W8Qfe9FDF6TYTt0fJAJhSV2MdoExsgRA==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.100.0.tgz",
+      "integrity": "sha512-9Ul7O1eKrc5YlhwWjkp8tZPSe3UEwSZ1uwUZOQom1HL0pRlBA6F/IlGZYFTLwnHMIP1fc77MMNaBRfc05mKMpw==",
       "cpu": [
         "arm"
       ],
@@ -12427,17 +12931,14 @@
       "os": [
         "linux"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.70.0.tgz",
-      "integrity": "sha512-PzhBg5xlyXcZ8FgyjqAcVtfaq462l3KeEid2OxrsOzBQgdgJb0La1tAEOpP9jz7YOOTr9A96vm609W9fRLI2Iw==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.100.0.tgz",
+      "integrity": "sha512-Dwjmj8Z6VRy7rAi53JAdEwIyUjpfl7PhpSc2/LpQPQx+aO5Dp7Spaipkax0ufJl1SoDUdchCsM4y/88YaluorQ==",
       "cpu": [
         "arm64"
       ],
@@ -12446,36 +12947,14 @@
       "os": [
         "linux"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.70.0.tgz",
-      "integrity": "sha512-UOxTJywQRC/HzFQthlyNWJ07MX8EzKuTgH0N5T3XyXQTNuGeJQ8EPWY9fv1weLCjydVOEwm853F3djtUNmkCtg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.70.0.tgz",
-      "integrity": "sha512-8zudDFpAoNrQDujNYBKkq8nwl4i0jMmXcysO9Ou0llrzdY7Keok2z1aS3IbZy7AvUXtGaeYSHUi5lXdOalJ/QQ==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.100.0.tgz",
+      "integrity": "sha512-sl0JgbGloPyJg66XXx5UDSDScZ0oU85DpMQU4JU/sCUCFj1Z8zZ69SJWKTCNE4/jwnce7WI2zPCV5AG+RHOZJw==",
       "cpu": [
         "arm"
       ],
@@ -12489,9 +12968,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.70.0.tgz",
-      "integrity": "sha512-DJl1AV9W7T3SHzXFqAtyjPZy4O2g4AC6QctY5/aM42DTY/xpWOmwUBgsDzDoRbNqP7qDl+GtHLlggrLWCBP9fg==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.100.0.tgz",
+      "integrity": "sha512-XpACJB2KjSLjf2e9uuvGVdOURsoNrFqgRiihhXyUHK9W0t3LIHb7z5MA/7XGPIT9bWSOO2zyw+rH/FHtDV/Yrg==",
       "cpu": [
         "arm64"
       ],
@@ -12504,12 +12983,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.70.0.tgz",
-      "integrity": "sha512-CcAvT3KPc7cCJfTu1E0HzsAjE/dPQsKaXQD/nsBXNZo081R+lLR2u22wpXM2pnzMNJETRV/pDwozHoYEcPkPqQ==",
+    "node_modules/sass-embedded-linux-musl-riscv64": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.100.0.tgz",
+      "integrity": "sha512-ShvI0Kx04mwoCARwZ0UjiT97isQvzO80tAt91zmFyHLN9kelc/IrQi940farSm2xQVPCKdeVyeG0ekBsokSpYQ==",
       "cpu": [
-        "ia32"
+        "riscv64"
       ],
       "license": "MIT",
       "optional": true,
@@ -12521,11 +13000,27 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.70.0.tgz",
-      "integrity": "sha512-g3i9PKmqTxuyrM1Yeju1s4Fj6fzAGyyfzw/LiZZtq0ZZGhJXJMVvEDog/OxQ37eYxWqq9XHFTW2PphMvukVK0g==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.100.0.tgz",
+      "integrity": "sha512-TDBCRWNuS4RDLQXvRc1gjZlWiWTWaWGp0Bwu/IKwJxov81lsvrCs3TihTyNXtW7V5aoN4Ky3r0QOkNb3mwmBnA==",
       "cpu": [
         "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-riscv64": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.100.0.tgz",
+      "integrity": "sha512-j4ENJGOheO+fm3j/yorLxCjBP6/XskrZx7dTLlT+lXYwN/qqCqoA/gsNLI0McS3DFM6GBwPiffzWsdWS8t6sEQ==",
+      "cpu": [
+        "riscv64"
       ],
       "license": "MIT",
       "optional": true,
@@ -12537,9 +13032,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.93.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.93.0.tgz",
-      "integrity": "sha512-9OD9OlZ61dmz/BbW4n29l3v74//ibiQCmWu8YBoXVgxxgcbi+2CFv+vRE8guA73BgEdPComw0tpgD1FkW3v12g==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.100.0.tgz",
+      "integrity": "sha512-0vUSN8j0WGtCJIOPh//EmUvYGHW0QOe5iul8qyhPk50MAcw49MA0r34AhftjDdx94ILPF6vApFs0gwHPQRlpVA==",
       "cpu": [
         "x64"
       ],
@@ -12552,31 +13047,43 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.70.0.tgz",
-      "integrity": "sha512-TITx2QwJouhMwA0CAjCmnTNeCDL9g2fkLe9z+5rf39OdmcX9CEBrY4CNaO5REnMpgoa+o82u272ZR3oWrsUs8Q==",
+    "node_modules/sass-embedded-unknown-all": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.100.0.tgz",
+      "integrity": "sha512-c+naBgWId4MIpToXcI0DgqetjdAkwTTAxFAuOaBz7HUXLdyG1oZRrEvSsbe41nEdQOKH0vgofVFCeSQgoXOG9A==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!android",
+        "!darwin",
+        "!linux",
+        "!win32"
+      ],
+      "dependencies": {
+        "sass": "1.100.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-arm64": {
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.100.0.tgz",
+      "integrity": "sha512-iE+yxj+hUXwwbqpHkXxgAWTzeRfcWxJ7SSTQEPMk48lwq3oCrWLlz5sQuWHbuTK/i0GKQfROdP+hOmPi89yjUg==",
       "cpu": [
-        "ia32"
+        "arm64"
       ],
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.70.0.tgz",
-      "integrity": "sha512-rPe8WUdARhlfgIhGcCTGbTNgd6OppcmjtBrxUNoGs3AENSREQCpaNv5d+HBOMhGUfYgXIHUSiipilFUhLWpsrQ==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.100.0.tgz",
+      "integrity": "sha512-qI4F8MI7/KYoy9NdjJfhSspG42WPkADSNDvwEV7qWvCSFC83koJssRsKO2/PfY+niZz6BG65Ic/D+A11h959hw==",
       "cpu": [
-        "arm64",
         "x64"
       ],
       "license": "MIT",
@@ -12584,28 +13091,6 @@
       "os": [
         "win32"
       ],
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded/node_modules/sass-embedded-linux-x64": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.70.0.tgz",
-      "integrity": "sha512-F9F2CA7C6z/ROfF0U/jtYWknbDe9S/TJoCJ5TlHafwS+SrZE1A+Czf2MWJ+8mc2NFiRjYzYxt4Ad29cuc6rrhw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
@@ -12623,6 +13108,36 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/sass/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/sass/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/sax": {
@@ -13447,9 +13962,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.23.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.1.tgz",
-      "integrity": "sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==",
+      "version": "17.14.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.1.tgz",
+      "integrity": "sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==",
       "funding": [
         {
           "type": "opencollective",
@@ -13462,56 +13977,53 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4",
-        "@csstools/media-query-list-parser": "^4.0.3",
-        "@csstools/selector-specificity": "^5.0.0",
-        "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "balanced-match": "^2.0.0",
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^9.0.0",
-        "css-functions-list": "^3.2.3",
-        "css-tree": "^3.1.0",
-        "debug": "^4.4.1",
+        "cosmiconfig": "^9.0.2",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.2.1",
+        "debug": "^4.4.3",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^10.1.3",
+        "file-entry-cache": "^11.1.5",
         "global-modules": "^2.0.0",
-        "globby": "^11.1.0",
+        "globby": "^16.2.1",
         "globjoin": "^0.1.4",
-        "html-tags": "^3.3.1",
+        "html-tags": "^5.1.0",
         "ignore": "^7.0.5",
-        "imurmurhash": "^0.1.4",
-        "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.37.0",
-        "mathml-tag-names": "^2.1.3",
-        "meow": "^13.2.0",
+        "import-meta-resolve": "^4.2.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.1.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.5.6",
-        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss": "^8.5.16",
         "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^7.1.0",
+        "postcss-selector-parser": "^7.1.4",
         "postcss-value-parser": "^4.2.0",
-        "resolve-from": "^5.0.0",
-        "string-width": "^4.2.3",
-        "supports-hyperlinks": "^3.2.0",
+        "string-width": "^8.2.1",
+        "supports-hyperlinks": "^4.5.0",
         "svg-tags": "^1.0.0",
         "table": "^6.9.0",
-        "write-file-atomic": "^5.0.1"
+        "write-file-atomic": "^7.0.1"
       },
       "bin": {
         "stylelint": "bin/stylelint.mjs"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/stylelint-config-recommended": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
-      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+      "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
       "funding": [
         {
           "type": "opencollective",
@@ -13524,28 +14036,28 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.1.0"
+        "stylelint": "^17.0.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.1.0.tgz",
-      "integrity": "sha512-bhaMhh1u5dQqSsf6ri2GVWWQW5iUjBYgcHkh7SgDDn92ijoItC/cfO/W+fpXshgTQWhwFkP1rVcewcv4jaftRg==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-17.0.1.tgz",
+      "integrity": "sha512-x5DVehzJudcwF0od3sGpgkln2PLLranFE7twwbp7dqDINCyZvwzFkMc6TLhNOvazRiVBJYATQLouJY0xPGB8WA==",
       "license": "MIT",
       "dependencies": {
         "postcss-scss": "^4.0.9",
-        "stylelint-config-recommended": "^14.0.1",
-        "stylelint-scss": "^6.4.0"
+        "stylelint-config-recommended": "^18.0.0",
+        "stylelint-scss": "^7.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.6.1"
+        "stylelint": "^17.0.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -13554,9 +14066,9 @@
       }
     },
     "node_modules/stylelint-config-standard": {
-      "version": "36.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
-      "integrity": "sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==",
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
+      "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
       "funding": [
         {
           "type": "opencollective",
@@ -13569,30 +14081,30 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "stylelint-config-recommended": "^14.0.1"
+        "stylelint-config-recommended": "^18.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.1.0"
+        "stylelint": "^17.0.0"
       }
     },
     "node_modules/stylelint-config-standard-scss": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-13.1.0.tgz",
-      "integrity": "sha512-Eo5w7/XvwGHWkeGLtdm2FZLOMYoZl1omP2/jgFCXyl2x5yNz7/8vv4Tj6slHvMSSUNTaGoam/GAZ0ZhukvalfA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-17.0.0.tgz",
+      "integrity": "sha512-uLJS6xgOCBw5EMsDW7Ukji8l28qRoMnkRch15s0qwZpskXvWt9oPzMmcYM307m9GN4MxuWLsQh4I6hU9yI53cQ==",
       "license": "MIT",
       "dependencies": {
-        "stylelint-config-recommended-scss": "^14.0.0",
-        "stylelint-config-standard": "^36.0.0"
+        "stylelint-config-recommended-scss": "^17.0.0",
+        "stylelint-config-standard": "^40.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.3.1"
+        "stylelint": "^17.0.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -13601,9 +14113,9 @@
       }
     },
     "node_modules/stylelint-prettier": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-5.0.0.tgz",
-      "integrity": "sha512-RHfSlRJIsaVg5Br94gZVdWlz/rBTyQzZflNE6dXvSxt/GthWMY3gEHsWZEBaVGg7GM+XrtVSp4RznFlB7i0oyw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-5.0.3.tgz",
+      "integrity": "sha512-B6V0oa35ekRrKZlf+6+jA+i50C4GXJ7X1PPmoCqSUoXN6BrNF6NhqqhanvkLjqw2qgvrS0wjdpeC+Tn06KN3jw==",
       "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0"
@@ -13617,25 +14129,92 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.12.1.tgz",
-      "integrity": "sha512-UJUfBFIvXfly8WKIgmqfmkGKPilKB4L5j38JfsDd+OCg2GBdU0vGUV08Uw82tsRZzd4TbsUURVVNGeOhJVF7pA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-7.2.0.tgz",
+      "integrity": "sha512-6E79Bachv0Iz0gqRUZgdqdXCsiq26DWBWIBNHYtjTmAp3wJu6cp/I37VfW7BPntmh2puF3bY09XWl4HZGrLhzw==",
       "license": "MIT",
       "dependencies": {
-        "css-tree": "^3.0.1",
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.4",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "css-tree": "^3.2.1",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.36.0",
-        "mdn-data": "^2.21.0",
+        "known-css-properties": "^0.37.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.6",
-        "postcss-selector-parser": "^7.1.0",
+        "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.0.2"
+        "stylelint": "^16.8.2 || ^17.0.0"
+      }
+    },
+    "node_modules/stylelint-scss/node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/stylelint-scss/node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/stylelint-scss/node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/stylelint-scss/node_modules/is-plain-object": {
@@ -13647,60 +14226,198 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stylelint-scss/node_modules/known-css-properties": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.36.0.tgz",
-      "integrity": "sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==",
-      "license": "MIT"
+    "node_modules/stylelint/node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
     },
-    "node_modules/stylelint-scss/node_modules/mdn-data": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.24.0.tgz",
-      "integrity": "sha512-i97fklrJl03tL1tdRVw0ZfLLvuDsdb6wxL+TrJ+PKkCbLrp2PCu2+OYdCKychIUm19nSM/35S6qz7pJpnXttoA==",
-      "license": "CC0-1.0"
+    "node_modules/stylelint/node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
     },
-    "node_modules/stylelint/node_modules/balanced-match": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-      "license": "MIT"
+    "node_modules/stylelint/node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/@csstools/media-query-list-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
-      "integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.13"
+        "flat-cache": "^6.1.23"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "6.1.14",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.14.tgz",
-      "integrity": "sha512-ExZSCSV9e7v/Zt7RzCbX57lY2dnPdxzU/h3UE6WJ6NtEMfwBd8jmi1n4otDEUfz+T/R+zxrFDpICFdjhD3H/zw==",
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^2.0.1",
-        "flatted": "^3.3.3",
-        "hookified": "^1.12.0"
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
       }
     },
-    "node_modules/stylelint/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+    "node_modules/stylelint/node_modules/globby": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stylelint/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+    "node_modules/stylelint/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/stylis": {
@@ -13723,19 +14440,43 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.5.0.tgz",
+      "integrity": "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==",
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -13869,6 +14610,27 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sync-child-process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
+      "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
+      "license": "MIT",
+      "dependencies": {
+        "sync-message-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/sync-message-port": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.2.0.tgz",
+      "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/synckit": {
       "version": "0.8.8",
@@ -14355,6 +15117,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/universalify": {
@@ -14887,16 +15661,15 @@
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2821,9 +2821,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4003,9 +4003,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "1.34.17",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.17.tgz",
-      "integrity": "sha512-dWS53n21DWkjovpM4XRzdYQt/qSM+EMR2F6g1nlTynhnsHjV5cHvCq5ssnLLQ1TYcb07JExa7NfGLPIJOUrZbQ==",
+      "version": "1.34.18",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.34.18.tgz",
+      "integrity": "sha512-xYt83IDBsQiw+eK0tSYMSjEsOdKpfP4jX1evma6nlsZdW+pYX0VUZDI1GdxngDDAH1gkpruJXSsPdUnIghtV9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4015,8 +4015,8 @@
         "@opentelemetry/sdk-trace-node": "1.26.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "@redocly/config": "0.22.0",
-        "@redocly/openapi-core": "1.34.17",
-        "@redocly/respect-core": "1.34.17",
+        "@redocly/openapi-core": "1.34.18",
+        "@redocly/respect-core": "1.34.18",
         "abort-controller": "3.0.0",
         "chokidar": "3.5.3",
         "colorette": "1.4.0",
@@ -4026,7 +4026,7 @@
         "get-port-please": "3.0.1",
         "glob": "7.2.3",
         "handlebars": "4.7.9",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "mobx": "6.12.3",
         "pluralize": "8.0.0",
         "react": "^17.0.0 || ^18.2.0 || ^19.2.1",
@@ -4154,9 +4154,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.17",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
-      "integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
+      "version": "1.34.18",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.18.tgz",
+      "integrity": "sha512-UyKIm0wTPw5BcY7Z2PkbK1Ma260um96LSBWXHrdSMe+ZV0EPMyDfAcUcjjm3qEiGST9OK/1TriekdPCZkn4Q3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4165,7 +4165,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -4176,15 +4176,15 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "1.34.17",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.17.tgz",
-      "integrity": "sha512-CeLMA8AHeLjhW3bhGAo2XdqvVh4OH+Cv7LHEevgMT12QbYo+mX/KXZQJChcSNZ6cSRPv5Ky19KDB2wXzPZGJUA==",
+      "version": "1.34.18",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-1.34.18.tgz",
+      "integrity": "sha512-gMF4o3oscRFUcHtPTT3YP52sSMDyFYiMexOV/tZGvoJSZlh7h1G6SBveDpfHCYBk9iaUdhCEFWve3YHJk3LlRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "7.6.0",
         "@redocly/ajv": "8.11.2",
-        "@redocly/openapi-core": "1.34.17",
+        "@redocly/openapi-core": "1.34.18",
         "better-ajv-errors": "1.2.0",
         "colorette": "2.0.20",
         "concat-stream": "2.0.0",
@@ -4193,7 +4193,7 @@
         "form-data": "4.0.6",
         "jest-diff": "29.7.0",
         "jest-matcher-utils": "29.7.0",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "json-pointer": "0.6.2",
         "jsonpath-plus": "10.3.0",
         "open": "10.1.0",
@@ -5277,9 +5277,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -5876,9 +5876,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -7546,9 +7546,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7629,9 +7629,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -7747,9 +7747,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -8018,9 +8018,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8193,9 +8193,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -8625,9 +8625,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -13193,9 +13193,9 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -14672,9 +14672,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "react-test-renderer": "^17.0.2",
     "sinon": "^16.0.0",
     "sinon-chai": "^3.7.0",
-    "stylelint": "^16.2.1",
+    "stylelint": "^17.14.1",
     "svgo": "^3.2.0",
     "swr": "^2.0.0",
     "typescript": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   },
   "overrides": {
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "fast-xml-builder": "1.1.9",
     "form-data": "4.0.6",
     "js-yaml": "4.3.0",

--- a/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
+++ b/spec/controllers/concerns/idv/historical_attempts_concern_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
   let(:encrypted_existing_events) do
     pii_encryptor.encrypt(idv_attempts.to_json, user_uuid: user.uuid)
   end
+  let(:acr_values) { Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF }
 
   controller ApplicationController do
     include Idv::HistoricalAttemptsConcern
@@ -28,9 +29,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       current_sp: sp,
       current_user: user,
       sp_from_sp_session: sp,
-      sp_session: {
-        acr_values: Saml::Idp::Constants::DEFAULT_AAL_AUTHN_CONTEXT_CLASSREF,
-      },
+      sp_session: { acr_values: },
       user_session: { 'idv/attempts' => idv_attempts },
     )
     allow(IdentityConfig.store).to receive_messages(
@@ -39,9 +38,11 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       historical_attempts_api_enabled: true,
     )
 
-    allow(user.active_profile).to receive(:decrypt_user_proofing_events).and_return(
-      idv_attempts.to_json,
-    )
+    if user.active_profile.present?
+      allow(user.active_profile).to receive(:decrypt_user_proofing_events).and_return(
+        idv_attempts.to_json,
+      )
+    end
   end
 
   describe '#cache_user_proofing_events' do
@@ -70,7 +71,7 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
       context 'user does not have an active profile' do
         let(:user) { create(:user, :fully_registered, password:, profiles: []) }
         it 'does not attempt to decrypt events' do
-          expect(user.active_profile).to_not receive(:decrypt_user_proofing_events)
+          expect(AttemptsApi::Cacher).to_not receive(:save)
 
           controller.cache_user_proofing_events(password:)
         end
@@ -122,6 +123,43 @@ RSpec.describe Idv::HistoricalAttemptsConcern, type: :controller do
 
           it 'does not raise an error' do
             expect { controller.cache_user_proofing_events(password:) }.to_not raise_error
+          end
+        end
+      end
+    end
+  end
+
+  describe '#send_historic_events?' do
+    context 'the request is not an idv request' do
+      let(:acr_values) { Saml::Idp::Constants::IAL_AUTH_ONLY_ACR }
+      it 'returns false with a message' do
+        expect(controller.send_historic_events?).to eq([false, :idv_not_requested])
+      end
+    end
+
+    context 'when the request is an idv request' do
+      context 'when user proofing event does not exist' do
+        it 'returns false with a message' do
+          expect(controller.send_historic_events?).to eq([false, :no_user_proofing_event])
+        end
+      end
+
+      context 'when user proofing event exists' do
+        let(:service_provider_ids_sent) { [] }
+        before do
+          user.active_profile.build_user_proofing_event(service_provider_ids_sent:)
+        end
+
+        context 'when historic data have not been released to the service provider' do
+          it 'returns true with no message' do
+            expect(controller.send_historic_events?).to eq([true, nil])
+          end
+        end
+
+        context 'The events have already been released to the service provider' do
+          let(:service_provider_ids_sent) { [sp.id] }
+          it 'returns false with a message' do
+            expect(controller.send_historic_events?).to eq([false, :already_sent])
           end
         end
       end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -1226,6 +1226,15 @@ RSpec.describe Idv::EnterPasswordController do
               expect(event.profile_id).to eq(user.profiles.last.id)
             end
 
+            it 'tracks an analytic event' do
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+              expect(@analytics).to have_logged_event(
+                :historic_event_data_saved,
+                profile_id: user.profiles.last.id,
+              )
+            end
+
             it 'caches user proofing events' do
               put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
               data = controller.user_session[:encrypted_proofing_events]
@@ -1250,6 +1259,8 @@ RSpec.describe Idv::EnterPasswordController do
 
           it 'does not create a UserProofingEvent for the profile' do
             put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(@analytics).to_not have_logged_event(:historic_event_data_saved)
             expect(UserProofingEvent.count).to eq(0)
           end
         end
@@ -1260,6 +1271,8 @@ RSpec.describe Idv::EnterPasswordController do
 
         it 'does not create a UserProofingEvent for the profile' do
           put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+          expect(@analytics).to_not have_logged_event(:historic_event_data_saved)
           expect(UserProofingEvent.count).to eq(0)
         end
       end

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SignUp::CompletionsController do
         expect(response).to redirect_to account_url
       end
 
-      context 'IAL1' do
+      context 'auth only' do
         let(:user) { create(:user, :fully_registered, email: temporary_email) }
 
         before do
@@ -50,12 +50,12 @@ RSpec.describe SignUp::CompletionsController do
           )
         end
 
-        it 'creates a presenter object that is not requesting ial2' do
-          expect(assigns(:presenter).ial2_requested?).to eq false
+        it 'creates a presenter object that is not requesting idv' do
+          expect(assigns(:presenter).idv_requested?).to eq false
         end
       end
 
-      context 'IAL2' do
+      context 'identity verification' do
         let(:user) do
           create(:user, :fully_registered, profiles: [create(:profile, :verified, :active)])
         end
@@ -87,8 +87,8 @@ RSpec.describe SignUp::CompletionsController do
           )
         end
 
-        it 'creates a presenter object that is requesting ial2' do
-          expect(assigns(:presenter).ial2_requested?).to eq true
+        it 'creates a presenter object that is requesting idv' do
+          expect(assigns(:presenter).idv_requested?).to eq true
         end
 
         context 'user is not identity verified' do
@@ -134,15 +134,15 @@ RSpec.describe SignUp::CompletionsController do
         end
 
         context 'verified user' do
-          it 'creates a presenter object that is requesting ial2' do
-            expect(assigns(:presenter).ial2_requested?).to eq true
+          it 'creates a presenter object that is requesting idv' do
+            expect(assigns(:presenter).idv_requested?).to eq true
           end
         end
 
         context 'unverified user' do
           let(:user) { create(:user) }
-          it 'creates a presenter object that is requesting ial2' do
-            expect(assigns(:presenter).ial2_requested?).to eq false
+          it 'creates a presenter object that is requesting idv' do
+            expect(assigns(:presenter).idv_requested?).to eq false
           end
         end
       end
@@ -210,7 +210,7 @@ RSpec.describe SignUp::CompletionsController do
       allow(IdentityLinker).to receive(:new).and_return(@linker)
     end
 
-    context 'IAL1' do
+    context 'auth only' do
       let(:user) { create(:user, :fully_registered) }
       it 'tracks analytics' do
         stub_sign_in(user)
@@ -332,7 +332,7 @@ RSpec.describe SignUp::CompletionsController do
       end
     end
 
-    context 'IAL2' do
+    context 'identity verification' do
       it 'tracks analytics' do
         DisposableEmailDomain.create(name: 'temporary.com')
         user = create(

--- a/spec/controllers/sign_up/completions_controller_spec.rb
+++ b/spec/controllers/sign_up/completions_controller_spec.rb
@@ -232,6 +232,7 @@ RSpec.describe SignUp::CompletionsController do
           needs_completion_screen_reason: :new_sp,
           in_account_creation_flow: true,
         )
+        expect(@analytics).to_not have_logged_event(:historic_event_data_released)
       end
 
       it 'updates verified attributes' do
@@ -366,6 +367,7 @@ RSpec.describe SignUp::CompletionsController do
           in_person_proofing_status: 'passed',
           doc_auth_result: 'Passed',
         )
+        expect(@analytics).to_not have_logged_event(:historic_event_data_released)
       end
 
       it 'updates verified attributes' do
@@ -445,20 +447,72 @@ RSpec.describe SignUp::CompletionsController do
                 create(
                   :user_proofing_event,
                   :existing,
-                  profile_id: profile.id,
+                  profile_id: user.active_profile.id,
                 )
               end
 
-              it 'updates the associated user proofing event' do
-                expect(proofing_event.service_provider_ids_sent).to_not include(current_sp.id)
-                patch :update
+              context 'there is no user proofing event' do
+                it 'tracks analytics' do
+                  patch :update
 
-                proofing_event.reload
-                expect(AttemptsApi::Tracker).to have_received(:write_existing_user_events).with(
-                  historical_attempts: JSON.parse(idv_attempts),
-                  sp: current_sp,
-                )
-                expect(proofing_event.service_provider_ids_sent).to include(current_sp.id)
+                  expect(@analytics).to have_logged_event(
+                    :historic_event_data_released,
+                    success: false,
+                    exception: :no_user_proofing_event,
+                    profile_id: profile.id,
+                  )
+                end
+              end
+
+              context 'there is a user proofing event' do
+                let!(:proofing_event) do
+                  create(
+                    :user_proofing_event,
+                    :existing,
+                    profile_id: user.active_profile.id,
+                  )
+                end
+
+                context 'the profile does not have an encrypted_attempts_file_reference' do
+                  it 'tracks analytics' do
+                    patch :update
+
+                    expect(@analytics).to have_logged_event(
+                      :historic_event_data_released,
+                      success: false,
+                      exception: :no_encrypted_file_reference,
+                      profile_id: profile.id,
+                    )
+                  end
+                end
+
+                context 'the profile has an encrypted_attempts_file_reference' do
+                  before do
+                    user.active_profile.update(encrypted_attempts_file_reference: 'file-reference')
+                  end
+
+                  it 'updates the associated user proofing event' do
+                    expect(proofing_event.service_provider_ids_sent).to_not include(current_sp.id)
+                    patch :update
+
+                    proofing_event.reload
+                    expect(AttemptsApi::Tracker).to have_received(:write_existing_user_events).with(
+                      historical_attempts: JSON.parse(idv_attempts),
+                      sp: current_sp,
+                    )
+                    expect(proofing_event.service_provider_ids_sent).to include(current_sp.id)
+                  end
+
+                  it 'tracks analytics' do
+                    patch :update
+
+                    expect(@analytics).to have_logged_event(
+                      :historic_event_data_released,
+                      success: true,
+                      profile_id: profile.id,
+                    )
+                  end
+                end
               end
             end
 

--- a/spec/controllers/sign_up/registrations_controller_spec.rb
+++ b/spec/controllers/sign_up/registrations_controller_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe SignUp::RegistrationsController, devise: true do
       before do
         allow(IdentityConfig.store).to receive(:idv_available).and_return(false)
       end
-      it 'redirects to idv vendor outage page when ial2 requested' do
-        allow(controller).to receive(:ial2_requested?).and_return(true)
+      it 'redirects to idv vendor outage page when idv requested' do
+        allow(controller).to receive(:idv_requested?).and_return(true)
         get :new
         expect(response).to redirect_to(
           idv_unavailable_path(from: SignUp::RegistrationsController::CREATE_ACCOUNT),

--- a/spec/features/openid_connect/openid_connect_spec.rb
+++ b/spec/features/openid_connect/openid_connect_spec.rb
@@ -715,7 +715,7 @@ RSpec.describe 'OpenID Connect' do
       client_id: client_id,
       handoff_page_steps: proc do
         click_button t('webauthn_platform_recommended.skip')
-        expect(page).to have_content(t('titles.sign_up.completion_consent_expired_ial1'))
+        expect(page).to have_content(t('titles.sign_up.completion_consent_expired_auth_only'))
         expect(page).to_not have_content(t('titles.sign_up.completion_new_sp'))
 
         click_agree_and_continue
@@ -740,7 +740,7 @@ RSpec.describe 'OpenID Connect' do
       handoff_page_steps: proc do
         click_button t('webauthn_platform_recommended.skip')
         expect(page).to have_content(t('titles.sign_up.completion_new_sp'))
-        expect(page).to_not have_content(t('titles.sign_up.completion_consent_expired_ial1'))
+        expect(page).to_not have_content(t('titles.sign_up.completion_consent_expired_auth_only'))
 
         click_agree_and_continue
       end,

--- a/spec/jobs/reports/monthly_key_metrics_s3_report_spec.rb
+++ b/spec/jobs/reports/monthly_key_metrics_s3_report_spec.rb
@@ -1,0 +1,287 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reports::MonthlyKeyMetricsS3Report do
+  let(:report_date) { Date.new(2026, 3, 2).in_time_zone('UTC').end_of_day }
+  subject(:report) { described_class.new(report_date) }
+
+  let(:s3_report_bucket_prefix) { 'reports-bucket' }
+  let(:report_folder) do
+    'int/MonthlyKeyMetricsIdvS3Report/2026/2026-03-02.MonthlyKeyMetricsIdvS3Report'
+  end
+
+  let(:expected_s3_paths) do
+    [
+      "#{report_folder}/active_users_count.csv",
+      "#{report_folder}/total_user_count.csv",
+      "#{report_folder}/condensed_idv.csv",
+      "#{report_folder}/proofing_rate_metrics.csv",
+      "#{report_folder}/account_deletion_rate.csv",
+      "#{report_folder}/account_reuse.csv",
+      "#{report_folder}/agency_and_sp_counts.csv",
+      "#{report_folder}/active_users_count_apg.csv",
+    ]
+  end
+
+  let(:s3_metadata) do
+    {
+      body: anything,
+      content_type: 'text/csv',
+      bucket: 'reports-bucket.1234-us-west-1',
+    }
+  end
+
+  let(:s3_metadata) do
+    {
+      body: anything,
+      content_type: 'text/csv',
+      bucket: 'reports-bucket.1234-us-west-1',
+    }
+  end
+
+  let(:mock_all_login_emails) { ['mock_feds@example.com', 'mock_contractors@example.com'] }
+  let(:mock_daily_reports_emails) { ['mock_agnes@example.com', 'mock_daily@example.com'] }
+
+  let(:condensed_idv_table) { [['Metric', 'Mar 2026'], ['IDV started', 100]] }
+  let(:proofing_rate_table) { [['Metric', 'Trailing 30d'], ['IDV Started', 100]] }
+
+  let(:condensed_idv_emailable_report) do
+    Reporting::EmailableReport.new(
+      title: 'Proofing Rate Metrics',
+      subtitle: 'Condensed (NEW)',
+      float_as_percent: true,
+      precision: 2,
+      table: condensed_idv_table,
+      filename: 'condensed_idv',
+    )
+  end
+
+  let(:proofing_rate_emailable_report) do
+    Reporting::EmailableReport.new(
+      subtitle: 'Detail',
+      float_as_percent: true,
+      precision: 2,
+      table: proofing_rate_table,
+      filename: 'proofing_rate_metrics',
+    )
+  end
+
+  let(:idv_s3_report) do
+    instance_double(
+      Reporting::MonthlyKeyMetricsIdvS3Report,
+      csv_file_names: %w[condensed_idv proofing_rate_metrics],
+      condensed_idv_emailable_report: condensed_idv_emailable_report,
+      proofing_rate_emailable_report: proofing_rate_emailable_report,
+    )
+  end
+
+  # All IDV files exist and are fresh by default.
+  let(:fresh_last_modified) { 1.day.ago }
+
+  before do
+    allow(Identity::Hostdata).to receive(:env).and_return('int')
+    allow(Identity::Hostdata).to receive(:aws_account_id).and_return('1234')
+    allow(Identity::Hostdata).to receive(:aws_region).and_return('us-west-1')
+    allow(IdentityConfig.store).to receive(:s3_report_bucket_prefix)
+      .and_return(s3_report_bucket_prefix)
+    allow(IdentityConfig.store).to receive(:s3_data_warehouse_replica_bucket_prefix)
+      .and_return('data-warehouse-bucket')
+
+    Aws.config[:s3] = {
+      stub_responses: {
+        put_object: {},
+      },
+    }
+
+    allow(report).to receive(:idv_s3_report).and_return(idv_s3_report)
+    allow(idv_s3_report).to receive(:get_file_last_modified)
+      .and_return(fresh_last_modified)
+
+    allow(IdentityConfig.store).to receive(:team_daily_reports_emails)
+      .and_return(mock_daily_reports_emails)
+    allow(IdentityConfig.store).to receive(:team_all_login_emails)
+      .and_return(mock_all_login_emails)
+  end
+
+  it 'sends out a report to just team agnes' do
+    expect(ReportMailer).to receive(:tables_report).once.with(
+      to: anything,
+      subject: 'Monthly Key Metrics Report NEW - 2026-03-02',
+      reports: anything,
+      message: report.preamble,
+      attachment_format: :xlsx,
+    ).and_call_original
+
+    report.perform(report_date)
+  end
+
+  context 'when queued from the first of the month' do
+    let(:report_date) { Date.new(2026, 3, 1).prev_day }
+
+    it 'sends out a report to everybody' do
+      expect(ReportMailer).to receive(:tables_report).once.with(
+        to: anything,
+        subject: 'Monthly Key Metrics Report NEW - 2026-02-28',
+        reports: anything,
+        message: report.preamble,
+        attachment_format: :xlsx,
+      ).and_call_original
+
+      report.perform(report_date)
+    end
+  end
+
+  it 'does not send out a report with no emails' do
+    allow(IdentityConfig.store).to receive(:team_daily_reports_emails).and_return('')
+
+    expect(report).to_not receive(:reports)
+    expect(ReportMailer).not_to receive(:tables_report)
+
+    report.perform(report_date)
+  end
+
+  it 'uploads a file to S3 based on the report date' do
+    expected_s3_paths.each do |path|
+      expect(subject).to receive(:upload_file_to_s3_bucket).with(
+        path: path,
+        **s3_metadata,
+      ).exactly(1).time.and_call_original
+    end
+
+    report.perform(report_date)
+  end
+
+  describe 'IDV S3 report availability' do
+    context 'when an IDV file is missing' do
+      before do
+        allow(idv_s3_report).to receive(:get_file_last_modified)
+          .with('condensed_idv')
+          .and_raise(Aws::S3::Errors::NoSuchKey.new(nil, 'Key not found'))
+      end
+
+      it 'aborts the whole report and does not email or upload' do
+        expect(report).to_not receive(:reports)
+        expect(report).to_not receive(:upload_to_s3)
+        expect(ReportMailer).to_not receive(:tables_report)
+
+        expect(report.perform(report_date)).to eq(false)
+      end
+
+      it 'logs an error' do
+        expect(Rails.logger).to receive(:error).at_least(:once)
+
+        report.perform(report_date)
+      end
+    end
+
+    context 'when an IDV file is stale' do
+      before do
+        allow(idv_s3_report).to receive(:get_file_last_modified)
+          .with('condensed_idv')
+          .and_return((described_class::MAX_FILE_AGE_DAYS + 1).days.ago)
+        allow(idv_s3_report).to receive(:get_file_last_modified)
+          .with('proofing_rate_metrics')
+          .and_return(fresh_last_modified)
+      end
+
+      it 'aborts the whole report' do
+        expect(report).to_not receive(:reports)
+        expect(ReportMailer).to_not receive(:tables_report)
+
+        expect(report.perform(report_date)).to eq(false)
+      end
+    end
+
+    context 'when the data warehouse bucket name is blank' do
+      before do
+        allow(IdentityConfig.store).to receive(:s3_data_warehouse_replica_bucket_prefix)
+          .and_return('')
+        allow(Identity::Hostdata).to receive(:aws_account_id).and_return('')
+        allow(Identity::Hostdata).to receive(:aws_region).and_return('')
+      end
+
+      it 'aborts when bucket resolves to blank' do
+        # data_warehouse_bucket_name builds from prefix-account-region; force fully blank
+        allow(report).to receive(:data_warehouse_bucket_name).and_return('')
+
+        expect(ReportMailer).to_not receive(:tables_report)
+        expect(report.perform(report_date)).to eq(false)
+      end
+    end
+
+    context 'when all IDV files exist and are fresh' do
+      it 'proceeds to send the report' do
+        expect(ReportMailer).to receive(:tables_report).and_call_original
+
+        report.perform(report_date)
+      end
+    end
+  end
+
+  describe '#reports' do
+    it 'includes the IDV reports sourced from the S3 reader in the correct positions' do
+      reports = report.reports
+
+      expect(reports[2]).to eq(condensed_idv_emailable_report)
+      expect(reports[3]).to eq(proofing_rate_emailable_report)
+      expect(reports.size).to eq(8)
+    end
+  end
+
+  describe '#idv_s3_path' do
+    before do
+      # Use the real method (un-stub idv_s3_report side effects don't matter here).
+      allow(report).to receive(:generate_base_s3_path)
+        .with(directory: 'idp')
+        .and_return('int/')
+    end
+
+    it 'builds the prefix matching reporting-rails paths_for' do
+      expect(report.idv_s3_path).to eq(
+        'int/MonthlyKeyMetricsIdvS3Report/2026/03/20260302_monthly',
+      )
+    end
+  end
+
+  describe '#emails' do
+    context 'on the first of the month' do
+      let(:report_date) { Date.new(2026, 3, 1).prev_day }
+
+      it 'emails the whole login team' do
+        expected_array = mock_daily_reports_emails + mock_all_login_emails
+        expect(report.emails).to match_array(expected_array)
+      end
+    end
+
+    context 'during the rest of the month' do
+      let(:report_date) { Date.new(2026, 3, 2).prev_day }
+
+      it 'only emails team_daily_reports' do
+        expect(report.emails).to match_array(mock_daily_reports_emails)
+      end
+    end
+  end
+
+  describe '#preamble' do
+    let(:env) { 'prod' }
+    subject(:preamble) { report.preamble(env:) }
+
+    it 'has a preamble that is valid HTML' do
+      expect(preamble).to be_html_safe
+      expect { Nokogiri::XML(preamble) { |config| config.strict } }.to_not raise_error
+    end
+
+    context 'in a non-prod environment' do
+      let(:env) { 'staging' }
+
+      it 'has an alert with the environment name' do
+        expect(preamble).to be_html_safe
+
+        doc = Nokogiri::XML(preamble)
+        alert = doc.at_css('.usa-alert')
+        expect(alert.text).to include(env)
+      end
+    end
+  end
+end

--- a/spec/lib/reporting/monthly_key_metrics_s3_report_spec.rb
+++ b/spec/lib/reporting/monthly_key_metrics_s3_report_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'reporting/monthly_key_metrics_idv_s3_report'
+
+RSpec.describe Reporting::MonthlyKeyMetricsIdvS3Report do
+  let(:bucket_name) { 'test-bucket' }
+  let(:custom_s3_path) { 'idp/MonthlyKeyMetricsIdvS3Report/2021/03/20210302_monthly' }
+  let(:s3_client) { instance_double(Aws::S3::Client) }
+  let(:s3_helper) { instance_double(JobHelpers::S3Helper) }
+
+  let(:report_reader) do
+    described_class.new(
+      bucket_name: bucket_name,
+      custom_s3_path: custom_s3_path,
+    )
+  end
+
+  before do
+    allow(JobHelpers::S3Helper).to receive(:new).and_return(s3_helper)
+    allow(s3_helper).to receive(:s3_client).and_return(s3_client)
+  end
+
+  describe '#initialize' do
+    it 'sets the required attributes' do
+      expect(report_reader.bucket_name).to eq(bucket_name)
+      expect(report_reader.s3_path).to eq(custom_s3_path)
+    end
+  end
+
+  describe '#csv_file_names' do
+    it 'returns the expected file names' do
+      expect(report_reader.csv_file_names).to eq(
+        %w[condensed_idv proofing_rate_metrics],
+      )
+    end
+  end
+
+  describe '#csv_data_for' do
+    let(:csv_content) { "Metric,Trailing 30d\nIDV Started,100\nBlanket Proofing Rate,0.8534" }
+    let(:s3_response) do
+      instance_double(Aws::S3::Types::GetObjectOutput, body: StringIO.new(csv_content))
+    end
+
+    before do
+      allow(s3_client).to receive(:get_object).and_return(s3_response)
+    end
+
+    it 'fetches CSV from the correct key' do
+      report_reader.csv_data_for('proofing_rate_metrics')
+
+      expect(s3_client).to have_received(:get_object).with(
+        bucket: bucket_name,
+        key: "#{custom_s3_path}_proofing_rate_metrics.csv",
+      )
+    end
+
+    it 'coerces integer-looking cells to Integer' do
+      result = report_reader.csv_data_for('proofing_rate_metrics')
+
+      idv_started_row = result.find { |row| row.first == 'IDV Started' }
+      expect(idv_started_row.last).to eq(100)
+      expect(idv_started_row.last).to be_a(Integer)
+    end
+
+    it 'coerces decimal-looking cells to Float (so float_as_percent works)' do
+      result = report_reader.csv_data_for('proofing_rate_metrics')
+
+      rate_row = result.find { |row| row.first == 'Blanket Proofing Rate' }
+      expect(rate_row.last).to eq(0.8534)
+      expect(rate_row.last).to be_a(Float)
+    end
+
+    it 'leaves non-numeric cells (labels/headers) as Strings' do
+      result = report_reader.csv_data_for('proofing_rate_metrics')
+
+      expect(result.first).to eq(['Metric', 'Trailing 30d'])
+      expect(result.first).to all(be_a(String))
+    end
+
+    it 'memoizes the result' do
+      report_reader.csv_data_for('condensed_idv')
+      report_reader.csv_data_for('condensed_idv')
+
+      expect(s3_client).to have_received(:get_object).once
+    end
+
+    it 'fetches different reports independently' do
+      report_reader.csv_data_for('condensed_idv')
+      report_reader.csv_data_for('proofing_rate_metrics')
+
+      expect(s3_client).to have_received(:get_object).twice
+    end
+
+    context 'when S3 file does not exist' do
+      before do
+        allow(s3_client).to receive(:get_object).and_raise(
+          Aws::S3::Errors::NoSuchKey.new(nil, 'Key not found'),
+        )
+      end
+
+      it 'logs an error and re-raises' do
+        expect(Rails.logger).to receive(:error)
+          .with(/Unexpected failure reading CSV file from S3/)
+
+        expect { report_reader.csv_data_for('condensed_idv') }
+          .to raise_error(Aws::S3::Errors::NoSuchKey)
+      end
+    end
+  end
+
+  describe 'coerce_cell edge cases' do
+    let(:csv_content) do
+      "Label,Value\nEmpty,\nNegative,-5\nNegativeFloat"\
+      ",-0.25\nLeadingDot,.5\nDate,2026-05-31\nMixed,12abc"
+    end
+    let(:s3_response) do
+      instance_double(Aws::S3::Types::GetObjectOutput, body: StringIO.new(csv_content))
+    end
+
+    before do
+      allow(s3_client).to receive(:get_object).and_return(s3_response)
+    end
+
+    it 'handles empties, negatives, decimals, dates, and mixed strings correctly' do
+      rows = report_reader.csv_data_for('condensed_idv').to_h { |r| [r.first, r.last] }
+
+      expect(rows['Empty']).to be_nil # CSV.parse yields nil for trailing empty cell
+      expect(rows['Negative']).to eq(-5).and be_a(Integer)
+      expect(rows['NegativeFloat']).to eq(-0.25).and be_a(Float)
+      expect(rows['LeadingDot']).to eq(0.5).and be_a(Float)
+      expect(rows['Date']).to eq('2026-05-31') # left as String, not coerced
+      expect(rows['Mixed']).to eq('12abc') # left as String
+    end
+  end
+
+  describe '#get_file_last_modified' do
+    let(:last_modified) { Time.zone.now - 1.day }
+    let(:head_response) do
+      instance_double(Aws::S3::Types::HeadObjectOutput, last_modified: last_modified)
+    end
+
+    before do
+      allow(s3_client).to receive(:head_object).and_return(head_response)
+    end
+
+    it 'returns the last modified time for the correct key' do
+      result = report_reader.get_file_last_modified('condensed_idv')
+
+      expect(s3_client).to have_received(:head_object).with(
+        bucket: bucket_name,
+        key: "#{custom_s3_path}_condensed_idv.csv",
+      )
+      expect(result).to eq(last_modified)
+    end
+
+    context 'when file does not exist' do
+      before do
+        allow(s3_client).to receive(:head_object).and_raise(
+          Aws::S3::Errors::NoSuchKey.new(nil, 'Key not found'),
+        )
+      end
+
+      it 'raises NoSuchKey' do
+        expect { report_reader.get_file_last_modified('condensed_idv') }
+          .to raise_error(Aws::S3::Errors::NoSuchKey)
+      end
+    end
+  end
+
+  describe 'emailable reports' do
+    let(:table) { [['Metric', 'Trailing 30d'], ['IDV Started', 100]] }
+
+    before do
+      allow(report_reader).to receive(:condensed_idv_table).and_return(table)
+      allow(report_reader).to receive(:proofing_rate_table).and_return(table)
+    end
+
+    describe '#as_emailable_reports' do
+      it 'returns both EmailableReports in order' do
+        reports = report_reader.as_emailable_reports
+
+        expect(reports).to all(be_a(Reporting::EmailableReport))
+        expect(reports.size).to eq(2)
+        expect(reports[0].filename).to eq('condensed_idv')
+        expect(reports[1].filename).to eq('proofing_rate_metrics')
+      end
+    end
+
+    describe '#condensed_idv_emailable_report' do
+      subject(:report) { report_reader.condensed_idv_emailable_report }
+
+      it 'mirrors MonthlyIdvReport formatting' do
+        expect(report.title).to eq('Proofing Rate Metrics')
+        expect(report.subtitle).to eq('Condensed (NEW)')
+        expect(report.float_as_percent).to eq(true)
+        expect(report.precision).to eq(2)
+        expect(report.filename).to eq('condensed_idv')
+        expect(report.table).to eq(table)
+      end
+    end
+
+    describe '#proofing_rate_emailable_report' do
+      subject(:report) { report_reader.proofing_rate_emailable_report }
+
+      it 'mirrors ProofingRateReport formatting' do
+        expect(report.subtitle).to eq('Detail')
+        expect(report.float_as_percent).to eq(true)
+        expect(report.precision).to eq(2)
+        expect(report.filename).to eq('proofing_rate_metrics')
+        expect(report.table).to eq(table)
+      end
+    end
+  end
+
+  describe 'table methods' do
+    let(:csv_data) { [['header'], ['data']] }
+
+    before do
+      allow(report_reader).to receive(:csv_data_for).and_return(csv_data)
+    end
+
+    it '#condensed_idv_table reads the condensed_idv file' do
+      expect(report_reader.condensed_idv_table).to eq(csv_data)
+      expect(report_reader).to have_received(:csv_data_for).with('condensed_idv')
+    end
+
+    it '#proofing_rate_table reads the proofing_rate_metrics file' do
+      expect(report_reader.proofing_rate_table).to eq(csv_data)
+      expect(report_reader).to have_received(:csv_data_for).with('proofing_rate_metrics')
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2189,12 +2189,18 @@ RSpec.describe User do
 
       describe 'historical_attempts_api_enabled is true' do
         let(:historical_attempts_api_enabled) { true }
+        before { allow(user.analytics).to receive(:historic_event_data_destroyed) }
 
         it 'deletes the event bundle' do
           expect(user_proofing_event.decrypt_events(password:)).to eq(attempt_events.to_json)
           user.destroy
 
           expect(user_proofing_event.decrypt_events(password:)).to be nil
+        end
+
+        it 'tracks an analytics event' do
+          user.destroy
+          expect(user.analytics).to have_received(:historic_event_data_destroyed)
         end
         describe 'when a user has multiple profiles with data' do
           let(:profile1) do
@@ -2219,6 +2225,11 @@ RSpec.describe User do
 
             expect(user_proofing_event.decrypt_events(password:)).to be nil
             expect(deactivated_user_proofing_event.decrypt_events(password:)).to be nil
+          end
+
+          it 'only tracks one analytic event' do
+            user.destroy
+            expect(user.analytics).to have_received(:historic_event_data_destroyed).once
           end
         end
       end

--- a/spec/presenters/completions_presenter_spec.rb
+++ b/spec/presenters/completions_presenter_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CompletionsPresenter do
       :verified_at
     ]
   end
-  let(:ial2_requested) { false }
+  let(:idv_requested) { false }
   let(:completion_context) { :new_sp }
 
   subject(:presenter) do
@@ -46,23 +46,23 @@ RSpec.describe CompletionsPresenter do
       current_sp:,
       decrypted_pii:,
       requested_attributes:,
-      ial2_requested:,
+      idv_requested:,
       completion_context:,
       selected_email_id:,
     )
   end
 
   describe '#heading' do
-    context 'ial2 sign in' do
-      let(:ial2_requested) { true }
+    context 'idv sign in' do
+      let(:idv_requested) { true }
 
-      it 'renders the ial2 message' do
+      it 'renders the idv message' do
         expect(presenter.heading).to eq(
-          I18n.t('titles.sign_up.completion_ial2', sp: current_sp.friendly_name),
+          I18n.t('titles.sign_up.completion_idv', sp: current_sp.friendly_name),
         )
       end
 
-      context 'renders the ial2 consent message if consent expired' do
+      context 'renders the idv consent message if consent expired' do
         let(:identities) do
           [
             build(
@@ -76,7 +76,7 @@ RSpec.describe CompletionsPresenter do
 
         it 'renders the expired consent message' do
           expect(presenter.heading).to eq(
-            I18n.t('titles.sign_up.completion_consent_expired_ial2'),
+            I18n.t('titles.sign_up.completion_consent_expired_idv'),
           )
         end
       end
@@ -90,7 +90,7 @@ RSpec.describe CompletionsPresenter do
       end
     end
 
-    context 'consent has expired since the last sign in with ial1' do
+    context 'consent has expired since the last sign in with auth only' do
       let(:identities) do
         [
           build(
@@ -104,7 +104,7 @@ RSpec.describe CompletionsPresenter do
 
       it 'renders the expired consent message' do
         expect(presenter.heading).to eq(
-          I18n.t('titles.sign_up.completion_consent_expired_ial1'),
+          I18n.t('titles.sign_up.completion_consent_expired_auth_only'),
         )
       end
     end
@@ -192,8 +192,8 @@ RSpec.describe CompletionsPresenter do
       end
     end
 
-    describe 'ial2' do
-      let(:ial2_requested) { true }
+    describe 'idv' do
+      let(:idv_requested) { true }
 
       context 'consent has expired since the last sign in' do
         let(:identities) do
@@ -238,7 +238,7 @@ RSpec.describe CompletionsPresenter do
         end
         let(:completion_context) { :reverified_after_consent }
 
-        it 'renders the reverified IAL2 consent intro message' do
+        it 'renders the reverified IDV consent intro message' do
           expect(presenter.intro).to eq(
             t(
               'help_text.requested_attributes.ial2_reverified_consent_info_html',
@@ -253,7 +253,7 @@ RSpec.describe CompletionsPresenter do
   describe '#pii' do
     subject(:pii) { presenter.pii }
 
-    context 'ial1' do
+    context 'auth only' do
       context 'with a subset of attributes requested' do
         let(:requested_attributes) { [:email] }
 
@@ -291,8 +291,8 @@ RSpec.describe CompletionsPresenter do
       end
     end
 
-    context 'ial2' do
-      let(:ial2_requested) { true }
+    context 'idv' do
+      let(:idv_requested) { true }
 
       context 'with a subset of attributes requested' do
         let(:requested_attributes) { [:email, :given_name, :phone] }

--- a/spec/presenters/idv/in_person/verification_results_email_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/verification_results_email_presenter_spec.rb
@@ -77,21 +77,30 @@ RSpec.describe Idv::InPerson::VerificationResultsEmailPresenter do
     end
   end
 
-  describe '#service_provider_homepage_url' do
+  describe '#service_provider_post_idv_follow_up_url' do
     context 'without service provider' do
       let(:sp) { nil }
 
       it 'returns nil' do
-        expect(presenter.service_provider_homepage_url).to eq(nil)
+        expect(presenter.service_provider_post_idv_follow_up_url).to eq(nil)
       end
     end
 
     context 'with service provider' do
-      let(:sp_url) { 'https://service.provider.gov' }
-      let(:sp) { create(:service_provider, return_to_sp_url: sp_url) }
+      let(:follow_up_url) { 'https://service.provider.gov/follow_up' }
+      let(:sp) { create(:service_provider, post_idv_follow_up_url: follow_up_url) }
 
-      it 'returns SP homepage url' do
-        expect(presenter.service_provider_homepage_url).to eq(sp_url)
+      it 'returns SP post IdV follow-up url' do
+        expect(presenter.service_provider_post_idv_follow_up_url).to eq(follow_up_url)
+      end
+    end
+
+    context 'with service provider that only has a return_to_sp_url' do
+      let(:sp_url) { 'https://service.provider.gov' }
+      let(:sp) { create(:service_provider, return_to_sp_url: sp_url, post_idv_follow_up_url: nil) }
+
+      it 'falls back to the SP homepage url' do
+        expect(presenter.service_provider_post_idv_follow_up_url).to eq(sp_url)
       end
     end
   end
@@ -104,23 +113,35 @@ RSpec.describe Idv::InPerson::VerificationResultsEmailPresenter do
     end
 
     context 'with service provider' do
+      let(:post_idv_follow_up_url) { nil }
       let(:homepage_url) { nil }
       let(:sp) { create(:service_provider) }
 
       before do
         resolver = instance_double(SpReturnUrlResolver)
+        allow(resolver).to receive(:post_idv_follow_up_url).and_return(post_idv_follow_up_url)
         allow(resolver).to receive(:homepage_url).and_return(homepage_url)
         allow(presenter).to receive(:sp_return_url_resolver).and_return(resolver)
       end
 
-      context 'without homepage_url' do
-        let(:homepage_url) { nil }
+      context 'without post_idv_follow_up_url' do
+        let(:post_idv_follow_up_url) { nil }
 
-        it { expect(presenter.show_cta?).to eq(false) }
+        context 'without homepage_url' do
+          let(:homepage_url) { nil }
+
+          it { expect(presenter.show_cta?).to eq(false) }
+        end
+
+        context 'with homepage_url' do
+          let(:homepage_url) { 'https://example.com' }
+
+          it { expect(presenter.show_cta?).to eq(true) }
+        end
       end
 
-      context 'with homepage_url' do
-        let(:homepage_url) { 'https://example.com' }
+      context 'with post_idv_follow_up_url' do
+        let(:post_idv_follow_up_url) { 'https://example.com' }
 
         it { expect(presenter.show_cta?).to eq(true) }
       end
@@ -137,20 +158,30 @@ RSpec.describe Idv::InPerson::VerificationResultsEmailPresenter do
     end
 
     context 'with service provider' do
+      let(:post_idv_follow_up_url) { nil }
       let(:homepage_url) { nil }
       let(:sp) { create(:service_provider) }
 
       before do
         resolver = instance_double(SpReturnUrlResolver)
+        allow(resolver).to receive(:post_idv_follow_up_url).and_return(post_idv_follow_up_url)
         allow(resolver).to receive(:homepage_url).and_return(homepage_url)
         allow(SpReturnUrlResolver).to receive(:new).with(service_provider: sp).and_return(resolver)
       end
 
-      context 'without homepage_url' do
-        let(:homepage_url) { nil }
+      context 'without post_idv_follow_up_url' do
+        let(:post_idv_follow_up_url) { nil }
 
         it 'returns root url' do
           expect(presenter.sign_in_url).to eq(root_url)
+        end
+      end
+
+      context 'with post_idv_follow_up_url' do
+        let(:post_idv_follow_up_url) { 'https://example.com' }
+
+        it 'returns post IdV follow-up url' do
+          expect(presenter.sign_in_url).to eq(post_idv_follow_up_url)
         end
       end
 
@@ -186,7 +217,7 @@ RSpec.describe Idv::InPerson::VerificationResultsEmailPresenter do
       context 'without homepage_url' do
         let(:homepage_url) { nil }
 
-        it 'returns root url' do
+        it 'returns nil' do
           expect(presenter.service_provider_homepage_url).to be_nil
         end
       end

--- a/spec/support/features/idv_helper.rb
+++ b/spec/support/features/idv_helper.rb
@@ -201,7 +201,7 @@ module IdvHelper
     expect(user.identity_verified?).to be(true)
     expect(page).to have_current_path sign_up_completed_path
     expect(page).to have_content t(
-      'titles.sign_up.completion_ial2',
+      'titles.sign_up.completion_idv',
       sp: 'Test SP',
     )
   end

--- a/spec/support/idv_examples/sp_handoff.rb
+++ b/spec/support/idv_examples/sp_handoff.rb
@@ -21,7 +21,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       acknowledge_and_confirm_personal_key
 
       expect(page).to have_content t(
-        'titles.sign_up.completion_ial2',
+        'titles.sign_up.completion_idv',
         sp: 'Test SP',
       )
       expect_csp_headers_to_be_present if sp == :oidc
@@ -51,7 +51,7 @@ RSpec.shared_examples 'sp handoff after identity verification' do |sp|
       acknowledge_and_confirm_personal_key
 
       expect(page).to have_content t(
-        'titles.sign_up.completion_ial2',
+        'titles.sign_up.completion_idv',
         sp: 'Test SP',
       )
       expect_csp_headers_to_be_present if sp == :oidc

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
   let(:selected_email_id) { user.email_addresses.first.id }
   let(:decrypted_pii) { {} }
   let(:requested_attributes) { [:email] }
-  let(:ial2_requested) { false }
+  let(:idv_requested) { false }
   let(:completion_context) { :new_sp }
 
   let(:view_context) { ActionController::Base.new.view_context }
@@ -25,7 +25,7 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
       current_sp: service_provider,
       decrypted_pii:,
       requested_attributes:,
-      ial2_requested:,
+      idv_requested:,
       completion_context:,
       selected_email_id:,
     )
@@ -86,8 +86,8 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
     end
   end
 
-  context 'ial2' do
-    let(:ial2_requested) { true }
+  context 'idv' do
+    let(:idv_requested) { true }
     let(:requested_attributes) { [:email, :social_security_number, :verified_at] }
     let(:decrypted_pii) do
       {


### PR DESCRIPTION
## User-Facing Improvements
- Identity Verification: Update in-person verified email to new format with partner agency CTA ([#13320](https://github.com/18F/identity-idp/pull/13320))
- Duplicate Accounts: Updating language for clarity regarding service provider requirements ([#13323](https://github.com/18F/identity-idp/pull/13323))

## Internal
- CI: Update kubectl image to use pull-through cache instead of dockerhub directly ([#13329](https://github.com/18F/identity-idp/pull/13329))
- Dependencies: Bump build-sass and stylelint-config dependencies ([#13327](https://github.com/18F/identity-idp/pull/13327))
- Historic Attempts Analytics: Add analytic events for Historic Attempt data capture and release ([#13289](https://github.com/18F/identity-idp/pull/13289))
- Refactoring: Rename ial2 to idv when only identity verification is implied ([#13322](https://github.com/18F/identity-idp/pull/13322))
- Refactoring: Rename ial2 to idv in RegistrationsController and ApplicationHelper ([#13332](https://github.com/18F/identity-idp/pull/13332))
- npm audit fix: Fix ([#13328](https://github.com/18F/identity-idp/pull/13328))
- reporting: Create job to ingest and email demographics report from S3 bucket ([#13221](https://github.com/18F/identity-idp/pull/13221))
