### PR TITLE
Prevent AAMVA from overriding an address failure when the address is …

### DIFF
--- a/app/controllers/idv/verify_info_controller.rb
+++ b/app/controllers/idv/verify_info_controller.rb
@@ -88,6 +88,10 @@ module Idv
         ssn: idv_session.ssn,
         consent_given_at: idv_session.idv_consent_given_at,
         aamva_verified_attributes: idv_session.aamva_verified_attributes,
+        # AAMVA ran against the document address at doc auth. Tell the adjudicator when the user
+        # has since changed their residential address, so a verified AAMVA address cannot cover an
+        # InstantVerify failure for an address AAMVA never saw.
+        address_edited: !!idv_session.address_edited,
         **idv_session.updated_user_address.to_h,
       ).with_indifferent_access
     end

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -161,8 +161,17 @@ module Proofing
 
         failed_resolution_attributes =
           resolution_result.attributes_requiring_additional_verification
-        passed_state_id_attributes = applicant_pii[:aamva_verified_attributes].to_a.map(&:to_sym)
         (failed_resolution_attributes.to_a - passed_state_id_attributes).empty?
+      end
+
+      # AAMVA verifies the address printed on the identity document. If the user edited their
+      # address afterwards, resolution proofed a different address than the one AAMVA verified,
+      # so the AAMVA response can no longer cover an address failure.
+      def passed_state_id_attributes
+        attributes = applicant_pii[:aamva_verified_attributes].to_a.map(&:to_sym)
+        return attributes unless applicant_pii[:address_edited] == true
+
+        attributes - [:address]
       end
 
       def biographical_info

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -161,17 +161,17 @@ module Proofing
 
         failed_resolution_attributes =
           resolution_result.attributes_requiring_additional_verification
-        (failed_resolution_attributes.to_a - passed_state_id_attributes).empty?
+        (failed_resolution_attributes.to_a - passed_state_id_attributes.map(&:to_sym)).empty?
       end
 
       # AAMVA verifies the address printed on the identity document. If the user edited their
       # address afterwards, resolution proofed a different address than the one AAMVA verified,
       # so the AAMVA response can no longer cover an address failure.
       def passed_state_id_attributes
-        attributes = applicant_pii[:aamva_verified_attributes].to_a.map(&:to_sym)
+        attributes = applicant_pii[:aamva_verified_attributes].to_a
         return attributes unless applicant_pii[:address_edited] == true
 
-        attributes - [:address]
+        attributes.reject { |attribute| attribute.to_sym == :address }
       end
 
       def biographical_info
@@ -203,10 +203,12 @@ module Proofing
         }
       end
 
+      # Reports the attributes AAMVA verified that were usable for this adjudication, so the logs
+      # match the coverage decision above rather than the raw AAMVA response.
       def state_id_verified_attributes
         return {} if applicant_pii[:aamva_verified_attributes].blank?
 
-        { state_id_verified_attributes: applicant_pii[:aamva_verified_attributes] }
+        { state_id_verified_attributes: passed_state_id_attributes }
       end
     end
   end

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -1285,10 +1285,28 @@ RSpec.describe Idv::VerifyInfoController do
           expect(Idv::Agent).to receive(:new).with(
             hash_including(
               aamva_verified_attributes: %w[ssn dob],
+              address_edited: false,
             ),
           ).and_call_original
 
           put :update
+        end
+
+        context 'when the user edited their residential address' do
+          before do
+            controller.idv_session.address_edited = true
+          end
+
+          it 'modifies PII to flag the edited address' do
+            expect(Idv::Agent).to receive(:new).with(
+              hash_including(
+                aamva_verified_attributes: %w[ssn dob],
+                address_edited: true,
+              ),
+            ).and_call_original
+
+            put :update
+          end
         end
       end
     end

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -798,8 +798,19 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
           expect(fake_analytics).to have_logged_event(
             'IdV: doc auth verify proofing results',
             hash_including(
+              success: true,
               address_edited: false,
               proofing_results: hash_including(
+                context: hash_including(
+                  resolution_adjudication_reason: 'state_id_covers_failed_resolution',
+                  stages: hash_including(
+                    resolution: hash_including(
+                      success: false,
+                      can_pass_with_additional_verification: true,
+                      attributes_requiring_additional_verification: ['address'],
+                    ),
+                  ),
+                ),
                 biographical_info: hash_including(
                   state_id_verified_attributes: match_array(aamva_verified_attributes),
                 ),
@@ -830,8 +841,19 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
           expect(fake_analytics).to have_logged_event(
             'IdV: doc auth verify proofing results',
             hash_including(
+              success: false,
               address_edited: true,
               proofing_results: hash_including(
+                context: hash_including(
+                  resolution_adjudication_reason: 'fail_resolution_without_state_id_coverage',
+                  stages: hash_including(
+                    resolution: hash_including(
+                      success: false,
+                      can_pass_with_additional_verification: true,
+                      attributes_requiring_additional_verification: ['address'],
+                    ),
+                  ),
+                ),
                 biographical_info: hash_including(
                   state_id_verified_attributes:
                     match_array(aamva_verified_attributes - ['address']),

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -744,6 +744,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       )
       reload_ab_tests
       stub_aamva_request(AamvaFixtures.verification_response)
+      allow_any_instance_of(ApplicationController).to receive(:analytics).and_return(fake_analytics)
 
       visit_idp_from_sp_with_ial2(:oidc)
       sign_in_and_2fa_user(user)
@@ -769,6 +770,76 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
       it('passes the verify info step') do
         complete_verify_step
         expect(page).to have_current_path(idv_phone_path)
+      end
+    end
+
+    context 'when instant verify fails on the address' do
+      let(:instant_verify_response) do
+        LexisNexisFixtures.instant_verify_address_fail_response_json
+      end
+
+      # Everything AamvaFixtures.verification_response marks as matching.
+      let(:aamva_verified_attributes) do
+        %w[
+          address document_type_received dob eye_color first_name height last_name middle_name
+          name_suffix sex state_id_expiration state_id_issued state_id_number weight
+        ]
+      end
+
+      before do
+        stub_instant_verify_request(instant_verify_response)
+      end
+
+      context 'when the user has not edited their address' do
+        it 'passes the verify info step because AAMVA verified the same address' do
+          complete_verify_step
+
+          expect(page).to have_current_path(idv_phone_path)
+          expect(fake_analytics).to have_logged_event(
+            'IdV: doc auth verify proofing results',
+            hash_including(
+              address_edited: false,
+              proofing_results: hash_including(
+                biographical_info: hash_including(
+                  state_id_verified_attributes: match_array(aamva_verified_attributes),
+                ),
+              ),
+            ),
+          )
+        end
+      end
+
+      context 'when the user has edited their address' do
+        before do
+          click_link t('idv.buttons.change_address_label')
+          fill_in 'idv_form_zipcode', with: '12345'
+          click_button t('forms.buttons.submit.update')
+
+          expect(page).to have_current_path(idv_verify_info_path)
+        end
+
+        it 'fails the verify info step because AAMVA never saw the edited address' do
+          complete_verify_step
+
+          expect(page).to have_current_path(idv_session_errors_warning_path)
+        end
+
+        it 'omits the address from the verified attributes it logs' do
+          complete_verify_step
+
+          expect(fake_analytics).to have_logged_event(
+            'IdV: doc auth verify proofing results',
+            hash_including(
+              address_edited: true,
+              proofing_results: hash_including(
+                biographical_info: hash_including(
+                  state_id_verified_attributes:
+                    match_array(aamva_verified_attributes - ['address']),
+                ),
+              ),
+            ),
+          )
+        end
       end
     end
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -912,6 +912,8 @@ RSpec.describe 'In Person Proofing', js: true do
 
     context 'when AAMVA is enabled at the state ID form' do
       let(:user) { user_with_2fa }
+      let(:fake_analytics) { FakeAnalytics.new(user: user) }
+      let(:current_address_matches_id) { true }
 
       before do
         allow(IdentityConfig.store).to receive_messages(
@@ -923,13 +925,15 @@ RSpec.describe 'In Person Proofing', js: true do
         )
         reload_ab_tests
         stub_aamva_request(AamvaFixtures.verification_response)
+        allow_any_instance_of(ApplicationController).to receive(:analytics)
+          .and_return(fake_analytics)
 
         sign_in_and_2fa_user(user)
         begin_in_person_proofing_with_opt_in_ipp_enabled_and_opting_in
         complete_prepare_step(user)
         complete_location_step(user)
-        fill_out_state_id_form_ok(current_address_matches_id: true)
-        click_idv_continue
+        complete_state_id_controller(user, current_address_matches_id:)
+        complete_address_step(user, current_address_matches_id:) unless current_address_matches_id
         complete_ssn_step(user)
       end
 
@@ -950,6 +954,76 @@ RSpec.describe 'In Person Proofing', js: true do
 
           expect(page).to have_current_path(idv_in_person_ready_to_verify_path, wait: 10)
           expect(page).to have_content(strip_nbsp(t('in_person_proofing.headings.barcode')))
+        end
+      end
+
+      context 'when instant verify fails on the address' do
+        let(:instant_verify_response) do
+          LexisNexisFixtures.instant_verify_address_fail_response_json
+        end
+
+        # Everything AamvaFixtures.verification_response marks as matching.
+        let(:aamva_verified_attributes) do
+          %w[
+            address document_type_received dob eye_color first_name height last_name middle_name
+            name_suffix sex state_id_expiration state_id_issued state_id_number weight
+          ]
+        end
+
+        before do
+          stub_instant_verify_request(instant_verify_response)
+        end
+
+        context 'when the current address matches the state ID address' do
+          it 'passes the verify info step because AAMVA verified the same address' do
+            complete_verify_step(user)
+
+            expect(page).to have_current_path(idv_phone_path, wait: 10)
+            expect(fake_analytics).to have_logged_event(
+              'IdV: doc auth verify proofing results',
+              hash_including(
+                success: true,
+                analytics_id: 'In Person Proofing',
+                proofing_results: hash_including(
+                  context: hash_including(
+                    resolution_adjudication_reason: 'state_id_covers_failed_resolution',
+                    stages: hash_including(
+                      resolution: hash_including(
+                        success: false,
+                        can_pass_with_additional_verification: true,
+                        attributes_requiring_additional_verification: ['address'],
+                      ),
+                    ),
+                  ),
+                  biographical_info: hash_including(
+                    state_id_verified_attributes: match_array(aamva_verified_attributes),
+                  ),
+                ),
+              ),
+            )
+          end
+        end
+
+        context 'when the current address differs from the state ID address' do
+          let(:current_address_matches_id) { false }
+
+          it 'fails the verify info step because AAMVA never saw the current address' do
+            complete_verify_step(user)
+
+            expect(page).to have_current_path(idv_session_errors_warning_path(flow: 'in_person'))
+            expect(fake_analytics).to have_logged_event(
+              'IdV: doc auth verify proofing results',
+              hash_including(
+                success: false,
+                analytics_id: 'In Person Proofing',
+                proofing_results: hash_including(
+                  context: hash_including(
+                    resolution_adjudication_reason: 'fail_resolution_skip_state_id',
+                  ),
+                ),
+              ),
+            )
+          end
         end
       end
 

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -1004,10 +1004,11 @@ RSpec.describe 'In Person Proofing', js: true do
           end
         end
 
-        context 'when the current address differs from the state ID address' do
+        context 'when the residential address differs from the state ID address' do
           let(:current_address_matches_id) { false }
 
-          it 'fails the verify info step because AAMVA never saw the current address' do
+          it 'fails resolution proofing because AAMVA does not cover the residential address ' \
+            'failures' do
             complete_verify_step(user)
 
             expect(page).to have_current_path(idv_session_errors_warning_path(flow: 'in_person'))

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -96,63 +96,23 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
       end
     end
 
-    context 'InstantVerify fails on address and AAMVA verified the address' do
+    context 'InstantVerify fails on address verification' do
       let(:resolution_success) { false }
       let(:can_pass_with_additional_verification) { true }
       let(:attributes_requiring_additional_verification) { [:address] }
-      let(:address_edited) { false }
-      let(:applicant_pii) do
-        Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
-          aamva_verified_attributes: [:address],
-          address_edited: address_edited,
-        )
-      end
 
-      context 'the residential address is unchanged' do
-        it 'lets the verified AAMVA address override the InstantVerify failure' do
-          result = subject.adjudicated_result
-
-          expect(result.success?).to eq(true)
-          expect(result.extra[:context][:resolution_adjudication_reason])
-            .to eq(:state_id_covers_failed_resolution)
+      context 'AAMVA verified the address' do
+        let(:applicant_pii) do
+          Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
+            aamva_verified_attributes: [:address],
+            address_edited: address_edited,
+          )
         end
 
-        it 'logs the address as a verified attribute' do
-          result = subject.adjudicated_result
+        context 'the address has not been edited' do
+          let(:address_edited) { false }
 
-          expect(result.extra[:biographical_info][:state_id_verified_attributes])
-            .to eq([:address])
-        end
-      end
-
-      context 'the residential address has been updated' do
-        let(:address_edited) { true }
-
-        it 'does not let the verified AAMVA address override the InstantVerify failure' do
-          result = subject.adjudicated_result
-
-          expect(result.success?).to eq(false)
-          expect(result.extra[:context][:resolution_adjudication_reason])
-            .to eq(:fail_resolution_without_state_id_coverage)
-        end
-
-        it 'logs the verified attributes without the address' do
-          result = subject.adjudicated_result
-
-          expect(result.extra[:biographical_info][:state_id_verified_attributes])
-            .to eq([])
-        end
-
-        context 'AAMVA also verified attributes unrelated to the address' do
-          let(:attributes_requiring_additional_verification) { [:dob] }
-          let(:applicant_pii) do
-            Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
-              aamva_verified_attributes: [:address, :dob],
-              address_edited: address_edited,
-            )
-          end
-
-          it 'still allows those attributes to cover the InstantVerify failure' do
+          it 'lets the verified AAMVA address override the InstantVerify failure' do
             result = subject.adjudicated_result
 
             expect(result.success?).to eq(true)
@@ -160,12 +120,80 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
               .to eq(:state_id_covers_failed_resolution)
           end
 
+          it 'logs the address as a verified attribute' do
+            result = subject.adjudicated_result
+
+            expect(result.extra[:biographical_info][:state_id_verified_attributes])
+              .to eq([:address])
+          end
+        end
+
+        context 'the address has been edited' do
+          let(:address_edited) { true }
+
+          it 'does not let the verified AAMVA address override the InstantVerify failure' do
+            result = subject.adjudicated_result
+
+            expect(result.success?).to eq(false)
+            expect(result.extra[:context][:resolution_adjudication_reason])
+              .to eq(:fail_resolution_without_state_id_coverage)
+          end
+
           it 'logs the verified attributes without the address' do
             result = subject.adjudicated_result
 
             expect(result.extra[:biographical_info][:state_id_verified_attributes])
-              .to eq([:dob])
+              .to eq([])
           end
+
+          context 'AAMVA verified additional attributes' do
+            let(:attributes_requiring_additional_verification) { [:dob] }
+            let(:applicant_pii) do
+              Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
+                aamva_verified_attributes: [:address, :dob],
+                address_edited: address_edited,
+              )
+            end
+
+            it 'allows those attributes to cover the InstantVerify failure' do
+              result = subject.adjudicated_result
+
+              expect(result.success?).to eq(true)
+              expect(result.extra[:context][:resolution_adjudication_reason])
+                .to eq(:state_id_covers_failed_resolution)
+            end
+
+            it 'logs the verified attributes without the address' do
+              result = subject.adjudicated_result
+
+              expect(result.extra[:biographical_info][:state_id_verified_attributes])
+                .to eq([:dob])
+            end
+          end
+        end
+      end
+
+      context 'AAMVA has not verified the address' do
+        let(:applicant_pii) do
+          Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
+            aamva_verified_attributes: [:dob],
+            address_edited: false,
+          )
+        end
+
+        it 'does not let AAMVA override the InstantVerify failure' do
+          result = subject.adjudicated_result
+
+          expect(result.success?).to eq(false)
+          expect(result.extra[:context][:resolution_adjudication_reason])
+            .to eq(:fail_resolution_without_state_id_coverage)
+        end
+
+        it 'logs only the attributes AAMVA verified' do
+          result = subject.adjudicated_result
+
+          expect(result.extra[:biographical_info][:state_id_verified_attributes])
+            .to eq([:dob])
         end
       end
     end

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -116,6 +116,13 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
           expect(result.extra[:context][:resolution_adjudication_reason])
             .to eq(:state_id_covers_failed_resolution)
         end
+
+        it 'logs the address as a verified attribute' do
+          result = subject.adjudicated_result
+
+          expect(result.extra[:biographical_info][:state_id_verified_attributes])
+            .to eq([:address])
+        end
       end
 
       context 'the residential address has been updated' do
@@ -129,11 +136,11 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
             .to eq(:fail_resolution_without_state_id_coverage)
         end
 
-        it 'still reports the attributes AAMVA verified' do
+        it 'logs the verified attributes without the address' do
           result = subject.adjudicated_result
 
           expect(result.extra[:biographical_info][:state_id_verified_attributes])
-            .to eq([:address])
+            .to eq([])
         end
 
         context 'AAMVA also verified attributes unrelated to the address' do
@@ -151,6 +158,13 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
             expect(result.success?).to eq(true)
             expect(result.extra[:context][:resolution_adjudication_reason])
               .to eq(:state_id_covers_failed_resolution)
+          end
+
+          it 'logs the verified attributes without the address' do
+            result = subject.adjudicated_result
+
+            expect(result.extra[:biographical_info][:state_id_verified_attributes])
+              .to eq([:dob])
           end
         end
       end

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -96,6 +96,66 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
       end
     end
 
+    context 'InstantVerify fails on address and AAMVA verified the address' do
+      let(:resolution_success) { false }
+      let(:can_pass_with_additional_verification) { true }
+      let(:attributes_requiring_additional_verification) { [:address] }
+      let(:address_edited) { false }
+      let(:applicant_pii) do
+        Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
+          aamva_verified_attributes: [:address],
+          address_edited: address_edited,
+        )
+      end
+
+      context 'the residential address is unchanged' do
+        it 'lets the verified AAMVA address override the InstantVerify failure' do
+          result = subject.adjudicated_result
+
+          expect(result.success?).to eq(true)
+          expect(result.extra[:context][:resolution_adjudication_reason])
+            .to eq(:state_id_covers_failed_resolution)
+        end
+      end
+
+      context 'the residential address has been updated' do
+        let(:address_edited) { true }
+
+        it 'does not let the verified AAMVA address override the InstantVerify failure' do
+          result = subject.adjudicated_result
+
+          expect(result.success?).to eq(false)
+          expect(result.extra[:context][:resolution_adjudication_reason])
+            .to eq(:fail_resolution_without_state_id_coverage)
+        end
+
+        it 'still reports the attributes AAMVA verified' do
+          result = subject.adjudicated_result
+
+          expect(result.extra[:biographical_info][:state_id_verified_attributes])
+            .to eq([:address])
+        end
+
+        context 'AAMVA also verified attributes unrelated to the address' do
+          let(:attributes_requiring_additional_verification) { [:dob] }
+          let(:applicant_pii) do
+            Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
+              aamva_verified_attributes: [:address, :dob],
+              address_edited: address_edited,
+            )
+          end
+
+          it 'still allows those attributes to cover the InstantVerify failure' do
+            result = subject.adjudicated_result
+
+            expect(result.success?).to eq(true)
+            expect(result.extra[:context][:resolution_adjudication_reason])
+              .to eq(:state_id_covers_failed_resolution)
+          end
+        end
+      end
+    end
+
     describe 'biographical_info' do
       context 'the applicant PII contains one address' do
         it 'includes formatted PII' do


### PR DESCRIPTION
changelog: Bug Fixes, Identity Verification, AAMVA no longer overrides an address failure when the address is edited

## 🎫 Ticket

Link to the relevant ticket:
[LG-17686](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17686)

## 🛠 Summary of changes

AAMVA verifies the address printed on the ID. If the user edits their residential address after doc auth, resolution proofs an address AAMVA never saw, but a verified AAMVA address could still cover the InstantVerify address failure.

`Idv::VerifyInfoController#pii` now passes `address_edited` through to the adjudicator, and `ResultAdjudicator` drops `:address` from the AAMVA-verified attributes when it is set. Other verified attributes (dob, ssn, etc.) still cover their corresponding resolution failures.

Remote flow only.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Complete doc auth so AAMVA verifies the address, edit the residential address on the address step, then submit Verify your info. Resolution fails and is not covered by AAMVA.
- [ ] Same flow without editing the address. AAMVA still covers the InstantVerify address failure and proofing passes.
- [ ] Edit the address where AAMVA verified a non-address attribute (for example dob) and InstantVerify fails on that attribute. Coverage still applies.
- [ ] Confirm `address_edited` appears in the `Idv::Agent` applicant PII on submit.


[LG-17686]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17686