### PR TITLE
LG-17793: Update expiration date threshold

### DIFF
--- a/app/validators/idv/form_state_id_validator.rb
+++ b/app/validators/idv/form_state_id_validator.rb
@@ -57,13 +57,19 @@ module Idv
       # rubocop:disable Layout/LineLength
       validates_with UspsInPersonProofing::DateValidator,
                      attributes: [:id_expiration], greater_than_or_equal_to: ->(_rec) {
-                       Time.zone.today + 2.days
+                       Time.zone.today + 7.days
                      },
-                     message: ->(_, _) do
-                       I18n.t(
-                         'in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired',
-                         app_name: APP_NAME,
-                       )
+                     message: ->(_, data) do
+                       if data[:value].is_a?(Date) && data[:value] > Time.zone.today
+                         I18n.t(
+                           'in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expiring_soon',
+                         )
+                       else
+                         I18n.t(
+                           'in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired',
+                           app_name: APP_NAME,
+                         )
+                       end
                      end
       # rubocop:enable Layout/LineLength
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1408,6 +1408,7 @@ in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.missing_mon
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: You must be over %{min_age} years of age to use %{app_name}
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_overflow: Enter a date that is in the past
 in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired: You cannot use an expired ID.
+in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expiring_soon: You cannot use an ID that expires within 7 days.
 in_person_proofing.form.state_id.state_id_jurisdiction: Issuing state
 in_person_proofing.form.state_id.state_id_jurisdiction_hint: This is the state that issued your ID
 in_person_proofing.form.state_id.state_id_jurisdiction_prompt: '- Select -'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1419,6 +1419,7 @@ in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.missing_mon
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: Debe ser mayor de %{min_age} años para usar %{app_name}
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_overflow: Ingrese una fecha ya transcurrida
 in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired: No puede usar una identificación vencida.
+in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expiring_soon: No puede usar una ID que caduque en los próximos 7 días.
 in_person_proofing.form.state_id.state_id_jurisdiction: Estado emisor
 in_person_proofing.form.state_id.state_id_jurisdiction_hint: Este es el estado que emitió su identificación
 in_person_proofing.form.state_id.state_id_jurisdiction_prompt: '- Seleccione -'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1408,6 +1408,7 @@ in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.missing_mon
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: Vous devez avoir plus de %{min_age} ans pour utiliser %{app_name}
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_overflow: Saisissez une date dans le passé
 in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired: Vous ne pouvez pas utiliser une pièce d’identité expirée.
+in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expiring_soon: Vous ne pouvez pas utiliser une ID qui expire dans les 7 jours.
 in_person_proofing.form.state_id.state_id_jurisdiction: État d’émission
 in_person_proofing.form.state_id.state_id_jurisdiction_hint: Il s’agit de l’État qui a émis votre pièce d’identité
 in_person_proofing.form.state_id.state_id_jurisdiction_prompt: '- Sélectionnez -'

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1421,6 +1421,7 @@ in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.missing_mon
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_min_age: 你年龄必须超过 %{min_age} 岁才能使用 %{app_name}
 in_person_proofing.form.state_id.memorable_date.errors.date_of_birth.range_overflow: 输入过去的一个日期
 in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired: 你不能使用过期 ID。
+in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expiring_soon: 您不能使用7天内过期的身份证件。
 in_person_proofing.form.state_id.state_id_jurisdiction: 颁发州
 in_person_proofing.form.state_id.state_id_jurisdiction_hint: 这是颁发你身份证件的州
 in_person_proofing.form.state_id.state_id_jurisdiction_prompt: '- 选择 -'

--- a/spec/features/idv/steps/in_person/state_id_spec.rb
+++ b/spec/features/idv/steps/in_person/state_id_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe 'state id controller enabled', :js do
 
     it 'shows error for an expired ID', allow_browser_log: true do
       complete_steps_before_state_id_controller
+      fill_out_state_id_form_ok(current_address_matches_id: true)
 
       yesterday = Time.zone.now - 1.day
       exp = [
@@ -163,11 +164,28 @@ RSpec.describe 'state id controller enabled', :js do
       fill_in_memorable_date('identity_doc[id_expiration]', exp)
 
       click_idv_continue
+      expect(page).to have_content(
+        t('in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expiring_soon'),
+      )
+
+      eight_days_from_today = Time.zone.now + 8.days
+      exp = [
+        eight_days_from_today.year,
+        eight_days_from_today.month,
+        eight_days_from_today.day,
+      ].join('-')
+
+      fill_in_memorable_date('identity_doc[id_expiration]', exp)
+
+      click_idv_continue
       expect(page).not_to have_content(
         t(
           'in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired',
           app_name: APP_NAME,
         ),
+      )
+      expect(page).not_to have_content(
+        t('in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expiring_soon'),
       )
     end
   end

--- a/spec/forms/idv/state_id_form_spec.rb
+++ b/spec/forms/idv/state_id_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Idv::StateIdForm do
     ).permit(:year, :month, :day)
   end
   let(:valid_exp) do
-    valid_d = Time.zone.today + 2.days
+    valid_d = Time.zone.today + 7.days
     ActionController::Parameters.new(
       year: valid_d.year,
       month: valid_d.month,
@@ -35,6 +35,14 @@ RSpec.describe Idv::StateIdForm do
     ).permit(:year, :month, :day)
   end
   let(:ipp_current_address_matches_id) { 'true' }
+  let(:expiring_soon_exp) do
+    exp_d = Time.zone.today + 2.days
+    ActionController::Parameters.new(
+      year: exp_d.year,
+      month: exp_d.month,
+      day: exp_d.mday,
+    ).permit(:year, :month, :day)
+  end
   let(:first_name) { Faker::Name.first_name }
   let(:dob) { valid_dob }
   let(:id_expiration) { valid_exp }
@@ -146,6 +154,21 @@ RSpec.describe Idv::StateIdForm do
           I18n.t(
             'in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expired',
             app_name: APP_NAME,
+          ),
+        ]
+      end
+    end
+
+    context 'when the ID expires within 7 days' do
+      let(:id_expiration) { expiring_soon_exp }
+
+      it 'returns the expiring soon error' do
+        expect(result).to be_kind_of(FormResponse)
+        expect(result.success?).to eq(false)
+        expect(subject.errors.empty?).to be(false)
+        expect(subject.errors[:id_expiration]).to eq [
+          I18n.t(
+            'in_person_proofing.form.state_id.memorable_date.errors.expiration_date.expiring_soon',
           ),
         ]
       end


### PR DESCRIPTION
## 🎫 Ticket

[LG-17793](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17793)

## 🛠 Summary of changes

Updates the in-person proofing state ID expiration validation to require the
ID be valid for at least **7 days** from the current date (previously 2 days),
so the ID stays valid throughout the enrollment period.

- Changed the threshold in `Idv::FormStateIdValidator` from `today + 2.days` to
  `today + 7.days`.
- Added a distinct error message for when the entered expiration date is in the
  future but within the 7-day window:
  > You cannot use an ID that expires within 7 days.
- Dates that are same-day or in the past continue to show the existing error:
  > You cannot use an expired ID.
- Added `expiring_soon` translations for EN, ES, FR, and ZH.
- Updated form and feature specs to cover the new threshold and error message.

## 📜 Testing Plan

- [ ] Start the app and begin the in-person proofing flow, continuing to the
      State ID step
- [ ] Enter an expiration date that is today or in the past → confirm
      "You cannot use an expired ID."
- [ ] Enter an expiration date within the next 7 days (e.g. today + 3) → confirm
      "You cannot use an ID that expires within 7 days."
- [ ] Enter an expiration date 7+ days out (e.g. today + 7) → confirm the form
      submits successfully
- [ ] Repeat with `?locale=es`, `?locale=fr`, and `?locale=zh` to confirm the
      translated messages


[LG-17793]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17793