### PR TITLE
LG-16085 Rename state ID same-address form param to ipp_current_address_matches_id

### DIFF
--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -23,13 +23,6 @@ module Idv
 
     attr_accessor(*ATTRIBUTES)
 
-    # 50/50 deploy compatibility (LG-16085): the rendered radio still uses the legacy
-    # param name `same_address_as_id`, so the form builder queries the form object for
-    # `same_address_as_id` when rendering `checked`. Alias it to the real attribute.
-    # Remove alongside LEGACY_PARAM_ALIASES once the form param rename is fully deployed.
-    alias_method :same_address_as_id, :ipp_current_address_matches_id
-    alias_method :same_address_as_id=, :ipp_current_address_matches_id=
-
     def self.model_name
       ActiveModel::Name.new(self, nil, 'StateId')
     end

--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -254,11 +254,7 @@
         form: f,
         label: t('in_person_proofing.form.state_id.current_address_matches_id'),
         legend_html: { class: 'h2' },
-        # 50/50 deploy compatibility (LG-16085): keep submitting the legacy param name
-        # so forms rendered by the new deploy are still accepted by old instances
-        # during the rollout. The server accepts both names. Rename to
-        # :ipp_current_address_matches_id in a follow-up once fully deployed.
-        name: :same_address_as_id,
+        name: :ipp_current_address_matches_id,
         required: true,
         wrapper: :uswds_radio_buttons,
       ) %>


### PR DESCRIPTION
Renames the state ID "current address matches ID" form parameter to `ipp_current_address_matches_id`. The form now submits the new name, and the server continues to accept the legacy `same_address_as_id` name for 50/50 deploy safety during the rollout. A follow-up removes the legacy-accept shim once this is fully deployed.

DO NOT MERGE!  Must not deploy until #13271 has shipped.

## 🎫 Ticket
[LG-16085](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-16085)

## 🛠 Summary of changes
This completes the visible half of the `same_address_as_id` -> `ipp_current_address_matches_id` rename. The internal attribute, session PII, and proofing pipeline were already migrated to the boolean `ipp_current_address_matches_id` in earlier deploys.  This changes the **rendered form parameter name** to match.
- `state_id/show.html.erb`: the radio `name:` is now `:ipp_current_address_matches_id` (was `:same_address_as_id`).
- `state_id_form.rb`: removed the render-side `same_address_as_id` reader/writer alias_methods. They were only needed so the form object responded to the legacy name at render time.  Now that the view renders the new name (already a native attribute), they're unnecessary.
**50/50 deploy safety:** the server still accepts the legacy `same_address_as_id` param on submit (`LEGACY_PARAM_ALIASES` + controller permit + `build_pending_pii` fallback are retained). This keeps both directions safe during the rollout:
- a form rendered by a not-yet-updated instance submits the legacy name -> accepted here;
- a form rendered by this deploy submits the new name -> accepted by not-yet-updated instances, which already accept both.
**Follow-up:** once this is fully deployed (no instance renders the legacy name), a separate PR removes the legacy-accept shim (`LEGACY_PARAM_ALIASES`, the permit key, and the `build_pending_pii` fallback).

## 📜 Testing Plan
- [x] Unit/controller specs pass (state_id form + controller), verified locally
- [x] Rubocop + erb_lint clean on the changed files
- [x] IPP State ID page: submitting the same-address answer stores the correct boolean and routes correctly (Yes copies address + skips Address step, No routes to Address step)
- [x] `#show` renders without error with the new param name

[LG-16085]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-16085