### PR TITLE
LG-17790 IPP profile & enrollment desync issue in AccountShowPresenter

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -19,6 +19,8 @@ module Idv
 
     rescue_from UspsInPersonProofing::Exception::RequestEnrollException,
                 with: :handle_request_enroll_exception
+    rescue_from UspsInPersonProofing::Exception::EnrollmentNotEstablishedError,
+                with: :handle_enrollment_not_established_error
 
     def new
       Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer)
@@ -219,6 +221,16 @@ module Idv
         original_exception_class: err.exception_class,
         exception_message: scrub_message(err.message),
         reason: 'Request exception',
+      )
+      flash[:error] = t('idv.failure.exceptions.internal_error')
+      idv_session.invalidate_personal_key!
+      redirect_to idv_enter_password_url
+    end
+
+    def handle_enrollment_not_established_error(err)
+      analytics.idv_in_person_usps_enrollment_not_established(
+        context: context,
+        enrollment_id: err.enrollment_id,
       )
       flash[:error] = t('idv.failure.exceptions.internal_error')
       idv_session.invalidate_personal_key!

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -19,8 +19,8 @@ module Idv
 
     rescue_from UspsInPersonProofing::Exception::RequestEnrollException,
                 with: :handle_request_enroll_exception
-    rescue_from UspsInPersonProofing::Exception::EnrollmentNotEstablishedError,
-                with: :handle_enrollment_not_established_error
+    rescue_from UspsInPersonProofing::Exception::EnrollmentNotPendingError,
+                with: :handle_enrollment_not_pending_error
 
     def new
       Funnel::DocAuth::RegisterStep.new(current_user.id, current_sp&.issuer)
@@ -227,7 +227,7 @@ module Idv
       redirect_to idv_enter_password_url
     end
 
-    def handle_enrollment_not_established_error(err)
+    def handle_enrollment_not_pending_error(err)
       analytics.idv_in_person_usps_enrollment_not_established(
         context: context,
         enrollment_id: err.enrollment_id,

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -228,7 +228,7 @@ module Idv
     end
 
     def handle_enrollment_not_pending_error(err)
-      analytics.idv_in_person_usps_enrollment_not_established(
+      analytics.idv_in_person_usps_enrollment_not_pending(
         context: context,
         enrollment_id: err.enrollment_id,
       )

--- a/app/forms/gpo_verify_form.rb
+++ b/app/forms/gpo_verify_form.rb
@@ -74,15 +74,6 @@ class GpoVerifyForm
     pending_profile.gpo_confirmation_codes.first_with_otp(otp)
   end
 
-  def schedule_in_person_enrollment_and_deactivate_profile(is_enhanced_ipp)
-    UspsInPersonProofing::EnrollmentHelper.schedule_in_person_enrollment(
-      user:,
-      pii:,
-      is_enhanced_ipp:,
-    )
-    pending_profile&.deactivate_for_in_person_verification
-  end
-
   def which_letter
     return if !valid_otp?
     pending_profile.gpo_confirmation_codes

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -65,8 +65,7 @@ class AccountShowPresenter
   end
 
   def pending_ipp?
-    !!user.pending_profile&.in_person_verification_pending? &&
-      user.pending_in_person_enrollment.present?
+    !!user.pending_profile&.in_person_verification_pending?
   end
 
   def pending_gpo?

--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -65,7 +65,8 @@ class AccountShowPresenter
   end
 
   def pending_ipp?
-    !!user.pending_profile&.in_person_verification_pending?
+    !!user.pending_profile&.in_person_verification_pending? &&
+      user.pending_in_person_enrollment.present?
   end
 
   def pending_gpo?
@@ -77,7 +78,10 @@ class AccountShowPresenter
   end
 
   def formatted_ipp_due_date
-    I18n.l(user.pending_in_person_enrollment.due_date, format: :event_date)
+    due_date = user.pending_in_person_enrollment&.due_date
+    return nil if due_date.blank?
+
+    I18n.l(due_date, format: :event_date)
   end
 
   def formatted_legacy_idv_date

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -4361,6 +4361,22 @@ module AnalyticsEvents
     )
   end
 
+  # Tracks when a USPS in-person proofing enrollment never reached "pending" status after scheduling
+  # @param [String] context
+  # @param [Integer] enrollment_id
+  def idv_in_person_usps_enrollment_not_established(
+    context:,
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      :idv_in_person_usps_enrollment_not_established,
+      context:,
+      enrollment_id:,
+      **extra,
+    )
+  end
+
   # LexisNexis Instant Verify API was called with the following results
   # @param [Boolean] success Result from LexisNexis Instant Verify API call
   # @param [Hash] errors Result from resolution proofing

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -3738,6 +3738,22 @@ module AnalyticsEvents
     track_event('IdV: in person proofing switch_back visited', flow_path: flow_path, **extra)
   end
 
+  # Tracks when a USPS in-person proofing enrollment never reached "pending" status after scheduling
+  # @param [String] context
+  # @param [Integer] enrollment_id
+  def idv_in_person_usps_enrollment_not_pending(
+    context:,
+    enrollment_id:,
+    **extra
+  )
+    track_event(
+      :idv_in_person_usps_enrollment_not_pending,
+      context:,
+      enrollment_id:,
+      **extra,
+    )
+  end
+
   # An email from USPS with an enrollment code has been received, indicating
   # the enrollment is approved or failed. A check is required to get the status
   # it is not included in the email.
@@ -4357,22 +4373,6 @@ module AnalyticsEvents
       original_exception_class:,
       exception_message:,
       reason:,
-      **extra,
-    )
-  end
-
-  # Tracks when a USPS in-person proofing enrollment never reached "pending" status after scheduling
-  # @param [String] context
-  # @param [Integer] enrollment_id
-  def idv_in_person_usps_enrollment_not_established(
-    context:,
-    enrollment_id:,
-    **extra
-  )
-    track_event(
-      :idv_in_person_usps_enrollment_not_established,
-      context:,
-      enrollment_id:,
       **extra,
     )
   end

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -148,18 +148,33 @@ module Idv
       end
 
       active_enrollment = current_user.active_enrollment
+      in_person_verification_needed = current_user.pending_in_person_enrollment.present?
+
+      # Enrollment never moves from establishing to pending
+      if active_enrollment.present? && !in_person_verification_needed
+        raise UspsInPersonProofing::Exception::EnrollmentNotEstablishedError.new(
+          active_enrollment.id,
+        )
+      end
 
       profile_maker = build_profile_maker(user_password)
-      profile = profile_maker.save_profile(
-        fraud_pending_reason: threatmetrix_fraud_pending_reason,
-        gpo_verification_needed: !phone_confirmed? || verify_by_mail?,
-        in_person_verification_needed: active_enrollment.present?,
-        selfie_check_performed: session[:selfie_check_performed],
-        proofing_components:,
-        proofing_agent_requested: agent_proofed,
-      )
+      profile = ActiveRecord::Base.transaction do
+        profile = profile_maker.save_profile(
+          fraud_pending_reason: threatmetrix_fraud_pending_reason,
+          gpo_verification_needed: !phone_confirmed? || verify_by_mail?,
+          in_person_verification_needed:,
+          selfie_check_performed: session[:selfie_check_performed],
+          proofing_components:,
+          proofing_agent_requested: agent_proofed,
+        )
 
-      profile.activate unless profile.reason_not_to_activate
+        profile.activate unless profile.reason_not_to_activate
+
+        # assign profile to the enrollment
+        active_enrollment.update!(profile:) if profile.in_person_verification_pending?
+
+        profile
+      end
 
       self.profile_id = profile.id
       self.personal_key = profile.personal_key
@@ -168,9 +183,6 @@ module Idv
         profile_maker.pii_attributes,
         profile.id,
       )
-
-      # assign profile to the enrollment
-      active_enrollment.update(profile:) if profile.in_person_verification_pending?
 
       if profile.gpo_verification_pending?
         create_gpo_entry(profile_maker.pii_attributes, profile)

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -148,11 +148,11 @@ module Idv
       end
 
       active_enrollment = current_user.active_enrollment
-      in_person_verification_needed = current_user.pending_in_person_enrollment.present?
+      user_has_pending_enrollment = current_user.pending_in_person_enrollment.present?
 
       # Enrollment never moves from establishing to pending
-      if active_enrollment.present? && !in_person_verification_needed
-        raise UspsInPersonProofing::Exception::EnrollmentNotEstablishedError.new(
+      if active_enrollment.present? && !user_has_pending_enrollment
+        raise UspsInPersonProofing::Exception::EnrollmentNotPendingError.new(
           active_enrollment.id,
         )
       end
@@ -162,7 +162,7 @@ module Idv
         profile = profile_maker.save_profile(
           fraud_pending_reason: threatmetrix_fraud_pending_reason,
           gpo_verification_needed: !phone_confirmed? || verify_by_mail?,
-          in_person_verification_needed:,
+          in_person_verification_needed: user_has_pending_enrollment,
           selfie_check_performed: session[:selfie_check_performed],
           proofing_components:,
           proofing_agent_requested: agent_proofed,

--- a/app/services/usps_in_person_proofing/exception.rb
+++ b/app/services/usps_in_person_proofing/exception.rb
@@ -17,5 +17,16 @@ module UspsInPersonProofing
         super("#{endpoint_name}: responded with an invalid response")
       end
     end
+
+    class EnrollmentNotEstablishedError < StandardError
+      attr_reader :enrollment_id
+
+      def initialize(enrollment_id)
+        @enrollment_id = enrollment_id
+        super(
+          "InPersonEnrollment #{enrollment_id} did not reach pending status after scheduling ",
+        )
+      end
+    end
   end
 end

--- a/app/services/usps_in_person_proofing/exception.rb
+++ b/app/services/usps_in_person_proofing/exception.rb
@@ -18,7 +18,7 @@ module UspsInPersonProofing
       end
     end
 
-    class EnrollmentNotEstablishedError < StandardError
+    class EnrollmentNotPendingError < StandardError
       attr_reader :enrollment_id
 
       def initialize(enrollment_id)

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -934,6 +934,52 @@ RSpec.describe Idv::EnterPasswordController do
           end
         end
 
+        context 'when USPS enrollment scheduling does not move the enrollment to pending' do
+          before do
+            allow(UspsInPersonProofing::EnrollmentHelper).to receive(:schedule_in_person_enrollment)
+          end
+
+          it 'logs an error message' do
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(@analytics).to have_logged_event(
+              :idv_in_person_usps_enrollment_not_established,
+              context: 'authentication',
+              enrollment_id: enrollment.id,
+            )
+          end
+
+          it 'does not create a profile and leaves the enrollment in establishing' do
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(user.profiles.count).to eq(0)
+            expect(InPersonEnrollment.count).to be(1)
+            enrollment.reload
+            expect(enrollment.status).to eq(InPersonEnrollment::STATUS_ESTABLISHING)
+            expect(enrollment.profile_id).to be_nil
+          end
+
+          it 'allows the user to retry the request' do
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+            expect(flash[:error]).to eq t('idv.failure.exceptions.internal_error')
+            expect(response).to redirect_to idv_enter_password_path
+
+            user.reload
+            allow(UspsInPersonProofing::EnrollmentHelper)
+              .to receive(:schedule_in_person_enrollment).and_call_original
+
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(response).to redirect_to idv_personal_key_path
+
+            enrollment.reload
+
+            expect(enrollment.status).to eq(InPersonEnrollment::STATUS_PENDING)
+            expect(enrollment.profile).to eq(user.profiles.last)
+            expect(enrollment.profile.in_person_verification_pending?).to eq(true)
+          end
+        end
+
         context 'when user enters an address2 value' do
           it 'does not include address2' do
             subject.idv_session.applicant =

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -943,7 +943,7 @@ RSpec.describe Idv::EnterPasswordController do
             put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
             expect(@analytics).to have_logged_event(
-              :idv_in_person_usps_enrollment_not_established,
+              :idv_in_person_usps_enrollment_not_pending,
               context: 'authentication',
               enrollment_id: enrollment.id,
             )

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -195,6 +195,22 @@ RSpec.describe AccountShowPresenter do
         expect(account_show.pending_ipp?).to be(false)
       end
     end
+
+    context 'when profile has ipp enrollment but the in_person_verification is not pending' do
+      let(:user) { create(:user, :fully_registered) }
+      let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user) }
+
+      before do
+        create(
+          :profile,
+          :in_person_verification_pending,
+          user: user,
+          in_person_enrollment: enrollment,
+        )
+      end
+
+      it { is_expected.to eq(false) }
+    end
   end
 
   context '#pending_gpo?' do
@@ -271,6 +287,24 @@ RSpec.describe AccountShowPresenter do
 
     it 'formats a date string' do
       expect { Date.parse(formatted_ipp_due_date) }.not_to raise_error
+    end
+
+    context 'when profile has ipp enrollment but the in_person_verification is not pending' do
+      let(:user) { create(:user, :fully_registered) }
+      let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user) }
+
+      before do
+        create(
+          :profile,
+          :in_person_verification_pending,
+          user: user,
+          in_person_enrollment: enrollment,
+        )
+      end
+
+      it 'returns nil without raising' do
+        expect(formatted_ipp_due_date).to be_nil
+      end
     end
   end
 

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -195,22 +195,6 @@ RSpec.describe AccountShowPresenter do
         expect(account_show.pending_ipp?).to be(false)
       end
     end
-
-    context 'when profile has ipp enrollment but the in_person_verification is not pending' do
-      let(:user) { create(:user, :fully_registered) }
-      let!(:enrollment) { create(:in_person_enrollment, :establishing, user: user) }
-
-      before do
-        create(
-          :profile,
-          :in_person_verification_pending,
-          user: user,
-          in_person_enrollment: enrollment,
-        )
-      end
-
-      it { is_expected.to eq(false) }
-    end
   end
 
   context '#pending_gpo?' do

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -195,7 +195,10 @@ RSpec.describe Idv::Session do
 
         context 'when the USPS enrollment is successful' do
           before do
-            allow(UspsInPersonProofing::EnrollmentHelper).to receive(:schedule_in_person_enrollment)
+            allow(UspsInPersonProofing::EnrollmentHelper)
+              .to receive(:schedule_in_person_enrollment) do
+                user.establishing_in_person_enrollment.update!(status: :pending)
+              end
           end
 
           it 'creates an USPS enrollment' do
@@ -241,19 +244,7 @@ RSpec.describe Idv::Session do
               user.password, is_enhanced_ipp:, proofing_components:
             )
             expect(enrollment.reload.profile_id).to eq(profile.id)
-          end
-
-          context 'when the in person enrollment is pending' do
-            before do
-              user.establishing_in_person_enrollment.update(status: 'pending')
-            end
-
-            it 'associates the in person enrollment with the created profile' do
-              subject.create_profile_from_applicant_with_password(
-                user.password, is_enhanced_ipp:, proofing_components:
-              )
-              expect(enrollment.reload.profile_id).to eq(profile.id)
-            end
+            expect(enrollment.reload.status).to eq('pending')
           end
         end
 
@@ -270,6 +261,28 @@ RSpec.describe Idv::Session do
             )
           rescue
             expect(profile).to be_nil
+          end
+        end
+
+        context 'when USPS enrollment scheduling does not move the enrollment to pending' do
+          before do
+            allow(UspsInPersonProofing::EnrollmentHelper).to receive(:schedule_in_person_enrollment)
+          end
+
+          it 'raises an EnrollmentNotEstablishedError and does not create a profile' do
+            expect do
+              subject.create_profile_from_applicant_with_password(
+                user.password, is_enhanced_ipp:, proofing_components:
+              )
+            end.to raise_error(
+              UspsInPersonProofing::Exception::EnrollmentNotEstablishedError,
+            ) do |error|
+              expect(error.enrollment_id).to eq(enrollment.id)
+            end
+
+            expect(profile).to be_nil
+            expect(enrollment.reload.status).to eq('establishing')
+            expect(enrollment.reload.profile_id).to be_nil
           end
         end
       end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -269,13 +269,13 @@ RSpec.describe Idv::Session do
             allow(UspsInPersonProofing::EnrollmentHelper).to receive(:schedule_in_person_enrollment)
           end
 
-          it 'raises an EnrollmentNotEstablishedError and does not create a profile' do
+          it 'raises an EnrollmentNotPendingError and does not create a profile' do
             expect do
               subject.create_profile_from_applicant_with_password(
                 user.password, is_enhanced_ipp:, proofing_components:
               )
             end.to raise_error(
-              UspsInPersonProofing::Exception::EnrollmentNotEstablishedError,
+              UspsInPersonProofing::Exception::EnrollmentNotPendingError,
             ) do |error|
               expect(error.enrollment_id).to eq(enrollment.id)
             end


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17790](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17790)



## 🛠 Summary of changes

The user profile table and IPP enrollments were not synced. There was a possibility that the profile would have an `in_person_verified_at` attribute indicating IPP, but the enrollment not existing on the enrollment table. This checks both to ensure there is an actual IPP enrollment in the `AccountShowPresenter.`


## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Ensure specs pass


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17790]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17790