### PR TITLE
build-sass: resolve LGDS Sass load path to packages-uswds, else packages

### DIFF
--- a/app/javascript/packages/build-sass/CHANGELOG.md
+++ b/app/javascript/packages/build-sass/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
 - Fix typecheck error due to updated arguments in `fileURLToPath` from `node:url`
+- Resolve the Login.gov Design System default Sass load path to its
+  `packages-uswds/` overlay, falling back to the legacy `packages/` alias when
+  `packages-uswds/` is not present. This supports the design system's
+  transitional dual-overlay layout without requiring a specific version.
 
 ## 3.1.0
 

--- a/app/javascript/packages/build-sass/get-default-load-paths.js
+++ b/app/javascript/packages/build-sass/get-default-load-paths.js
@@ -8,9 +8,9 @@ const LGDS = '@18f/identity-design-system';
 // one root is returned: listing both would load (and re-configure) the shared
 // `uswds-core` module twice, which Sass rejects.
 const lgdsLoadPath = (pathExists) => {
-  const preferred = `node_modules/${LGDS}/packages-uswds`;
-  const legacy = `node_modules/${LGDS}/packages`;
-  return pathExists(preferred) ? preferred : legacy;
+  const uswdsOverlayPath = `node_modules/${LGDS}/packages-uswds`;
+  const backCompatPath = `node_modules/${LGDS}/packages`;
+  return pathExists(uswdsOverlayPath) ? uswdsOverlayPath : backCompatPath;
 };
 
 /**

--- a/app/javascript/packages/build-sass/get-default-load-paths.js
+++ b/app/javascript/packages/build-sass/get-default-load-paths.js
@@ -1,17 +1,37 @@
-/** @type {Record<string, string[]>} */
-const DEPENDENCY_LOAD_PATHS_MAPPING = {
-  '@18f/identity-design-system': ['node_modules/@18f/identity-design-system/packages'],
-  '@uswds/uswds': ['node_modules/@uswds/uswds/packages'],
+import { existsSync } from 'node:fs';
+
+const LGDS = '@18f/identity-design-system';
+
+// The Login.gov Design System publishes its Sass overlay under
+// `packages-uswds/`, keeping `packages/` as a back-compat alias. Prefer
+// `packages-uswds/` and fall back to `packages/` for older versions. Exactly
+// one root is returned: listing both would load (and re-configure) the shared
+// `uswds-core` module twice, which Sass rejects.
+const lgdsLoadPath = (pathExists) => {
+  const preferred = `node_modules/${LGDS}/packages-uswds`;
+  const legacy = `node_modules/${LGDS}/packages`;
+  return pathExists(preferred) ? preferred : legacy;
 };
 
 /**
  * Returns an array of load paths which should be loaded by default based on supported dependencies.
  *
+ * @param {(dependency: string) => boolean} isDependency Whether a package is an installed dependency.
+ * @param {(path: string) => boolean} [pathExists] Filesystem existence check (injectable for tests).
  * @return {string[]} Array of load paths.
  */
-const getDefaultLoadPaths = (isDependency) =>
-  Object.entries(DEPENDENCY_LOAD_PATHS_MAPPING)
-    .filter(([dependency]) => isDependency(dependency))
-    .flatMap(([, loadPaths]) => loadPaths);
+const getDefaultLoadPaths = (isDependency, pathExists = existsSync) => {
+  const loadPaths = [];
+
+  if (isDependency(LGDS)) {
+    loadPaths.push(lgdsLoadPath(pathExists));
+  }
+
+  if (isDependency('@uswds/uswds')) {
+    loadPaths.push('node_modules/@uswds/uswds/packages');
+  }
+
+  return loadPaths;
+};
 
 export default getDefaultLoadPaths;

--- a/app/javascript/packages/build-sass/get-default-load-paths.js
+++ b/app/javascript/packages/build-sass/get-default-load-paths.js
@@ -8,9 +8,9 @@ const LGDS = '@18f/identity-design-system';
 // one root is returned: listing both would load (and re-configure) the shared
 // `uswds-core` module twice, which Sass rejects.
 const lgdsLoadPath = (pathExists) => {
-  const uswdsOverlayPath = `node_modules/${LGDS}/packages-uswds`;
-  const backCompatPath = `node_modules/${LGDS}/packages`;
-  return pathExists(uswdsOverlayPath) ? uswdsOverlayPath : backCompatPath;
+  const lgdsUswdsOverlayPath = `node_modules/${LGDS}/packages-uswds`;
+  const lgdsBackCompatPath = `node_modules/${LGDS}/packages`;
+  return pathExists(lgdsUswdsOverlayPath) ? lgdsUswdsOverlayPath : lgdsBackCompatPath;
 };
 
 /**

--- a/app/javascript/packages/build-sass/get-default-load-paths.spec.js
+++ b/app/javascript/packages/build-sass/get-default-load-paths.spec.js
@@ -1,27 +1,27 @@
 import getDefaultLoadPaths from './get-default-load-paths.js';
 
 describe('getDefaultLoadPaths', () => {
-  const allExist = () => true;
-  const noneExist = () => false;
+  const overlayPathExists = () => true;
+  const overlayPathMissing = () => false;
 
   it('returns an empty array if no dependencies are in load paths', () => {
-    const alwaysFalse = () => false;
-    const result = getDefaultLoadPaths(alwaysFalse, allExist);
+    const isNotDependency = () => false;
+    const result = getDefaultLoadPaths(isNotDependency, overlayPathExists);
 
     expect(result).to.deep.equal([]);
   });
 
   context('with the Login.gov Design System as a dependency', () => {
-    const trueForLgds = (dependency) => dependency === '@18f/identity-design-system';
+    const isLgdsDependency = (dependency) => dependency === '@18f/identity-design-system';
 
     it('prefers the packages-uswds overlay when present', () => {
-      const result = getDefaultLoadPaths(trueForLgds, allExist);
+      const result = getDefaultLoadPaths(isLgdsDependency, overlayPathExists);
 
       expect(result).to.deep.equal(['node_modules/@18f/identity-design-system/packages-uswds']);
     });
 
     it('falls back to the legacy packages overlay when packages-uswds is absent', () => {
-      const result = getDefaultLoadPaths(trueForLgds, noneExist);
+      const result = getDefaultLoadPaths(isLgdsDependency, overlayPathMissing);
 
       expect(result).to.deep.equal(['node_modules/@18f/identity-design-system/packages']);
     });
@@ -29,8 +29,8 @@ describe('getDefaultLoadPaths', () => {
 
   context('with the U.S. Web Design System as a dependency', () => {
     it('returns load paths for the U.S. Web Design System', () => {
-      const trueForUswds = (dependency) => dependency === '@uswds/uswds';
-      const result = getDefaultLoadPaths(trueForUswds, allExist);
+      const isUswdsDependency = (dependency) => dependency === '@uswds/uswds';
+      const result = getDefaultLoadPaths(isUswdsDependency, overlayPathExists);
 
       expect(result).to.deep.equal(['node_modules/@uswds/uswds/packages']);
     });

--- a/app/javascript/packages/build-sass/get-default-load-paths.spec.js
+++ b/app/javascript/packages/build-sass/get-default-load-paths.spec.js
@@ -1,19 +1,27 @@
 import getDefaultLoadPaths from './get-default-load-paths.js';
 
 describe('getDefaultLoadPaths', () => {
+  const allExist = () => true;
+  const noneExist = () => false;
+
   it('returns an empty array if no dependencies are in load paths', () => {
-    const alwaysFalse = () => {
-      false;
-    };
-    const result = getDefaultLoadPaths(alwaysFalse);
+    const alwaysFalse = () => false;
+    const result = getDefaultLoadPaths(alwaysFalse, allExist);
 
     expect(result).to.deep.equal([]);
   });
 
   context('with the Login.gov Design System as a dependency', () => {
-    it('returns load paths for the Login.gov Design System', () => {
-      const trueForLgds = (dependency) => dependency === '@18f/identity-design-system';
-      const result = getDefaultLoadPaths(trueForLgds);
+    const trueForLgds = (dependency) => dependency === '@18f/identity-design-system';
+
+    it('prefers the packages-uswds overlay when present', () => {
+      const result = getDefaultLoadPaths(trueForLgds, allExist);
+
+      expect(result).to.deep.equal(['node_modules/@18f/identity-design-system/packages-uswds']);
+    });
+
+    it('falls back to the legacy packages overlay when packages-uswds is absent', () => {
+      const result = getDefaultLoadPaths(trueForLgds, noneExist);
 
       expect(result).to.deep.equal(['node_modules/@18f/identity-design-system/packages']);
     });
@@ -22,7 +30,7 @@ describe('getDefaultLoadPaths', () => {
   context('with the U.S. Web Design System as a dependency', () => {
     it('returns load paths for the U.S. Web Design System', () => {
       const trueForUswds = (dependency) => dependency === '@uswds/uswds';
-      const result = getDefaultLoadPaths(trueForUswds);
+      const result = getDefaultLoadPaths(trueForUswds, allExist);
 
       expect(result).to.deep.equal(['node_modules/@uswds/uswds/packages']);
     });

--- a/app/javascript/packages/build-sass/get-default-load-paths.spec.js
+++ b/app/javascript/packages/build-sass/get-default-load-paths.spec.js
@@ -1,12 +1,12 @@
 import getDefaultLoadPaths from './get-default-load-paths.js';
 
 describe('getDefaultLoadPaths', () => {
-  const overlayPathExists = () => true;
-  const overlayPathMissing = () => false;
+  const lgdsUswdsOverlayExists = () => true;
+  const lgdsUswdsOverlayMissing = () => false;
 
   it('returns an empty array if no dependencies are in load paths', () => {
     const isNotDependency = () => false;
-    const result = getDefaultLoadPaths(isNotDependency, overlayPathExists);
+    const result = getDefaultLoadPaths(isNotDependency, lgdsUswdsOverlayExists);
 
     expect(result).to.deep.equal([]);
   });
@@ -15,13 +15,13 @@ describe('getDefaultLoadPaths', () => {
     const isLgdsDependency = (dependency) => dependency === '@18f/identity-design-system';
 
     it('prefers the packages-uswds overlay when present', () => {
-      const result = getDefaultLoadPaths(isLgdsDependency, overlayPathExists);
+      const result = getDefaultLoadPaths(isLgdsDependency, lgdsUswdsOverlayExists);
 
       expect(result).to.deep.equal(['node_modules/@18f/identity-design-system/packages-uswds']);
     });
 
     it('falls back to the legacy packages overlay when packages-uswds is absent', () => {
-      const result = getDefaultLoadPaths(isLgdsDependency, overlayPathMissing);
+      const result = getDefaultLoadPaths(isLgdsDependency, lgdsUswdsOverlayMissing);
 
       expect(result).to.deep.equal(['node_modules/@18f/identity-design-system/packages']);
     });
@@ -30,7 +30,7 @@ describe('getDefaultLoadPaths', () => {
   context('with the U.S. Web Design System as a dependency', () => {
     it('returns load paths for the U.S. Web Design System', () => {
       const isUswdsDependency = (dependency) => dependency === '@uswds/uswds';
-      const result = getDefaultLoadPaths(isUswdsDependency, overlayPathExists);
+      const result = getDefaultLoadPaths(isUswdsDependency, lgdsUswdsOverlayExists);
 
       expect(result).to.deep.equal(['node_modules/@uswds/uswds/packages']);
     });

--- a/app/javascript/packages/build-sass/package.json
+++ b/app/javascript/packages/build-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/identity-build-sass",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "private": false,
   "description": "Stylesheet compilation utility with reasonable defaults and fast performance.",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
     },
     "app/javascript/packages/build-sass": {
       "name": "@18f/identity-build-sass",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@aduth/is-dependency": "^1.0.0",


### PR DESCRIPTION
## Summary

The Login.gov Design System now ships its Sass overlay under `packages-uswds/`, keeping `packages/` as a back-compat alias. This updates the `@18f/identity-build-sass` default load-path resolution to prefer `packages-uswds/` when present and fall back to `packages/` otherwise.

- Returns **exactly one** design-system root. (Listing both would load and re-configure the shared `uswds-core` module twice, which Sass rejects.)
- The existence check keeps builds working against both current and future design-system versions, so this can land ahead of any dependency bump.
- Bumps `@18f/identity-build-sass` to **3.3.0**.

No dependency bump is included here; the app continues to build against its currently-pinned design-system version (falls back to `packages/`), byte-identical.

## Test plan

- [x] `get-default-load-paths` unit specs pass (prefers `packages-uswds`, falls back to `packages`)
- [x] `npm run build:css` produces byte-identical `application.css` / `email.css` against the pinned design-system version
- [ ] CI green