### PR TITLE
Add NDS_LOOK_AND_FEEL A/B test scaffold at 0%

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
     rescue_from error, with: :render_timeout
   end
 
-  helper_method :decorated_sp_session, :current_sp, :user_fully_authenticated?
+  helper_method :decorated_sp_session, :current_sp, :user_fully_authenticated?, :nds_layout?
 
   prepend_before_action :add_new_relic_trace_attributes
   prepend_before_action :set_session_start_value_if_nil
@@ -40,6 +40,14 @@ class ApplicationController < ActionController::Base
   def set_session_start_value_if_nil
     return if @skip_session_expiration || @skip_session_load
     session[:session_started_at] = Time.zone.now if session[:session_started_at].nil?
+  end
+
+  def nds_layout?
+    unless Rails.env.production?
+      return true if request.headers['X-Force-Nds-Bucket'] == 'nds'
+      return true if params[:nds_bucket] == 'nds'
+    end
+    ab_test_bucket(:NDS_LOOK_AND_FEEL) == :nds
   end
 
   # for lograge

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -362,6 +362,7 @@ mfa_report_config: '[]'
 min_password_score: 3
 minimum_wait_before_another_usps_letter_in_hours: 24
 mx_timeout: 3
+nds_look_and_feel_percent: 0
 new_device_alert_delay_in_minutes: 5
 new_device_alert_window_start_in_minutes: 480
 newrelic_license_key: ''

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -238,7 +238,7 @@ module AbTests
 
   NDS_LOOK_AND_FEEL = AbTest.new(
     experiment_name: 'NDS Look and Feel Phase 1',
-    should_log: /^(Sign in|Multi-Factor|Account)/i,
+    should_log: AbTest::ALL_EVENTS,
     buckets: { nds: IdentityConfig.store.nds_look_and_feel_percent },
   ) do |user:, session:, **|
     user&.uuid || session&.dig(:session_id) || 'anon'

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -235,4 +235,12 @@ module AbTests
   ) do |user:, user_session:, **|
     user&.uuid
   end.freeze
+
+  NDS_LOOK_AND_FEEL = AbTest.new(
+    experiment_name: 'NDS Look and Feel Phase 1',
+    should_log: /^(Sign in|Multi-Factor|Account)/i,
+    buckets: { nds: IdentityConfig.store.nds_look_and_feel_percent },
+  ) do |user:, session:, **|
+    user&.uuid || session&.dig(:session_id) || 'anon'
+  end.freeze
 end

--- a/lib/ab_test.rb
+++ b/lib/ab_test.rb
@@ -14,6 +14,8 @@ class AbTest
 
   MAX_SHA = (16 ** 64) - 1
 
+  ALL_EVENTS = //
+
   ReportQueryConfig = Struct.new(:title, :query, :row_labels, keyword_init: true).freeze
 
   ReportConfig = Struct.new(:email, :queries, keyword_init: true) do

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -375,6 +375,7 @@ module IdentityConfig
     config.add(:mx_timeout, type: :integer)
     config.add(:new_device_alert_delay_in_minutes, type: :integer)
     config.add(:new_device_alert_window_start_in_minutes, type: :integer, allow_nil: true)
+    config.add(:nds_look_and_feel_percent, type: :integer)
     config.add(:newrelic_license_key, type: :string)
     config.add(:openid_connect_authorization_code_expiration_seconds, type: :integer)
     config.add(:openid_connect_content_security_form_action_enabled, type: :boolean)

--- a/spec/config/initializers/ab_tests_spec.rb
+++ b/spec/config/initializers/ab_tests_spec.rb
@@ -596,4 +596,48 @@ RSpec.describe AbTests do
 
     it_behaves_like 'an A/B test that uses user_uuid as a discriminator'
   end
+
+  describe 'NDS_LOOK_AND_FEEL' do
+    it 'is registered in AbTests.all' do
+      expect(AbTests.all[:NDS_LOOK_AND_FEEL]).to be_a(AbTest)
+    end
+
+    context 'when nds_look_and_feel_percent is 0' do
+      before do
+        allow(IdentityConfig.store).to receive(:nds_look_and_feel_percent).and_return(0)
+        reload_ab_tests
+      end
+
+      it 'does not assign the nds bucket' do
+        bucket = AbTests.all[:NDS_LOOK_AND_FEEL].bucket(
+          request: nil, service_provider: nil,
+          session: { session_id: 'sid' }, user: nil, user_session: nil
+        )
+        expect(bucket).to be_nil
+      end
+    end
+
+    context 'when nds_look_and_feel_percent is 100' do
+      before do
+        allow(IdentityConfig.store).to receive(:nds_look_and_feel_percent).and_return(100)
+        reload_ab_tests
+      end
+
+      it 'assigns the nds bucket' do
+        bucket = AbTests.all[:NDS_LOOK_AND_FEEL].bucket(
+          request: nil, service_provider: nil,
+          session: { session_id: 'sid' }, user: nil, user_session: nil
+        )
+        expect(bucket).to eq(:nds)
+      end
+
+      it 'falls back to an anon discriminator when both user and session are nil' do
+        bucket = AbTests.all[:NDS_LOOK_AND_FEEL].bucket(
+          request: nil, service_provider: nil,
+          session: nil, user: nil, user_session: nil
+        )
+        expect(bucket).to eq(:nds)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Registers the `NDS_LOOK_AND_FEEL` A/B test and its typed config schema entry so the app boots with the new gate. Behavior is unchanged at **0% rollout**.

- Adds `NDS_LOOK_AND_FEEL` to `AbTests` (0% via `nds_look_and_feel_percent`, default `0`).
- Registers `nds_look_and_feel_percent` in the typed config schema and `application.yml.default`.
- Adds a non-production request override (`X-Force-Nds-Bucket` header or `?nds_bucket` param) to enable staging and local previews ahead of the look-and-feel work this gate will drive.
- No layout switching, view forking, or CSS changes — purely the gate scaffold.

## Test plan

- [x] `spec/config/initializers/ab_tests_spec.rb` passes (0% assigns no bucket; 100% assigns; anon discriminator fallback)
- [x] App boots; `IdentityConfig.store.nds_look_and_feel_percent` resolves to `0`
- [x] No visual change in either bucket
- [ ] CI green