### PR TITLE
LG-17798 proofing sms not sent

### DIFF
--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -178,21 +178,10 @@ module Idv
     end
 
     def proofing_completion_phone_number
-      if idv_session.address_verification_mechanism == 'phone'
-        # A successful phone precheck completes the phone step without an OTP, so there is no
-        # phone confirmation session to read the number from.
-        idv_session.user_phone_confirmation_session&.phone || precheck_phone_number
-      elsif idv_session.phone_for_mobile_flow.present?
-        idv_session.phone_for_mobile_flow
-      else
+      return unless idv_session.address_verification_mechanism == 'phone'
+
+      idv_session.verification_phone_number ||
         current_user.default_phone_configuration&.formatted_phone
-      end
-    end
-
-    def precheck_phone_number
-      return unless idv_session.phone_precheck_successful
-
-      idv_session.precheck_phone&.dig(:phone)
     end
 
     def confirm_no_profile_yet

--- a/app/controllers/idv/enter_password_controller.rb
+++ b/app/controllers/idv/enter_password_controller.rb
@@ -179,12 +179,20 @@ module Idv
 
     def proofing_completion_phone_number
       if idv_session.address_verification_mechanism == 'phone'
-        idv_session.user_phone_confirmation_session&.phone
+        # A successful phone precheck completes the phone step without an OTP, so there is no
+        # phone confirmation session to read the number from.
+        idv_session.user_phone_confirmation_session&.phone || precheck_phone_number
       elsif idv_session.phone_for_mobile_flow.present?
         idv_session.phone_for_mobile_flow
       else
         current_user.default_phone_configuration&.formatted_phone
       end
+    end
+
+    def precheck_phone_number
+      return unless idv_session.phone_precheck_successful
+
+      idv_session.precheck_phone&.dig(:phone)
     end
 
     def confirm_no_profile_yet

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -257,6 +257,21 @@ module Idv
       vendor_phone_confirmation && address_verification_mechanism == 'phone'
     end
 
+    # The phone number confirmed for address verification. A successful phone precheck
+    # completes the phone step without sending an OTP, so there is no phone confirmation
+    # session to read the number from in that case.
+    def verification_phone_number
+      user_phone_confirmation_session&.phone.presence ||
+        precheck_phone_number.presence ||
+        phone_for_mobile_flow.presence
+    end
+
+    def precheck_phone_number
+      return unless phone_precheck_successful
+
+      precheck_phone&.with_indifferent_access&.dig(:phone)
+    end
+
     def user_phone_confirmation_session
       session_value = session[:user_phone_confirmation_session]
       return if session_value.blank?

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -534,14 +534,14 @@ RSpec.describe Idv::EnterPasswordController do
           context 'when there is no precheck phone' do
             before { subject.idv_session.precheck_phone = nil }
 
-            it 'dispatches account verified alert without a phone' do
+            it 'falls back to the default phone configuration phone' do
               allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
 
               put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
 
               expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
                 profile: user.reload.active_profile,
-                phone: nil,
+                phone: user.default_phone_configuration.formatted_phone,
               )
             end
           end
@@ -557,7 +557,7 @@ RSpec.describe Idv::EnterPasswordController do
 
                 expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
                   profile: user.reload.active_profile,
-                  phone: nil,
+                  phone: user.default_phone_configuration.formatted_phone,
                 )
               end
             end
@@ -566,7 +566,7 @@ RSpec.describe Idv::EnterPasswordController do
 
         context 'when the user completed verification via the hybrid/mobile flow' do
           before do
-            subject.idv_session.address_verification_mechanism = nil
+            subject.idv_session.user_phone_confirmation_session = nil
             subject.idv_session.phone_for_mobile_flow = '+1 202-555-5555'
           end
 
@@ -584,7 +584,7 @@ RSpec.describe Idv::EnterPasswordController do
 
         context 'when there is no phone confirmation session or mobile flow phone' do
           before do
-            subject.idv_session.address_verification_mechanism = nil
+            subject.idv_session.user_phone_confirmation_session = nil
             subject.idv_session.phone_for_mobile_flow = nil
           end
 
@@ -596,6 +596,23 @@ RSpec.describe Idv::EnterPasswordController do
             expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
               profile: user.reload.active_profile,
               phone: user.default_phone_configuration.formatted_phone,
+            )
+          end
+        end
+
+        context 'when the address verification mechanism is not phone' do
+          before do
+            subject.idv_session.address_verification_mechanism = nil
+          end
+
+          it 'dispatches account verified alert without a phone' do
+            allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+              profile: user.reload.active_profile,
+              phone: nil,
             )
           end
         end

--- a/spec/controllers/idv/enter_password_controller_spec.rb
+++ b/spec/controllers/idv/enter_password_controller_spec.rb
@@ -455,6 +455,115 @@ RSpec.describe Idv::EnterPasswordController do
           )
         end
 
+        context 'when the user skipped the phone step because of a phone precheck' do
+          let(:precheck_phone) { '+1 202-555-1313' }
+
+          # A successful precheck marks the phone step started and complete without ever
+          # sending an OTP, so there is no phone confirmation session in the session.
+          before do
+            subject.idv_session.user_phone_confirmation_session = nil
+            subject.idv_session.phone_precheck_successful = true
+            subject.idv_session.precheck_phone = { source: :mfa, phone: precheck_phone }
+          end
+
+          it 'dispatches account verified alert with the precheck phone' do
+            allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+            put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+            expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+              profile: user.reload.active_profile,
+              phone: precheck_phone,
+            )
+          end
+
+          context 'when the profile is proofed at an enhanced idv level' do
+            before do
+              subject.idv_session.selfie_check_performed = true
+            end
+
+            it 'sends the proofing completion SMS to the precheck phone' do
+              allow(Telephony).to receive(:send_proofing_completion_confirmation)
+
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+              expect(user.reload.active_profile).to be_enhanced
+              expect(Telephony).to have_received(:send_proofing_completion_confirmation).with(
+                hash_including(to: precheck_phone),
+              )
+            end
+          end
+
+          context 'when the precheck phone was rehydrated from the serialized session' do
+            # Sessions round-trip through JSON and come back with indifferent access,
+            # so the precheck phone is read back with string keys.
+            before do
+              subject.idv_session.precheck_phone =
+                { 'source' => 'mfa', 'phone' => precheck_phone }.with_indifferent_access
+            end
+
+            it 'dispatches account verified alert with the precheck phone' do
+              allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+              expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+                profile: user.reload.active_profile,
+                phone: precheck_phone,
+              )
+            end
+          end
+
+          context 'when the user confirmed a phone by OTP after the precheck' do
+            before do
+              subject.idv_session.user_phone_confirmation_session = user_phone_confirmation_session
+            end
+
+            it 'prefers the confirmed phone over the precheck phone' do
+              allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+              expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+                profile: user.reload.active_profile,
+                phone: user_phone_confirmation_session.phone,
+              )
+            end
+          end
+
+          context 'when there is no precheck phone' do
+            before { subject.idv_session.precheck_phone = nil }
+
+            it 'dispatches account verified alert without a phone' do
+              allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+              put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+              expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+                profile: user.reload.active_profile,
+                phone: nil,
+              )
+            end
+          end
+
+          [false, nil].each do |precheck_result|
+            context "when the phone precheck result is #{precheck_result.inspect}" do
+              before { subject.idv_session.phone_precheck_successful = precheck_result }
+
+              it 'does not fall back to the unverified precheck phone' do
+                allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call)
+
+                put :create, params: { user: { password: ControllerHelper::VALID_PASSWORD } }
+
+                expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+                  profile: user.reload.active_profile,
+                  phone: nil,
+                )
+              end
+            end
+          end
+        end
+
         context 'when the user completed verification via the hybrid/mobile flow' do
           before do
             subject.idv_session.address_verification_mechanism = nil

--- a/spec/controllers/idv/verify_info_controller_spec.rb
+++ b/spec/controllers/idv/verify_info_controller_spec.rb
@@ -889,6 +889,49 @@ RSpec.describe Idv::VerifyInfoController do
       end
     end
 
+    context 'when the phone precheck passes' do
+      let(:document_capture_session) { create(:document_capture_session, user:) }
+
+      let(:adjudicated_result) do
+        Proofing::Resolution::ResultAdjudicator.new(
+          phone_result: Proofing::AddressResult.new(
+            success: true,
+            errors: {},
+            exception: nil,
+            vendor_name: 'test-phone-vendor',
+          ).to_h,
+          device_profiling_result: Proofing::DdpResult.new(success: true),
+          hybrid_mobile_device_profiling_result: Proofing::DdpResult.new(success: true),
+          ipp_enrollment_in_progress: false,
+          residential_resolution_result: Proofing::Resolution::Result.new(success: true),
+          resolution_result: Proofing::Resolution::Result.new(success: true),
+          ipp_current_address_matches_id: true,
+          applicant_pii: Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN,
+          precheck_phone_number: subject.idv_session.precheck_phone[:phone],
+        ).adjudicated_result
+      end
+
+      before do
+        # Here we're trying to match the store to redis -> read from redis flow this data travels
+        document_capture_session.create_proofing_session
+        document_capture_session.store_proofing_result(adjudicated_result.to_h)
+        allow(controller).to receive(:load_async_state)
+          .and_return(document_capture_session.load_proofing_result)
+      end
+
+      # Idv::EnterPasswordController#proofing_completion_phone_number reads this exact session
+      # shape to pick the phone for the account verified SMS. See LG-17798.
+      it 'completes the phone step without a phone confirmation session' do
+        get :show
+
+        expect(subject.idv_session.phone_precheck_successful).to eq(true)
+        expect(subject.idv_session.precheck_phone[:phone]).to eq('+1 703-555-5555')
+        expect(subject.idv_session.address_verification_mechanism).to eq('phone')
+        expect(subject.idv_session.phone_confirmed?).to eq(true)
+        expect(subject.idv_session.user_phone_confirmation_session).to be_nil
+      end
+    end
+
     context 'when instant verify address proofing results in an exception' do
       let(:document_capture_session) { create(:document_capture_session, user:) }
       let(:success) { false }

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -474,6 +474,25 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
           expect(page).to have_current_path(idv_enter_password_path)
         end
 
+        # Skipping the phone step means there is no phone confirmation session, which used to
+        # leave the account verified alert without a phone number. See LG-17798.
+        it 'sends the account verified alert with the precheck phone' do
+          allow(UserAlerts::AlertUserAboutAccountVerified).to receive(:call).and_call_original
+
+          complete_ssn_step
+          complete_verify_step
+          expect(page).to have_current_path(idv_enter_password_path)
+
+          complete_enter_password_step(user)
+
+          # best_effort_phone falls back to the default phone configuration, which is what the
+          # precheck ran against.
+          expect(UserAlerts::AlertUserAboutAccountVerified).to have_received(:call).with(
+            profile: user.reload.active_profile,
+            phone: user.default_phone_configuration.formatted_phone,
+          )
+        end
+
         context 'when secondary vendor is enabled' do
           let(:user) do
             create(:user, :fully_registered, with: { phone: '703-555-5555' })

--- a/spec/features/idv/phone_precheck_completion_sms_spec.rb
+++ b/spec/features/idv/phone_precheck_completion_sms_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+# A successful phone precheck completes the phone step without sending an OTP, which used to
+# leave the proofing completion SMS without a phone number to send to. See LG-17798.
+RSpec.feature 'phone precheck proofing completion SMS', :js do
+  include IdvStepHelper
+  include IdvHelper
+  include DocAuthHelper
+
+  let(:user) { user_with_2fa }
+
+  before do
+    allow(IdentityConfig.store).to receive(:idv_phone_precheck_percent).and_return(100)
+    allow(IdentityConfig.store).to receive(:use_vot_in_sp_requests).and_return(true)
+  end
+
+  it 'sends the proofing completion SMS to the precheck phone' do
+    # Facial match mints the profile at an enhanced idv_level, which the SMS is gated on.
+    start_idv_from_sp(:oidc, facial_match_required: true)
+    sign_in_and_2fa_user(user)
+    complete_doc_auth_steps_before_ssn_step(with_selfie: true)
+    complete_ssn_step
+
+    complete_verify_step
+
+    # The phone step is skipped entirely because the precheck passed.
+    expect(page).to have_current_path(idv_enter_password_path)
+
+    Telephony::Test::Message.clear_messages
+    complete_enter_password_step(user)
+
+    # Wait for the password submission to finish before inspecting delivered messages, otherwise
+    # the assertion can race the request that sends the SMS.
+    expect(page).to have_current_path(idv_personal_key_path)
+
+    proofing_sms = Telephony::Test::Message.messages.find do |message|
+      message.body.include?('Identity verified on')
+    end
+
+    expect(proofing_sms).to be_present
+    expect(proofing_sms.to).to eq(user.default_phone_configuration.formatted_phone)
+  end
+end

--- a/spec/services/idv/session_spec.rb
+++ b/spec/services/idv/session_spec.rb
@@ -413,6 +413,121 @@ RSpec.describe Idv::Session do
     end
   end
 
+  describe '#verification_phone_number' do
+    let(:confirmation_session) do
+      Idv::PhoneConfirmationSession.new(
+        code: '123456',
+        phone: '+1 202-555-1212',
+        delivery_method: :sms,
+        user:,
+        sent_at: Time.zone.now,
+      )
+    end
+
+    context 'with a phone confirmation session' do
+      before { subject.user_phone_confirmation_session = confirmation_session }
+
+      it 'returns the confirmed phone' do
+        expect(subject.verification_phone_number).to eq('+1 202-555-1212')
+      end
+
+      context 'with a successful precheck as well' do
+        before do
+          subject.phone_precheck_successful = true
+          subject.precheck_phone = { source: :mfa, phone: '+1 202-555-1313' }
+        end
+
+        it 'prefers the confirmed phone' do
+          expect(subject.verification_phone_number).to eq('+1 202-555-1212')
+        end
+      end
+    end
+
+    context 'without a phone confirmation session' do
+      before { subject.user_phone_confirmation_session = nil }
+
+      context 'with a successful precheck' do
+        before do
+          subject.phone_precheck_successful = true
+          subject.precheck_phone = { source: :mfa, phone: '+1 202-555-1313' }
+        end
+
+        it 'returns the precheck phone' do
+          expect(subject.verification_phone_number).to eq('+1 202-555-1313')
+        end
+
+        context 'with a mobile flow phone as well' do
+          before { subject.phone_for_mobile_flow = '+1 202-555-1414' }
+
+          it 'prefers the precheck phone over the mobile flow phone' do
+            expect(subject.verification_phone_number).to eq('+1 202-555-1313')
+          end
+        end
+      end
+
+      context 'without a successful precheck' do
+        before do
+          subject.phone_precheck_successful = false
+          subject.precheck_phone = { source: :mfa, phone: '+1 202-555-1313' }
+        end
+
+        context 'with a mobile flow phone' do
+          before { subject.phone_for_mobile_flow = '+1 202-555-1414' }
+
+          it 'returns the mobile flow phone' do
+            expect(subject.verification_phone_number).to eq('+1 202-555-1414')
+          end
+        end
+
+        context 'without a mobile flow phone' do
+          before { subject.phone_for_mobile_flow = nil }
+
+          it 'returns nil' do
+            expect(subject.verification_phone_number).to be_nil
+          end
+        end
+      end
+    end
+  end
+
+  describe '#precheck_phone_number' do
+    context 'when the precheck succeeded' do
+      before { subject.phone_precheck_successful = true }
+
+      it 'returns the precheck phone' do
+        subject.precheck_phone = { source: :mfa, phone: '+1 202-555-1313' }
+
+        expect(subject.precheck_phone_number).to eq('+1 202-555-1313')
+      end
+
+      it 'reads a precheck phone rehydrated with string keys' do
+        subject.precheck_phone =
+          { 'source' => 'mfa', 'phone' => '+1 202-555-1313' }.with_indifferent_access
+
+        expect(subject.precheck_phone_number).to eq('+1 202-555-1313')
+      end
+
+      it 'returns nil without a precheck phone' do
+        subject.precheck_phone = nil
+
+        expect(subject.precheck_phone_number).to be_nil
+      end
+    end
+
+    [false, nil].each do |precheck_result|
+      context "when the precheck result is #{precheck_result.inspect}" do
+        before do
+          subject.phone_precheck_successful = precheck_result
+          subject.precheck_phone = { source: :mfa, phone: '+1 202-555-1313' }
+        end
+
+        it 'returns nil' do
+          expect(subject.precheck_phone_number).to be_nil
+        end
+      end
+    end
+  end
+
   describe '#profile' do
     it 'is nil by default' do
       expect(subject.profile).to eql(nil)


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17798](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17798)

## 🛠 Summary of changes

A passing phone precheck completes the phone step without sending an OTP, so there is no phone confirmation session. `Idv::EnterPasswordController#proofing_completion_phone_number` still took the `address_verification_mechanism == 'phone'` branch and returned `nil`, so `UserAlerts::AlertUserAboutAccountVerified` received `phone: nil` and skipped the SMS.

It now falls back to the precheck phone, guarded on `phone_precheck_successful` so an unverified number is never used. A confirmed OTP phone still takes precedence.

the SMS is also gated on an enhanced `idv_level`, so this restores it for enhanced profiles only. `legacy_unsupervised` precheck users still get none, as was true before precheck existed.

## 📜 Testing Plan

- [ ] `bundle exec rspec spec/features/idv/phone_precheck_completion_sms_spec.rb spec/controllers/idv/enter_password_controller_spec.rb spec/controllers/idv/verify_info_controller_spec.rb`
- [ ] Delete the `|| precheck_phone_number` fallback, confirm the feature spec fails with no SMS delivered, then restore it.
- [ ] Set `idv_phone_precheck_percent: 100` (defaults to `0), then start IdV from `/test/oidc` via "Sign in with Facial Match" as a user whose MFA phone will pass the precheck.
- [ ] Confirm the phone step is skipped, submit your password, and confirm the "Identity verified on ..." message at `/test/telephony`.
- [ ] Confirm the account verified email is still sent.
- [ ] Regression: with `idv_phone_precheck_percent: 0`, confirm a phone by OTP and confirm the SMS goes to that phone.
- [ ] Regression: with a failing precheck, confirm the user is routed to the phone step.


[LG-17798]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17798