### PR TITLE
LG-17527: Support passport cards capture through LN/DocAuthMock

### DIFF
--- a/app/services/doc_auth/lexis_nexis/responses/ddp/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/ddp/true_id_response.rb
@@ -46,7 +46,7 @@ module DocAuth
           # vendor (document and selfie if requested)
           # Will be further implemented in future tickets
           def successful_result?
-            return false if passport_card_detected? # && !passport_cards_supported
+            return false if unsupported_passport_card?
 
             doc_auth_success? &&
               (@liveness_checking_enabled ? selfie_passed? : true)
@@ -59,7 +59,7 @@ module DocAuth
           def error_messages
             return {} if successful_result?
 
-            if passport_card_detected? # && !passport_cards_supported
+            if unsupported_passport_card?
               { passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') }
             elsif id_type.present? && !expected_document_type_received?
               { unexpected_id_type: true, expected_id_type: expected_id_type }

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response.rb
@@ -44,7 +44,7 @@ module DocAuth
         ## returns full check success status, considering all checks:
         #    vendor (document and selfie if requested)
         def successful_result?
-          return false if passport_card_detected? && !passport_cards_supported
+          return false if unsupported_passport_card?
 
           doc_auth_success? &&
             (@liveness_checking_enabled ? selfie_passed? : true)
@@ -61,7 +61,7 @@ module DocAuth
         def error_messages
           return {} if successful_result?
 
-          if passport_card_detected? # && !passport_cards_supported
+          if unsupported_passport_card?
             { passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') }
           elsif id_type.present? && !expected_document_type_received?
             { unexpected_id_type: true, expected_id_type: expected_id_type }

--- a/app/services/doc_auth/lexis_nexis/responses/true_id_response_concern.rb
+++ b/app/services/doc_auth/lexis_nexis/responses/true_id_response_concern.rb
@@ -62,6 +62,10 @@ module DocAuth
           )
         end
 
+        def unsupported_passport_card?
+          passport_card_detected? && !passport_cards_supported
+        end
+
         def expected_document_type_received?
           expected_id_types = passport_requested ?
             Idp::Constants::DocumentTypes::SUPPORTED_PASSPORT_TYPES :

--- a/app/services/doc_auth/mock/result_response.rb
+++ b/app/services/doc_auth/mock/result_response.rb
@@ -68,6 +68,10 @@ module DocAuth
               passport_check_result,
             ].any?(&:present?)
 
+            if unsupported_passport_card?
+              return { passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') }
+            end
+
             if id_type.present? && !expected_document_type_received?
               return { unexpected_id_type: true, expected_id_type: expected_id_type }
             end
@@ -130,6 +134,7 @@ module DocAuth
       end
 
       def doc_auth_success?
+        return false if unsupported_passport_card?
         return false unless id_type_supported?
         return false unless expected_document_type_received?
         return false if transaction_status_from_uploaded_file ==
@@ -176,7 +181,7 @@ module DocAuth
         document = parsed_data_from_uploaded_file['document'].symbolize_keys
         doc_type = document[:document_type_received]
 
-        if doc_type == 'passport'
+        if Idp::Constants::DocumentTypes::PASSPORT_TYPES.include?(doc_type)
           Pii::Passport.new(
             **Idp::Constants::MOCK_IDV_APPLICANT.merge(document).slice(*Pii::Passport.members),
           )
@@ -257,6 +262,14 @@ module DocAuth
 
       def id_type
         parsed_data_from_uploaded_file&.dig('document', 'document_type_received')
+      end
+
+      def passport_card_detected?
+        id_type == Idp::Constants::DocumentTypes::PASSPORT_CARD
+      end
+
+      def unsupported_passport_card?
+        passport_card_detected? && !passport_cards_supported
       end
 
       def expected_id_type

--- a/spec/services/doc_auth/lexis_nexis/responses/ddp/true_id_response_spec.rb
+++ b/spec/services/doc_auth/lexis_nexis/responses/ddp/true_id_response_spec.rb
@@ -365,8 +365,16 @@ RSpec.describe DocAuth::LexisNexis::Responses::Ddp::TrueIdResponse do
       let(:passport_cards_supported) { true }
       let(:ddp_response_body) { LexisNexisFixtures.ddp_true_id_passport_card_response_success }
 
-      it 'is an usuccessful result' do
-        expect(response.success?).to eq(false)
+      it 'is a successful result' do
+        expect(response.success?).to eq(true)
+      end
+
+      it 'records the document_type_received as passport_card' do
+        expect(response.pii_from_doc.document_type_received).to eq('passport_card')
+      end
+
+      it 'does not have passport card error messages' do
+        expect(response.error_messages[:passport_card]).to eq(nil)
       end
     end
   end

--- a/spec/services/doc_auth/mock/result_response_spec.rb
+++ b/spec/services/doc_auth/mock/result_response_spec.rb
@@ -115,6 +115,54 @@ RSpec.describe DocAuth::Mock::ResultResponse do
     end
   end
 
+  context 'when a passport card is submitted' do
+    subject(:response) do
+      described_class.new(
+        input, config,
+        selfie_required:,
+        passport_submittal: true,
+        passport_requested: true,
+        passport_cards_supported:
+      )
+    end
+
+    let(:input) do
+      <<~YAML
+        document:
+          first_name: Susan
+          last_name: Smith
+          middle_name: Q
+          birth_place: 'Springfield, IL'
+          passport_expiration: '2030-01-01'
+          mrz: 'P<USASMITH<<SUSAN<<<<<<<<<<<<<<<<<<<<<<<<<1234567890USA8001019F2301012<<<<<<<<<<<<<<04'
+          passport_issued: '2020-01-01'
+          nationality_code: USA
+          document_number: '1234567890'
+          document_type_received: passport_card
+      YAML
+    end
+
+    context 'when passport cards are supported' do
+      let(:passport_cards_supported) { true }
+
+      it 'returns a successful result with the passport card document type' do
+        expect(response.success?).to eq(true)
+        expect(response.pii_from_doc).to be_a(Pii::Passport)
+        expect(response.pii_from_doc.document_type_received).to eq('passport_card')
+      end
+    end
+
+    context 'when passport cards are not supported' do
+      let(:passport_cards_supported) { false }
+
+      it 'is not a successful result and returns a passport card doc type error' do
+        expect(response.success?).to eq(false)
+        expect(response.errors)
+          .to eq({ passport_card: I18n.t('doc_auth.errors.doc.doc_type_check') })
+      end
+    end
+  end
+
   context 'with a yaml file containing PII' do
     let(:input) do
       <<~YAML


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17527](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17527)

## 🛠 Summary of changes

Accept passport cards during document capture when passport card support is enabled.

- Enable the previously-stubbed `passport_cards_supported` guard in the LexisNexis TrueID responses (`true_id_response.rb` and `ddp/true_id_response.rb`) so a detected passport card is only treated as an unsuccessful result / error when passport cards are **not** supported.
- Update the mock `ResultResponse` to:
  - Return a `passport_card` doc type error (and fail `doc_auth_success?`) when a passport card is received but passport cards are not supported.
  - Recognize all `PASSPORT_TYPES` (not just `passport`) when building `Pii::Passport`, so passport cards produce passport PII.
  - Add a `passport_card_received?` helper based on the resolved `id_type`.
- Add/adjust specs covering supported vs. unsupported passport card submittal across the DDP TrueID response and the mock response.

## 📜 Testing Plan

- [ ] With passport card support **enabled**, submit a passport card and confirm the result is successful and `document_type_received` is `passport_card`.
- [ ] With passport card support **enabled**, confirm no `passport_card` error message is returned.
- [ ] With passport card support **disabled**, submit a passport card and confirm the result is unsuccessful with the `doc.doc_type_check` error.
- [ ] Run the specs:
  - `bundle exec rspec spec/services/doc_auth/lexis_nexis/responses/ddp/true_id_response_spec.rb`
  - `bundle exec rspec spec/services/doc_auth/mock/result_response_spec.rb`

[LG-17527]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17527