### PR TITLE
Deploy RC 601 to Production

### DIFF
--- a/app/forms/idv/state_id_form.rb
+++ b/app/forms/idv/state_id_form.rb
@@ -23,13 +23,6 @@ module Idv
 
     attr_accessor(*ATTRIBUTES)
 
-    # 50/50 deploy compatibility (LG-16085): the rendered radio still uses the legacy
-    # param name `same_address_as_id`, so the form builder queries the form object for
-    # `same_address_as_id` when rendering `checked`. Alias it to the real attribute.
-    # Remove alongside LEGACY_PARAM_ALIASES once the form param rename is fully deployed.
-    alias_method :same_address_as_id, :ipp_current_address_matches_id
-    alias_method :same_address_as_id=, :ipp_current_address_matches_id=
-
     def self.model_name
       ActiveModel::Name.new(self, nil, 'StateId')
     end

--- a/app/views/idv/in_person/state_id/show.html.erb
+++ b/app/views/idv/in_person/state_id/show.html.erb
@@ -254,11 +254,7 @@
         form: f,
         label: t('in_person_proofing.form.state_id.current_address_matches_id'),
         legend_html: { class: 'h2' },
-        # 50/50 deploy compatibility (LG-16085): keep submitting the legacy param name
-        # so forms rendered by the new deploy are still accepted by old instances
-        # during the rollout. The server accepts both names. Rename to
-        # :ipp_current_address_matches_id in a follow-up once fully deployed.
-        name: :same_address_as_id,
+        name: :ipp_current_address_matches_id,
         required: true,
         wrapper: :uswds_radio_buttons,
       ) %>


### PR DESCRIPTION
## Internal
- In-person proofing: Rename the state ID same-address form parameter to ipp_current_address_matches_id ([#13347](https://github.com/18F/identity-idp/pull/13347))
