### PR TITLE
Sync Proofing Agent AAMVA address selection with resolution state-ID stage

### DIFF
--- a/app/jobs/proofing_agent_job.rb
+++ b/app/jobs/proofing_agent_job.rb
@@ -322,7 +322,7 @@ class ProofingAgentJob < ApplicationJob
       applicant_pii:,
       current_sp:,
       state_id_address_resolution_result: nil,
-      ipp_enrollment_in_progress: false,
+      ipp_enrollment_in_progress: user.has_in_person_enrollment?,
       timer:,
       doc_auth_flow: true,
       analytics:,

--- a/app/jobs/proofing_agent_job.rb
+++ b/app/jobs/proofing_agent_job.rb
@@ -7,6 +7,12 @@ class ProofingAgentJob < ApplicationJob
 
   queue_as :high_proofing_agent
 
+  # PA can submit a residential and a document address, so we always verify both (dual
+  # address verification), the same as IPP. AAMVA and resolution must use this same value
+  # so they verify the same (document) address and a verified AAMVA :address cannot cover
+  # a resolution failure for an address it never saw.
+  PA_BEHAVES_LIKE_IPP = true
+
   discard_on JobHelpers::StaleJobHelper::StaleJobError
 
   attr_reader :document_capture_session, :proofing_components, :proofing_agent
@@ -245,6 +251,8 @@ class ProofingAgentJob < ApplicationJob
             [:proofing_results, :biographical_info, :ipp_current_address_matches_id],
             [:proofing_results, :biographical_info, :phone],
             [:proofing_results, :context, :stages, :resolution, :errors, :ssn],
+            [:proofing_results, :context, :stages, :residential_address, :errors, :zipcode],
+            [:proofing_results, :context, :stages, :residential_address, :errors, :ssn],
             [:errors, :zipcode],
             [:errors, :ssn],
           ],
@@ -308,7 +316,7 @@ class ProofingAgentJob < ApplicationJob
         trace_id:,
         user_id:,
         service_provider_issuer:,
-        ipp_enrollment_in_progress: user.has_in_person_enrollment?,
+        ipp_enrollment_in_progress: PA_BEHAVES_LIKE_IPP,
         proofing_vendor:,
         is_proofing_agent: true,
       )
@@ -322,7 +330,7 @@ class ProofingAgentJob < ApplicationJob
       applicant_pii:,
       current_sp:,
       state_id_address_resolution_result: nil,
-      ipp_enrollment_in_progress: user.has_in_person_enrollment?,
+      ipp_enrollment_in_progress: PA_BEHAVES_LIKE_IPP,
       timer:,
       doc_auth_flow: true,
       analytics:,

--- a/spec/jobs/proofing_agent_job_spec.rb
+++ b/spec/jobs/proofing_agent_job_spec.rb
@@ -399,6 +399,43 @@ RSpec.describe ProofingAgentJob, type: :job do
         result = document_capture_session.reload.load_agent_proofed_user
         expect(result[:pii][:aamva_verified_attributes]).to be_present
       end
+
+      context 'AAMVA address selection matches the resolution state-ID stage' do
+        let(:aamva_plugin) { Proofing::Resolution::Plugins::AamvaPlugin.new }
+
+        before do
+          allow(Proofing::Resolution::Plugins::AamvaPlugin).to receive(:new)
+            .and_return(aamva_plugin)
+        end
+
+        context 'when the user has an in-person enrollment' do
+          before do
+            allow_any_instance_of(User).to receive(:has_in_person_enrollment?).and_return(true)
+          end
+
+          it 'verifies AAMVA with ipp_enrollment_in_progress: true' do
+            expect(aamva_plugin).to receive(:call)
+              .with(hash_including(ipp_enrollment_in_progress: true))
+              .and_call_original
+
+            perform
+          end
+        end
+
+        context 'when the user does not have an in-person enrollment' do
+          before do
+            allow_any_instance_of(User).to receive(:has_in_person_enrollment?).and_return(false)
+          end
+
+          it 'verifies AAMVA with ipp_enrollment_in_progress: false' do
+            expect(aamva_plugin).to receive(:call)
+              .with(hash_including(ipp_enrollment_in_progress: false))
+              .and_call_original
+
+            perform
+          end
+        end
+      end
     end
 
     context 'when the AAMVA check fails' do

--- a/spec/jobs/proofing_agent_job_spec.rb
+++ b/spec/jobs/proofing_agent_job_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe ProofingAgentJob, type: :job do
             proofing_components: {
               document_check: Idp::Constants::Vendors::PROOFING_AGENT,
               source_check: 'StateIdMock',
-              residential_resolution_check: 'ResidentialAddressNotRequired',
+              residential_resolution_check: 'ResolutionMock',
               resolution_check: 'ResolutionMock',
               address_check: 'AddressMock',
             },
@@ -174,13 +174,13 @@ RSpec.describe ProofingAgentJob, type: :job do
                     errors: {},
                     exception: nil,
                     timed_out: false,
-                    transaction_id: '',
-                    reference: '',
+                    transaction_id: Proofing::Mock::ResolutionMockClient::TRANSACTION_ID,
+                    reference: Proofing::Mock::ResolutionMockClient::REFERENCE,
                     reason_codes: {},
                     can_pass_with_additional_verification: false,
                     attributes_requiring_additional_verification: [],
                     source_attribution: [],
-                    vendor_name: 'ResidentialAddressNotRequired',
+                    vendor_name: 'ResolutionMock',
                     vendor_id: nil,
                     vendor_workflow: nil,
                     verified_attributes: nil },
@@ -230,7 +230,7 @@ RSpec.describe ProofingAgentJob, type: :job do
             },
             proofing_components: {
               source_check: 'StateIdMock',
-              residential_resolution_check: 'ResidentialAddressNotRequired',
+              residential_resolution_check: 'ResolutionMock',
               resolution_check: 'ResolutionMock',
               address_check: 'AddressMock',
             },
@@ -385,7 +385,7 @@ RSpec.describe ProofingAgentJob, type: :job do
             transaction_id: transaction_id,
           },
           proofing_components: {
-            residential_resolution_check: 'ResidentialAddressNotRequired',
+            residential_resolution_check: 'ResolutionMock',
             resolution_check: 'ResolutionMock',
             address_check: 'AddressMock',
             source_check: 'StateIdMock',
@@ -400,7 +400,7 @@ RSpec.describe ProofingAgentJob, type: :job do
         expect(result[:pii][:aamva_verified_attributes]).to be_present
       end
 
-      context 'AAMVA address selection matches the resolution state-ID stage' do
+      context 'AAMVA and resolution use the same address selection (dual address verification)' do
         let(:aamva_plugin) { Proofing::Resolution::Plugins::AamvaPlugin.new }
 
         before do
@@ -408,32 +408,20 @@ RSpec.describe ProofingAgentJob, type: :job do
             .and_return(aamva_plugin)
         end
 
-        context 'when the user has an in-person enrollment' do
-          before do
-            allow_any_instance_of(User).to receive(:has_in_person_enrollment?).and_return(true)
-          end
+        it 'verifies AAMVA with ipp_enrollment_in_progress: true' do
+          expect(aamva_plugin).to receive(:call)
+            .with(hash_including(ipp_enrollment_in_progress: true))
+            .and_call_original
 
-          it 'verifies AAMVA with ipp_enrollment_in_progress: true' do
-            expect(aamva_plugin).to receive(:call)
-              .with(hash_including(ipp_enrollment_in_progress: true))
-              .and_call_original
-
-            perform
-          end
+          perform
         end
 
-        context 'when the user does not have an in-person enrollment' do
-          before do
-            allow_any_instance_of(User).to receive(:has_in_person_enrollment?).and_return(false)
-          end
+        it 'runs the resolution job with ipp_enrollment_in_progress: true' do
+          expect(ResolutionProofingJob).to receive(:perform_now)
+            .with(hash_including(ipp_enrollment_in_progress: true))
+            .and_call_original
 
-          it 'verifies AAMVA with ipp_enrollment_in_progress: false' do
-            expect(aamva_plugin).to receive(:call)
-              .with(hash_including(ipp_enrollment_in_progress: false))
-              .and_call_original
-
-            perform
-          end
+          perform
         end
       end
     end


### PR DESCRIPTION
## 🎫 Ticket
Link to the relevant ticket:
[JOAN-118](https://gitlab.login.gov/lg-teams/joan/joan/-/work_items/118)

## 🛠 Summary of changes
Similar to IPP, the Proofing Agent (PA) flow can submit 2 addresses, a residential
address and a document address. AAMVA was called with a hardcoded
`ipp_enrollment_in_progress: false`, so it verified the residential address keys, while
the resolution job's state-ID stage runs with
`ipp_enrollment_in_progress: user.has_in_person_enrollment?`, so it verifies the document
address. When those addresses differ, `aamva_verified_attributes` reflected a different
address than the resolution result being adjudicated, allowing a verified AAMVA `:address`
to cover a document-address resolution failure it never saw.

This changes both the AAMVA call and the resolution job call in the PA flow to a hardcoded
`ipp_enrollment_in_progress: true`, so PA behaves like IPP when it comes to address checks
and performs dual address verification (DAV). This ensures that AAMVA and resolution both verify the document
address, which is consistent with every other flow.

The key to avoiding a cross-address bug is that AAMVA and resolution use the same address.
Any of the following achieve that, but they differ in behavior:
- false: AAMVA and resolution use the residential (current) address. Single address check performed.
- true: AAMVA and resolution use the document address. Dual address verification (DAV) performed.
- both `user.has_in_person_enrollment?`: can behave like either of the previous, depending on whether the user has started an IPP flow.

We chose `true` so PA behaves like IPP and AAMVA checks the document address, consistent
with all other flows.

Remote flow is unaffected. That case is being handled separately in LG-17686 (#13343) via
`address_edited`. 

## 📜 Testing Plan
- PA flow behaves the same as IPP.  Specifically:
    - [x] PA flow with single address: resolution and AAMVA verify the document address, single address check performed.
    - [x] PA flow with differing addresses: dual address verification performed, and a verified AAMVA `:address` can no longer cover a document-address resolution failure proofed against a different address.
- [x] AAMVA and the resolution state-ID stage are called with `ipp_enrollment_in_progress: true`.
- [x] `bundle exec rspec spec/jobs/proofing_agent_job_spec.rb` passes.
- [x] `bundle exec rspec spec/services/proofing/resolution/plugins/aamva_plugin_spec.rb` passes (regression).