### PR TITLE
LG-17757 Show link to privacy statement on consent screen

### DIFF
--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -68,6 +68,18 @@
   <% end %>
 <% end %>
 
+<p class="margin-top-4 margin-bottom-4">
+  <%= t(
+        'sign_up.information_sharing_html',
+        app_name: APP_NAME,
+        link_html: new_tab_link_to(
+          t('notices.privacy.privacy_act_statement'),
+          MarketingSite.privacy_act_statement_url,
+        ),
+      )
+  %>
+</p>
+
 <%= simple_form_for(:idv_form, url: sign_up_completed_path, html: { class: 'margin-y-5' }) do |f| %>
   <%= f.submit t('sign_up.agree_and_continue') %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1702,6 +1702,7 @@ sign_up.agree_and_continue: Agree and continue
 sign_up.cancel.success: Your account has been deleted. We did not save your information.
 sign_up.cancel.warning_header: 'If you cancel now:'
 sign_up.completed.smiling_image_alt: A smiling person with a green checkmark indicating success
+sign_up.information_sharing_html: To learn how %{app_name} shares your information, review our %{link_html}.
 sign_up.terms: I read and accept the %{app_name}
 simple_form.error_notification.default_message: 'Please review the problems below:'
 simple_form.no: 'No'
@@ -1790,7 +1791,7 @@ titles.sign_in: Sign in
 titles.sign_up.completion_consent_expired_auth_only: It’s been a year since you gave us consent to share your information
 titles.sign_up.completion_consent_expired_idv: It’s been a year since you gave us consent to share your verified identity
 titles.sign_up.completion_first_sign_in: Continue to %{sp}
-titles.sign_up.completion_idv: Connect your verified information to %{sp}
+titles.sign_up.completion_idv: Connect your information to %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} is requesting new information'
 titles.sign_up.completion_new_sp: You are now signing in for the first time
 titles.sign_up.completion_reverified_consent: Share your updated information with %{sp}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1714,6 +1714,7 @@ sign_up.agree_and_continue: Aceptar y continuar
 sign_up.cancel.success: Su cuenta fue eliminada. No guardamos su información.
 sign_up.cancel.warning_header: 'Si cancela ahora:'
 sign_up.completed.smiling_image_alt: Una persona sonriente con una marca de verificación verde
+sign_up.information_sharing_html: Para saber cómo %{app_name} comparte su información, consulte nuestra %{link_html}.
 sign_up.terms: Leí y acepto %{app_name}
 simple_form.error_notification.default_message: 'Revise los siguientes problemas:'
 simple_form.no: 'No'
@@ -1802,7 +1803,7 @@ titles.sign_in: Iniciar sesión
 titles.sign_up.completion_consent_expired_auth_only: Hace un año que nos dio su consentimiento para divulgar su información
 titles.sign_up.completion_consent_expired_idv: Hace un año que nos dio su consentimiento para divulgar su identidad verificada
 titles.sign_up.completion_first_sign_in: Continuar con %{sp}
-titles.sign_up.completion_idv: Conecte su información verificada a %{sp}
+titles.sign_up.completion_idv: Conecte su información a %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} está solicitando nueva información'
 titles.sign_up.completion_new_sp: Está iniciando sesión por primera vez
 titles.sign_up.completion_reverified_consent: Comunique su información actualizada a %{sp}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1703,6 +1703,7 @@ sign_up.agree_and_continue: Accepter et continuer
 sign_up.cancel.success: Votre compte a été supprimé. Nous n’avons pas sauvegardé vos informations.
 sign_up.cancel.warning_header: 'Si vous annulez maintenant :'
 sign_up.completed.smiling_image_alt: Une personne souriante avec une coche verte indiquant la réussite de la procédure
+sign_up.information_sharing_html: Pour savoir comment %{app_name} partage vos informations, consultez notre déclaration relative à la %{link_html}.
 sign_up.terms: J’ai lu et j’accepte les %{app_name}
 simple_form.error_notification.default_message: 'Veuillez examiner les problèmes ci-dessous :'
 simple_form.no: Non
@@ -1791,7 +1792,7 @@ titles.sign_in: Se connecter
 titles.sign_up.completion_consent_expired_auth_only: Cela fait un an que vous nous avez donné votre consentement pour partager vos informations
 titles.sign_up.completion_consent_expired_idv: Cela fait un an que vous nous avez donné votre consentement pour partager votre identité vérifiée
 titles.sign_up.completion_first_sign_in: Continuer vers %{sp}
-titles.sign_up.completion_idv: Connecter vos informations vérifiées à %{sp}
+titles.sign_up.completion_idv: Connecter vos informations à %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} demande de nouvelles informations'
 titles.sign_up.completion_new_sp: Vous vous connectez pour la première fois
 titles.sign_up.completion_reverified_consent: Partager vos informations mises à jour avec %{sp}

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1715,6 +1715,7 @@ sign_up.agree_and_continue: 同意并继续
 sign_up.cancel.success: 你的账户已被删除。我们没有存储你的信息。
 sign_up.cancel.warning_header: 如果你现在取消：
 sign_up.completed.smiling_image_alt: 面带笑容的一个人加上绿勾说明成功了
+sign_up.information_sharing_html: 如需了解 %{app_name} 如何共享您的信息，请查阅我们的《%{link_html}》。
 sign_up.terms: 我已阅读并接受 %{app_name}
 simple_form.error_notification.default_message: 请仔细阅读以下问题：
 simple_form.no: 不
@@ -1803,7 +1804,7 @@ titles.sign_in: 登录
 titles.sign_up.completion_consent_expired_auth_only: 从你上次授权我们分享你的信息已经一年了。
 titles.sign_up.completion_consent_expired_idv: 从你上次授权我们分享你验证过的身份已经一年了。
 titles.sign_up.completion_first_sign_in: 继续到 %{sp}
-titles.sign_up.completion_idv: 连接你验证过的信息到 %{sp}
+titles.sign_up.completion_idv: 将您的信息连接到 %{sp}
 titles.sign_up.completion_new_attributes: '%{sp} 在要求新信息'
 titles.sign_up.completion_new_sp: 你现在正在首次登入
 titles.sign_up.completion_reverified_consent: 与 %{sp}分享你更新后的信息

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'sign_up/completions/show.html.erb' do
+  include LinkHelper
+
   let(:user) { create(:user, :proofed) }
   let(:service_provider) { create(:service_provider) }
   let(:selected_email_id) { user.email_addresses.first.id }
@@ -58,6 +60,20 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
     expect(rendered).to have_link(
       t('links.cancel'),
       href: sign_up_completed_cancel_path,
+    )
+  end
+
+  it 'shows how the information will be shared with the sp' do
+    render
+    expect(rendered).to include(
+      t(
+        'sign_up.information_sharing_html',
+        app_name: APP_NAME,
+        link_html: new_tab_link_to(
+          t('notices.privacy.privacy_act_statement'),
+          MarketingSite.privacy_act_statement_url,
+        ),
+      ),
     )
   end
 


### PR DESCRIPTION
changelog: User-Facing Improvements, Consent screen, Show link to privacy statement on consent screen

Remove the adjective "verified" from post IdV consent screens

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
