### PR TITLE
[bug] attempts/fraudops tracker hybrid null user bug

### DIFF
--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -467,7 +467,7 @@ module Idv
         user_id: user_uuid,
       )
       attempts_api_tracker.idv_rate_limited(user_id: user_uuid, limiter_type: :idv_doc_auth)
-      fraud_ops_tracker.idv_rate_limited(limiter_type: :idv_doc_auth)
+      fraud_ops_tracker.idv_rate_limited(user_id: user_uuid, limiter_type: :idv_doc_auth)
     end
 
     def document_capture_session_uuid

--- a/app/forms/idv/api_image_upload_form.rb
+++ b/app/forms/idv/api_image_upload_form.rb
@@ -84,6 +84,7 @@ module Idv
         attempts_api_tracker.idv_document_upload_submitted(
           **doc_escrow_images,
           success: response.success?,
+          user_id: user_uuid,
           document_state: pii_from_doc[:state],
           document_number: pii_from_doc[:state_id_number],
           document_issued: pii_from_doc[:state_id_issued],
@@ -103,6 +104,7 @@ module Idv
         fraud_ops_tracker.fraud_ops_idv_document_upload_submitted(
           **doc_escrow_images,
           success: response.success?,
+          user_id: user_uuid,
           document_state: pii_from_doc[:state],
           document_number: pii_from_doc[:state_id_number],
           document_issued: pii_from_doc[:state_id_issued],
@@ -179,11 +181,13 @@ module Idv
       attempts_api_tracker.idv_document_uploaded(
         **doc_escrow_images,
         success: response.success?,
+        user_id: user_uuid,
         failure_reason: attempts_api_tracker.parse_failure_reason(response),
       )
       fraud_ops_tracker.idv_document_uploaded(
         **doc_escrow_images,
         success: response.success?,
+        user_id: user_uuid,
         failure_reason: fraud_ops_tracker.parse_failure_reason(response),
       )
     end
@@ -462,7 +466,7 @@ module Idv
         limiter_type: :idv_doc_auth,
         user_id: user_uuid,
       )
-      attempts_api_tracker.idv_rate_limited(limiter_type: :idv_doc_auth)
+      attempts_api_tracker.idv_rate_limited(user_id: user_uuid, limiter_type: :idv_doc_auth)
       fraud_ops_tracker.idv_rate_limited(limiter_type: :idv_doc_auth)
     end
 

--- a/app/services/attempts_api/tracker.rb
+++ b/app/services/attempts_api/tracker.rb
@@ -44,11 +44,7 @@ module AttemptsApi
     def track_event(event_type, metadata = {})
       return unless should_track?(event_type)
 
-      user_id = metadata.delete(:user_id)
-
-      if user_blank? && user_id.present?
-        @user = User.find_by(uuid: user_id)
-      end
+      overwrite_user_if_applicable(metadata.delete(:user_id))
 
       event = AttemptEvent.new(
         event_type: event_type,
@@ -111,6 +107,10 @@ module AttemptsApi
 
     def session
       @request&.session
+    end
+
+    def overwrite_user_if_applicable(uuid)
+      @user = User.find_by(uuid:) if user_blank? && uuid.present?
     end
 
     def user_blank?

--- a/app/services/attempts_api/tracker_events.rb
+++ b/app/services/attempts_api/tracker_events.rb
@@ -25,6 +25,7 @@ module AttemptsApi
     end
 
     # @param [Boolean] success True if the images were successfully uploaded
+    # @param [String] user_id The user's uuid (will not be used in Redis event)
     # @param [String] document_back_image_encryption_key Base64-encoded AES key used for back
     # @param [String] document_back_image_file_id Filename in S3 w/encrypted data for back image
     # @param [String] document_front_image_encryption_key Base64-encoded AES key used for front
@@ -37,6 +38,7 @@ module AttemptsApi
     # A user has uploaded documents locally
     def idv_document_uploaded(
         success:,
+        user_id: nil,
         document_back_image_encryption_key: nil,
         document_back_image_file_id: nil,
         document_front_image_encryption_key: nil,
@@ -50,6 +52,7 @@ module AttemptsApi
       track_event(
         'idv-document-uploaded',
         success:,
+        user_id:,
         document_back_image_encryption_key:,
         document_back_image_file_id:,
         document_front_image_encryption_key:,
@@ -63,6 +66,7 @@ module AttemptsApi
     end
 
     # @param [Boolean] success
+    # @param [String] user_id The user's uuid (will not be used in Redis event)
     # @param [String] document_state
     # @param [String] document_number
     # @param [String] document_issued
@@ -89,6 +93,7 @@ module AttemptsApi
     # The document was uploaded during the IDV process
     def idv_document_upload_submitted(
       success:,
+      user_id: nil,
       document_state: nil,
       document_number: nil,
       document_issued: nil,
@@ -116,6 +121,7 @@ module AttemptsApi
       track_event(
         'idv-document-upload-submitted',
         success:,
+        user_id:,
         document_state:,
         document_number:,
         document_issued:,
@@ -353,12 +359,14 @@ module AttemptsApi
     # @param limiter_type [String<'idv_doc_auth', 'idv_resolution', 'proof_ssn', 'proof_address',
     #   'confirmation', 'idv_send_link']
     # @param phone_number [String] The user's the provided phone number IdV phone risk
+    # @param [String] user_id The user's uuid (will not be used in Redis event)
     #  Type of rate limit
-    def idv_rate_limited(limiter_type:, phone_number: nil)
+    def idv_rate_limited(limiter_type:, phone_number: nil, user_id: nil)
       track_event(
         'idv-rate-limited',
         limiter_type:,
         phone_number:,
+        user_id:,
       )
     end
 

--- a/app/services/fraud_ops/tracker.rb
+++ b/app/services/fraud_ops/tracker.rb
@@ -21,6 +21,8 @@ module FraudOps
     def track_event(event_type, metadata = {})
       return unless enabled?
 
+      overwrite_user_if_applicable(metadata.delete(:user_id))
+
       event = AttemptsApi::AttemptEvent.new(
         event_type: event_type,
         session_id: session_id,

--- a/app/services/fraud_ops/tracker_events.rb
+++ b/app/services/fraud_ops/tracker_events.rb
@@ -3,6 +3,7 @@
 module FraudOps
   module TrackerEvents
     # @param [Boolean] success
+    # @param [String] user_id The user's uuid (will not be used in Redis event)
     # @param [String] document_state
     # @param [String] document_number
     # @param [String] document_issued
@@ -29,6 +30,7 @@ module FraudOps
     # The document was uploaded during the IDV process
     def fraud_ops_idv_document_upload_submitted(
       success:,
+      user_id: nil,
       document_state: nil,
       document_number: nil,
       document_issued: nil,
@@ -59,6 +61,7 @@ module FraudOps
       track_event(
         :idv_document_upload_submitted,
         success:,
+        user_id:,
         document_state:,
         document_number:,
         document_issued:,

--- a/spec/controllers/idv/image_uploads_controller_spec.rb
+++ b/spec/controllers/idv/image_uploads_controller_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe Idv::ImageUploadsController do
           it 'does not upload the images' do
             expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
               success: false,
+              user_id: user.uuid,
               failure_reason: { front: [:blank] },
             )
 
@@ -164,6 +165,7 @@ RSpec.describe Idv::ImageUploadsController do
           it 'tracks the event' do
             expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
               success: false,
+              user_id: user.uuid,
               document_back_image_encryption_key: '12345',
               document_back_image_file_id: 'name',
               document_front_image_encryption_key: nil,
@@ -184,6 +186,7 @@ RSpec.describe Idv::ImageUploadsController do
           it 'does not upload the images' do
             expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
               success: false,
+              user_id: user.uuid,
               failure_reason: { front: [:not_a_file] },
             )
 
@@ -223,6 +226,7 @@ RSpec.describe Idv::ImageUploadsController do
             it 'records the event' do
               expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
                 success: false,
+                user_id: nil,
                 document_back_image_encryption_key: '12345',
                 document_back_image_file_id: 'name',
                 document_front_image_encryption_key: '12345',
@@ -242,6 +246,7 @@ RSpec.describe Idv::ImageUploadsController do
             it 'does not upload the images' do
               expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
                 success: false,
+                user_id: nil,
                 failure_reason: { document_capture_session: [:blank] },
               )
 
@@ -281,6 +286,7 @@ RSpec.describe Idv::ImageUploadsController do
             it 'records the event' do
               expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
                 success: false,
+                user_id: nil,
                 document_back_image_encryption_key: '12345',
                 document_back_image_file_id: 'name',
                 document_front_image_encryption_key: '12345',
@@ -300,6 +306,7 @@ RSpec.describe Idv::ImageUploadsController do
             it 'does not upload the images' do
               expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
                 success: false,
+                user_id: nil,
                 failure_reason: { document_capture_session: [:blank] },
               )
 
@@ -386,6 +393,7 @@ RSpec.describe Idv::ImageUploadsController do
             it 'tracks the event' do
               expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
                 success: false,
+                user_id: user.uuid,
                 document_back_image_encryption_key: '12345',
                 document_back_image_file_id: 'name',
                 document_front_image_encryption_key: '12345',
@@ -407,6 +415,7 @@ RSpec.describe Idv::ImageUploadsController do
             it 'does not upload the images' do
               expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
                 success: false,
+                user_id: user.uuid,
                 failure_reason: { limit: [:rate_limited] },
               )
 
@@ -502,6 +511,7 @@ RSpec.describe Idv::ImageUploadsController do
             # the local upload succeeds
             expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
               success: true,
+              user_id: user.uuid,
               document_back_image_encryption_key: '12345',
               document_back_image_file_id: 'name',
               document_front_image_encryption_key: '12345',
@@ -511,6 +521,7 @@ RSpec.describe Idv::ImageUploadsController do
 
             expect(@attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: false,
+              user_id: user.uuid,
               document_expiration: nil,
               document_issued: nil,
               document_number: nil,
@@ -548,11 +559,13 @@ RSpec.describe Idv::ImageUploadsController do
             # the local upload succeeds
             expect(@attempts_api_tracker).to receive(:idv_document_uploaded).with(
               success: true,
+              user_id: user.uuid,
               failure_reason: nil,
             )
 
             expect(@attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: false,
+              user_id: user.uuid,
               document_expiration: nil,
               document_issued: nil,
               document_number: nil,
@@ -652,6 +665,7 @@ RSpec.describe Idv::ImageUploadsController do
             pii = Idp::Constants::MOCK_IDV_APPLICANT
             expect(@attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: true,
+              user_id: user.uuid,
               document_expiration: pii[:state_id_expiration],
               document_issued: pii[:state_id_issued],
               document_number: pii[:state_id_number],
@@ -686,6 +700,7 @@ RSpec.describe Idv::ImageUploadsController do
             pii = Idp::Constants::MOCK_IDV_APPLICANT
             expect(@attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: true,
+              user_id: user.uuid,
               document_expiration: pii[:state_id_expiration],
               document_issued: pii[:state_id_issued],
               document_number: pii[:state_id_number],
@@ -1017,6 +1032,7 @@ RSpec.describe Idv::ImageUploadsController do
               it 'records attempts api events' do
                 expect(@attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                   success: false,
+                  user_id: user.uuid,
                   document_expiration: state_id_expiration,
                   document_issued: nil,
                   document_number: state_id_number,
@@ -1046,6 +1062,7 @@ RSpec.describe Idv::ImageUploadsController do
               it 'does not upload the images' do
                 expect(@attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                   success: false,
+                  user_id: user.uuid,
                   document_expiration: state_id_expiration,
                   document_issued: nil,
                   document_number: state_id_number,
@@ -1157,6 +1174,7 @@ RSpec.describe Idv::ImageUploadsController do
               it 'records attempts api events' do
                 expect(@attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                   success: false,
+                  user_id: user.uuid,
                   document_expiration: state_id_expiration,
                   document_issued: nil,
                   document_number: state_id_number,
@@ -1190,6 +1208,7 @@ RSpec.describe Idv::ImageUploadsController do
               it 'does not upload the images' do
                 expect(@attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                   success: false,
+                  user_id: user.uuid,
                   document_expiration: state_id_expiration,
                   document_issued: nil,
                   document_number: state_id_number,

--- a/spec/features/idv/doc_auth/document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/document_capture_spec.rb
@@ -81,6 +81,7 @@ RSpec.feature 'document capture step', :js do
       it 'logs the rate limited analytics event for doc_auth' do
         expect(attempts_api_tracker).to receive(:idv_rate_limited).with(
           limiter_type: :idv_doc_auth,
+          user_id: @user.uuid,
         )
 
         attach_and_submit_images
@@ -462,6 +463,7 @@ RSpec.feature 'document capture step', :js do
       it 'logs the rate limited analytics event for doc_auth' do
         expect(attempts_api_tracker).to receive(:idv_rate_limited).with(
           limiter_type: :idv_doc_auth,
+          user_id: @user.uuid,
         )
         attach_and_submit_images
         expect(fake_analytics).to have_logged_event(

--- a/spec/features/idv/doc_auth/redo_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/redo_document_capture_spec.rb
@@ -66,6 +66,7 @@ RSpec.feature 'document capture step', :js do
       it 'logs the rate limited analytics event for doc_auth' do
         expect(attempts_api_tracker).to receive(:idv_rate_limited).with(
           limiter_type: :idv_doc_auth,
+          user_id: @user.uuid,
         )
 
         attach_and_submit_images
@@ -227,6 +228,7 @@ RSpec.feature 'document capture step', :js do
       it 'logs the rate limited analytics event for doc_auth' do
         expect(attempts_api_tracker).to receive(:idv_rate_limited).with(
           limiter_type: :idv_doc_auth,
+          user_id: @user.uuid,
         )
 
         attach_and_submit_images

--- a/spec/forms/idv/api_image_upload_form_spec.rb
+++ b/spec/forms/idv/api_image_upload_form_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe Idv::ApiImageUploadForm do
     context 'when rate limited from submission' do
       it 'is not valid' do
         expect(attempts_api_tracker).to receive(:idv_rate_limited).with(
+          user_id: document_capture_session.user.uuid,
           limiter_type: :idv_doc_auth,
         )
         RateLimiter.new(
@@ -522,6 +523,7 @@ RSpec.describe Idv::ApiImageUploadForm do
             it 'tracks the event' do
               expect(attempts_api_tracker).to receive(:idv_document_uploaded).with(
                 success: true,
+                user_id: document_capture_session.user.uuid,
                 document_back_image_encryption_key: '12345',
                 document_back_image_file_id: 'name',
                 document_front_image_encryption_key: '12345',
@@ -531,6 +533,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
               expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                 success: true,
+                user_id: document_capture_session.user.uuid,
                 document_back_image_encryption_key: '12345',
                 document_back_image_file_id: 'name',
                 document_front_image_encryption_key: '12345',
@@ -567,11 +570,13 @@ RSpec.describe Idv::ApiImageUploadForm do
             it 'tracks the event' do
               expect(attempts_api_tracker).to receive(:idv_document_uploaded).with(
                 success: true,
+                user_id: document_capture_session.user.uuid,
                 failure_reason: nil,
               )
 
               expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                 success: true,
+                user_id: document_capture_session.user.uuid,
                 document_state: pii_from_doc[:state],
                 document_number: pii_from_doc[:state_id_number],
                 document_issued: pii_from_doc[:state_id_issued],
@@ -747,6 +752,7 @@ RSpec.describe Idv::ApiImageUploadForm do
               it 'tracks the event' do
                 expect(attempts_api_tracker).to receive(:idv_document_uploaded).with(
                   success: true,
+                  user_id: document_capture_session.user.uuid,
                   document_back_image_encryption_key: '12345',
                   document_back_image_file_id: 'name',
                   document_front_image_encryption_key: '12345',
@@ -758,6 +764,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
                 expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                   success: true,
+                  user_id: document_capture_session.user.uuid,
                   document_back_image_encryption_key: '12345',
                   document_back_image_file_id: 'name',
                   document_front_image_encryption_key: '12345',
@@ -794,11 +801,13 @@ RSpec.describe Idv::ApiImageUploadForm do
               it 'tracks the event' do
                 expect(attempts_api_tracker).to receive(:idv_document_uploaded).with(
                   success: true,
+                  user_id: document_capture_session.user.uuid,
                   failure_reason: nil,
                 )
 
                 expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
                   success: true,
+                  user_id: document_capture_session.user.uuid,
                   document_state: pii_from_doc[:state],
                   document_number: pii_from_doc[:state_id_number],
                   document_issued: pii_from_doc[:state_id_issued],
@@ -946,6 +955,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           it 'tracks the event' do
             expect(attempts_api_tracker).to receive(:idv_document_uploaded).with(
               success: false,
+              user_id: document_capture_session.user.uuid,
               document_back_image_encryption_key: '12345',
               document_back_image_file_id: 'name',
               failure_reason: { front: [:blank] },
@@ -965,6 +975,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           it 'tracks the event' do
             expect(attempts_api_tracker).to receive(:idv_document_uploaded).with(
               success: false,
+              user_id: document_capture_session.user.uuid,
               failure_reason: { front: [:blank] },
             )
 
@@ -1027,6 +1038,7 @@ RSpec.describe Idv::ApiImageUploadForm do
           it 'tracks the event (as a success as doc upload succeeded)' do
             expect(attempts_api_tracker).to receive(:idv_document_uploaded).with(
               success: true,
+              user_id: document_capture_session.user.uuid,
               document_back_image_encryption_key: '12345',
               document_back_image_file_id: 'name',
               document_front_image_encryption_key: '12345',
@@ -1036,6 +1048,7 @@ RSpec.describe Idv::ApiImageUploadForm do
 
             expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: false,
+              user_id: document_capture_session.user.uuid,
               document_back_image_encryption_key: '12345',
               document_back_image_file_id: 'name',
               document_front_image_encryption_key: '12345',
@@ -1069,11 +1082,13 @@ RSpec.describe Idv::ApiImageUploadForm do
           it 'does not write the event' do
             expect(attempts_api_tracker).to receive(:idv_document_uploaded).with(
               success: true,
+              user_id: document_capture_session.user.uuid,
               failure_reason: nil,
             )
 
             expect(attempts_api_tracker).to receive(:idv_document_upload_submitted).with(
               success: false,
+              user_id: document_capture_session.user.uuid,
               document_state: nil,
               document_number: nil,
               document_issued: nil,


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[Secure Protocols 127](https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/work_items/127)

## 🛠 Summary of changes

This change addresses a bug that was discovered via the fraud ops tracker when we turned on the historic attempts feature in `int`. 

In the Lexus Nexus hybrid flow, the user is sent a link onto their phone so they can use the phone camera. If they are starting on a desktop, this goes to a different browser, where their user context is lost. 

The analytics events pass a `user_id` through the event itself to retain the user context. The AttemptsAPI Tracker has a similar process, so this change:

- adds the user_id handling to the fraud ops tracker
- passes the user_id through the attempts and fraud ops events that were impacted by the null user bug

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
