### PR TITLE
LG-17839 Update mDL interstitial to list supported wallets

### DIFF
--- a/app/views/idv/shared/_doc_capture_interstitial.html.erb
+++ b/app/views/idv/shared/_doc_capture_interstitial.html.erb
@@ -33,16 +33,7 @@
     </p>
   <% end %>
 <% elsif @mdl_requested %>
-  <p class="margin-bottom-0"><%= t('idv.mdl.subtitle', app_name: APP_NAME) %></p>
-  <p class="margin-bottom-4">
-    <%= new_tab_link_to(
-          t('idv.mdl.learn_more'),
-          help_center_redirect_url(
-            category: 'verify-your-identity',
-            article: 'accepted-identification-documents',
-          ),
-        ) %>
-  </p>
+  <p class="margin-bottom-4"><%= t('idv.mdl.subtitle', app_name: APP_NAME) %></p>
   <h2 class="margin-bottom-2"><%= t('idv.mdl.steps_heading') %></h2>
 
   <ol class="usa-process-list">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1215,9 +1215,8 @@ idv.gpo.return_to_profile: Return to your profile
 idv.gpo.title: Enter your verification code
 idv.gpo.will_send_to: 'You’ll get a letter in the mail from %{app_name} in 5 to 10 days at the address we verified and associated with you:'
 idv.images.come_back_later: Letter with a check mark
-idv.mdl.alert_html: <strong>Don’t have an mDL yet?</strong> It is available only for some U.S. states and territories. Please contact your state’s DMV for more information.
+idv.mdl.alert_html: <strong>Currently supported with Google Wallet and Samsung Wallet.</strong> Other wallets will be supported later this year.
 idv.mdl.button: Open digital wallet
-idv.mdl.learn_more: Learn more about how to use mDL
 idv.mdl.steps_heading: 'You’ll need:'
 idv.mdl.steps.device.title: A device with a digital wallet
 idv.mdl.steps.have_mdl.title: An active mobile driver’s license

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1226,9 +1226,8 @@ idv.gpo.return_to_profile: Vuelva a su perfil
 idv.gpo.title: Introduzca su código de verificación
 idv.gpo.will_send_to: 'En un plazo de 5 a 10 días, recibirá por correo una carta de %{app_name} en la dirección que verificamos y asociamos con usted:'
 idv.images.come_back_later: Carta con una marca de verificación
-idv.mdl.alert_html: <strong>¿Aún no tiene una mDL?</strong> Solo está disponible en algunos estados y territorios de EE. UU. Comuníquese con el DMV de su estado para obtener más información.
+idv.mdl.alert_html: <strong>Actualmente disponible con Google Wallet y Samsung Wallet.</strong> Se añadirán otras billeteras a finales de este año.
 idv.mdl.button: Abrir cartera digital
-idv.mdl.learn_more: Más información sobre cómo usar su mDL
 idv.mdl.steps_heading: 'Necesitará:'
 idv.mdl.steps.device.title: Un dispositivo con una cartera digital
 idv.mdl.steps.have_mdl.title: Una licencia de conducir móvil (mDL) activa

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -630,7 +630,7 @@ doc_auth.headings.how_to_verify: Choisir la manière dont vous souhaitez confirm
 doc_auth.headings.interstitial: Nous traitons vos informations.
 doc_auth.headings.lets_go: Comment fonctionne la vérification de votre identité
 doc_auth.headings.mailing_address: Saisir votre adresse postale de contact
-doc_auth.headings.mdl_capture: Renseignez les informations de votre permis de conduire mobile
+doc_auth.headings.mdl_capture: Renseignez les informations de votre permis de conduire mobile (mDL)
 doc_auth.headings.no_ssn: Vous n’avez pas de numéro de sécurité sociale ?
 doc_auth.headings.passport: Votre passeport
 doc_auth.headings.passport_capture: Ajouter une photo de votre passeport
@@ -1220,7 +1220,7 @@ idv.mdl.button: Ouvrir le portefeuille numérique
 idv.mdl.steps_heading: 'Vous aurez besoin de:'
 idv.mdl.steps.device.title: Un appareil doté d’un portefeuille numérique
 idv.mdl.steps.have_mdl.title: Un permis de conduire mobile actif
-idv.mdl.subtitle: '%{app_name} vérifiera votre permis de conduire mobile par l’intermédiaire d’un prestataire de services de confiance (Socure).'
+idv.mdl.subtitle: '%{app_name} vérifiera votre permis de conduire mobile (mDL) par l’intermédiaire d’un prestataire de services de confiance (Socure).'
 idv.messages.activated_html: Votre identité a été vérifiée. Si vous souhaitez modifier les informations qui ont été vérifiées, veuillez %{link_html}.
 idv.messages.activated_link: nous contacter
 idv.messages.come_back_later: Une fois ce courrier reçu, reconnectez-vous pour saisir le code de vérification qui y figure.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1215,9 +1215,8 @@ idv.gpo.return_to_profile: Retourner à votre profil
 idv.gpo.title: Saisir votre code de vérification
 idv.gpo.will_send_to: 'Vous recevrez un courrier de %{app_name} d’ici 5 à 10 jours à l’adresse que nous avons confirmée qui est associée à votre nom :'
 idv.images.come_back_later: Lettre avec une coche
-idv.mdl.alert_html: <strong>Vous n’avez pas encore de permis de conduire mobile ?</strong> Ce service n’est disponible que dans certains États et territoires des États-Unis. Veuillez contacter le service des immatriculations et des permis (Department of Motor Vehicles) de votre État pour plus d’informations.
+idv.mdl.alert_html: <strong>Actuellement compatible avec Google Wallet et Samsung Wallet.</strong> D’autres portefeuilles seront pris en charge plus tard cette année.
 idv.mdl.button: Ouvrir le portefeuille numérique
-idv.mdl.learn_more: En savoir plus sur l’utilisation du permis de conduire mobile
 idv.mdl.steps_heading: 'Vous aurez besoin de:'
 idv.mdl.steps.device.title: Un appareil doté d’un portefeuille numérique
 idv.mdl.steps.have_mdl.title: Un permis de conduire mobile actif

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1228,9 +1228,8 @@ idv.gpo.return_to_profile: 返回你的用户资料
 idv.gpo.title: 输入你的验证代码
 idv.gpo.will_send_to: 你会在5到10天内在我们验证过的与你相关的地址收到来自%{app_name}寄给你的一封信：
 idv.images.come_back_later: 带有打勾符的信件
-idv.mdl.alert_html: <strong>还没有 mDL？</strong> 目前仅部分美国州和领地提供此服务。请联系您所在州的机动车管理局 （DMV） 了解详情。
+idv.mdl.alert_html: <strong>目前支持 Google Wallet 和 Samsung Wallet。</strong>其他钱包将于今年晚些时候支持。
 idv.mdl.button: 打开数字钱包
-idv.mdl.learn_more: 了解如何使用 mDL
 idv.mdl.steps_heading: '您需要准备：'
 idv.mdl.steps.device.title: 带有数字钱包功能的设备
 idv.mdl.steps.have_mdl.title: 有效的移动驾驶证

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -534,6 +534,9 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
 
             expect(page).to have_current_path(idv_socure_document_capture_url)
             expect_step_indicator_current_step(t('step_indicator.flows.idv.verify_id'))
+            expect(page).to have_content(t('idv.mdl.subtitle', app_name: APP_NAME))
+            expect(page).to have_content(strip_tags(t('idv.mdl.alert_html')))
+            expect(page).to_not have_link('Learn more about how to use mDL')
 
             # remove_request_stub(@docv_stub)
             @docv_stub = stub_docv_verification_data_pass(


### PR DESCRIPTION
changelog: User-Facing Improvements, Identity Verification, Update mDL interstitial to list supported digital wallets

## 🎫 Ticket

Link to the relevant ticket:
[LG-17839](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17839)

## 🛠 Summary of changes

Updates the mDL interstitial screen to highlight which digital wallets are currently supported.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] local environment set `socure_docv_enabled: true`, `doc_auth_vendor_default: 'mock_socure'`, and `idv_doc_auth_mdl_enabled_percent: 100`, start IdV, choose "Mobile driver's license (mDL)" at the Choose your ID type step, and confirm the interstitial shows
- [ ] Confirm the "Learn more about how to use mDL" link no longer appears on the interstitial
- [ ] Switch the page language to Spanish, French, and Chinese and confirm the translated alert renders with the first sentence bolded in each

## 👀 Screenshots

EN:
<img width="565" height="953" alt="Screenshot 2026-08-17 at 4 46 29 PM" src="https://github.com/user-attachments/assets/2cc9589c-8467-4802-ae0a-8f81d6bfd2c6" />

ES:
<img width="568" height="974" alt="Screenshot 2026-08-17 at 4 40 22 PM" src="https://github.com/user-attachments/assets/2e49a7da-3bd9-4836-92a6-ca82f712b6bc" />

FR:
<img width="561" height="982" alt="Screenshot 2026-08-17 at 4 47 31 PM" src="https://github.com/user-attachments/assets/792c23f7-d63d-484f-8230-ee8755bad606" />


ZH:
<img width="571" height="886" alt="Screenshot 2026-08-17 at 4 41 18 PM" src="https://github.com/user-attachments/assets/3fc1d04e-442a-467a-9892-05da2854559c" />


[LG-17839]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17839