### PR TITLE
[LG-17625] Remove chevrons from Spanish and French translations on duplicate accounts page

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -785,7 +785,7 @@ duplicate_profiles_detected.intro.link: las cuentas duplicativas
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> Último inicio de sesión: </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: Nunca he iniciado sesión en
 duplicate_profiles_detected.select_an_account.details_html: 'Conserva la cuenta que esté conectada a la mayor cantidad de servicios. Ve a la página %{link_html} para ver las servicios conectadas seleccionando “Tus servicios conectados” en el menú de la izquierda.'
-duplicate_profiles_detected.select_an_account.details.link: «Su cuenta»
+duplicate_profiles_detected.select_an_account.details.link: Su cuenta
 duplicate_profiles_detected.select_an_account.heading: Elija la cuenta que desea conservar.
 duplicate_profiles_detected.sign_back_in.details: Vuelva al sitio web de %{app_name} e inicie sesión usando la cuenta de %{app_name} que conservó.
 duplicate_profiles_detected.sign_back_in.heading: Vuelva a iniciar sesión en %{app_name} con una cuenta.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -774,7 +774,7 @@ duplicate_profiles_detected.intro.link: comptes en double
 duplicate_profiles_detected.last_sign_in_at_html: '<strong> Dernière connexion : </strong> %{timestamp_html}'
 duplicate_profiles_detected.never_logged_in: 'Jamais connecté à'
 duplicate_profiles_detected.select_an_account.details_html: 'Conservez le compte connecté au plus grand nombre de services. Rendez-vous sur la page %{link_html} pour consulter les services connectées en sélectionnant «Vos services connectés» dans le menu de gauche.'
-duplicate_profiles_detected.select_an_account.details.link: '«Votre compte»'
+duplicate_profiles_detected.select_an_account.details.link: 'Votre compte'
 duplicate_profiles_detected.select_an_account.heading: Choisir le compte que vous voulez conserver
 duplicate_profiles_detected.sign_back_in.details: Retournez sur le site web de %{app_name} et connectez-vous à l’aide du compte %{app_name} que vous avez conservé.
 duplicate_profiles_detected.sign_back_in.heading: Reconnectez-vous à %{app_name} avec un seul compte


### PR DESCRIPTION
changelog: User-Facing Improvements, update duplicate account content, remove chevrons from french and spanish

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-17625](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17625)
-->


## 🛠 Summary of changes

Removing chevron quotes from duplicate account page for Spanish and French.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17625]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17625