### PR TITLE
Persist NDS dev bucket override in a cookie; support ui_test_bucket =legacy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -165,22 +165,22 @@ class ApplicationController < ActionController::Base
 
   def resolve_nds_bucket
     unless Rails.env.production?
-      # Dev override: ?nds_bucket=nds|legacy selects the bucket and persists it
-      # in an httponly cookie so it sticks across navigation without re-appending
-      # the param; ?nds_bucket=clear forgets it. This is only an override in
-      # front of the real A/B assignment (it does not change the user's actual
-      # experiment bucket), so it cannot desync experiment traffic.
-      case params[:nds_bucket]
+      # Dev override: ?ui_test_bucket=nds|legacy selects the bucket and persists
+      # it in an httponly cookie so it sticks across navigation without
+      # re-appending the param; ?ui_test_bucket=clear forgets it. This is only an
+      # override in front of the real A/B assignment (it does not change the
+      # user's actual experiment bucket), so it cannot desync experiment traffic.
+      case params[:ui_test_bucket]
       when 'nds', 'legacy'
-        cookies[:nds_bucket] = { value: params[:nds_bucket], httponly: true }
+        cookies[:ui_test_bucket] = { value: params[:ui_test_bucket], httponly: true }
       when 'clear'
-        cookies.delete(:nds_bucket)
+        cookies.delete(:ui_test_bucket)
       end
 
-      return true if params[:nds_bucket] == 'nds'
-      return false if params[:nds_bucket] == 'legacy'
-      return true if cookies[:nds_bucket] == 'nds'
-      return false if cookies[:nds_bucket] == 'legacy'
+      return true if params[:ui_test_bucket] == 'nds'
+      return false if params[:ui_test_bucket] == 'legacy'
+      return true if cookies[:ui_test_bucket] == 'nds'
+      return false if cookies[:ui_test_bucket] == 'legacy'
     end
 
     ab_test_bucket(:NDS_LOOK_AND_FEEL, service_provider: nil) == :nds

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,12 +47,7 @@ class ApplicationController < ActionController::Base
   def nds_layout?
     return @nds_layout if defined?(@nds_layout)
 
-    @nds_layout =
-      if !Rails.env.production? && params[:nds_bucket] == 'nds'
-        true
-      else
-        ab_test_bucket(:NDS_LOOK_AND_FEEL, service_provider: nil) == :nds
-      end
+    @nds_layout = resolve_nds_bucket
   end
 
   # for lograge
@@ -166,6 +161,29 @@ class ApplicationController < ActionController::Base
 
   def resolve_layout
     nds_layout? ? 'nds/application' : 'application'
+  end
+
+  def resolve_nds_bucket
+    unless Rails.env.production?
+      # Dev override: ?nds_bucket=nds|legacy selects the bucket and persists it
+      # in an httponly cookie so it sticks across navigation without re-appending
+      # the param; ?nds_bucket=clear forgets it. This is only an override in
+      # front of the real A/B assignment (it does not change the user's actual
+      # experiment bucket), so it cannot desync experiment traffic.
+      case params[:nds_bucket]
+      when 'nds', 'legacy'
+        cookies[:nds_bucket] = { value: params[:nds_bucket], httponly: true }
+      when 'clear'
+        cookies.delete(:nds_bucket)
+      end
+
+      return true if params[:nds_bucket] == 'nds'
+      return false if params[:nds_bucket] == 'legacy'
+      return true if cookies[:nds_bucket] == 'nds'
+      return false if cookies[:nds_bucket] == 'legacy'
+    end
+
+    ab_test_bucket(:NDS_LOOK_AND_FEEL, service_provider: nil) == :nds
   end
 
   def attempts_api_enabled_for_session?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -902,6 +902,63 @@ RSpec.describe ApplicationController do
         expect(controller.nds_layout?).to eq(true)
         expect(controller.send(:resolve_layout)).to eq('nds/application')
       end
+
+      it 'persists the selected bucket in an httponly cookie' do
+        get :index, params: { nds_bucket: 'nds' }
+        controller.nds_layout?
+
+        controller_set_cookies = controller.send(:cookies).instance_variable_get(:@set_cookies)
+        expect(controller_set_cookies['nds_bucket'][:value]).to eq('nds')
+        expect(controller_set_cookies['nds_bucket'][:httponly]).to eq(true)
+      end
+
+      it 'switches back to the legacy layout and persists it, overriding the A/B bucket' do
+        allow(controller).to receive(:ab_test_bucket)
+          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
+          .and_return(:nds)
+        get :index, params: { nds_bucket: 'legacy' }
+
+        expect(controller.nds_layout?).to eq(false)
+        expect(controller.send(:resolve_layout)).to eq('application')
+        controller_set_cookies = controller.send(:cookies).instance_variable_get(:@set_cookies)
+        expect(controller_set_cookies['nds_bucket'][:value]).to eq('legacy')
+      end
+    end
+
+    context 'when the nds_bucket cookie is set (no param)' do
+      it 'sticks to nds when the cookie is nds, even if the A/B bucket is not nds' do
+        allow(controller).to receive(:ab_test_bucket)
+          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
+          .and_return(nil)
+        cookies[:nds_bucket] = 'nds'
+        get :index
+        expect(controller.nds_layout?).to eq(true)
+      end
+
+      it 'sticks to legacy when the cookie is legacy, even if the A/B bucket is nds' do
+        allow(controller).to receive(:ab_test_bucket)
+          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
+          .and_return(:nds)
+        cookies[:nds_bucket] = 'legacy'
+        get :index
+        expect(controller.nds_layout?).to eq(false)
+      end
+    end
+
+    context 'when clearing the nds_bucket cookie' do
+      it 'stops forcing legacy and falls back to the A/B bucket' do
+        allow(controller).to receive(:ab_test_bucket)
+          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
+          .and_return(:nds)
+        cookies[:nds_bucket] = 'legacy'
+        get :index, params: { nds_bucket: 'clear' }
+
+        # Asserts the override no longer forces a bucket (falls back to A/B). The
+        # raw cookie-delete marker isn't checked here: render plain skips layout,
+        # so this calls nds_layout? directly, and a request-only cookie delete
+        # doesn't round-trip to the integration cookies[] helper.
+        expect(controller.nds_layout?).to eq(true)
+      end
     end
 
     context 'in production the dev override is ignored' do
@@ -912,6 +969,15 @@ RSpec.describe ApplicationController do
           .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
           .and_return(nil)
         get :index, params: { nds_bucket: 'nds' }
+        expect(controller.nds_layout?).to eq(false)
+      end
+
+      it 'does not honor the cookie and falls back to the A/B bucket' do
+        allow(controller).to receive(:ab_test_bucket)
+          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
+          .and_return(nil)
+        cookies[:nds_bucket] = 'nds'
+        get :index
         expect(controller.nds_layout?).to eq(false)
       end
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -888,7 +888,17 @@ RSpec.describe ApplicationController do
       end
     end
 
-    context 'default (no nds bucket forced)' do
+    # The underlying A/B assignment, overridden per context. nil means the user
+    # is not in the NDS bucket; :nds means they are.
+    let(:nds_ab_bucket) { nil }
+
+    before do
+      allow(controller).to receive(:ab_test_bucket)
+        .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
+        .and_return(nds_ab_bucket)
+    end
+
+    context 'default (no bucket forced)' do
       it 'resolves the legacy application layout' do
         get :index
         expect(controller.send(:resolve_layout)).to eq('application')
@@ -896,62 +906,62 @@ RSpec.describe ApplicationController do
       end
     end
 
-    context 'when forced via the nds_bucket param' do
+    context 'when forced via the ui_test_bucket param' do
       it 'resolves the nds/application layout' do
-        get :index, params: { nds_bucket: 'nds' }
+        get :index, params: { ui_test_bucket: 'nds' }
         expect(controller.nds_layout?).to eq(true)
         expect(controller.send(:resolve_layout)).to eq('nds/application')
       end
 
       it 'persists the selected bucket in an httponly cookie' do
-        get :index, params: { nds_bucket: 'nds' }
+        get :index, params: { ui_test_bucket: 'nds' }
         controller.nds_layout?
 
         controller_set_cookies = controller.send(:cookies).instance_variable_get(:@set_cookies)
-        expect(controller_set_cookies['nds_bucket'][:value]).to eq('nds')
-        expect(controller_set_cookies['nds_bucket'][:httponly]).to eq(true)
+        expect(controller_set_cookies['ui_test_bucket'][:value]).to eq('nds')
+        expect(controller_set_cookies['ui_test_bucket'][:httponly]).to eq(true)
       end
 
-      it 'switches back to the legacy layout and persists it, overriding the A/B bucket' do
-        allow(controller).to receive(:ab_test_bucket)
-          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
-          .and_return(:nds)
-        get :index, params: { nds_bucket: 'legacy' }
+      context 'when the A/B bucket is nds' do
+        let(:nds_ab_bucket) { :nds }
 
-        expect(controller.nds_layout?).to eq(false)
-        expect(controller.send(:resolve_layout)).to eq('application')
-        controller_set_cookies = controller.send(:cookies).instance_variable_get(:@set_cookies)
-        expect(controller_set_cookies['nds_bucket'][:value]).to eq('legacy')
-      end
-    end
+        it 'switches back to the legacy layout and persists it, overriding the A/B bucket' do
+          get :index, params: { ui_test_bucket: 'legacy' }
 
-    context 'when the nds_bucket cookie is set (no param)' do
-      it 'sticks to nds when the cookie is nds, even if the A/B bucket is not nds' do
-        allow(controller).to receive(:ab_test_bucket)
-          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
-          .and_return(nil)
-        cookies[:nds_bucket] = 'nds'
-        get :index
-        expect(controller.nds_layout?).to eq(true)
-      end
-
-      it 'sticks to legacy when the cookie is legacy, even if the A/B bucket is nds' do
-        allow(controller).to receive(:ab_test_bucket)
-          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
-          .and_return(:nds)
-        cookies[:nds_bucket] = 'legacy'
-        get :index
-        expect(controller.nds_layout?).to eq(false)
+          expect(controller.nds_layout?).to eq(false)
+          expect(controller.send(:resolve_layout)).to eq('application')
+          controller_set_cookies = controller.send(:cookies).instance_variable_get(:@set_cookies)
+          expect(controller_set_cookies['ui_test_bucket'][:value]).to eq('legacy')
+        end
       end
     end
 
-    context 'when clearing the nds_bucket cookie' do
+    context 'when the ui_test_bucket cookie is set' do
+      context 'when there is no param passed' do
+        it 'sticks to nds when the cookie is nds, even if the A/B bucket is not nds' do
+          cookies[:ui_test_bucket] = 'nds'
+          get :index
+          expect(controller.nds_layout?).to eq(true)
+        end
+
+        context 'when the A/B bucket is nds' do
+          let(:nds_ab_bucket) { :nds }
+
+          it 'sticks to legacy when the cookie is legacy, even if the A/B bucket is nds' do
+            cookies[:ui_test_bucket] = 'legacy'
+            get :index
+            expect(controller.nds_layout?).to eq(false)
+          end
+        end
+      end
+    end
+
+    context 'when clearing the ui_test_bucket cookie' do
+      let(:nds_ab_bucket) { :nds }
+
       it 'stops forcing legacy and falls back to the A/B bucket' do
-        allow(controller).to receive(:ab_test_bucket)
-          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
-          .and_return(:nds)
-        cookies[:nds_bucket] = 'legacy'
-        get :index, params: { nds_bucket: 'clear' }
+        cookies[:ui_test_bucket] = 'legacy'
+        get :index, params: { ui_test_bucket: 'clear' }
 
         # Asserts the override no longer forces a bucket (falls back to A/B). The
         # raw cookie-delete marker isn't checked here: render plain skips layout,
@@ -965,18 +975,12 @@ RSpec.describe ApplicationController do
       before { allow(Rails.env).to receive(:production?).and_return(true) }
 
       it 'does not honor the param and falls back to the A/B bucket' do
-        allow(controller).to receive(:ab_test_bucket)
-          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
-          .and_return(nil)
-        get :index, params: { nds_bucket: 'nds' }
+        get :index, params: { ui_test_bucket: 'nds' }
         expect(controller.nds_layout?).to eq(false)
       end
 
       it 'does not honor the cookie and falls back to the A/B bucket' do
-        allow(controller).to receive(:ab_test_bucket)
-          .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
-          .and_return(nil)
-        cookies[:nds_bucket] = 'nds'
+        cookies[:ui_test_bucket] = 'nds'
         get :index
         expect(controller.nds_layout?).to eq(false)
       end

--- a/spec/requests/nds_layout_stylesheet_spec.rb
+++ b/spec/requests/nds_layout_stylesheet_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'NDS layout stylesheet swap', type: :request do
 
   context 'forced nds bucket' do
     it 'renders the nds_application stylesheet via the nds base layout' do
-      get root_url, params: { nds_bucket: 'nds' }
+      get root_url, params: { ui_test_bucket: 'nds' }
 
       expect(response.body).to match(%r{stylesheet["'][^>]*/assets/nds_application[-.]})
     end


### PR DESCRIPTION
## Summary

- Stacked on #13381 (NDS layout resolver + Sass bundle). Adds cookie persistence and legacy switch-back to the non-production NDS preview override, closing the scope gap noted in review.
- `?nds_bucket=nds|legacy` selects the bucket and persists the choice in an httponly cookie so it sticks across navigation without re-appending the param; `?nds_bucket=clear` forgets it. Precedence is param > cookie > A/B.
- Dev-only and purely an override in front of the real A/B assignment: it does not change the user's actual experiment bucket, so it cannot desync experiment traffic.

## Notes for reviewers

- Stacked PR: base branch is `nds-phase1-keystone-layout-nds-bundle`, not `main`. Review/merge #13381 first; this diff will retarget to `main` once the base merges.
- Bucket resolution is extracted to a private `resolve_nds_bucket` helper to keep `nds_layout?` small and memoized (single evaluation + single cookie write per request).
- No CSS or package.json changes; the legacy A/B control remains byte-identical.

## Test plan

- [x] `bundle exec rspec spec/controllers/application_controller_spec.rb` green (covers param nds/legacy, cookie sticky nds/legacy, clear fallback, production ignores param and cookie)
- [x] `bundle exec rspec spec/requests/nds_layout_stylesheet_spec.rb` green
- [x] `bundle exec rubocop` clean on changed files