### PR TITLE
Remove deprecated String#mb_chars

### DIFF
--- a/app/services/browser_cache.rb
+++ b/app/services/browser_cache.rb
@@ -15,7 +15,7 @@ class BrowserCache
     return DEFAULT_BROWSER if user_agent.nil?
 
     @cache.getset(user_agent) do
-      Browser.new(user_agent.mb_chars.limit(USER_AGENT_SIZE).to_s)
+      Browser.new(user_agent.truncate_bytes(USER_AGENT_SIZE, omission: ''))
     end
   end
 


### PR DESCRIPTION
It is scheduled to be removed in Rails 8.2

changelog: Internal, User Agent handling, Remove deprecated String#mb_chars

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
