### PR TITLE
LG-17848: Proofing Agent completed pii bundle missing physical address values

### DIFF
--- a/app/services/proofing_agent/applicant_pii_transformer.rb
+++ b/app/services/proofing_agent/applicant_pii_transformer.rb
@@ -33,7 +33,7 @@ module ProofingAgent
     end
 
     def residential_address_fields
-      address = pii[:residential_address]
+      address = residential_address
       return {} if address.blank?
 
       {
@@ -43,6 +43,22 @@ module ProofingAgent
         state: address[:state],
         zipcode: address[:zip_code],
       }
+    end
+
+    # When the agent only sends the state-ID address (no separate residential
+    # address), the current address matches the ID, so the state-ID address is
+    # also the residential address. Mirror the in-person flow, which copies the
+    # identity-doc address into the residential address fields in this case
+    # (see Idv::InPerson::StateIdController#pending_pii).
+    def residential_address
+      pii[:residential_address].presence || state_id_address
+    end
+
+    def state_id_address
+      state_id = pii[:state_id]
+      return if state_id.blank?
+
+      state_id.slice(:address1, :address2, :city, :state, :zip_code)
     end
 
     def state_id_fields

--- a/spec/services/proofing_agent/applicant_pii_transformer_spec.rb
+++ b/spec/services/proofing_agent/applicant_pii_transformer_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe ProofingAgent::ApplicantPiiTransformer do
           )
         end
 
-        it 'returns an applicant with state id' do
+        it 'returns an applicant with state id and copies the id address to the ' \
+           'residential address fields' do
           expect(subject.transform).to include(
             suspected_fraud: false,
             email: 'janesmith@example.com',
@@ -72,6 +73,11 @@ RSpec.describe ProofingAgent::ApplicantPiiTransformer do
             identity_doc_city: 'Anytown',
             identity_doc_address_state: 'CA',
             identity_doc_zipcode: '12345',
+            address1: '123 Main St',
+            address2: nil,
+            city: 'Anytown',
+            state: 'CA',
+            zipcode: '12345',
             state_id_number: 'A1234567',
             state_id_jurisdiction: 'CA',
             state_id_expiration: '2030-01-01',


### PR DESCRIPTION
[LG-17848](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17848)

## 🛠 Summary of changes

When a user completes proofing through the Proofing Agent flow using only their
driver's license address (i.e. no separate residential address is submitted), the
physical address values were missing from the completed PII bundle — the Address
field rendered blank on the Connect to partner page.

`ProofingAgent::ApplicantPiiTransformer` only populated the shared address fields
(`address1`, `address2`, `city`, `state`, `zipcode`) from an explicit
`residential_address`. When only `state_id` was sent, the ID's address landed
solely in the `identity_doc_*` fields, and the shared address fields stayed blank —
even though `ipp_current_address_matches_id` was correctly set to `true`.

This change falls back to the state ID address for the residential address fields
when no residential address is provided, mirroring the in-person flow
(`Idv::InPerson::StateIdController#pending_pii`). An explicitly-submitted
residential address still takes precedence, so that behavior is unchanged.

## 📜 Testing Plan

- [ ] Perform a `proof_user` action sending **only** the state ID address (no
      `residential_address`)
- [ ] Complete the binding flow and proceed to the Connect to partner page
- [ ] Confirm all proofed values are present and correct, including the physical
      Address
- [ ] Perform a `proof_user` action that **does** include a `residential_address`
- [ ] Confirm the residential address still displays correctly (no regression)
- [ ] `bundle exec rspec spec/services/proofing_agent/applicant_pii_transformer_spec.rb`

[LG-17848]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17848