### PR TITLE
Lg-17849 Redirect to binding step when user is awaiting binding from proofing agent

### DIFF
--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -9,6 +9,7 @@ module Idv
     before_action :confirm_step_allowed
     before_action :confirm_not_rate_limited
     before_action :cancel_previous_in_person_enrollments, only: :show
+    before_action :check_for_pending_agent_proofed_user, only: :show
 
     def show
       analytics.idv_doc_auth_welcome_visited(**analytics_arguments)
@@ -83,6 +84,10 @@ module Idv
       UspsInPersonProofing::EnrollmentHelper.cancel_establishing_and_in_progress_enrollments(
         current_user,
       )
+    end
+
+    def check_for_pending_agent_proofed_user
+      redirect_to idv_enter_dob_ssn_url if current_user&.proofing_agent_user_awaiting_binding?
     end
 
     def mdl_enabled?

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -162,6 +162,41 @@ RSpec.describe Idv::WelcomeController do
       expect(response).to redirect_to(idv_please_call_url)
     end
 
+    context 'when user is awaiting binding from proofing agent' do
+      let(:session) do
+        create(
+          :document_capture_session,
+          user:,
+          pending_agent_proofed_user_at: Time.zone.now,
+          doc_auth_vendor: Idp::Constants::Vendors::PROOFING_AGENT,
+        )
+      end
+      let(:agent_proofing_result) do
+        {
+          pii: { first_name: 'Testy', last_name: 'Testerson' },
+          proofing_location_id: '123',
+          proofing_agent_id: '456',
+          correlation_id: '789',
+          service_provider_issuer: 'test_issuer',
+          success: true,
+          reason: nil,
+          resolution: nil,
+          mrz: nil,
+          aamva: nil,
+        }
+      end
+      before do
+        allow(IdentityConfig.store).to receive(:idv_proofing_agent_enabled).and_return(true)
+        session.store_agent_proofed_user(agent_proofing_result)
+      end
+
+      it 'redirects to binding step' do
+        get :show
+
+        expect(response).to redirect_to(idv_enter_dob_ssn_url)
+      end
+    end
+
     context 'has pending in-person enrollment' do
       before do
         allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)

--- a/spec/features/idv/proofing_agent_activation_spec.rb
+++ b/spec/features/idv/proofing_agent_activation_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Proofing agent activation', :js do
   include IdvStepHelper
+  include OidcAuthHelper
 
   let(:user) { create(:user, :fully_registered) }
   let(:service_provider) do
@@ -66,6 +67,16 @@ RSpec.describe 'Proofing agent activation', :js do
   before do
     allow(IdentityConfig.store).to receive(:idv_proofing_agent_enabled).and_return(true)
     document_capture_session.store_agent_proofed_user(agent_proofing_result)
+  end
+
+  context 'user tries going to welcome page' do
+    scenario 'user is redirected to binding page' do
+      visit_idp_from_ial2_oidc_sp
+      sign_in_live_with_2fa(user)
+      expect(page).to have_current_path idv_enter_dob_ssn_path
+      visit idv_welcome_path
+      expect(page).to have_current_path idv_enter_dob_ssn_path
+    end
   end
 
   scenario 'user activates their profile after being proofed by proofing agent' do


### PR DESCRIPTION

## 🎫 Ticket

Link to the relevant ticket:
[LG-17849](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17849)

## 🛠 Summary of changes
Added functionality and tests to redirect user when awaiting binding for proofing agent

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1 - ensure specs pass
- [ ] Step 2 - send SSA reqeust and proof then try and login (or manually go to idv welcome page). You can also set the values manually on a dcs from the terminal if you want another approach


<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17849]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17849