### PR TITLE
LG-17850 Navigate proofing agent users to the partner connect page …

### DIFF
--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -90,12 +90,6 @@ module Idv
         current_user.proofing_agent_user_awaiting_binding?
     end
 
-    def agent_proofed_service_provider
-      return @agent_proofed_service_provider if defined?(@agent_proofed_service_provider)
-
-      @agent_proofed_service_provider = ServiceProvider.find_by(issuer: agent_proofed_user&.issuer)
-    end
-
     def tmx_job_attrs
       {
         user_id: current_user.id,

--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -9,6 +9,20 @@ module Idv
     include Steps::ThreatMetrixStepHelper
     include ThreatMetrixConcern
 
+    # the binding email is a plain sign in link, so there is no SP authorization
+    # request to pull requested attributes from. these are the attributes an
+    # agent proofed profile shares. if the SP's real request asks for less, the
+    # user re-consents with the scope derived list on their next sign in
+    AGENT_PROOFED_REQUESTED_ATTRIBUTES = %w[
+      email
+      given_name
+      family_name
+      birthdate
+      social_security_number
+      address
+      phone
+    ].freeze
+
     before_action :confirm_two_factor_authenticated
     before_action :confirm_verification_needed
     before_action :move_agent_proofed_user_pii_to_idv_session
@@ -64,7 +78,11 @@ module Idv
         session[:sp] = {
           issuer: agent_proofed_user&.issuer,
           acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
-        }
+          request_url: agent_proofed_sp_return_url,
+          # dup because SessionEncryptor#dump mutates session values in place
+          # and raises FrozenError on the frozen constant
+          requested_attributes: AGENT_PROOFED_REQUESTED_ATTRIBUTES.dup,
+        }.compact
         idv_session.applicant = agent_proofed_user&.pii
         idv_session.agent_proofed = true
         # a successful agent proofed user should have phone precheck completed
@@ -82,6 +100,22 @@ module Idv
     def verification_needed?
       IdentityConfig.store.idv_proofing_agent_enabled &&
         current_user.proofing_agent_user_awaiting_binding?
+    end
+
+    def agent_proofed_service_provider
+      return @agent_proofed_service_provider if defined?(@agent_proofed_service_provider)
+
+      @agent_proofed_service_provider = ServiceProvider.find_by(issuer: agent_proofed_user&.issuer)
+    end
+
+    # there is no SP authorization request to return to, so use the SP's post
+    # idv follow up url so the completion screen can hand the user back to the
+    # SP after consent
+    def agent_proofed_sp_return_url
+      return if agent_proofed_service_provider.blank?
+
+      resolver = SpReturnUrlResolver.new(service_provider: agent_proofed_service_provider)
+      resolver.post_idv_follow_up_url || resolver.return_to_sp_url
     end
 
     def tmx_job_attrs

--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -9,20 +9,6 @@ module Idv
     include Steps::ThreatMetrixStepHelper
     include ThreatMetrixConcern
 
-    # the binding email is a plain sign in link, so there is no SP authorization
-    # request to pull requested attributes from. these are the attributes an
-    # agent proofed profile shares. if the SP's real request asks for less, the
-    # user re-consents with the scope derived list on their next sign in
-    AGENT_PROOFED_REQUESTED_ATTRIBUTES = %w[
-      email
-      given_name
-      family_name
-      birthdate
-      social_security_number
-      address
-      phone
-    ].freeze
-
     before_action :confirm_two_factor_authenticated
     before_action :confirm_verification_needed
     before_action :move_agent_proofed_user_pii_to_idv_session
@@ -83,10 +69,6 @@ module Idv
           session[:sp] = {
             issuer: agent_proofed_user&.issuer,
             acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
-            request_url: agent_proofed_sp_return_url,
-            # dup because SessionEncryptor#dump mutates session values in place
-            # and raises FrozenError on the frozen constant
-            requested_attributes: AGENT_PROOFED_REQUESTED_ATTRIBUTES.dup,
           }.compact
         end
         idv_session.applicant = agent_proofed_user&.pii
@@ -112,16 +94,6 @@ module Idv
       return @agent_proofed_service_provider if defined?(@agent_proofed_service_provider)
 
       @agent_proofed_service_provider = ServiceProvider.find_by(issuer: agent_proofed_user&.issuer)
-    end
-
-    # there is no SP authorization request to return to, so use the SP's post
-    # idv follow up url so the completion screen can hand the user back to the
-    # SP after consent
-    def agent_proofed_sp_return_url
-      return if agent_proofed_service_provider.blank?
-
-      resolver = SpReturnUrlResolver.new(service_provider: agent_proofed_service_provider)
-      resolver.post_idv_follow_up_url || resolver.return_to_sp_url
     end
 
     def tmx_job_attrs

--- a/app/controllers/idv/enter_dob_ssn_controller.rb
+++ b/app/controllers/idv/enter_dob_ssn_controller.rb
@@ -75,14 +75,20 @@ module Idv
 
     def move_agent_proofed_user_pii_to_idv_session
       if agent_proofed_user
-        session[:sp] = {
-          issuer: agent_proofed_user&.issuer,
-          acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
-          request_url: agent_proofed_sp_return_url,
-          # dup because SessionEncryptor#dump mutates session values in place
-          # and raises FrozenError on the frozen constant
-          requested_attributes: AGENT_PROOFED_REQUESTED_ATTRIBUTES.dup,
-        }.compact
+        # a user who signed in through a live SP authorization request already
+        # has a session[:sp] whose request_url finishes that request; only
+        # synthesize one for users arriving from the plain sign in link in the
+        # binding email
+        if sp_session[:request_url].blank?
+          session[:sp] = {
+            issuer: agent_proofed_user&.issuer,
+            acr_values: Saml::Idp::Constants::IAL_VERIFIED_FACIAL_MATCH_REQUIRED_ACR,
+            request_url: agent_proofed_sp_return_url,
+            # dup because SessionEncryptor#dump mutates session values in place
+            # and raises FrozenError on the frozen constant
+            requested_attributes: AGENT_PROOFED_REQUESTED_ATTRIBUTES.dup,
+          }.compact
+        end
         idv_session.applicant = agent_proofed_user&.pii
         idv_session.agent_proofed = true
         # a successful agent proofed user should have phone precheck completed

--- a/app/jobs/proofing_agent_job.rb
+++ b/app/jobs/proofing_agent_job.rb
@@ -89,7 +89,10 @@ class ProofingAgentJob < ApplicationJob
     reason = combined_result[:reason]
 
     if success
-      ProofingAgent::SuccessEmailSender.new(user: user, analytics: analytics).call(
+      ProofingAgent::SuccessEmailSender.new(
+        user: user, analytics: analytics,
+        service_provider: current_sp
+      ).call(
         verified_at: document_capture_session.load_agent_proofed_user&.verified_at,
         proofing_agent_id: proofing_agent_id,
         proofing_location_id: proofing_location_id,

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -526,7 +526,7 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def agent_proofing_succeeded(verified_at:)
+  def agent_proofing_succeeded(verified_at:, service_provider:)
     return if verified_at.blank?
 
     attachments.inline['info.png'] =
@@ -539,6 +539,7 @@ class UserMailer < ActionMailer::Base
       @presenter = Idv::ProofingAgent::AgentProofingSucceededPresenter.new(
         verified_at:,
         url_options:,
+        service_provider:,
       )
       @verified_at_display = I18n.l(@presenter.verified_at, format: :event_date)
       @deadline_display = I18n.l(@presenter.deadline, format: :event_date)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -526,7 +526,7 @@ class UserMailer < ActionMailer::Base
     end
   end
 
-  def agent_proofing_succeeded(verified_at:, service_provider:)
+  def agent_proofing_succeeded(verified_at:, service_provider: nil)
     return if verified_at.blank?
 
     attachments.inline['info.png'] =

--- a/app/presenters/idv/proofing_agent/agent_proofing_succeeded_presenter.rb
+++ b/app/presenters/idv/proofing_agent/agent_proofing_succeeded_presenter.rb
@@ -5,7 +5,7 @@ module Idv
     class AgentProofingSucceededPresenter
       include Rails.application.routes.url_helpers
 
-      attr_reader :verified_at_string, :url_options
+      attr_reader :verified_at_string, :url_options, :service_provider
 
       # Per analysis linked on ticket: EOD UTC-5 + 2 days provides the best
       # coverage over all U.S. timezones (-11 to +10). +10 will be correct after 3pm local.
@@ -13,13 +13,14 @@ module Idv
         Time.zone.parse(verified_at).in_time_zone('Etc/GMT+5').end_of_day + 2.days
       end
 
-      def initialize(verified_at:, url_options:)
+      def initialize(verified_at:, url_options:, service_provider:)
         @verified_at_string = verified_at
         @url_options = url_options
+        @service_provider = service_provider
       end
 
       def confirmation_url
-        new_user_session_url
+        service_provider_homepage_url || new_user_session_url
       end
 
       def contact_us_url
@@ -36,6 +37,16 @@ module Idv
 
       def verified_at
         Time.zone.parse(@verified_at_string).in_time_zone('Etc/GMT+5')
+      end
+
+      private
+
+      def service_provider_homepage_url
+        sp_return_url_resolver.homepage_url if service_provider
+      end
+
+      def sp_return_url_resolver
+        SpReturnUrlResolver.new(service_provider: service_provider)
       end
     end
   end

--- a/app/presenters/idv/proofing_agent/agent_proofing_succeeded_presenter.rb
+++ b/app/presenters/idv/proofing_agent/agent_proofing_succeeded_presenter.rb
@@ -13,7 +13,7 @@ module Idv
         Time.zone.parse(verified_at).in_time_zone('Etc/GMT+5').end_of_day + 2.days
       end
 
-      def initialize(verified_at:, url_options:, service_provider:)
+      def initialize(verified_at:, url_options:, service_provider: nil)
         @verified_at_string = verified_at
         @url_options = url_options
         @service_provider = service_provider

--- a/app/services/proofing_agent/success_email_sender.rb
+++ b/app/services/proofing_agent/success_email_sender.rb
@@ -4,7 +4,7 @@ module ProofingAgent
   class SuccessEmailSender
     attr_reader :user, :analytics, :service_provider
 
-    def initialize(user:, analytics:, service_provider:)
+    def initialize(user:, analytics:, service_provider: nil)
       @user = user
       @analytics = analytics
       @service_provider = service_provider

--- a/app/services/proofing_agent/success_email_sender.rb
+++ b/app/services/proofing_agent/success_email_sender.rb
@@ -2,11 +2,12 @@
 
 module ProofingAgent
   class SuccessEmailSender
-    attr_reader :user, :analytics
+    attr_reader :user, :analytics, :service_provider
 
-    def initialize(user:, analytics:)
+    def initialize(user:, analytics:, service_provider:)
       @user = user
       @analytics = analytics
+      @service_provider = service_provider
     end
 
     def call(
@@ -23,7 +24,7 @@ module ProofingAgent
 
       user.confirmed_email_addresses.each do |email_address|
         UserMailer.with(user: user, email_address: email_address)
-          .agent_proofing_succeeded(verified_at: verified_at)
+          .agent_proofing_succeeded(verified_at: verified_at, service_provider:)
           .deliver_now_or_later
       end
 

--- a/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
+++ b/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
@@ -116,13 +116,6 @@ RSpec.describe Idv::EnterDobSsnController do
         expect(session[:sp].with_indifferent_access[:issuer]).to eq(sp.issuer)
       end
 
-      it 'sets the sp session return url and requested attributes for the completion screen' do
-        sp_session = session[:sp].with_indifferent_access
-        expect(sp_session[:request_url]).to eq(sp.return_to_sp_url)
-        expect(sp_session[:requested_attributes])
-          .to eq(described_class::AGENT_PROOFED_REQUESTED_ATTRIBUTES)
-      end
-
       it 'sets current_sp to the service provider from the agent proofed session' do
         expect(controller.current_sp).to eq(sp)
       end

--- a/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
+++ b/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
@@ -142,6 +142,30 @@ RSpec.describe Idv::EnterDobSsnController do
       end
     end
 
+    context 'user arrived through a live SP authorization request' do
+      let(:live_sp_session) do
+        {
+          issuer: 'urn:gov:gsa:openidconnect:sp:other',
+          acr_values: Saml::Idp::Constants::IAL_VERIFIED_ACR,
+          request_url: 'http://www.example.com/openid_connect/authorize?client_id=example',
+          requested_attributes: %w[email],
+        }
+      end
+
+      before do
+        session[:sp] = live_sp_session
+        get :new
+      end
+
+      it 'keeps the SP session for the original authorization request' do
+        expect(session[:sp]).to eq(live_sp_session)
+      end
+
+      it 'still moves agent proofed user pii to idv_session applicant' do
+        expect(subject.idv_session.applicant).to eq(pii.stringify_keys)
+      end
+    end
+
     context 'with threatmetrix disabled' do
       let(:proofing_agent_device_profiling) { :disabled }
 

--- a/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
+++ b/spec/controllers/idv/enter_dob_ssn_controller_spec.rb
@@ -116,6 +116,13 @@ RSpec.describe Idv::EnterDobSsnController do
         expect(session[:sp].with_indifferent_access[:issuer]).to eq(sp.issuer)
       end
 
+      it 'sets the sp session return url and requested attributes for the completion screen' do
+        sp_session = session[:sp].with_indifferent_access
+        expect(sp_session[:request_url]).to eq(sp.return_to_sp_url)
+        expect(sp_session[:requested_attributes])
+          .to eq(described_class::AGENT_PROOFED_REQUESTED_ATTRIBUTES)
+      end
+
       it 'sets current_sp to the service provider from the agent proofed session' do
         expect(controller.current_sp).to eq(sp)
       end

--- a/spec/features/idv/proofing_agent_activation_spec.rb
+++ b/spec/features/idv/proofing_agent_activation_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe 'Proofing agent activation', :js do
       proofing_location_id: 'location-456',
       correlation_id: 'correlation-789',
       transaction_id: document_capture_session.uuid,
+      service_provider_issuer: service_provider.issuer,
     }
   end
 
@@ -79,13 +80,36 @@ RSpec.describe 'Proofing agent activation', :js do
     end
   end
 
-  scenario 'user activates their profile after being proofed by proofing agent' do
+  scenario 'user activates their profile and connects it to the service provider' do
     sign_in_live_with_2fa(user)
     expect(page).to have_current_path idv_enter_dob_ssn_path
     complete_idv_enter_dob_ssn_step
     complete_enter_password_step(user)
     acknowledge_and_confirm_personal_key
+
+    expect(page).to have_current_path(sign_up_completed_path)
+    expect(page).to have_content(
+      t('titles.sign_up.completion_idv', sp: service_provider.friendly_name),
+    )
+
+    # the consent screen must list the identity attributes shared with the SP,
+    # not just the email address
+    expect(page).to have_content(t('help_text.requested_attributes.full_name'))
+    expect(page).to have_content(t('help_text.requested_attributes.birthdate'))
+    expect(page).to have_content(t('help_text.requested_attributes.social_security_number'))
+    expect(page).to have_content(t('help_text.requested_attributes.address'))
+    expect(page).to have_content(t('help_text.requested_attributes.phone'))
+
+    click_agree_and_continue
+
+    # the SP return url in the factory is '/', which routes signed in users to
+    # their account, so landing there means the consent submission finished
     expect(page).to have_current_path(account_path)
+
+    identity = user.identities.find_by(service_provider: service_provider.issuer)
+    expect(identity).to be_present
+    expect(identity.verified_attributes)
+      .to match_array(Idv::EnterDobSsnController::AGENT_PROOFED_REQUESTED_ATTRIBUTES)
   end
 
   context 'when the user enters an incorrect SSN' do
@@ -124,7 +148,7 @@ RSpec.describe 'Proofing agent activation', :js do
 
       complete_enter_password_step(user)
       acknowledge_and_confirm_personal_key
-      expect(page).to have_current_path account_path
+      expect(page).to have_current_path sign_up_completed_path
     end
   end
 
@@ -144,7 +168,7 @@ RSpec.describe 'Proofing agent activation', :js do
 
       complete_enter_password_step(user)
       acknowledge_and_confirm_personal_key
-      expect(page).to have_current_path account_path
+      expect(page).to have_current_path sign_up_completed_path
     end
   end
 

--- a/spec/features/idv/proofing_agent_activation_spec.rb
+++ b/spec/features/idv/proofing_agent_activation_spec.rb
@@ -86,30 +86,7 @@ RSpec.describe 'Proofing agent activation', :js do
     complete_idv_enter_dob_ssn_step
     complete_enter_password_step(user)
     acknowledge_and_confirm_personal_key
-
-    expect(page).to have_current_path(sign_up_completed_path)
-    expect(page).to have_content(
-      t('titles.sign_up.completion_idv', sp: service_provider.friendly_name),
-    )
-
-    # the consent screen must list the identity attributes shared with the SP,
-    # not just the email address
-    expect(page).to have_content(t('help_text.requested_attributes.full_name'))
-    expect(page).to have_content(t('help_text.requested_attributes.birthdate'))
-    expect(page).to have_content(t('help_text.requested_attributes.social_security_number'))
-    expect(page).to have_content(t('help_text.requested_attributes.address'))
-    expect(page).to have_content(t('help_text.requested_attributes.phone'))
-
-    click_agree_and_continue
-
-    # the SP return url in the factory is '/', which routes signed in users to
-    # their account, so landing there means the consent submission finished
     expect(page).to have_current_path(account_path)
-
-    identity = user.identities.find_by(service_provider: service_provider.issuer)
-    expect(identity).to be_present
-    expect(identity.verified_attributes)
-      .to match_array(Idv::EnterDobSsnController::AGENT_PROOFED_REQUESTED_ATTRIBUTES)
   end
 
   context 'user signs in through the service provider' do
@@ -172,7 +149,7 @@ RSpec.describe 'Proofing agent activation', :js do
 
       complete_enter_password_step(user)
       acknowledge_and_confirm_personal_key
-      expect(page).to have_current_path sign_up_completed_path
+      expect(page).to have_current_path account_path
     end
   end
 
@@ -192,7 +169,7 @@ RSpec.describe 'Proofing agent activation', :js do
 
       complete_enter_password_step(user)
       acknowledge_and_confirm_personal_key
-      expect(page).to have_current_path sign_up_completed_path
+      expect(page).to have_current_path account_path
     end
   end
 

--- a/spec/features/idv/proofing_agent_activation_spec.rb
+++ b/spec/features/idv/proofing_agent_activation_spec.rb
@@ -112,6 +112,30 @@ RSpec.describe 'Proofing agent activation', :js do
       .to match_array(Idv::EnterDobSsnController::AGENT_PROOFED_REQUESTED_ATTRIBUTES)
   end
 
+  context 'user signs in through the service provider' do
+    scenario 'binding completes the original authorization request' do
+      visit_idp_from_ial2_oidc_sp(client_id: service_provider.issuer)
+      sign_in_live_with_2fa(user)
+
+      # the redirect from sign in to the binding page ships separately; this
+      # covers the sp session surviving the binding step
+      visit idv_enter_dob_ssn_path
+      complete_idv_enter_dob_ssn_step
+      complete_enter_password_step(user)
+      acknowledge_and_confirm_personal_key
+
+      expect(page).to have_current_path(sign_up_completed_path, wait: 10)
+      click_agree_and_continue
+
+      expect(page).to have_current_path(
+        'http://localhost:7654/auth/result',
+        url: true,
+        ignore_query: true,
+        wait: 10,
+      )
+    end
+  end
+
   context 'when the user enters an incorrect SSN' do
     scenario 'stays on the confirmation page and shows a warning' do
       sign_in_live_with_2fa(user)

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -386,7 +386,13 @@ class UserMailerPreview < ActionMailer::Preview
 
   def agent_proofing_succeeded
     UserMailer.with(user: user, email_address: email_address_record)
-      .agent_proofing_succeeded(verified_at: Time.zone.now.to_s)
+      .agent_proofing_succeeded(
+        verified_at: Time.zone.now.to_s,
+        # partner-routed CTA when a seeded SP exists; plain sign-in link otherwise
+        service_provider: ServiceProvider.find_by(
+          issuer: 'urn:gov:gsa:openidconnect:sp:sinatra',
+        ),
+      )
   end
 
   private

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -774,6 +774,31 @@ RSpec.describe UserMailer, type: :mailer do
       expect(mail.html_part.body).to have_content('March 20, 2026')
     end
 
+    it 'links the confirmation button to the sign-in screen' do
+      expect(mail.html_part.body).to have_link(
+        t('user_mailer.agent_proofing_succeeded.cta'),
+        href: new_user_session_url,
+      )
+    end
+
+    context 'with a service provider' do
+      let(:service_provider) do
+        create(:service_provider, return_to_sp_url: 'https://partner.example.gov')
+      end
+
+      let(:mail) do
+        UserMailer.with(user: user, email_address: email_address)
+          .agent_proofing_succeeded(verified_at: verified_at, service_provider:)
+      end
+
+      it 'links the confirmation button to the partner' do
+        expect(mail.html_part.body).to have_link(
+          t('user_mailer.agent_proofing_succeeded.cta'),
+          href: 'https://partner.example.gov',
+        )
+      end
+    end
+
     it 'inlines the info icon' do
       icon = mail.attachments['info.png']
       expect(icon).not_to be_nil

--- a/spec/presenters/idv/proofing_agent/agent_proofing_succeeded_presenter_spec.rb
+++ b/spec/presenters/idv/proofing_agent/agent_proofing_succeeded_presenter_spec.rb
@@ -16,6 +16,32 @@ RSpec.describe Idv::ProofingAgent::AgentProofingSucceededPresenter do
     it 'routes users to the sign-in screen' do
       expect(presenter.confirmation_url).to eq(new_user_session_url(host: 'example.com'))
     end
+
+    context 'with a service provider' do
+      let(:service_provider) do
+        create(:service_provider, return_to_sp_url: 'https://partner.example.gov')
+      end
+
+      subject(:presenter) do
+        described_class.new(
+          verified_at: '2026-04-02 16:24:00 -0500',
+          url_options: { host: 'example.com' },
+          service_provider:,
+        )
+      end
+
+      it 'routes users to the partner' do
+        expect(presenter.confirmation_url).to eq('https://partner.example.gov')
+      end
+
+      context 'when the service provider has no return to SP url' do
+        let(:service_provider) { create(:service_provider, return_to_sp_url: nil) }
+
+        it 'falls back to the sign-in screen' do
+          expect(presenter.confirmation_url).to eq(new_user_session_url(host: 'example.com'))
+        end
+      end
+    end
   end
 
   describe '#contact_us_url' do

--- a/spec/services/proofing_agent/success_email_sender_spec.rb
+++ b/spec/services/proofing_agent/success_email_sender_spec.rb
@@ -63,6 +63,29 @@ RSpec.describe ProofingAgent::SuccessEmailSender do
       )
     end
 
+    context 'with a service provider' do
+      let(:service_provider) do
+        create(:service_provider, return_to_sp_url: 'https://partner.example.gov')
+      end
+
+      subject(:sender) do
+        described_class.new(user: user, analytics: analytics, service_provider: service_provider)
+      end
+
+      it 'delivers an email whose confirmation link routes to the partner' do
+        sender.call(
+          verified_at: verified_at,
+          proofing_agent_id: proofing_agent_id,
+          proofing_location_id: proofing_location_id,
+          correlation_id: correlation_id,
+          transaction_id: transaction_id,
+        )
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.html_part.body.decoded).to include('href="https://partner.example.gov"')
+      end
+    end
+
     context 'when verified_at is blank' do
       it 'does not deliver an email or log the analytics event' do
         expect do


### PR DESCRIPTION
changelog: Upcoming Features, Proofing Agent, connect users to the partner agency after binding

## 🎫 Ticket

Link to the relevant ticket:
[LG-17850 ](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17850 )


## 🛠 Summary of changes
After binding, agent proofed users landed on their account page instead of the connect to partner page: the binding flow set `session[:sp]` without a `request_url`, and the completion screen skips itself when that is missing. The binding step now fills in the SP session (request_url from the SP's post idv follow up url, requested_attributes with what an agent proofed profile shares), so users land on the connect page, consent, and get handed back to the partner. If the user signed in through a live SP authorization request instead, that session is kept so the original request completes after binding.


## 📜 Testing Plan
**Local testing note**: with the default dev `idv_proofing_agent_config`, post-binding redirects go to the Example SAML App on localhost:4567. To end on the OIDC sinatra app (9292), point the config at `urn:gov:gsa:openidconnect:sp:sinatra` or start from a 9292 sign-in.

- [ ] SP sign-in path: start from the OIDC sinatra app (localhost:9292) with an IAL2 request, sign in as the user awaiting binding, complete binding and consent, and confirm you are redirected back to localhost:9292/auth/result and the sinatra app logs you in with the IAL2 attributes.
- [ ] Seed a user awaiting binding (agent proofed document capture session with a service_provider_issuer), sign in, complete the DOB/SSN, password, and personal key steps, and confirm you land on the connect to partner page listing full name, DOB, SSN, address, and phone. Agree and continue should redirect to the SP follow up url instead of the account page.
- [ ] Confirm `log/events.log` shows a service_provider on `idv_proofing_agent_user_confirmation_visited` and every event after it through `User registration: complete`