### PR TITLE
Update build commands to fix local build

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: WEBPACK_PORT=${WEBPACK_PORT:-3035} bundle exec rackup config.ru --port ${PORT:-3000} --host ${FOREMAN_HOST:-${HOST:-localhost}}
 worker: bundle exec good_job start
 js: WEBPACK_PORT=${WEBPACK_PORT:-3035} ORIGIN_PORT=${ORIGIN_PORT:-3000} npm exec webpack -- --watch
-css: npm run build:css -- --watch
+css: npm run watch:css

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build": "npm run build:js",
     "build:js": "concurrently 'webpack' 'make browsers.json'",
     "build:css": "npm run build:css:legacy && npm run build:css:nds",
+    "watch:css": "concurrently 'npm run build:css:legacy -- --watch' 'npm run build:css:nds -- --watch'",
     "build:css:legacy": "build-sass app/assets/stylesheets/application.css.scss app/assets/stylesheets/document-capture.css.scss app/assets/stylesheets/email.css.scss app/assets/stylesheets/navigation.css.scss app/assets/stylesheets/print.css.scss app/assets/stylesheets/tables-report.css.scss app/assets/stylesheets/utilities.css.scss app/components/*.scss --load-path=app/assets/stylesheets --out-dir=app/assets/builds",
     "build:css:nds": "build-sass app/assets/stylesheets/nds_application.css.scss --load-path=app/assets/stylesheets/nds --load-path=app/assets/stylesheets --load-path=node_modules/@18f/identity-design-system/packages-nds --out-dir=app/assets/builds",
     "build:openapi": "redocly bundle ./docs/attempts-api/openapi.yml -o ./docs/attempts-api/compiled-api --ext yml -d"


### PR DESCRIPTION
## 🛠 Summary of changes
As part of the NDS changes, we are now bundling both NDS and our original CSS. 

When this was added to package.json and the procfile, local build was failing because the css step was exiting early.

## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] pull down this branch
- [ ] run `make run`
- [ ] local server starts

error i was getting:
```
08:18:33 css.1    | exited with code 0
08:18:33 system   | sending SIGTERM to all processes
08:18:33 web.1    | - Gracefully stopping, waiting for requests to finish
08:18:33 js.1     | terminated by SIGTERM
08:18:33 web.1    | terminated by SIGTERM
```
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
