### PR TITLE
Add NDS utilities, navigation, and print stylesheet bundles

### DIFF
--- a/app/assets/stylesheets/nds_navigation.css.scss
+++ b/app/assets/stylesheets/nds_navigation.css.scss
@@ -1,0 +1,28 @@
+// NDS variant of navigation.css.scss. Structurally identical to the legacy
+// bundle but uses 'nds/uswds-core' so the header/nav/sidenav graph resolves
+// through packages-nds and emits NDS token values.
+// LOAD-PATH ORDER (see nds_application.css.scss / package.json build:css:nds):
+// app/assets/stylesheets/nds MUST precede app/assets/stylesheets.
+@use 'nds/uswds-core' as *;
+
+@forward 'usa-header/src/styles/usa-header';
+@forward 'usa-nav/src/styles';
+@forward 'usa-sidenav/src/styles';
+
+.sidenav-mobile .usa-nav__close {
+  @include u-display('flex');
+  @include u-flex('align-center', 'justify-center');
+  @include u-square(6);
+  @include u-text('primary');
+}
+
+@media (prefers-reduced-motion) {
+  // The design system should be responsible for disabling inessential animations when user prefers
+  // reduced motion. This is not currently implemented, but the style is implemented ad hoc here
+  // for use in feature specs (see BrowserEmulationHelper#emulate_reduced_motion).
+  //
+  // Upstream issue: https://github.com/uswds/uswds/issues/5256
+  .usa-nav.is-visible {
+    animation: none;
+  }
+}

--- a/app/assets/stylesheets/nds_print.css.scss
+++ b/app/assets/stylesheets/nds_print.css.scss
@@ -1,0 +1,12 @@
+// NDS variant of print.css.scss. print.css.scss has no USWDS/token
+// dependency (plain display:none rules), so this is byte-identical to legacy
+// print.css — created only to mirror main's bundle topology for the nds
+// bucket. If print ever gains token-dependent rules, route it through
+// 'nds/uswds-core' like the other nds bundles.
+nav,
+footer,
+.usa-button,
+.usa-radio__input--bordered,
+.usa-checkbox__input--bordered {
+  display: none;
+}

--- a/app/assets/stylesheets/nds_utilities.css.scss
+++ b/app/assets/stylesheets/nds_utilities.css.scss
@@ -1,0 +1,8 @@
+// NDS variant of utilities.css.scss. Structurally identical to the legacy
+// bundle but forwards 'nds/uswds-core' first so the whole utilities graph
+// resolves through packages-nds and emits NDS token values.
+// LOAD-PATH ORDER (see nds_application.css.scss / package.json build:css:nds):
+// app/assets/stylesheets/nds MUST precede app/assets/stylesheets.
+@forward 'nds/uswds-core';
+@forward 'uswds-utilities';
+@forward 'utilities';

--- a/app/views/layouts/nds/base.html.erb
+++ b/app/views/layouts/nds/base.html.erb
@@ -23,8 +23,8 @@
   <%= yield(:early_head) if content_for?(:early_head) %>
   <%= stylesheet_link_tag 'nds_application', nopush: false %>
   <%= render_stylesheet_once_tags %>
-  <%= stylesheet_link_tag 'utilities', nopush: false %>
-  <%= stylesheet_link_tag 'print', media: :print, preload_links_header: false %>
+  <%= stylesheet_link_tag 'nds_utilities', nopush: false %>
+  <%= stylesheet_link_tag 'nds_print', media: :print, preload_links_header: false %>
   <%= csrf_meta_tags %>
 
   <%= favicon_link_tag(

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:css": "npm run build:css:legacy && npm run build:css:nds",
     "watch:css": "concurrently 'npm run build:css:legacy -- --watch' 'npm run build:css:nds -- --watch'",
     "build:css:legacy": "build-sass app/assets/stylesheets/application.css.scss app/assets/stylesheets/document-capture.css.scss app/assets/stylesheets/email.css.scss app/assets/stylesheets/navigation.css.scss app/assets/stylesheets/print.css.scss app/assets/stylesheets/tables-report.css.scss app/assets/stylesheets/utilities.css.scss app/components/*.scss --load-path=app/assets/stylesheets --out-dir=app/assets/builds",
-    "build:css:nds": "build-sass app/assets/stylesheets/nds_application.css.scss --load-path=app/assets/stylesheets/nds --load-path=app/assets/stylesheets --load-path=node_modules/@18f/identity-design-system/packages-nds --out-dir=app/assets/builds",
+    "build:css:nds": "build-sass app/assets/stylesheets/nds_application.css.scss app/assets/stylesheets/nds_utilities.css.scss app/assets/stylesheets/nds_navigation.css.scss app/assets/stylesheets/nds_print.css.scss --load-path=app/assets/stylesheets/nds --load-path=app/assets/stylesheets --load-path=node_modules/@18f/identity-design-system/packages-nds --out-dir=app/assets/builds",
     "build:openapi": "redocly bundle ./docs/attempts-api/openapi.yml -o ./docs/attempts-api/compiled-api --ext yml -d"
   },
   "dependencies": {

--- a/spec/requests/nds_layout_stylesheet_spec.rb
+++ b/spec/requests/nds_layout_stylesheet_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe 'NDS layout stylesheet swap', type: :request do
       expect(response.body).to include('public-sans/PublicSans')
       expect(response.body).not_to include('inter/InterVariable')
     end
+
+    it 'loads the legacy utilities and print bundles, not the nds variants' do
+      get root_url
+
+      expect(response.body).to match(%r{stylesheet["'][^>]*/assets/utilities[-.]})
+      expect(response.body).to match(%r{stylesheet["'][^>]*/assets/print[-.]})
+      expect(response.body).not_to include('nds_utilities')
+      expect(response.body).not_to include('nds_print')
+    end
   end
 
   context 'forced nds bucket' do
@@ -29,6 +38,15 @@ RSpec.describe 'NDS layout stylesheet swap', type: :request do
 
       expect(response.body).to include('inter/InterVariable')
       expect(response.body).not_to include('public-sans/PublicSans')
+    end
+
+    it 'loads the nds_utilities and nds_print bundles, not the legacy variants' do
+      get root_url, params: { ui_test_bucket: 'nds' }
+
+      expect(response.body).to match(%r{stylesheet["'][^>]*/assets/nds_utilities[-.]})
+      expect(response.body).to match(%r{stylesheet["'][^>]*/assets/nds_print[-.]})
+      expect(response.body).not_to match(%r{stylesheet["'][^>]*/assets/utilities[-.]})
+      expect(response.body).not_to match(%r{stylesheet["'][^>]*/assets/print[-.]})
     end
   end
 end


### PR DESCRIPTION
## Summary

Mirrors main's CSS bundle topology for the NDS bucket by adding three NDS-variant stylesheet bundles — `nds_utilities`, `nds_navigation`, `nds_print` — each structurally identical to its legacy counterpart but routed through `packages-nds` via `nds/uswds-core`, and wires the NDS base layout to load `nds_utilities`/`nds_print` instead of the legacy bundles.

- **Legacy bucket is proven byte-identical** (A/B control): all legacy build outputs and `nds_application.css` are unchanged; only the new `nds_*` bundles appear.
- **`nds_print` is byte-identical to legacy `print`** (no token dependency) — created only to mirror bundle topology. `nds_utilities`/`nds_navigation` are topology mirrors that will diverge on NDS tokens once a primary-color override lands (not present on current main yet).
- `package.json` `build:css:nds` gains the three new entrypoints; `watch:css` (#13391) is untouched and picks them up automatically.

## Test plan

- [x] `npm run build:css`, `build:css:nds`, `build:css:legacy` all exit 0; new bundles emitted
- [x] `npm run watch:css` launches both watchers and compiles all bundles incl. new nds ones
- [x] Legacy outputs byte-identical to main (before/after shasum diff empty)
- [x] `nds_print.css` == `print.css` byte-for-byte
- [x] Zero emitted `ads-` in built nds CSS and new source
- [x] `rspec spec/requests/nds_layout_stylesheet_spec.rb` green
- [x] `rubocop` clean on changed spec