### PR TITLE
Reference SVG favicon to match identity-site tab icon

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -34,6 +34,11 @@
         type: 'image/png',
       ) %>
   <%= favicon_link_tag(
+        asset_path('favicons/favicon.svg'),
+        rel: 'icon',
+        type: 'image/svg+xml',
+      ) %>
+  <%= favicon_link_tag(
         asset_path('favicons/favicon-40.png'),
         rel: 'icon',
         sizes: '40x40',

--- a/app/views/layouts/nds/base.html.erb
+++ b/app/views/layouts/nds/base.html.erb
@@ -34,6 +34,11 @@
         type: 'image/png',
       ) %>
   <%= favicon_link_tag(
+        asset_path('favicons/favicon.svg'),
+        rel: 'icon',
+        type: 'image/svg+xml',
+      ) %>
+  <%= favicon_link_tag(
         asset_path('favicons/favicon-40.png'),
         rel: 'icon',
         sizes: '40x40',


### PR DESCRIPTION
## Summary

- The idp layouts (`base.html.erb` and `nds/base.html.erb`) declared only a 16×16 and a 40×40 PNG as `rel=icon`. On HiDPI/retina displays the tab slot is 32 device px, so browsers upscaled the 16px PNG (or downscaled the 40px), producing the blurry, undersized shield seen in `secure.login.gov` tabs.
- `login.gov` (identity-site) renders a sharp, full-frame icon. The `@18f/identity-design-system` package already ships `favicons/favicon.svg` that is **byte-identical** to the one identity-site uses — it just wasn't referenced here.
- This adds a `rel="icon" type="image/svg+xml"` link to `favicons/favicon.svg` in both layouts. Modern browsers prefer the SVG and render it crisply at any size/DPI; the existing PNGs remain as fallbacks for older browsers. No new/vendored binary assets.

## Test plan

- [ ] Load a page in a modern browser (Chrome/Firefox/Safari) on a retina display and confirm the tab favicon is crisp and matches login.gov.
- [ ] Confirm fallback PNGs still load in a browser without SVG favicon support.
- [ ] Verify both standard and NDS layouts render the new `<link>`.