### PR TITLE
NDS: add variant/size to account-management button call sites

### DIFF
--- a/app/views/accounts/_auth_apps.html.erb
+++ b/app/views/accounts/_auth_apps.html.erb
@@ -22,6 +22,8 @@
 <% if current_user.auth_app_configurations.count < IdentityConfig.store.max_auth_apps_per_account %>
   <%= render ButtonComponent.new(
         url: authenticator_setup_url,
+        variant: :secondary,
+        size: :md,
         icon: :add,
         class: 'usa-button usa-button--outline margin-top-2',
       ).with_content(t('account.index.auth_app_add')) %>

--- a/app/views/accounts/_phone.html.erb
+++ b/app/views/accounts/_phone.html.erb
@@ -26,6 +26,8 @@
 <% if current_user.phone_configurations.count < IdentityConfig.store.max_phone_numbers_per_account %>
   <%= render ButtonComponent.new(
         url: phone_setup_path,
+        variant: :secondary,
+        size: :md,
         outline: true,
         icon: :add,
         class: 'margin-top-2',

--- a/app/views/accounts/_piv_cac.html.erb
+++ b/app/views/accounts/_piv_cac.html.erb
@@ -22,6 +22,8 @@
 <% if current_user.piv_cac_configurations.count < IdentityConfig.store.max_piv_cac_per_account %>
   <%= render ButtonComponent.new(
         url: setup_piv_cac_url,
+        variant: :secondary,
+        size: :md,
         icon: :add,
         outline: true,
         class: 'margin-top-2',

--- a/app/views/accounts/_webauthn_platform.html.erb
+++ b/app/views/accounts/_webauthn_platform.html.erb
@@ -21,6 +21,8 @@
 
 <%= render ButtonComponent.new(
       url: webauthn_setup_path(platform: true),
+      variant: :secondary,
+      size: :md,
       icon: :add,
       outline: true,
       class: 'margin-top-2',

--- a/app/views/accounts/_webauthn_roaming.html.erb
+++ b/app/views/accounts/_webauthn_roaming.html.erb
@@ -26,6 +26,8 @@
 
 <%= render ButtonComponent.new(
       url: webauthn_setup_path,
+      variant: :secondary,
+      size: :md,
       icon: :add,
       outline: true,
       class: 'margin-top-2',

--- a/app/views/accounts/actions/_generate_backup_codes.html.erb
+++ b/app/views/accounts/actions/_generate_backup_codes.html.erb
@@ -1,5 +1,7 @@
 <%= render ButtonComponent.new(
       url: backup_code_setup_path,
+      variant: :secondary,
+      size: :md,
       icon: :add,
       class: 'usa-button usa-button--outline margin-top-2',
     ).with_content(t('forms.backup_code.generate')) %>

--- a/app/views/accounts/actions/_regenerate_backup_codes.html.erb
+++ b/app/views/accounts/actions/_regenerate_backup_codes.html.erb
@@ -1,5 +1,7 @@
 <%= render ButtonComponent.new(
       url: backup_code_regenerate_path,
+      variant: :secondary,
+      size: :md,
       icon: :add,
       outline: true,
       class: 'margin-top-2',

--- a/spec/views/accounts/_piv_cac.html.erb_spec.rb
+++ b/spec/views/accounts/_piv_cac.html.erb_spec.rb
@@ -26,4 +26,28 @@ RSpec.describe 'accounts/_piv_cac.html.erb' do
   it 'renders a list of piv cac configurations' do
     expect(rendered).to have_selector('[role="list"] [role="listitem"]', count: 2)
   end
+
+  describe 'add-piv/cac button bucket-conditional rendering' do
+    before do
+      # Ensure the add button renders (default max is 2 and the user has 2).
+      allow(IdentityConfig.store).to receive(:max_piv_cac_per_account).and_return(10)
+    end
+
+    context 'legacy bucket' do
+      it 'renders origin/main classes (outline), no nds variant modifiers' do
+        expect(rendered).to have_css('.usa-button.usa-button--outline')
+        expect(rendered).not_to have_css('.usa-button--secondary')
+        expect(rendered).not_to have_css('.usa-button--md')
+      end
+    end
+
+    context 'nds bucket' do
+      before { allow(view).to receive(:nds_layout?).and_return(true) }
+
+      it 'renders variant :secondary + size :md, dropping the legacy outline class' do
+        expect(rendered).to have_css('.usa-button.usa-button--secondary.usa-button--md')
+        expect(rendered).not_to have_css('.usa-button--outline')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds gsa-staging's `variant: :secondary, size: :md` to the account-management "add" and backup-code buttons across seven `accounts/` view partials, keeping all legacy args (`outline:`, `icon:`, `class:`).
- Legacy/control bucket output is **byte-identical** to origin/main (migration-safety invariant); the NDS bucket renders the secondary/md variant.

## Stacking

- **Stacked on the bucket-conditional ButtonComponent PR-F** (#TBD, branch `nds-phase1-button-component`) — the `variant:`/`size:` kwargs only take effect because PR-F teaches `ButtonComponent` to honor them per A/B bucket.
- Base is `nds-phase1-button-component`; **retarget to `main` after PR-F merges**.

## Test plan

- [x] `spec/views/accounts/_piv_cac.html.erb_spec.rb` — new bucket-conditional examples (legacy: outline, no secondary/md; nds: secondary+md, no outline) pass with F's ButtonComponent.
- [x] All existing account view specs (`_auth_apps`, `_webauthn_platform`, `_webauthn_roaming`, `accounts/show`) green.
- [x] rubocop + erb_lint clean.
- [x] Legacy bucket byte-identical to origin/main.