### PR TITLE
Remove redundant nav prefers-reduced-motion override now handled by USWDS

### DIFF
--- a/app/assets/stylesheets/navigation.css.scss
+++ b/app/assets/stylesheets/navigation.css.scss
@@ -10,14 +10,3 @@
   @include u-square(6);
   @include u-text('primary');
 }
-
-@media (prefers-reduced-motion) {
-  // The design system should be responsible for disabling inessential animations when user prefers
-  // reduced motion. This is not currently implemented, but the style is implemented ad hoc here
-  // for use in feature specs (see BrowserEmulationHelper#emulate_reduced_motion).
-  //
-  // Upstream issue: https://github.com/uswds/uswds/issues/5256
-  .usa-nav.is-visible {
-    animation: none;
-  }
-}

--- a/app/assets/stylesheets/nds_navigation.css.scss
+++ b/app/assets/stylesheets/nds_navigation.css.scss
@@ -15,14 +15,3 @@
   @include u-square(6);
   @include u-text('primary');
 }
-
-@media (prefers-reduced-motion) {
-  // The design system should be responsible for disabling inessential animations when user prefers
-  // reduced motion. This is not currently implemented, but the style is implemented ad hoc here
-  // for use in feature specs (see BrowserEmulationHelper#emulate_reduced_motion).
-  //
-  // Upstream issue: https://github.com/uswds/uswds/issues/5256
-  .usa-nav.is-visible {
-    animation: none;
-  }
-}


### PR DESCRIPTION
## Summary

USWDS 3.13.0 ships a native `prefers-reduced-motion` rule that disables the `.usa-nav.is-visible` mobile flyout animation ([uswds/uswds#6268](https://github.com/uswds/uswds/pull/6268), closes [uswds/uswds#5256](https://github.com/uswds/uswds/issues/5256)).

idp's ad-hoc override in `navigation.css.scss` — added in #8093 (commit 573b1ed3) referencing uswds#5256 — now duplicates that upstream rule. idp compiles against `@uswds/uswds` 3.13.0 (arrived via the `@18f/identity-design-system` 9.7.0 bump in #13381), so the override is redundant. Removing it de-duplicates while the USWDS-provided rule preserves identical behavior.

## Changes

- Remove the ad-hoc `@media (prefers-reduced-motion) { .usa-nav.is-visible { animation: none; } }` block from `navigation.css.scss` and `nds_navigation.css.scss`.

## Evidence

Compiled CSS still contains the USWDS-provided reduced-motion rule after removal:

```css
@media (width <= 639px) and (prefers-reduced-motion) {
  .usa-nav.is-visible {
    animation: none;
  }
}
```

Only the `navigation.css` / `nds_navigation.css` bundles change; all other compiled bundles are byte-identical. stylelint passes.

## Test plan

- [x] Confirm compiled `navigation.css` / `nds_navigation.css` retain the USWDS reduced-motion rule
- [ ] `spec/features/users/user_profile_spec.rb` reduced-motion mobile-menu example passes in CI