### PR TITLE
LG-17616 Prevent nil sp_name error in duplicate_profiles_detected acc…

### DIFF
--- a/app/controllers/duplicate_profiles_detected_controller.rb
+++ b/app/controllers/duplicate_profiles_detected_controller.rb
@@ -3,6 +3,7 @@
 class DuplicateProfilesDetectedController < ApplicationController
   before_action :confirm_two_factor_authenticated
   before_action :redirect_unless_user_has_active_duplicate_profile
+  before_action :redirect_unless_request_has_current_sp
   rescue_from ActionView::Template::Error, with: :handle_template_error
 
   def show
@@ -19,6 +20,10 @@ class DuplicateProfilesDetectedController < ApplicationController
   def redirect_unless_user_has_active_duplicate_profile
     return redirect_to(root_url) unless current_user&.identity_verified_with_facial_match?
     return redirect_to(root_url) unless duplicate_profile_set.present?
+  end
+
+  def redirect_unless_request_has_current_sp
+    redirect_to(root_url) unless current_sp.present?
   end
 
   def duplicate_profile_set

--- a/spec/controllers/duplicate_profiles_detected_controller_spec.rb
+++ b/spec/controllers/duplicate_profiles_detected_controller_spec.rb
@@ -67,32 +67,30 @@ RSpec.describe DuplicateProfilesDetectedController, type: :controller do
       end
     end
 
-    context 'when service provider is not available and global detection is enabled' do
-      render_views
-
+    context 'when a service provider is not present in the request' do
       let(:global_duplicate_profile_set) do
-        create(:duplicate_profile_set, :global, profile_ids: [user.active_profile.id, profile2.id])
+        create(
+          :duplicate_profile_set, :global,
+          profile_ids: [user.active_profile.id, profile2.id]
+        )
       end
 
       before do
         global_duplicate_profile_set
         allow(controller).to receive(:user_session).and_return(session)
         allow(controller).to receive(:current_sp).and_return(nil)
-        allow(IdentityConfig.store)
-          .to receive(:enable_one_account_global_detection)
-          .and_return(true)
       end
 
       it 'redirects to the root path' do
-        expect(Rails.logger).to receive(:error)
-          .with(a_string_including('Template error in duplicate_profiles_detected#show')
-            .and(a_string_including('global_detection_enabled: true'))
-            .and(a_string_including('no implicit conversion of nil into String'))
-            .and(a_string_including('sp_name: ')))
+        get :show, params: { source: :sign_in }
 
-        get :show, params: { source: :account_page }
-        expect(response).to render_template(:show)
         expect(response).to redirect_to(root_path)
+      end
+
+      it 'does not raise or log a template error' do
+        expect(Rails.logger).not_to receive(:error)
+
+        get :show, params: { source: :sign_in }
       end
     end
   end


### PR DESCRIPTION

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-17868](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17868)
-->


## 🛠 Summary of changes

**Problem**:
- The duplicate_profiles_detected#show page raised `no implicit conversion of
nil into String` when rendered without a service provider in context. The view
built the "never logged in" text as `t('...never_logged_in') + ' ' + sp_name`,
which fails when `sp_name` is nil (i.e. when `current_sp` is absent).
- This was a previously reported bug. About two months ago a rescue was added
that caught the template error and redirected users to root, which stopped users
from seeing an error. However, the exception was still raised, logged, and
captured by New Relic on every affected page view, so the error kept being
reported and counted.
- Product intent is that a user should not be on this page without a service
provider present in the request. `current_sp` is derived from the session/request
(`sp_from_sp_session || sp_from_request_id`) independently of how the duplicate
profile set is looked up, so it can legitimately be nil (e.g. direct navigation
or an expired SP session).

**Fix**:
- Add a `redirect_unless_request_has_current_sp` before_action that redirects to
root when `current_sp` is not present, so the page never renders without a
service provider and the nil `sp_name` path is never reached.
- Update the controller spec to reflect real conditions: global detection
enabled with an SP-less (`service_provider: nil`) duplicate profile set and no
`current_sp`, asserting the redirect occurs and no template error is logged.


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17868]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17868