### PR TITLE
Align NDSButtonComponent constant with NDS acronym autoloading

### DIFF
--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -46,7 +46,7 @@ class ButtonComponent < BaseComponent
   end
 
   # Legacy/control bucket behavior. Byte-identical to origin/main: variant:/size:
-  # are ignored and the boolean API is honored. NdsButtonComponent overrides
+  # are ignored and the boolean API is honored. NDSButtonComponent overrides
   # css_class/parts for the NDS bucket.
   def css_class
     classes = ['usa-button', *tag_options[:class]]
@@ -79,13 +79,13 @@ class ButtonComponent < BaseComponent
   # The A/B bucket can only be resolved at render time (helpers are unavailable
   # in #initialize). Callers always instantiate ButtonComponent (or one of its
   # subclasses); when the render resolves to the NDS bucket we delegate to
-  # NdsButtonComponent, which renders itself with the variant/size API. The
-  # guard excludes NdsButtonComponent itself so it renders its own (NDS) markup
+  # NDSButtonComponent, which renders itself with the variant/size API. The
+  # guard excludes NDSButtonComponent itself so it renders its own (NDS) markup
   # instead of recursing — every other button (including the Submit/Print/
   # Download subclasses) flips to NDS in the NDS bucket.
   def before_render
     super
-    @render_as_nds = nds_bucket? && !is_a?(NdsButtonComponent)
+    @render_as_nds = nds_bucket? && !is_a?(NDSButtonComponent)
   end
 
   private
@@ -95,7 +95,7 @@ class ButtonComponent < BaseComponent
   end
 
   def nds_delegate
-    NdsButtonComponent.new(
+    NDSButtonComponent.new(
       url:, method:, icon:, icon_position:, size:, variant:,
       big:, wide:, full_width:, outline:, unstyled:, danger:,
       **tag_options

--- a/app/components/nds_button_component.rb
+++ b/app/components/nds_button_component.rb
@@ -6,7 +6,7 @@
 # the render resolves to the NDS bucket; not instantiated by call sites
 # directly. Deleting this file + the delegation branch in ButtonComponent tears
 # the experiment down cleanly.
-class NdsButtonComponent < ButtonComponent
+class NDSButtonComponent < ButtonComponent
   VARIANTS = {
     primary: nil,
     secondary: 'usa-button--secondary',

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Register NDS as an acronym so Zeitwerk autoloads NDS-prefixed constants under
+# the NDS name (e.g. app/components/nds_button_component.rb -> NDSButtonComponent)
+# rather than expecting the camelized `Nds` form.
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'NDS'
+end


### PR DESCRIPTION
## Summary

- `NdsButtonComponent` (added in #13393) does not match the `NDS` acronym casing. This registers `inflect.acronym 'NDS'` and renames the class to `NDSButtonComponent` so Zeitwerk autoloading is consistent with the `NDS`-namespaced constants the design-system work introduces.
- Without the acronym, `nds_button_component.rb` must define `NdsButtonComponent`; with it, Zeitwerk expects `NDSButtonComponent`. The rename therefore requires the acronym, so both land together.

## Why now

The acronym inflection is foundational for the ongoing NDS work (it will govern `NDS::*` services and components). It is inert for everything currently on `main`: there are no other `Nds`-cased Ruby constants, and the `nds` views/assets are not autoloaded. Landing it here — alongside the one constant that needs it — keeps autoloading correct and de-risks later NDS-namespaced PRs.

## Verification

- `bin/rails zeitwerk:check` passes with the rename + acronym; removing the acronym reproduces the boot failure, confirming the dependency direction.
- `git grep NdsButtonComponent` returns nothing after the rename.
- `bundle exec rspec spec/components/button_component_spec.rb` green (29 examples); `bundle exec rubocop` clean on changed files.

## Test plan

- [x] `bin/rails zeitwerk:check` passes
- [x] `bundle exec rspec spec/components/button_component_spec.rb` green
- [x] `bundle exec rubocop` clean