### PR TITLE
Add NDS variant options to users account-management button call sites

### DIFF
--- a/app/views/users/auth_app/edit.html.erb
+++ b/app/views/users/auth_app/edit.html.erb
@@ -24,6 +24,7 @@
       url: auth_app_path(id: @form.configuration.id),
       method: :delete,
       form: { aria: { label: t('two_factor_authentication.auth_app.delete') } },
+      variant: :destructive,
       big: true,
       wide: true,
       danger: true,

--- a/app/views/users/authorization_confirmation/new.html.erb
+++ b/app/views/users/authorization_confirmation/new.html.erb
@@ -31,6 +31,7 @@
   <%= render ButtonComponent.new(
         url: reset_user_authorization_path,
         method: :delete,
+        variant: :secondary,
         big: true,
         wide: true,
       ).with_content(t('user_authorization_confirmation.sign_in')) %>

--- a/app/views/users/backup_code_reminder/show.html.erb
+++ b/app/views/users/backup_code_reminder/show.html.erb
@@ -21,5 +21,6 @@
 <%= render ButtonComponent.new(
       url: backup_code_reminder_path,
       method: :post,
+      variant: :quaternary,
       unstyled: true,
     ).with_content(t('forms.backup_code_reminder.need_new_codes')) %>

--- a/app/views/users/backup_code_setup/edit.html.erb
+++ b/app/views/users/backup_code_setup/edit.html.erb
@@ -15,6 +15,7 @@
 
   <%= render ButtonComponent.new(
         url: account_path,
+        variant: :quaternary,
         big: true,
         wide: true,
         outline: true,

--- a/app/views/users/backup_code_setup/new.html.erb
+++ b/app/views/users/backup_code_setup/new.html.erb
@@ -19,6 +19,7 @@
 
 <%= render ButtonComponent.new(
       url: session[:account_redirect_path] || account_path,
+      variant: :quaternary,
       big: true,
       wide: true,
       outline: true,

--- a/app/views/users/piv_cac/edit.html.erb
+++ b/app/views/users/piv_cac/edit.html.erb
@@ -23,6 +23,7 @@
       url: piv_cac_path(id: @form.configuration.id),
       method: :delete,
       form: { aria: { label: @presenter.delete_button_label } },
+      variant: :destructive,
       big: true,
       wide: true,
       danger: true,

--- a/app/views/users/piv_cac_authentication_setup/new.html.erb
+++ b/app/views/users/piv_cac_authentication_setup/new.html.erb
@@ -39,6 +39,7 @@
         url: submit_new_piv_cac_url,
         method: :post,
         params: { skip: 'true' },
+        variant: :tertiary,
         unstyled: true,
       ).with_content(t('mfa.skip')) %>
 <% end %>

--- a/app/views/users/piv_cac_login/error.html.erb
+++ b/app/views/users/piv_cac_login/error.html.erb
@@ -11,6 +11,7 @@
 
   <%= render ButtonComponent.new(
         url: new_user_session_url,
+        variant: :quaternary,
         class: 'margin-top-3',
         big: true,
       ).with_content(t('instructions.mfa.piv_cac.back_to_sign_in')) %>

--- a/app/views/users/piv_cac_recommended/show.html.erb
+++ b/app/views/users/piv_cac_recommended/show.html.erb
@@ -22,6 +22,7 @@
 <%= render ButtonComponent.new(
       url: login_piv_cac_recommended_skip_path,
       method: :post,
+      variant: :quaternary,
       unstyled: true,
     ).with_content(@recommended_presenter.skip_text) %>
 

--- a/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
+++ b/app/views/users/piv_cac_setup_from_sign_in/prompt.html.erb
@@ -30,6 +30,7 @@
 <%= render ButtonComponent.new(
       url: login_add_piv_cac_prompt_path,
       method: :post,
+      variant: :secondary,
       big: true,
       wide: true,
       outline: true,

--- a/app/views/users/second_mfa_reminder/new.html.erb
+++ b/app/views/users/second_mfa_reminder/new.html.erb
@@ -18,6 +18,7 @@
       <%= render ButtonComponent.new(
             url: second_mfa_reminder_path,
             method: :post,
+            variant: :secondary,
             outline: true,
             big: true,
             full_width: true,

--- a/app/views/users/verify_personal_key/new.html.erb
+++ b/app/views/users/verify_personal_key/new.html.erb
@@ -23,6 +23,7 @@
 <%= render ButtonComponent.new(
       url: reactivate_account_path,
       method: :put,
+      variant: :secondary,
       unstyled: true,
     ).with_content(t('links.reverify')) %>
 

--- a/app/views/users/webauthn/edit.html.erb
+++ b/app/views/users/webauthn/edit.html.erb
@@ -21,6 +21,7 @@
       url: webauthn_path(id: @form.configuration.id),
       method: :delete,
       form: { aria: { label: @presenter.delete_button_label } },
+      variant: :destructive,
       big: true,
       wide: true,
       danger: true,

--- a/app/views/users/webauthn_setup_mismatch/show.html.erb
+++ b/app/views/users/webauthn_setup_mismatch/show.html.erb
@@ -36,6 +36,7 @@
 <%= render ButtonComponent.new(
       url: webauthn_setup_mismatch_url,
       method: :delete,
+      variant: :secondary,
       big: true,
       wide: true,
       outline: true,

--- a/spec/views/users/auth_app/edit.html.erb_spec.rb
+++ b/spec/views/users/auth_app/edit.html.erb_spec.rb
@@ -39,4 +39,23 @@ RSpec.describe 'users/auth_app/edit.html.erb' do
       auth_app_path(id: configuration.id),
     )
   end
+
+  describe 'delete button bucket-conditional rendering' do
+    context 'legacy bucket' do
+      it 'renders origin/main danger classes, no nds variant modifier' do
+        expect(rendered).to have_css('.usa-button--danger.usa-button--big.usa-button--wide')
+        expect(rendered).not_to have_css('.usa-button--secondary, .usa-button--quaternary')
+      end
+    end
+
+    context 'nds bucket' do
+      before { allow(view).to receive(:nds_layout?).and_return(true) }
+
+      it 'renders destructive as .usa-button--danger, dropping legacy size classes' do
+        expect(rendered).to have_css('.usa-button--danger')
+        expect(rendered).not_to have_css('.usa-button--big')
+        expect(rendered).not_to have_css('.usa-button--wide')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `variant:` options to the `ButtonComponent` call sites across the
  `users/*` account-management pages (14 view partials).
- These options are honored only when the `NDS_LOOK_AND_FEEL` A/B test is
  active, where they render the mapped USWDS button variants (secondary,
  tertiary, quaternary, destructive). The current default styling is
  unchanged.
- Builds on the `ButtonComponent` variant/size API introduced in #13393.

## Test plan

- [ ] `bundle exec rspec spec/views/users/auth_app/edit.html.erb_spec.rb`
      (covers both the default and NDS_LOOK_AND_FEEL rendering of the delete button)
- [ ] Existing `users/*` view specs still pass with the added options
- [ ] `bundle exec erb_lint app/views` clean on the touched partials
- [ ] Verify default styling is unchanged with NDS_LOOK_AND_FEEL off