### PR TITLE
Add NDS variant options to miscellaneous button call sites

### DIFF
--- a/app/views/account_reset/pending/show.html.erb
+++ b/app/views/account_reset/pending/show.html.erb
@@ -17,6 +17,7 @@
 <%= render ButtonComponent.new(
       url: account_reset_pending_cancel_path,
       method: :post,
+      variant: :primary,
       class: 'margin-top-3 margin-bottom-2',
       wide: true,
       big: true,

--- a/app/views/completions_cancellation/show.html.erb
+++ b/app/views/completions_cancellation/show.html.erb
@@ -31,6 +31,7 @@
 
       <%= render ButtonComponent.new(
             url: return_to_sp_cancel_path(step: :sign_up),
+            variant: :destructive,
             big: true,
             wide: true,
             outline: true,

--- a/app/views/duplicate_profiles_detected/show.html.erb
+++ b/app/views/duplicate_profiles_detected/show.html.erb
@@ -84,6 +84,7 @@
   <div class="margin-top-3 grid-col-4">
     <%= render ButtonComponent.new(
           url: logout_path,
+          variant: :quaternary,
           outline: true,
           method: :delete,
           class: 'usa-button usa-button usa-button--outline usa-button--wide usa-button--big',

--- a/app/views/session_timeout/_warning.html.erb
+++ b/app/views/session_timeout/_warning.html.erb
@@ -51,6 +51,7 @@
   <%= render ButtonComponent.new(
         url: logout_path,
         method: :delete,
+        variant: :secondary,
         big: true,
         full_width: true,
         outline: true,

--- a/app/views/sign_up/select_email/show.html.erb
+++ b/app/views/sign_up/select_email/show.html.erb
@@ -32,6 +32,7 @@
   <% if @can_add_email %>
     <%= render ButtonComponent.new(
           url: add_email_path(in_select_email_flow: true),
+          variant: :quaternary,
           outline: true,
           big: true,
           wide: true,

--- a/spec/views/sign_up/select_email/show.html.erb_spec.rb
+++ b/spec/views/sign_up/select_email/show.html.erb_spec.rb
@@ -45,4 +45,23 @@ RSpec.describe 'sign_up/select_email/show.html.erb' do
       )
     end
   end
+
+  describe 'add-email button bucket-conditional rendering' do
+    context 'legacy bucket' do
+      it 'renders origin/main outline classes, no nds variant modifier' do
+        expect(rendered).to have_css('.usa-button--outline.usa-button--big.usa-button--wide')
+        expect(rendered).not_to have_css('.usa-button--quaternary')
+      end
+    end
+
+    context 'nds bucket' do
+      before { allow(view).to receive(:nds_layout?).and_return(true) }
+
+      it 'renders variant :quaternary, dropping legacy size/outline classes' do
+        expect(rendered).to have_css('.usa-button--quaternary')
+        expect(rendered).not_to have_css('.usa-button--outline')
+        expect(rendered).not_to have_css('.usa-button--big')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `variant:` options to the button on five pages (account reset pending, completions cancellation, duplicate profiles detected, the session timeout warning, and select email), following the shared button component introduced in #13393.
- These options are only applied when the NDS_LOOK_AND_FEEL A/B test is active; when it is off, the current default styling is unchanged.
- The session timeout warning is a shared, high-traffic partial: the option was added only to the sign-out button; the continue button is untouched.

## Changes

- `app/views/account_reset/pending/show.html.erb` — sign-out/cancel button
- `app/views/completions_cancellation/show.html.erb` — exit button
- `app/views/duplicate_profiles_detected/show.html.erb` — sign-out button
- `app/views/session_timeout/_warning.html.erb` — sign-out button
- `app/views/sign_up/select_email/show.html.erb` — add-email button
- `spec/views/sign_up/select_email/show.html.erb_spec.rb` — coverage for both default and NDS rendering

## Test plan

- [x] `rspec spec/views/sign_up/select_email/show.html.erb_spec.rb` — green (default + NDS)
- [x] `rubocop` on the spec — clean
- [x] `erb_lint` on the five views — clean
- [x] CI