### PR TITLE
Add NDS variant options to IDV button call sites

### DIFF
--- a/app/views/idv/by_mail/sp_follow_up/new.html.erb
+++ b/app/views/idv/by_mail/sp_follow_up/new.html.erb
@@ -17,6 +17,7 @@
 <div>
   <%= render ButtonComponent.new(
         url: idv_sp_follow_up_cancel_path,
+        variant: :secondary,
         big: true,
         wide: true,
         outline: true,

--- a/app/views/idv/cancellations/new.html.erb
+++ b/app/views/idv/cancellations/new.html.erb
@@ -26,6 +26,7 @@
       <%= render ButtonComponent.new(
             url: idv_session_path(step: params[:step]),
             method: :delete,
+            variant: :destructive,
             big: true,
             wide: true,
             form: { 'aria-label': t('idv.cancel.actions.start_over') },
@@ -35,6 +36,7 @@
         <%= render ButtonComponent.new(
               url: idv_cancel_path(step: params[:step]),
               method: :put,
+              variant: :secondary,
               big: true,
               wide: true,
               outline: true,

--- a/spec/views/idv/cancellations/new.html.erb_spec.rb
+++ b/spec/views/idv/cancellations/new.html.erb_spec.rb
@@ -81,3 +81,30 @@ RSpec.describe 'idv/cancellations/new.html.erb' do
     end
   end
 end
+
+RSpec.describe 'idv/cancellations/new.html.erb bucket-conditional buttons' do
+  let(:params) { ActionController::Parameters.new }
+
+  def render_bucket(nds:)
+    assign(:hybrid_session, false)
+    assign(:presenter, Idv::CancellationsPresenter.new(sp_name: nil, url_options: {}))
+    allow(view).to receive(:params).and_return(params)
+    allow(view).to receive(:nds_layout?).and_return(nds)
+    render template: 'idv/cancellations/new'
+  end
+
+  it 'legacy bucket emits origin/main classes, no nds variant modifiers' do
+    render_bucket(nds: false)
+    expect(rendered).to have_css('.usa-button--big.usa-button--wide')
+    expect(rendered).to have_css('.usa-button--outline')
+    expect(rendered).not_to have_css('.usa-button--destructive, .usa-button--secondary')
+  end
+
+  it 'nds bucket emits start_over=destructive (--danger) and keep_going=secondary' do
+    render_bucket(nds: true)
+    expect(rendered).to have_css('.usa-button--danger')
+    expect(rendered).to have_css('.usa-button--secondary')
+    expect(rendered).not_to have_css('.usa-button--big')
+    expect(rendered).not_to have_css('.usa-button--outline')
+  end
+end


### PR DESCRIPTION
## Summary

- Add explicit `variant` options to the buttons on the identity
  verification cancellation page (start over → destructive, keep going →
  secondary) and the by-mail follow-up page (go to account → secondary).
- These variants are honored only when the `NDS_LOOK_AND_FEEL` A/B test is
  active, using the button component introduced in #13393. When the test
  is not active, the current default button styling is unchanged.

## Test plan

- [ ] `bundle exec rspec spec/views/idv/cancellations/new.html.erb_spec.rb`
- [ ] `bundle exec rspec spec/features/idv/sp_follow_up_spec.rb`
- [ ] `bundle exec rubocop spec/views/idv/cancellations/new.html.erb_spec.rb`
- [ ] `bundle exec erb_lint app/views/idv/by_mail/sp_follow_up/new.html.erb app/views/idv/cancellations/new.html.erb`