### PR TITLE
Extract shared NDS bucket resolution into a reusable concern

### DIFF
--- a/app/components/alert_component.rb
+++ b/app/components/alert_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AlertComponent < BaseComponent
+  include NDSBucketResolvable
+
   attr_reader :type, :title, :message, :dismissible, :action, :text_tag, :tag_options
 
   # nil is the historical default for existing call sites; :neutral is the
@@ -55,20 +57,12 @@ class AlertComponent < BaseComponent
     end
   end
 
-  # The A/B bucket can only be resolved at render time (helpers are unavailable
-  # in #initialize). Callers always instantiate AlertComponent; when the render
-  # resolves to the NDS bucket we delegate to NDSAlertComponent. The guard
-  # excludes NDSAlertComponent itself so it renders its own markup instead of
-  # recursing.
-  def before_render
-    super
-    @render_as_nds = nds_bucket? && !is_a?(NDSAlertComponent)
-  end
-
   private
 
-  def render_as_nds?
-    @render_as_nds
+  # The NDS variant excluded from the render-time flip (see
+  # NDSBucketResolvable) so it renders its own markup instead of recursing.
+  def nds_variant_class
+    NDSAlertComponent
   end
 
   def nds_delegate
@@ -76,19 +70,5 @@ class AlertComponent < BaseComponent
       type:, title:, message:, dismissible:, action:, text_tag:,
       **tag_options
     )
-  end
-
-  # ViewComponent delegates #helpers to the current view context, where
-  # nds_layout? is exposed as a controller helper_method. Guard for view
-  # contexts without that helper (e.g. mailers). When the bucket can't be
-  # resolved because there is no auth context (background jobs, isolated
-  # component renders — Devise::MissingWarden), default to the legacy bucket:
-  # legacy is the conservative default and rendering must never crash.
-  def nds_bucket?
-    return false unless helpers.respond_to?(:nds_layout?)
-
-    helpers.nds_layout?
-  rescue Devise::MissingWarden
-    false
   end
 end

--- a/app/components/button_component.rb
+++ b/app/components/button_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ButtonComponent < BaseComponent
+  include NDSBucketResolvable
+
   attr_reader :url,
               :method,
               :icon,
@@ -76,22 +78,14 @@ class ButtonComponent < BaseComponent
     trimmed_content
   end
 
-  # The A/B bucket can only be resolved at render time (helpers are unavailable
-  # in #initialize). Callers always instantiate ButtonComponent (or one of its
-  # subclasses); when the render resolves to the NDS bucket we delegate to
-  # NDSButtonComponent, which renders itself with the variant/size API. The
-  # guard excludes NDSButtonComponent itself so it renders its own (NDS) markup
-  # instead of recursing — every other button (including the Submit/Print/
-  # Download subclasses) flips to NDS in the NDS bucket.
-  def before_render
-    super
-    @render_as_nds = nds_bucket? && !is_a?(NDSButtonComponent)
-  end
-
   private
 
-  def render_as_nds?
-    @render_as_nds
+  # The NDS variant excluded from the render-time flip (see
+  # NDSBucketResolvable). Every other button (including the Submit/Print/
+  # Download subclasses) flips to NDS in the NDS bucket; NDSButtonComponent
+  # renders its own markup instead of recursing.
+  def nds_variant_class
+    NDSButtonComponent
   end
 
   def nds_delegate
@@ -100,20 +94,6 @@ class ButtonComponent < BaseComponent
       big:, wide:, full_width:, outline:, unstyled:, danger:,
       **tag_options
     )
-  end
-
-  # ViewComponent delegates #helpers to the current view context, where
-  # nds_layout? is exposed as a controller helper_method. Guard for view
-  # contexts without that helper (e.g. mailers). When the A/B bucket can't be
-  # resolved because there is no auth context (background jobs, isolated
-  # component renders — Devise::MissingWarden), default to the legacy bucket:
-  # legacy is the conservative default and rendering must never crash.
-  def nds_bucket?
-    return false unless helpers.respond_to?(:nds_layout?)
-
-    helpers.nds_layout?
-  rescue Devise::MissingWarden
-    false
   end
 
   def action

--- a/app/components/concerns/nds_bucket_resolvable.rb
+++ b/app/components/concerns/nds_bucket_resolvable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Shared render-time A/B bucket resolution for components that have an NDS
+# variant. The bucket can only be resolved at render time (helpers are
+# unavailable in #initialize). Callers always instantiate the base component
+# (or one of its non-NDS subclasses); when the render resolves to the NDS
+# bucket we delegate to the variant returned by #nds_delegate, which renders
+# itself with the NDS markup. The guard excludes the NDS variant class itself
+# so it renders its own markup instead of recursing — every other subclass
+# still flips to NDS in the NDS bucket.
+#
+# Each including component must define:
+#   - #nds_variant_class: the NDS subclass to exclude from the flip.
+#   - #nds_delegate: builds the NDS variant with the component's own args.
+module NDSBucketResolvable
+  extend ActiveSupport::Concern
+
+  included do
+    def before_render
+      super
+      @render_as_nds = nds_bucket? && !is_a?(nds_variant_class)
+    end
+  end
+
+  private
+
+  def render_as_nds?
+    @render_as_nds
+  end
+
+  # ViewComponent delegates #helpers to the current view context, where
+  # nds_layout? is exposed as a controller helper_method. Guard for view
+  # contexts without that helper (e.g. mailers). When the A/B bucket can't be
+  # resolved because there is no auth context (background jobs, isolated
+  # component renders — Devise::MissingWarden), default to the legacy bucket:
+  # legacy is the conservative default and rendering must never crash.
+  def nds_bucket?
+    return false unless helpers.respond_to?(:nds_layout?)
+
+    helpers.nds_layout?
+  rescue Devise::MissingWarden
+    false
+  end
+end


### PR DESCRIPTION
## Summary

- ButtonComponent (#13393) and AlertComponent (#13404) each carried an identical private `nds_bucket?` and a `before_render` that set `@render_as_nds`. This extracts that duplicated render-time bucket-resolution logic into a single `NDSBucketResolvable` concern that both components `include`.
- Each component still owns its `nds_delegate` (it builds the component-specific variant) and defines an `nds_variant_class` hook naming the variant to exclude from the flip, so behavior is unchanged for every component and subclass.

## Stacking

This PR is **stacked on #13404** (AlertComponent) and targets its branch, because it dedups code that PR introduces. It will be retargeted to `main` once #13404 merges.

## Test plan

- [x] `button_component_spec` and `alert_component_spec` pass unchanged (both buckets, subclass-flip test) — pure refactor, zero behavior change
- [x] rubocop clean