### PR TITLE
Remove authentication timestamp feature flag

### DIFF
--- a/app/controllers/concerns/saml_idp_auth_concern.rb
+++ b/app/controllers/concerns/saml_idp_auth_concern.rb
@@ -204,9 +204,8 @@ module SamlIdpAuthConcern
       encryption: encryption_opts,
       signature: saml_response_signature_options,
       signed_response_message: saml_request_service_provider&.signed_response_message_requested,
-    }.tap do |options|
-      options[:authn_instant] = saml_authn_instant if FeatureManagement.auth_time_attribute_enabled?
-    end
+      authn_instant: saml_authn_instant,
+    }
   end
 
   def saml_authn_instant

--- a/app/presenters/openid_connect_user_info_presenter.rb
+++ b/app/presenters/openid_connect_user_info_presenter.rb
@@ -26,7 +26,7 @@ class OpenidConnectUserInfoPresenter
     info[:verified_at] = verified_at if scoper.verified_at_requested?
     info[:ial] = authn_context_resolver.asserted_ial_acr
     info[:aal] = requested_aal_value
-    info[:auth_time] = auth_time if FeatureManagement.auth_time_attribute_enabled?
+    info[:auth_time] = auth_time
 
     scoper.filter(info)
   end

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -56,7 +56,6 @@ attempts_api_signing_enabled: false
 attempts_api_signing_key: ''
 attribute_encryption_key:
 attribute_encryption_key_queue: '[]'
-auth_time_attribute_enabled: false
 available_locales: 'en,es,fr,zh'
 aws_http_retry_limit: 2
 aws_http_retry_max_delay: 1

--- a/lib/feature_management.rb
+++ b/lib/feature_management.rb
@@ -114,10 +114,6 @@ class FeatureManagement
     !Rails.env.test? && IdentityConfig.store.log_to_stdout
   end
 
-  def self.auth_time_attribute_enabled?
-    IdentityConfig.store.auth_time_attribute_enabled
-  end
-
   def self.phone_recaptcha_enabled?
     IdentityConfig.store.phone_recaptcha_score_threshold.positive? && recaptcha_enabled?
   end

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -73,7 +73,6 @@ module IdentityConfig
     config.add(:attempts_api_signing_enabled, type: :boolean)
     config.add(:attribute_encryption_key, type: :string)
     config.add(:attribute_encryption_key_queue, type: :json)
-    config.add(:auth_time_attribute_enabled, type: :boolean)
     config.add(:available_locales, type: :comma_separated_string_list)
     config.add(:aws_http_retry_limit, type: :integer)
     config.add(:aws_http_retry_max_delay, type: :integer)

--- a/spec/controllers/openid_connect/token_controller_spec.rb
+++ b/spec/controllers/openid_connect/token_controller_spec.rb
@@ -71,14 +71,13 @@ RSpec.describe OpenidConnect::TokenController do
         expect(@analytics).to_not have_logged_event(:sp_integration_errors_present)
       end
 
-      context 'when auth_time is enabled' do
+      context 'with an authentication event' do
         let(:authentication_event_at) { Time.zone.parse('2026-07-01 12:00:00 UTC') }
         let(:remember_device_at) { Time.zone.parse('2026-07-01 12:30:00 UTC') }
         let(:federation_at) { Time.zone.parse('2026-07-01 13:00:00 UTC') }
         let(:stale_identity_timestamp) { 1.week.before(authentication_event_at) }
 
         before do
-          allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
           identity.update!(last_authenticated_at: stale_identity_timestamp)
 
           travel_to(federation_at) do

--- a/spec/controllers/openid_connect/user_info_controller_spec.rb
+++ b/spec/controllers/openid_connect/user_info_controller_spec.rb
@@ -179,13 +179,12 @@ RSpec.describe OpenidConnect::UserInfoController do
         expect(request.session.to_h).to eq(session_hash)
       end
 
-      context 'when auth_time is enabled' do
+      context 'with an authentication event' do
         let(:authentication_event_at) { Time.zone.parse('2026-07-01 12:00:00 UTC') }
         let(:remember_device_at) { Time.zone.parse('2026-07-01 12:30:00 UTC') }
         let(:federation_at) { Time.zone.parse('2026-07-01 13:00:00 UTC') }
 
         before do
-          allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
           identity.update!(last_authenticated_at: federation_at)
           write_out_of_band_user_session(
             session_uuid: identity.rails_session_id,

--- a/spec/controllers/saml_idp_controller_spec.rb
+++ b/spec/controllers/saml_idp_controller_spec.rb
@@ -2448,12 +2448,8 @@ RSpec.describe SamlIdpController do
       let(:user) { create(:user, :fully_registered) }
       let(:response_at) { nil }
       let(:auth_events) { nil }
-      let(:auth_time_attribute_enabled) { false }
 
       before do
-        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?)
-          .and_return(auth_time_attribute_enabled)
-
         if response_at
           travel_to(response_at) do
             generate_saml_response(user, saml_settings, auth_events: auth_events)
@@ -2772,8 +2768,7 @@ RSpec.describe SamlIdpController do
           expect(subject.attributes['AuthnInstant'].value).to_not be_nil
         end
 
-        context 'when authentication timestamp support is enabled' do
-          let(:auth_time_attribute_enabled) { true }
+        context 'with an authentication timestamp' do
           let(:idp_authn_at) { Time.zone.parse('2026-07-08 12:04:56 UTC') }
           let(:response_at) { Time.zone.parse('2026-07-08 12:34:56 UTC') }
           let(:auth_events) do

--- a/spec/features/saml/saml_spec.rb
+++ b/spec/features/saml/saml_spec.rb
@@ -171,24 +171,18 @@ RSpec.feature 'saml api' do
         expect(user.last_identity.last_authenticated_at).to be_present
       end
 
-      context 'when auth_time_attribute_enabled is enabled' do
-        before do
-          allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
-        end
+      it 'refreshes the identity last authenticated time during SAML login' do
+        stale_authn_at = 1.week.ago
+        now = Time.zone.parse('2026-07-08 12:34:56 UTC')
+        identity = user.identities.find_by(service_provider: sp.issuer)
+        identity.update!(last_authenticated_at: stale_authn_at)
 
-        it 'refreshes the identity last authenticated time during SAML login' do
-          stale_authn_at = 1.week.ago
-          now = Time.zone.parse('2026-07-08 12:34:56 UTC')
-          identity = user.identities.find_by(service_provider: sp.issuer)
-          identity.update!(last_authenticated_at: stale_authn_at)
+        travel_to(now) do
+          visit_saml_authn_request_url
 
-          travel_to(now) do
-            visit_saml_authn_request_url
+          identity.reload
 
-            identity.reload
-
-            expect(identity.last_authenticated_at).to be_within(1.second).of(now)
-          end
+          expect(identity.last_authenticated_at).to be_within(1.second).of(now)
         end
       end
 

--- a/spec/lib/feature_management_spec.rb
+++ b/spec/lib/feature_management_spec.rb
@@ -81,26 +81,6 @@ RSpec.describe 'FeatureManagement' do
     end
   end
 
-  describe '#auth_time_attribute_enabled?' do
-    subject(:enabled) { FeatureManagement.auth_time_attribute_enabled? }
-
-    context 'when enabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:auth_time_attribute_enabled).and_return(true)
-      end
-
-      it { expect(enabled).to eq(true) }
-    end
-
-    context 'when disabled' do
-      before do
-        allow(IdentityConfig.store).to receive(:auth_time_attribute_enabled).and_return(false)
-      end
-
-      it { expect(enabled).to eq(false) }
-    end
-  end
-
   describe '#use_dashboard_service_providers?' do
     context 'when enabled' do
       before do

--- a/spec/presenters/openid_connect_user_info_presenter_spec.rb
+++ b/spec/presenters/openid_connect_user_info_presenter_spec.rb
@@ -69,36 +69,23 @@ RSpec.describe OpenidConnectUserInfoPresenter do
 
     subject(:user_info) { presenter.user_info }
 
-    context 'when auth_time attribute is enabled' do
-      before do
-        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(true)
-        allow(session_accessor).to receive(:authentication_event_at)
-          .and_return(authentication_event_at)
-      end
-
-      it 'includes auth_time from the session authentication event timestamp' do
-        expect(user_info[:auth_time]).to eq(authentication_event_at.to_i)
-      end
-
-      context 'without an authentication event timestamp' do
-        let(:authentication_event_at) { nil }
-        let(:now) { Time.zone.parse('2026-06-01 12:00:00 UTC') }
-
-        it 'falls back to the current time' do
-          travel_to(now) do
-            expect(user_info[:auth_time]).to eq(now.to_i)
-          end
-        end
-      end
+    before do
+      allow(session_accessor).to receive(:authentication_event_at)
+        .and_return(authentication_event_at)
     end
 
-    context 'when auth_time attribute is disabled' do
-      before do
-        allow(FeatureManagement).to receive(:auth_time_attribute_enabled?).and_return(false)
-      end
+    it 'includes auth_time from the session authentication event timestamp' do
+      expect(user_info[:auth_time]).to eq(authentication_event_at.to_i)
+    end
 
-      it 'does not include auth_time' do
-        expect(user_info).to_not have_key(:auth_time)
+    context 'without an authentication event timestamp' do
+      let(:authentication_event_at) { nil }
+      let(:now) { Time.zone.parse('2026-06-01 12:00:00 UTC') }
+
+      it 'falls back to the current time' do
+        travel_to(now) do
+          expect(user_info[:auth_time]).to eq(now.to_i)
+        end
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket

https://gitlab.login.gov/lg-teams/FIE/secure-protocols/-/work_items/123

## 🛠 Summary of changes

- Make the NIST-compliant OIDC auth_time claim permanent.
- Make the SAML AuthnInstant authentication timestamp permanent.
- Remove the auth_time_attribute_enabled configuration and feature-management plumbing.
- Convert feature-flag-specific tests into permanent regression coverage.

## 📜 Testing Plan

- [x] Run affected RSpec files: 306 examples, 0 failures.
- [x] Run RuboCop against all changed Ruby files: 10 files, no offenses.
- [x] Normalize config/application.yml.default and confirm no formatting changes.
- [x] Confirm no auth_time_attribute_enabled references remain.
- [x] Validate the commit changelog entry.

changelog: Internal, Authentication, Make NIST-compliant authentication timestamps permanent