### PR TITLE
Add NDS::Stack and NDS::Link layout primitives

### DIFF
--- a/app/components/nds/link_component.rb
+++ b/app/components/nds/link_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module NDS
+  # Net-new NDS link primitive (renders only in the nds layout). Renders an
+  # anchor with the .link class; .link styles the external-link icon for
+  # [target='_blank'] and supports the .link--nowrap modifier.
+  class LinkComponent < BaseComponent
+    attr_reader :url, :html_options
+
+    def initialize(url:, **html_options)
+      @url = url
+      @html_options = html_options
+    end
+
+    def call
+      link_to(url, **html_options.except(:class), class: css_class) { content }
+    end
+
+    private
+
+    def css_class
+      helpers.class_names('link', html_options[:class])
+    end
+  end
+end

--- a/app/components/nds/stack_component.rb
+++ b/app/components/nds/stack_component.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module NDS
+  # Vertical stack primitive (net-new NDS layout component; renders only in the
+  # nds layout). Renders the .stack/.flow/.form/.actions/.links layout classes
+  # with optional --gap-N and --align-* modifiers.
+  #
+  #   NDS::StackComponent(kind: :form) do        # 32 - between groups
+  #     NDS::StackComponent(align: :stretch) do  # 12 - fields / title+copy
+  #     NDS::StackComponent(kind: :actions) do   # 12 - buttons
+  class StackComponent < BaseComponent
+    CLASS_BY_KIND = {
+      actions: 'actions',
+      flow: 'flow',
+      form: 'form',
+      links: 'links',
+      stack: 'stack',
+    }.freeze
+
+    attr_reader :tag_name, :kind, :gap, :align, :html_options
+
+    def initialize(tag: :div, kind: :stack, gap: nil, align: nil, **html_options)
+      @tag_name = tag
+      @kind = kind.to_sym
+      @gap = normalize_gap(gap)
+      @align = normalize(align)
+      @html_options = html_options
+    end
+
+    def call
+      content_tag(tag_name, content, html_options.except(:class).merge(class: css_class))
+    end
+
+    private
+
+    def base_class
+      CLASS_BY_KIND.fetch(kind)
+    end
+
+    def css_class
+      [base_class, gap_class, align_class, html_options[:class]].compact.join(' ')
+    end
+
+    def gap_class
+      return if gap.blank?
+
+      "#{base_class}--gap-#{gap}"
+    end
+
+    def align_class
+      return if align.blank?
+
+      "#{base_class}--align-#{align}"
+    end
+
+    def normalize(value)
+      value.to_s.dasherize.presence
+    end
+
+    def normalize_gap(value)
+      return if value.nil?
+
+      Integer(value)
+    rescue ArgumentError, TypeError
+      nil
+    end
+  end
+end

--- a/spec/components/nds/link_component_spec.rb
+++ b/spec/components/nds/link_component_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe NDS::LinkComponent, type: :component do
+  it 'renders an anchor with the .link class to the url' do
+    rendered = render_inline(NDS::LinkComponent.new(url: '/somewhere')) { 'Go' }
+    expect(rendered).to have_css('a.link[href="/somewhere"]', text: 'Go')
+  end
+
+  it 'merges custom classes with .link' do
+    rendered = render_inline(NDS::LinkComponent.new(url: '/x', class: 'link--nowrap')) { 'Go' }
+    expect(rendered).to have_css('a.link.link--nowrap')
+  end
+
+  it 'passes through extra html options' do
+    rendered = render_inline(
+      NDS::LinkComponent.new(url: '/x', target: '_blank'),
+    ) { 'Go' }
+    expect(rendered).to have_css('a.link[target="_blank"]')
+  end
+end

--- a/spec/components/nds/stack_component_spec.rb
+++ b/spec/components/nds/stack_component_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe NDS::StackComponent, type: :component do
+  it 'renders a div.stack by default' do
+    rendered = render_inline(NDS::StackComponent.new) { 'x' }
+    expect(rendered).to have_css('div.stack', text: 'x')
+  end
+
+  it 'maps kind to the base class' do
+    {
+      stack: 'stack', flow: 'flow', form: 'form', actions: 'actions', links: 'links'
+    }.each do |kind, base|
+      rendered = render_inline(NDS::StackComponent.new(kind:)) { 'x' }
+      expect(rendered).to have_css("div.#{base}")
+    end
+  end
+
+  it 'adds a gap modifier scoped to the base class' do
+    rendered = render_inline(NDS::StackComponent.new(kind: :form, gap: 32)) { 'x' }
+    expect(rendered).to have_css('div.form.form--gap-32')
+  end
+
+  it 'adds an align modifier scoped to the base class' do
+    rendered = render_inline(NDS::StackComponent.new(kind: :actions, align: :center)) { 'x' }
+    expect(rendered).to have_css('div.actions.actions--align-center')
+  end
+
+  it 'dasherizes align values' do
+    rendered = render_inline(NDS::StackComponent.new(align: :mobile_start)) { 'x' }
+    expect(rendered).to have_css('div.stack.stack--align-mobile-start')
+  end
+
+  it 'ignores a non-integer gap' do
+    rendered = render_inline(NDS::StackComponent.new(gap: 'bogus')) { 'x' }
+    expect(rendered).to have_css('div.stack')
+    expect(rendered).not_to have_css('[class*="--gap-"]')
+  end
+
+  it 'honors a custom tag and passes through extra html options' do
+    rendered = render_inline(
+      NDS::StackComponent.new(tag: :ul, kind: :links, class: 'extra', data: { foo: 'bar' }),
+    ) { 'x' }
+    expect(rendered).to have_css('ul.links.extra[data-foo="bar"]')
+  end
+end


### PR DESCRIPTION
## Ticket
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/38

## Summary

Adds two net-new NDS layout primitives that render only in the nds layout:

- `NDS::StackComponent` — vertical stack rendering the
  `.stack`/`.flow`/`.form`/`.actions`/`.links` classes with optional
  `--gap-N` and `--align-*` modifiers.
- `NDS::LinkComponent` — anchor with the `.link` class (external-link icon
  styling for `[target='_blank']`, `.link--nowrap` support).

These have no legacy equivalent; the layout choice gates them, so they are not bucket-conditional.

## Test plan

- [x] `bundle exec rspec spec/components/nds/{stack,link}_component_spec.rb` — 10 examples, 0 failures
- [x] `bundle exec rubocop --parallel` on the 4 files — no offenses
- [x] `bin/rails zeitwerk:check` — clean