### PR TITLE
Add NDS::PageShell, PageChrome, and PageFooterChrome components

### DIFF
--- a/app/components/nds/page_chrome_component.html.erb
+++ b/app/components/nds/page_chrome_component.html.erb
@@ -1,0 +1,30 @@
+<% unless hide_banner %>
+  <%= render 'shared/banner' %>
+<% end %>
+
+<header class="auth-page__top-chrome">
+  <% unless hide_logo %>
+    <div class="auth-page__logo-banner">
+      <%= link_to root_path, class: 'auth-page__logo-banner-link', aria: { label: APP_NAME } do %>
+        <%= image_tag(
+              asset_url('logo.svg'),
+              alt: '',
+              class: 'auth-page__logo-banner-image',
+              aria: { hidden: true },
+              width: 155,
+              height: 21,
+            ) %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if progress? %>
+    <div class="auth-page__top-chrome-progress">
+      <%= progress %>
+    </div>
+  <% end %>
+
+  <% if trailing? %>
+    <%= trailing %>
+  <% end %>
+</header>

--- a/app/components/nds/page_chrome_component.rb
+++ b/app/components/nds/page_chrome_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module NDS
+  # Net-new NDS top chrome (renders only in the nds layout). Emits the gov
+  # banner and logo banner inside .auth-page__top-chrome, plus an optional
+  # progress slot.
+  #
+  # NOTE (idp gap, flagged): idp has no dedicated official-banner component and
+  # no route-map progress helper, so this reuses idp's existing shared/banner
+  # partial and exposes progress only as an explicit slot (no auto-progress).
+  # Revisit when the NDS progress/step-indicator lands.
+  class PageChromeComponent < BaseComponent
+    renders_one :trailing
+    renders_one :progress
+
+    attr_reader :hide_logo, :hide_banner
+
+    def initialize(hide_logo: false, hide_banner: false)
+      @hide_logo = hide_logo
+      @hide_banner = hide_banner
+    end
+  end
+end

--- a/app/components/nds/page_footer_chrome_component.html.erb
+++ b/app/components/nds/page_footer_chrome_component.html.erb
@@ -1,0 +1,89 @@
+<lg-nds-page-footer>
+  <footer class="page-footer">
+    <%= link_to gsa_url, class: 'page-footer__agency' do %>
+      <%= image_tag(
+            asset_url('sp-logos/square-gsa.svg'),
+            size: 20,
+            alt: '',
+            aria: { hidden: true },
+          ) %>
+      <span class="page-footer__agency-name"><%= agency_name %></span>
+    <% end %>
+
+    <div class="page-footer__actions">
+      <div class="page-footer__control">
+        <%= tag.label(
+              t('i18n.language'),
+              for: "footer-language-#{unique_id}",
+              class: 'page-footer__select-label',
+            ) %>
+        <div class="page-footer__select-face" aria-hidden="true">
+          <%= render ButtonComponent.new(
+                variant: :quaternary,
+                size: :sm,
+                icon: :expand_more,
+                icon_position: :right,
+                tabindex: -1,
+                type: :button,
+              ).with_content(selected_language_label) %>
+        </div>
+        <%= content_tag(
+              :select,
+              id: "footer-language-#{unique_id}",
+              name: 'locale',
+              class: 'page-footer__select',
+              data: { nds_footer_navigation: true },
+            ) do %>
+          <% language_options.each do |option| %>
+            <%= tag.option(
+                  option[:label],
+                  value: option[:value],
+                  lang: option[:lang],
+                  selected: option[:selected],
+                ) %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <%= render ButtonComponent.new(
+            url: resolved_help_url,
+            variant: :quaternary,
+            size: :sm,
+            class: 'page-footer__help',
+          ).with_content(t('links.help')) %>
+
+      <div class="page-footer__control">
+        <%= tag.label(
+              more_label,
+              for: "footer-destination-#{unique_id}",
+              class: 'page-footer__select-label',
+            ) %>
+        <div class="page-footer__select-face" aria-hidden="true">
+          <%= render ButtonComponent.new(
+                variant: :quaternary,
+                size: :sm,
+                icon: :expand_more,
+                icon_position: :right,
+                tabindex: -1,
+                type: :button,
+              ).with_content(more_label) %>
+        </div>
+        <%= content_tag(
+              :select,
+              id: "footer-destination-#{unique_id}",
+              name: 'footer_destination',
+              class: 'page-footer__select',
+              data: {
+                nds_footer_navigation: true,
+                nds_footer_navigation_reset: true,
+              },
+            ) do %>
+          <%= tag.option(more_label, value: '', selected: true, disabled: true) %>
+          <% destination_options.each do |option| %>
+            <%= tag.option(option[:label], value: option[:value]) %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </footer>
+</lg-nds-page-footer>

--- a/app/components/nds/page_footer_chrome_component.rb
+++ b/app/components/nds/page_footer_chrome_component.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module NDS
+  # Net-new NDS page footer chrome (renders only in the nds layout). Emits the
+  # page-footer / footer-destination-* / footer-language-* class contract.
+  #
+  # NOTE (flagged): the footer-content classes are not styled yet (only the
+  # .auth-page__footer-wrapper slot), so this renders inert/unstyled for now.
+  # The class contract is emitted now so it lights up once the styles land. The
+  # language/destination selects and the help link render via the
+  # bucket-conditional ButtonComponent (quaternary in nds).
+  class PageFooterChromeComponent < BaseComponent
+    GSA_URL = 'https://www.gsa.gov'
+
+    attr_reader :gsa_url, :help_url
+
+    def initialize(
+      agency_name: nil,
+      gsa_url: GSA_URL,
+      help_url: nil,
+      language_options: nil,
+      destination_options: nil
+    )
+      @agency_name = agency_name
+      @gsa_url = gsa_url
+      @help_url = help_url
+      @language_options = language_options
+      @destination_options = destination_options
+    end
+
+    def language_options
+      @language_options || locale_urls.map do |locale, url|
+        {
+          label: t("i18n.locale.#{locale}"),
+          value: url,
+          lang: locale,
+          selected: locale == I18n.locale,
+        }
+      end
+    end
+
+    def destination_options
+      @destination_options || [
+        { label: t('links.contact'), value: helpers.contact_redirect_url },
+        {
+          label: t('links.privacy_policy'),
+          value: MarketingSite.security_and_privacy_practices_url,
+        },
+        {
+          label: t('notices.privacy.privacy_act_statement'),
+          value: MarketingSite.privacy_act_statement_url,
+        },
+        {
+          label: t('links.accessibility_statement'),
+          value: MarketingSite.accessibility_statement_url,
+        },
+      ]
+    end
+
+    def resolved_help_url
+      help_url || helpers.help_center_redirect_url
+    end
+
+    def selected_language_label
+      language_options.find { |option| option[:selected] }&.fetch(:label) || t('i18n.language')
+    end
+
+    def more_label
+      t('links.more')
+    end
+
+    def agency_name
+      @agency_name || t('shared.footer_lite.gsa')
+    end
+
+    private
+
+    def locale_urls
+      I18n.available_locales.index_with { |locale| "/#{locale}#{fullpath_without_locale}" }
+    end
+
+    def fullpath_without_locale
+      @fullpath_without_locale ||= begin
+        path = request.fullpath
+        path = path.slice(params[:locale].size + 1..) if params[:locale].present?
+        path
+      end
+    end
+  end
+end

--- a/app/components/nds/page_shell_component.html.erb
+++ b/app/components/nds/page_shell_component.html.erb
@@ -1,0 +1,27 @@
+<div class="<%= body_class %>"<%= ' data-nds-page-transition'.html_safe if transition %>>
+  <% unless hide_chrome %>
+    <% if chrome? %>
+      <%= chrome %>
+    <% else %>
+      <%= render NDS::PageChromeComponent.new %>
+    <% end %>
+  <% end %>
+
+  <%= content_tag(main_tag, **main_options) do %>
+    <% if body? %>
+      <%= body %>
+    <% else %>
+      <%= content %>
+    <% end %>
+  <% end %>
+
+  <% unless hide_footer %>
+    <div class="auth-page__footer-wrapper">
+      <% if footer? %>
+        <%= footer %>
+      <% else %>
+        <%= render NDS::PageFooterChromeComponent.new %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/nds/page_shell_component.rb
+++ b/app/components/nds/page_shell_component.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module NDS
+  # Net-new NDS page shell (renders only in the nds layout). Emits the
+  # .auth-page / .auth-page__* class contract with align/density/surface/width
+  # modifiers.
+  #
+  # CRITICAL: the [data-nds-page-transition] attribute goes on the .auth-page
+  # element (the view-transition rules use > combinators requiring it as the
+  # direct parent; on <body> it is a silent no-op).
+  class PageShellComponent < BaseComponent
+    MODIFIERS = {
+      align: %w[mobile-start start stretch],
+      density: %w[fullscreen mobile-compact spacious],
+      surface: %w[overlay],
+      width: %w[form wide],
+    }.freeze
+
+    renders_one :chrome
+    renders_one :footer
+    renders_one :body
+
+    attr_reader :page_class, :density, :align, :surface, :width, :hide_chrome, :hide_footer,
+                :main_tag, :transition
+
+    MODIFIERS.each do |name, values|
+      validates name, inclusion: { in: values }, allow_nil: true
+    end
+
+    def initialize(
+      page_class: nil,
+      width: nil,
+      density: nil,
+      align: nil,
+      surface: nil,
+      main_tag: :main,
+      transition: true,
+      hide_chrome: false,
+      hide_footer: false
+    )
+      @page_class = page_class.to_s.squish
+      @width = normalize(width)
+      @density = normalize(density)
+      @align = normalize(align)
+      @surface = normalize(surface)
+      @main_tag = main_tag
+      @transition = transition
+      @hide_chrome = hide_chrome
+      @hide_footer = hide_footer
+    end
+
+    def body_class
+      [
+        'site',
+        'auth-page',
+        page_class.presence,
+        *modifier_classes,
+      ].compact.join(' ')
+    end
+
+    def main_options
+      {
+        class: 'auth-page__main',
+        id: ('main-content' if main_tag.to_sym == :main),
+      }
+    end
+
+    private
+
+    def normalize(value)
+      value.to_s.dasherize.presence
+    end
+
+    def modifier_classes
+      MODIFIERS.keys.filter_map do |name|
+        value = public_send(name)
+        "auth-page--#{name}-#{value}" if value
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1556,6 +1556,7 @@ links.create_account: Create an account
 links.exit_login: Exit %{app_name}
 links.go_back: Go back
 links.help: Help
+links.more: More
 links.new_tab: '(opens new tab)'
 links.passwords.forgot: Forgot your password?
 links.privacy_policy: Privacy & security

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1567,6 +1567,7 @@ links.create_account: Crear una cuenta
 links.exit_login: Salir de %{app_name}
 links.go_back: Volver
 links.help: Ayuda
+links.more: Más
 links.new_tab: '(abrir nueva pestaña)'
 links.passwords.forgot: '¿Olvidó su contraseña?'
 links.privacy_policy: Privacidad y seguridad

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1556,6 +1556,7 @@ links.create_account: Créer un compte
 links.exit_login: Quitter %{app_name}
 links.go_back: Retour
 links.help: Aide
+links.more: Plus
 links.new_tab: '(ouvre un nouvel onglet)'
 links.passwords.forgot: Mot de passe oublié ?
 links.privacy_policy: Confidentialité et sécurité

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1569,6 +1569,7 @@ links.create_account: 设立账户
 links.exit_login: 退出 %{app_name}
 links.go_back: 返回
 links.help: 帮助
+links.more: 更多
 links.new_tab: '（打开新窗口）'
 links.passwords.forgot: 忘了你的密码?
 links.privacy_policy: 隐私与安全

--- a/spec/components/nds/page_chrome_component_spec.rb
+++ b/spec/components/nds/page_chrome_component_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe NDS::PageChromeComponent, type: :component do
+  before do
+    allow_any_instance_of(BaseComponent).to receive(:nds_bucket?).and_return(true)
+  end
+
+  it 'renders the top-chrome header with the gov banner and logo banner' do
+    rendered = render_inline(NDS::PageChromeComponent.new)
+    expect(rendered).to have_css('header.auth-page__top-chrome')
+    expect(rendered).to have_css('.auth-page__logo-banner .auth-page__logo-banner-link')
+    expect(rendered).to have_css('.auth-page__logo-banner-image')
+  end
+
+  it 'hides the logo when hide_logo: true' do
+    rendered = render_inline(NDS::PageChromeComponent.new(hide_logo: true))
+    expect(rendered).to have_css('header.auth-page__top-chrome')
+    expect(rendered).not_to have_css('.auth-page__logo-banner')
+  end
+
+  it 'renders a progress slot inside a progress wrapper' do
+    rendered = render_inline(NDS::PageChromeComponent.new) do |chrome|
+      chrome.with_progress { 'PROGRESS' }
+    end
+    expect(rendered).to have_css('.auth-page__top-chrome-progress', text: 'PROGRESS')
+  end
+end

--- a/spec/components/nds/page_footer_chrome_component_spec.rb
+++ b/spec/components/nds/page_footer_chrome_component_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe NDS::PageFooterChromeComponent, type: :component do
+  before do
+    allow_any_instance_of(BaseComponent).to receive(:nds_bucket?).and_return(true)
+    # A few redirect-url helpers are the only external deps; stub them so the
+    # component renders in isolation. The real ViewComponent test request
+    # supplies request.fullpath/base_url.
+    allow_any_instance_of(NDS::PageFooterChromeComponent).to receive_message_chain(
+      :helpers, :contact_redirect_url
+    ).and_return('/contact')
+    allow_any_instance_of(NDS::PageFooterChromeComponent).to receive_message_chain(
+      :helpers, :help_center_redirect_url
+    ).and_return('/help')
+  end
+
+  subject(:rendered) { render_inline(NDS::PageFooterChromeComponent.new) }
+
+  it 'renders the unprefixed page-footer custom element + footer' do
+    expect(rendered).to have_css('lg-nds-page-footer > footer.page-footer')
+  end
+
+  it 'renders the agency link with unprefixed classes' do
+    expect(rendered).to have_css('a.page-footer__agency .page-footer__agency-name')
+  end
+
+  it 'renders language + destination select controls with unprefixed classes' do
+    expect(rendered).to have_css('select.page-footer__select[name="locale"]')
+    expect(rendered).to have_css('select.page-footer__select[name="footer_destination"]')
+    expect(rendered).to have_css('.page-footer__control', count: 2)
+    html = rendered.to_html
+    expect(html).to include('footer-language-')
+    expect(html).to include('footer-destination-')
+  end
+end

--- a/spec/components/nds/page_shell_component_spec.rb
+++ b/spec/components/nds/page_shell_component_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe NDS::PageShellComponent, type: :component do
+  before do
+    # Chrome + footer sub-renders reach controller helpers; the shell's own
+    # class contract is what these specs assert. Stub the bucket true so nested
+    # bucket-conditional ButtonComponents (footer) resolve nds.
+    allow_any_instance_of(BaseComponent).to receive(:nds_bucket?).and_return(true)
+  end
+
+  def render_shell(**opts, &block)
+    render_inline(NDS::PageShellComponent.new(hide_chrome: true, hide_footer: true, **opts), &block)
+  end
+
+  it 'renders the .auth-page shell with a main region' do
+    rendered = render_shell { 'Body' }
+    expect(rendered).to have_css('div.site.auth-page')
+    expect(rendered).to have_css('main.auth-page__main#main-content', text: 'Body')
+  end
+
+  it 'puts data-nds-page-transition on the .auth-page element (not body) by default' do
+    rendered = render_shell { 'Body' }
+    expect(rendered).to have_css('div.auth-page[data-nds-page-transition]')
+  end
+
+  it 'omits the transition attribute when transition: false' do
+    rendered = render_shell(transition: false) { 'Body' }
+    expect(rendered).not_to have_css('[data-nds-page-transition]')
+  end
+
+  it 'emits width/density/align/surface modifiers (unprefixed)' do
+    rendered = render_shell(
+      width: :form, density: :spacious, align: :start, surface: :overlay,
+    ) { 'x' }
+    expect(rendered).to have_css(
+      '.auth-page.auth-page--width-form.auth-page--density-spacious' \
+      '.auth-page--align-start.auth-page--surface-overlay',
+    )
+  end
+
+  it 'dasherizes multi-word modifier values' do
+    rendered = render_shell(density: :mobile_compact, align: :mobile_start) { 'x' }
+    expect(rendered).to have_css('.auth-page--density-mobile-compact.auth-page--align-mobile-start')
+  end
+
+  it 'uses a div main (no main-content id) when main_tag: :div' do
+    rendered = render_shell(main_tag: :div) { 'x' }
+    expect(rendered).to have_css('div.auth-page__main')
+    expect(rendered).not_to have_css('#main-content')
+  end
+
+  it 'validates modifier values' do
+    expect do
+      render_inline(
+        NDS::PageShellComponent.new(width: :bogus, hide_chrome: true, hide_footer: true),
+      )
+    end.to raise_error(ActiveModel::ValidationError)
+  end
+
+  it 'renders a footer wrapper slot when not hidden' do
+    rendered = render_inline(
+      NDS::PageShellComponent.new(hide_chrome: true),
+    ) do |shell|
+      shell.with_footer { 'custom footer' }
+      'body'
+    end
+    expect(rendered).to have_css('.auth-page__footer-wrapper', text: 'custom footer')
+  end
+end

--- a/spec/components/previews/nds/page_chrome_component_preview.rb
+++ b/spec/components/previews/nds/page_chrome_component_preview.rb
@@ -1,0 +1,21 @@
+module NDS
+  # Net-new NDS top chrome; only renders in the NDS layout. Add
+  # ?ui_test_bucket=nds to the preview URL to load the NDS styles and see it.
+  #
+  # The government banner needs full controller/session context not available
+  # to Lookbook previews, so these scenarios hide it and show the logo chrome.
+  class PageChromeComponentPreview < BaseComponentPreview
+    def default
+      render(NDS::PageChromeComponent.new(hide_banner: true))
+    end
+
+    def without_logo
+      render(NDS::PageChromeComponent.new(hide_banner: true, hide_logo: true))
+    end
+
+    # @param hide_logo toggle
+    def workbench(hide_logo: false)
+      render(NDS::PageChromeComponent.new(hide_banner: true, hide_logo:))
+    end
+  end
+end

--- a/spec/components/previews/nds/page_footer_chrome_component_preview.rb
+++ b/spec/components/previews/nds/page_footer_chrome_component_preview.rb
@@ -1,0 +1,11 @@
+module NDS
+  # Net-new NDS page footer chrome; only renders in the NDS layout. Add
+  # ?ui_test_bucket=nds to the preview URL to load the NDS styles and see it.
+  # The language/destination selects and help link render via the
+  # bucket-conditional ButtonComponent (quaternary in the nds bucket).
+  class PageFooterChromeComponentPreview < BaseComponentPreview
+    def default
+      render(NDS::PageFooterChromeComponent.new)
+    end
+  end
+end

--- a/spec/components/previews/nds/page_shell_component_preview.rb
+++ b/spec/components/previews/nds/page_shell_component_preview.rb
@@ -1,0 +1,77 @@
+module NDS
+  # Net-new NDS page shell; only renders in the NDS layout. Add
+  # ?ui_test_bucket=nds to the preview URL to load the NDS styles and see it.
+  #
+  # The shell's default top chrome renders the shared government banner, which
+  # needs full controller/session context not available to Lookbook previews,
+  # so these scenarios hide the chrome and show the shell frame + footer. See
+  # the Page Chrome preview for the chrome in isolation.
+  class PageShellComponentPreview < BaseComponentPreview
+    include ActionView::Helpers::TagHelper
+
+    def default
+      render(NDS::PageShellComponent.new(width: :form, hide_chrome: true)) do
+        example_body
+      end
+    end
+
+    def wide
+      render(NDS::PageShellComponent.new(width: :wide, hide_chrome: true)) do
+        example_body
+      end
+    end
+
+    def spacious
+      render(
+        NDS::PageShellComponent.new(width: :form, density: :spacious, hide_chrome: true),
+      ) do
+        example_body
+      end
+    end
+
+    def bare
+      render(
+        NDS::PageShellComponent.new(width: :form, hide_chrome: true, hide_footer: true),
+      ) do
+        example_body
+      end
+    end
+
+    # @param width select [~,form,wide]
+    # @param density select [~,spacious,mobile-compact,fullscreen]
+    # @param align select [~,start,mobile-start,stretch]
+    # @param surface select [~,overlay]
+    # @param hide_footer toggle
+    def workbench(
+      width: :form,
+      density: nil,
+      align: nil,
+      surface: nil,
+      hide_footer: false
+    )
+      render(
+        NDS::PageShellComponent.new(
+          width: width&.to_sym,
+          density: density&.to_sym,
+          align: align&.to_sym,
+          surface: surface&.to_sym,
+          hide_chrome: true,
+          hide_footer:,
+        ),
+      ) do
+        example_body
+      end
+    end
+
+    private
+
+    def example_body
+      safe_join(
+        [
+          content_tag(:h1, 'Sign in'),
+          content_tag(:p, 'Enter your email address and password.'),
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Tickets

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/27
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/26

## Summary
- Adds net-new NDS::PageShellComponent, NDS::PageChromeComponent, and NDS::PageFooterChromeComponent that render only in the nds layout (not bucket-conditional).
- Adds the `links.more` label to the en/es/fr/zh locales for the footer.

## Changes
- Page shell emits the `.auth-page` class contract (align/density/surface/width modifiers, `.auth-page__main`) and the `[data-nds-page-transition]` hook.
- Page chrome emits `.auth-page__top-chrome` with the gov banner, logo banner, and an optional progress slot.
- Footer chrome emits the `.page-footer` contract (destination/language selects + help link) via ButtonComponent.

## Test plan
- [x] `bundle exec rspec spec/components/nds/page_shell_component_spec.rb spec/components/nds/page_chrome_component_spec.rb spec/components/nds/page_footer_chrome_component_spec.rb` (14 examples, 0 failures)
- [x] `bundle exec rubocop` on the new components/specs (clean)
- [x] `bundle exec erb_lint` on the new templates (clean)
- [x] `make lint_yaml` / normalize-yaml on en/es/fr/zh (zero diff)
- [x] `bin/rails zeitwerk:check`