### PR TITLE
Add NDS bucket-conditional BadgeComponent

### DIFF
--- a/app/components/badge_component.html.erb
+++ b/app/components/badge_component.html.erb
@@ -1,4 +1,8 @@
+<%- if render_as_nds? -%>
+<%= render(nds_delegate) { content } %>
+<%- else -%>
 <%= content_tag('div', **tag_options, class: ['lg-verification-badge', border_css_class, *tag_options[:class]]) do %>
   <%= render IconComponent.new(icon:, class: icon_css_class) %>
   <%= content %>
 <% end %>
+<%- end -%>

--- a/app/components/badge_component.rb
+++ b/app/components/badge_component.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
 class BadgeComponent < BaseComponent
-  attr_reader :icon, :tag_options
+  attr_reader :icon, :variant, :on_background, :tag_options
 
-  validates_inclusion_of :icon, in: %i[
-    lock
-    check_circle
-    warning
-    info
-  ]
+  # Legacy rendering requires a known icon. NDS rendering makes the icon
+  # optional and selects styling from variant:, so the icon inclusion check
+  # only runs when this badge renders its legacy markup.
+  validates_inclusion_of :icon,
+                         in: %i[lock check_circle warning info],
+                         if: :legacy_render?
 
-  def initialize(icon:, **tag_options)
-    @icon = icon
+  # variant: and on_background: are part of the shared badge API. Legacy
+  # rendering ignores both; on_background: is accepted for API compatibility
+  # but never emits anything.
+  def initialize(icon: nil, variant: :primary, on_background: :light, **tag_options)
+    @icon = icon&.to_sym
+    @variant = variant.to_sym
+    @on_background = on_background&.to_sym
     @tag_options = tag_options
   end
 
@@ -32,5 +37,47 @@ class BadgeComponent < BaseComponent
 
   def icon_css_class
     "text-#{color_token}"
+  end
+
+  # The badge's rendering can only be resolved at render time (helpers are
+  # unavailable in #initialize). Callers always instantiate BadgeComponent;
+  # when the render resolves to the NDS bucket we delegate to
+  # NDSBadgeComponent, which renders its own markup. The guard excludes
+  # NDSBadgeComponent itself so it renders its own markup instead of recursing.
+  def before_render
+    super
+    @render_as_nds = nds_bucket? && !is_a?(NDSBadgeComponent)
+  end
+
+  private
+
+  def render_as_nds?
+    @render_as_nds
+  end
+
+  def legacy_render?
+    !nds_bucket? && !is_a?(NDSBadgeComponent)
+  end
+
+  def nds_delegate
+    nds_variant_class.new(icon:, variant:, on_background:, **tag_options)
+  end
+
+  def nds_variant_class
+    NDSBadgeComponent
+  end
+
+  # ViewComponent delegates #helpers to the current view context, where
+  # nds_layout? is exposed as a controller helper_method. Guard for view
+  # contexts without that helper (e.g. mailers). When the bucket can't be
+  # resolved because there is no auth context (background jobs, isolated
+  # component renders — Devise::MissingWarden), default to the legacy bucket:
+  # legacy is the conservative default and rendering must never crash.
+  def nds_bucket?
+    return false unless helpers.respond_to?(:nds_layout?)
+
+    helpers.nds_layout?
+  rescue Devise::MissingWarden
+    false
   end
 end

--- a/app/components/nds_badge_component.html.erb
+++ b/app/components/nds_badge_component.html.erb
@@ -1,0 +1,1 @@
+<%= content_tag(:span, **tag_options.except(:class), class: css_class) { safe_join(parts.compact) } %>

--- a/app/components/nds_badge_component.rb
+++ b/app/components/nds_badge_component.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# NDS badge. Renders a <span class="badge badge--<variant>"> with an optional
+# icon and content. Instantiated by BadgeComponent when a render resolves to
+# the NDS bucket; call sites always use BadgeComponent directly.
+class NDSBadgeComponent < BadgeComponent
+  VARIANTS = {
+    primary: 'badge--primary',
+    secondary: 'badge--secondary',
+    tertiary: 'badge--tertiary',
+    success: 'badge--success',
+    error: 'badge--error',
+    warning: 'badge--warning',
+    info: 'badge--info',
+  }.freeze
+
+  def css_class
+    classes = ['badge', VARIANTS.fetch(variant), *tag_options[:class]]
+    classes << 'badge--icon-only' if icon_only?
+    classes
+  end
+
+  def parts
+    return [icon_content] if icon_only?
+
+    [content]
+  end
+
+  def icon_content
+    render IconComponent.new(icon:) if icon
+  end
+
+  private
+
+  def icon_only?
+    icon.present? && content.blank?
+  end
+end

--- a/spec/components/badge_component_spec.rb
+++ b/spec/components/badge_component_spec.rb
@@ -70,4 +70,110 @@ RSpec.describe BadgeComponent, type: :component do
       end
     end
   end
+
+  # Safety invariant: in the legacy bucket, adding variant:/on_background:
+  # must not change the emitted output, and the icon stays required/validated.
+  describe 'legacy bucket ignores variant/on_background kwargs' do
+    before do
+      allow_any_instance_of(BadgeComponent).to receive(:nds_bucket?).and_return(false)
+    end
+
+    def html(**opts)
+      raw = render_inline(BadgeComponent.new(icon: :check_circle, **opts).with_content('C')).to_html
+      # IconComponent assigns a random per-render id; normalize it so the
+      # comparison reflects only structural/class differences.
+      raw.gsub(/icon-[0-9a-f]+/, 'icon-XXXX')
+    end
+
+    it 'renders identical output whether or not variant/on_background are passed' do
+      baseline = html
+      %i[primary secondary tertiary success error warning info].each do |variant|
+        expect(html(variant:)).to eq(baseline)
+      end
+      expect(html(on_background: :dark)).to eq(baseline)
+      expect(html(variant: :success, on_background: :dark)).to eq(baseline)
+    end
+
+    it 'renders the legacy div.lg-verification-badge structure' do
+      rendered = render_inline(
+        BadgeComponent.new(icon: :lock, variant: :error).with_content('X'),
+      )
+      expect(rendered).to have_css(
+        'div.lg-verification-badge.border-success > .usa-icon.text-success',
+      )
+      expect(rendered).not_to have_css('span.badge')
+      expect(rendered).not_to have_css('.badge--error')
+    end
+
+    it 'still requires an icon' do
+      expect { render_inline(BadgeComponent.new(variant: :primary).with_content('x')) }
+        .to raise_error(ActiveModel::ValidationError)
+    end
+
+    it 'still validates the icon against the allowed list' do
+      expect { render_inline(BadgeComponent.new(icon: :invalid).with_content('x')) }
+        .to raise_error(ActiveModel::ValidationError)
+    end
+  end
+
+  describe 'nds bucket' do
+    before do
+      allow_any_instance_of(BadgeComponent).to receive(:nds_bucket?).and_return(true)
+    end
+
+    it 'renders a span.badge with the variant + content, dropping the icon when content present' do
+      rendered = render_inline(
+        BadgeComponent.new(icon: :check_circle, variant: :success).with_content('Verified'),
+      )
+      expect(rendered).to have_css('span.badge.badge--success')
+      expect(rendered).to have_content('Verified')
+      expect(rendered).not_to have_css('span.badge .usa-icon')
+      expect(rendered).not_to have_css('.lg-verification-badge')
+    end
+
+    it 'defaults to badge--primary' do
+      expect(render_inline(BadgeComponent.new(icon: :info).with_content('x')))
+        .to have_css('span.badge.badge--primary')
+    end
+
+    {
+      primary: 'badge--primary',
+      secondary: 'badge--secondary',
+      tertiary: 'badge--tertiary',
+      success: 'badge--success',
+      error: 'badge--error',
+      warning: 'badge--warning',
+      info: 'badge--info',
+    }.each do |variant, modifier|
+      it "maps variant #{variant} to .#{modifier}" do
+        expect(render_inline(BadgeComponent.new(icon: :info, variant:).with_content('x')))
+          .to have_css("span.badge.#{modifier}")
+      end
+    end
+
+    it 'adds badge--icon-only when icon present and no content' do
+      rendered = render_inline(BadgeComponent.new(icon: :lock))
+      expect(rendered).to have_css('span.badge.badge--icon-only .usa-icon')
+    end
+
+    it 'does not emit an on-light/on-dark modifier' do
+      rendered = render_inline(
+        BadgeComponent.new(icon: :info, on_background: :dark).with_content('x'),
+      )
+      expect(rendered).not_to have_css('[class*="on-light"], [class*="on-dark"]')
+    end
+
+    it 'renders without an icon (icon optional in nds)' do
+      rendered = render_inline(BadgeComponent.new(variant: :secondary).with_content('No icon'))
+      expect(rendered).to have_css('span.badge.badge--secondary')
+      expect(rendered).to have_content('No icon')
+      expect(rendered).not_to have_css('.usa-icon')
+    end
+
+    it 'raises on an unknown variant (fetch guards the map)' do
+      expect do
+        render_inline(BadgeComponent.new(icon: :info, variant: :bogus).with_content('x'))
+      end.to raise_error(KeyError)
+    end
+  end
 end


### PR DESCRIPTION
## Ticket
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/39

## Summary

- Adds an NDS variant of `BadgeComponent` following the subclass pattern from ButtonComponent (#13393) and AlertComponent (#13404). `BadgeComponent` remains the caller-facing entry point; default styling is unchanged.
- When a render resolves to the NDS bucket, `BadgeComponent` delegates to the new `NDSBadgeComponent`, which renders `<span class="badge badge--<variant>">` with an optional icon (icon-only when no content, otherwise text-only). Variant map: primary/secondary/tertiary/success/error/warning/info. `on_background:` is accepted for API compatibility but emits nothing.
- Component-only; call-site adoption deferred to a follow-up.

## Test plan

- [x] `bundle exec rspec spec/components/badge_component_spec.rb`
- [x] `bundle exec rubocop`
- [x] `bundle exec erb_lint app/views app/components`