### PR TITLE
Add MFA Lookup script

### DIFF
--- a/lib/data_pull.rb
+++ b/lib/data_pull.rb
@@ -41,6 +41,8 @@ class DataPull
 
         * #{basename} mfa-report uuid1 uuid2
 
+        * #{basename} mfa-lookup uuid1 uuid2
+
         * #{basename} ssn-signature-report ssn1
 
         * #{basename} profile-summary uuid1 uuid2
@@ -65,6 +67,7 @@ class DataPull
       'email-lookup' => EmailLookup,
       'events-summary' => EventsSummary,
       'ig-request' => InspectorGeneralRequest,
+      'mfa-lookup' => MfaLookup,
       'mfa-report' => MfaReport,
       'ssn-signature-report' => SsnSignatureReport,
       'profile-summary' => ProfileSummary,
@@ -159,6 +162,47 @@ class DataPull
 
       ScriptBase::Result.new(
         subtask: 'email-lookup',
+        uuids: users.map(&:uuid),
+        table:,
+      )
+    end
+  end
+
+  class MfaLookup
+    def run(args:, config:)
+      uuids = args
+
+      users = User.includes(
+        :phone_configurations,
+        :auth_app_configurations,
+        :webauthn_configurations,
+        :piv_cac_configurations,
+        :backup_code_configurations,
+      ).where(uuid: uuids).order(:uuid)
+
+      table = []
+      table << %w[uuid phone_count auth_app_count webauthn_count piv_cac_count backup_code_count]
+
+      users.each do |user|
+        table << [
+          user.uuid,
+          user.phone_configurations.size,
+          user.auth_app_configurations.size,
+          user.webauthn_configurations.size,
+          user.piv_cac_configurations.size,
+          user.backup_code_configurations.size,
+        ]
+      end
+
+      if config.include_missing?
+        (uuids - users.map(&:uuid)).each do |missing_uuid|
+          table << [missing_uuid, '[UUID NOT FOUND]', '[UUID NOT FOUND]', '[UUID NOT FOUND]',
+                    '[UUID NOT FOUND]', '[UUID NOT FOUND]']
+        end
+      end
+
+      ScriptBase::Result.new(
+        subtask: 'mfa-lookup',
         uuids: users.map(&:uuid),
         table:,
       )

--- a/spec/lib/data_pull_spec.rb
+++ b/spec/lib/data_pull_spec.rb
@@ -293,6 +293,142 @@ RSpec.describe DataPull do
     end
   end
 
+  describe DataPull::MfaLookup do
+    subject(:subtask) { DataPull::MfaLookup.new }
+
+    describe '#run when user only has an auth app' do
+      let(:user) { create(:user, :with_authentication_app) }
+
+      let(:args) { [user.uuid, 'does-not-exist'] }
+      let(:include_missing) { true }
+      let(:config) { ScriptBase::Config.new(include_missing:) }
+      subject(:result) { subtask.run(args:, config:) }
+
+      it 'loads MFA configurations for the user', aggregate_failures: true do
+        expected_table = [
+          %w[uuid phone_count auth_app_count webauthn_count piv_cac_count backup_code_count],
+          [user.uuid, 0, 1, 0, 0, 0],
+          ['does-not-exist', '[UUID NOT FOUND]', '[UUID NOT FOUND]', '[UUID NOT FOUND]',
+           '[UUID NOT FOUND]', '[UUID NOT FOUND]'],
+        ]
+        expect(result.table).to match(expected_table)
+        expect(result.subtask).to eq('mfa-lookup')
+        expect_consistent_row_length(result.table)
+        expect(result.uuids).to eq([user.uuid])
+      end
+    end
+
+    describe '#run when user only has piv_cac' do
+      let(:user) { create(:user, :with_piv_or_cac) }
+
+      let(:args) { [user.uuid, 'does-not-exist'] }
+      let(:include_missing) { true }
+      let(:config) { ScriptBase::Config.new(include_missing:) }
+      subject(:result) { subtask.run(args:, config:) }
+
+      it 'loads MFA configurations for the user', aggregate_failures: true do
+        expected_table = [
+          %w[uuid phone_count auth_app_count webauthn_count piv_cac_count backup_code_count],
+          [user.uuid, 0, 0, 0, 1, 0],
+          ['does-not-exist', '[UUID NOT FOUND]', '[UUID NOT FOUND]', '[UUID NOT FOUND]',
+           '[UUID NOT FOUND]', '[UUID NOT FOUND]'],
+        ]
+        expect(result.table).to match(expected_table)
+        expect(result.subtask).to eq('mfa-lookup')
+        expect_consistent_row_length(result.table)
+        expect(result.uuids).to eq([user.uuid])
+      end
+    end
+
+    describe '#run when user only has phone' do
+      let(:user) { create(:user, :with_phone) }
+
+      let(:args) { [user.uuid, 'does-not-exist'] }
+      let(:include_missing) { true }
+      let(:config) { ScriptBase::Config.new(include_missing:) }
+      subject(:result) { subtask.run(args:, config:) }
+
+      it 'loads MFA configurations for the user', aggregate_failures: true do
+        expected_table = [
+          %w[uuid phone_count auth_app_count webauthn_count piv_cac_count backup_code_count],
+          [user.uuid, 1, 0, 0, 0, 0],
+          ['does-not-exist', '[UUID NOT FOUND]', '[UUID NOT FOUND]', '[UUID NOT FOUND]',
+           '[UUID NOT FOUND]', '[UUID NOT FOUND]'],
+        ]
+        expect(result.table).to match(expected_table)
+        expect(result.subtask).to eq('mfa-lookup')
+        expect_consistent_row_length(result.table)
+        expect(result.uuids).to eq([user.uuid])
+      end
+    end
+
+    describe '#run when user only has webauthn' do
+      let(:user) { create(:user, :with_webauthn) }
+
+      let(:args) { [user.uuid, 'does-not-exist'] }
+      let(:include_missing) { true }
+      let(:config) { ScriptBase::Config.new(include_missing:) }
+      subject(:result) { subtask.run(args:, config:) }
+
+      it 'loads MFA configurations for the user', aggregate_failures: true do
+        expected_table = [
+          %w[uuid phone_count auth_app_count webauthn_count piv_cac_count backup_code_count],
+          [user.uuid, 0, 0, 1, 0, 0],
+          ['does-not-exist', '[UUID NOT FOUND]', '[UUID NOT FOUND]', '[UUID NOT FOUND]',
+           '[UUID NOT FOUND]', '[UUID NOT FOUND]'],
+        ]
+        expect(result.table).to match(expected_table)
+        expect(result.subtask).to eq('mfa-lookup')
+        expect_consistent_row_length(result.table)
+        expect(result.uuids).to eq([user.uuid])
+      end
+    end
+
+    describe '#run when user only has backup codes' do
+      let(:user) { create(:user, :with_backup_code) }
+
+      let(:args) { [user.uuid, 'does-not-exist'] }
+      let(:include_missing) { true }
+      let(:config) { ScriptBase::Config.new(include_missing:) }
+      subject(:result) { subtask.run(args:, config:) }
+
+      it 'loads MFA configurations for the user', aggregate_failures: true do
+        expected_table = [
+          %w[uuid phone_count auth_app_count webauthn_count piv_cac_count backup_code_count],
+          [user.uuid, 0, 0, 0, 0, 10],
+          ['does-not-exist', '[UUID NOT FOUND]', '[UUID NOT FOUND]', '[UUID NOT FOUND]',
+           '[UUID NOT FOUND]', '[UUID NOT FOUND]'],
+        ]
+        expect(result.table).to match(expected_table)
+        expect(result.subtask).to eq('mfa-lookup')
+        expect_consistent_row_length(result.table)
+        expect(result.uuids).to eq([user.uuid])
+      end
+    end
+
+    describe '#run when user has multiple MFA options' do
+      let(:user) { create(:user, :with_piv_or_cac, :with_webauthn) }
+
+      let(:args) { [user.uuid, 'does-not-exist'] }
+      let(:include_missing) { true }
+      let(:config) { ScriptBase::Config.new(include_missing:) }
+      subject(:result) { subtask.run(args:, config:) }
+
+      it 'displays the count of all MFA configurations for the user', aggregate_failures: true do
+        expected_table = [
+          %w[uuid phone_count auth_app_count webauthn_count piv_cac_count backup_code_count],
+          [user.uuid, 0, 0, 1, 1, 0],
+          ['does-not-exist', '[UUID NOT FOUND]', '[UUID NOT FOUND]', '[UUID NOT FOUND]',
+           '[UUID NOT FOUND]', '[UUID NOT FOUND]'],
+        ]
+        expect(result.table).to match(expected_table)
+        expect(result.subtask).to eq('mfa-lookup')
+        expect_consistent_row_length(result.table)
+        expect(result.uuids).to eq([user.uuid])
+      end
+    end
+  end
+
   describe DataPull::MfaReport do
     subject(:subtask) { DataPull::MfaReport.new }
 


### PR DESCRIPTION
During user support requests, on-call team members are often asked to
look up how many MFA options a user has configured. This script makes it
easier to pull up a UUID's MFA configurations.

Usage: ./bin/data-pull mfa-lookup uuid1 uuid2

Example output:
```
+--------------------------------------+-------------+---------------+----------------+---------------+-------------------+
| uuid                                 | phone_count | auth_app_count | webauthn_count | piv_cac_count | backup_code_count |
+--------------------------------------+-------------+---------------+----------------+---------------+-------------------+
| 3e0c3f5c-a31f-4ffd-8916-a2d6e11f30ca | 0           | 1             | 2              | 0             | 0                 |
+--------------------------------------+-------------+---------------+----------------+---------------+-------------------+
```