### PR TITLE
Preview NDS components in Lookbook via ui_test_bucket

### DIFF
--- a/app/assets/stylesheets/nds_application.css.scss
+++ b/app/assets/stylesheets/nds_application.css.scss
@@ -13,3 +13,9 @@
 @forward 'uswds';
 @forward 'design-system-waiting-room';
 @forward 'components';
+// NDS component overlays from identity-design-system, resolved from
+// packages-nds/nds/components/ via the packages-nds load path. Forwarded LAST
+// so the NDS look wins on equal specificity over both stock 'uswds' and idp's
+// own 'components'. The overlay index is an empty placeholder in the currently
+// pinned release; per-component overlays land in later design-system releases.
+@forward 'nds/components/index';

--- a/app/assets/stylesheets/nds_application.css.scss
+++ b/app/assets/stylesheets/nds_application.css.scss
@@ -13,9 +13,4 @@
 @forward 'uswds';
 @forward 'design-system-waiting-room';
 @forward 'components';
-// NDS component overlays from identity-design-system, resolved from
-// packages-nds/nds/components/ via the packages-nds load path. Forwarded LAST
-// so the NDS look wins on equal specificity over both stock 'uswds' and idp's
-// own 'components'. The overlay index is an empty placeholder in the currently
-// pinned release; per-component overlays land in later design-system releases.
 @forward 'nds/components/index';

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -21,11 +21,6 @@ class ComponentPreviewController < ViewComponentsController
       I18n.locale = LocaleChooser.new(params[:locale], request).locale
     end
 
-    # Force the NDS bucket in previews via ?ui_test_bucket=nds so
-    # bucket-conditional components can be inspected in both looks. Previews
-    # have no A/B or auth context (the app's full resolution also reads a
-    # cookie and the A/B assignment), so this honors only the query param and
-    # defaults to the legacy bucket.
     def nds_layout?
       params[:ui_test_bucket] == 'nds'
     end

--- a/app/controllers/component_preview_controller.rb
+++ b/app/controllers/component_preview_controller.rb
@@ -13,10 +13,21 @@ class ComponentPreviewController < ViewComponentsController
     helper_method :enqueue_component_stylesheets
     alias_method :enqueue_component_stylesheets, :stylesheet_tag_once
 
+    helper_method :nds_layout?
+
     before_action :set_locale
 
     def set_locale
       I18n.locale = LocaleChooser.new(params[:locale], request).locale
+    end
+
+    # Force the NDS bucket in previews via ?ui_test_bucket=nds so
+    # bucket-conditional components can be inspected in both looks. Previews
+    # have no A/B or auth context (the app's full resolution also reads a
+    # cookie and the A/B assignment), so this honors only the query param and
+    # defaults to the legacy bucket.
+    def nds_layout?
+      params[:ui_test_bucket] == 'nds'
     end
   end
 end

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -2,9 +2,15 @@
 <html>
   <head>
     <title>Component Preview</title>
-    <%= stylesheet_link_tag 'application', nopush: false %>
-    <%= render_stylesheet_once_tags %>
-    <%= stylesheet_link_tag 'utilities', nopush: false %>
+    <% if nds_layout? %>
+      <%= stylesheet_link_tag 'nds_application', nopush: false %>
+      <%= render_stylesheet_once_tags %>
+      <%= stylesheet_link_tag 'nds_utilities', nopush: false %>
+    <% else %>
+      <%= stylesheet_link_tag 'application', nopush: false %>
+      <%= render_stylesheet_once_tags %>
+      <%= stylesheet_link_tag 'utilities', nopush: false %>
+    <% end %>
   </head>
   <body class="height-auto padding-2 <%= params.dig(:lookbook, :display, :body_class) %>">
     <% if params.dig(:lookbook, :display, :form) == true %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "app/javascript/packages/*"
       ],
       "dependencies": {
-        "@18f/identity-design-system": "^9.7.0",
+        "@18f/identity-design-system": "^9.8.0",
         "@babel/core": "^7.20.7",
         "@babel/preset-env": "^7.28.0",
         "@babel/preset-react": "^7.14.5",
@@ -557,13 +557,13 @@
       "link": true
     },
     "node_modules/@18f/identity-design-system": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-9.7.0.tgz",
-      "integrity": "sha512-t7/NXLjTqNfTTIwUwOedXMxa5tnFoswIEogR0VQOzOcVAl1N99dIlg9MHgpj9UOANzGGykhlXKAXrOvone0TvQ==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@18f/identity-design-system/-/identity-design-system-9.8.0.tgz",
+      "integrity": "sha512-GNa8RtUIi11XMC4oRnE48EskOJKY7tHQ/g6O7r+rcHMw0vSOhE3XkrrmrRb0DtWccaNwPq+XNWmwRkiekRDWFQ==",
       "license": "CC0-1.0",
       "dependencies": {
         "@types/uswds__uswds": "~3.11.1",
-        "@uswds/uswds": "~3.13.0"
+        "@uswds/uswds": "~3.14.0"
       },
       "engines": {
         "node": ">=12",
@@ -3105,18 +3105,18 @@
       "license": "MIT"
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.4.0.tgz",
-      "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.1.tgz",
-      "integrity": "sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -4848,19 +4848,15 @@
       "license": "ISC"
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.13.0.tgz",
-      "integrity": "sha512-8P494gmXv/0sm09ExSdj8wAMjGLnM7UMRY/XgsMIRKnWfDXG+TyuCOKIuD4lqs+gLvSmi1nTQKyd0c0/A7VWJQ==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.14.0.tgz",
+      "integrity": "sha512-kwZ50TqGszxj3+MQhm+c84hI0y8rIKoc7ZLKbuHg+8rTkFisp9lXOMRD2wclyyuYZahpADxMvaPong7bwL7cew==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "lit": "^3.2.1",
-        "receptor": "1.0.0"
+        "lit": "3.3.3"
       },
       "engines": {
-        "node": ">= 4"
-      },
-      "optionalDependencies": {
-        "sass-embedded-linux-x64": "^1.89.0"
+        "node": ">=20"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -6986,15 +6982,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.406.tgz",
       "integrity": "sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==",
       "license": "ISC"
-    },
-    "node_modules/element-closest": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
-      "integrity": "sha512-QCqAWP3kwj8Gz9UXncVXQGdrhnWxD8SQBSeZp5pOsyCcQ6RpL738L1/tfuwBiMi6F1fYkxqPnBrFBR4L+f49Cg==",
-      "license": "CC0-1.0",
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -9972,12 +9959,6 @@
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "license": "MIT"
     },
-    "node_modules/keyboardevent-key-polyfill": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboardevent-key-polyfill/-/keyboardevent-key-polyfill-1.1.0.tgz",
-      "integrity": "sha512-NTDqo7XhzL1fqmUzYroiyK2qGua7sOMzLav35BfNA/mPUSCtw8pZghHFMTYR9JdnJ23IQz695FcaM6EE6bpbFQ==",
-      "license": "CC0-1.0"
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10307,9 +10288,9 @@
       "license": "MIT"
     },
     "node_modules/lit": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
-      "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -10318,20 +10299,20 @@
       }
     },
     "node_modules/lit-element": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.1.tgz",
-      "integrity": "sha512-WGAWRGzirAgyphK2urmYOV72tlvnxw7YfyLDgQ+OZnM9vQQBQnumQ7jUJe6unEzwGU3ahFOjuz1iz1jjrpCPuw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
         "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.1.tgz",
-      "integrity": "sha512-S9hbyDu/vs1qNrithiNyeyv64c9yqiW9l+DBgI18fL+MTvOtWoFR0FWiyq1TxaYef5wNlpEmzlXoBlZEO+WjoA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -10530,12 +10511,6 @@
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/matches-selector": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
-      "integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA==",
-      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -12128,18 +12103,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/receptor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/receptor/-/receptor-1.0.0.tgz",
-      "integrity": "sha512-yvVEqVQDNzEmGkluCkEdbKSXqZb3WGxotI/VukXIQ+4/BXEeXVjWtmC6jWaR1BIsmEAGYQy3OTaNgDj2Svr01w==",
-      "license": "CC0-1.0",
-      "dependencies": {
-        "element-closest": "^2.0.1",
-        "keyboardevent-key-polyfill": "^1.0.2",
-        "matches-selector": "^1.0.0",
-        "object-assign": "^4.1.0"
       }
     },
     "node_modules/rechoir": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:openapi": "redocly bundle ./docs/attempts-api/openapi.yml -o ./docs/attempts-api/compiled-api --ext yml -d"
   },
   "dependencies": {
-    "@18f/identity-design-system": "^9.7.0",
+    "@18f/identity-design-system": "^9.8.0",
     "@babel/core": "^7.20.7",
     "@babel/preset-env": "^7.28.0",
     "@babel/preset-react": "^7.14.5",

--- a/spec/components/previews/nds/link_component_preview.rb
+++ b/spec/components/previews/nds/link_component_preview.rb
@@ -1,6 +1,4 @@
 module NDS
-  # Net-new NDS link primitive; only renders in the NDS layout. Add
-  # ?ui_test_bucket=nds to the preview URL to load the NDS styles and see it.
   class LinkComponentPreview < BaseComponentPreview
     def default
       render(NDS::LinkComponent.new(url: '#').with_content('Manage your account'))

--- a/spec/components/previews/nds/link_component_preview.rb
+++ b/spec/components/previews/nds/link_component_preview.rb
@@ -1,0 +1,32 @@
+module NDS
+  # Net-new NDS link primitive; only renders in the NDS layout. Add
+  # ?ui_test_bucket=nds to the preview URL to load the NDS styles and see it.
+  class LinkComponentPreview < BaseComponentPreview
+    def default
+      render(NDS::LinkComponent.new(url: '#').with_content('Manage your account'))
+    end
+
+    def external
+      render(
+        NDS::LinkComponent.new(url: 'https://login.gov', target: '_blank')
+          .with_content('Open login.gov'),
+      )
+    end
+
+    def nowrap
+      render(
+        NDS::LinkComponent.new(url: '#', class: 'link--nowrap')
+          .with_content('Do not wrap this link'),
+      )
+    end
+
+    # @param content text
+    # @param nowrap toggle
+    def workbench(content: 'Manage your account', nowrap: false)
+      render(
+        NDS::LinkComponent.new(url: '#', class: ('link--nowrap' if nowrap))
+          .with_content(content),
+      )
+    end
+  end
+end

--- a/spec/components/previews/nds/stack_component_preview.rb
+++ b/spec/components/previews/nds/stack_component_preview.rb
@@ -1,6 +1,4 @@
 module NDS
-  # Net-new NDS layout primitive; only renders in the NDS layout. Add
-  # ?ui_test_bucket=nds to the preview URL to load the NDS styles and see it.
   class StackComponentPreview < BaseComponentPreview
     include ActionView::Helpers::TagHelper
 

--- a/spec/components/previews/nds/stack_component_preview.rb
+++ b/spec/components/previews/nds/stack_component_preview.rb
@@ -1,0 +1,48 @@
+module NDS
+  # Net-new NDS layout primitive; only renders in the NDS layout. Add
+  # ?ui_test_bucket=nds to the preview URL to load the NDS styles and see it.
+  class StackComponentPreview < BaseComponentPreview
+    include ActionView::Helpers::TagHelper
+
+    def default
+      render(NDS::StackComponent.new(gap: 12)) do
+        safe_join(
+          ['One', 'Two', 'Three'].map { |label| content_tag(:div, label) },
+        )
+      end
+    end
+
+    def form_group
+      render(NDS::StackComponent.new(kind: :form)) do
+        safe_join(
+          ['Name', 'Email', 'Password'].map { |label| content_tag(:div, label) },
+        )
+      end
+    end
+
+    def actions
+      render(NDS::StackComponent.new(kind: :actions, gap: 12)) do
+        safe_join(
+          [
+            content_tag(:button, 'Continue', type: 'button', class: 'usa-button'),
+            content_tag(
+              :button, 'Cancel',
+              type: 'button', class: 'usa-button usa-button--outline'
+            ),
+          ],
+        )
+      end
+    end
+
+    # @param kind select [stack,flow,form,actions,links]
+    # @param gap number
+    # @param align select [~,start,center,end,stretch]
+    def workbench(kind: :stack, gap: 12, align: nil)
+      render(NDS::StackComponent.new(kind: kind&.to_sym, gap:, align: align&.to_sym)) do
+        safe_join(
+          ['One', 'Two', 'Three'].map { |label| content_tag(:div, label) },
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## TIcket
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/40

## Summary

- Bump `@18f/identity-design-system` to `^9.8.0` and forward the NDS component overlay index (`nds/components/index`) into the NDS Sass bundle, so a locally npm-linked design-system build's in-progress component overlays render in Lookbook. The index is an empty placeholder in 9.8.0, so this compiles today and renders NDS-bucket components with their structural markup; per-component overlays land in later design-system releases.
- Wire the component preview controller and layout to the `ui_test_bucket` dev override: the preview controller exposes `nds_layout?` from `?ui_test_bucket=nds`, and the layout loads the NDS stylesheet bundle in the NDS bucket / the legacy bundle otherwise. Bucket-conditional components (button, alert, badge) can be inspected in both looks from one preview.
- Add previews for the net-new `NDS::Stack` and `NDS::Link` primitives.

## How to preview local design-system overlays

1. Build the design-system's `packages-nds` locally and `npm link` it into `node_modules/@18f/identity-design-system`.
2. `npm run build:css:nds`.
3. Open `/components/…?ui_test_bucket=nds` to see the NDS look; drop the param (or `=legacy`) for the control look.

## Test plan

- [x] `build:css:legacy` + `build:css:nds` compile against published 9.8.0
- [x] `rubocop` + `erb_lint` clean on changed files
- [x] Existing component specs pass (button/alert/badge, NDS::Stack, NDS::Link)
- [x] Manual: bucket-conditional badge flips markup between `?ui_test_bucket=nds` and `=legacy`; NDS::Stack/Link preview scenarios render
- [ ] CI green