### PR TITLE
Use the shared NDSBucketResolvable concern in BadgeComponent

### DIFF
--- a/app/components/badge_component.rb
+++ b/app/components/badge_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BadgeComponent < BaseComponent
+  include NDSBucketResolvable
+
   attr_reader :icon, :variant, :on_background, :tag_options
 
   # Legacy rendering requires a known icon. NDS rendering makes the icon
@@ -39,21 +41,7 @@ class BadgeComponent < BaseComponent
     "text-#{color_token}"
   end
 
-  # The badge's rendering can only be resolved at render time (helpers are
-  # unavailable in #initialize). Callers always instantiate BadgeComponent;
-  # when the render resolves to the NDS bucket we delegate to
-  # NDSBadgeComponent, which renders its own markup. The guard excludes
-  # NDSBadgeComponent itself so it renders its own markup instead of recursing.
-  def before_render
-    super
-    @render_as_nds = nds_bucket? && !is_a?(NDSBadgeComponent)
-  end
-
   private
-
-  def render_as_nds?
-    @render_as_nds
-  end
 
   def legacy_render?
     !nds_bucket? && !is_a?(NDSBadgeComponent)
@@ -63,21 +51,9 @@ class BadgeComponent < BaseComponent
     nds_variant_class.new(icon:, variant:, on_background:, **tag_options)
   end
 
+  # The NDS variant excluded from the render-time flip (see
+  # NDSBucketResolvable) so it renders its own markup instead of recursing.
   def nds_variant_class
     NDSBadgeComponent
-  end
-
-  # ViewComponent delegates #helpers to the current view context, where
-  # nds_layout? is exposed as a controller helper_method. Guard for view
-  # contexts without that helper (e.g. mailers). When the bucket can't be
-  # resolved because there is no auth context (background jobs, isolated
-  # component renders — Devise::MissingWarden), default to the legacy bucket:
-  # legacy is the conservative default and rendering must never crash.
-  def nds_bucket?
-    return false unless helpers.respond_to?(:nds_layout?)
-
-    helpers.nds_layout?
-  rescue Devise::MissingWarden
-    false
   end
 end


### PR DESCRIPTION
## Ticket
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/39

Follow-up to #13410. BadgeComponent had an inline copy of the render-time bucket resolution; this swaps it for the shared NDSBucketResolvable concern (#13405) that ButtonComponent/AlertComponent already use. nds_variant_class + nds_delegate hooks kept. Pure refactor — full badge spec passes unchanged (25 examples).