### PR TITLE
Joan-119: Use DDP review_status to determine PhoneFinder pass/fail

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer.rb
@@ -6,6 +6,7 @@ module Proofing
       module Proofers
         class PhoneFinderProofer < Proofing::LexisNexis::Ddp::Proofer
           NOT_VERIFIED_TO_NAME = 'Input phone number could not be verified to name'
+          VALID_REVIEW_STATUSES = %w[pass review reject].freeze
 
           private
 
@@ -13,9 +14,12 @@ module Proofing
             response_body = verification_response.response_body
             parsed_response =
               Proofing::LexisNexis::Ddp::ParsedResponse.new(raw_response(response_body))
+            review_status = response_body['review_status']
+
+            validate_review_status!(review_status)
 
             AddressResult.new(
-              success: parsed_response.verification_status == 'passed',
+              success: review_status == 'pass',
               errors: parse_verification_errors(parsed_response),
               exception: nil,
               vendor_name: 'lexisnexis:phone_finder_ddp',
@@ -23,6 +27,12 @@ module Proofing
               dual_vendor_check_eligible: dual_vendor_check_eligible?(parsed_response),
               result: phone_metadata(response_body),
             )
+          end
+
+          def validate_review_status!(review_status)
+            return if VALID_REVIEW_STATUSES.include?(review_status)
+
+            raise "Unexpected PhoneFinder review_status value: #{review_status}"
           end
 
           def build_result_from_exception(exception)

--- a/spec/fixtures/proofing/lexis_nexis/ddp/phone_finder/response.json
+++ b/spec/fixtures/proofing/lexis_nexis/ddp/phone_finder/response.json
@@ -234,7 +234,7 @@
   "request_duration": "988",
   "request_id": "e8671760-e2ba-4694-ac90-3adcc522748b",
   "request_result": "success",
-  "review_status": "reject",
+  "review_status": "pass",
   "risk_rating": "neutral",
   "secondary_industry": "civilian",
   "service_type": "all",

--- a/spec/jobs/address_proofing_job_spec.rb
+++ b/spec/jobs/address_proofing_job_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe AddressProofingJob, type: :job do
 
         result = document_capture_session.load_proofing_result[:result]
 
-        expect(result[:result][:review_status]).to eq('reject')
+        expect(result[:result][:review_status]).to eq('pass')
       end
 
       it 'adds cost data' do

--- a/spec/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
             risk_count_high: '0',
             risk_count_med: '1',
             risk_count_low: '4',
-            review_status: 'reject',
+            review_status: 'pass',
           }
         end
 
@@ -109,7 +109,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
         it 'surfaces the top-level DDP policy review_status in the result' do
           result = proofer.proof(proofing_applicant)
 
-          expect(result.result[:review_status]).to eq('reject')
+          expect(result.result[:review_status]).to eq('pass')
         end
 
         it 'surfaces phone metadata in result' do
@@ -121,6 +121,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
         context 'when the phone metadata fields are absent' do
           let(:response_body) do
             {
+              'review_status' => 'pass',
               'integration_hub_results' => {
                 'test_org_id:test-policy' => {
                   'Phone Finder' => {
@@ -147,7 +148,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
               risk_count_high: nil,
               risk_count_med: nil,
               risk_count_low: nil,
-              review_status: nil,
+              review_status: 'pass',
             )
           end
         end
@@ -200,6 +201,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
         context 'when the failure is "could not be verified to name" with additional errors' do
           let(:response_body) do
             {
+              'review_status' => 'reject',
               'integration_hub_results' => {
                 'test_org_id:test-policy' => {
                   'Phone Finder' => {
@@ -265,6 +267,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
         context 'when the response fails with "Risk Indicators match determined"' do
           let(:response_body) do
             {
+              'review_status' => 'reject',
               'integration_hub_results' => {
                 'test_org_id:test-policy' => {
                   'Phone Finder' => {
@@ -323,6 +326,93 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
             expect(result.vendor_name).to eq('lexisnexis:phone_finder_ddp')
             expect(result.dual_vendor_check_eligible).to be(false)
           end
+        end
+
+        context 'when review_status is "review"' do
+          let(:response_body) do
+            {
+              'review_status' => 'review',
+              'integration_hub_results' => {
+                'test_org_id:test-policy' => {
+                  'Phone Finder' => {
+                    'tps_vendor_raw_response' => {
+                      'Products' => [],
+                      'Status' => {
+                        'ConversationId' => 'super-cool-test-session-id',
+                        'TransactionStatus' => 'passed',
+                      },
+                    },
+                  },
+                },
+              },
+            }.to_json
+          end
+
+          it 'is a failure result' do
+            result = proofer.proof(proofing_applicant)
+
+            expect(result.success?).to eq(false)
+          end
+        end
+
+        context 'when TransactionStatus is "passed" but review_status is "reject"' do
+          let(:response_body) do
+            {
+              'review_status' => 'reject',
+              'integration_hub_results' => {
+                'test_org_id:test-policy' => {
+                  'Phone Finder' => {
+                    'tps_vendor_raw_response' => {
+                      'Products' => [],
+                      'Status' => {
+                        'ConversationId' => 'super-cool-test-session-id',
+                        'TransactionStatus' => 'passed',
+                      },
+                    },
+                  },
+                },
+              },
+            }.to_json
+          end
+
+          it 'is a failure result driven by review_status' do
+            result = proofer.proof(proofing_applicant)
+
+            expect(result.success?).to eq(false)
+          end
+        end
+      end
+
+      context 'when review_status is an unexpected value' do
+        let(:response_body) do
+          {
+            'review_status' => 'unexpected_status',
+            'integration_hub_results' => {
+              'test_org_id:test-policy' => {
+                'Phone Finder' => {
+                  'tps_vendor_raw_response' => {
+                    'Products' => [],
+                    'Status' => {
+                      'ConversationId' => 'super-cool-test-session-id',
+                      'TransactionStatus' => 'passed',
+                    },
+                  },
+                },
+              },
+            },
+          }.to_json
+        end
+
+        it 'returns a failure result with a RuntimeError exception' do
+          expect(NewRelic::Agent).to receive(:notice_error)
+            .with(an_instance_of(RuntimeError))
+
+          result = proofer.proof(proofing_applicant)
+
+          expect(result.success?).to eq(false)
+          expect(result.exception).to be_a(RuntimeError)
+          expect(result.exception.message)
+            .to eq('Unexpected PhoneFinder review_status value: unexpected_status')
         end
       end
 


### PR DESCRIPTION
## 🎫 Ticket

[joan-119](https://gitlab.login.gov/lg-teams/joan/joan/-/work_items/119)

## 🛠 Summary of changes

Base LexisNexis DDP PhoneFinder pass/fail on the top-level `review_status` field (`pass` only) instead of the inner `tps_vendor_raw_response.Status.TransactionStatus`. This mirrors the existing `ThreatMetrixProofer` approach.
- `phone_finder_proofer.rb`: read top-level `review_status`, validate it (`pass`/`review`/`reject`), raise on unexpected values), set `success: review_status == 'pass'`.
- `errors`, `dual_vendor_check_eligible`, and the timeout/exception path are unchanged.
- fixtures/specs updated. 

## 📜 Testing Plan

- [x] `bundle exec rspec spec/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer_spec.rb` passes
- [x] `bundle exec rspec spec/jobs/address_proofing_job_spec.rb` passes
- [x] Confirm a transaction with `TransactionStatus: passed` + `review_status: reject` now fails (regression case)
- [x] Confirm timeouts still fail closed (`Proofing::TimeoutError`, `success: false`)