### PR TITLE
Add NDS::CardComponent

### DIFF
--- a/app/components/nds/card_component.html.erb
+++ b/app/components/nds/card_component.html.erb
@@ -1,0 +1,15 @@
+<%= action.call(
+      **wrapper_options,
+      class: css_class,
+    ) do %>
+  <div class="card__inner">
+    <div class="card__body">
+      <%= content %>
+    </div>
+    <% if trailing? %>
+      <div class="card__trailing">
+        <%= trailing %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/nds/card_component.rb
+++ b/app/components/nds/card_component.rb
@@ -15,8 +15,9 @@ module NDS
 
     attr_reader :url, :method, :button, :padding, :tag_options
 
-    alias_method :button?, :button
     validate :validate_action_mode
+
+    def button? = button
 
     def initialize(url: nil, method: nil, button: false, padding: :default, **tag_options)
       @url = url

--- a/app/components/nds/card_component.rb
+++ b/app/components/nds/card_component.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module NDS
+  # NDS card component. Renders in the nds layout. A card is a plain container
+  # by default and becomes interactive when given a url or rendered as a button.
+  # Supports a compact padding variant and an optional trailing slot. Emits
+  # unprefixed `card*` classes.
+  class CardComponent < BaseComponent
+    PADDINGS = {
+      default: nil,
+      compact: 'card--compact',
+    }.freeze
+
+    renders_one :trailing
+
+    attr_reader :url, :method, :button, :padding, :tag_options
+
+    alias_method :button?, :button
+    validate :validate_action_mode
+
+    def initialize(url: nil, method: nil, button: false, padding: :default, **tag_options)
+      @url = url
+      @method = method
+      @button = button
+      @padding = padding.to_sym
+      @tag_options = tag_options
+    end
+
+    def interactive?
+      url.present? || button?
+    end
+
+    def css_class
+      classes = ['card', PADDINGS.fetch(padding), *tag_options[:class]]
+      classes << 'card--interactive' if interactive?
+      classes.compact
+    end
+
+    private
+
+    def action
+      @action ||= begin
+        if url
+          if method && method != :get
+            lambda do |**opts, &block|
+              button_to(url, method:, form_class: 'card-form', **opts, &block)
+            end
+          else
+            ->(**opts, &block) { link_to(url, **opts, &block) }
+          end
+        elsif button?
+          ->(**opts, &block) { button_tag(**opts, &block) }
+        else
+          ->(**opts, &block) { content_tag(:div, **opts, &block) }
+        end
+      end
+    end
+
+    def wrapper_options
+      options = tag_options.except(:class)
+      options[:type] ||= :button if button? && !url
+      options
+    end
+
+    def validate_action_mode
+      if button? && url.present?
+        errors.add(
+          :button, :conflicts_with_url, message: 'cannot be combined with url',
+                                        type: :conflicts_with_url
+        )
+      end
+      if method.present? && url.blank?
+        errors.add(:method, :missing_url, message: 'requires a url', type: :missing_url)
+      end
+    end
+  end
+end

--- a/app/components/nds/card_component.rb
+++ b/app/components/nds/card_component.rb
@@ -3,8 +3,8 @@
 module NDS
   # NDS card component. Renders in the nds layout. A card is a plain container
   # by default and becomes interactive when given a url or rendered as a button.
-  # Supports a compact padding variant and an optional trailing slot. Emits
-  # unprefixed `card*` classes.
+  # Supports a compact padding variant and an optional trailing slot. Renders
+  # the card, card__inner, card__body, and card__trailing classes.
   class CardComponent < BaseComponent
     PADDINGS = {
       default: nil,

--- a/spec/components/nds/card_component_spec.rb
+++ b/spec/components/nds/card_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe NDS::CardComponent, type: :component do
       .to raise_error(ActiveModel::ValidationError)
   end
 
-  it 'emits unprefixed card classes' do
+  it 'emits the card classes' do
     rendered = render_inline(NDS::CardComponent.new(url: '/x', padding: :compact)) { 'x' }
     expect(rendered).to have_css('a.card.card--compact.card--interactive[href="/x"]')
   end

--- a/spec/components/nds/card_component_spec.rb
+++ b/spec/components/nds/card_component_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe NDS::CardComponent, type: :component do
+  it 'renders a plain div.card by default (non-interactive)' do
+    rendered = render_inline(NDS::CardComponent.new) { 'Body' }
+    expect(rendered).to have_css('div.card > .card__inner > .card__body', text: 'Body')
+    expect(rendered).not_to have_css('.card--interactive')
+    expect(rendered).not_to have_css('.card--compact')
+  end
+
+  it 'adds --compact for padding: :compact' do
+    rendered = render_inline(NDS::CardComponent.new(padding: :compact)) { 'x' }
+    expect(rendered).to have_css('div.card.card--compact')
+  end
+
+  it 'renders an interactive link card when url is given' do
+    rendered = render_inline(NDS::CardComponent.new(url: '/somewhere')) { 'Go' }
+    expect(rendered).to have_css('a.card.card--interactive[href="/somewhere"]', text: 'Go')
+  end
+
+  it 'renders a button card when button: true' do
+    rendered = render_inline(NDS::CardComponent.new(button: true)) { 'Press' }
+    expect(rendered).to have_css('button.card.card--interactive[type="button"]', text: 'Press')
+  end
+
+  it 'renders a button_to (card-form) when url + non-get method' do
+    rendered = render_inline(NDS::CardComponent.new(url: '/act', method: :post)) { 'Act' }
+    expect(rendered).to have_css('form.card-form')
+    expect(rendered).to have_css('form.card-form button.card.card--interactive', text: 'Act')
+  end
+
+  it 'renders the trailing slot' do
+    rendered = render_inline(NDS::CardComponent.new) do |c|
+      c.with_trailing { 'TRAIL' }
+      'Body'
+    end
+    expect(rendered).to have_css('.card__inner > .card__trailing', text: 'TRAIL')
+    expect(rendered).to have_css('.card__inner > .card__body', text: 'Body')
+  end
+
+  it 'passes through custom classes (e.g. --mfa)' do
+    rendered = render_inline(NDS::CardComponent.new(class: 'card--mfa')) { 'x' }
+    expect(rendered).to have_css('div.card.card--mfa')
+  end
+
+  it 'validates button cannot combine with url' do
+    expect { render_inline(NDS::CardComponent.new(button: true, url: '/x')) { 'x' } }
+      .to raise_error(ActiveModel::ValidationError)
+  end
+
+  it 'validates method requires a url' do
+    expect { render_inline(NDS::CardComponent.new(method: :post)) { 'x' } }
+      .to raise_error(ActiveModel::ValidationError)
+  end
+
+  it 'emits unprefixed card classes' do
+    rendered = render_inline(NDS::CardComponent.new(url: '/x', padding: :compact)) { 'x' }
+    expect(rendered).to have_css('a.card.card--compact.card--interactive[href="/x"]')
+  end
+end

--- a/spec/components/previews/nds/card_component_preview.rb
+++ b/spec/components/previews/nds/card_component_preview.rb
@@ -1,0 +1,46 @@
+module NDS
+  # Previews for NDS::CardComponent. Intended to be viewed in the nds bucket
+  # (?ui_test_bucket=nds) so the card is painted with the NDS styles.
+  class CardComponentPreview < BaseComponentPreview
+    include ActionView::Helpers::TagHelper
+
+    # @!group Preview
+    def default
+      render(NDS::CardComponent.new) { 'A plain card container.' }
+    end
+
+    def compact
+      render(NDS::CardComponent.new(padding: :compact)) { 'A compact card.' }
+    end
+
+    def interactive_link
+      render(NDS::CardComponent.new(url: '#')) { 'A card that links somewhere.' }
+    end
+
+    def button
+      render(NDS::CardComponent.new(button: true)) { 'A card that acts as a button.' }
+    end
+
+    def form_action
+      render(NDS::CardComponent.new(url: '#', method: :post)) { 'A card that submits a form.' }
+    end
+
+    def with_trailing
+      render(NDS::CardComponent.new(url: '#')) do |card|
+        card.with_trailing { content_tag(:span, '→') }
+        'A card with a trailing element.'
+      end
+    end
+    # @!endgroup
+
+    # @param padding select [default,compact]
+    # @param url text
+    # @param button toggle
+    # @param content text
+    def workbench(padding: :default, url: '', button: false, content: 'Card content')
+      render(
+        NDS::CardComponent.new(padding: padding&.to_sym, url: url.presence, button:),
+      ) { content }
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

[Link to ticket](https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/9)

## Summary

- Adds net-new `NDS::CardComponent` (renders in the nds layout; not bucket-conditional).
- Plain `div.card` by default; becomes an interactive link (`url`), a `button` (`button: true`), or a `button_to`/`card-form` (`url` + non-get `method`). Supports `padding: :compact` and a `trailing` slot. Emits the `card*` classes.
- Validations: `button` conflicts with `url`; `method` requires a `url`.

## Test plan

- [x] `bundle exec rspec spec/components/nds/card_component_spec.rb` (10 examples, 0 failures)
- [x] rubocop + erb_lint clean
- [x] `rails zeitwerk:check` clean (NDS:: autoloads)