### PR TITLE
Render the NDS page shell in the nds application layout

### DIFF
--- a/app/views/layouts/nds/application.html.erb
+++ b/app/views/layouts/nds/application.html.erb
@@ -3,21 +3,30 @@
   <%= javascript_include_tag('init.js', nopush: false, integrity: 'sha256-eMXV2njRJxgQrFbuljRT/UTWePGrhl83bHHDDd+jFPw=') %>
 <% end %>
 
-<%= extends_layout 'nds/base', body_class: local_assigns.fetch(:body_class, 'site tablet:bg-primary-lighter') do %>
-  <%= link_to t('shared.skip_link'), '#main-content', class: 'usa-skipnav' %>
-  <%= render 'shared/banner' %>
-  <%= content_tag(
-        local_assigns[:user_main_tag] == false ? 'div' : 'main',
-        class: 'site-wrap bg-primary-lighter',
-        id: local_assigns[:user_main_tag] == false ? nil : 'main-content',
-      ) do %>
-    <div class="grid-container padding-y-4 tablet:padding-y-8 <%= local_assigns[:disable_card].present? ? '' : 'card padding-x-2 tablet:padding-x-10 tablet:margin-bottom-8' %>">
+<%= extends_layout 'nds/base', body_class: local_assigns.fetch(:body_class, 'site') do %>
+  <%= link_to t('shared.skip_link'), '#main-content', class: 'skip-link' %>
+
+  <%= render NDS::PageShellComponent.new(
+        width: local_assigns.fetch(:page_width, :form),
+        density: local_assigns[:page_density],
+        align: local_assigns[:page_align],
+        surface: local_assigns[:page_surface],
+        main_tag: local_assigns[:user_main_tag] == false ? :div : :main,
+        hide_chrome: local_assigns.fetch(:hide_page_chrome, false) ||
+          content_for?(:hide_page_chrome),
+        hide_footer: local_assigns.fetch(:hide_page_footer, false) ||
+          content_for?(:hide_page_footer),
+      ) do |shell| %>
+    <% shell.with_body do %>
       <%= yield(:pre_flash_content) if content_for?(:pre_flash_content) %>
-      <%= render FlashComponent.new(flash: flash) %>
+      <% unless content_for?(:skip_layout_flash) %>
+        <div class="auth-page__flash">
+          <%= render FlashComponent.new(flash: flash) %>
+        </div>
+      <% end %>
       <%= yield %>
-    </div>
+    <% end %>
   <% end %>
-  <%= render 'shared/footer_lite' %>
 
   <% if current_user %>
     <%= render partial: 'session_timeout/ping',

--- a/spec/requests/nds_layout_stylesheet_spec.rb
+++ b/spec/requests/nds_layout_stylesheet_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe 'NDS layout stylesheet swap', type: :request do
       expect(response.body).not_to include('nds_utilities')
       expect(response.body).not_to include('nds_print')
     end
+
+    it 'renders the legacy page structure (grid-container/card), not the nds shell' do
+      get root_url
+      doc = Nokogiri::HTML(response.body)
+
+      expect(doc.at_css('.grid-container')).to be_present
+      expect(doc.at_css('.auth-page')).to be_nil
+      expect(response.body).not_to include('data-nds-page-transition')
+    end
   end
 
   context 'forced nds bucket' do
@@ -47,6 +56,19 @@ RSpec.describe 'NDS layout stylesheet swap', type: :request do
       expect(response.body).to match(%r{stylesheet["'][^>]*/assets/nds_print[-.]})
       expect(response.body).not_to match(%r{stylesheet["'][^>]*/assets/utilities[-.]})
       expect(response.body).not_to match(%r{stylesheet["'][^>]*/assets/print[-.]})
+    end
+
+    it 'renders the NDS page shell with the transition attribute on .auth-page' do
+      get root_url, params: { ui_test_bucket: 'nds' }
+      doc = Nokogiri::HTML(response.body)
+
+      shell = doc.at_css('.auth-page')
+      expect(shell).to be_present
+      expect(shell.attributes).to have_key('data-nds-page-transition')
+      expect(doc.at_css('.auth-page__main#main-content')).to be_present
+      expect(doc.at_css('.auth-page__top-chrome')).to be_present
+      # nds shell replaces the legacy grid-container/card chrome
+      expect(doc.at_css('.grid-container.card')).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Ticket
Chrome/page shell mostly falls under the [ticket for the header](https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/26)

## Summary

- Wires `app/views/layouts/nds/application.html.erb` to render `NDS::PageShellComponent` (page chrome + footer chrome) in place of the legacy grid-container/card markup, emitting the `.auth-page` contract with `[data-nds-page-transition]` on the shell element.
- Builds on the shell components from #13409; the nds bucket now renders the full NDS page shell against real painting CSS. Aligns with NDS_LOOK_AND_FEEL.
- The legacy `application.html.erb` layout is unchanged, so the default (legacy) experience is unaffected; a request spec proves the default bucket keeps grid-container/card and the nds bucket renders the shell.

## Test plan

- [x] `bundle exec rspec spec/requests/nds_layout_stylesheet_spec.rb` (green — both buckets)
- [x] Manually confirm the nds bucket renders `.auth-page` / top chrome and the default bucket is unchanged