### PR TITLE
Add NDS bucket-conditional ModalComponent

### DIFF
--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -1,3 +1,13 @@
+<%- if render_as_nds? -%>
+<%= render(nds_delegate) do |c|
+      c.with_trigger { trigger.to_s } if trigger?
+      c.with_media { media.to_s } if media?
+      c.with_title { title.to_s } if title?
+      c.with_description { description.to_s } if description?
+      c.with_footer { footer.to_s } if footer?
+      content
+    end %>
+<%- else -%>
 <%= content_tag(:'lg-modal', **tag_options) do %>
   <%= content_tag(
         :dialog,
@@ -9,3 +19,4 @@
         class: 'modal__content',
       ) %>
 <% end %>
+<%- end -%>

--- a/app/components/modal_component.rb
+++ b/app/components/modal_component.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
 class ModalComponent < BaseComponent
-  attr_reader :tag_options
+  include NDSBucketResolvable
 
-  def initialize(**tag_options)
+  # NDS slot API, accepted additively. The legacy bucket ignores these slots
+  # and renders block content byte-identical to origin/main.
+  renders_one :trigger
+  renders_one :media
+  renders_one :title
+  renders_one :description
+  renders_one :footer
+
+  attr_reader :dismissible, :wide, :tag_options
+
+  # dismissible:/wide: are part of the NDS look and feel; the legacy bucket
+  # accepts them for API compatibility but never emits anything from them.
+  def initialize(dismissible: true, wide: false, **tag_options)
+    @dismissible = dismissible
+    @wide = wide
     @tag_options = tag_options
   end
 
@@ -23,5 +37,21 @@ class ModalComponent < BaseComponent
       ),
       &block
     )
+  end
+
+  private
+
+  # The NDS variant excluded from the render-time flip (see
+  # NDSBucketResolvable) so it renders its own markup instead of recursing.
+  def nds_variant_class
+    NDSModalComponent
+  end
+
+  def nds_delegate
+    delegate = NDSModalComponent.new(dismissible:, wide:, **tag_options)
+    # Share this component's id so the label_id/description_id the caller set on
+    # its own block content still match the delegate's aria references.
+    delegate.unique_id = unique_id
+    delegate
   end
 end

--- a/app/components/modal_component.rb
+++ b/app/components/modal_component.rb
@@ -4,7 +4,7 @@ class ModalComponent < BaseComponent
   include NDSBucketResolvable
 
   # NDS slot API, accepted additively. The legacy bucket ignores these slots
-  # and renders block content byte-identical to origin/main.
+  # and renders the same block-content markup as the default modal.
   renders_one :trigger
   renders_one :media
   renders_one :title

--- a/app/components/nds_modal_component.html.erb
+++ b/app/components/nds_modal_component.html.erb
@@ -1,0 +1,61 @@
+<%= content_tag(:'lg-modal', **tag_options.except(:class, :data, :id)) do %>
+  <% if trigger? %>
+    <%= render ButtonComponent.new(
+          type: :button,
+          data: { nds_modal_open: true },
+          aria: { controls: dialog_id, haspopup: 'dialog', expanded: false },
+        ).with_content(trigger) %>
+  <% end %>
+
+  <%= tag.dialog(
+        id: dialog_id,
+        class: nds_css_class,
+        data: nds_dialog_data,
+        aria: nds_dialog_aria,
+      ) do %>
+    <% if dismissible %>
+      <button
+        type="button"
+        class="modal__close"
+        aria-label="<%= t('doc_auth.buttons.close') %>"
+        data-nds-modal-close
+      >
+        <%= render IconComponent.new(icon: :close, size: 20) %>
+      </button>
+    <% end %>
+
+    <div class="<%= class_names(body_css_class) %>">
+      <% if media? %>
+        <div class="modal__media"><%= media %></div>
+        <div class="modal__body-inner">
+      <% end %>
+
+      <% if title? %>
+        <div class="modal__heading">
+          <h2 id="<%= title_id %>" class="modal__title"><%= title %></h2>
+          <% if description? %>
+            <div id="<%= nds_description_id %>" class="modal__description">
+              <%= description %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% if (body = content).present? %>
+        <div class="modal__content">
+          <%= body %>
+        </div>
+      <% end %>
+
+      <% if footer? %>
+        <div class="modal__actions">
+          <%= footer %>
+        </div>
+      <% end %>
+
+      <% if media? %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/nds_modal_component.rb
+++ b/app/components/nds_modal_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# NDS modal. Renders the .modal structure (dialog.modal inside the shared
+# lg-modal wrapper so the same JS drives it) with optional trigger/media/
+# title/description/footer slots. Instantiated by ModalComponent when a render
+# resolves to the NDS bucket; call sites always use ModalComponent directly.
+class NDSModalComponent < ModalComponent
+  attr_writer :unique_id
+
+  def dialog_id
+    tag_options[:id].presence || "modal-#{unique_id}"
+  end
+
+  def title_id
+    "#{dialog_id}-title"
+  end
+
+  def nds_description_id
+    "#{dialog_id}-description"
+  end
+
+  def nds_css_class
+    ['modal', ('modal--wide' if wide), *tag_options[:class]].compact
+  end
+
+  def body_css_class
+    ['modal__body', ('modal__body--media' if media?)].compact
+  end
+
+  def nds_dialog_aria
+    {
+      # Fall back to the legacy label_id/description_id so block-content sites
+      # (which set those ids on their own heading/description) stay labelled and
+      # described without title/description slots, matching legacy a11y.
+      labelledby: (title? ? title_id : label_id),
+      describedby: (description? ? nds_description_id : description_id),
+    }.compact
+  end
+
+  def nds_dialog_data
+    tag_options[:data].to_h.merge(
+      nds_modal: true,
+      nds_modal_dismissible: dismissible,
+    )
+  end
+end

--- a/spec/components/modal_component_spec.rb
+++ b/spec/components/modal_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ModalComponent, type: :component do
         allow_any_instance_of(ModalComponent).to receive(:nds_bucket?).and_return(false)
       end
 
-      it 'renders the origin/main lg-modal > dialog.modal__content block, no nds structure' do
+      it 'renders the default lg-modal > dialog.modal__content block, no nds structure' do
         rendered = render_inline(ModalComponent.new(wide: true, dismissible: false)) { 'Body' }
 
         expect(rendered).to have_css('lg-modal > dialog.modal__content', visible: false)
@@ -64,7 +64,7 @@ RSpec.describe ModalComponent, type: :component do
         expect(rendered).not_to have_css('dialog.modal')
       end
 
-      it 'ignores the nds slots and renders byte-identical to origin/main' do
+      it 'ignores the nds slots and renders the same markup as the default modal' do
         normalize = ->(html) { html.gsub(/[0-9a-f]{8}/, 'ID') }
 
         legacy = render_inline(ModalComponent.new) { 'Body' }.to_html
@@ -161,12 +161,15 @@ RSpec.describe ModalComponent, type: :component do
         expect(rendered).not_to have_css('.modal__title')
       end
 
-      it 'emits no prefixed ads- classes' do
+      it 'renders the modal structure classes' do
         rendered = render_inline(ModalComponent.new(wide: true)) do |c|
           c.with_title { 'T' }
           'Body'
         end
-        expect(rendered.to_html).not_to include('ads-')
+        expect(rendered).to have_css('dialog.modal.modal--wide', visible: false)
+        expect(rendered).to have_css('.modal__body', visible: false)
+        expect(rendered).to have_css('.modal__title', visible: false)
+        expect(rendered).to have_css('.modal__content', visible: false)
       end
     end
   end

--- a/spec/components/modal_component_spec.rb
+++ b/spec/components/modal_component_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.describe ModalComponent, type: :component do
   include ActionView::Helpers::TagHelper
 
+  let(:title_text) { 'The Title' }
+  let(:description_text) { 'The Description' }
+  let(:footer_text) { 'The Footer' }
+  let(:media_text) { 'MEDIA' }
+  let(:body_text) { 'Body' }
+  let(:heading_text) { 'Heading' }
+
   it 'renders modal element' do
     rendered = render_inline ModalComponent.new
 
@@ -12,8 +19,8 @@ RSpec.describe ModalComponent, type: :component do
   it 'renders label and description association' do
     rendered = render_inline ModalComponent.new do |c|
       safe_join [
-        content_tag(:h1, 'Heading', id: c.label_id),
-        content_tag(:p, 'Description', id: c.description_id),
+        content_tag(:h1, heading_text, id: c.label_id),
+        content_tag(:p, description_text, id: c.description_id),
       ]
     end
 
@@ -48,17 +55,17 @@ RSpec.describe ModalComponent, type: :component do
   end
 
   describe 'bucket-conditional rendering' do
-    context 'legacy bucket (nds_bucket? false)' do
+    context 'in the default bucket' do
       before do
         allow_any_instance_of(ModalComponent).to receive(:nds_bucket?).and_return(false)
       end
 
       it 'renders the default lg-modal > dialog.modal__content block, no nds structure' do
-        rendered = render_inline(ModalComponent.new(wide: true, dismissible: false)) { 'Body' }
+        rendered = render_inline(ModalComponent.new(wide: true, dismissible: false)) { body_text }
 
         expect(rendered).to have_css('lg-modal > dialog.modal__content', visible: false)
-        expect(rendered).to have_text('Body')
-        # nds params ignored in legacy
+        expect(rendered).to have_text(body_text)
+        # nds params ignored in the default bucket
         expect(rendered).not_to have_css('.modal--wide')
         expect(rendered).not_to have_css('.modal__close')
         expect(rendered).not_to have_css('dialog.modal')
@@ -67,109 +74,121 @@ RSpec.describe ModalComponent, type: :component do
       it 'ignores the nds slots and renders the same markup as the default modal' do
         normalize = ->(html) { html.gsub(/[0-9a-f]{8}/, 'ID') }
 
-        legacy = render_inline(ModalComponent.new) { 'Body' }.to_html
+        default_markup = render_inline(ModalComponent.new) { body_text }.to_html
 
         with_slots = render_inline(ModalComponent.new(wide: true, dismissible: false)) do |c|
-          c.with_title { 'The Title' }
-          c.with_footer { 'The Footer' }
-          'Body'
+          c.with_title { title_text }
+          c.with_footer { footer_text }
+          body_text
         end.to_html
 
-        expect(normalize.call(with_slots)).to eq(normalize.call(legacy))
+        expect(normalize.call(with_slots)).to eq(normalize.call(default_markup))
         expect(with_slots).not_to include('modal__title')
         expect(with_slots).not_to include('modal__actions')
       end
     end
 
-    context 'nds bucket (nds_bucket? true)' do
+    context 'in the nds bucket' do
       before do
         allow_any_instance_of(ModalComponent).to receive(:nds_bucket?).and_return(true)
       end
 
       it 'renders lg-modal > dialog.modal with a close button by default' do
-        rendered = render_inline(ModalComponent.new) { 'Body' }
+        rendered = render_inline(ModalComponent.new) { body_text }
 
         expect(rendered).to have_css('lg-modal > dialog.modal[data-nds-modal]', visible: false)
         expect(rendered).to have_css(
           'dialog.modal > button.modal__close[data-nds-modal-close]',
           visible: false,
         )
-        expect(rendered).to have_css('.modal__body .modal__content', text: 'Body', visible: false)
-      end
-
-      it 'omits the close button when dismissible: false' do
-        rendered = render_inline(ModalComponent.new(dismissible: false)) { 'Body' }
-        expect(rendered).not_to have_css('.modal__close')
         expect(rendered).to have_css(
-          'dialog.modal[data-nds-modal-dismissible="false"]',
-          visible: false,
+          '.modal__body .modal__content', text: body_text, visible: false
         )
-      end
-
-      it 'adds --wide when wide: true' do
-        rendered = render_inline(ModalComponent.new(wide: true)) { 'Body' }
-        expect(rendered).to have_css('dialog.modal.modal--wide', visible: false)
-      end
-
-      it 'renders title/description/footer slots into the nds structure' do
-        rendered = render_inline(ModalComponent.new) do |c|
-          c.with_title { 'The Title' }
-          c.with_description { 'The Description' }
-          c.with_footer { 'The Footer' }
-          'Body'
-        end
-
-        expect(rendered).to have_css(
-          '.modal__heading > h2.modal__title', text: 'The Title', visible: false
-        )
-        expect(rendered).to have_css('.modal__description', text: 'The Description', visible: false)
-        expect(rendered).to have_css('.modal__content', text: 'Body', visible: false)
-        expect(rendered).to have_css('.modal__actions', text: 'The Footer', visible: false)
-
-        dialog = rendered.css('dialog').first
-        title_id = rendered.css('.modal__title').first['id']
-        description_id = rendered.css('.modal__description').first['id']
-        expect(dialog['aria-labelledby']).to eq(title_id)
-        expect(dialog['aria-describedby']).to eq(description_id)
-      end
-
-      it 'renders the media slot with the media body modifier' do
-        rendered = render_inline(ModalComponent.new) do |c|
-          c.with_media { 'MEDIA' }
-          c.with_title { 'T' }
-          'Body'
-        end
-        expect(rendered).to have_css('.modal__body.modal__body--media', visible: false)
-        expect(rendered).to have_css('.modal__media', text: 'MEDIA', visible: false)
-        expect(rendered).to have_css('.modal__body-inner', visible: false)
-      end
-
-      it 'falls back to label_id/description_id for block-content sites without slots' do
-        # The 2 existing call sites use block content + c.label_id/c.description_id
-        # (no title/description slots); parity with legacy aria wiring.
-        rendered = render_inline(ModalComponent.new) do |c|
-          safe_join [
-            content_tag(:h2, 'Heading', id: c.label_id),
-            content_tag(:p, 'Description', id: c.description_id),
-          ]
-        end
-        dialog = rendered.css('dialog').first
-        heading_id = rendered.css('h2').first['id']
-        description_id = rendered.css('p').first['id']
-        expect(dialog['aria-labelledby']).to eq(heading_id)
-        expect(dialog['aria-describedby']).to eq(description_id)
-        expect(rendered).not_to have_css('.modal__title')
       end
 
       it 'renders the modal structure classes' do
         rendered = render_inline(ModalComponent.new(wide: true)) do |c|
-          c.with_title { 'T' }
-          'Body'
+          c.with_title { title_text }
+          body_text
         end
         expect(rendered).to have_css('dialog.modal.modal--wide', visible: false)
         expect(rendered).to have_css('.modal__body', visible: false)
         expect(rendered).to have_css('.modal__title', visible: false)
         expect(rendered).to have_css('.modal__content', visible: false)
+      end
+
+      context 'when dismissible: false' do
+        it 'omits the close button' do
+          rendered = render_inline(ModalComponent.new(dismissible: false)) { body_text }
+          expect(rendered).not_to have_css('.modal__close')
+          expect(rendered).to have_css(
+            'dialog.modal[data-nds-modal-dismissible="false"]',
+            visible: false,
+          )
+        end
+      end
+
+      context 'when wide: true' do
+        it 'adds the --wide modifier' do
+          rendered = render_inline(ModalComponent.new(wide: true)) { body_text }
+          expect(rendered).to have_css('dialog.modal.modal--wide', visible: false)
+        end
+      end
+
+      context 'without slots' do
+        it 'falls back to label_id/description_id for block-content sites' do
+          # The 2 existing call sites use block content + c.label_id/c.description_id
+          # (no title/description slots); parity with the default modal aria wiring.
+          rendered = render_inline(ModalComponent.new) do |c|
+            safe_join [
+              content_tag(:h2, heading_text, id: c.label_id),
+              content_tag(:p, description_text, id: c.description_id),
+            ]
+          end
+          dialog = rendered.css('dialog').first
+          heading_id = rendered.css('h2').first['id']
+          description_id = rendered.css('p').first['id']
+          expect(dialog['aria-labelledby']).to eq(heading_id)
+          expect(dialog['aria-describedby']).to eq(description_id)
+          expect(rendered).not_to have_css('.modal__title')
+        end
+      end
+
+      describe 'slots' do
+        it 'renders title/description/footer slots into the nds structure' do
+          rendered = render_inline(ModalComponent.new) do |c|
+            c.with_title { title_text }
+            c.with_description { description_text }
+            c.with_footer { footer_text }
+            body_text
+          end
+
+          expect(rendered).to have_css(
+            '.modal__heading > h2.modal__title', text: title_text, visible: false
+          )
+          expect(rendered).to have_css(
+            '.modal__description', text: description_text, visible: false
+          )
+          expect(rendered).to have_css('.modal__content', text: body_text, visible: false)
+          expect(rendered).to have_css('.modal__actions', text: footer_text, visible: false)
+
+          dialog = rendered.css('dialog').first
+          title_id = rendered.css('.modal__title').first['id']
+          description_id = rendered.css('.modal__description').first['id']
+          expect(dialog['aria-labelledby']).to eq(title_id)
+          expect(dialog['aria-describedby']).to eq(description_id)
+        end
+
+        it 'renders the media slot with the media body modifier' do
+          rendered = render_inline(ModalComponent.new) do |c|
+            c.with_media { media_text }
+            c.with_title { title_text }
+            body_text
+          end
+          expect(rendered).to have_css('.modal__body.modal__body--media', visible: false)
+          expect(rendered).to have_css('.modal__media', text: media_text, visible: false)
+          expect(rendered).to have_css('.modal__body-inner', visible: false)
+        end
       end
     end
   end

--- a/spec/components/modal_component_spec.rb
+++ b/spec/components/modal_component_spec.rb
@@ -46,4 +46,128 @@ RSpec.describe ModalComponent, type: :component do
       expect(rendered).to have_css('lg-modal.example[data-foo="bar"]', visible: false)
     end
   end
+
+  describe 'bucket-conditional rendering' do
+    context 'legacy bucket (nds_bucket? false)' do
+      before do
+        allow_any_instance_of(ModalComponent).to receive(:nds_bucket?).and_return(false)
+      end
+
+      it 'renders the origin/main lg-modal > dialog.modal__content block, no nds structure' do
+        rendered = render_inline(ModalComponent.new(wide: true, dismissible: false)) { 'Body' }
+
+        expect(rendered).to have_css('lg-modal > dialog.modal__content', visible: false)
+        expect(rendered).to have_text('Body')
+        # nds params ignored in legacy
+        expect(rendered).not_to have_css('.modal--wide')
+        expect(rendered).not_to have_css('.modal__close')
+        expect(rendered).not_to have_css('dialog.modal')
+      end
+
+      it 'ignores the nds slots and renders byte-identical to origin/main' do
+        normalize = ->(html) { html.gsub(/[0-9a-f]{8}/, 'ID') }
+
+        legacy = render_inline(ModalComponent.new) { 'Body' }.to_html
+
+        with_slots = render_inline(ModalComponent.new(wide: true, dismissible: false)) do |c|
+          c.with_title { 'The Title' }
+          c.with_footer { 'The Footer' }
+          'Body'
+        end.to_html
+
+        expect(normalize.call(with_slots)).to eq(normalize.call(legacy))
+        expect(with_slots).not_to include('modal__title')
+        expect(with_slots).not_to include('modal__actions')
+      end
+    end
+
+    context 'nds bucket (nds_bucket? true)' do
+      before do
+        allow_any_instance_of(ModalComponent).to receive(:nds_bucket?).and_return(true)
+      end
+
+      it 'renders lg-modal > dialog.modal with a close button by default' do
+        rendered = render_inline(ModalComponent.new) { 'Body' }
+
+        expect(rendered).to have_css('lg-modal > dialog.modal[data-nds-modal]', visible: false)
+        expect(rendered).to have_css(
+          'dialog.modal > button.modal__close[data-nds-modal-close]',
+          visible: false,
+        )
+        expect(rendered).to have_css('.modal__body .modal__content', text: 'Body', visible: false)
+      end
+
+      it 'omits the close button when dismissible: false' do
+        rendered = render_inline(ModalComponent.new(dismissible: false)) { 'Body' }
+        expect(rendered).not_to have_css('.modal__close')
+        expect(rendered).to have_css(
+          'dialog.modal[data-nds-modal-dismissible="false"]',
+          visible: false,
+        )
+      end
+
+      it 'adds --wide when wide: true' do
+        rendered = render_inline(ModalComponent.new(wide: true)) { 'Body' }
+        expect(rendered).to have_css('dialog.modal.modal--wide', visible: false)
+      end
+
+      it 'renders title/description/footer slots into the nds structure' do
+        rendered = render_inline(ModalComponent.new) do |c|
+          c.with_title { 'The Title' }
+          c.with_description { 'The Description' }
+          c.with_footer { 'The Footer' }
+          'Body'
+        end
+
+        expect(rendered).to have_css(
+          '.modal__heading > h2.modal__title', text: 'The Title', visible: false
+        )
+        expect(rendered).to have_css('.modal__description', text: 'The Description', visible: false)
+        expect(rendered).to have_css('.modal__content', text: 'Body', visible: false)
+        expect(rendered).to have_css('.modal__actions', text: 'The Footer', visible: false)
+
+        dialog = rendered.css('dialog').first
+        title_id = rendered.css('.modal__title').first['id']
+        description_id = rendered.css('.modal__description').first['id']
+        expect(dialog['aria-labelledby']).to eq(title_id)
+        expect(dialog['aria-describedby']).to eq(description_id)
+      end
+
+      it 'renders the media slot with the media body modifier' do
+        rendered = render_inline(ModalComponent.new) do |c|
+          c.with_media { 'MEDIA' }
+          c.with_title { 'T' }
+          'Body'
+        end
+        expect(rendered).to have_css('.modal__body.modal__body--media', visible: false)
+        expect(rendered).to have_css('.modal__media', text: 'MEDIA', visible: false)
+        expect(rendered).to have_css('.modal__body-inner', visible: false)
+      end
+
+      it 'falls back to label_id/description_id for block-content sites without slots' do
+        # The 2 existing call sites use block content + c.label_id/c.description_id
+        # (no title/description slots); parity with legacy aria wiring.
+        rendered = render_inline(ModalComponent.new) do |c|
+          safe_join [
+            content_tag(:h2, 'Heading', id: c.label_id),
+            content_tag(:p, 'Description', id: c.description_id),
+          ]
+        end
+        dialog = rendered.css('dialog').first
+        heading_id = rendered.css('h2').first['id']
+        description_id = rendered.css('p').first['id']
+        expect(dialog['aria-labelledby']).to eq(heading_id)
+        expect(dialog['aria-describedby']).to eq(description_id)
+        expect(rendered).not_to have_css('.modal__title')
+      end
+
+      it 'emits no prefixed ads- classes' do
+        rendered = render_inline(ModalComponent.new(wide: true)) do |c|
+          c.with_title { 'T' }
+          'Body'
+        end
+        expect(rendered.to_html).not_to include('ads-')
+      end
+    end
+  end
 end

--- a/spec/components/previews/modal_component_preview.rb
+++ b/spec/components/previews/modal_component_preview.rb
@@ -1,0 +1,82 @@
+class ModalComponentPreview < BaseComponentPreview
+  include ActionView::Context
+  include ActionView::Helpers::TagHelper
+
+  # ModalComponent renders the default modal by default. Add ?ui_test_bucket=nds
+  # to the preview URL to load the NDS layout and see the NDS `.modal` structure
+  # (`dialog.modal` with the close button, heading, and action slots); without
+  # it the preview shows the default `lg-modal > dialog.modal__content` markup.
+
+  # @!group Preview
+  def default
+    render(ModalComponent.new) do |c|
+      heading_and_body(c)
+    end
+  end
+
+  def non_dismissible
+    render(ModalComponent.new(dismissible: false)) do |c|
+      heading_and_body(c)
+    end
+  end
+
+  def wide
+    render(ModalComponent.new(wide: true)) do |c|
+      heading_and_body(c)
+    end
+  end
+
+  def with_slots
+    render(ModalComponent.new) do |c|
+      c.with_title { 'Modal title' }
+      c.with_description { 'A short supporting description for the modal.' }
+      c.with_footer { 'Footer actions go here' }
+      'Modal body content.'
+    end
+  end
+
+  def with_media
+    render(ModalComponent.new) do |c|
+      c.with_media { 'Media area' }
+      c.with_title { 'Modal title' }
+      'Modal body content.'
+    end
+  end
+  # @!endgroup
+
+  # @param title text
+  # @param description text
+  # @param footer text
+  # @param body text
+  # @param dismissible toggle
+  # @param wide toggle
+  def workbench(
+    title: 'Modal title',
+    description: 'A short supporting description for the modal.',
+    footer: 'Footer actions go here',
+    body: 'Modal body content.',
+    dismissible: true,
+    wide: false
+  )
+    render(ModalComponent.new(dismissible:, wide:)) do |c|
+      c.with_title { title } if title.present?
+      c.with_description { description } if description.present?
+      c.with_footer { footer } if footer.present?
+      body
+    end
+  end
+
+  private
+
+  # The default modal has no title slot; its callers set label_id/description_id
+  # on their own heading. This mirrors that so the preview reads sensibly in
+  # both buckets.
+  def heading_and_body(component)
+    safe_join(
+      [
+        content_tag(:h2, 'Modal title', id: component.label_id),
+        content_tag(:p, 'Modal body content.', id: component.description_id),
+      ],
+    )
+  end
+end


### PR DESCRIPTION
## Ticket
[Modals ticket](https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/32)

## Summary

- Adds `NDSModalComponent`, an NDS `.modal` variant of `ModalComponent`, following the merged subclass pattern (#13393) and the shared `NDSBucketResolvable` concern (per `NDS_LOOK_AND_FEEL`). Legacy markup is unchanged; in the NDS bucket the base delegates to the subclass, which renders the `.modal` dialog structure with title/description/footer/media slots inside the same `lg-modal` wrapper.
- Component-only, no call-site changes: existing block-content call sites keep working via `label_id`/`description_id` fallbacks for `aria-labelledby`/`aria-describedby`, preserving the existing accessibility associations. Call-site adoption (and the session-timeout `dismissible: false` change) are deferred to follow-ups.

## Test plan

- [ ] `bundle exec rspec spec/components/modal_component_spec.rb` (default-bucket + NDS-bucket examples)
- [ ] `bundle exec rubocop` clean
- [ ] `bundle exec erb_lint app/views app/components` clean