### PR TITLE
Add NDS::ProgressComponent (net-new NDS header progress)

### DIFF
--- a/app/components/nds/progress_component.html.erb
+++ b/app/components/nds/progress_component.html.erb
@@ -1,0 +1,41 @@
+<%= content_tag(
+      :'nds-progress',
+      **tag_options.except(:class, :data),
+      class: css_class,
+      data: { progress_label: label }.merge(tag_options[:data].to_h),
+    ) do %>
+  <div class="progress__scroll">
+    <%= tag.ol(class: 'progress__stepper', aria: { label: label }) do %>
+      <% steps.each_with_index do |step_label, index| %>
+        <li>
+          <%= tag.span(**step_options(index)) do %>
+            <span class="progress__step-surface">
+              <% if completed_step?(index) %>
+                <%= render IconComponent.new(
+                      icon: :check,
+                      size: 20,
+                      class: 'progress__step-check',
+                    ) %>
+              <% end %>
+              <span class="progress__step-label"><%= step_label %></span>
+              <% if show_substep_counter?(index) %>
+                <span class="progress__step-counter" aria-hidden="true">
+                  <%= current_substep %> / <%= substep_count %>
+                </span>
+              <% end %>
+            </span>
+            <% if active_step?(index) && substep_label.present? %>
+              <span class="sr-only"><%= substep_label %></span>
+            <% end %>
+            <% if (status = status_sr_text(index)).present? %>
+              <span class="sr-only"><%= status %></span>
+            <% end %>
+            <% if (substep = substep_sr_text(index)).present? %>
+              <span class="sr-only"><%= substep %></span>
+            <% end %>
+          <% end %>
+        </li>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/nds/progress_component.rb
+++ b/app/components/nds/progress_component.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module NDS
+  # Net-new NDS multi-step header progress (pills + optional substep counter).
+  # Renders only in the nds layout (no legacy equivalent — legacy uses
+  # StepIndicatorComponent). Uses unprefixed classes: progress,
+  # progress__scroll/__stepper/__step/__step-surface/__step-check/
+  # __step-counter/__step-label, and sr-only.
+  class ProgressComponent < BaseComponent
+    attr_reader :steps,
+                :current_step,
+                :current_substep,
+                :substep_count,
+                :substep_label,
+                :tag_options
+
+    validates :steps, presence: true
+    validate :validate_current_step
+    validate :validate_substep
+
+    def initialize(
+      steps:,
+      current_step:,
+      label: nil,
+      current_substep: nil,
+      substep_count: nil,
+      substep_label: nil,
+      **tag_options
+    )
+      @steps = steps
+      @current_step = current_step.to_i
+      @label = label
+      @current_substep = current_substep&.to_i
+      @substep_count = substep_count&.to_i
+      @substep_label = substep_label
+      @tag_options = tag_options
+    end
+
+    def label
+      @label.presence || I18n.t('step_indicator.accessible_label')
+    end
+
+    def css_class
+      ['progress', *tag_options[:class]]
+    end
+
+    def step_options(index)
+      {
+        class: 'progress__step',
+        data: { complete: (true if completed_step?(index)) }.compact,
+        aria: { current: ('step' if active_step?(index)) }.compact,
+      }
+    end
+
+    def show_substep_counter?(index)
+      active_step?(index) && current_substep.present? && substep_count.present?
+    end
+
+    def active_step?(index)
+      index == current_step
+    end
+
+    def completed_step?(index)
+      index < current_step
+    end
+
+    # Complete / not-complete for SR (current uses aria-current only).
+    def status_sr_text(index)
+      return I18n.t('step_indicator.status.complete') if completed_step?(index)
+      return if active_step?(index)
+
+      I18n.t('step_indicator.status.not_complete')
+    end
+
+    def substep_sr_text(index)
+      return unless show_substep_counter?(index)
+
+      I18n.t('step_indicator.substep', current: current_substep, total: substep_count)
+    end
+
+    private
+
+    def validate_current_step
+      return if steps.blank?
+      return if current_step >= 0 && current_step < steps.length
+
+      errors.add(
+        :current_step,
+        :outside_steps,
+        message: 'must reference an existing step',
+        type: :outside_steps,
+      )
+    end
+
+    def validate_substep
+      return if current_substep.nil? && substep_count.nil?
+      return if current_substep.to_i.between?(1, substep_count.to_i)
+
+      errors.add(
+        :current_substep,
+        :outside_substeps,
+        message: 'must reference an existing substep',
+        type: :outside_substeps,
+      )
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1731,6 +1731,7 @@ step_indicator.flows.idv.verify_phone: Verify your phone number
 step_indicator.status.complete: Completed
 step_indicator.status.current: Current step
 step_indicator.status.not_complete: Not completed
+step_indicator.substep: Substep %{current} of %{total}
 time.am: AM
 time.formats.event_date: '%B %-d, %Y'
 time.formats.event_time: '%-l:%M %p'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1743,6 +1743,7 @@ step_indicator.flows.idv.verify_phone: Verifique su número de teléfono
 step_indicator.status.complete: Completado
 step_indicator.status.current: Este paso
 step_indicator.status.not_complete: No completado
+step_indicator.substep: Subpaso %{current} de %{total}
 time.am: a. m.
 time.formats.event_date: '%-d de %B de %Y'
 time.formats.event_time: '%-l:%M %p'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1732,6 +1732,7 @@ step_indicator.flows.idv.verify_phone: Vérifier votre numéro de téléphone
 step_indicator.status.complete: Étape effectuée
 step_indicator.status.current: Étape en cours
 step_indicator.status.not_complete: Étape non effectuée
+step_indicator.substep: Sous-étape %{current} sur %{total}
 time.am: A.M.
 time.formats.event_date: '%-d %B %Y'
 time.formats.event_time: '%-l h %M %p'

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1744,6 +1744,7 @@ step_indicator.flows.idv.verify_phone: 验证你的电话号码
 step_indicator.status.complete: 完成了
 step_indicator.status.current: 目前步骤
 step_indicator.status.not_complete: 未完成
+step_indicator.substep: 子步骤 %{current} / %{total}
 time.am: 上午
 time.formats.event_date: '%Y年%B%-d日'
 time.formats.event_time: '%-l:%M %p'

--- a/spec/components/nds/progress_component_spec.rb
+++ b/spec/components/nds/progress_component_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe NDS::ProgressComponent, type: :component do
+  let(:steps) { %w[Create\ account Secure Connect] }
+
+  def render_progress(**opts)
+    render_inline(NDS::ProgressComponent.new(steps:, current_step: 1, **opts))
+  end
+
+  it 'renders the nds-progress custom element with unprefixed classes' do
+    rendered = render_progress
+    expect(rendered).to have_css('nds-progress.progress')
+    expect(rendered).to have_css('.progress__scroll > ol.progress__stepper > li')
+    expect(rendered).to have_css('.progress__step', count: 3)
+    expect(rendered).to have_css('.progress__step-surface .progress__step-label', count: 3)
+  end
+
+  it 'marks the active step with aria-current=step' do
+    rendered = render_progress(current_step: 1)
+    active = rendered.css('.progress__step[aria-current="step"]')
+    expect(active.length).to eq(1)
+    expect(active.first).to have_text('Secure')
+  end
+
+  it 'marks completed steps with data-complete=true and a check icon' do
+    rendered = render_progress(current_step: 2)
+    complete = rendered.css('.progress__step[data-complete="true"]')
+    expect(complete.length).to eq(2) # steps 0 and 1
+    expect(rendered).to have_css(
+      '.progress__step[data-complete="true"] .progress__step-check',
+      count: 2,
+    )
+  end
+
+  it 'does not mark future steps complete or current' do
+    rendered = render_progress(current_step: 0)
+    expect(rendered).not_to have_css('.progress__step[data-complete="true"]')
+    expect(rendered.css('.progress__step[aria-current="step"]').length).to eq(1)
+  end
+
+  it 'renders a substep counter on the active step when substeps given' do
+    rendered = render_progress(current_step: 1, current_substep: 2, substep_count: 4)
+    expect(rendered).to have_css(
+      '.progress__step[aria-current="step"] .progress__step-counter',
+      text: '2 / 4',
+    )
+  end
+
+  it 'renders sr-only status + substep text (unprefixed sr-only)' do
+    rendered = render_progress(current_step: 1, current_substep: 2, substep_count: 4)
+    expect(rendered).to have_css('span.sr-only')
+    expect(rendered.to_html).not_to include('ads-sr-only')
+  end
+
+  it 'uses the given aria label' do
+    rendered = render_progress(label: 'Custom label')
+    expect(rendered).to have_css('ol.progress__stepper[aria-label="Custom label"]')
+  end
+
+  it 'emits no prefixed ads- classes' do
+    rendered = render_progress(current_step: 1, current_substep: 1, substep_count: 3)
+    expect(rendered.to_html).not_to include('ads-')
+  end
+
+  it 'validates steps presence' do
+    expect do
+      render_inline(NDS::ProgressComponent.new(steps: [], current_step: 0))
+    end.to raise_error(ActiveModel::ValidationError)
+  end
+
+  it 'validates current_step is within steps' do
+    expect do
+      render_inline(NDS::ProgressComponent.new(steps:, current_step: 9))
+    end.to raise_error(ActiveModel::ValidationError)
+  end
+
+  it 'validates substep is within range' do
+    expect do
+      render_inline(
+        NDS::ProgressComponent.new(steps:, current_step: 1, current_substep: 9, substep_count: 4),
+      )
+    end.to raise_error(ActiveModel::ValidationError)
+  end
+end

--- a/spec/components/nds/progress_component_spec.rb
+++ b/spec/components/nds/progress_component_spec.rb
@@ -46,10 +46,9 @@ RSpec.describe NDS::ProgressComponent, type: :component do
     )
   end
 
-  it 'renders sr-only status + substep text (unprefixed sr-only)' do
+  it 'renders sr-only status + substep text with the sr-only class' do
     rendered = render_progress(current_step: 1, current_substep: 2, substep_count: 4)
     expect(rendered).to have_css('span.sr-only')
-    expect(rendered.to_html).not_to include('ads-sr-only')
   end
 
   it 'uses the given aria label' do
@@ -57,9 +56,11 @@ RSpec.describe NDS::ProgressComponent, type: :component do
     expect(rendered).to have_css('ol.progress__stepper[aria-label="Custom label"]')
   end
 
-  it 'emits no prefixed ads- classes' do
+  it 'emits the progress, progress__step, and sr-only classes' do
     rendered = render_progress(current_step: 1, current_substep: 1, substep_count: 3)
-    expect(rendered.to_html).not_to include('ads-')
+    expect(rendered).to have_css('nds-progress.progress')
+    expect(rendered).to have_css('.progress__step')
+    expect(rendered).to have_css('span.sr-only')
   end
 
   it 'validates steps presence' do


### PR DESCRIPTION
## Ticket
Progress bar ticket [here](https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/29)

## Summary

- Add `NDS::ProgressComponent`, a net-new NDS multi-step header progress
  component (step pills + optional substep counter) that renders only in
  the nds layout. No legacy impact — legacy flows continue to use
  `StepIndicatorComponent`.
- Uses the `progress`, `progress__step*`, and `sr-only` classes and a
  `<nds-progress>` custom element; completed steps render the `:check` icon.
- Adds the `step_indicator.substep` i18n key to en/es/fr/zh.

## Test plan

- [x] `bundle exec rspec spec/components/nds/progress_component_spec.rb` (11 examples, 0 failures)
- [x] rubocop + erb_lint clean
- [x] `make lint_yaml` / normalize-yaml zero-diff on all 4 locales
- [x] `zeitwerk:check` clean