### PR TITLE
Render NDS progress in StepIndicatorComponent for the nds bucket

### DIFF
--- a/app/components/nds_step_indicator_component.html.erb
+++ b/app/components/nds_step_indicator_component.html.erb
@@ -1,0 +1,1 @@
+<%= render progress_component %>

--- a/app/components/nds_step_indicator_component.rb
+++ b/app/components/nds_step_indicator_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# NDS step indicator. In the nds bucket this renders NDS::ProgressComponent
+# (the pill stepper) in place of the legacy lg-step-indicator dots.
+# Instantiated by StepIndicatorComponent when a render resolves to the nds
+# bucket; call sites always use StepIndicatorComponent directly.
+#
+# Steps map 1:1 to progress pills: each step's localized title becomes a pill
+# label and current_step's name resolves to the active pill index. Placement
+# is in-body at the step indicator's spot.
+class NDSStepIndicatorComponent < StepIndicatorComponent
+  def progress_component
+    NDS::ProgressComponent.new(
+      steps: step_titles,
+      current_step: current_step_index,
+      label: t('step_indicator.accessible_label'),
+      **tag_options,
+    )
+  end
+end

--- a/app/components/nds_step_indicator_component.rb
+++ b/app/components/nds_step_indicator_component.rb
@@ -17,4 +17,14 @@ class NDSStepIndicatorComponent < StepIndicatorComponent
       **tag_options,
     )
   end
+
+  private
+
+  def step_titles
+    @steps.map { |step| step_title(step) }
+  end
+
+  def current_step_index
+    @steps.index { |step| step[:name] == current_step } || 0
+  end
 end

--- a/app/components/step_indicator_component.html.erb
+++ b/app/components/step_indicator_component.html.erb
@@ -1,3 +1,6 @@
+<%- if render_as_nds? -%>
+<%= render nds_delegate %>
+<%- else -%>
 <%= content_tag(
       :'lg-step-indicator',
       role: 'region',
@@ -10,3 +13,4 @@
     <% end %>
   </ol>
 <% end %>
+<%- end -%>

--- a/app/components/step_indicator_component.rb
+++ b/app/components/step_indicator_component.rb
@@ -20,14 +20,6 @@ class StepIndicatorComponent < BaseComponent
     @steps.map { |step| { status: step_status(step), title: step_title(step) }.merge(step) }
   end
 
-  def step_titles
-    @steps.map { |step| step_title(step) }
-  end
-
-  def current_step_index
-    @steps.index { |step| step[:name] == current_step } || 0
-  end
-
   private
 
   def nds_delegate

--- a/app/components/step_indicator_component.rb
+++ b/app/components/step_indicator_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class StepIndicatorComponent < BaseComponent
+  include NDSBucketResolvable
+
   attr_reader :current_step, :locale_scope, :tag_options
 
   def initialize(steps:, current_step:, locale_scope: nil, **tag_options)
@@ -18,7 +20,30 @@ class StepIndicatorComponent < BaseComponent
     @steps.map { |step| { status: step_status(step), title: step_title(step) }.merge(step) }
   end
 
+  def step_titles
+    @steps.map { |step| step_title(step) }
+  end
+
+  def current_step_index
+    @steps.index { |step| step[:name] == current_step } || 0
+  end
+
   private
+
+  def nds_delegate
+    nds_variant_class.new(
+      steps: @steps,
+      current_step:,
+      locale_scope:,
+      **tag_options,
+    )
+  end
+
+  # The NDS variant excluded from the render-time flip (see
+  # NDSBucketResolvable) so it renders its own markup instead of recursing.
+  def nds_variant_class
+    NDSStepIndicatorComponent
+  end
 
   def step_status(step)
     if step[:name] == current_step

--- a/spec/components/step_indicator_component_spec.rb
+++ b/spec/components/step_indicator_component_spec.rb
@@ -145,4 +145,47 @@ RSpec.describe StepIndicatorComponent, type: :component do
       expect(rendered).not_to have_css('.step-indicator__step--current')
     end
   end
+
+  describe 'bucket-conditional rendering' do
+    context 'in the legacy bucket' do
+      it 'renders the lg-step-indicator dots' do
+        expect(rendered).to have_css('lg-step-indicator.step-indicator')
+        expect(rendered).to have_css('.step-indicator__scroller .step-indicator__step')
+        expect(rendered).not_to have_css('nds-progress')
+      end
+    end
+
+    context 'in the nds bucket' do
+      before do
+        allow_any_instance_of(StepIndicatorComponent).to receive(:nds_bucket?).and_return(true)
+      end
+
+      it 'renders NDS::ProgressComponent in place of the dots' do
+        expect(rendered).to have_css('nds-progress.progress')
+        expect(rendered).to have_css('.progress__stepper .progress__step', count: 3)
+        expect(rendered).not_to have_css('lg-step-indicator')
+        expect(rendered).not_to have_css('.step-indicator__scroller')
+      end
+
+      it 'maps localized step titles to progress pills' do
+        expect(rendered).to have_css('.progress__step-label', text: 'One')
+        expect(rendered).to have_css('.progress__step-label', text: 'Two')
+        expect(rendered).to have_css('.progress__step-label', text: 'Three')
+      end
+
+      it 'maps the current step name to the active pill' do
+        active = rendered.css('.progress__step[aria-current="step"]')
+        expect(active.length).to eq(1)
+        expect(active.first).to have_text('One')
+      end
+
+      context 'with a later current step' do
+        let(:current_step) { :three }
+
+        it 'marks preceding pills complete' do
+          expect(rendered.css('.progress__step[data-complete="true"]').length).to eq(2)
+        end
+      end
+    end
+  end
 end

--- a/spec/views/idv/how_to_verify/show.html.erb_spec.rb
+++ b/spec/views/idv/how_to_verify/show.html.erb_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe 'idv/how_to_verify/show.html.erb' do
       )
     end
 
+    context 'in the nds bucket' do
+      before { allow(view).to receive(:nds_layout?).and_return(true) }
+
+      it 'renders the NDS progress pill in place of the step indicator dots' do
+        render
+        pre_flash = view.content_for(:pre_flash_content)
+        expect(pre_flash).to have_css('nds-progress.progress')
+        expect(pre_flash).to have_css(
+          '.progress__step[aria-current="step"]',
+          text: t('step_indicator.flows.idv.getting_started'),
+        )
+        expect(pre_flash).not_to have_css('.step-indicator__scroller')
+      end
+    end
+
     it 'renders a title' do
       render
       expect(rendered).to have_content(t('doc_auth.headings.how_to_verify'))


### PR DESCRIPTION
## Ticket
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/29

## Summary

- Makes `StepIndicatorComponent` bucket-conditional using the shared `NDSBucketResolvable` concern (same pattern as Badge, Alert, Button, and Modal). The legacy bucket renders the existing `lg-step-indicator` dots unchanged; the nds bucket renders `NDS::ProgressComponent` in place of the dots via a new `NDSStepIndicatorComponent`.
- Maps each step's localized title to a progress pill label and the current step name to the active pill index. Call sites are unchanged.
- Stacked on #13420 (adds `NDS::ProgressComponent`); this branch targets `nds-progress-component` and will retarget to `main` once #13420 merges.
- Gated by the `NDS_LOOK_AND_FEEL` A/B bucket: legacy output is unchanged; the pill only renders in the nds layout.

## Test plan

- [ ] `bundle exec rspec spec/components/step_indicator_component_spec.rb` (legacy + nds bucket)
- [ ] `bundle exec rspec spec/views/idv/how_to_verify/show.html.erb_spec.rb`
- [ ] Legacy step indicator output is unchanged in the legacy bucket