### PR TITLE
Remove unexpected button parameter from SAML requests

### DIFF
--- a/app/views/shared/saml_post_form.html.erb
+++ b/app/views/shared/saml_post_form.html.erb
@@ -14,7 +14,7 @@
           <% form_params.each do |key, val| %>
             <%= hidden_field_tag(key, val) %>
           <% end %>
-          <%= f.submit t('forms.buttons.submit.default'), data: { click_immediate: '' } %>
+          <%= f.submit t('forms.buttons.submit.default'), name: nil, data: { click_immediate: '' } %>
         <% end %>
       </div>
     </div>

--- a/spec/controllers/saml_completion_controller_spec.rb
+++ b/spec/controllers/saml_completion_controller_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe SamlCompletionController do
         expect(response.body).to match(hidden_field_tag('SigAlg', sig_alg))
         expect(response.body).to match(hidden_field_tag('Signature', signature))
       end
+
+      it 'does not name the submit button' do
+        get :index, params: { path_year: path_year }
+
+        expect(response.body).not_to include('name="button"')
+      end
     end
 
     context 'with a blank service provider request session' do


### PR DESCRIPTION
## 🎫 Ticket

[SECURE-PROTOCOLS-17](https://gsa-standard.atlassian-us-gov-mod.net/browse/SECURE-PROTOCOLS-17)

## 🛠 Summary of changes

- Remove the submit button name from the shared SAML POST form so browsers do not add an unexpected `button` parameter to the final authentication request.
- Add a focused regression test for the final SAML authentication form.

## 📜 Testing Plan

- [x] `bundle exec rspec spec/controllers/saml_completion_controller_spec.rb spec/controllers/saml_post_controller_spec.rb`
- [x] `bundle exec rubocop spec/controllers/saml_completion_controller_spec.rb`
- [x] `bundle exec erb_lint app/views/shared/saml_post_form.html.erb`