### PR TITLE
Add NDS::ToastComponent and lg-toast custom element

### DIFF
--- a/app/components/nds/toast_component.html.erb
+++ b/app/components/nds/toast_component.html.erb
@@ -1,0 +1,18 @@
+<%= content_tag(
+      :'lg-toast',
+      **tag_options.except(:class, :data),
+      class: css_class,
+      data: {
+        open: 'false',
+        show_delay:,
+        dismiss_after:,
+        **tag_options.fetch(:data, {}),
+      },
+    ) do %>
+  <div class="toast__announcement" data-nds-toast-announcement>
+    <span class="toast__icon" aria-hidden="true">
+      <%= render IconComponent.new(icon: :check, size: 16) %>
+    </span>
+    <p class="toast__text"><%= content %></p>
+  </div>
+<% end %>

--- a/app/components/nds/toast_component.rb
+++ b/app/components/nds/toast_component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module NDS
+  # Net-new NDS toast; renders only in the NDS bucket. Emits an
+  # <lg-toast class="toast"> announcement with a check icon and message text.
+  class ToastComponent < BaseComponent
+    DEFAULT_SHOW_DELAY_MS = 500
+    DEFAULT_DISMISS_AFTER_MS = 3000
+
+    attr_reader :message, :show_delay, :dismiss_after, :tag_options
+
+    def initialize(
+      message: nil,
+      show_delay: DEFAULT_SHOW_DELAY_MS,
+      dismiss_after: DEFAULT_DISMISS_AFTER_MS,
+      **tag_options
+    )
+      @message = message
+      @show_delay = show_delay
+      @dismiss_after = dismiss_after
+      @tag_options = tag_options
+    end
+
+    def content
+      @message || super
+    end
+
+    def css_class
+      ['toast', *tag_options[:class]]
+    end
+  end
+end

--- a/app/components/nds/toast_component.ts
+++ b/app/components/nds/toast_component.ts
@@ -1,0 +1,1 @@
+import '@18f/identity-nds-toast/toast-element';

--- a/app/javascript/packages/nds-toast/README.md
+++ b/app/javascript/packages/nds-toast/README.md
@@ -1,0 +1,29 @@
+# `@18f/identity-nds-toast`
+
+Custom element for the NDS toast notification.
+
+## Usage
+
+Importing the element will register the `<lg-toast>` custom element:
+
+```ts
+import '@18f/identity-nds-toast/toast-element';
+```
+
+The custom element implements the toast behavior, but all markup must already
+exist. Rendering is typically handled by `NDS::ToastComponent`.
+
+```html
+<lg-toast class="toast" data-open="false" data-show-delay="500" data-dismiss-after="3000">
+  <div class="toast__announcement" data-nds-toast-announcement>
+    <span class="toast__icon" aria-hidden="true"><!-- icon --></span>
+    <p class="toast__text">Your changes were saved.</p>
+  </div>
+</lg-toast>
+```
+
+After `data-show-delay` milliseconds the element reveals the toast, marks the
+announcement region live, and (when `data-dismiss-after` is greater than zero)
+schedules an automatic dismissal that many milliseconds later. Clicking the
+toast dismisses it immediately. The dismissal animation is skipped when the
+user prefers reduced motion.

--- a/app/javascript/packages/nds-toast/package.json
+++ b/app/javascript/packages/nds-toast/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@18f/identity-nds-toast",
+  "version": "1.0.0",
+  "private": true,
+  "sideEffects": [
+    "./toast-element.ts"
+  ]
+}

--- a/app/javascript/packages/nds-toast/toast-element.spec.ts
+++ b/app/javascript/packages/nds-toast/toast-element.spec.ts
@@ -1,0 +1,77 @@
+import sinon from 'sinon';
+import './toast-element';
+
+describe('NDS ToastElement', () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+    document.body.innerHTML = '';
+  });
+
+  function addToast(attrs = '') {
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      `<lg-toast class="toast" data-open="false" ${attrs}>
+         <div class="toast__announcement" data-nds-toast-announcement>
+           <span class="toast__icon"></span>
+           <p class="toast__text">Saved</p>
+         </div>
+       </lg-toast>`,
+    );
+    return document.querySelector('lg-toast') as HTMLElementTagNameMap['lg-toast'];
+  }
+
+  it('opens after the show delay and marks the announcement live', () => {
+    const toast = addToast('data-show-delay="500" data-dismiss-after="3000"');
+    expect(toast.dataset.open).to.equal('false');
+
+    clock.tick(500);
+    clock.next();
+
+    expect(toast.dataset.open).to.equal('true');
+    const announcement = toast.querySelector('[data-nds-toast-announcement]')!;
+    expect(announcement.getAttribute('role')).to.equal('status');
+    expect(announcement.getAttribute('aria-live')).to.equal('polite');
+  });
+
+  it('auto-dismisses after dismiss_after (reduced-motion removes immediately)', () => {
+    sinon.stub(window, 'matchMedia').returns({ matches: true } as MediaQueryList);
+    const toast = addToast('data-show-delay="500" data-dismiss-after="3000"');
+
+    clock.tick(500);
+    clock.next();
+    expect(toast.dataset.open).to.equal('true');
+
+    clock.tick(3000);
+    expect(toast.dataset.open).to.equal('false');
+    expect(document.querySelector('lg-toast')).to.be.null();
+    (window.matchMedia as sinon.SinonStub).restore();
+  });
+
+  it('dismisses on click', () => {
+    sinon.stub(window, 'matchMedia').returns({ matches: true } as MediaQueryList);
+    const toast = addToast('data-show-delay="0" data-dismiss-after="0"');
+    clock.tick(0);
+    clock.next();
+
+    toast.dispatchEvent(new MouseEvent('click'));
+    expect(document.querySelector('lg-toast')).to.be.null();
+    (window.matchMedia as sinon.SinonStub).restore();
+  });
+
+  it('does not auto-dismiss when dismiss_after <= 0', () => {
+    const toast = addToast('data-show-delay="0" data-dismiss-after="0"');
+    clock.tick(0);
+    clock.next();
+    expect(toast.dataset.open).to.equal('true');
+
+    clock.tick(100000);
+    expect(toast.dataset.open).to.equal('true');
+    expect(document.querySelector('lg-toast')).to.not.be.null();
+  });
+});

--- a/app/javascript/packages/nds-toast/toast-element.ts
+++ b/app/javascript/packages/nds-toast/toast-element.ts
@@ -1,0 +1,110 @@
+const DEFAULT_SHOW_DELAY_MS = 500;
+const DEFAULT_DISMISS_AFTER_MS = 3000;
+const TOAST_DURATION_MS = 300;
+
+class ToastElement extends HTMLElement {
+  #dismissing = false;
+
+  #showTimer?: number;
+
+  #autoDismissTimer?: number;
+
+  #removeTimer?: number;
+
+  connectedCallback() {
+    // Reparent to the body so the toast escapes any fixed or transformed
+    // containing block from surrounding page chrome.
+    if (this.parentElement !== document.body) {
+      document.body.append(this);
+      return;
+    }
+
+    this.addEventListener('click', this.#onClick);
+
+    const showDelay = this.#numberDataset('showDelay', DEFAULT_SHOW_DELAY_MS);
+
+    this.#showTimer = window.setTimeout(() => {
+      requestAnimationFrame(() => {
+        this.dataset.open = 'true';
+        const announcement = this.querySelector('[data-nds-toast-announcement]');
+        announcement?.setAttribute('role', 'status');
+        announcement?.setAttribute('aria-live', 'polite');
+        this.#scheduleAutoDismiss();
+      });
+    }, showDelay);
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener('click', this.#onClick);
+    this.#clearTimers();
+  }
+
+  dismiss() {
+    if (this.#dismissing) {
+      return;
+    }
+
+    this.#dismissing = true;
+    this.#clearTimers();
+    this.dataset.open = 'false';
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      this.remove();
+      return;
+    }
+
+    let onTransitionEnd: (event: TransitionEvent) => void;
+    const remove = () => {
+      this.removeEventListener('transitionend', onTransitionEnd);
+      window.clearTimeout(this.#removeTimer);
+      this.remove();
+    };
+    onTransitionEnd = (event: TransitionEvent) => {
+      if (
+        event.target === this &&
+        (event.propertyName === 'opacity' || event.propertyName === 'transform')
+      ) {
+        remove();
+      }
+    };
+
+    this.addEventListener('transitionend', onTransitionEnd);
+    this.#removeTimer = window.setTimeout(remove, TOAST_DURATION_MS + 40);
+  }
+
+  #onClick = () => {
+    this.dismiss();
+  };
+
+  #scheduleAutoDismiss() {
+    const dismissAfter = this.#numberDataset('dismissAfter', DEFAULT_DISMISS_AFTER_MS);
+    if (dismissAfter <= 0) {
+      return;
+    }
+
+    this.#autoDismissTimer = window.setTimeout(() => this.dismiss(), dismissAfter);
+  }
+
+  #numberDataset(key: 'showDelay' | 'dismissAfter', fallback: number) {
+    const value = Number(this.dataset[key]);
+    return Number.isFinite(value) ? value : fallback;
+  }
+
+  #clearTimers() {
+    window.clearTimeout(this.#showTimer);
+    window.clearTimeout(this.#autoDismissTimer);
+    window.clearTimeout(this.#removeTimer);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lg-toast': ToastElement;
+  }
+}
+
+if (!customElements.get('lg-toast')) {
+  customElements.define('lg-toast', ToastElement);
+}
+
+export default ToastElement;

--- a/package-lock.json
+++ b/package-lock.json
@@ -330,6 +330,10 @@
       "name": "@18f/identity-modal",
       "version": "1.0.0"
     },
+    "app/javascript/packages/nds-toast": {
+      "name": "@18f/identity-nds-toast",
+      "version": "1.0.0"
+    },
     "app/javascript/packages/normalize-yaml": {
       "name": "@18f/identity-normalize-yaml",
       "version": "2.0.0",
@@ -612,6 +616,10 @@
     },
     "node_modules/@18f/identity-modal": {
       "resolved": "app/javascript/packages/modal",
+      "link": true
+    },
+    "node_modules/@18f/identity-nds-toast": {
+      "resolved": "app/javascript/packages/nds-toast",
       "link": true
     },
     "node_modules/@18f/identity-normalize-yaml": {

--- a/spec/components/nds/toast_component_spec.rb
+++ b/spec/components/nds/toast_component_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe NDS::ToastComponent, type: :component do
+  it 'renders lg-toast.toast with the announcement structure' do
+    rendered = render_inline(NDS::ToastComponent.new(message: 'Saved'))
+
+    expect(rendered).to have_css('lg-toast.toast[data-open="false"]', visible: :all)
+    expect(rendered).to have_css(
+      'lg-toast .toast__announcement[data-nds-toast-announcement]',
+      visible: :all,
+    )
+    expect(rendered).to have_css('.toast__announcement .toast__icon .usa-icon', visible: :all)
+    expect(rendered).to have_css('p.toast__text', text: 'Saved', visible: :all)
+  end
+
+  it 'renders content from a block when no message given' do
+    rendered = render_inline(NDS::ToastComponent.new) { 'Blocky' }
+    expect(rendered).to have_css('.toast__text', text: 'Blocky', visible: :all)
+  end
+
+  it 'defaults show-delay and dismiss-after data attributes' do
+    rendered = render_inline(NDS::ToastComponent.new(message: 'x'))
+    toast = rendered.css('lg-toast').first
+    expect(toast['data-show-delay']).to eq('500')
+    expect(toast['data-dismiss-after']).to eq('3000')
+  end
+
+  it 'accepts custom show_delay and dismiss_after' do
+    rendered = render_inline(
+      NDS::ToastComponent.new(message: 'x', show_delay: 0, dismiss_after: 8000),
+    )
+    toast = rendered.css('lg-toast').first
+    expect(toast['data-show-delay']).to eq('0')
+    expect(toast['data-dismiss-after']).to eq('8000')
+  end
+
+  it 'passes through custom classes and merges data' do
+    rendered = render_inline(
+      NDS::ToastComponent.new(message: 'x', class: 'extra', data: { foo: 'bar' }),
+    )
+    expect(rendered).to have_css('lg-toast.toast.extra[data-foo="bar"]', visible: :all)
+  end
+
+  it 'emits the toast class and NDS announcement data hook' do
+    html = render_inline(NDS::ToastComponent.new(message: 'x')).to_html
+    expect(html).to include('class="toast"')
+    expect(html).to include('data-nds-toast-announcement')
+  end
+end

--- a/spec/components/previews/nds/toast_component_preview.rb
+++ b/spec/components/previews/nds/toast_component_preview.rb
@@ -1,0 +1,32 @@
+module NDS
+  # Net-new NDS toast; only renders in the NDS bucket. Add ?ui_test_bucket=nds
+  # to the preview URL to load the NDS styles and see it.
+  class ToastComponentPreview < BaseComponentPreview
+    def default
+      render(NDS::ToastComponent.new(message: 'Your changes were saved.'))
+    end
+
+    def custom_timing
+      render(
+        NDS::ToastComponent.new(
+          message: 'Shows immediately and stays for eight seconds.',
+          show_delay: 0,
+          dismiss_after: 8000,
+        ),
+      )
+    end
+
+    # @param message text
+    # @param show_delay number
+    # @param dismiss_after number
+    def workbench(message: 'Your changes were saved.', show_delay: 500, dismiss_after: 3000)
+      render(
+        NDS::ToastComponent.new(
+          message:,
+          show_delay:,
+          dismiss_after:,
+        ),
+      )
+    end
+  end
+end

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ const originPort = process.env.ORIGIN_PORT || 3000;
 const devServerPort = process.env.WEBPACK_PORT;
 const devtool = process.env.WEBPACK_DEVTOOL || (isProductionEnv ? 'source-map' : 'eval-source-map');
 
-const entries = glob('app/{components,javascript/packs}/*.{ts,tsx}');
+const entries = glob('app/{components,components/nds,javascript/packs}/*.{ts,tsx}');
 
 module.exports = /** @type {import('webpack').Configuration} */ ({
   mode,


### PR DESCRIPTION
## Ticket:

 https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/31

## Summary

- Adds a net-new `NDS::ToastComponent` (renders only in the NDS bucket) that emits an accessible `<lg-toast class="toast">` announcement with a check icon, message text, and configurable `show_delay` / `dismiss_after`.
- Adds an `@18f/identity-nds-toast` JS workspace with the `lg-toast` custom element (reveal-after-delay, live announcement, auto-dismiss / click-to-dismiss, `prefers-reduced-motion` aware) and its unit spec; a one-line sidecar in `app/components/nds/toast_component.ts` imports it and the webpack entry glob is extended to bundle `app/components/nds/*.ts`.
- Adds a Lookbook preview (view with `?ui_test_bucket=nds`).

## Test plan

- [ ] `npx mocha 'app/javascript/packages/nds-toast/*.spec.ts'` (4 passing)
- [ ] `npx eslint` + `npx tsc` clean
- [ ] `bundle exec rspec spec/components/nds/toast_component_spec.rb` (6 examples)
- [ ] `bundle exec rubocop` + `bundle exec erb_lint` clean
- [ ] `bundle exec rails zeitwerk:check`
- [ ] Verify the toast in Lookbook at `?ui_test_bucket=nds`