### PR TITLE
Add NDS::FormPageComponent page scaffold

### DIFF
--- a/app/components/nds/form_page_component.html.erb
+++ b/app/components/nds/form_page_component.html.erb
@@ -1,0 +1,29 @@
+<%= tag.section(**html_options.except(:class).merge(class: css_class)) do %>
+  <%= render flash_component if claim_flash! && flash_component.render? %>
+  <%= alert if alert? && !alert_below? %>
+
+  <div class="auth__header<%= ' auth__header--with-media' if media? %>">
+    <%= media if media? %>
+    <%= render NDS::StackComponent.new(align: :center, class: 'auth__intro') do %>
+      <h1><%= title %></h1>
+      <% if subtitle.present? %>
+        <div class="auth__intro-description"><%= subtitle %></div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%= alert if alert? && alert_below? %>
+
+  <% if body? %>
+    <div class="auth__form-page-body">
+      <%= body %>
+    </div>
+  <% end %>
+
+  <% if actions? %>
+    <%= tag.hr(class: 'divider') if divider %>
+    <div class="auth__actions">
+      <%= actions %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/nds/form_page_component.rb
+++ b/app/components/nds/form_page_component.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module NDS
+  # Net-new NDS page scaffold; only renders in the NDS layout. Emits auth and
+  # divider classes styled by the NDS bundle, and uses NDS::StackComponent for
+  # the centered intro.
+  class FormPageComponent < BaseComponent
+    renders_one :alert
+    renders_one :media
+    renders_one :body
+    renders_one :actions
+
+    attr_reader :title, :subtitle, :alert_position, :divider, :class_name, :html_options
+
+    def initialize(
+      title:,
+      subtitle: nil,
+      alert_position: :above,
+      divider: false,
+      class_name: nil,
+      **html_options
+    )
+      @title = title
+      @subtitle = subtitle
+      @alert_position = alert_position.to_sym
+      @divider = divider
+      @class_name = class_name
+      @html_options = html_options
+    end
+
+    def alert_below?
+      alert_position == :below
+    end
+
+    def css_class
+      ['auth', 'auth--form-page', class_name, html_options[:class]].compact
+    end
+
+    def flash_component
+      @flash_component ||= FlashComponent.new(flash: helpers.flash)
+    end
+
+    def claim_flash!
+      return false if helpers.content_for?(:form_page_flash)
+
+      helpers.content_for(:form_page_flash, 'true')
+      helpers.content_for(:skip_layout_flash, 'true')
+      true
+    end
+  end
+end

--- a/spec/components/nds/form_page_component_spec.rb
+++ b/spec/components/nds/form_page_component_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe NDS::FormPageComponent, type: :component do
+  it 'renders section.auth.auth--form-page with the title h1 in a centered stack' do
+    rendered = render_inline(NDS::FormPageComponent.new(title: 'Sign in'))
+    expect(rendered).to have_css('section.auth.auth--form-page')
+    expect(rendered).to have_css(
+      '.auth__header .stack.stack--align-center.auth__intro > h1', text: 'Sign in'
+    )
+    expect(rendered).not_to have_css('.auth__intro-description')
+    expect(rendered).not_to have_css('.auth__header--with-media')
+  end
+
+  it 'renders the subtitle as an intro description' do
+    rendered = render_inline(NDS::FormPageComponent.new(title: 'T', subtitle: 'Sub'))
+    expect(rendered).to have_css('.auth__intro-description', text: 'Sub')
+  end
+
+  it 'renders the media slot and flags the header' do
+    rendered = render_inline(NDS::FormPageComponent.new(title: 'T')) do |c|
+      c.with_media { 'MEDIA' }
+    end
+    expect(rendered).to have_css('.auth__header.auth__header--with-media', text: 'MEDIA')
+  end
+
+  it 'renders the body slot inside auth__form-page-body' do
+    rendered = render_inline(NDS::FormPageComponent.new(title: 'T')) do |c|
+      c.with_body { 'BODY' }
+    end
+    expect(rendered).to have_css('.auth__form-page-body', text: 'BODY')
+  end
+
+  it 'renders the actions slot inside auth__actions' do
+    rendered = render_inline(NDS::FormPageComponent.new(title: 'T')) do |c|
+      c.with_actions { 'ACTIONS' }
+    end
+    expect(rendered).to have_css('.auth__actions', text: 'ACTIONS')
+    expect(rendered).not_to have_css('hr.divider')
+  end
+
+  it 'renders a divider before actions when divider: true' do
+    rendered = render_inline(NDS::FormPageComponent.new(title: 'T', divider: true)) do |c|
+      c.with_actions { 'ACTIONS' }
+    end
+    expect(rendered).to have_css('hr.divider + .auth__actions', text: 'ACTIONS')
+  end
+
+  it 'renders the alert above the header by default' do
+    rendered = render_inline(NDS::FormPageComponent.new(title: 'T')) do |c|
+      c.with_alert { '<div class="my-alert">ALERT</div>'.html_safe }
+    end
+    expect(rendered).to have_css('.auth > .my-alert:first-child', text: 'ALERT')
+  end
+
+  it 'renders the alert below the header when alert_position: :below' do
+    rendered = render_inline(NDS::FormPageComponent.new(title: 'T', alert_position: :below)) do |c|
+      c.with_alert { '<div class="my-alert">ALERT</div>'.html_safe }
+    end
+    expect(rendered).to have_css('.auth__header + .my-alert', text: 'ALERT')
+  end
+
+  it 'passes through class_name and html options' do
+    rendered = render_inline(NDS::FormPageComponent.new(title: 'T', class_name: 'extra', id: 'foo'))
+    expect(rendered).to have_css('section.auth.auth--form-page.extra#foo')
+  end
+
+  it 'emits auth-namespaced classes across every slot' do
+    component = NDS::FormPageComponent.new(title: 'T', subtitle: 'S', divider: true)
+    rendered = render_inline(component) do |c|
+      c.with_media { 'M' }
+      c.with_body { 'B' }
+      c.with_actions { 'A' }
+    end
+    expect(rendered).to have_css('section.auth.auth--form-page')
+    expect(rendered).to have_css('.auth__header--with-media', text: 'M')
+    expect(rendered).to have_css('.auth__intro-description', text: 'S')
+    expect(rendered).to have_css('.auth__form-page-body', text: 'B')
+    expect(rendered).to have_css('hr.divider + .auth__actions', text: 'A')
+  end
+end

--- a/spec/components/previews/nds/form_page_component_preview.rb
+++ b/spec/components/previews/nds/form_page_component_preview.rb
@@ -1,0 +1,73 @@
+module NDS
+  # Net-new NDS page scaffold; only renders in the NDS layout. Add
+  # ?ui_test_bucket=nds to the preview URL to load the NDS styles and see it.
+  class FormPageComponentPreview < BaseComponentPreview
+    include ActionView::Helpers::TagHelper
+
+    def default
+      render(
+        NDS::FormPageComponent.new(title: 'Sign in', subtitle: 'Enter your email address.'),
+      ) do |c|
+        c.with_body { example_body }
+        c.with_actions { example_actions }
+      end
+    end
+
+    def with_alert
+      render(NDS::FormPageComponent.new(title: 'Sign in')) do |c|
+        c.with_alert do
+          content_tag(:div, 'Your session expired.', class: 'usa-alert usa-alert--warning')
+        end
+        c.with_body { example_body }
+      end
+    end
+
+    def with_media
+      render(NDS::FormPageComponent.new(title: 'Verify your identity')) do |c|
+        c.with_media { content_tag(:div, 'ILLUSTRATION', class: 'auth__media-example') }
+        c.with_body { example_body }
+      end
+    end
+
+    def with_divider
+      render(NDS::FormPageComponent.new(title: 'Sign in', divider: true)) do |c|
+        c.with_body { example_body }
+        c.with_actions { example_actions }
+      end
+    end
+
+    # @param title text
+    # @param subtitle text
+    # @param alert_position select [above,below]
+    # @param divider toggle
+    def workbench(
+      title: 'Sign in',
+      subtitle: 'Enter your email address and password.',
+      alert_position: :above,
+      divider: false
+    )
+      render(
+        NDS::FormPageComponent.new(
+          title:,
+          subtitle:,
+          alert_position: alert_position&.to_sym,
+          divider:,
+        ),
+      ) do |c|
+        c.with_alert { content_tag(:div, 'Heads up.', class: 'usa-alert usa-alert--info') }
+        c.with_body { example_body }
+        c.with_actions { example_actions }
+      end
+    end
+
+    private
+
+    def example_body
+      content_tag(:p, 'Enter your email address and password to continue.')
+    end
+
+    def example_actions
+      content_tag(:button, 'Sign in', type: 'submit', class: 'usa-button')
+    end
+  end
+end


### PR DESCRIPTION
## TIcket:

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/28

## Summary

- Adds `NDS::FormPageComponent`, a net-new page-scaffold component that renders only in the NDS layout (not bucket-conditional).
- Composes a centered intro (title + optional subtitle) with `NDS::StackComponent` and exposes `alert`, `media`, `body`, and `actions` slots; supports an optional divider before the actions and `alert_position` above/below the header.
- Adds a Lookbook preview (`NDS::FormPageComponentPreview`) with examples for each slot plus a workbench; view it at `?ui_test_bucket=nds` to load the NDS painting CSS.

## Test plan

- [ ] `bundle exec rspec spec/components/nds/form_page_component_spec.rb` (10 examples, 0 failures)
- [ ] `bundle exec rubocop` on the new files (clean)
- [ ] `bundle exec erb_lint app/components/nds/form_page_component.html.erb` (clean)
- [ ] `bundle exec rails zeitwerk:check` (clean)
- [ ] View the preview in Lookbook at `?ui_test_bucket=nds`