### PR TITLE
Add NDS::OfficialBannerComponent official government banner

### DIFF
--- a/app/assets/images/usa-icons/authority.svg
+++ b/app/assets/images/usa-icons/authority.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 1 3 5v1h18V5l-9-4zM4 8v9H2v2h20v-2h-2V8h-2v9h-3V8h-2v9h-2V8H7v9H4V8H4z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 1 3 5v1h18V5zM4 8v9H2v2h20v-2h-2V8h-2v9h-3V8h-2v9h-2V8H7v9H4z"/></svg>

--- a/app/assets/images/usa-icons/authority.svg
+++ b/app/assets/images/usa-icons/authority.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 1 3 5v1h18V5l-9-4zM4 8v9H2v2h20v-2h-2V8h-2v9h-3V8h-2v9h-2V8H7v9H4V8H4z"/></svg>

--- a/app/components/icon_component.rb
+++ b/app/components/icon_component.rb
@@ -26,6 +26,7 @@ class IconComponent < BaseComponent
     assessment
     attach_file
     attach_money
+    authority
     autorenew
     backpack
     bathtub

--- a/app/components/nds/official_banner_component.html.erb
+++ b/app/components/nds/official_banner_component.html.erb
@@ -1,0 +1,46 @@
+<% dialog_id = self.dialog_id %>
+
+<section class="official-banner" aria-label="<%= t('shared.banner.landmark_label') %>">
+  <div class="official-banner__content">
+    <span class="official-banner__flag" aria-hidden="true">
+      <%= render IconComponent.new(icon: :flag, size: 20) %>
+    </span>
+    <p class="official-banner__text">
+      <%= t('shared.banner.official_site') %>
+      <button
+        type="button"
+        class="link official-banner__how"
+        data-nds-modal-open
+        aria-controls="<%= dialog_id %>"
+        aria-haspopup="dialog"
+        aria-expanded="false"
+      ><%= t('shared.banner.how') %></button>
+    </p>
+  </div>
+  <% if show_test_notice? %>
+    <p class="official-banner__test-notice"><%= t('idv.messages.sessions.no_pii') %></p>
+  <% end %>
+</section>
+
+<%= render ModalComponent.new(id: dialog_id, class: 'official-banner-modal') do |modal| %>
+  <% modal.with_title { t('shared.banner.modal_title') } %>
+  <div class="official-banner-modal__item">
+    <div class="official-banner-modal__header">
+      <%= render IconComponent.new(icon: :authority, size: 24) %>
+      <h3 class="official-banner-modal__heading"><%= t('shared.banner.gov_heading') %></h3>
+    </div>
+    <p class="official-banner-modal__description">
+      <%= t('shared.banner.gov_description') %>
+    </p>
+  </div>
+  <hr class="official-banner-modal__rule">
+  <div class="official-banner-modal__item">
+    <div class="official-banner-modal__header">
+      <%= render IconComponent.new(icon: :lock, size: 24) %>
+      <h3 class="official-banner-modal__heading"><%= t('shared.banner.secure_heading') %></h3>
+    </div>
+    <p class="official-banner-modal__description">
+      <%= t('shared.banner.secure_description') %>
+    </p>
+  </div>
+<% end %>

--- a/app/components/nds/official_banner_component.rb
+++ b/app/components/nds/official_banner_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module NDS
+  # Net-new NDS official government banner. Renders only in the NDS layout via
+  # NDS::PageChromeComponent. Emits .official-banner markup with a "how you
+  # know" button that opens an explainer dialog rendered through
+  # NDS::ModalComponent (.modal).
+  class OfficialBannerComponent < BaseComponent
+    DIALOG_ID = 'official-banner-modal'
+
+    def dialog_id
+      DIALOG_ID
+    end
+
+    def show_test_notice?
+      FeatureManagement.show_no_pii_banner?
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1695,12 +1695,15 @@ service_providers.errors.inactive.heading: '%{sp_name} no longer uses %{app_name
 service_providers.errors.inactive.instructions: '%{sp_name} no longer uses %{app_name} as a sign-in service for their website. If you already created a %{app_name} account, it is still active and can be used to access other participating government websites.'
 service_providers.errors.inactive.instructions2: Please visit the agency’s website to contact them for more information.
 shared.banner.fake_site: A DEMO website of the United States government
+shared.banner.gov_description: A .gov website belongs to an official government organization in the United States.
 shared.banner.gov_description_html: A <strong>.gov</strong> website belongs to an official government organization in the United States.
 shared.banner.gov_heading: Official websites use .gov
 shared.banner.how: Here’s how you know
 shared.banner.landmark_label: Official government website
 shared.banner.lock_description: A locked padlock
+shared.banner.modal_title: U.S. Government Websites
 shared.banner.official_site: An official website of the United States government
+shared.banner.secure_description: A lock or https:// means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
 shared.banner.secure_description_html: A <strong>lock</strong> ( %{lock_icon} ) or <strong>https://</strong> means you’ve safely connected to the .gov website. Share sensitive information only on official, secure websites.
 shared.banner.secure_heading: Secure .gov websites use HTTPS
 shared.footer_lite.gsa: US General Services Administration

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1707,12 +1707,15 @@ service_providers.errors.inactive.heading: '%{sp_name} ya no utiliza %{app_name}
 service_providers.errors.inactive.instructions: '%{sp_name} ya no utiliza %{app_name} como servicio para iniciar sesión en su sitio web. Si ya creó una cuenta de %{app_name}, todavía está activa y se puede usar para acceder a otros sitios web participantes del gobierno.'
 service_providers.errors.inactive.instructions2: Visite la agencia para contactarlos y obtener más información.
 shared.banner.fake_site: Un sitio web de demostración del Gobierno de los Estados Unidos
+shared.banner.gov_description: Un sitio web .gov pertenece a una organización oficial del Gobierno de los Estados Unidos.
 shared.banner.gov_description_html: 'Un sitio web <strong>.gov</strong> pertenece a una organización oficial del Gobierno de los Estados Unidos.'
 shared.banner.gov_heading: Los sitios web oficiales usan .gov
 shared.banner.how: Así es como usted puede saberlo
 shared.banner.landmark_label: Sitio web oficial del Gobierno
 shared.banner.lock_description: Un candado cerrado
+shared.banner.modal_title: Sitios web del Gobierno de EE. UU.
 shared.banner.official_site: Un sitio web oficial del Gobierno de los Estados Unidos
+shared.banner.secure_description: Un candado o https:// significa que se conectó de forma segura a un sitio web .gov. Comunique información confidencial solo en los sitios web oficiales protegidos.
 shared.banner.secure_description_html: Un <strong>candado</strong> ( %{lock_icon} ) o <strong>https://</strong> significa que se conectó de forma segura a un sitio web .gov. Comunique información confidencial solo en los sitios web oficiales protegidos.
 shared.banner.secure_heading: Los sitios web .gov protegidos usan HTTPS
 shared.footer_lite.gsa: Administración General de Servicios de los EE. UU.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1696,12 +1696,15 @@ service_providers.errors.inactive.heading: '%{sp_name} n’utilise plus %{app_na
 service_providers.errors.inactive.instructions: '%{sp_name} n’utilise plus %{app_name} comme service de connexion pour son site Web. Si vous avez déjà créé un compte %{app_name}, sachez qu’il est toujours actif et qu’il peut être utilisé pour accéder aux autres sites Web participants de l’administration.'
 service_providers.errors.inactive.instructions2: Pour plus d’informations, veuillez vous rendre sur le site de l’organisme concerné pour le contacter.
 shared.banner.fake_site: Un site Web de DÉMONSTRATION des autorités des États-Unis
+shared.banner.gov_description: Un site Web .gov appartient à un organisme officiel des États-Unis.
 shared.banner.gov_description_html: Un site Web <strong>.gov</strong> appartient à un organisme officiel des États-Unis.
 shared.banner.gov_heading: Les sites Web officiels utilisent .gov
 shared.banner.how: Voici comment le savoir
 shared.banner.landmark_label: Site Web officiel des autorités
 shared.banner.lock_description: Un cadenas fermé
+shared.banner.modal_title: Sites Web du gouvernement des États-Unis
 shared.banner.official_site: Un site Web officiel de l’administration des États-Unis
+shared.banner.secure_description: La présence d’un cadenas ou de https:// signifie que vous êtes connecté en toute sécurité au site Web .gov. Ne partagez des informations sensibles que sur des sites Web officiels et sécurisés.
 shared.banner.secure_description_html: La présence d’un <strong>cadenas</strong> ( %{lock_icon} ) ou de <strong>https://</strong> signifie que vous êtes connecté en toute sécurité au site Web .gov. Ne partagez des informations sensibles que sur des sites Web officiels et sécurisés.
 shared.banner.secure_heading: Les sites Web sécurisés .gov utilisent HTTPS
 shared.footer_lite.gsa: Administration des services généraux des États-Unis

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1708,12 +1708,15 @@ service_providers.errors.inactive.heading: '%{sp_name} 不再使用 %{app_name}'
 service_providers.errors.inactive.instructions: '%{sp_name}不再用 %{app_name} 为其网站提供登录服务。如果你设立了 %{app_name} 账户的话，账户仍然有效，可用来访问其他参与本项目的政府网站。'
 service_providers.errors.inactive.instructions2: 请访问该机构的网站来联系他们并获得更多信息。
 shared.banner.fake_site: 美国政府的一个示范网站
+shared.banner.gov_description: .gov 网站属于一个美国官方政府机构。
 shared.banner.gov_description_html: '<strong>.gov</strong> 网站属于一个美国官方政府机构。'
 shared.banner.gov_heading: 官方网站使用 .gov
 shared.banner.how: 这里告诉你如何知道
 shared.banner.landmark_label: 官方政府网站
 shared.banner.lock_description: 锁上的锁头
+shared.banner.modal_title: 美国政府网站
 shared.banner.official_site: 美国政府的一个官方网站
+shared.banner.secure_description: 一把锁或者 https:// 意味着你已安全连接到 .gov 网站。只在官方、安全的网站上分享敏感信息。
 shared.banner.secure_description_html: 一把 <strong>锁</strong>（ %{lock_icon} ）或者 <strong>https://</strong> 意味着你已安全连接到 .gov 网站。只在官方、安全的网站上分享敏感信息。
 shared.banner.secure_heading: 安全的 .gov 网站使用 HTTPS
 shared.footer_lite.gsa: 美国联邦总务管理局

--- a/spec/components/nds/official_banner_component_spec.rb
+++ b/spec/components/nds/official_banner_component_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe NDS::OfficialBannerComponent, type: :component do
+  subject(:rendered) { render_inline(NDS::OfficialBannerComponent.new) }
+
+  before { allow(FeatureManagement).to receive(:show_no_pii_banner?).and_return(false) }
+
+  it 'renders the .official-banner section with flag and how button' do
+    expect(rendered).to have_css('section.official-banner[aria-label]')
+    expect(rendered).to have_css('.official-banner__content .official-banner__flag .usa-icon')
+    expect(rendered).to have_css('.official-banner__text', text: t('shared.banner.official_site'))
+    expect(rendered).to have_css(
+      'button.link.official-banner__how[data-nds-modal-open]' \
+      '[aria-controls="official-banner-modal"]',
+      text: t('shared.banner.how'),
+    )
+  end
+
+  it 'renders the explainer through NDS::ModalComponent as .modal' do
+    # ModalComponent resolves nds_bucket?; force nds so it emits .modal.
+    allow_any_instance_of(ModalComponent).to receive(:nds_bucket?).and_return(true)
+    rendered = render_inline(NDS::OfficialBannerComponent.new)
+
+    expect(rendered).to have_css('dialog.modal#official-banner-modal', visible: :all)
+    expect(rendered).to have_css(
+      '.modal__title',
+      text: t('shared.banner.modal_title'),
+      visible: :all,
+    )
+    expect(rendered).to have_css(
+      '.official-banner-modal__item .official-banner-modal__heading',
+      text: t('shared.banner.gov_heading'),
+      visible: :all,
+    )
+    expect(rendered).to have_css(
+      '.official-banner-modal__description',
+      text: t('shared.banner.gov_description'),
+      visible: :all,
+    )
+    expect(rendered).to have_css('hr.official-banner-modal__rule', visible: :all)
+    expect(rendered).to have_css(
+      '.official-banner-modal__heading',
+      text: t('shared.banner.secure_heading'),
+      visible: :all,
+    )
+  end
+
+  it 'points the how button at the explainer dialog id' do
+    button_controls = rendered.css('.official-banner__how').first['aria-controls']
+    expect(button_controls).to eq('official-banner-modal')
+  end
+
+  it 'renders the test-notice only when show_no_pii_banner?' do
+    expect(rendered).not_to have_css('.official-banner__test-notice')
+
+    allow(FeatureManagement).to receive(:show_no_pii_banner?).and_return(true)
+    with_notice = render_inline(NDS::OfficialBannerComponent.new)
+    expect(with_notice).to have_css('.official-banner__test-notice')
+  end
+end

--- a/spec/components/previews/nds/official_banner_component_preview.rb
+++ b/spec/components/previews/nds/official_banner_component_preview.rb
@@ -1,0 +1,13 @@
+module NDS
+  # Net-new NDS official government banner. Add ?ui_test_bucket=nds to the
+  # preview URL to load the NDS styles and see it.
+  #
+  # The banner opens its explainer through NDS::ModalComponent, which needs the
+  # nds bucket to emit the .modal markup, so previews render inside the NDS
+  # layout via ?ui_test_bucket=nds.
+  class OfficialBannerComponentPreview < BaseComponentPreview
+    def default
+      render(NDS::OfficialBannerComponent.new)
+    end
+  end
+end


### PR DESCRIPTION
## Ticket

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/26


## Summary
- Add net-new NDS::OfficialBannerComponent: the official government banner that renders in the NDS layout, with a "how you know" button opening an explainer dialog via NDS::ModalComponent (.modal).
- Register a new idp-owned authority.svg icon in IconComponent (additive; existing icons unaffected) and add plain shared.banner.{gov_description,secure_description,modal_title} i18n keys to en/es/fr/zh.
- Add a Lookbook preview (view at ?ui_test_bucket=nds) and a component spec.

## Test plan
- [ ] rspec spec/components/nds/official_banner_component_spec.rb
- [ ] rubocop + erb_lint clean
- [ ] rails zeitwerk:check
- [ ] normalize-yaml reports no diff
- [ ] Lookbook preview renders at ?ui_test_bucket=nds