### PR TITLE
LG-17876 Log an event when users continue to the Socure DocV capture app

### DIFF
--- a/app/controllers/frontend_log_controller.rb
+++ b/app/controllers/frontend_log_controller.rb
@@ -60,6 +60,7 @@ class FrontendLogController < ApplicationController
     idv_sdk_selfie_image_taken
     idv_selfie_image_added
     idv_selfie_image_clicked
+    idv_socure_docv_redirect_requested
     passkey_authentication_initiated
     phone_input_country_changed
     tab_navigation_current_page_clicked

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -37,6 +37,7 @@ module Idv
           @hybrid_flow = true
           @passport_requested = document_capture_session.passport_requested?
           @mdl_requested = document_capture_session.mdl_requested?
+          @document_type_requested = document_capture_session.document_type_requested
           @url = document_capture_session.socure_docv_capture_app_url
 
           return if @url.present?

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -33,6 +33,7 @@ module Idv
         @hybrid_flow = false
         @passport_requested = document_capture_session.passport_requested?
         @mdl_requested = document_capture_session.mdl_requested?
+        @document_type_requested = document_capture_session.document_type_requested
         @url = document_capture_session.socure_docv_capture_app_url
 
         return if @url.present?

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6109,6 +6109,17 @@ module AnalyticsEvents
     )
   end
 
+  # @param [String] document_type_requested The type of document the user chose to verify with
+  # The user clicked the button on the document capture interstitial page that redirects
+  # them to the Socure DocV capture app
+  def idv_socure_docv_redirect_requested(document_type_requested: nil, **extra)
+    track_event(
+      :idv_socure_docv_redirect_requested,
+      document_type_requested:,
+      **extra,
+    )
+  end
+
   # Socure KYC API was called with the following results
   # @param [Boolean] success Result from Socure KYC API call
   # @param [Hash] errors Result from resolution proofing

--- a/app/views/idv/shared/_doc_capture_interstitial.html.erb
+++ b/app/views/idv/shared/_doc_capture_interstitial.html.erb
@@ -62,5 +62,10 @@
 <% end %>
 </p>
 
-<%= link_to (@mdl_requested ? t('idv.mdl.button') : t('forms.buttons.continue')), @url, class: 'usa-button usa-button--big usa-button--wide margin-top-4 margin-bottom-4' %>
+<%= render ClickObserverComponent.new(
+      event_name: 'idv_socure_docv_redirect_requested',
+      payload: { document_type_requested: @document_type_requested },
+    ) do %>
+  <%= link_to (@mdl_requested ? t('idv.mdl.button') : t('forms.buttons.continue')), @url, class: 'usa-button usa-button--big usa-button--wide margin-top-4 margin-bottom-4' %>
+<% end %>
 <%= render 'idv/doc_auth/cancel', step: 'verify_id' %>

--- a/spec/features/idv/doc_auth/socure_document_capture_spec.rb
+++ b/spec/features/idv/doc_auth/socure_document_capture_spec.rb
@@ -498,6 +498,10 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
 
           expect(DocAuthLog.find_by(user_id: user.id).state).to eq('MD')
           expect(fake_analytics).to have_logged_event(
+            :idv_socure_docv_redirect_requested,
+            document_type_requested: Idp::Constants::DocumentTypes::STATE_ID_CARD,
+          )
+          expect(fake_analytics).to have_logged_event(
             :idv_socure_document_request_submitted,
           )
           expect(fake_analytics).to have_logged_event(
@@ -605,6 +609,10 @@ RSpec.feature 'document capture step', :js, driver: :headless_chrome_mobile do
 
             expect(page).to have_current_path(idv_ssn_url)
 
+            expect(fake_analytics).to have_logged_event(
+              :idv_socure_docv_redirect_requested,
+              document_type_requested: Idp::Constants::DocumentTypes::MDL,
+            )
             expect(fake_analytics).to have_logged_event(
               :idv_socure_document_request_submitted,
             )


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17876](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17876)

## 🛠 Summary of changes

Added an `idv_socure_docv_redirect_requested` event that logs when the user clicks the button on the document capture interstitial that sends them to the Socure DocV capture app. The event includes a `document_type_requested` attribute so mDL, state ID, and passport clicks can be told apart.

## 📜 Testing Plan

Configurations:
```yaml
socure_docv_enabled: true
doc_auth_vendor_default: 'mock_socure'
idv_doc_auth_mdl_enabled_percent: 100
```

**Scenario: mDL selected**
```cucumber
Given the user selected "Mobile driver's license (mDL)" on the Choose your ID type step
When the user clicks "Open digital wallet" on the interstitial
Then an "idv_socure_docv_redirect_requested" event is logged
And the event includes "document_type_requested": "mobile_drivers_license"
```

**Scenario: State ID selected**
```cucumber
Given the user selected "U.S. driver's license or state ID" on the Choose your ID type step
When the user clicks "Continue" on the interstitial
Then an "idv_socure_docv_redirect_requested" event is logged
And the event includes "document_type_requested": "state_id_card"
```


[LG-17876]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17876