### PR TITLE
LG-17877 Fix PA job proofing vendor bucket routing

### DIFF
--- a/app/jobs/proofing_agent_job.rb
+++ b/app/jobs/proofing_agent_job.rb
@@ -363,7 +363,7 @@ class ProofingAgentJob < ApplicationJob
     @proofing_vendor ||= begin
       # if proofing vendor A/B test is disabled, return default vendor
       vendor = ab_test_bucket(
-        :PROOFING_VENDOR,
+        :PROOFING_AGENT_PROOFING_VENDOR,
         user:,
         service_provider: service_provider_issuer,
         current_session: nil,

--- a/config/initializers/ab_tests.rb
+++ b/config/initializers/ab_tests.rb
@@ -163,6 +163,22 @@ module AbTests
     )
   end.freeze
 
+  PROOFING_AGENT_PROOFING_VENDOR = AbTest.new(
+    experiment_name: 'Proofing Agent Proofing Vendor',
+    should_log: /^idv/i,
+    default_bucket: IdentityConfig.store.idv_resolution_default_vendor,
+    buckets: {
+      socure_kyc: IdentityConfig.store.idv_resolution_vendor_switching_enabled ?
+        IdentityConfig.store.idv_resolution_vendor_socure_kyc_percent : 0,
+      instant_verify: IdentityConfig.store.idv_resolution_vendor_switching_enabled ?
+        IdentityConfig.store.idv_resolution_vendor_instant_verify_percent : 0,
+      instant_verify_ddp: IdentityConfig.store.idv_resolution_vendor_switching_enabled ?
+        IdentityConfig.store.idv_resolution_vendor_instant_verify_ddp_percent : 0,
+    },
+  ) do |service_provider:, session:, user:, user_session:, **|
+    user&.uuid
+  end.freeze
+
   PHONE_FINDER_RDP_VERSION = AbTest.new(
     experiment_name: 'phone_finder_rdp_version',
     should_log: /^idv/i,

--- a/spec/config/initializers/ab_tests_spec.rb
+++ b/spec/config/initializers/ab_tests_spec.rb
@@ -557,6 +557,34 @@ RSpec.describe AbTests do
     it_behaves_like 'A/B test using verify_info_step_document_capture_session_uuid discriminator'
   end
 
+  describe 'PROOFING_AGENT_PROOFING_VENDOR' do
+    let(:ab_test) { :PROOFING_AGENT_PROOFING_VENDOR }
+
+    let(:enable_ab_test) do
+      -> {
+        allow(IdentityConfig.store).to receive(:idv_resolution_default_vendor)
+          .and_return('vendor_a')
+        allow(IdentityConfig.store).to receive(:idv_resolution_vendor_switching_enabled)
+          .and_return(true)
+        allow(IdentityConfig.store).to receive(:idv_resolution_vendor_socure_kyc_percent)
+          .and_return(25)
+        allow(IdentityConfig.store).to receive(:idv_resolution_vendor_instant_verify_percent)
+          .and_return(25)
+        allow(IdentityConfig.store).to receive(:idv_resolution_vendor_instant_verify_ddp_percent)
+          .and_return(25)
+      }
+    end
+
+    let(:disable_ab_test) do
+      -> {
+        allow(IdentityConfig.store).to receive(:idv_resolution_vendor_switching_enabled)
+          .and_return(false)
+      }
+    end
+
+    it_behaves_like 'an A/B test that uses user_uuid as a discriminator'
+  end
+
   describe 'HYBRID_MOBILE_TMX_PROCESSED' do
     let(:ab_test) { :HYBRID_MOBILE_TMX_PROCESSED }
 


### PR DESCRIPTION
The proofing agent proofing vendor bucket routing was returning nil for the user because they had a null session. The bucketing was updated to use the user's UUID for the discriminator.

changelog: Bug Fixes, Proofing Agent, Fix proofing agent job proofing vendor bucket routing.

co-authored by: Alex Bradley <alexander.bradley@gsa.gov>

## 🎫 Ticket

Link to the relevant ticket:
[LG-17877](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17877)

## 🛠 Summary of changes

The proofing agent proofing vendor bucket routing was returning nil for the user because they had a null session. The bucketing was updated to use the user's UUID for the discriminator.

## 📜 Testing Plan

Run application locally and ensure that resolution proofing vendor bucketing works allowing for different vendors to be chosen.

[LG-17877]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17877