### PR TITLE
Replace Rails.env.prod? conditional with feature flag.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -164,11 +164,13 @@ class ApplicationController < ActionController::Base
   end
 
   def resolve_nds_bucket
-    unless Rails.env.production?
-      # Dev override: ?ui_test_bucket=nds|legacy selects the bucket and persists
+    if IdentityConfig.store.ui_test_bucket_params_enabled
+      # Feature flag enabled override:
+      # ?ui_test_bucket=nds|legacy selects the bucket and persists
       # it in an httponly cookie so it sticks across navigation without
-      # re-appending the param; ?ui_test_bucket=clear forgets it. This is only an
-      # override in front of the real A/B assignment (it does not change the
+      # re-appending the param;
+      # ?ui_test_bucket=clear clears out the cookie.
+      # This is only an override in front of the real A/B assignment (it does not change the
       # user's actual experiment bucket), so it cannot desync experiment traffic.
       case params[:ui_test_bucket]
       when 'nds', 'legacy'

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -540,6 +540,7 @@ team_ursula_email: ''
 telephony_adapter: test
 test_ssn_allowed_list: ''
 totp_code_interval: 30
+ui_test_bucket_params_enabled: true
 unauthorized_scope_enabled: false
 update_cancel_account_reset_path: false
 use_dashboard_service_providers: false
@@ -672,6 +673,7 @@ production:
   session_encryptor_alert_enabled: true
   state_tracking_enabled: false
   telephony_adapter: pinpoint
+  ui_test_bucket_params_enabled: false
   use_kms: true
   usps_auth_token_refresh_job_enabled: true
 

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -571,6 +571,7 @@ module IdentityConfig
     config.add(:telephony_adapter, type: :string)
     config.add(:test_ssn_allowed_list, type: :comma_separated_string_list)
     config.add(:totp_code_interval, type: :integer)
+    config.add(:ui_test_bucket_params_enabled, type: :boolean)
     config.add(:unauthorized_scope_enabled, type: :boolean)
     config.add(:update_cancel_account_reset_path, type: :boolean)
     config.add(:use_dashboard_service_providers, type: :boolean)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -881,6 +881,7 @@ RSpec.describe ApplicationController do
   describe 'NDS layout resolution' do
     before { routes.draw { get 'index' => 'anonymous#index' } }
     after { Rails.application.reload_routes! }
+    let(:ui_test_bucket_params_enabled) { true }
 
     controller do
       def index
@@ -893,6 +894,10 @@ RSpec.describe ApplicationController do
     let(:nds_ab_bucket) { nil }
 
     before do
+      allow(IdentityConfig.store).to receive(
+        :ui_test_bucket_params_enabled,
+      ).and_return(ui_test_bucket_params_enabled)
+
       allow(controller).to receive(:ab_test_bucket)
         .with(:NDS_LOOK_AND_FEEL, service_provider: nil)
         .and_return(nds_ab_bucket)
@@ -971,9 +976,8 @@ RSpec.describe ApplicationController do
       end
     end
 
-    context 'in production the dev override is ignored' do
-      before { allow(Rails.env).to receive(:production?).and_return(true) }
-
+    context 'when ui_tets_bucket_params_enabled is false' do
+      let(:ui_test_bucket_params_enabled) { false }
       it 'does not honor the param and falls back to the A/B bucket' do
         get :index, params: { ui_test_bucket: 'nds' }
         expect(controller.nds_layout?).to eq(false)


### PR DESCRIPTION
## 🛠 Summary of changes
As our sandbox environments are considered "production" environments by the Rails application framework, in order to test the new designs in a sandbox using the `ui_test_bucket=nds|legacy|clear` param handling, we need to replace the conditional with a true feature flag.

This change:
- Creates the feature flag `ui_test_bucket_params_enabled`
- Defaults production-like environments, which includes *.identitysandbox.gov and *.login.gov, to `false`
- Defaults all other environements to `true`
- Updates the specs

Once this is in, we can set this value on the uirefresh env, and be able to utilize the params.

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
