### PR TITLE
LG-17886: Proofing request for user with unconfirmed email unprocessed

### DIFF
--- a/app/controllers/api/proofing_agent/proofing_agent_controller.rb
+++ b/app/controllers/api/proofing_agent/proofing_agent_controller.rb
@@ -37,7 +37,7 @@ module Api
 
       def proof_user
         return render_user_not_found if user.blank?
-        return render_user_email_unconfirmed if User.find_with_confirmed_email(email).blank?
+        return render_user_email_unconfirmed unless email_confirmed?
         return render_already_proofed if already_proofed?
         return render_user_awaiting_binding if user.proofing_agent_user_awaiting_binding?
 
@@ -253,7 +253,15 @@ module Api
       end
 
       def user
-        @user ||= User.find_with_email(email)
+        @user ||= email_address&.user
+      end
+
+      def email_address
+        @email_address ||= EmailAddress.find_with_confirmed_or_unconfirmed_email(email)
+      end
+
+      def email_confirmed?
+        !!email_address&.confirmed_at
       end
 
       def ssn_active_profiles

--- a/app/controllers/api/proofing_agent/proofing_agent_controller.rb
+++ b/app/controllers/api/proofing_agent/proofing_agent_controller.rb
@@ -37,7 +37,7 @@ module Api
 
       def proof_user
         return render_user_not_found if user.blank?
-        return render_user_email_unconfirmed if user.last_sign_in_email_address.blank?
+        return render_user_email_unconfirmed if User.find_with_confirmed_email(email).blank?
         return render_already_proofed if already_proofed?
         return render_user_awaiting_binding if user.proofing_agent_user_awaiting_binding?
 

--- a/app/controllers/api/proofing_agent/proofing_agent_controller.rb
+++ b/app/controllers/api/proofing_agent/proofing_agent_controller.rb
@@ -37,6 +37,7 @@ module Api
 
       def proof_user
         return render_user_not_found if user.blank?
+        return render_user_email_unconfirmed if user.last_sign_in_email_address.blank?
         return render_already_proofed if already_proofed?
         return render_user_awaiting_binding if user.proofing_agent_user_awaiting_binding?
 
@@ -133,6 +134,18 @@ module Api
 
       def render_user_not_found
         response_body = { status: 'failed', reason: 'email_not_found' }
+
+        analytics.idv_proofing_agent_proof_user_requested(
+          **analytics_arguments,
+          response_body:,
+          transaction_id: nil,
+        )
+
+        render json: response_body, status: :unprocessable_content
+      end
+
+      def render_user_email_unconfirmed
+        response_body = { status: 'failed', reason: 'account_email_unconfirmed' }
 
         analytics.idv_proofing_agent_proof_user_requested(
           **analytics_arguments,

--- a/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
+++ b/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
@@ -936,6 +936,29 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             end
           end
 
+          context 'when a ser has not confirmed their email address' do
+            before do
+              user.email_addresses.update(confirmed_at: nil)
+            end
+
+            it 'returns a failed account email not confirmed response body' do
+              action
+              body = JSON.parse(response.body)
+              expect(body['status']).to eq('failed')
+              expect(body['reason']).to eq('account_email_unconfirmed')
+
+              expect(@analytics).to have_logged_event(
+                :idv_proofing_agent_proof_user_requested,
+                response_body: a_hash_including(
+                  status: 'failed',
+                  reason: 'account_email_unconfirmed',
+                ),
+                proofing_agent: proofing_agent_analytics_hash,
+                issuer:,
+              )
+            end
+          end
+
           context 'user already has a pending agent proofed document_capture_session' do
             let(:session) do
               create(

--- a/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
+++ b/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
@@ -941,6 +941,10 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               user.email_addresses.update(confirmed_at: nil)
             end
 
+            it 'returns 422 unprocessable_content' do
+              expect(action.status).to eq(422)
+            end
+
             it 'returns a failed account email not confirmed response body' do
               action
               body = JSON.parse(response.body)
@@ -956,6 +960,20 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
                 proofing_agent: proofing_agent_analytics_hash,
                 issuer:,
               )
+            end
+          end
+
+          context 'when the submitted email is unconfirmed' do
+            let(:email) { 'unconfirmed@example.test' }
+
+            before do
+              create(:email_address, :unconfirmed, user:, email:)
+            end
+
+            it 'does not proof even though the account has a confirmed email' do
+              expect(action.status).to eq(422)
+              body = JSON.parse(response.body)
+              expect(body['reason']).to eq('account_email_unconfirmed')
             end
           end
 

--- a/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
+++ b/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
@@ -936,7 +936,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             end
           end
 
-          context 'when a ser has not confirmed their email address' do
+          context 'when a user has not confirmed their email address' do
             before do
               user.email_addresses.update(confirmed_at: nil)
             end


### PR DESCRIPTION
changelog: Bug Fixes, Proofing Agent, Proofing agent request for a user with unconfirmed email unprocessed

<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-17886](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17886)

## 🛠 Summary of changes
Return a 422 when a proofing agent request is received for an unconfirmed user.

## 📜 Testing Plan
1. Register a new user and do not confirm the email
2. Send proofing agent request
3. response should be status: 422 reason: 'account_email_unconfirmed'

<!--
Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17786]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17786

[LG-17886]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17886