### PR TITLE
Handle nil pending_in_person_enrollment

### DIFF
--- a/app/presenters/account_show_presenter.rb
+++ b/app/presenters/account_show_presenter.rb
@@ -77,6 +77,8 @@ class AccountShowPresenter
   end
 
   def formatted_ipp_due_date
+    return nil unless user.pending_in_person_enrollment
+
     I18n.l(user.pending_in_person_enrollment.due_date, format: :event_date)
   end
 

--- a/spec/presenters/account_show_presenter_spec.rb
+++ b/spec/presenters/account_show_presenter_spec.rb
@@ -274,6 +274,16 @@ RSpec.describe AccountShowPresenter do
     end
   end
 
+  describe '#formatted_ipp_due_date when user does not have a pending IPP enrollment' do
+    let(:user) { build(:user) }
+
+    subject(:formatted_ipp_due_date) { presenter.formatted_ipp_due_date }
+
+    it 'returns nil' do
+      expect(subject).to be_nil
+    end
+  end
+
   describe '#formatted_legacy_idv_date' do
     let(:user) { build(:user, :proofed_with_selfie) }
 


### PR DESCRIPTION
New Relic is showing several errors due to undefined method 'due_date' for nil

This is a quick way to fix that bug.

changelog: Bug Fixes, AccountShowPresenter, gracefully handle when user.pending_in_person_enrollment is nil

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->

<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
