### PR TITLE
Joan-117: Add a per-vendor feature flag to control AAMVA get-to-yes and fix DDP Instant Verify missing additional verification attributes

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer.rb
@@ -46,7 +46,8 @@ module Proofing
             return if parsed_response.product_list.blank?
 
             product = parsed_response.product_list.first
-            return unless product['ProductType'] == 'Verify'
+            return unless product['ProductType'] == 'Verification' ||
+                          product['ProductType'] == 'Verify'
 
             product
           end

--- a/app/services/proofing/resolution/progressive_proofer.rb
+++ b/app/services/proofing/resolution/progressive_proofer.rb
@@ -119,6 +119,7 @@ module Proofing
           ipp_current_address_matches_id: applicant_pii[:ipp_current_address_matches_id],
           applicant_pii:,
           precheck_phone_number: phone_plugin.phone_number,
+          proofing_vendor:,
         )
       end
 

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -169,7 +169,7 @@ module Proofing
       end
 
       # The "get to yes" feature is enabled per resolution vendor, since each vendor reports failed
-      # attributes differently. A nil vendor is never enabled, so the gate fails closed.
+      # attributes differently. A nil vendor won't match the allowlist, so it stays disabled.
       def get_to_yes_enabled_for_vendor?
         IdentityConfig.store.idv_aamva_get_to_yes_enabled_vendors
           .include?(proofing_vendor.to_s)

--- a/app/services/proofing/resolution/result_adjudicator.rb
+++ b/app/services/proofing/resolution/result_adjudicator.rb
@@ -11,7 +11,8 @@ module Proofing
                   :phone_result,
                   :ipp_current_address_matches_id,
                   :applicant_pii,
-                  :precheck_phone_number
+                  :precheck_phone_number,
+                  :proofing_vendor
 
       def initialize(
         resolution_result:, # InstantVerify
@@ -22,7 +23,8 @@ module Proofing
         ipp_current_address_matches_id:,
         applicant_pii:,
         precheck_phone_number:,
-        hybrid_mobile_device_profiling_result: nil # ThreatMetrix (Hybrid Mobile)
+        hybrid_mobile_device_profiling_result: nil, # ThreatMetrix (Hybrid Mobile)
+        proofing_vendor: nil # resolution vendor that produced resolution_result
       )
         @resolution_result = resolution_result
         @ipp_enrollment_in_progress = ipp_enrollment_in_progress
@@ -33,6 +35,7 @@ module Proofing
         @ipp_current_address_matches_id = ipp_current_address_matches_id # boolean(nil outside IPP)
         @applicant_pii = applicant_pii
         @precheck_phone_number = precheck_phone_number
+        @proofing_vendor = proofing_vendor
       end
 
       def adjudicated_result
@@ -157,11 +160,19 @@ module Proofing
       end
 
       def state_id_attributes_cover_resolution_failures?
+        return false unless get_to_yes_enabled_for_vendor?
         return false unless resolution_result.failed_result_can_pass_with_additional_verification?
 
         failed_resolution_attributes =
           resolution_result.attributes_requiring_additional_verification
         (failed_resolution_attributes.to_a - passed_state_id_attributes.map(&:to_sym)).empty?
+      end
+
+      # The "get to yes" feature is enabled per resolution vendor, since each vendor reports failed
+      # attributes differently. A nil vendor is never enabled, so the gate fails closed.
+      def get_to_yes_enabled_for_vendor?
+        IdentityConfig.store.idv_aamva_get_to_yes_enabled_vendors
+          .include?(proofing_vendor.to_s)
       end
 
       # AAMVA verifies the address printed on the identity document. If the user edited their

--- a/config/application.yml.default
+++ b/config/application.yml.default
@@ -215,6 +215,7 @@ identity_verification_outcomes_report_issuers: '[]'
 idv_aamva_at_doc_auth_enabled: false
 idv_aamva_at_doc_auth_ipp_enabled: false
 idv_aamva_bypass_exception_ids: '[]'
+idv_aamva_get_to_yes_enabled_vendors: '[]'
 idv_aamva_split_last_name_states: '[]'
 idv_account_verified_email_campaign_id: '20241028'
 idv_acuant_sdk_upgrade_a_b_testing_enabled: false

--- a/lib/identity_config.rb
+++ b/lib/identity_config.rb
@@ -291,6 +291,7 @@ module IdentityConfig
     config.add(:idv_socure_reason_codes_docv_selfie_pass, type: :json)
     config.add(:idv_sp_required, type: :boolean)
     config.add(:idv_aamva_bypass_exception_ids, type: :json)
+    config.add(:idv_aamva_get_to_yes_enabled_vendors, type: :json)
     config.add(:idv_aamva_split_last_name_states, type: :json)
     config.add(:in_person_completion_survey_delivery_enabled, type: :boolean)
     config.add(:in_person_completion_survey_url, type: :string)

--- a/spec/features/idv/doc_auth/verify_info_step_spec.rb
+++ b/spec/features/idv/doc_auth/verify_info_step_spec.rb
@@ -738,6 +738,7 @@ RSpec.feature 'verify_info step and verify_info_concern', :js do
     before do
       allow(IdentityConfig.store).to receive_messages(
         idv_aamva_at_doc_auth_enabled: true,
+        idv_aamva_get_to_yes_enabled_vendors: ['instant_verify', 'instant_verify_ddp'],
         proofer_mock_fallback: false,
         idv_resolution_default_vendor: :instant_verify,
         idv_resolution_vendor_switching_enabled: false,

--- a/spec/features/idv/in_person_spec.rb
+++ b/spec/features/idv/in_person_spec.rb
@@ -919,6 +919,7 @@ RSpec.describe 'In Person Proofing', js: true do
         allow(IdentityConfig.store).to receive_messages(
           idv_aamva_at_doc_auth_enabled: true,
           idv_aamva_at_doc_auth_ipp_enabled: true,
+          idv_aamva_get_to_yes_enabled_vendors: ['instant_verify', 'instant_verify_ddp'],
           proofer_mock_fallback: false,
           idv_resolution_default_vendor: :instant_verify,
           idv_resolution_vendor_switching_enabled: false,

--- a/spec/jobs/resolution_proofing_job_spec.rb
+++ b/spec/jobs/resolution_proofing_job_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
   let(:hybrid_mobile_threatmetrix_session_id) { nil }
   let(:hybrid_mobile_request_ip) { nil }
   let(:proofing_device_hybrid_profiling) { :disabled }
+  let(:get_to_yes_enabled_vendors) { [] }
 
   before do
     allow(IdentityConfig.store).to receive(:proofing_device_profiling)
@@ -33,6 +34,8 @@ RSpec.describe ResolutionProofingJob, type: :job do
       .and_return('https://www.example.com')
     allow(IdentityConfig.store).to receive(:idv_resolution_default_vendor)
       .and_return(:instant_verify)
+    allow(IdentityConfig.store).to receive(:idv_aamva_get_to_yes_enabled_vendors)
+      .and_return(get_to_yes_enabled_vendors)
   end
 
   describe '#perform' do
@@ -257,6 +260,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
         end
 
         context 'when attributes requiring additional verification were verified by AAMVA' do
+          let(:get_to_yes_enabled_vendors) { ['instant_verify', 'instant_verify_ddp'] }
           let(:pii) do
             { aamva_verified_attributes: [:address, :ssn] }
               .merge(Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID)
@@ -503,6 +507,7 @@ RSpec.describe ResolutionProofingJob, type: :job do
 
       context 'when the InstantVerify proofing fails' do
         context 'when aamva already proofed at doc auth' do
+          let(:get_to_yes_enabled_vendors) { ['instant_verify', 'instant_verify_ddp'] }
           let(:pii) do
             { aamva_verified_attributes: [:address, :ssn] }
               .merge(Idp::Constants::MOCK_IDV_APPLICANT_SAME_ADDRESS_AS_ID)

--- a/spec/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer_spec.rb
@@ -129,19 +129,100 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::InstantVerifyProofer do
             LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json
           end
 
-          it 'returns a result that identifies attribute as needing verification' do
-            stub_request(
-              :post,
-              proofing_verification_request.url,
-            ).to_return(
-              body: LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json,
-              status: 200,
-            )
+          context 'response ProductType is "Verification"' do
+            let(:response_body) do
+              result = JSON.parse(
+                LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json,
+              )
+              result.dig(
+                'integration_hub_results',
+                'test_org_id:test-policy',
+                'Execute Instant Verify',
+                'tps_vendor_raw_response',
+                'Products',
+              ).first['ProductType'] = 'Verification'
 
-            result = subject.proof(proofing_applicant)
+              result.to_json
+            end
 
-            expect(result.failed_result_can_pass_with_additional_verification?).to eq(true)
-            expect(result.attributes_requiring_additional_verification).to eq([:dob])
+            it 'returns a result that identifies attribute as needing verification' do
+              stub_request(
+                :post,
+                proofing_verification_request.url,
+              ).to_return(
+                body: response_body,
+                status: 200,
+              )
+
+              result = subject.proof(proofing_applicant)
+
+              expect(result.failed_result_can_pass_with_additional_verification?).to eq(true)
+              expect(result.attributes_requiring_additional_verification).to eq([:dob])
+            end
+          end
+
+          context 'response ProductType is "Verify"' do
+            let(:response_body) do
+              result = JSON.parse(
+                LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json,
+              )
+              result.dig(
+                'integration_hub_results',
+                'test_org_id:test-policy',
+                'Execute Instant Verify',
+                'tps_vendor_raw_response',
+                'Products',
+              ).first['ProductType'] = 'Verify'
+
+              result.to_json
+            end
+
+            it 'returns a result that identifies attribute as needing verification' do
+              stub_request(
+                :post,
+                proofing_verification_request.url,
+              ).to_return(
+                body: response_body,
+                status: 200,
+              )
+
+              result = subject.proof(proofing_applicant)
+
+              expect(result.failed_result_can_pass_with_additional_verification?).to eq(true)
+              expect(result.attributes_requiring_additional_verification).to eq([:dob])
+            end
+          end
+
+          context 'response ProductType is not "Verify" or "Verification"' do
+            let(:response_body) do
+              result = JSON.parse(
+                LexisNexisFixtures.ddp_instant_verify_date_of_birth_fail_response_json,
+              )
+              result.dig(
+                'integration_hub_results',
+                'test_org_id:test-policy',
+                'Execute Instant Verify',
+                'tps_vendor_raw_response',
+                'Products',
+              ).first['ProductType'] = 'UKNOWN'
+
+              result.to_json
+            end
+
+            it 'returns a result that does not identify attributes as needing verification' do
+              stub_request(
+                :post,
+                proofing_verification_request.url,
+              ).to_return(
+                body: response_body,
+                status: 200,
+              )
+
+              result = subject.proof(proofing_applicant)
+
+              expect(result.failed_result_can_pass_with_additional_verification?).to eq(false)
+              expect(result.attributes_requiring_additional_verification).to eq([])
+            end
           end
         end
 

--- a/spec/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofers/instant_verify_proofer_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::InstantVerifyProofer do
                 'Execute Instant Verify',
                 'tps_vendor_raw_response',
                 'Products',
-              ).first['ProductType'] = 'UKNOWN'
+              ).first['ProductType'] = 'UNKNOWN'
 
               result.to_json
             end

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
 
   let(:applicant_pii) { Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN }
 
+  let(:proofing_vendor) { :instant_verify_ddp }
+  let(:get_to_yes_enabled_vendors) { ['instant_verify', 'instant_verify_ddp'] }
+
+  before do
+    allow(IdentityConfig.store).to receive(:idv_aamva_get_to_yes_enabled_vendors)
+      .and_return(get_to_yes_enabled_vendors)
+  end
+
   subject do
     described_class.new(
       resolution_result: resolution_result,
@@ -64,6 +72,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
       ipp_current_address_matches_id: ipp_current_address_matches_id,
       applicant_pii: applicant_pii,
       precheck_phone_number: phone_result.empty? ? nil : '202-555-5555',
+      proofing_vendor: proofing_vendor,
     )
   end
 
@@ -194,6 +203,68 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
 
           expect(result.extra[:biographical_info][:state_id_verified_attributes])
             .to eq([:dob])
+        end
+      end
+
+      context 'get to yes is configured per resolution vendor' do
+        let(:applicant_pii) do
+          Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN.merge(
+            aamva_verified_attributes: [:address],
+            address_edited: false,
+          )
+        end
+
+        context 'the resolution vendor that proofed is enabled' do
+          [:instant_verify, :instant_verify_ddp].each do |vendor|
+            context "when #{vendor} proofed the resolution result" do
+              let(:proofing_vendor) { vendor }
+
+              it 'lets AAMVA cover the failure' do
+                result = subject.adjudicated_result
+
+                expect(result.success?).to eq(true)
+                expect(result.extra[:context][:resolution_adjudication_reason])
+                  .to eq(:state_id_covers_failed_resolution)
+              end
+            end
+          end
+        end
+
+        context 'no resolution vendor is enabled' do
+          let(:get_to_yes_enabled_vendors) { [] }
+
+          it 'does not let AAMVA cover the failure' do
+            result = subject.adjudicated_result
+
+            expect(result.success?).to eq(false)
+            expect(result.extra[:context][:resolution_adjudication_reason])
+              .to eq(:fail_resolution_without_state_id_coverage)
+          end
+        end
+
+        context 'a different resolution vendor is enabled' do
+          let(:proofing_vendor) { :instant_verify_ddp }
+          let(:get_to_yes_enabled_vendors) { ['socure_kyc'] }
+
+          it 'does not let AAMVA cover the failure for the vendor that proofed' do
+            result = subject.adjudicated_result
+
+            expect(result.success?).to eq(false)
+            expect(result.extra[:context][:resolution_adjudication_reason])
+              .to eq(:fail_resolution_without_state_id_coverage)
+          end
+        end
+
+        context 'the proofing vendor is unknown' do
+          let(:proofing_vendor) { nil }
+
+          it 'fails closed' do
+            result = subject.adjudicated_result
+
+            expect(result.success?).to eq(false)
+            expect(result.extra[:context][:resolution_adjudication_reason])
+              .to eq(:fail_resolution_without_state_id_coverage)
+          end
         end
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

[Joan-117](https://gitlab.login.gov/lg-teams/joan/joan/-/work_items/117)

## 🛠 Summary of changes

Puts the AAMVA "get to yes" behavior (passing a failed resolution result when AAMVA verified the failed attributes) behind a new config flag, and re-lands the DDP Instant Verify fix from #13228 that was reverted in #13235.

The flag is a list of resolution vendors rather than a boolean, because each vendor reports failed attributes differently. Socure KYC does not populate the rescue fields at all today, so enabling it there is a separate evaluation.

- `idv_aamva_get_to_yes_enabled_vendors` defaults to `'[]'`, which preserves current production behavior. Get-to-yes is inert for both prod buckets today: it is structurally unavailable for `socure_kyc` and broken for `instant_verify_ddp` by the bug #13228 fixes.
- `ProgressiveProofer` passes `proofing_vendor` to `ResultAdjudicator`, which checks the list before letting AAMVA coverage rescue a failed resolution. An unknown vendor is never enabled, so the gate fails closed.
- Adds direct `ResultAdjudicator` coverage for the rescue branch, which previously had none.

To enable in an environment, set the vendors in that environment's `application.yml`, for example `'["instant_verify", "instant_verify_ddp"]'`.

## 📜 Testing Plan

- [x] `bundle exec rspec spec/services/proofing/resolution/result_adjudicator_spec.rb spec/jobs/resolution_proofing_job_spec.rb` passes (36 examples)
- [x] `bundle exec rspec spec/lib/identity_config_spec.rb spec/services/proofing/resolution/progressive_proofer_spec.rb` passes
- [x] `bundle exec rspec spec/controllers/idv/verify_info_controller_spec.rb spec/controllers/idv/in_person/verify_info_controller_spec.rb` passes
- [x] `bundle exec rspec spec/features/idv/doc_auth/verify_info_step_spec.rb` passes the AAMVA contexts
- [x] `bundle exec rspec spec/features/idv/in_person_spec.rb:913` passes the AAMVA contexts
- [x] With the flag unset, a resolution failure that AAMVA covers still fails and logs `fail_resolution_without_state_id_coverage`
- [x] With the vendor added to the flag, the same case passes and logs `state_id_covers_failed_resolution`
