### PR TITLE
Fix OTP expiration warning banner flashing incorrect phase

### DIFF
--- a/app/components/countdown_phase_alert_component.rb
+++ b/app/components/countdown_phase_alert_component.rb
@@ -63,7 +63,10 @@ class CountdownPhaseAlertComponent < BaseComponent
   end
 
   def initial_phase
-    phases.max_by { |p| p[:at_s] }
+    seconds_left = (expiration - Time.zone.now).ceil
+    # if TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_SECONDS is icreased from 600
+    # PhoneDeliveryPresenter alert_countdown_phases will need to be updated
+    phases.find { |p| seconds_left <= p[:at_s] } || phases.first
   end
 
   def normalize_phases(phases)

--- a/spec/components/countdown_phase_alert_component_spec.rb
+++ b/spec/components/countdown_phase_alert_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CountdownPhaseAlertComponent, type: :component do
   around { |ex| freeze_time { ex.run } }
 
-  let(:expiration) { Time.zone.now + 90.seconds }
+  let(:expiration) { Time.zone.now + 10.seconds }
 
   let(:phases_unsorted) do
     [
@@ -18,7 +18,8 @@ RSpec.describe CountdownPhaseAlertComponent, type: :component do
   let(:phases_sorted) { phases_unsorted.sort_by { |p| p[:at_s] } }
 
   let(:first_displayed_phase) do
-    phases_sorted.last
+    seconds_left = (expiration - Time.zone.now).ceil
+    phases_sorted.find { |p| seconds_left <= p[:at_s] } || phases_sorted.first
   end
 
   let(:base_opts) do
@@ -47,6 +48,48 @@ RSpec.describe CountdownPhaseAlertComponent, type: :component do
     )
 
     expect(rendered).to have_css('.usa-alert.margin-bottom-4.usa-alert--info')
+  end
+
+  describe 'initial phase selection based on time remaining' do
+    it 'renders the info phase when well within the largest threshold' do
+      rendered = render_inline described_class.new(
+        **base_opts,
+        expiration: Time.zone.now + 12.seconds,
+      )
+
+      expect(rendered).to have_css('.usa-alert.usa-alert--info')
+      expect(rendered).to have_css('[data-role="phase-label"]', text: '12 seconds')
+    end
+
+    it 'renders a warning phase once a lower threshold is crossed' do
+      rendered = render_inline described_class.new(
+        **base_opts,
+        expiration: Time.zone.now + 5.seconds,
+      )
+
+      expect(rendered).to have_css('.usa-alert.usa-alert--warning')
+      expect(rendered).to have_css('[data-role="phase-label"]', text: '6 seconds left')
+    end
+
+    it 'renders the expired phase when no time remains' do
+      rendered = render_inline described_class.new(
+        **base_opts,
+        expiration: Time.zone.now,
+      )
+
+      expect(rendered).to have_css('.usa-alert.usa-alert--error')
+      expect(rendered).to have_css('[data-role="phase-label"]', text: 'Expired')
+    end
+
+    it 'renders the expired phase when expiration is already in the past' do
+      rendered = render_inline described_class.new(
+        **base_opts,
+        expiration: Time.zone.now - 5.seconds,
+      )
+
+      expect(rendered).to have_css('.usa-alert.usa-alert--error')
+      expect(rendered).to have_css('[data-role="phase-label"]', text: 'Expired')
+    end
   end
 
   it 'renders a hidden countdown element with an expiration' do


### PR DESCRIPTION
- changelog: Bug Fixes, Two-Factor Authentication, Fix one-time code expiration warning briefly showing an incorrect time remainin

<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Link to the relevant ticket:
[LG-17727](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17727)



## 🛠 Summary of changes

**Why**:
- When loading the SMS one-time code entry page, users briefly saw the
  "10 minutes remaining" info badge before it flashed to the actual
  time-remaining warning (e.g. "5 minutes remaining"). This happened
  because the server always rendered the maximum phase as the initial
  state, regardless of how much time was actually left on the code, and
  the correct phase was only applied later on the client's first
  countdown tick.

**How**:
- Update CountdownPhaseAlertComponent#initial_phase to select the phase
  based on the actual seconds remaining until expiration, rather than
  always rendering the largest phase. The initial server-rendered phase
  now matches the phase the client resolves to, eliminating the flash.
- Update countdown_phase_alert_component_spec to reflect time-based
  initial phase selection, and add coverage for the info, warning, and
  expired phases based on time remaining.

## How it works:
<img width="647" height="254" alt="Screenshot 2026-09-01 at 10 54 38 AM" src="https://github.com/user-attachments/assets/63f66eb3-639f-4910-94eb-1b8ab46b06a8" />
<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17727]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17727