### PR TITLE
Render the NDS PIV/CAC sign-in page

### DIFF
--- a/app/assets/images/nds/icons/chevron_left/20.svg
+++ b/app/assets/images/nds/icons/chevron_left/20.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path fill="currentColor" fill-rule="evenodd" d="m7.768 10 5.293-5.293-1.415-1.414L4.94 10l6.707 6.707 1.415-1.414z" clip-rule="evenodd"/></svg>

--- a/app/views/users/piv_cac_login/new.html.erb
+++ b/app/views/users/piv_cac_login/new.html.erb
@@ -1,15 +1,44 @@
 <% self.title = @presenter.title %>
 
-<%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
+<% if nds_layout? %>
+  <%= render NDS::AuthEntryComponent.new do %>
+    <%= render ButtonComponent.new(
+          url: new_user_session_url,
+          variant: :secondary,
+          size: :md,
+          class: 'auth-entry__back usa-button--icon-only',
+          aria: { label: t('forms.buttons.back') },
+        ) do %>
+      <%= render NDS::IconComponent.new(icon: :chevron_left, size: 20) %>
+    <% end %>
 
-<p class="margin-bottom-5">
-  <%= @presenter.info %>
-</p>
+    <%= render NDS::FormPageComponent.new(title: @presenter.heading) do |page| %>
+      <% page.with_body do %>
+        <div class="copy copy--muted">
+          <p><%= @presenter.info %></p>
+        </div>
+      <% end %>
 
-<%= render SpinnerButtonComponent.new(
-      url: @presenter.piv_cac_service_link,
-      big: true,
-      wide: true,
-    ).with_content(@presenter.piv_cac_capture_text) %>
+      <% page.with_actions do %>
+        <%= render ButtonComponent.new(
+              url: @presenter.piv_cac_service_link,
+              full_width: true,
+            ).with_content(@presenter.piv_cac_capture_text) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render PageHeadingComponent.new.with_content(@presenter.heading) %>
 
-<%= render 'shared/cancel', link: new_user_session_url %>
+  <p class="margin-bottom-5">
+    <%= @presenter.info %>
+  </p>
+
+  <%= render SpinnerButtonComponent.new(
+        url: @presenter.piv_cac_service_link,
+        big: true,
+        wide: true,
+      ).with_content(@presenter.piv_cac_capture_text) %>
+
+  <%= render 'shared/cancel', link: new_user_session_url %>
+<% end %>

--- a/spec/views/users/piv_cac_login/new.html.erb_spec.rb
+++ b/spec/views/users/piv_cac_login/new.html.erb_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'users/piv_cac_login/new.html.erb' do
+  let(:presenter) do
+    instance_double(
+      PivCacAuthenticationLoginPresenter,
+      title: 'PIV/CAC title',
+      heading: 'Sign in with your government employee ID',
+      info: 'Make sure you have a Login.gov account.',
+      piv_cac_service_link: '/account/login/present_piv_cac',
+      piv_cac_capture_text: 'Insert PIV/CAC',
+    )
+  end
+
+  before do
+    assign(:presenter, presenter)
+    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:user_signing_up?).and_return(false)
+  end
+
+  it 'renders the legacy heading, info, and capture button' do
+    render
+
+    expect(rendered).to have_content('Sign in with your government employee ID')
+    expect(rendered).to have_content('Make sure you have a Login.gov account.')
+    expect(rendered).to have_link(
+      'Insert PIV/CAC',
+      href: '/account/login/present_piv_cac',
+    )
+  end
+
+  context 'nds bucket' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the NDS auth-entry PIV/CAC card' do
+      render
+
+      expect(rendered).to have_css('.auth-entry .auth-entry__card section.auth.auth--form-page')
+      expect(rendered).to have_css('h1', text: 'Sign in with your government employee ID')
+      expect(rendered).to have_content('Make sure you have a Login.gov account.')
+    end
+
+    it 'renders the full-width primary capture button' do
+      render
+
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button',
+        text: 'Insert PIV/CAC',
+      )
+      expect(rendered).to have_link(
+        'Insert PIV/CAC',
+        href: '/account/login/present_piv_cac',
+      )
+    end
+
+    it 'renders an icon-only back affordance linking to sign in' do
+      render
+
+      expect(rendered).to have_css(
+        'a.auth-entry__back.usa-button--icon-only[aria-label="Back"]',
+      )
+      expect(rendered).to have_css('a.auth-entry__back svg.usa-icon')
+      expect(rendered).to have_link(nil, href: new_user_session_url)
+    end
+  end
+end


### PR DESCRIPTION
## Tickets

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/58

## Summary

- Renders `users/piv_cac_login#new` in the NDS auth-entry layout (nds bucket only): the shared marketing column + card (`NDS::AuthEntryComponent`), the presenter heading/info via `NDS::FormPageComponent`, a full-width primary "Insert PIV/CAC" button, and an icon-only chevron-left back affordance pinned to the card's top-start corner linking to sign in.
- Adds the `chevron_left` NDS icon SVG.
- The default (non-nds) experience is byte-preserved.

## Dependencies

- Design-system side (npm-linked): IDS MR !97 (`.usa-button--icon-only`, `.auth-entry__back`) stacked on !96.
- Built on top of the sign-in PR #13450 (which adds `NDS::AuthEntryComponent` + `NDS::IconComponent`). **Merge #13450 first, then retarget this PR's base to `main`.**

## Test plan

- [ ] `bundle exec rspec spec/views/users/piv_cac_login/new.html.erb_spec.rb` (4 examples)
- [ ] `bundle exec erb_lint app/views/users/piv_cac_login/new.html.erb`
- [ ] `bundle exec rubocop`
- [ ] Page renders at `/account/login/piv_cac?ui_test_bucket=nds`; back button clears the heading; "Insert PIV/CAC" navigates to the PIV/CAC service
- [ ] Non-nds bucket unchanged