### PR TITLE
Render the NDS check-your-email page

### DIFF
--- a/app/views/sign_up/emails/show.html.erb
+++ b/app/views/sign_up/emails/show.html.erb
@@ -1,5 +1,57 @@
 <% self.title = t('titles.verify_email') %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :account, substep: 1) %>
+  <% end %>
+
+  <%= render NDS::FormPageComponent.new(
+        title: t('headings.verify_email'),
+        subtitle: t(
+          'notices.verify_email.body_html',
+          email: email,
+        ),
+      ) do |page| %>
+    <% if @resend_confirmation %>
+      <% page.with_alert do %>
+        <%= render AlertComponent.new(
+              type: :success,
+              message: t('notices.resend_confirmation_email.success'),
+            ) %>
+      <% end %>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+        <%= simple_form_for @resend_email_confirmation_form,
+                            url: sign_up_register_path do |f| %>
+          <%= f.input :email, as: :hidden %>
+          <%= f.input :resend, as: :hidden %>
+          <%= f.input :terms_accepted, as: :hidden %>
+          <%= render ButtonComponent.new(
+                type: :submit,
+                variant: :secondary,
+                full_width: true,
+              ).with_content(t('notices.verify_email.resend')) %>
+        <% end %>
+
+        <%= render ButtonComponent.new(
+              url: sign_up_email_path,
+              variant: :tertiary,
+              full_width: true,
+            ).with_content(t('notices.verify_email.use_different_email')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if FeatureManagement.enable_load_testing_mode? && EmailAddress.find_with_email(email) %>
+    <%= link_to(
+          'CONFIRM NOW',
+          sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email).confirmation_token),
+          id: 'confirm-now',
+        ) %>
+  <% end %>
+<% else %>
 <% if @resend_confirmation %>
   <%= render AlertComponent.new(
         type: :success,
@@ -41,4 +93,5 @@
         sign_up_create_email_confirmation_url(confirmation_token: EmailAddress.find_with_email(email).confirmation_token),
         id: 'confirm-now',
       ) %>
+<% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1649,6 +1649,9 @@ notices.timeout_warning.signed_in.sign_out: Sign me out
 notices.totp_configured: An authentication app was added to your account.
 notices.use_diff_email.link: use a different email address
 notices.use_diff_email.text_html: Or, %{link_html}
+notices.verify_email.body_html: We sent a link to <strong>%{email}</strong>. If you don’t receive an email shortly, check your spam or junk folder.
+notices.verify_email.resend: Resend confirmation email
+notices.verify_email.use_different_email: Use a different email
 notices.webauthn_configured: A security key was added to your account.
 notices.webauthn_platform_configured: You used your device’s screen lock to add face or touch unlock to your account.
 openid_connect.authorization.errors.bad_client_id: Bad client_id. Please see our documentation at https://developers.login.gov/support/#bad-client-id

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1660,6 +1660,9 @@ notices.timeout_warning.signed_in.sign_out: Cerrar mi sesión
 notices.totp_configured: Se agregó una aplicación de autenticación a su cuenta.
 notices.use_diff_email.link: use una dirección de correo electrónico diferente
 notices.use_diff_email.text_html: O %{link_html}
+notices.verify_email.body_html: Le enviamos un enlace a <strong>%{email}</strong>. Si no recibe un correo electrónico en breve, revise su carpeta de correo no deseado.
+notices.verify_email.resend: Reenviar correo de confirmación
+notices.verify_email.use_different_email: Usar un correo electrónico diferente
 notices.webauthn_configured: Se agregó una clave de seguridad a su cuenta.
 notices.webauthn_platform_configured: Usó el bloqueo de pantalla de su dispositivo para agregar el desbloqueo facial o táctil a su cuenta.
 openid_connect.authorization.errors.bad_client_id: client_id incorrecto. Consulte nuestra documentación en https://developers.login.gov/support/#bad-client-id

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1649,6 +1649,9 @@ notices.timeout_warning.signed_in.sign_out: Déconnectez-moi
 notices.totp_configured: Une appli d’authentification a été ajoutée à votre compte.
 notices.use_diff_email.link: utiliser une adresse e-mail différente
 notices.use_diff_email.text_html: Ou %{link_html}
+notices.verify_email.body_html: Nous avons envoyé un lien à <strong>%{email}</strong>. Si vous ne recevez pas d’e-mail rapidement, vérifiez votre dossier de courrier indésirable.
+notices.verify_email.resend: Renvoyer l’e-mail de confirmation
+notices.verify_email.use_different_email: Utiliser une autre adresse e-mail
 notices.webauthn_configured: Une clé de sécurité a été ajoutée à votre compte.
 notices.webauthn_platform_configured: Vous avez utilisé le verrouillage de l’écran de votre appareil pour ajouter le déverrouillage facial ou tactile à votre compte.
 openid_connect.authorization.errors.bad_client_id: Mauvaise client_id. Veuillez consulter notre documentation à https://developers.login.gov/support/#bad-client-id

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1662,6 +1662,9 @@ notices.timeout_warning.signed_in.sign_out: 把我登出
 notices.totp_configured: 你账户添加了一个身份证实应用程序。
 notices.use_diff_email.link: 使用一个不同的电邮地址
 notices.use_diff_email.text_html: 或者，%{link_html}
+notices.verify_email.body_html: 我们向 <strong>%{email}</strong> 发送了一个链接。如果你没有很快收到电子邮件，请检查你的垃圾邮件文件夹。
+notices.verify_email.resend: 重新发送确认电子邮件
+notices.verify_email.use_different_email: 使用其他电子邮件
 notices.webauthn_configured: 你账户添加了一个安全密钥。
 notices.webauthn_platform_configured: 你用了自己设备的屏幕锁定给账户添加了人脸或触摸解锁。
 openid_connect.authorization.errors.bad_client_id: 坏的client_id。请参阅我们的文档：https://developers.login.gov/support/#bad-client-id

--- a/spec/views/sign_up/emails/show.html.erb_spec.rb
+++ b/spec/views/sign_up/emails/show.html.erb_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe 'sign_up/emails/show.html.erb' do
   let(:email) { 'foo@bar.com' }
   before do
     allow(view).to receive(:email).and_return(email)
-    @resend_email_confirmation_form = ResendEmailConfirmationForm.new
+    allow(view).to receive(:nds_layout?).and_return(false)
+    @resend_email_confirmation_form = ResendEmailConfirmationForm.new(email:)
   end
 
   it 'has a localized title' do
@@ -17,6 +18,77 @@ RSpec.describe 'sign_up/emails/show.html.erb' do
     render
 
     expect(rendered).to have_selector('h1', text: t('headings.verify_email'))
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    render
+
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the check-your-email heading' do
+      render
+
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector('.auth--form-page h1', text: t('headings.verify_email'))
+    end
+
+    it 'sets the account-creation header progress at the Account 1/2 substep' do
+      render
+
+      progress = view.content_for(:nds_header_progress)
+      expect(progress).to have_css('nds-progress .progress__step[aria-current="step"]')
+      expect(progress).to have_css('.progress__step-counter', text: '1 / 2')
+    end
+
+    it 'renders the body copy including the email address' do
+      render
+
+      expect(rendered).to have_selector(
+        '.auth__intro-description',
+        text: "We sent a link to #{email}",
+      )
+      expect(rendered).to have_selector('.auth__intro-description strong', text: email)
+    end
+
+    it 'renders the resend confirmation submit button posting to the register path' do
+      render
+
+      expect(rendered).to have_css("form[action='#{sign_up_register_path}']")
+      expect(rendered).to have_field('user[email]', type: :hidden, with: email)
+      expect(rendered)
+        .to have_button(t('notices.verify_email.resend'))
+    end
+
+    it 'renders the use-a-different-email link to the email entry path' do
+      render
+
+      expect(rendered).to have_link(
+        t('notices.verify_email.use_different_email'),
+        href: sign_up_email_path,
+      )
+    end
+
+    it 'does not render the success alert without a resend confirmation' do
+      render
+
+      expect(rendered).to_not have_content(t('notices.resend_confirmation_email.success'))
+    end
+
+    context 'when a confirmation email was just resent' do
+      before { @resend_confirmation = true }
+
+      it 'renders the success alert inside the card' do
+        render
+
+        expect(rendered).to have_content(t('notices.resend_confirmation_email.success'))
+      end
+    end
   end
 
   it 'contains a form link to resend confirmation page' do


### PR DESCRIPTION
## Tickets

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/59
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/60

## Summary

- Renders `sign_up/emails#show` (`/sign_up/verify_email`) in the NDS layout (nds bucket only): a single centered `NDS::FormPageComponent` card with the "Check your email" heading, the body copy with the bolded email, a secondary "Resend confirmation email" submit and a tertiary "Use a different email" link, plus the success alert on resend.
- The default (non-nds) experience is byte-preserved.
- Independent of the other NDS auth PRs — bases off `main` (this page uses only components already on `main`; no `AuthEntryComponent` dependency).

## i18n

- New key (real translations, all four locales): `notices.verify_email.body_html`.

## Test plan

- [ ] `bundle exec rspec spec/views/sign_up/emails/show.html.erb_spec.rb spec/i18n_spec.rb`
- [ ] `bundle exec erb_lint app/views/sign_up/emails/show.html.erb`
- [ ] `bundle exec rubocop`
- [ ] Page renders at `/sign_up/verify_email?ui_test_bucket=nds`; resend re-sends and shows the success alert; "Use a different email" returns to enter-email
- [ ] Non-nds bucket unchanged