### PR TITLE
LG-17895 Redirect DocV user with undetected mDL to Choose ID Type screen

### DIFF
--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -79,6 +79,7 @@ module Idv
         auto_check_value:,
         passport_cards_enabled: document_capture_session.passport_cards_supported?,
         mdl_enabled: mdl_enabled?,
+        disable_mdl: disable_mdl?,
       }
     end
 
@@ -93,6 +94,10 @@ module Idv
 
     def mdl_enabled?
       document_capture_session.mdl_enabled
+    end
+
+    def disable_mdl?
+      params.permit(:disable_mdl)[:disable_mdl].present?
     end
   end
 end

--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -53,7 +53,11 @@ module Idv
     def locals_attrs(presenter:, form_submit_url: nil)
       auto_check_value = case document_capture_session.document_type_requested
                         when Idp::Constants::DocumentTypes::MDL
-                          :mobile_drivers_license
+                          if disable_mdl?
+                            :state_id_card
+                          else
+                            :mobile_drivers_license
+                          end
                         when *Idp::Constants::DocumentTypes::SUPPORTED_STATE_ID_TYPES
                           :state_id_card
                         when Idp::Constants::DocumentTypes::PASSPORT

--- a/app/controllers/concerns/idv/document_capture_concern.rb
+++ b/app/controllers/concerns/idv/document_capture_concern.rb
@@ -138,6 +138,7 @@ module Idv
         customer_user_id: document_request_body[:customerUserId],
         document_type_requested: document_request_body[:documentType],
         use_case_key: document_request_body[:useCaseKey],
+        error_redirect: document_request_body[:errorRedirect],
         docv_transaction_token: response_hash.dig(:data, :docvTransactionToken),
         socure_status: response_hash[:status],
         socure_msg: response_hash[:msg],
@@ -147,6 +148,7 @@ module Idv
         .merge(document_request_body).except(
           :documentType, # requested document type
           :useCaseKey,
+          :errorRedirect, # logged as error_redirect
         )
         .merge(response_body: document_response.to_h)
       analytics.idv_socure_document_request_submitted(**analytics_hash)

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -49,6 +49,7 @@ module Idv
             language: I18n.locale,
             liveness_checking_required: resolved_authn_context_result.facial_match?,
             document_capture_session:,
+            error_redirect_url:,
           )
           timer = JobHelpers::Timer.new
           document_response = timer.time('vendor_request') do
@@ -190,6 +191,14 @@ module Idv
           @rate_limiter ||= RateLimiter.new(
             user: document_capture_user,
             rate_limit_type: :idv_doc_auth,
+          )
+        end
+
+        def error_redirect_url
+          return unless document_captue_session.mdl_requested?
+
+          idv_hybrid_mobile_socure_document_capture_errors_url(
+            error_code: :mdl_not_found,
           )
         end
       end

--- a/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/document_capture_controller.rb
@@ -195,7 +195,7 @@ module Idv
         end
 
         def error_redirect_url
-          return unless document_captue_session.mdl_requested?
+          return unless document_capture_session.mdl_requested?
 
           idv_hybrid_mobile_socure_document_capture_errors_url(
             error_code: :mdl_not_found,

--- a/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
@@ -22,6 +22,7 @@ module Idv
           end
           track_event(error_code: error_code)
           if error_code == 'mdl_not_found'
+            document_capture_session.update!(mdl_enabled: false)
             redirect_to idv_hybrid_mobile_choose_id_type_url(disable_mdl: true)
           else
             @presenter = socure_errors_presenter(error_code)

--- a/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
+++ b/app/controllers/idv/hybrid_mobile/socure/errors_controller.rb
@@ -21,7 +21,11 @@ module Idv
             error_code = error_code_for(result)
           end
           track_event(error_code: error_code)
-          @presenter = socure_errors_presenter(error_code)
+          if error_code == 'mdl_not_found'
+            redirect_to idv_hybrid_mobile_choose_id_type_url(disable_mdl: true)
+          else
+            @presenter = socure_errors_presenter(error_code)
+          end
         end
 
         def self.step_info

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -45,6 +45,7 @@ module Idv
           language: I18n.locale,
           liveness_checking_required: resolved_authn_context_result.facial_match?,
           document_capture_session:,
+          error_redirect_url:,
         )
         timer = JobHelpers::Timer.new
         document_response = timer.time('vendor_request') do
@@ -187,7 +188,7 @@ module Idv
       end
 
       def error_redirect_url
-        return unless document_captue_session.mdl_requested?
+        return unless document_capture_session.mdl_requested?
 
         idv_socure_document_capture_errors_url(
           error_code: :mdl_not_found,

--- a/app/controllers/idv/socure/document_capture_controller.rb
+++ b/app/controllers/idv/socure/document_capture_controller.rb
@@ -185,6 +185,14 @@ module Idv
           pii_like_keypaths: [[:pii]],
         }.merge(ab_test_analytics_buckets)
       end
+
+      def error_redirect_url
+        return unless document_captue_session.mdl_requested?
+
+        idv_socure_document_capture_errors_url(
+          error_code: :mdl_not_found,
+        )
+      end
     end
   end
 end

--- a/app/controllers/idv/socure/errors_controller.rb
+++ b/app/controllers/idv/socure/errors_controller.rb
@@ -20,6 +20,7 @@ module Idv
         track_event(error_code:)
 
         if error_code == 'mdl_not_found'
+          document_capture_session&.update!(mdl_enabled: false)
           redirect_to idv_choose_id_type_url(disable_mdl: true)
         else
           @presenter = socure_errors_presenter(error_code)

--- a/app/controllers/idv/socure/errors_controller.rb
+++ b/app/controllers/idv/socure/errors_controller.rb
@@ -17,8 +17,13 @@ module Idv
         if error_code.nil?
           error_code = error_code_for(handle_stored_result)
         end
-        track_event(error_code: error_code)
-        @presenter = socure_errors_presenter(error_code)
+        track_event(error_code:)
+
+        if error_code == 'mdl_not_found'
+          redirect_to idv_choose_id_type_url(disable_mdl: true)
+        else
+          @presenter = socure_errors_presenter(error_code)
+        end
       end
 
       def self.step_info

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -6051,6 +6051,7 @@ module AnalyticsEvents
   # @param [String] socure_status Socure's status value for internal errors on their side.
   # @param [String] socure_msg Socure's status message for interal errors on their side.
   # @param [String] use_case_key name of requested DocV flow
+  # @param [Hash] error_redirect hash for error redirect (url and method)
   # The request for socure verification was sent
   def idv_socure_document_request_submitted(
     success:,
@@ -6077,6 +6078,7 @@ module AnalyticsEvents
     socure_status: nil,
     socure_msg: nil,
     use_case_key: nil,
+    error_redirect: nil,
     **extra
   )
     track_event(
@@ -6105,6 +6107,7 @@ module AnalyticsEvents
       socure_status:,
       socure_msg:,
       use_case_key:,
+      error_redirect:,
       **extra,
     )
   end

--- a/app/services/doc_auth/socure/requests/document_request.rb
+++ b/app/services/doc_auth/socure/requests/document_request.rb
@@ -4,7 +4,7 @@ module DocAuth
   module Socure
     module Requests
       class DocumentRequest < DocAuth::Socure::Request
-        attr_reader :customer_user_id, :redirect_url, :language,
+        attr_reader :customer_user_id, :redirect_url, :language, :error_redirect_url,
                     :liveness_checking_required, :document_capture_session
 
         PASSPORT_DOCUMENT_TYPE = 'passport'
@@ -16,13 +16,15 @@ module DocAuth
           redirect_url:,
           language:,
           document_capture_session:,
-          liveness_checking_required: false
+          liveness_checking_required: false,
+          error_redirect_url: nil
         )
           @customer_user_id = customer_user_id
           @redirect_url = redirect_url
           @language = language
           @liveness_checking_required = liveness_checking_required
           @document_capture_session = document_capture_session
+          @error_redirect_url = error_redirect_url
         end
 
         def body
@@ -31,12 +33,23 @@ module DocAuth
             url: redirect_url,
           }
 
-          redirect = nil if Rails.env.development?
+          error_redirect = {
+            method: 'GET',
+            url: error_redirect_url,
+          }
+
+          if Rails.env.development?
+            redirect = nil
+            error_redirect = nil
+          elsif document_type != MDL_DOCUMENT_TYPE
+            error_redirect = nil
+          end
 
           {
             config: {
               documentType: document_type,
               redirect:,
+              errorRedirect: error_redirect,
               language: lang(language),
               useCaseKey: use_case_key,
             },

--- a/app/services/doc_auth/socure/requests/document_request.rb
+++ b/app/services/doc_auth/socure/requests/document_request.rb
@@ -33,26 +33,24 @@ module DocAuth
             url: redirect_url,
           }
 
-          error_redirect = {
-            method: 'GET',
-            url: error_redirect_url,
+          redirect = nil if Rails.env.development?
+
+          config = {
+            documentType: document_type,
+            redirect:,
+            language: lang(language),
+            useCaseKey: use_case_key,
           }
 
-          if Rails.env.development?
-            redirect = nil
-            error_redirect = nil
-          elsif document_type != MDL_DOCUMENT_TYPE
-            error_redirect = nil
+          if error_redirect_url.present? && !Rails.env.development?
+            config[:errorRedirect] = {
+              method: 'GET',
+              url: error_redirect_url,
+            }
           end
 
           {
-            config: {
-              documentType: document_type,
-              redirect:,
-              errorRedirect: error_redirect,
-              language: lang(language),
-              useCaseKey: use_case_key,
-            },
+            config:,
             customerUserId: customer_user_id,
           }.to_json
         end

--- a/app/views/idv/shared/choose_id_type.html.erb
+++ b/app/views/idv/shared/choose_id_type.html.erb
@@ -63,7 +63,7 @@
               [t('doc_auth.forms.id_type_preference.drivers_license'), :state_id_card],
               [t('doc_auth.forms.id_type_preference.passport'), :passport, disabled: disable_passports],
               (passport_cards_enabled ? [t('doc_auth.forms.id_type_preference.passport_card'), :passport_card, disabled: disable_passports] : nil),
-              (mdl_enabled ? [t('doc_auth.forms.id_type_preference.mdl'), :mobile_drivers_license] : nil),
+              (mdl_enabled ? [t('doc_auth.forms.id_type_preference.mdl'), :mobile_drivers_license, disabled: disable_mdl] : nil),
             ].compact,
             form: f,
             input_html: { class: 'usa-radio__input--tile' },

--- a/app/views/idv/shared/choose_id_type.html.erb
+++ b/app/views/idv/shared/choose_id_type.html.erb
@@ -63,7 +63,7 @@
               [t('doc_auth.forms.id_type_preference.drivers_license'), :state_id_card],
               [t('doc_auth.forms.id_type_preference.passport'), :passport, disabled: disable_passports],
               (passport_cards_enabled ? [t('doc_auth.forms.id_type_preference.passport_card'), :passport_card, disabled: disable_passports] : nil),
-              (mdl_enabled ? [t('doc_auth.forms.id_type_preference.mdl'), :mobile_drivers_license, disabled: disable_mdl] : nil),
+              (mdl_enabled || disable_mdl ? [t('doc_auth.forms.id_type_preference.mdl'), :mobile_drivers_license, disabled: disable_mdl] : nil),
             ].compact,
             form: f,
             input_html: { class: 'usa-radio__input--tile' },

--- a/spec/controllers/idv/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/choose_id_type_controller_spec.rb
@@ -58,6 +58,36 @@ RSpec.describe Idv::ChooseIdTypeController do
       end
     end
 
+    context 'when mdl was not detected' do
+      render_views
+
+      let(:document_capture_session) do
+        create(
+          :document_capture_session,
+          user:,
+          mdl_enabled: false,
+          document_type_requested: Idp::Constants::DocumentTypes::MDL,
+        )
+      end
+
+      before do
+        subject.idv_session.flow_path = 'standard'
+        get :show, params: { disable_mdl: true }
+      end
+
+      it 'renders the mdl option disabled' do
+        expect(response.body).to have_css(
+          'input[type=radio][value=mobile_drivers_license][disabled]',
+        )
+      end
+
+      it 'pre-checks the drivers license option' do
+        expect(response.body).to have_css(
+          'input[type=radio][value=state_id_card][checked]',
+        )
+      end
+    end
+
     context 'when the user does not have a flow path' do
       before do
         subject.idv_session.flow_path = nil

--- a/spec/controllers/idv/hybrid_mobile/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/choose_id_type_controller_spec.rb
@@ -123,6 +123,30 @@ RSpec.describe Idv::HybridMobile::ChooseIdTypeController do
         expect(@analytics).to have_logged_event(analytics_name, analytics_args)
       end
     end
+
+    context 'when mdl was not detected' do
+      render_views
+
+      subject(:response) { get :show, params: { disable_mdl: true } }
+
+      let(:document_type_requested) { Idp::Constants::DocumentTypes::MDL }
+
+      before do
+        document_capture_session.update!(mdl_enabled: false)
+      end
+
+      it 'renders the mdl option disabled' do
+        expect(response.body).to have_css(
+          'input[type=radio][value=mobile_drivers_license][disabled]',
+        )
+      end
+
+      it 'pre-checks the drivers license option' do
+        expect(response.body).to have_css(
+          'input[type=radio][value=state_id_card][checked]',
+        )
+      end
+    end
   end
 
   describe '#update' do

--- a/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/document_capture_controller_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
               redirect_url: idv_hybrid_mobile_socure_document_capture_update_url,
               language: expected_language,
               liveness_checking_required: false,
+              error_redirect_url: nil,
             )
         end
 
@@ -218,6 +219,12 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
                       },
                       language: expected_language,
                       useCaseKey: IdentityConfig.store.idv_socure_docv_flow_id_only,
+                      errorRedirect: {
+                        method: 'GET',
+                        url: idv_hybrid_mobile_socure_document_capture_errors_url(
+                          error_code: :mdl_not_found,
+                        ),
+                      },
                     },
                     customerUserId: user.uuid,
                   },
@@ -358,6 +365,12 @@ RSpec.describe Idv::HybridMobile::Socure::DocumentCaptureController do
                       },
                       language: expected_language,
                       useCaseKey: IdentityConfig.store.idv_socure_docv_flow_id_only,
+                      errorRedirect: {
+                        method: 'GET',
+                        url: idv_hybrid_mobile_socure_document_capture_errors_url(
+                          error_code: :mdl_not_found,
+                        ),
+                      },
                     },
                     customerUserId: user.uuid,
                   },

--- a/spec/controllers/idv/hybrid_mobile/socure/errors_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_mobile/socure/errors_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Idv::HybridMobile::Socure::ErrorsController do
+  let(:user) { create(:user) }
+  let(:document_capture_session) do
+    create(
+      :document_capture_session,
+      user:,
+      requested_at: Time.zone.now,
+      doc_auth_vendor: Idp::Constants::Vendors::SOCURE,
+      mdl_enabled: true,
+      document_type_requested: Idp::Constants::DocumentTypes::MDL,
+    )
+  end
+
+  before do
+    stub_analytics
+
+    session[:doc_capture_user_id] = user.id
+    session[:document_capture_session_uuid] = document_capture_session.uuid
+  end
+
+  describe '#show' do
+    context 'when error_code is mdl_not_found' do
+      it 'redirects to choose id type with mdl disabled' do
+        get(:show, params: { error_code: 'mdl_not_found' })
+
+        expect(response).to redirect_to idv_hybrid_mobile_choose_id_type_url(disable_mdl: true)
+      end
+
+      it 'disables mdl on the document capture session' do
+        expect { get(:show, params: { error_code: 'mdl_not_found' }) }
+          .to change { document_capture_session.reload.mdl_enabled }
+          .from(true).to(false)
+      end
+
+      it 'logs an event with the error code' do
+        get(:show, params: { error_code: 'mdl_not_found' })
+
+        expect(@analytics).to have_logged_event(
+          :idv_doc_auth_socure_error_visited,
+          hash_including(error_code: 'mdl_not_found'),
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/idv/socure/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/socure/document_capture_controller_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
               redirect_url: idv_socure_document_capture_update_url,
               language: expected_language,
               liveness_checking_required: false,
+              error_redirect_url: nil,
             )
         end
 
@@ -281,6 +282,7 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
                 redirect_url: idv_socure_document_capture_update_url,
                 language: expected_language,
                 liveness_checking_required: false,
+                error_redirect_url: nil,
               )
           end
 
@@ -316,6 +318,7 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
                 redirect_url: idv_socure_document_capture_update_url,
                 language: expected_language,
                 liveness_checking_required: false,
+                error_redirect_url: nil,
               )
           end
 
@@ -351,6 +354,9 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
                 redirect_url: idv_socure_document_capture_update_url,
                 language: expected_language,
                 liveness_checking_required: false,
+                error_redirect_url: idv_socure_document_capture_errors_url(
+                  error_code: :mdl_not_found,
+                ),
               )
           end
 
@@ -367,6 +373,12 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
                       },
                       language: :en,
                       useCaseKey: idv_socure_docv_flow_id_only,
+                      errorRedirect: {
+                        method: 'GET',
+                        url: idv_socure_document_capture_errors_url(
+                          error_code: :mdl_not_found,
+                        ),
+                      },
                     },
                     customerUserId: user.uuid,
                   },
@@ -393,6 +405,7 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
               redirect_url: idv_socure_document_capture_update_url,
               language: expected_language,
               liveness_checking_required: true,
+              error_redirect_url: nil,
             )
         end
 
@@ -427,6 +440,7 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
                 redirect_url: idv_socure_document_capture_update_url,
                 language: expected_language,
                 liveness_checking_required: true,
+                error_redirect_url: nil,
               )
           end
 
@@ -462,6 +476,9 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
                 redirect_url: idv_socure_document_capture_update_url,
                 language: expected_language,
                 liveness_checking_required: true,
+                error_redirect_url: idv_socure_document_capture_errors_url(
+                  error_code: :mdl_not_found,
+                ),
               )
           end
 
@@ -478,6 +495,12 @@ RSpec.describe Idv::Socure::DocumentCaptureController do
                       },
                       language: :en,
                       useCaseKey: idv_socure_docv_flow_id_only,
+                      errorRedirect: {
+                        method: 'GET',
+                        url: idv_socure_document_capture_errors_url(
+                          error_code: :mdl_not_found,
+                        ),
+                      },
                     },
                     customerUserId: user.uuid,
                   },

--- a/spec/controllers/idv/socure/errors_controller_spec.rb
+++ b/spec/controllers/idv/socure/errors_controller_spec.rb
@@ -26,5 +26,53 @@ RSpec.describe Idv::Socure::ErrorsController do
         hash_including(docv_transaction_token: transaction_token),
       )
     end
+
+    context 'when error_code is mdl_not_found' do
+      let(:document_capture_session) do
+        create(
+          :document_capture_session,
+          user:,
+          mdl_enabled: true,
+          document_type_requested: Idp::Constants::DocumentTypes::MDL,
+        )
+      end
+
+      before do
+        subject.idv_session.document_capture_session_uuid = document_capture_session.uuid
+      end
+
+      it 'redirects to choose id type with mdl disabled' do
+        get(:show, params: { error_code: 'mdl_not_found' })
+
+        expect(response).to redirect_to idv_choose_id_type_url(disable_mdl: true)
+      end
+
+      it 'disables mdl on the document capture session' do
+        expect { get(:show, params: { error_code: 'mdl_not_found' }) }
+          .to change { document_capture_session.reload.mdl_enabled }
+          .from(true).to(false)
+      end
+
+      it 'logs an event with the error code' do
+        get(:show, params: { error_code: 'mdl_not_found' })
+
+        expect(@analytics).to have_logged_event(
+          :idv_doc_auth_socure_error_visited,
+          hash_including(error_code: 'mdl_not_found'),
+        )
+      end
+
+      context 'without a document capture session' do
+        before do
+          subject.idv_session.document_capture_session_uuid = nil
+        end
+
+        it 'still redirects to choose id type' do
+          get(:show, params: { error_code: 'mdl_not_found' })
+
+          expect(response).to redirect_to idv_choose_id_type_url(disable_mdl: true)
+        end
+      end
+    end
   end
 end

--- a/spec/forms/idv/choose_id_type_form_spec.rb
+++ b/spec/forms/idv/choose_id_type_form_spec.rb
@@ -38,6 +38,32 @@ RSpec.describe Idv::ChooseIdTypeForm do
       end
     end
 
+    context 'when the choose_id_type_preference is a mobile drivers license' do
+      let(:mdl_enabled) { true }
+      let(:subject) { Idv::ChooseIdTypeForm.new(mdl_enabled:, passport_cards_enabled:) }
+      let(:params) do
+        { choose_id_type_preference: Idp::Constants::DocumentTypes::MDL }
+      end
+
+      it 'returns a successful form response' do
+        result = subject.submit(params)
+
+        expect(result.success?).to eq(true)
+        expect(result.errors).to be_empty
+      end
+
+      context 'when mdl is not enabled' do
+        let(:mdl_enabled) { false }
+
+        it 'returns a failed form response' do
+          result = subject.submit(params)
+
+          expect(result.success?).to eq(false)
+          expect(result.errors).not_to be_empty
+        end
+      end
+    end
+
     context 'when the choose_id_type_preference is nil' do
       let(:params) { { choose_id_type_preference: nil } }
 

--- a/spec/services/doc_auth/socure/requests/document_request_spec.rb
+++ b/spec/services/doc_auth/socure/requests/document_request_spec.rb
@@ -112,6 +112,36 @@ RSpec.describe DocAuth::Socure::Requests::DocumentRequest do
       end
     end
 
+    context 'when an error redirect url is provided' do
+      let(:error_redirect_url) { 'https://idv.test/errors?error_code=mdl_not_found' }
+      let(:document_type_requested) { Idp::Constants::DocumentTypes::MDL }
+      let(:document_type) { DocAuth::Socure::Requests::DocumentRequest::MDL_DOCUMENT_TYPE }
+
+      subject(:document_request) do
+        described_class.new(
+          customer_user_id: customer_user_id,
+          redirect_url: redirect_url,
+          language:,
+          document_capture_session:,
+          error_redirect_url:,
+        )
+      end
+
+      before do
+        expected_request_body[:config][:errorRedirect] = {
+          method: 'GET',
+          url: error_redirect_url,
+        }
+      end
+
+      it 'includes errorRedirect in the config' do
+        document_request.fetch
+
+        expect(WebMock).to have_requested(:post, fake_socure_endpoint)
+          .with(body: JSON.generate(expected_request_body))
+      end
+    end
+
     it 'passes the response through' do
       response = document_request.fetch
 


### PR DESCRIPTION
changelog: Upcoming Features, Document Authentication, Redirect users with an undetected mDL to choose another ID type

## 🎫 Ticket

Link to the relevant ticket:
[LG-17895](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17895)

## 🛠 Summary of changes

When Socure can't detect an mDL the DocV session was dead-ending on a generic error page. The `DocumentRequest` payload now includes an `errorRedirect` (mdl sessions only) pointing at the socure errors controller with `error_code=mdl_not_found`. Both standard and hybrid errors controllers log the error event, set `mdl_enabled` to false on the document capture session, and redirect to Choose ID Type with the mdl radio disabled and drivers license pre-checked. The non-mdl resubmit is enforced server side since `ChooseIdTypeForm` reads `mdl_enabled` from the session.

## 📜 Testing Plan

- [ ] With an mdl session, hit the errors url with `error_code=mdl_not_found` in both flows and confirm you land on Choose ID Type with the mdl radio disabled and drivers license pre-checked
- [ ] Re-enable the radio in devtools and submit mdl, confirm it's rejected and mdl is no longer offered
- [ ] Pick a non-mdl type and confirm document capture proceeds normally

## 📸 Screenshots

**Before:** (error_code=mdl_not_found dead-ends on the generic unreadable ID page, Try again loops back to mdl capture)
<img width="1232" height="970" alt="LG-17895-before-error-dead-end" src="https://github.com/user-attachments/assets/5a6dd226-c18b-4e15-8699-c60efefd7909" />

**After:** redirected to Choose ID Type, mdl disabled, drivers license pre-checked
<img width="1232" height="970" alt="LG-17895-after-choose-id-type-mdl-disabled" src="https://github.com/user-attachments/assets/048532b2-b2ac-4d6c-a781-a4ab128ceb91" />


[LG-17895]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17895