### PR TITLE
Render the NDS one-time code entry page

### DIFF
--- a/app/controllers/two_factor_authentication/otp_verification_controller.rb
+++ b/app/controllers/two_factor_authentication/otp_verification_controller.rb
@@ -10,7 +10,9 @@ module TwoFactorAuthentication
     before_action :redirect_if_blank_phone, only: [:show]
     before_action :confirm_voice_capability, only: [:show]
 
-    helper_method :in_multi_mfa_selection_flow?
+    delegate :enabled_mfa_methods_count, to: :mfa_context
+    helper_method :in_multi_mfa_selection_flow?, :in_account_creation_flow?,
+                  :enabled_mfa_methods_count
 
     def show
       recaptcha_annotation = annotate_recaptcha(

--- a/app/javascript/packs/nds-input-otp.ts
+++ b/app/javascript/packs/nds-input-otp.ts
@@ -1,0 +1,12 @@
+import * as designSystem from '@18f/identity-design-system';
+
+interface NDSBehavior {
+  on(root?: ParentNode): void;
+  off(): void;
+}
+
+// `inputOtp` ships in the design system's next release; until the published
+// typings include it, read it off the module without a static member check.
+const { inputOtp } = designSystem as unknown as { inputOtp: NDSBehavior };
+
+inputOtp.on(document.body);

--- a/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
+++ b/app/presenters/two_factor_auth_code/phone_delivery_presenter.rb
@@ -40,6 +40,29 @@ module TwoFactorAuthCode
       )
     end
 
+    # NDS (design-system refresh) subtitle. Combines the delivery message and
+    # the do-not-share guidance into one string, with the refreshed copy
+    # (no "(SMS)" qualifier, plain "Learn more" link).
+    def nds_code_sent_message
+      t(
+        "nds.otp_verification.#{otp_delivery_preference}.code_sent_html",
+        number_html: content_tag(:strong, phone_number),
+      )
+    end
+
+    def nds_do_not_share_message
+      t(
+        'nds.otp_verification.do_not_share_html',
+        link_html: new_tab_link_to(
+          t('nds.otp_verification.learn_more'),
+          MarketingSite.help_center_article_url(
+            category: 'fraud-concerns',
+            article: 'overview',
+          ),
+        ),
+      )
+    end
+
     def landline_warning
       t(
         'two_factor_authentication.otp_delivery_preference.landline_warning_html',
@@ -106,6 +129,15 @@ module TwoFactorAuthCode
         account_path(locale: locale)
       else
         sign_out_path(locale: locale)
+      end
+    end
+
+    def choose_another_authentication_method_path
+      locale = LinkLocaleResolver.locale
+      if in_multi_mfa_selection_flow
+        authentication_methods_setup_path(locale: locale)
+      else
+        login_two_factor_options_path(locale: locale)
       end
     end
 

--- a/app/views/two_factor_authentication/otp_verification/show.html.erb
+++ b/app/views/two_factor_authentication/otp_verification/show.html.erb
@@ -1,5 +1,134 @@
 <% self.title = t('titles.enter_2fa_code.one_time_code') %>
 
+<% if nds_layout? %>
+  <% if in_account_creation_flow? %>
+    <% content_for(:nds_header_progress) do %>
+      <%= nds_account_creation_progress(
+            step: :security,
+            substep: enabled_mfa_methods_count >= 1 ? 2 : 1,
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% otp_invalid_error = flash[:error] == t('two_factor_authentication.invalid_otp') ? flash.delete(:error) : nil %>
+
+  <%= render NDS::FormPageComponent.new(
+        title: @presenter.header,
+        subtitle: safe_join([@presenter.nds_code_sent_message, @presenter.nds_do_not_share_message], ' '),
+      ) do |page| %>
+    <% if otp_invalid_error || @landline_alert || @presenter.otp_expiration.present? %>
+      <% page.with_alert do %>
+        <% if otp_invalid_error %>
+          <%= render AlertComponent.new(
+                type: :error,
+                title: t('nds.otp_verification.invalid_otp_heading'),
+                class: 'margin-bottom-4',
+              ).with_content(t('nds.otp_verification.invalid_otp_body')) %>
+        <% end %>
+        <% if @landline_alert %>
+          <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-2') do %>
+            <%= @presenter.landline_warning %>
+          <% end %>
+        <% end %>
+        <% if @presenter.otp_expiration.present? %>
+          <div id="otp-live-phase" class="usa-sr-only" aria-live="polite" aria-atomic="true"></div>
+          <div id="otp-live-expiry" class="usa-sr-only" role="alert" aria-atomic="true"></div>
+
+          <%= render CountdownPhaseAlertComponent.new(
+                expiration: @presenter.otp_expiration,
+                phases: @presenter.alert_countdown_phases,
+                sr_phase_region_id: 'otp-live-phase',
+                sr_expiry_region_id: 'otp-live-expiry',
+                alert_options: { class: 'margin-bottom-4', role: 'presentation' },
+                countdown_options: { update_interval: 1.second },
+              ) %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% page.with_body do %>
+      <%= simple_form_for('') do |f| %>
+        <% if @presenter.reauthn %>
+          <%= render 'two_factor_authentication/totp_verification/reauthn' %>
+        <% end %>
+        <%= render NDS::StackComponent.new(kind: :form, align: :stretch) do %>
+          <% otp_length = TwoFactorAuthenticatable::DIRECT_OTP_LENGTH %>
+          <% otp_value = @presenter.code_value.to_s %>
+          <lg-nds-input-otp>
+            <div class="input-otp">
+              <%= f.label :code, t('components.one_time_code_input.label'), class: 'input-otp__label' %>
+              <div class="input-otp__shell">
+                <%= f.text_field(
+                      :code,
+                      value: otp_value,
+                      id: 'code',
+                      class: 'input-otp__input usa-input__control',
+                      type: :text,
+                      inputmode: 'numeric',
+                      pattern: "[0-9]{#{otp_length}}",
+                      maxlength: otp_length,
+                      autocomplete: 'one-time-code',
+                      autofocus: true,
+                      'aria-describedby': 'otp-hint',
+                    ) %>
+                <div class="input-otp__slots" aria-hidden="true">
+                  <div class="input-otp__group">
+                    <% otp_length.times do |i| %>
+                      <% char = otp_value[i] %>
+                      <div class="input-otp__slot<%= ' input-otp__slot--active input-otp__slot--caret' if otp_value.length == i %>"><%= char %></div>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
+              <p class="input-otp__hint usa-sr-only" id="otp-hint"><%= t('components.one_time_code_input.hint.numeric') %></p>
+            </div>
+          </lg-nds-input-otp>
+          <%= render NDS::CardComponent.new do %>
+            <div class="checkbox-group">
+              <div class="checkbox">
+                <%= f.check_box(
+                      :remember_device,
+                      { class: 'checkbox__input',
+                        checked: @presenter.remember_device_box_checked?,
+                        autocomplete: 'off',
+                        aria: { describedby: 'remember-browser-description' } },
+                      '1',
+                      '0',
+                    ) %>
+                <%= f.label :remember_device, class: 'checkbox__label' do %>
+                  <span class="checkbox__label-text"><%= t('forms.messages.remember_device') %></span>
+                  <span class="checkbox__label-description" id="remember-browser-description"><%= t('nds.mfa.remember_device_info') %></span>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+          <%= hidden_field_tag 'otp_make_default_number', @presenter.otp_make_default_number %>
+          <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+            <%= render ButtonComponent.new(type: :submit, full_width: true)
+                  .with_content(t('forms.buttons.continue')) %>
+            <%= render ButtonComponent.new(
+                  url: otp_send_path(
+                    otp_delivery_selection_form: {
+                      otp_delivery_preference: @presenter.otp_delivery_preference,
+                      resend: true,
+                    },
+                  ),
+                  variant: :secondary,
+                  full_width: true,
+                ).with_content(t('links.two_factor_authentication.send_another_code')) %>
+            <%= render ButtonComponent.new(
+                  url: @presenter.choose_another_authentication_method_path,
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(t('nds.mfa.choose_another_method')) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('nds-input-otp', preload_links_header: false) %>
+<% else %>
 <% if @landline_alert %>
   <%= render AlertComponent.new(type: :warning, class: 'margin-bottom-2') do %>
     <%= @presenter.landline_warning %>
@@ -77,4 +206,5 @@
   <%= render 'shared/cancel', link: @presenter.cancel_link %>
 <% else %>
   <%= render 'shared/cancel_or_back_to_options' %>
+<% end %>
 <% end %>

--- a/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
+++ b/spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'two_factor_authentication/otp_verification/show.html.erb' do
   context 'user has a phone' do
     before do
       allow(view).to receive(:user_session).and_return({})
+      allow(view).to receive(:nds_layout?).and_return(false)
       allow(view).to receive(:current_user).and_return(User.new)
       allow(view).to receive(:user_fully_authenticated?).and_return(false)
       controller.request.path_parameters[:otp_delivery_preference] =
@@ -341,6 +342,200 @@ RSpec.describe 'two_factor_authentication/otp_verification/show.html.erb' do
             t('two_factor_authentication.login_options_link_text'),
             href: login_two_factor_options_path,
           )
+        end
+      end
+    end
+
+    context 'legacy (non-nds) bucket' do
+      it 'does not render the NDS form-page card' do
+        render
+
+        expect(rendered).not_to have_css('.auth--form-page')
+      end
+    end
+
+    context 'nds bucket' do
+      let(:enabled_mfa_methods_count) { 0 }
+      let(:in_account_creation_flow) { true }
+      let(:resend_path) do
+        otp_send_path(
+          otp_delivery_selection_form: {
+            otp_delivery_preference: presenter_data[:otp_delivery_preference],
+            resend: true,
+          },
+        )
+      end
+
+      before do
+        allow(view).to receive(:nds_layout?).and_return(true)
+        allow(view).to receive(:in_account_creation_flow?).and_return(in_account_creation_flow)
+        allow(view).to receive(:enabled_mfa_methods_count).and_return(enabled_mfa_methods_count)
+      end
+
+      it 'renders the FormPageComponent card with the presenter heading' do
+        render
+
+        expect(rendered).to have_css('.auth--form-page')
+        expect(rendered).to have_css('.auth--form-page h1', text: @presenter.header)
+      end
+
+      it 'renders the one-time code input inside the card' do
+        render
+
+        expect(rendered).to have_css('.auth--form-page lg-nds-input-otp .input-otp__input#code')
+        expect(rendered).to have_css(
+          '.auth--form-page .input-otp__slots .input-otp__slot', count: 6
+        )
+      end
+
+      it 'submits the code with a Continue primary button' do
+        render
+
+        expect(rendered).to have_button(t('forms.buttons.continue'))
+      end
+
+      it 'renders the resend control pointing at the resend path' do
+        render
+
+        expect(rendered).to have_link(
+          t('links.two_factor_authentication.send_another_code'),
+          href: resend_path,
+        )
+      end
+
+      it 'renders the choose-another-method control' do
+        render
+
+        expect(rendered).to have_link(
+          t('nds.mfa.choose_another_method'),
+          href: login_two_factor_options_path,
+        )
+      end
+
+      context 'in the multi-mfa selection flow' do
+        before do
+          data = presenter_data.merge(in_multi_mfa_selection_flow: true)
+          @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
+            data: data,
+            view: view,
+            service_provider: nil,
+          )
+        end
+
+        it 'points choose-another-method at the authentication methods setup page' do
+          render
+
+          expect(rendered).to have_link(
+            t('nds.mfa.choose_another_method'),
+            href: authentication_methods_setup_path,
+          )
+        end
+      end
+
+      context 'during account creation' do
+        let(:in_account_creation_flow) { true }
+
+        context 'confirming the first mfa method' do
+          let(:enabled_mfa_methods_count) { 0 }
+
+          it 'sets the Security header progress to substep 1 / 2' do
+            render
+            progress = view.content_for(:nds_header_progress)
+
+            expect(progress).to have_css(
+              '.progress__step[aria-current="step"]',
+              text: t('step_indicator.flows.account_creation.security'),
+            )
+            expect(progress).to have_css(
+              '.progress__step[aria-current="step"] .progress__step-counter',
+              text: '1 / 2',
+            )
+          end
+        end
+
+        context 'confirming an additional mfa method' do
+          let(:enabled_mfa_methods_count) { 1 }
+
+          it 'sets the Security header progress to substep 2 / 2' do
+            render
+            progress = view.content_for(:nds_header_progress)
+
+            expect(progress).to have_css(
+              '.progress__step[aria-current="step"] .progress__step-counter',
+              text: '2 / 2',
+            )
+          end
+        end
+      end
+
+      context 'during sign-in (not account creation)' do
+        let(:in_account_creation_flow) { false }
+
+        it 'does not emit the account-creation header progress' do
+          render
+
+          expect(view.content_for(:nds_header_progress)).to be_nil
+        end
+      end
+
+      context 'with a landline setup warning' do
+        before { assign(:landline_alert, true) }
+
+        it 'shows the landline warning inside the card' do
+          render
+
+          expect(rendered).to have_css('.auth--form-page .usa-alert--warning')
+          expect(rendered).to have_css('.auth--form-page', text: /landline phone/)
+        end
+      end
+
+      context 'when the invalid one-time code flash is present' do
+        before { flash[:error] = t('two_factor_authentication.invalid_otp') }
+
+        it 'renders a titled error alert with the NDS heading and body copy' do
+          render
+
+          expect(rendered).to have_css(
+            '.auth--form-page .usa-alert--error .usa-alert__heading',
+            text: t('nds.otp_verification.invalid_otp_heading'),
+          )
+          expect(rendered).to have_css(
+            '.auth--form-page .usa-alert--error .usa-alert__text',
+            text: t('nds.otp_verification.invalid_otp_body'),
+          )
+        end
+
+        it 'does not also render the generic layout flash for the same message' do
+          render
+
+          expect(rendered).to have_css('.usa-alert--error', count: 1)
+        end
+      end
+
+      context 'with an OTP expiration' do
+        around do |example|
+          freeze_time { example.run }
+        end
+
+        before do
+          otp_user = create(
+            :user,
+            :fully_registered,
+            otp_delivery_preference: 'voice',
+            direct_otp_sent_at: Time.zone.now,
+          )
+          allow(view).to receive(:current_user).and_return(otp_user)
+          otp_expiration = otp_user.direct_otp_sent_at +
+                           TwoFactorAuthenticatable::DIRECT_OTP_VALID_FOR_SECONDS
+          allow(@presenter).to receive(:otp_expiration).and_return(otp_expiration)
+        end
+
+        it 'renders the countdown alert with screen-reader live regions' do
+          render
+
+          expect(rendered).to include('countdown-phase-alert')
+          expect(rendered).to have_css('#otp-live-phase[aria-live="polite"]', visible: :all)
+          expect(rendered).to have_css('#otp-live-expiry[role="alert"]', visible: :all)
         end
       end
     end


### PR DESCRIPTION
## Tickets

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/75

## Summary

- Renders `two_factor_authentication/otp_verification#show` ("Enter your one-time code") in the NDS layout (nds bucket only): a centered `NDS::FormPageComponent` card with heading + masked-phone/do-not-share copy, the `OneTimeCodeInputComponent`, remember-device checkbox, and a three-button action stack (Continue submit / Send another code / Choose another method).
- This view is shared between sign-in 2FA and account-creation phone confirmation. The card applies to both; the **account-creation header stepper (Security step) is gated to `in_account_creation_flow?` only** — sign-in shows the card without the stepper.
- The default (non-nds) experience is byte-preserved.

## Details

- **Stepper substep** mirrors mfa-setup: `nds_account_creation_progress(step: :security, substep: enabled_mfa_methods_count >= 1 ? 2 : 1)`.
- **Accessibility preserved:** the OTP countdown (`CountdownPhaseAlertComponent`) with its `aria-live`/`role="alert"` SR live-regions and the landline warning are carried into the NDS card (not dropped) so screen-reader behavior matches legacy.
- **Choose-another-method destination** routes correctly per flow (`authentication_methods_setup_path` in multi-MFA/account-creation vs `login_two_factor_options_path` at sign-in) — resolved in the presenter.
- Form contract preserved (OTP input, remember-device, `otp_make_default_number` hidden field, reauthn partial, resend GET path). No new i18n keys.

## Test plan

- [ ] `bundle exec rspec spec/views/two_factor_authentication/otp_verification/show.html.erb_spec.rb spec/presenters/two_factor_auth_code/phone_delivery_presenter_spec.rb spec/i18n_spec.rb`
- [ ] `bundle exec erb_lint app/views/two_factor_authentication/otp_verification/show.html.erb`, `bundle exec rubocop`, `bundle exec rake zeitwerk:check`
- [ ] Account-creation phone confirm at `?ui_test_bucket=nds` shows the Security stepper; sign-in 2FA shows the card without it; countdown/landline SR regions present; submit/resend/choose-another all work
- [ ] Non-nds bucket unchanged

## Follow-up (IDS, not blocking)

- The Resend button omits the Figma "loop"/refresh icon — the NDS icon registry has no `loop`/`refresh` SVG yet. Adding one (svgo-optimized) to the design system is a separate follow-up.