### PR TITLE
Add a dev-only NDS page-state explorer + conversion inventory

### DIFF
--- a/app/controllers/test/nds_pages_controller.rb
+++ b/app/controllers/test/nds_pages_controller.rb
@@ -1,0 +1,833 @@
+# frozen_string_literal: true
+
+# This is only used in development/test. Routes aren't constructed unless
+# IdentityConfig.store.enable_test_routes is true, and the controller renders
+# 404 otherwise as defense in depth. It renders the real NDS auth views with
+# fabricated presenters/ivars so a developer can inspect every page state
+# without walking the whole flow.
+module Test
+  class NDSPagesController < ApplicationController
+    SpSessionStub = Struct.new(:sp_name, :sp_alert_text, :cancel_link_url, keyword_init: true) do
+      def sp_alert(_section)
+        sp_alert_text
+      end
+
+      def remember_device_default
+        true
+      end
+    end
+
+    ServiceProviderStub = Struct.new(:logo, :logo_url, :issuer, keyword_init: true)
+
+    EmailAddressStub = Struct.new(:email, keyword_init: true)
+
+    DEV_USER_EMAIL = 'nds-explorer-dev@example.com'
+    DEV_DUPLICATE_EMAIL = 'nds-explorer-dupe@example.com'
+    DEV_USER_PASSWORD = 'NDS explorer dev pass!1'
+    DEV_PHONE = '+12025551212'
+    DEV_OPT_OUT_PHONE = '+12025559999'
+    DEV_SP_ISSUER = 'urn:gov:gsa:openidconnect:test:nds-explorer'
+
+    # Registry of legacy pages whose before_actions need seeded DB/session state
+    # (beyond a signed-in dev session) before they render. Maps the live route
+    # path to a { label:, seeder:, resetter: } — the seeder is a private method
+    # that provisions exactly what that page's guards demand (seed_state then
+    # redirects to the page); the resetter tears that state back down so the
+    # empty/redirect state can be tested. Add a page by registering it here.
+    PAGE_STATES = {
+      '/duplicate_profiles_detected' => {
+        label: 'Seed duplicate profiles',
+        seeder: :seed_duplicate_profiles_detected,
+        resetter: :reset_duplicate_profiles_detected,
+      },
+      '/webauthn_setup_mismatch' => {
+        label: 'Seed webauthn mismatch',
+        seeder: :seed_webauthn_setup_mismatch,
+        resetter: :reset_webauthn_setup_mismatch,
+      },
+      '/login/two_factor/piv_cac_mismatch' => {
+        label: 'Seed PIV/CAC mismatch',
+        seeder: :seed_piv_cac_mismatch,
+        resetter: :reset_piv_cac_mismatch,
+      },
+      '/account/connected_services' => {
+        label: 'Seed connected services',
+        seeder: :seed_connected_services,
+        resetter: :reset_connected_services,
+      },
+    }.freeze
+
+    # Service providers seeded for the connected-services page: a distinct issuer
+    # each so the account page lists multiple realistic connected apps.
+    CONNECTED_SP_ISSUERS = [
+      { issuer: 'urn:gov:gsa:openidconnect:test:nds-explorer-sp-a', name: 'NDS Dev App A' },
+      { issuer: 'urn:gov:gsa:openidconnect:test:nds-explorer-sp-b', name: 'NDS Dev App B' },
+    ].freeze
+
+    # Maps a parameterized template to the record-kind key in record_specs. The
+    # route segment is always ":id" (ambiguous), so the index tags each select
+    # with this stable kind for delete/option lookup while the segment name still
+    # drives URL substitution. Uniquely-named params are their own kind.
+    TEMPLATE_RECORD_KINDS = {
+      '/manage/phone/:id' => 'phone',
+      '/manage/webauthn/:id' => 'webauthn',
+      '/manage/piv_cac/:id' => 'piv_cac',
+      '/manage/auth_app/:id' => 'auth_app',
+      '/manage/email/confirm_delete/:id' => 'email',
+      '/account/devices/:id/events' => 'device',
+    }.freeze
+
+    # Record kinds that back a real deletable model (i.e. keys of record_specs).
+    # Uniquely-named route params that are not records (e.g. :source) are absent
+    # so the index omits their delete button.
+    DELETABLE_RECORD_KINDS = (
+      TEMPLATE_RECORD_KINDS.values + %w[sp_id identity_id opt_out_uuid]
+    ).freeze
+
+    # Identity/proofing levels a developer can put the dev user into, to test how
+    # pages behave for unverified vs IAL1 vs IAL2 (and its proofing variants) and
+    # the reentrant pending flows. Each maps to a setter method; :detect reports
+    # whether the user is currently at that level for the index status display.
+    # Ordered as the dropdown should render.
+    IDENTITY_LEVELS = [
+      { key: 'unverified', label: 'Unverified (IAL1, no profile)' },
+      { key: 'ial2', label: 'IAL2 verified (legacy)' },
+      { key: 'ial2_facial_match', label: 'IAL2 verified (facial match)' },
+      { key: 'in_person_verified', label: 'IAL2 verified (in-person)' },
+      { key: 'in_person_pending', label: 'In-person pending (reentrant)' },
+      { key: 'gpo_pending', label: 'Verify-by-mail pending (reentrant)' },
+      { key: 'fraud_review_pending', label: 'Fraud review pending' },
+    ].freeze
+
+    before_action :require_test_routes_enabled
+    before_action :require_dev_or_test_env,
+                  only: %i[seed_session generate_mfa record_options delete_record
+                           seed_state reset_state set_identity_level sign_out_dev]
+
+    helper_method :nds_layout?, :decorated_sp_session, :current_sp, :current_user,
+                  :desktop_device?, :enabled_mfa_methods_count,
+                  :in_multi_mfa_selection_flow?, :in_account_creation_flow?,
+                  :resource, :resource_name, :session_path, :page_state_for,
+                  :record_kind_for, :deletable_record_kind?,
+                  :identity_levels, :current_identity_level
+
+    def index
+      @grouped_pages = NDSPageCatalog.grouped
+      @inventory = NDSPageCatalog.inventory
+      @dev_user = warden_user
+      render layout: false
+    end
+
+    def show
+      @page = NDSPageCatalog.find(params[:page])
+      return render_not_found if @page.nil?
+
+      locals = send(:"setup_#{@page.key.tr('-', '_')}")
+      render template: @page.template, locals: locals || {}
+    end
+
+    # Seeds a fully-registered, 2FA-authenticated dev session so the deep-linked
+    # legacy pages (account/manage/IdV) render instead of bouncing to sign-in.
+    # Devise's sign_in establishes the Warden user; the app then gates on
+    # user_fully_authenticated?, which reads session['warden.user.user.session']
+    # for auth_events + the NEED_AUTHENTICATION flag (see AuthMethodsSession and
+    # ApplicationController#user_fully_authenticated?). We set those directly,
+    # mirroring spec/support/features/session_helper.rb#sign_in_with_warden.
+    def seed_session
+      user = find_or_create_dev_user
+      sign_in(user)
+      warden_session = (session['warden.user.user.session'] ||= {}).with_indifferent_access
+      warden_session[TwoFactorAuthenticatable::NEED_AUTHENTICATION] = false
+      warden_session[:auth_events] =
+        [{ auth_method: TwoFactorAuthenticatable::AuthMethod::SMS, at: Time.zone.now }]
+      session['warden.user.user.session'] = warden_session
+      redirect_to test_nds_path
+    end
+
+    # Seeds one of each record the parameterized legacy routes need, then
+    # returns the full option catalog so the index can render dropdowns.
+    def generate_mfa
+      user = find_or_create_dev_user
+      seed_dev_records(user)
+      render json: dev_record_options(user)
+    end
+
+    # Returns the current option catalog without seeding (used on page load and
+    # to refresh the dropdowns after a delete). Read-only: never creates the dev
+    # user, so a GET has no side effects. Empty catalog when not signed in.
+    def record_options
+      user = warden_user
+      return render(json: { by_template: {}, by_param: {} }) if user.nil?
+
+      render json: dev_record_options(user)
+    end
+
+    # Deletes a single seeded record (by param + id) so a developer can test the
+    # empty/404 states, then returns the refreshed option catalog.
+    def delete_record
+      user = warden_user || find_or_create_dev_user
+      destroy_dev_record(user, params[:param], params[:id])
+      render json: dev_record_options(user)
+    end
+
+    # Seeds the DB/session state a specific gated legacy page requires, then
+    # redirects to it. Requires an already-seeded dev session (the target pages
+    # sit behind confirm_two_factor_authenticated). warden_user is used rather
+    # than the fabricated current_user this controller exposes for render-only.
+    def seed_state
+      user = warden_user
+      return render_not_found if user.nil?
+
+      state = PAGE_STATES[params[:path]]
+      return render_not_found if state.nil?
+
+      send(state[:seeder], user)
+      redirect_to params[:path]
+    end
+
+    # Tears down the state a page's seeder provisioned so the empty/redirect
+    # state can be tested, then returns to the index.
+    def reset_state
+      user = warden_user
+      return render_not_found if user.nil?
+
+      state = PAGE_STATES[params[:path]]
+      return render_not_found if state.nil? || state[:resetter].nil?
+
+      send(state[:resetter], user)
+      redirect_to test_nds_path
+    end
+
+    def sign_out_dev
+      sign_out(:user)
+      redirect_to test_nds_path
+    end
+
+    # Reshapes the dev user's profiles/enrollments to the requested identity
+    # level so pages can be tested at every proofing state, then returns to the
+    # index. Always starts from a clean slate (destroys existing profiles +
+    # enrollments) so the resulting state is deterministic.
+    def set_identity_level
+      user = warden_user
+      return render_not_found if user.nil?
+
+      level = params[:level]
+      return render_not_found unless IDENTITY_LEVELS.any? { |l| l[:key] == level }
+
+      apply_identity_level(user, level)
+      redirect_to test_nds_path
+    end
+
+    def page_state_for(path)
+      PAGE_STATES[path]
+    end
+
+    def identity_levels
+      IDENTITY_LEVELS
+    end
+
+    # Best-effort label of the dev user's current identity level for the index.
+    def current_identity_level(user)
+      return 'unverified' if user.nil?
+      return 'in_person_pending' if user.in_person_enrollments.exists?(status: :pending)
+      return 'gpo_pending' if user.profiles.where.not(gpo_verification_pending_at: nil).exists?
+      if user.profiles.where.not(fraud_review_pending_at: nil).exists?
+        return 'fraud_review_pending'
+      end
+
+      active = user.profiles.find_by(active: true)
+      return 'unverified' if active.nil?
+      return 'in_person_verified' if active.idv_level == 'in_person'
+      return 'ial2_facial_match' if active.facial_match?
+
+      'ial2'
+    end
+
+    # Resolves the record-kind key for a template + segment name: the shared
+    # ":id" maps via TEMPLATE_RECORD_KINDS; uniquely-named params are their own
+    # kind. Used by the index to tag each select for delete/option lookup.
+    def record_kind_for(template, param)
+      return param unless param == 'id'
+
+      TEMPLATE_RECORD_KINDS[template]
+    end
+
+    def deletable_record_kind?(kind)
+      DELETABLE_RECORD_KINDS.include?(kind)
+    end
+
+    def nds_layout?
+      true
+    end
+
+    def decorated_sp_session
+      @decorated_sp_session ||= NullServiceProviderSession.new(view_context:)
+    end
+
+    def current_sp
+      @current_sp
+    end
+
+    def current_user
+      @nds_current_user
+    end
+
+    def user_session
+      @user_session ||= {}
+    end
+
+    def desktop_device?
+      @desktop_device.nil? || @desktop_device
+    end
+
+    def enabled_mfa_methods_count
+      return 0 if current_user.nil?
+
+      MfaContext.new(current_user).enabled_mfa_methods_count
+    end
+
+    def in_multi_mfa_selection_flow?
+      @in_multi_mfa_selection_flow || false
+    end
+
+    def in_account_creation_flow?
+      @in_account_creation_flow || false
+    end
+
+    def resource
+      @resource
+    end
+
+    def resource_name
+      :user
+    end
+
+    def session_path(_resource_name = nil)
+      new_user_session_path
+    end
+
+    private
+
+    def require_test_routes_enabled
+      render_not_found unless IdentityConfig.store.enable_test_routes
+    end
+
+    def require_dev_or_test_env
+      render_not_found unless Rails.env.local?
+    end
+
+    def warden_user
+      request.env['warden']&.user(:user)
+    end
+
+    # Builds a confirmed, fully-registered, phone-2FA dev user with plain model
+    # writes (factory_bot is test-only, so no create(:user) here). Replicates the
+    # essential writes of the :fully_registered + :with_phone factory traits.
+    def find_or_create_dev_user(email: DEV_USER_EMAIL)
+      existing = EmailAddress.find_with_email(email)&.user
+      return existing if existing
+
+      now = Time.zone.now
+      user = User.new(password: DEV_USER_PASSWORD, confirmed_at: now, accepted_terms_at: now)
+      user.email = email
+      user.email_addresses.build(
+        email: email, confirmed_at: now,
+        confirmation_sent_at: now
+      )
+      user.save!
+      user.phone_configurations.create!(
+        phone: DEV_PHONE, confirmed_at: now, delivery_preference: :sms, mfa_enabled: true,
+      )
+      user.create_registration_log(registered_at: now)
+      user
+    end
+
+    # The parameterized legacy routes reference records by either a per-template
+    # ":id" (ambiguous across templates) or a uniquely-named param. The hash keys
+    # identify each record kind in the option catalog; :collection resolves the
+    # user's records, :value maps a record to its route value, :label to a human
+    # label. The index binds each ":id" select to a template via :templates and
+    # uniquely-named selects via :params.
+    def record_specs(user)
+      {
+        'phone' => {
+          templates: ['/manage/phone/:id'],
+          collection: user.phone_configurations,
+          value: ->(r) { r.id },
+          label: ->(r) { "phone ##{r.id}" },
+        },
+        'webauthn' => {
+          templates: ['/manage/webauthn/:id'],
+          collection: user.webauthn_configurations,
+          value: ->(r) { r.id },
+          label: ->(r) { "#{r.name} (##{r.id})" },
+        },
+        'piv_cac' => {
+          templates: ['/manage/piv_cac/:id'],
+          collection: user.piv_cac_configurations,
+          value: ->(r) { r.id },
+          label: ->(r) { "#{r.name} (##{r.id})" },
+        },
+        'auth_app' => {
+          templates: ['/manage/auth_app/:id'],
+          collection: user.auth_app_configurations,
+          value: ->(r) { r.id },
+          label: ->(r) { "#{r.name} (##{r.id})" },
+        },
+        'email' => {
+          templates: ['/manage/email/confirm_delete/:id'],
+          collection: user.email_addresses,
+          value: ->(r) { r.id },
+          label: ->(r) { "#{r.email} (##{r.id})" },
+        },
+        'device' => {
+          templates: ['/account/devices/:id/events'],
+          collection: user.devices,
+          value: ->(r) { r.id },
+          label: ->(r) { "device ##{r.id}" },
+        },
+        'sp_id' => {
+          params: ['sp_id'],
+          collection: ServiceProvider.where(issuer: DEV_SP_ISSUER),
+          value: ->(r) { r.id },
+          label: ->(r) { "#{r.friendly_name} (##{r.id})" },
+        },
+        'identity_id' => {
+          params: ['identity_id'],
+          collection: user.identities,
+          value: ->(r) { r.id },
+          label: ->(r) { "identity ##{r.id}" },
+        },
+        'opt_out_uuid' => {
+          params: ['opt_out_uuid'],
+          collection: PhoneNumberOptOut.where(phone_fingerprint: dev_opt_out_fingerprint),
+          value: ->(r) { r.uuid },
+          label: ->(r) { "opt-out #{r.uuid}" },
+        },
+      }
+    end
+
+    # Creates one of each record type if the dev user has none, so the dropdowns
+    # start non-empty. Idempotent: existing records are reused.
+    def seed_dev_records(user)
+      now = Time.zone.now
+      user.phone_configurations.first ||
+        user.phone_configurations.create!(
+          phone: DEV_PHONE, confirmed_at: now, delivery_preference: :sms, mfa_enabled: true,
+        )
+      user.webauthn_configurations.first ||
+        user.webauthn_configurations.create!(
+          name: 'NDS dev key', credential_id: SecureRandom.hex(16),
+          credential_public_key: SecureRandom.hex(16), transports: ['usb']
+        )
+      user.piv_cac_configurations.first ||
+        user.piv_cac_configurations.create!(name: 'NDS dev PIV', x509_dn_uuid: SecureRandom.uuid)
+      user.auth_app_configurations.first ||
+        user.auth_app_configurations.create!(
+          name: 'NDS dev app', otp_secret_key: ROTP::Base32.random_base32,
+        )
+      primary_email_id = user.email_addresses.order(:id).first&.id
+      user.email_addresses.where.not(id: primary_email_id).first ||
+        user.email_addresses.create!(
+          email: 'nds-dev-extra@example.com', confirmed_at: now, confirmation_sent_at: now,
+        )
+      user.devices.first ||
+        user.devices.create!(
+          cookie_uuid: SecureRandom.hex(32), user_agent: 'NDS explorer dev',
+          last_used_at: now, last_ip: '127.0.0.1'
+        )
+      service_provider = dev_service_provider
+      user.identities.where(service_provider: service_provider.issuer).first ||
+        user.identities.create!(
+          service_provider: service_provider.issuer, uuid: SecureRandom.uuid,
+          last_authenticated_at: Time.zone.now
+        )
+      PhoneNumberOptOut.create_or_find_with_phone(DEV_OPT_OUT_PHONE)
+    end
+
+    # Builds the dropdown catalog. Each entry lists the real record options plus
+    # synthetic "(none / blank)" and "(invalid)" choices so the empty and 404
+    # states can be exercised. by_template resolves the shared ":id" segment;
+    # by_param covers uniquely-named segments.
+    def dev_record_options(user)
+      by_template = {}
+      by_param = {}
+      extra = [{ value: '', label: '(none / blank)' }, { value: '0', label: '(invalid)' }]
+
+      record_specs(user).each_value do |spec|
+        options = spec[:collection].map do |record|
+          { value: spec[:value].call(record).to_s, label: spec[:label].call(record) }
+        end + extra
+        Array(spec[:templates]).each { |template| by_template[template] = options }
+        Array(spec[:params]).each { |param| by_param[param] = options }
+      end
+
+      by_param['source'] = %w[dont_recognize cant_access].map do |source|
+        { value: source, label: source }
+      end + [{ value: 'invalid_source', label: '(invalid)' }]
+
+      { by_template:, by_param: }
+    end
+
+    def destroy_dev_record(user, param, id)
+      spec = record_specs(user)[param]
+      return if spec.nil? || id.blank?
+
+      collection = spec[:collection]
+      record = collection.find_by(id:) if id.match?(/\A\d+\z/)
+      if record.nil? && collection.model.column_names.include?('uuid')
+        record = collection.find_by(uuid: id)
+      end
+      record&.destroy
+    end
+
+    def dev_opt_out_fingerprint
+      Pii::Fingerprinter.fingerprint(PhoneNumberOptOut.normalize(DEV_OPT_OUT_PHONE))
+    end
+
+    def dev_agency
+      Agency.find_by(name: 'NDS Explorer Dev Agency') || Agency.first ||
+        Agency.create!(name: 'NDS Explorer Dev Agency', abbreviation: "NDS#{SecureRandom.hex(2)}")
+    end
+
+    def dev_service_provider
+      ServiceProvider.find_by(issuer: DEV_SP_ISSUER) ||
+        ServiceProvider.create!(
+          issuer: DEV_SP_ISSUER, friendly_name: 'NDS Explorer Dev SP', agency: dev_agency,
+        )
+    end
+
+    def active_facial_match_profile(user)
+      user.profiles.where(active: true).first ||
+        user.profiles.create!(
+          active: true, activated_at: Time.zone.now, verified_at: Time.zone.now,
+          idv_level: :unsupervised_with_selfie
+        )
+    end
+
+    # duplicate_profiles_detected#show requires: an active facial-match profile,
+    # an open DuplicateProfileSet involving it, and a current_sp in session.
+    def seed_duplicate_profiles_detected(user)
+      service_provider = dev_service_provider
+      session[:sp] = {
+        issuer: service_provider.issuer,
+        acr_values: Saml::Idp::Constants::IAL_AUTH_ONLY_ACR,
+      }
+      profile = active_facial_match_profile(user)
+      other_profile = active_facial_match_profile(
+        find_or_create_dev_user(email: DEV_DUPLICATE_EMAIL),
+      )
+      # Match the detection mode the page reads: global sets have a nil
+      # service_provider, SP-scoped sets carry the issuer.
+      global = IdentityConfig.store.enable_one_account_global_detection
+      set_issuer = global ? nil : service_provider.issuer
+      existing = if global
+                   DuplicateProfileSet.involving_profile_global(profile_id: profile.id)
+                 else
+                   DuplicateProfileSet.involving_profile(
+                     profile_id: profile.id, service_provider: set_issuer,
+                   )
+                 end
+      return if existing
+
+      DuplicateProfileSet.create!(
+        profile_ids: [profile.id, other_profile.id],
+        service_provider: set_issuer,
+      )
+    end
+
+    # Removes the duplicate-profile state (sets + seeded profiles + the SP
+    # session) so the page redirects to root again.
+    def reset_duplicate_profiles_detected(user)
+      session.delete(:sp)
+      dupe_user = EmailAddress.find_with_email(DEV_DUPLICATE_EMAIL)&.user
+      profile_ids = [user, dupe_user].compact.flat_map { |u| u.profiles.pluck(:id) }
+      profile_ids.each do |profile_id|
+        DuplicateProfileSet.duplicate_profile_sets_for_profile(profile_id:).destroy_all
+      end
+      user.profiles.destroy_all
+      dupe_user&.profiles&.destroy_all
+    end
+
+    # Reads, mutates, and writes back the Warden user session hash (the same
+    # store ApplicationController#user_session exposes) so seeded session keys
+    # survive to the target page's request.
+    def merge_warden_user_session(attrs)
+      warden_session = (session['warden.user.user.session'] ||= {}).with_indifferent_access
+      warden_session.merge!(attrs)
+      session['warden.user.user.session'] = warden_session
+    end
+
+    # webauthn_setup_mismatch#show requires a recent 2FA session (dev session has
+    # it) plus user_session[:webauthn_mismatch_id] pointing at a real webauthn
+    # configuration; validate_session_mismatch_id redirects away otherwise.
+    def seed_webauthn_setup_mismatch(user)
+      configuration = user.webauthn_configurations.first ||
+                      user.webauthn_configurations.create!(
+                        name: 'NDS dev key', credential_id: SecureRandom.hex(16),
+                        credential_public_key: SecureRandom.hex(16), transports: ['usb']
+                      )
+      merge_warden_user_session(webauthn_mismatch_id: configuration.id)
+    end
+
+    def reset_webauthn_setup_mismatch(_user)
+      merge_warden_user_session(webauthn_mismatch_id: nil)
+    end
+
+    # piv_cac_mismatch#show is a mid-authentication page: check_already_authenticated
+    # redirects a fully-authenticated user away only in the authentication context.
+    # The dev session is fully authenticated, so switch its context to
+    # reauthentication (same view, no redirect) rather than downgrading 2FA.
+    def seed_piv_cac_mismatch(_user)
+      merge_warden_user_session(context: UserSessionContext::REAUTHENTICATION_CONTEXT)
+    end
+
+    def reset_piv_cac_mismatch(_user)
+      merge_warden_user_session(context: UserSessionContext::AUTHENTICATION_CONTEXT)
+    end
+
+    # account/connected_services lists the user's non-deleted identities joined to
+    # their service_provider_record. Seeds one identity per CONNECTED_SP_ISSUERS
+    # entry, each with a confirmed email association and verified attributes, so
+    # the page renders realistic connected apps (with revoke + change-email links).
+    def seed_connected_services(user)
+      email = user.email_addresses.confirmed.first || user.email_addresses.first
+      CONNECTED_SP_ISSUERS.each do |sp|
+        service_provider = connected_service_provider(sp)
+        identity = user.identities.find_or_initialize_by(service_provider: service_provider.issuer)
+        identity.update!(
+          uuid: identity.uuid || SecureRandom.uuid,
+          last_authenticated_at: Time.zone.now,
+          last_consented_at: Time.zone.now,
+          deleted_at: nil,
+          email_address: email,
+          verified_attributes: %w[email],
+        )
+      end
+    end
+
+    def reset_connected_services(user)
+      issuers = CONNECTED_SP_ISSUERS.map { |sp| sp[:issuer] }
+      user.identities.where(service_provider: issuers).destroy_all
+    end
+
+    def connected_service_provider(sp)
+      ServiceProvider.find_by(issuer: sp[:issuer]) ||
+        ServiceProvider.create!(
+          issuer: sp[:issuer], friendly_name: sp[:name],
+          return_to_sp_url: root_url, agency: dev_agency
+        )
+    end
+
+    # Clears the dev user's active-profile cache and destroys all profiles +
+    # in-person enrollments, then builds the requested level from scratch.
+    def apply_identity_level(user, level)
+      user.in_person_enrollments.destroy_all
+      user.profiles.destroy_all
+      user.instance_variable_set(:@active_profile, nil)
+
+      case level
+      when 'ial2'
+        build_verified_profile(user, idv_level: :legacy_unsupervised)
+      when 'ial2_facial_match'
+        build_verified_profile(user, idv_level: :unsupervised_with_selfie)
+      when 'in_person_verified'
+        build_verified_profile(user, idv_level: :in_person)
+      when 'in_person_pending' then build_in_person_pending(user)
+      when 'gpo_pending' then build_gpo_pending(user)
+      when 'fraud_review_pending' then build_fraud_review_pending(user)
+      end
+    end
+
+    # Builds an active, verified profile carrying real encrypted PII so pages
+    # that decrypt it (account, connected accounts) work.
+    def build_verified_profile(user, idv_level:, **attrs)
+      now = Time.zone.now
+      profile = user.profiles.new(
+        active: true, activated_at: now, verified_at: now, idv_level:, **attrs,
+      )
+      encrypt_dev_pii(profile)
+      profile.save!
+      profile
+    end
+
+    # A pending in-person enrollment + its non-active pending profile — the state
+    # a user re-enters the in-person proofing flow from.
+    def build_in_person_pending(user)
+      now = Time.zone.now
+      profile = user.profiles.new(
+        active: false, idv_level: :in_person, in_person_verification_pending_at: now,
+      )
+      encrypt_dev_pii(profile)
+      profile.save!
+      user.in_person_enrollments.create!(
+        profile:, status: :pending, enrollment_code: dev_enrollment_code,
+        enrollment_established_at: now, status_updated_at: now,
+        current_address_matches_id: true, unique_id: InPersonEnrollment.generate_unique_id,
+        sponsor_id: IdentityConfig.store.usps_ipp_sponsor_id
+      )
+      profile
+    end
+
+    # The ready_to_verify barcode is Code128C, which requires an even-length
+    # numeric string, so a hex code would raise "Data not valid".
+    def dev_enrollment_code
+      SecureRandom.random_number(10 ** 16).to_s.rjust(16, '0')
+    end
+
+    def build_gpo_pending(user)
+      profile = user.profiles.new(
+        active: false, idv_level: :legacy_unsupervised,
+        gpo_verification_pending_at: Time.zone.now
+      )
+      encrypt_dev_pii(profile)
+      profile.save!
+      profile
+    end
+
+    def build_fraud_review_pending(user)
+      profile = user.profiles.new(
+        active: false, idv_level: :legacy_unsupervised,
+        fraud_pending_reason: 'threatmetrix_review', fraud_review_pending_at: Time.zone.now
+      )
+      encrypt_dev_pii(profile)
+      profile.save!
+      profile
+    end
+
+    def encrypt_dev_pii(profile)
+      pii = Pii::Attributes.new_from_hash(Idp::Constants::MOCK_IDV_APPLICANT_WITH_PHONE)
+      profile.encrypt_pii(pii, DEV_USER_PASSWORD)
+    end
+
+    def setup_sign_in
+      @resource = User.new
+      error = params[:error]
+      if error == 'email' || error == 'both'
+        @resource.errors.add(:email, t('valid_email.validations.email.invalid'))
+      end
+      if error == 'password' || error == 'both'
+        @resource.errors.add(:password, t('errors.messages.blank'))
+      end
+
+      @issuer_forced_reauthentication = params[:reauth].present?
+      @desktop_device = params[:device] != 'mobile'
+
+      if params[:sp].present?
+        @decorated_sp_session = SpSessionStub.new(
+          sp_name: 'Example Service Provider',
+          sp_alert_text: params[:sp_alert].present? ? 'Example service provider alert.' : nil,
+          cancel_link_url: root_url,
+        )
+      end
+      if params[:logo].present?
+        @current_sp = ServiceProviderStub.new(
+          logo: 'logo.svg',
+          logo_url: image_path('logo.svg'),
+          issuer: 'urn:gov:gsa:test',
+        )
+      end
+      {}
+    end
+
+    def setup_piv_cac
+      @presenter = PivCacAuthenticationLoginPresenter.new(nil, url_options)
+      {}
+    end
+
+    def setup_create_account
+      @register_user_email_form = RegisterUserEmailForm.new(analytics:, attempts_api_tracker:)
+      if params[:error] == 'email'
+        @register_user_email_form.errors.add(:email, t('valid_email.validations.email.invalid'))
+      end
+      if params[:sp_alert].present?
+        @decorated_sp_session = SpSessionStub.new(
+          sp_name: 'Example Service Provider',
+          sp_alert_text: 'Example service provider alert.',
+          cancel_link_url: root_url,
+        )
+      end
+      {}
+    end
+
+    def setup_verify_email
+      email = 'user@example.com'
+      @resend_confirmation = params[:resend].present?
+      @resend_email_confirmation_form = ResendEmailConfirmationForm.new(
+        email:, terms_accepted: true,
+      )
+      { email: }
+    end
+
+    def setup_enter_password
+      user = User.new
+      @password_form = PasswordForm.new(user:)
+      if params[:error].present?
+        @password_form.errors.add(:password, t('errors.messages.too_short.other', count: 12))
+      end
+      @email_address = EmailAddressStub.new(email: 'user@example.com')
+      @confirmation_token = 'test-confirmation-token'
+      @forbidden_passwords = []
+      flash.now[:success] = t('devise.confirmations.confirmed_but_must_set_password') if
+        params[:toast].present?
+      {}
+    end
+
+    def setup_mfa_setup
+      user = build_mfa_user(configured: params[:second].present?)
+      @nds_current_user = user
+      phishing_resistant_required = params[:phishing].present?
+      piv_cac_required = params[:piv_cac].present?
+      @presenter = TwoFactorOptionsPresenter.new(
+        user_agent: request.user_agent,
+        user:,
+        phishing_resistant_required:,
+        piv_cac_required:,
+        show_skip_additional_mfa_link: params[:skip].present?,
+        after_mfa_setup_path: account_path,
+        return_to_sp_cancel_path: root_path,
+      )
+      @two_factor_options_form = TwoFactorOptionsForm.new(
+        user:, phishing_resistant_required:, piv_cac_required:,
+      )
+      {}
+    end
+
+    def setup_otp_entry
+      @nds_current_user = User.new
+      delivery = params[:delivery] == 'voice' ? 'voice' : 'sms'
+      @landline_alert = params[:landline].present?
+      @in_account_creation_flow = params[:account_creation].present?
+      @presenter = TwoFactorAuthCode::PhoneDeliveryPresenter.new(
+        data: {
+          confirmation_for_add_phone: false,
+          phone_number: '(202) 555-1212',
+          code_value: params[:code].present? ? '123456' : nil,
+          in_multi_mfa_selection_flow: false,
+          otp_expiration: params[:countdown].present? ? 10.minutes.from_now : nil,
+          otp_delivery_preference: delivery,
+          otp_make_default_number: false,
+          unconfirmed_phone: false,
+          user_opted_remember_device_cookie: nil,
+          reauthn: params[:reauthn].present?,
+        },
+        view: view_context,
+        service_provider: nil,
+        remember_device_default: true,
+      )
+      {}
+    end
+
+    def build_mfa_user(configured:)
+      user = User.new
+      if configured
+        user.phone_configurations.build(
+          phone: '+12025551212',
+          confirmed_at: Time.zone.now,
+          delivery_preference: :sms,
+        )
+      end
+      user
+    end
+  end
+end

--- a/app/services/test/nds_page_catalog.rb
+++ b/app/services/test/nds_page_catalog.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+module Test
+  # Single source of truth for the dev-only NDS page-state explorer.
+  # Both the index and the render action read from PAGES so the list can
+  # never drift. Each page maps a slug to the real view template it renders
+  # plus the visually-distinct permutations a developer may want to inspect.
+  module NDSPageCatalog
+    Permutation = Struct.new(:label, :params, keyword_init: true)
+    Page = Struct.new(:key, :title, :flow, :template, :permutations, keyword_init: true)
+
+    SIGN_IN = 'Sign in'
+    CREATE_ACCOUNT = 'Create account'
+    MFA = 'MFA'
+    OTP = 'OTP'
+
+    PAGES = [
+      Page.new(
+        key: 'sign-in',
+        title: 'Sign in',
+        flow: SIGN_IN,
+        template: 'devise/sessions/new',
+        permutations: [
+          Permutation.new(label: 'Default', params: {}),
+          Permutation.new(label: 'With service provider', params: { sp: '1' }),
+          Permutation.new(label: 'SP + logo', params: { sp: '1', logo: '1' }),
+          Permutation.new(label: 'SP alert', params: { sp: '1', sp_alert: '1' }),
+          Permutation.new(label: 'Forced reauthentication', params: { sp: '1', reauth: '1' }),
+          Permutation.new(label: 'Email error', params: { error: 'email' }),
+          Permutation.new(label: 'Password error', params: { error: 'password' }),
+          Permutation.new(label: 'Both errors', params: { error: 'both' }),
+          Permutation.new(label: 'Mobile device', params: { device: 'mobile' }),
+        ],
+      ),
+      Page.new(
+        key: 'piv-cac',
+        title: 'PIV/CAC sign in',
+        flow: SIGN_IN,
+        template: 'users/piv_cac_login/new',
+        permutations: [
+          Permutation.new(label: 'Default', params: {}),
+        ],
+      ),
+      Page.new(
+        key: 'create-account',
+        title: 'Create account (enter email)',
+        flow: CREATE_ACCOUNT,
+        template: 'sign_up/registrations/new',
+        permutations: [
+          Permutation.new(label: 'Default', params: {}),
+          Permutation.new(label: 'SP alert', params: { sp_alert: '1' }),
+          Permutation.new(label: 'Email error', params: { error: 'email' }),
+        ],
+      ),
+      Page.new(
+        key: 'verify-email',
+        title: 'Verify email',
+        flow: CREATE_ACCOUNT,
+        template: 'sign_up/emails/show',
+        permutations: [
+          Permutation.new(label: 'Default', params: {}),
+          Permutation.new(label: 'Resend confirmation', params: { resend: '1' }),
+        ],
+      ),
+      Page.new(
+        key: 'enter-password',
+        title: 'Enter password',
+        flow: CREATE_ACCOUNT,
+        template: 'sign_up/passwords/new',
+        permutations: [
+          Permutation.new(label: 'Default', params: {}),
+          Permutation.new(label: 'Confirmation toast', params: { toast: '1' }),
+          Permutation.new(label: 'Password error', params: { error: '1' }),
+        ],
+      ),
+      Page.new(
+        key: 'mfa-setup',
+        title: 'Authentication methods setup',
+        flow: MFA,
+        template: 'users/two_factor_authentication_setup/index',
+        permutations: [
+          Permutation.new(label: 'First MFA', params: {}),
+          Permutation.new(label: 'Second MFA (configured)', params: { second: '1' }),
+          Permutation.new(label: 'Skip link', params: { second: '1', skip: '1' }),
+          Permutation.new(label: 'Phishing resistant required', params: { phishing: '1' }),
+          Permutation.new(label: 'PIV/CAC required', params: { piv_cac: '1' }),
+        ],
+      ),
+      Page.new(
+        key: 'otp-entry',
+        title: 'One-time code entry',
+        flow: OTP,
+        template: 'two_factor_authentication/otp_verification/show',
+        permutations: [
+          Permutation.new(label: 'SMS', params: {}),
+          Permutation.new(label: 'Voice', params: { delivery: 'voice' }),
+          Permutation.new(label: 'Landline alert', params: { landline: '1' }),
+          Permutation.new(label: 'Countdown', params: { countdown: '1' }),
+          Permutation.new(label: 'Reauthentication', params: { reauthn: '1' }),
+          Permutation.new(label: 'Prefilled code', params: { code: '1' }),
+        ],
+      ),
+    ].freeze
+
+    def self.pages
+      PAGES
+    end
+
+    def self.find(key)
+      PAGES.find { |page| page.key == key }
+    end
+
+    def self.grouped
+      PAGES.group_by(&:flow)
+    end
+
+    # NDS pages that render under the NDS layout without an `nds_layout?`
+    # branch in their template, so the template scan below cannot detect them.
+    # Kept explicit and minimal; unioned into the discovered set.
+    BRANCHLESS_NDS_TEMPLATES = [
+      'sign_up/emails/show',
+      'two_factor_authentication/otp_verification/show',
+      'users/piv_cac_login/new',
+    ].freeze
+
+    # Dynamic single source of truth for NDS-page completeness: the set of
+    # view templates is scanned at runtime rather than hardcoded. A template is
+    # an NDS page if it contains an `nds_layout?` conditional (its authoritative
+    # NDS-bucket branch), plus the explicit branchless allowlist above. Scanning
+    # templates is preferred over resolving every route's render target because
+    # render resolution is unreliable for non-conventional actions.
+    def self.discovered_templates
+      scanned = Rails.root.glob('app/views/**/*.html.erb').filter_map do |path|
+        rel = path.relative_path_from(Rails.root.join('app/views')).to_s
+        template = rel.delete_suffix('.html.erb')
+        next if File.basename(template).start_with?('_')
+        next if template.start_with?('layouts/')
+        next unless path.read.include?('nds_layout?')
+
+        template
+      end
+      (scanned + BRANCHLESS_NDS_TEMPLATES).uniq.sort
+    end
+
+    def self.template_exists?(template)
+      Rails.root.join('app/views', "#{template}.html.erb").exist?
+    end
+
+    def self.branch_template?(template)
+      path = Rails.root.join('app/views', "#{template}.html.erb")
+      path.exist? && path.read.include?('nds_layout?')
+    end
+
+    # Cross-check the dynamically discovered NDS templates against PAGES so the
+    # explorer is self-auditing:
+    #   covered: catalog templates that are still valid NDS pages
+    #   missing: discovered NDS templates absent from the catalog (coverage gap)
+    #   stale:   catalog templates that no longer exist or dropped their NDS
+    #            branch (and are not in the branchless allowlist)
+    def self.coverage
+      discovered = discovered_templates
+      catalog_templates = PAGES.map(&:template)
+
+      missing = discovered - catalog_templates
+      stale = catalog_templates.reject do |template|
+        BRANCHLESS_NDS_TEMPLATES.include?(template) || branch_template?(template)
+      end
+      covered = catalog_templates - stale
+
+      { covered:, missing:, stale: }
+    end
+
+    # Best-guess GET route path for a template, mapping the Rails-conventional
+    # controller/action back to the router. Returns nil when unresolved.
+    def self.route_for_template(template)
+      controller = File.dirname(template)
+      action = File.basename(template)
+      route = Rails.application.routes.routes.find do |r|
+        defaults = r.defaults
+        defaults[:controller] == controller && defaults[:action] == action &&
+          r.verb.to_s.include?('GET')
+      end
+      route&.path&.spec.to_s.delete_suffix('(.:format)').presence
+    end
+
+    Entry = Struct.new(:path, :controller, :action, :template, :page, keyword_init: true)
+
+    # Controller namespaces/mounts that are never user-facing HTML pages.
+    NON_PAGE_CONTROLLER_PREFIXES = %w[
+      api/ test/ health_check/ rails/ well_known/
+    ].freeze
+
+    # Dynamic full-inventory scan. The route table is the single source of
+    # truth for the "Legacy universe" of renderable pages; the curated PAGES
+    # catalog only supplies render/permutation detail for the NDS ones.
+    #
+    # Heuristic for "renderable page": a GET route mapping to a controller#action
+    # whose Rails-conventional view template (app/views/<controller>/<action>.html.erb)
+    # actually exists. This deliberately errs toward precision over recall:
+    #   - non-GET, redirects, mounts (Lookbook/sidekiq/mailers), and API/test/
+    #     health/rails namespaces are dropped;
+    #   - actions that render a non-conventional template (render :other, or a
+    #     shared template) are missed — acceptable for a dev audit tool.
+    # A page counts as NDS-converted when its template has an `nds_layout?`
+    # branch or is in BRANCHLESS_NDS_TEMPLATES.
+    def self.inventory
+      catalog_by_template = PAGES.index_by(&:template)
+      seen = {}
+
+      Rails.application.routes.routes.each do |route|
+        defaults = route.defaults
+        controller = defaults[:controller]
+        action = defaults[:action]
+        next if controller.blank? || action.blank?
+        next unless route.verb.to_s.include?('GET')
+        next if NON_PAGE_CONTROLLER_PREFIXES.any? { |p| controller.start_with?(p) }
+
+        template = "#{controller}/#{action}"
+        next unless template_exists?(template)
+        next if seen.key?(template)
+
+        seen[template] = Entry.new(
+          path: route.path.spec.to_s.delete_suffix('(.:format)'),
+          controller:,
+          action:,
+          template:,
+          page: catalog_by_template[template],
+        )
+      end
+
+      entries = seen.values
+      nds, legacy = entries.partition do |entry|
+        BRANCHLESS_NDS_TEMPLATES.include?(entry.template) || branch_template?(entry.template)
+      end
+
+      # Some NDS pages render a template that does not match their route's
+      # controller#action (e.g. Devise sign-in: route controller users/sessions
+      # renders devise/sessions/new). The template scan is authoritative for the
+      # NDS set, so fold in any discovered NDS template the route walk missed.
+      nds_templates = nds.map(&:template)
+      discovered_templates.each do |template|
+        next if nds_templates.include?(template)
+
+        nds << Entry.new(
+          path: route_for_template(template),
+          controller: File.dirname(template),
+          action: File.basename(template),
+          template:,
+          page: catalog_by_template[template],
+        )
+      end
+
+      audit = coverage
+      {
+        nds: nds.sort_by(&:template),
+        legacy: legacy.sort_by(&:template),
+        missing: audit[:missing],
+        stale: audit[:stale],
+      }
+    end
+  end
+end

--- a/app/views/test/nds_pages/index.html.erb
+++ b/app/views/test/nds_pages/index.html.erb
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>NDS page-state explorer</title>
+    <%= csrf_meta_tags %>
+    <style nonce="<%= content_security_policy_nonce %>">
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        color: #1b1b1b;
+        line-height: 1.4;
+      }
+      .explorer { max-width: 90rem; margin: 0 auto; padding: 2rem; }
+      .explorer h1 { margin-bottom: 0.25rem; }
+      .explorer__summary {
+        background: #eef4ff; border: 1px solid #cbd7f0; border-radius: 0.5rem;
+        padding: 0.75rem 1rem; font-size: 1.1rem; margin: 1rem 0 2rem;
+      }
+      .explorer__meter {
+        display: block; width: 100%; height: 0.5rem; margin-top: 0.5rem;
+        border: 0; border-radius: 999px; background: #dfe1e2; overflow: hidden;
+        -webkit-appearance: none; appearance: none;
+      }
+      .explorer__meter::-webkit-progress-bar { background: #dfe1e2; border-radius: 999px; }
+      .explorer__meter::-webkit-progress-value { background: #00a91c; border-radius: 999px; }
+      .explorer__meter::-moz-progress-bar { background: #00a91c; border-radius: 999px; }
+      .explorer__audit {
+        background: #fff5c2; border: 1px solid #e6c000; border-radius: 0.5rem;
+        padding: 0.75rem 1rem; margin-bottom: 2rem;
+      }
+      .explorer__columns { display: flex; gap: 2rem; align-items: flex-start; }
+      .explorer__columns > section { flex: 1 1 0; min-width: 0; }
+      .explorer__col-head {
+        position: sticky; top: 0; background: #fff; padding: 0.5rem 0;
+        border-bottom: 2px solid #1b1b1b; margin-bottom: 0.75rem;
+      }
+      .explorer__col-head h2 { margin: 0; font-size: 1.2rem; }
+      .explorer__list { list-style: none; margin: 0; padding: 0; }
+      .explorer__item {
+        border: 1px solid #dfe1e2; border-radius: 0.4rem; padding: 0.6rem 0.75rem;
+        margin-bottom: 0.5rem;
+      }
+      .explorer__item--nds { border-left: 4px solid #00a91c; }
+      .explorer__item--legacy { border-left: 4px solid #adadad; }
+      .explorer__meta { color: #5c5c5c; font-size: 0.8rem; margin-top: 0.15rem; }
+      .explorer__params {
+        display: inline-flex; align-items: center; gap: 0.4rem;
+        margin-left: 0.5rem; font-size: 0.75rem; color: #71767a;
+      }
+      .explorer__param { display: inline-flex; align-items: center; gap: 0.2rem; }
+      .explorer__params input {
+        border: 1px solid #c6cace; border-radius: 0.25rem; padding: 0.1rem 0.3rem;
+        font-size: 0.75rem;
+      }
+      .explorer__go {
+        border: 1px solid #005ea2; background: #005ea2; color: #fff;
+        border-radius: 0.25rem; padding: 0.1rem 0.5rem; font-size: 0.75rem; cursor: pointer;
+      }
+      .explorer__go:hover { background: #1a4480; }
+      .explorer__seed-state {
+        display: inline-block; margin-top: 0.4rem;
+        border: 1px solid #4d8055; background: #4d8055; color: #fff;
+        border-radius: 0.25rem; padding: 0.15rem 0.5rem; font-size: 0.75rem; cursor: pointer;
+      }
+      .explorer__seed-state:hover { background: #3d6644; }
+      .explorer__reset-state {
+        display: inline-block; margin-top: 0.4rem;
+        border: 1px solid #b50909; background: #fff; color: #b50909;
+        border-radius: 0.25rem; padding: 0.15rem 0.5rem; font-size: 0.75rem; cursor: pointer;
+      }
+      .explorer__reset-state:hover { background: #b50909; color: #fff; }
+      .explorer__item form { display: inline-block; margin: 0 0.3rem 0 0; }
+      .explorer__session {
+        display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;
+        background: #f0f0f0; border: 1px solid #dfe1e2; border-radius: 0.5rem;
+        padding: 0.75rem 1rem; margin-bottom: 1.5rem;
+      }
+      .explorer__session form { margin: 0; }
+      .explorer__session button {
+        border: 1px solid #005ea2; background: #005ea2; color: #fff;
+        border-radius: 0.25rem; padding: 0.35rem 0.75rem; font-size: 0.9rem; cursor: pointer;
+      }
+      .explorer__session button:hover { background: #1a4480; }
+      .explorer__session-status { font-weight: 600; }
+      .explorer__ial {
+        display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
+        margin-bottom: 1.5rem;
+      }
+      .explorer__ial select { font-size: 0.9rem; padding: 0.2rem; }
+      .explorer__perms { margin: 0.4rem 0 0; padding-left: 1rem; }
+      .explorer__perms a { font-size: 0.9rem; }
+      .explorer__badge {
+        display: inline-block; background: #00a91c; color: #fff; font-size: 0.65rem;
+        border-radius: 0.25rem; padding: 0.05rem 0.35rem; margin-right: 0.4rem;
+        text-transform: uppercase; letter-spacing: 0.03em;
+      }
+      .explorer__params select {
+        border: 1px solid #c6cace; border-radius: 0.25rem; font-size: 0.75rem; max-width: 12rem;
+      }
+      .explorer__del {
+        border: 1px solid #b50909; background: #fff; color: #b50909;
+        border-radius: 0.25rem; padding: 0 0.3rem; font-size: 0.75rem; cursor: pointer;
+      }
+      .explorer__del:hover { background: #b50909; color: #fff; }
+      code { font-size: 0.85rem; }
+    </style>
+  </head>
+  <body>
+    <div class="explorer">
+      <% total = @inventory[:nds].length + @inventory[:legacy].length %>
+      <% pct = total.zero? ? 0 : (@inventory[:nds].length * 100.0 / total).round %>
+      <h1>NDS page-state explorer</h1>
+      <p>Dev-only tool for jumping to NDS page states and tracking conversion coverage.</p>
+
+      <div class="explorer__session">
+        <span class="explorer__session-status">
+          <% if @dev_user %>
+            Signed in as <%= @dev_user.email_addresses.take&.email || @dev_user.uuid %>
+          <% else %>
+            Not signed in
+          <% end %>
+        </span>
+        <%= button_to 'Sign in as dev user', test_nds_seed_session_path %>
+        <button type="button" id="explorer-generate">Generate MFA &amp; records</button>
+        <%= button_to 'Sign out', test_nds_sign_out_path %>
+      </div>
+
+      <% if @dev_user %>
+        <% current_level = current_identity_level(@dev_user) %>
+        <%= form_with url: test_nds_set_identity_level_path, method: :post, class: 'explorer__ial' do |f| %>
+          <span class="explorer__session-status">Identity level:</span>
+          <%= f.select :level,
+                       identity_levels.map { |level| [level[:label], level[:key]] },
+                       { selected: current_level } %>
+          <%= f.submit 'Apply' %>
+        <% end %>
+      <% end %>
+
+      <div class="explorer__summary">
+        <strong><%= @inventory[:nds].length %> of <%= total %></strong> pages converted to NDS
+        (<%= @inventory[:legacy].length %> remaining &mdash; <%= pct %>%).
+        <progress class="explorer__meter" value="<%= @inventory[:nds].length %>" max="<%= total %>"></progress>
+      </div>
+
+      <% if @inventory[:missing].any? || @inventory[:stale].any? %>
+        <div class="explorer__audit">
+          <strong>Catalog self-audit</strong>
+          <% if @inventory[:missing].any? %>
+            <p>NDS templates missing from the catalog:</p>
+            <ul>
+              <% @inventory[:missing].each do |template| %>
+                <li>
+                  <code>app/views/<%= template %>.html.erb</code>
+                  <% route = Test::NDSPageCatalog.route_for_template(template) %>
+                  <% if route %>&rarr; <code><%= route %></code><% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+          <% if @inventory[:stale].any? %>
+            <p>Stale catalog entries:</p>
+            <ul>
+              <% @inventory[:stale].each do |template| %>
+                <li><code><%= template %></code></li>
+              <% end %>
+            </ul>
+          <% end %>
+        </div>
+      <% end %>
+
+      <div class="explorer__columns">
+        <section>
+          <div class="explorer__col-head">
+            <h2>Live / legacy routes</h2>
+          </div>
+          <p class="explorer__meta">Every renderable live page. NDS-converted ones are tagged and open with <code>ui_test_bucket=legacy</code> so you can compare the pre-NDS version against the NDS render on the right. Seed records first to populate the dropdowns.</p>
+          <ul class="explorer__list">
+            <% left_entries = (@inventory[:legacy] + @inventory[:nds]).select { |e| e.path.present? }.sort_by(&:path) %>
+            <% left_entries.each do |entry| %>
+              <% converted = entry.page.present? || @inventory[:nds].include?(entry) %>
+              <% url = entry.path.sub(%r{\(/:locale\)}, '') %>
+              <li class="explorer__item explorer__item--legacy">
+                <% if converted %><span class="explorer__badge">NDS-converted</span><% end %>
+                <% if url.exclude?(':') %>
+                  <% href = converted ? "#{url}?ui_test_bucket=legacy" : url %>
+                  <%= link_to url, href, target: '_blank', rel: 'noopener' %>
+                <% else %>
+                  <code><%= url %></code>
+                  <% params = url.scan(/:(\w+)/).flatten %>
+                  <span class="explorer__params" data-template="<%= url %>" data-converted="<%= converted %>">
+                    <% params.each do |param| %>
+                      <% kind = record_kind_for(url, param) %>
+                      <label class="explorer__param">
+                        <%= param %>
+                        <select data-param="<%= param %>" data-record="<%= kind %>">
+                          <option value="1">(seed records first)</option>
+                        </select>
+                        <% if deletable_record_kind?(kind) %>
+                          <button type="button" class="explorer__del" data-record="<%= kind %>" title="Delete selected record">&times;</button>
+                        <% end %>
+                      </label>
+                    <% end %>
+                    <button type="button" class="explorer__go">Go</button>
+                  </span>
+                <% end %>
+                <% if (state = page_state_for(url)) %>
+                  <%= button_to state[:label], test_nds_seed_state_path,
+                                params: { path: url }, class: 'explorer__seed-state' %>
+                  <% if state[:resetter] %>
+                    <%= button_to 'Clear state', test_nds_reset_state_path,
+                                  params: { path: url }, class: 'explorer__reset-state' %>
+                  <% end %>
+                <% end %>
+                <div class="explorer__meta">
+                  <%= entry.controller %>#<%= entry.action %>
+                  &middot; <%= entry.template %>.html.erb
+                </div>
+              </li>
+            <% end %>
+          </ul>
+        </section>
+
+        <section>
+          <div class="explorer__col-head">
+            <h2>NDS (<%= @inventory[:nds].length %>)</h2>
+          </div>
+          <p class="explorer__meta">Pages with an NDS treatment. Cataloged pages link to their rendered states + permutations.</p>
+          <ul class="explorer__list">
+            <% @inventory[:nds].each do |entry| %>
+              <li class="explorer__item explorer__item--nds">
+                <% if entry.page %>
+                  <strong><%= link_to entry.page.title, test_nds_page_path(page: entry.page.key) %></strong>
+                  <div class="explorer__meta"><%= entry.template %>.html.erb</div>
+                  <ul class="explorer__perms">
+                    <% entry.page.permutations.each do |permutation| %>
+                      <li>
+                        <%= link_to(
+                              permutation.label,
+                              test_nds_page_path(page: entry.page.key, **permutation.params),
+                            ) %>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% else %>
+                  <code><%= entry.template %>.html.erb</code>
+                  <span class="explorer__meta">(not cataloged)</span>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </section>
+      </div>
+    </div>
+    <script nonce="<%= content_security_policy_nonce %>">
+      var csrfToken = (function () {
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        return meta ? meta.getAttribute('content') : '';
+      })();
+
+      function populateSelects(data) {
+        var byTemplate = data.by_template || {};
+        var byParam = data.by_param || {};
+        document.querySelectorAll('.explorer__params').forEach(function (container) {
+          var template = container.dataset.template;
+          container.querySelectorAll('select[data-param]').forEach(function (select) {
+            var param = select.dataset.param;
+            var options = byTemplate[template] || byParam[param];
+            if (!options) { return; }
+            var previous = select.value;
+            select.innerHTML = '';
+            options.forEach(function (option) {
+              var el = document.createElement('option');
+              el.value = option.value;
+              el.textContent = option.label;
+              select.appendChild(el);
+            });
+            select.value = previous;
+          });
+        });
+      }
+
+      function fetchOptions(url, method) {
+        return fetch(url, {
+          method: method,
+          headers: { 'X-CSRF-Token': csrfToken, Accept: 'application/json' },
+          credentials: 'same-origin',
+        }).then(function (response) {
+          if (!response.ok) { throw new Error('request failed: ' + response.status); }
+          return response.json();
+        }).then(populateSelects).catch(function (error) {
+          window.console && window.console.error('[nds-explorer]', error);
+        });
+      }
+
+      document.querySelectorAll('.explorer__go').forEach(function (button) {
+        button.addEventListener('click', function () {
+          var container = button.closest('.explorer__params');
+          var path = container.dataset.template;
+          container.querySelectorAll('select[data-param]').forEach(function (select) {
+            path = path.replace(':' + select.dataset.param, encodeURIComponent(select.value));
+          });
+          if (container.dataset.converted === 'true') {
+            path += (path.indexOf('?') === -1 ? '?' : '&') + 'ui_test_bucket=legacy';
+          }
+          window.open(path, '_blank', 'noopener');
+        });
+      });
+
+      document.querySelectorAll('.explorer__del').forEach(function (button) {
+        button.addEventListener('click', function () {
+          var label = button.closest('.explorer__param');
+          var select = label.querySelector('select[data-param]');
+          if (!select || !select.value || select.value === '0') { return; }
+          button.disabled = true;
+          var body = new URLSearchParams({ param: button.dataset.record, id: select.value });
+          fetch('<%= test_nds_delete_record_path %>', {
+            method: 'POST',
+            headers: {
+              'X-CSRF-Token': csrfToken,
+              Accept: 'application/json',
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            credentials: 'same-origin',
+            body: body,
+          }).then(function (response) {
+            if (!response.ok) { throw new Error('delete failed: ' + response.status); }
+            return response.json();
+          }).then(populateSelects).catch(function (error) {
+            window.console && window.console.error('[nds-explorer]', error);
+          }).finally(function () {
+            button.disabled = false;
+          });
+        });
+      });
+
+      var generateButton = document.getElementById('explorer-generate');
+      if (generateButton) {
+        generateButton.addEventListener('click', function () {
+          generateButton.disabled = true;
+          fetchOptions('<%= test_nds_generate_mfa_path %>', 'POST').finally(function () {
+            generateButton.disabled = false;
+          });
+        });
+      }
+
+      fetchOptions('<%= test_nds_record_options_path %>', 'GET');
+    </script>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,18 @@ Rails.application.routes.draw do
 
         get '/session_data' => 'session_data#index'
 
+        get '/nds' => 'nds_pages#index', as: :nds
+        post '/nds/seed_session' => 'nds_pages#seed_session', as: :nds_seed_session
+        post '/nds/generate_mfa' => 'nds_pages#generate_mfa', as: :nds_generate_mfa
+        get '/nds/record_options' => 'nds_pages#record_options', as: :nds_record_options
+        post '/nds/delete_record' => 'nds_pages#delete_record', as: :nds_delete_record
+        post '/nds/seed_state' => 'nds_pages#seed_state', as: :nds_seed_state
+        post '/nds/reset_state' => 'nds_pages#reset_state', as: :nds_reset_state
+        post '/nds/set_identity_level' => 'nds_pages#set_identity_level',
+             as: :nds_set_identity_level
+        post '/nds/sign_out' => 'nds_pages#sign_out_dev', as: :nds_sign_out
+        get '/nds/:page' => 'nds_pages#show', as: :nds_page
+
         get '/mock_socure/document_capture' => 'mock_socure#index'
         post '/mock_socure/document_capture' => 'mock_socure#update'
         post '/mock_socure/document_capture/continue' => 'mock_socure#continue'

--- a/spec/requests/test/nds_pages_spec.rb
+++ b/spec/requests/test/nds_pages_spec.rb
@@ -1,0 +1,432 @@
+require 'rails_helper'
+
+RSpec.describe 'Test::NdsPages', type: :request do
+  before do
+    allow(IdentityConfig.store).to receive(:enable_test_routes).and_return(true)
+  end
+
+  describe 'GET /test/nds' do
+    it 'renders the index listing every catalog page' do
+      get test_nds_path
+
+      expect(response).to have_http_status(:ok)
+      Test::NDSPageCatalog.pages.each do |page|
+        expect(response.body).to include(page.title)
+      end
+    end
+
+    it 'hides the identity-level control until a dev session exists' do
+      get test_nds_path
+      expect(response.body).not_to include('Identity level:')
+
+      post test_nds_seed_session_path
+      get test_nds_path
+      expect(response.body).to include('Identity level:')
+    end
+  end
+
+  describe 'GET /test/nds/:page' do
+    context 'with the default permutation for every page' do
+      it 'renders 200' do
+        Test::NDSPageCatalog.pages.each do |page|
+          get test_nds_page_path(page: page.key)
+
+          expect(response).to have_http_status(:ok), "expected 200 for #{page.key}"
+        end
+      end
+    end
+
+    context 'with representative permutations' do
+      {
+        'sign-in' => { sp: '1', error: 'email' },
+        'create-account' => { sp_alert: '1', error: 'email' },
+        'verify-email' => { resend: '1' },
+        'enter-password' => { toast: '1', error: '1' },
+        'mfa-setup' => { piv_cac: '1' },
+        'otp-entry' => { delivery: 'voice', landline: '1', countdown: '1' },
+      }.each do |page_key, params|
+        it "renders 200 for #{page_key} with #{params}" do
+          get test_nds_page_path(page: page_key, **params)
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
+    end
+
+    context 'with an unknown page' do
+      it 'renders 404' do
+        get test_nds_page_path(page: 'does-not-exist')
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  context 'when test routes are disabled' do
+    before do
+      allow(IdentityConfig.store).to receive(:enable_test_routes).and_return(false)
+    end
+
+    it 'renders 404 from the controller guard' do
+      get test_nds_path
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'POST /test/nds/seed_session' do
+    it 'creates a fully-authenticated dev session so gated pages render' do
+      expect { post test_nds_seed_session_path }.to change(User, :count).by(1)
+      expect(response).to redirect_to(test_nds_path)
+
+      get account_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'seeds recent 2FA so reauthentication-gated pages render' do
+      post test_nds_seed_session_path
+
+      get '/manage/password'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'reuses the existing dev user on a second seed' do
+      post test_nds_seed_session_path
+      expect { post test_nds_seed_session_path }.not_to change(User, :count)
+    end
+  end
+
+  describe 'POST /test/nds/generate_mfa' do
+    before { post test_nds_seed_session_path }
+
+    it 'creates records and returns the option catalog' do
+      expect { post test_nds_generate_mfa_path }
+        .to change(WebauthnConfiguration, :count).by(1)
+        .and change(PivCacConfiguration, :count).by(1)
+        .and change(AuthAppConfiguration, :count).by(1)
+        .and change(Device, :count).by(1)
+
+      body = response.parsed_body
+      expect(body['by_template']).to include(
+        '/manage/webauthn/:id', '/manage/piv_cac/:id', '/manage/auth_app/:id',
+        '/manage/email/confirm_delete/:id', '/account/devices/:id/events',
+        '/manage/phone/:id'
+      )
+      expect(body['by_param']).to include('sp_id', 'identity_id', 'opt_out_uuid', 'source')
+    end
+
+    it 'includes synthetic none/invalid choices for each param' do
+      post test_nds_generate_mfa_path
+
+      webauthn_options = response.parsed_body.dig('by_template', '/manage/webauthn/:id')
+      values = webauthn_options.pluck('value')
+      expect(values).to include('', '0')
+      expect(webauthn_options.length).to be >= 3
+    end
+
+    it 'is idempotent across repeated calls' do
+      post test_nds_generate_mfa_path
+      webauthn_count = WebauthnConfiguration.count
+      device_count = Device.count
+
+      post test_nds_generate_mfa_path
+
+      expect(WebauthnConfiguration.count).to eq(webauthn_count)
+      expect(Device.count).to eq(device_count)
+    end
+
+    it 'seeds an identity that account/history can sort by happened_at' do
+      post test_nds_generate_mfa_path
+
+      get '/account/history'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET /test/nds/record_options' do
+    it 'returns the option catalog without creating records' do
+      post test_nds_seed_session_path
+      post test_nds_generate_mfa_path
+
+      expect { get test_nds_record_options_path }.not_to change(WebauthnConfiguration, :count)
+      expect(response.parsed_body['by_template']).to include('/manage/webauthn/:id')
+    end
+
+    it 'returns an empty catalog and creates no user when not signed in' do
+      expect { get test_nds_record_options_path }.not_to change(User, :count)
+      expect(response.parsed_body).to eq('by_template' => {}, 'by_param' => {})
+    end
+  end
+
+  describe 'POST /test/nds/delete_record' do
+    before do
+      post test_nds_seed_session_path
+      post test_nds_generate_mfa_path
+    end
+
+    it 'deletes the identified record and returns the refreshed catalog' do
+      webauthn = User.last.webauthn_configurations.first
+
+      expect do
+        post test_nds_delete_record_path, params: { param: 'webauthn', id: webauthn.id }
+      end.to change(WebauthnConfiguration, :count).by(-1)
+
+      values = response.parsed_body.dig('by_template', '/manage/webauthn/:id').pluck('value')
+      expect(values).not_to include(webauthn.id.to_s)
+    end
+
+    it 'ignores an unknown param without error' do
+      expect do
+        post test_nds_delete_record_path, params: { param: 'nope', id: '1' }
+      end.not_to change(WebauthnConfiguration, :count)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'handles a stale numeric id for a uuid-less model without error' do
+      post test_nds_delete_record_path, params: { param: 'webauthn', id: '999999' }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /test/nds/seed_state' do
+    let(:target) { '/duplicate_profiles_detected' }
+
+    context 'with a seeded dev session' do
+      before { post test_nds_seed_session_path }
+
+      it 'seeds state and makes the gated page render' do
+        expect { post test_nds_seed_state_path, params: { path: target } }
+          .to change(DuplicateProfileSet, :count).by(1)
+        expect(response).to redirect_to(target)
+
+        get target
+        expect(response).to have_http_status(:ok)
+      end
+
+      context 'when global duplicate detection is enabled' do
+        before do
+          allow(IdentityConfig.store)
+            .to receive(:enable_one_account_global_detection).and_return(true)
+        end
+
+        it 'seeds a global (SP-null) set so the page still renders' do
+          post test_nds_seed_state_path, params: { path: target }
+          expect(DuplicateProfileSet.last.service_provider).to be_nil
+
+          get target
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      it 'is idempotent across repeated calls' do
+        post test_nds_seed_state_path, params: { path: target }
+        expect { post test_nds_seed_state_path, params: { path: target } }
+          .not_to change(DuplicateProfileSet, :count)
+      end
+
+      it 'renders 404 for an unregistered path' do
+        post test_nds_seed_state_path, params: { path: '/not/registered' }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'tears the state back down on reset' do
+        post test_nds_seed_state_path, params: { path: target }
+
+        expect { post test_nds_reset_state_path, params: { path: target } }
+          .to change(DuplicateProfileSet, :count).to(0)
+        expect(response).to redirect_to(test_nds_path)
+
+        get target
+        expect(response).to redirect_to(root_url)
+      end
+    end
+
+    context 'without a signed-in dev user' do
+      it 'renders 404' do
+        post test_nds_seed_state_path, params: { path: target }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'POST /test/nds/set_identity_level' do
+    before { post test_nds_seed_session_path }
+
+    def dev_user
+      EmailAddress.find_with_email('nds-explorer-dev@example.com').user
+    end
+
+    it 'builds an active verified IAL2 profile' do
+      post test_nds_set_identity_level_path, params: { level: 'ial2' }
+      expect(response).to redirect_to(test_nds_path)
+
+      profile = dev_user.reload.profiles.find_by(active: true)
+      expect(profile).to be_present
+      expect(profile.idv_level).to eq('legacy_unsupervised')
+    end
+
+    it 'builds a facial-match verified profile' do
+      post test_nds_set_identity_level_path, params: { level: 'ial2_facial_match' }
+      expect(dev_user.reload.profiles.find_by(active: true).facial_match?).to be(true)
+    end
+
+    it 'builds a pending in-person enrollment for the reentrant flow' do
+      expect { post test_nds_set_identity_level_path, params: { level: 'in_person_pending' } }
+        .to change(InPersonEnrollment, :count).by(1)
+
+      user = dev_user.reload
+      expect(user.in_person_enrollments.where(status: :pending)).to be_present
+      expect(user.profiles.find_by(active: true)).to be_nil
+    end
+
+    it 'seeds an in-person enrollment whose ready_to_verify barcode renders' do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      post test_nds_set_identity_level_path, params: { level: 'in_person_pending' }
+
+      get '/verify/in_person/ready_to_verify'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'builds a verify-by-mail pending profile' do
+      post test_nds_set_identity_level_path, params: { level: 'gpo_pending' }
+      expect(dev_user.reload.profiles.where.not(gpo_verification_pending_at: nil)).to be_present
+    end
+
+    it 'clears prior state when switching levels' do
+      post test_nds_set_identity_level_path, params: { level: 'in_person_pending' }
+      post test_nds_set_identity_level_path, params: { level: 'unverified' }
+
+      user = dev_user.reload
+      expect(user.profiles).to be_empty
+      expect(user.in_person_enrollments).to be_empty
+    end
+
+    it 'renders 404 for an unknown level' do
+      post test_nds_set_identity_level_path, params: { level: 'bogus' }
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'renders 404 when not signed in' do
+      post test_nds_sign_out_path
+      post test_nds_set_identity_level_path, params: { level: 'ial2' }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'session-gated page states' do
+    before { post test_nds_seed_session_path }
+
+    {
+      '/webauthn_setup_mismatch' => WebauthnConfiguration,
+      '/login/two_factor/piv_cac_mismatch' => nil,
+    }.each do |path, model|
+      context "for #{path}" do
+        it 'renders 200 after seeding and redirects after reset' do
+          post test_nds_seed_state_path, params: { path: }
+          expect(response).to redirect_to(path)
+          expect(model.count).to be >= 1 if model
+
+          get path
+          expect(response).to have_http_status(:ok)
+
+          post test_nds_reset_state_path, params: { path: }
+          get path
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+    end
+
+    context 'for /account/connected_services' do
+      let(:path) { '/account/connected_services' }
+
+      it 'seeds connected identities and clears them on reset' do
+        expect { post test_nds_seed_state_path, params: { path: } }
+          .to change { ServiceProviderIdentity.where.not(deleted_at: nil).count }
+          .by(0)
+        expect(response).to redirect_to(path)
+
+        user = EmailAddress.find_with_email('nds-explorer-dev@example.com').user
+        expect(user.connected_apps.count).to eq(2)
+
+        get path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('NDS Dev App A', 'NDS Dev App B')
+
+        post test_nds_reset_state_path, params: { path: }
+        expect(user.reload.connected_apps.count).to eq(0)
+      end
+
+      it 'is idempotent across repeated seeds' do
+        post test_nds_seed_state_path, params: { path: }
+        user = EmailAddress.find_with_email('nds-explorer-dev@example.com').user
+        expect { post test_nds_seed_state_path, params: { path: } }
+          .not_to change { user.reload.connected_apps.count }
+      end
+    end
+  end
+
+  describe 'POST /test/nds/sign_out' do
+    it 'signs the dev user out' do
+      post test_nds_seed_session_path
+      post test_nds_sign_out_path
+      expect(response).to redirect_to(test_nds_path)
+
+      get account_path
+      expect(response).to redirect_to(new_user_session_url)
+    end
+  end
+
+  describe 'dev-only guards on the seed/generate actions' do
+    context 'when test routes are disabled' do
+      before do
+        allow(IdentityConfig.store).to receive(:enable_test_routes).and_return(false)
+      end
+
+      it 'renders 404 without creating records' do
+        expect { post test_nds_seed_session_path }.not_to change(User, :count)
+        expect(response).to have_http_status(:not_found)
+
+        post test_nds_generate_mfa_path
+        expect(response).to have_http_status(:not_found)
+
+        post test_nds_seed_state_path, params: { path: '/duplicate_profiles_detected' }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when running in a prod-like env' do
+      before do
+        allow(Rails).to receive(:env)
+          .and_return(ActiveSupport::EnvironmentInquirer.new('production'))
+      end
+
+      it 'renders 404 and mutates nothing for every seeding/mutating action' do
+        aggregate_failures do
+          expect { post test_nds_seed_session_path }.not_to change(User, :count)
+          expect(response).to have_http_status(:not_found)
+
+          expect { post test_nds_generate_mfa_path }.not_to change(WebauthnConfiguration, :count)
+          expect(response).to have_http_status(:not_found)
+
+          post test_nds_delete_record_path, params: { param: 'webauthn', id: '1' }
+          expect(response).to have_http_status(:not_found)
+
+          expect do
+            post test_nds_seed_state_path, params: { path: '/duplicate_profiles_detected' }
+          end.not_to change(DuplicateProfileSet, :count)
+          expect(response).to have_http_status(:not_found)
+
+          post test_nds_reset_state_path, params: { path: '/duplicate_profiles_detected' }
+          expect(response).to have_http_status(:not_found)
+
+          expect { post test_nds_set_identity_level_path, params: { level: 'ial2' } }
+            .not_to change(Profile, :count)
+          expect(response).to have_http_status(:not_found)
+
+          get test_nds_record_options_path
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/test/nds_page_catalog_spec.rb
+++ b/spec/services/test/nds_page_catalog_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Test::NDSPageCatalog do
+  describe '.discovered_templates' do
+    subject(:discovered) { described_class.discovered_templates }
+
+    it 'finds the known NDS branch templates' do
+      expect(discovered).to include(
+        'devise/sessions/new',
+        'sign_up/registrations/new',
+        'sign_up/passwords/new',
+        'users/two_factor_authentication_setup/index',
+      )
+    end
+
+    it 'includes the branchless NDS templates' do
+      expect(discovered).to include(*described_class::BRANCHLESS_NDS_TEMPLATES)
+    end
+
+    it 'is not trivially empty' do
+      expect(discovered.length).to be >= described_class::PAGES.length
+    end
+
+    it 'excludes partials and layouts' do
+      expect(discovered).to all(satisfy { |t| !File.basename(t).start_with?('_') })
+      expect(discovered).to all(satisfy { |t| !t.start_with?('layouts/') })
+    end
+  end
+
+  describe '.coverage' do
+    subject(:coverage) { described_class.coverage }
+
+    it 'reports no missing NDS pages for the current tree' do
+      expect(coverage[:missing]).to be_empty
+    end
+
+    it 'reports no stale catalog entries for the current tree' do
+      expect(coverage[:stale]).to be_empty
+    end
+
+    it 'covers every catalog template' do
+      expect(coverage[:covered]).to match_array(described_class::PAGES.map(&:template))
+    end
+  end
+
+  describe '.inventory' do
+    subject(:inventory) { described_class.inventory }
+
+    it 'populates both the legacy and nds sets non-trivially' do
+      expect(inventory[:legacy].length).to be >= 1
+      expect(inventory[:nds].length).to be >= described_class::PAGES.length
+    end
+
+    it 'classifies a known NDS page under :nds' do
+      expect(inventory[:nds].map(&:template)).to include('devise/sessions/new')
+    end
+
+    it 'classifies a known legacy page under :legacy' do
+      expect(inventory[:legacy].map(&:template)).to include('account_reset/pending/show')
+    end
+
+    it 'never lists the same template in both columns' do
+      expect(inventory[:nds].map(&:template) & inventory[:legacy].map(&:template)).to be_empty
+    end
+
+    it 'carries the coverage self-audit' do
+      expect(inventory[:missing]).to be_empty
+      expect(inventory[:stale]).to be_empty
+    end
+  end
+
+  describe '.route_for_template' do
+    it 'resolves a conventional GET route to a path' do
+      expect(described_class.route_for_template('sign_up/registrations/new'))
+        .to match(%r{/sign_up/enter_email\z})
+    end
+
+    it 'returns nil when the controller does not follow template conventions' do
+      expect(described_class.route_for_template('devise/sessions/new')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A **dev-only** tool to (1) jump directly to any NDS page's rendered state with permutation toggles, and (2) track NDS-conversion coverage against the **full** page inventory — so no legacy page gets missed.

- `GET /test/nds` — a **two-column Legacy | NDS inventory**, dynamically built from the router (single source of truth).
- `GET /test/nds/:page?<axes>` — renders the real NDS view with permutation options.

Gated by `namespace :test` (`IdentityConfig.store.enable_test_routes`, false in prod) **plus** a controller 404 guard. Renders real views via fabricated presenters + per-view helper stubs; **no production flow code modified**.

## Two-column inventory (headline)

Driven by a dynamic scan of `Rails.application.routes.routes`:
- **Left — "Legacy / not yet NDS"**: every renderable GET page whose template lacks an `nds_layout?` branch (the conversion backlog) — path + controller#action + template.
- **Right — "NDS"**: every page with an NDS treatment, linked to its explorer render + permutation sublinks.
- **Summary**: "X of Y pages converted to NDS (Z remaining)" — currently **7 of 131 (124 remaining)**.
- **Self-audit banner**: any NDS template missing from the catalog, or stale catalog entries.

`Test::NDSPageCatalog.inventory` → `{ nds:, legacy:, missing:, stale: }`. The route+template scan drives the universe; the curated `PAGES` catalog supplies render/permutation detail for NDS pages.

### Guardrail
A spec asserts `coverage[:missing]` is empty — so the suite **fails** if someone adds an NDS page (a template with `nds_layout?`) without cataloging it. Classification uses `nds_layout?` presence plus a minimal `BRANCHLESS_NDS_TEMPLATES` allowlist for NDS pages that render under the NDS layout without a branch.

### Heuristic limits (documented in-code)
Route walk keeps GET routes mapping to a controller#action whose conventional `app/views/<controller>/<action>.html.erb` exists; drops non-GET, redirects, mounts, api/test/health/rails endpoints. Off-convention renders (e.g. Devise sign-in: `users/sessions` → `devise/sessions/new`) are caught by unioning the authoritative `nds_layout?` template scan into `:nds`. Legacy pages that render off-convention may not appear — acceptable for a dev audit tool.

## Permutation axes
sign-in (SP/logo/alert/reauth/errors/mobile), piv-cac, create-account (sp_alert/email error), verify-email (resend), enter-password (error/toast), mfa-setup (first/second MFA, skip, phishing-resistant, piv-cac), otp-entry (sms/voice, landline, countdown, reauthn, prefilled).

## Test plan

- [ ] `bundle exec rspec spec/requests/test/nds_pages_spec.rb spec/services/test/nds_page_catalog_spec.rb` (24 examples)
- [ ] `bundle exec rubocop`, `bundle exec erb_lint app/views/test/nds_pages`, `bundle exec rake zeitwerk:check`
- [ ] `/test/nds` unreachable in prod (route + controller gate)
- [ ] Adding an uncataloged NDS page makes `coverage[:missing]` non-empty (guardrail fails)