### PR TITLE
LG-17843: IPP: Add Expiration date to 'Verify your information' screen

### DIFF
--- a/app/presenters/idv/in_person/verify_info_presenter.rb
+++ b/app/presenters/idv/in_person/verify_info_presenter.rb
@@ -17,10 +17,6 @@ class Idv::InPerson::VerifyInfoPresenter
     @enrollment.passport_book?
   end
 
-  def show_state_id_expiration?
-    IdentityConfig.store.in_person_proofing_expiration_edge_cases_enabled
-  end
-
   # Human-readable expiration value for the verify-info screen, handling the
   # edge-case sentinels and literal placeholder dates.
   def formatted_state_id_expiration(pii)

--- a/app/views/idv/in_person/verify_info/_state_id_section.html.erb
+++ b/app/views/idv/in_person/verify_info/_state_id_section.html.erb
@@ -25,12 +25,10 @@
       <dt class="display-inline"> <%= t('idv.form.id_number') %>: </dt>
       <dd class="display-inline margin-left-0"> <%= pii[:state_id_number] %> </dd>
     </div>
-    <% if @presenter.show_state_id_expiration? %>
-      <div>
-        <dt class="display-inline"> <%= t('in_person_proofing.form.state_id.expiration_date') %>: </dt>
-        <dd class="display-inline margin-left-0"> <%= @presenter.formatted_state_id_expiration(pii) %> </dd>
-      </div>
-    <% end %>
+    <div>
+      <dt class="display-inline"> <%= t('in_person_proofing.form.state_id.expiration_date') %>: </dt>
+      <dd class="display-inline margin-left-0"> <%= @presenter.formatted_state_id_expiration(pii) %> </dd>
+    </div>
     <div class="margin-top-105">
       <dt class="display-inline"> <%= t('idv.form.address1') %>: </dt>
       <dd class="display-inline margin-left-0"> <%= pii[:identity_doc_address1] %> </dd>

--- a/spec/features/idv/steps/in_person/verify_info_spec.rb
+++ b/spec/features/idv/steps/in_person/verify_info_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'doc auth IPP VerifyInfo', js: true, allow_browser_log: true do
       expect(page).to have_text(InPersonHelper::GOOD_LAST_NAME)
       expect(page).to have_text(InPersonHelper::GOOD_DOB_FORMATTED_EVENT)
       expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_NUMBER)
+      expect(page).to have_text(InPersonHelper::GOOD_STATE_ID_EXPIRATION_FORMATTED_EVENT)
       expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS1).twice
       expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_ADDRESS2).twice
       expect(page).to have_text(InPersonHelper::GOOD_IDENTITY_DOC_CITY).twice

--- a/spec/presenters/idv/in_person/verify_info_presenter_spec.rb
+++ b/spec/presenters/idv/in_person/verify_info_presenter_spec.rb
@@ -35,21 +35,6 @@ RSpec.describe Idv::InPerson::VerifyInfoPresenter do
     end
   end
 
-  describe '#show_state_id_expiration?' do
-    [true, false].each do |flag|
-      context "when the feature flag is #{flag}" do
-        before do
-          allow(IdentityConfig.store)
-            .to receive(:in_person_proofing_expiration_edge_cases_enabled).and_return(flag)
-        end
-
-        it "returns #{flag}" do
-          expect(subject.show_state_id_expiration?).to eq(flag)
-        end
-      end
-    end
-  end
-
   describe '#formatted_state_id_expiration' do
     def formatted(value)
       subject.formatted_state_id_expiration(state_id_expiration: value)

--- a/spec/support/features/in_person_helper.rb
+++ b/spec/support/features/in_person_helper.rb
@@ -17,6 +17,9 @@ module InPersonHelper
   GOOD_STATE_ID_NUMBER = Idp::Constants::MOCK_IDV_APPLICANT[:state_id_number].freeze
   GOOD_STATE_ID_EXPIRATION =
     Idp::Constants::MOCK_IPP_APPLICANT[:state_id_expiration].freeze
+  GOOD_STATE_ID_EXPIRATION_FORMATTED_EVENT = I18n.l(
+    Date.parse(GOOD_STATE_ID_EXPIRATION), format: I18n.t('time.formats.event_date')
+  ).freeze
 
   GOOD_ADDRESS1 = Idp::Constants::MOCK_IDV_APPLICANT[:address1].freeze
   GOOD_ADDRESS2 = Idp::Constants::MOCK_IDV_APPLICANT[:address2].freeze

--- a/spec/views/idv/in_person/verify_info/show.html.erb_spec.rb
+++ b/spec/views/idv/in_person/verify_info/show.html.erb_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'idv/in_person/verify_info/show.html.erb' do
           dob: Faker::Date.in_date_period(year: 1985).to_s,
           state_id_jurisdiction: Faker::Address.state_abbr,
           state_id_number: Faker::Number.number(digits: 6).to_s,
+          state_id_expiration: Faker::Date.in_date_period(year: Time.zone.now.year + 1).to_s,
           identity_doc_address1: Faker::Address.street_address,
           identity_doc_address2: Faker::Address.secondary_address,
           identity_doc_city: Faker::Address.city,
@@ -72,6 +73,11 @@ RSpec.describe 'idv/in_person/verify_info/show.html.erb' do
         # State ID number
         expect(rendered).to have_content(t('idv.form.id_number'))
         expect(rendered).to have_content(pii[:state_id_number])
+        # State ID expiration date
+        expect(rendered).to have_content(t('in_person_proofing.form.state_id.expiration_date'))
+        expect(rendered).to have_content(
+          I18n.l(Date.parse(pii[:state_id_expiration]), format: I18n.t('time.formats.event_date')),
+        )
         # State ID address 1
         expect(rendered).to have_content(t('idv.form.address1'))
         expect(rendered).to have_content(pii[:identity_doc_address1])


### PR DESCRIPTION
## 🎫 Ticket

Link to the relevant ticket:
[LG-17843](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17843)

## 🛠 Summary of changes

As an In-Person Proofing user, I want to corroborate the expiration date I self-asserted so I can make sure the details entered match my valid ID.

The display code for the expiration date already existed but was gated behind the `in_person_proofing_expiration_edge_cases_enabled` feature flag (added in LG-17733), so it was hidden in production even though the entry form always collects an expiration date. This PR decouples the display from that flag so the self-asserted expiration date always appears on the "Verify your information" screen.

- Removed the `if @presenter.show_state_id_expiration?` conditional in `_state_id_section.html.erb` so the expiration date always renders, directly under the ID number and before the ID address (the spacing before the address block is preserved).
- Removed the now-unused `show_state_id_expiration?` presenter method. `formatted_state_id_expiration` is retained and formats the date using the same `time.formats.event_date` format as Date of birth, and continues to handle edge-case values.
- Reuses the existing `in_person_proofing.form.state_id.expiration_date` ("Expiration date") translation.
- Updated presenter, view, and feature specs; added a `GOOD_STATE_ID_EXPIRATION_FORMATTED_EVENT` test helper constant.

## 📜 Testing Plan

- [ ] Start an in-person proofing flow and complete the state ID step, entering an expiration date
- [ ] On the "Verify your information" screen, confirm the expiration date appears under the ID number
- [ ] Confirm the date is formatted the same way as Date of birth (e.g. "December 31, 2099")
- [ ] Confirm the spacing between the user details and the ID address is preserved
- [ ] Confirm the "Expiration date" label matches the label used on the state ID entry form

[LG-17843]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17843