### PR TITLE
Update the NDS secure your account page

### DIFF
--- a/app/controllers/test/nds_pages_controller.rb
+++ b/app/controllers/test/nds_pages_controller.rb
@@ -790,7 +790,10 @@ module Test
       @two_factor_options_form = TwoFactorOptionsForm.new(
         user:, phishing_resistant_required:, piv_cac_required:,
       )
-      {}
+      # dev config enables account-creation device profiling (collect_only), so
+      # the view renders the ThreatMetrix partial; supply the inert no-op locals
+      # the real controller passes when no session is bootstrapped.
+      ThreatMetrixHelper::NO_THREAT_METRIX_VARIABLES.dup
     end
 
     def setup_piv_cac_setup

--- a/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
+++ b/app/views/partials/multi_factor_authentication/_mfa_selection.html.erb
@@ -26,17 +26,17 @@
       <% end %>
     <% end %>
     <% if show_recommended %>
-      <span class="card__badge"><%= t('two_factor_authentication.recommended') %></span>
+      <span class="card__badge"><%= t('nds.mfa_setup.badge_passkey') %></span>
     <% end %>
     <% if description.present? %>
       <span class="card__badge card__badge--success"><%= description %></span>
     <% end %>
     <div class="card__row">
       <%= render NDS::IconComponent.new(icon: icons.fetch(option.type), size: 24) %>
-      <p class="card__title"><%= option.label %></p>
+      <p class="card__title"><%= t("nds.mfa_setup.options.#{option.type}") %></p>
     </div>
     <% unless option.disabled? %>
-      <p class="card__description"><%= option.info %></p>
+      <p class="card__description"><%= t("nds.mfa_setup.options.#{option.type}_info") %></p>
     <% end %>
   <% end %>
 <% else %>

--- a/app/views/users/two_factor_authentication_setup/index.html.erb
+++ b/app/views/users/two_factor_authentication_setup/index.html.erb
@@ -17,8 +17,12 @@
                       method: :patch,
                       url: authentication_methods_setup_path do %>
     <%= render NDS::FormPageComponent.new(
-          title: @presenter.heading,
-          subtitle: @presenter.intro,
+          title: @presenter.two_factor_enabled? ?
+            t('nds.mfa_setup.heading_second') :
+            t('nds.mfa_setup.heading'),
+          subtitle: @presenter.two_factor_enabled? ?
+            t('nds.mfa_setup.intro_second') :
+            t('nds.mfa_setup.intro'),
         ) do |c| %>
       <% c.with_alert do %>
         <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice], context: :voice, only_if_all: true)) %>
@@ -37,7 +41,7 @@
           <% if nds_options.length > 2 %>
             <%= render ButtonComponent.new(
                   type: :button,
-                  variant: :tertiary,
+                  variant: :secondary,
                   size: :md,
                   class: 'mfa-options__more',
                   data: { mfa_more: '' },
@@ -59,14 +63,14 @@
         <% end %>
       <% end %>
 
-      <% if @presenter.skip_path || !@presenter.two_factor_enabled? %>
+      <% if @presenter.skip_path %>
         <% c.with_actions do %>
-          <%= render NDS::StackComponent.new(kind: :links) do %>
-            <% if @presenter.skip_path %>
-              <%= link_to @presenter.skip_label, @presenter.skip_path %>
-            <% elsif !@presenter.two_factor_enabled? %>
-              <%= link_to t('links.cancel_account_creation'), sign_up_cancel_path %>
-            <% end %>
+          <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+            <%= render ButtonComponent.new(
+                  url: @presenter.skip_path,
+                  variant: :secondary,
+                  full_width: true,
+                ).with_content(@presenter.skip_label) %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1619,6 +1619,23 @@ nds.idv_welcome.intro: '%{sp_name} needs to verify your identity before you cont
 nds.idv_welcome.no_phone_link: I don’t have a U.S. phone number
 nds.idv_welcome.title: Let’s verify your identity to access %{sp_name}
 nds.idv_welcome.what_youll_need: What you’ll need
+nds.mfa_setup.badge_passkey: Fast and secure
+nds.mfa_setup.heading: Secure your account
+nds.mfa_setup.heading_second: Choose a second authentication method
+nds.mfa_setup.intro: Your account safeguards personal information. Add a layer of protection by choosing a multi-factor authentication method. Update your methods any time in your account settings.
+nds.mfa_setup.intro_second: Set up a second method so you can always access your account even if your primary method is unavailable.
+nds.mfa_setup.options.auth_app: Authentication app
+nds.mfa_setup.options.auth_app_info: Get a one-time code from an app on your phone. It works even without a signal.
+nds.mfa_setup.options.backup_code: Backup codes
+nds.mfa_setup.options.backup_code_info: Save a list of one-time codes. Use them to sign in if another method isn’t available.
+nds.mfa_setup.options.phone: Text or phone call
+nds.mfa_setup.options.phone_info: We send a one-time code by text or phone call. Enter it on the next screen to sign in.
+nds.mfa_setup.options.piv_cac: Government employee ID
+nds.mfa_setup.options.piv_cac_info: Sign in with your government PIV or CAC card using a card reader on your device.
+nds.mfa_setup.options.webauthn: Security key
+nds.mfa_setup.options.webauthn_info: Insert a small physical key into your device, to prove it’s really you.
+nds.mfa_setup.options.webauthn_platform: Passkey
+nds.mfa_setup.options.webauthn_platform_info: Use your face, fingerprint, or a PIN to sign in. Nothing to remember, nothing for hackers to steal.
 nds.mfa.choose_another_method: Choose another method
 nds.passwords.new.heading: Create your password
 nds.passwords.new.info: Create a strong password to secure your account and keep personal information safe.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1630,6 +1630,23 @@ nds.idv_welcome.intro: '%{sp_name} necesita verificar su identidad antes de que 
 nds.idv_welcome.no_phone_link: No tengo un número de teléfono de los EE. UU.
 nds.idv_welcome.title: Verifiquemos su identidad para acceder a %{sp_name}
 nds.idv_welcome.what_youll_need: Lo que necesitará
+nds.mfa_setup.badge_passkey: Rápido y seguro
+nds.mfa_setup.heading: Proteja su cuenta
+nds.mfa_setup.heading_second: Elija un segundo método de autenticación
+nds.mfa_setup.intro: Su cuenta protege su información personal. Agregue una capa de protección eligiendo un método de autenticación de múltiples factores. Actualice sus métodos en cualquier momento en la configuración de su cuenta.
+nds.mfa_setup.intro_second: Configure un segundo método para que siempre pueda acceder a su cuenta, incluso si su método principal no está disponible.
+nds.mfa_setup.options.auth_app: Aplicación de autenticación
+nds.mfa_setup.options.auth_app_info: Obtenga un código de un solo uso desde una aplicación en su teléfono. Funciona incluso sin señal.
+nds.mfa_setup.options.backup_code: Códigos de recuperación
+nds.mfa_setup.options.backup_code_info: Guarde una lista de códigos de un solo uso. Úselos para iniciar sesión si no tiene disponible otro método.
+nds.mfa_setup.options.phone: Mensaje de texto o llamada
+nds.mfa_setup.options.phone_info: Le enviamos un código de un solo uso por mensaje de texto o llamada. Ingréselo en la siguiente pantalla para iniciar sesión.
+nds.mfa_setup.options.piv_cac: Identificación de empleado del Gobierno
+nds.mfa_setup.options.piv_cac_info: Inicie sesión con su tarjeta PIV o CAC del Gobierno usando un lector de tarjetas en su dispositivo.
+nds.mfa_setup.options.webauthn: Llave de seguridad
+nds.mfa_setup.options.webauthn_info: Inserte una pequeña llave física en su dispositivo para comprobar que realmente es usted.
+nds.mfa_setup.options.webauthn_platform: Clave de acceso
+nds.mfa_setup.options.webauthn_platform_info: Use su rostro, huella digital o un PIN para iniciar sesión. Nada que recordar, nada que los piratas informáticos puedan robar.
 nds.mfa.choose_another_method: Elija otro método
 nds.passwords.new.heading: Cree su contraseña
 nds.passwords.new.info: Cree una contraseña segura para proteger su cuenta y mantener a salvo su información personal.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1619,6 +1619,23 @@ nds.idv_welcome.intro: '%{sp_name} doit vérifier votre identité avant que vous
 nds.idv_welcome.no_phone_link: Je n’ai pas de numéro de téléphone américain
 nds.idv_welcome.title: Vérifions votre identité pour accéder à %{sp_name}
 nds.idv_welcome.what_youll_need: Ce dont vous aurez besoin
+nds.mfa_setup.badge_passkey: Rapide et sécurisé
+nds.mfa_setup.heading: Sécurisez votre compte
+nds.mfa_setup.heading_second: Choisissez une deuxième méthode d’authentification
+nds.mfa_setup.intro: Votre compte protège vos renseignements personnels. Ajoutez une couche de protection en choisissant une méthode d’authentification à plusieurs facteurs. Modifiez vos méthodes à tout moment dans les paramètres de votre compte.
+nds.mfa_setup.intro_second: Configurez une deuxième méthode pour toujours pouvoir accéder à votre compte, même si votre méthode principale n’est pas disponible.
+nds.mfa_setup.options.auth_app: Application d’authentification
+nds.mfa_setup.options.auth_app_info: Obtenez un code à usage unique depuis une application sur votre téléphone. Elle fonctionne même sans signal.
+nds.mfa_setup.options.backup_code: Codes de sauvegarde
+nds.mfa_setup.options.backup_code_info: Enregistrez une liste de codes à usage unique. Utilisez-les pour vous connecter si une autre méthode n’est pas disponible.
+nds.mfa_setup.options.phone: Texto ou appel téléphonique
+nds.mfa_setup.options.phone_info: Nous envoyons un code à usage unique par texto ou appel téléphonique. Saisissez-le sur l’écran suivant pour vous connecter.
+nds.mfa_setup.options.piv_cac: Pièce d’identité d’employé du gouvernement
+nds.mfa_setup.options.piv_cac_info: Connectez-vous avec votre carte PIV ou CAC du gouvernement à l’aide d’un lecteur de carte sur votre appareil.
+nds.mfa_setup.options.webauthn: Clé de sécurité
+nds.mfa_setup.options.webauthn_info: Insérez une petite clé physique dans votre appareil pour prouver que c’est bien vous.
+nds.mfa_setup.options.webauthn_platform: Clé d’accès
+nds.mfa_setup.options.webauthn_platform_info: Utilisez votre visage, votre empreinte digitale ou un PIN pour vous connecter. Rien à retenir, rien à voler pour les pirates.
 nds.mfa.choose_another_method: Choisir une autre méthode
 nds.passwords.new.heading: Créez votre mot de passe
 nds.passwords.new.info: Créez un mot de passe fort pour sécuriser votre compte et protéger vos renseignements personnels.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1632,6 +1632,23 @@ nds.idv_welcome.intro: '%{sp_name}需要先验证您的身份，然后您才能�
 nds.idv_welcome.no_phone_link: 我没有美国电话号码
 nds.idv_welcome.title: 让我们验证您的身份以访问%{sp_name}
 nds.idv_welcome.what_youll_need: 您需要准备的内容
+nds.mfa_setup.badge_passkey: 快速又安全
+nds.mfa_setup.heading: 保护您的账户
+nds.mfa_setup.heading_second: 选择第二种身份验证方法
+nds.mfa_setup.intro: 您的账户保护着个人信息。通过选择一种多因素身份验证方法来增加一层保护。您可以随时在账户设置中更新您的方法。
+nds.mfa_setup.intro_second: 设置第二种方法，这样即使您的主要方法不可用，您也能始终访问自己的账户。
+nds.mfa_setup.options.auth_app: 身份验证应用程序
+nds.mfa_setup.options.auth_app_info: 从您手机上的应用程序获取一次性代码。即使没有信号也能使用。
+nds.mfa_setup.options.backup_code: 备用代码
+nds.mfa_setup.options.backup_code_info: 保存一份一次性代码清单。当没有其他方法可用时，用它们来登录。
+nds.mfa_setup.options.phone: 短信或电话
+nds.mfa_setup.options.phone_info: 我们通过短信或电话向您发送一次性代码。在下一个屏幕上输入它即可登录。
+nds.mfa_setup.options.piv_cac: 政府雇员身份证件
+nds.mfa_setup.options.piv_cac_info: 使用您设备上的读卡器，通过您的政府 PIV 或 CAC 卡登录。
+nds.mfa_setup.options.webauthn: 安全密钥
+nds.mfa_setup.options.webauthn_info: 将一个小型实体密钥插入您的设备，以证明确实是您本人。
+nds.mfa_setup.options.webauthn_platform: 通行密钥
+nds.mfa_setup.options.webauthn_platform_info: 使用您的面容、指纹或 PIN 码登录。无需记忆，也没有可供黑客窃取的东西。
 nds.mfa.choose_another_method: 选择另一种方法
 nds.passwords.new.heading: 创建您的密码
 nds.passwords.new.info: 创建一个强密码来保护您的账户并确保个人信息安全。

--- a/spec/views/partials/multi_factor_authentication/_mfa_selection.html.erb_spec.rb
+++ b/spec/views/partials/multi_factor_authentication/_mfa_selection.html.erb_spec.rb
@@ -176,12 +176,18 @@ RSpec.describe 'partials/multi_factor_authentication/_mfa_selection.html.erb' do
 
     it 'renders the method icon and title' do
       expect(rendered).to have_css('.card--mfa .card__row .usa-icon')
-      expect(rendered).to have_css('.card--mfa .card__title', text: option.label)
+      expect(rendered).to have_css(
+        '.card--mfa .card__title',
+        text: t("nds.mfa_setup.options.#{option.type}"),
+      )
     end
 
     it 'renders a chevron and description for an enabled option' do
       expect(rendered).to have_css('.card--mfa .card__trailing .usa-icon')
-      expect(rendered).to have_css('.card--mfa .card__description', text: option.info)
+      expect(rendered).to have_css(
+        '.card--mfa .card__description',
+        text: t("nds.mfa_setup.options.#{option.type}_info"),
+      )
     end
 
     it 'does not render the legacy checkbox markup' do
@@ -198,7 +204,7 @@ RSpec.describe 'partials/multi_factor_authentication/_mfa_selection.html.erb' do
       it 'renders the recommended badge' do
         expect(rendered).to have_css(
           '.card__badge',
-          text: t('two_factor_authentication.recommended'),
+          text: t('nds.mfa_setup.badge_passkey'),
         )
       end
     end

--- a/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
+++ b/spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb
@@ -131,9 +131,9 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
   context 'nds bucket' do
     before { allow(view).to receive(:nds_layout?).and_return(true) }
 
-    it 'renders the FormPageComponent card with the presenter heading' do
+    it 'renders the FormPageComponent card with the NDS heading' do
       expect(rendered).to have_css('.auth--form-page')
-      expect(rendered).to have_css('.auth--form-page h1', text: @presenter.heading)
+      expect(rendered).to have_css('.auth--form-page h1', text: t('nds.mfa_setup.heading'))
     end
 
     it 'renders the mfa options card list container' do
@@ -144,7 +144,7 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
       expect(rendered).to have_css('.mfa-options .card--mfa[type="submit"]')
       expect(rendered).to have_css(
         '.mfa-options .card--mfa .card__title',
-        text: t('two_factor_authentication.two_factor_choice_options.phone'),
+        text: t('nds.mfa_setup.options.phone'),
       )
     end
 
@@ -178,8 +178,8 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
       expect(rendered).to have_css('input#platform_authenticator_available', visible: false)
     end
 
-    it 'renders the cancel account creation footer link for a new user' do
-      expect(rendered).to have_link(t('links.cancel_account_creation'), href: sign_up_cancel_path)
+    it 'does not render a cancel account creation link for a new user' do
+      expect(rendered).to have_no_link(t('links.cancel_account_creation'))
     end
 
     context 'first MFA (no methods configured yet)' do
@@ -210,6 +210,26 @@ RSpec.describe 'users/two_factor_authentication_setup/index.html.erb' do
           '.progress__step[aria-current="step"] .progress__step-counter',
           text: '2 / 2',
         )
+      end
+    end
+
+    context 'when a method is already configured' do
+      let(:user) { build(:user, :with_phone) }
+
+      it 'renders the second-method heading and intro' do
+        expect(rendered).to have_css(
+          '.auth--form-page h1',
+          text: t('nds.mfa_setup.heading_second'),
+        )
+        expect(rendered).to have_content(t('nds.mfa_setup.intro_second'))
+      end
+
+      it 'renders skip as a secondary button in the actions region, not a link' do
+        expect(rendered).to have_css(
+          '.auth__actions a.usa-button.usa-button--secondary',
+          text: t('mfa.skip'),
+        )
+        expect(rendered).to have_no_link(t('links.cancel_account_creation'))
       end
     end
   end


### PR DESCRIPTION
## 🎫 Tickets

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Refreshes the NDS branch of `users/two_factor_authentication_setup#index`
(the "Secure your account" MFA method-selection page) to match the current
Figma design. States (first MFA / expanded / second MFA) are all the same
page, driven by `TwoFactorOptionsPresenter`; the legacy (non-NDS) branch and
its shared i18n keys are untouched.

- **Copy** — new `nds.mfa_setup.*` keys (en/es/fr/zh): "Secure your account" /
  "Choose a second authentication method" headings + intros, and all six
  method labels/descriptions (Passkey, Text or phone call, Authentication app,
  Security key, Backup codes, Government employee ID). "Face or touch unlock" →
  **Passkey**.
- **Badge** — the Passkey card badge now reads "Fast and secure".
- **Buttons** — "More options" is a secondary button; the skip action is a
  full-width secondary button; the "Cancel account creation" link is removed.
- **Explorer fix** — `setup_mfa_setup` now supplies the inert
  `NO_THREAT_METRIX_VARIABLES` locals so the dev explorer page renders when
  account-creation device profiling is enabled (previously 500'd).

> Note: the matching NDS visual tweaks (solid-fill `.card__badge`, intro
> `text-wrap`, form width) live in the design-system (IDS) repo and are tracked
> separately; this PR is the identity-idp view/copy/spec work.

## 👀 Preview

- Live via the dev NDS explorer: http://localhost:3005/test/nds/mfa-setup
  (permutations: First MFA / Second MFA `?second=1` / Skip `?second=1&skip=1` /
  Phishing-resistant / PIV/CAC required)
- Explorer index: http://localhost:3005/test/nds

## 📜 Testing Plan

- [ ] `bundle exec rspec spec/views/users/two_factor_authentication_setup/index.html.erb_spec.rb`
- [ ] `bundle exec rspec spec/controllers/users/two_factor_authentication_setup_controller_spec.rb`
- [ ] `bundle exec rspec spec/services/test/nds_page_catalog_spec.rb spec/requests/test/nds_pages_spec.rb`
- [ ] `bundle exec rspec spec/i18n_spec.rb`
- [ ] erb_lint / rubocop clean
- [ ] `/test/nds/mfa-setup` renders all states under the NDS layout; non-NDS bucket unchanged