### PR TITLE
Render the NDS authentication app setup page

### DIFF
--- a/app/assets/images/nds/icons/copy/24.svg
+++ b/app/assets/images/nds/icons/copy/24.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24"><path fill="currentColor" d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2m0 16H8V7h11z"/></svg>

--- a/app/controllers/test/nds_pages_controller.rb
+++ b/app/controllers/test/nds_pages_controller.rb
@@ -829,6 +829,23 @@ module Test
       {}
     end
 
+    def setup_totp_setup
+      user = build_mfa_user(configured: params[:second].present?)
+      @nds_current_user = user
+      @in_account_creation_flow = params[:account_creation].present?
+      email = EmailAddressStub.new(email: DEV_USER_EMAIL)
+      user.define_singleton_method(:last_sign_in_email_address) { email }
+      @code = user.generate_totp_secret
+      @qrcode = user.qrcode(@code)
+      @presenter = SetupPresenter.new(
+        current_user: user,
+        user_fully_authenticated: true,
+        user_opted_remember_device_cookie: nil,
+        remember_device_default: false,
+      )
+      {}
+    end
+
     def build_mfa_user(configured:)
       user = User.new
       if configured

--- a/app/controllers/users/totp_setup_controller.rb
+++ b/app/controllers/users/totp_setup_controller.rb
@@ -14,7 +14,8 @@ module Users
     before_action :cap_auth_app_count, only: %i[new confirm]
     before_action :confirm_recently_authenticated_2fa
 
-    helper_method :in_multi_mfa_selection_flow?
+    helper_method :in_multi_mfa_selection_flow?, :in_account_creation_flow?,
+                  :enabled_mfa_methods_count
 
     def new
       store_totp_secret_in_session
@@ -44,6 +45,10 @@ module Users
     end
 
     private
+
+    def enabled_mfa_methods_count
+      MfaContext.new(current_user).enabled_mfa_methods_count
+    end
 
     def totp_setup_form
       @totp_setup_form ||= TotpSetupForm.new(

--- a/app/services/test/nds_page_catalog.rb
+++ b/app/services/test/nds_page_catalog.rb
@@ -98,6 +98,23 @@ module Test
         ],
       ),
       Page.new(
+        key: 'totp-setup',
+        title: 'Authentication app setup',
+        flow: MFA,
+        template: 'users/totp_setup/new',
+        permutations: [
+          Permutation.new(label: 'During sign-in (no stepper)', params: {}),
+          Permutation.new(
+            label: 'First MFA (account creation)',
+            params: { account_creation: '1' },
+          ),
+          Permutation.new(
+            label: 'Second MFA (account creation)',
+            params: { account_creation: '1', second: '1' },
+          ),
+        ],
+      ),
+      Page.new(
         key: 'otp-entry',
         title: 'One-time code entry',
         flow: OTP,

--- a/app/views/users/totp_setup/new.html.erb
+++ b/app/views/users/totp_setup/new.html.erb
@@ -1,5 +1,156 @@
 <% self.title = t('titles.totp_setup.new') %>
 
+<% if nds_layout? %>
+  <% if in_account_creation_flow? %>
+    <% content_for(:nds_header_progress) do %>
+      <%= nds_account_creation_progress(
+            step: :security,
+            substep: enabled_mfa_methods_count >= 1 ? 2 : 1,
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% content_for(:skip_layout_flash, 'true') %>
+  <% content_for(:form_page_flash, 'true') %>
+
+  <%= simple_form_for('', method: :patch, html: { data: { nds_submit_gate: true } }) do |f| %>
+    <%= render NDS::FormPageComponent.new(title: t('nds.totp_setup.new.heading')) do |page| %>
+      <% page.with_body do %>
+        <%= render NDS::StackComponent.new(gap: 16, align: :stretch) do %>
+          <%= render NDS::StackComponent.new(tag: :ol, gap: 16, class: 'usa-list--unstyled') do %>
+            <li>
+              <div class="card stack stack--gap-24">
+                <ol class="usa-list margin-0" start="1">
+                  <li class="text-body-emphasis" id="totp-step-1-label"><%= t('nds.totp_setup.new.step_1') %></li>
+                </ol>
+                <div class="usa-form-group usa-input-group--floating">
+                  <%= f.text_field(
+                        :name,
+                        class: 'usa-input',
+                        id: 'name',
+                        placeholder: ' ',
+                        required: true,
+                        maxlength: 20,
+                        aria: { labelledby: 'totp-step-1-label' },
+                      ) %>
+                  <%= f.label :name, t('nds.totp_setup.new.nickname_label'), class: 'usa-label' %>
+                </div>
+              </div>
+            </li>
+
+            <li>
+              <div class="card stack stack--gap-24">
+                <ol class="usa-list margin-0" start="2">
+                  <li class="text-body-emphasis"><%= t('nds.totp_setup.new.step_2') %></li>
+                </ol>
+              </div>
+            </li>
+
+            <li>
+              <div class="card stack stack--gap-24">
+                <ol class="usa-list margin-0" start="3">
+                  <li class="text-body-emphasis"><%= t('nds.totp_setup.new.step_3') %></li>
+                </ol>
+                <div class="nds-totp-setup__qrcode text-center padding-y-105">
+                  <%= image_tag @qrcode, size: 220, skip_pipeline: true, alt: t('image_description.totp_qrcode') %>
+                </div>
+                <lg-clipboard-button class="display-block width-full" clipboard-text="<%= @code.upcase %>" tooltip-text="<%= t('components.clipboard_button.tooltip') %>">
+                  <div class="field-readout">
+                    <span class="field-readout__body">
+                      <span class="field-readout__label" id="totp-setup-code-label"><%= t('nds.totp_setup.new.setup_code_label') %></span>
+                      <span class="field-readout__value font-mono-sm" id="qr-code" aria-labelledby="totp-setup-code-label totp-manual-entry"><%= @code %></span>
+                      <span id="totp-manual-entry" class="usa-sr-only"><%= t('instructions.mfa.authenticator.manual_entry') %></span>
+                    </span>
+                    <button type="button" class="field-readout__action" aria-label="<%= t('components.clipboard_button.label') %>">
+                      <%= render NDS::IconComponent.new(icon: :content_copy, size: 24) %>
+                    </button>
+                  </div>
+                </lg-clipboard-button>
+              </div>
+            </li>
+
+            <li>
+              <div class="card stack stack--gap-24">
+                <ol class="usa-list margin-0" start="4">
+                  <li class="text-body-emphasis" id="totp-step-4-label"><%= t('forms.totp_setup.totp_step_4') %></li>
+                </ol>
+                <lg-one-time-code-input class="display-block width-full">
+                  <div class="usa-form-group usa-input-group--floating margin-0">
+                    <%= f.text_field(
+                          :code,
+                          class: 'usa-input',
+                          id: 'code',
+                          placeholder: ' ',
+                          required: true,
+                          autocomplete: 'one-time-code',
+                          inputmode: 'numeric',
+                          pattern: "[0-9]{#{TwoFactorAuthenticatable::OTP_LENGTH}}",
+                          maxlength: TwoFactorAuthenticatable::OTP_LENGTH,
+                        ) %>
+                    <%= f.label :code, t('nds.totp_setup.new.code_label'), class: 'usa-label' %>
+                  </div>
+                </lg-one-time-code-input>
+              </div>
+            </li>
+          <% end %>
+
+          <div class="card">
+            <div class="checkbox-group">
+              <div class="checkbox">
+                <%= f.check_box(
+                      :remember_device,
+                      { class: 'checkbox__input',
+                        checked: @presenter.remember_device_box_checked?,
+                        autocomplete: 'off',
+                        aria: { describedby: 'remember-browser-description' } },
+                      '1',
+                      '0',
+                    ) %>
+                <%= f.label :remember_device, class: 'checkbox__label' do %>
+                  <span class="checkbox__label-text"><%= t('forms.messages.remember_device') %></span>
+                  <span class="checkbox__label-description" id="remember-browser-description"><%= t('nds.totp_setup.new.remember_device_info') %></span>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+          <%= render ButtonComponent.new(type: :submit, full_width: true).with_content(t('forms.buttons.continue')) %>
+          <% if MfaPolicy.new(current_user).two_factor_enabled? && !in_multi_mfa_selection_flow? %>
+            <%= render ButtonComponent.new(
+                  url: account_path,
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(t('links.cancel')) %>
+          <% else %>
+            <%= render ButtonComponent.new(
+                  url: authentication_methods_setup_path,
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(t('nds.mfa.choose_another_method')) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= javascript_packs_tag_once(
+          'nds-auth-submit-gate',
+          'clipboard_button_component',
+          'one_time_code_input_component',
+          preload_links_header: false,
+        ) %>
+
+    <%= javascript_tag(nonce: true) do %>
+      window.addEventListener('pageshow', function () {
+        var el = document.getElementById('remember_device');
+        if (el) { el.checked = el.defaultChecked; }
+      });
+    <% end %>
+  <% end %>
+<% else %>
 <%= render PageHeadingComponent.new.with_content(t('headings.totp_setup.new')) %>
 
 <p>
@@ -77,3 +228,4 @@
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1619,6 +1619,14 @@ nds.piv_cac_setup.step_1: Enter a nickname
 nds.piv_cac_setup.step_2: Insert your PIV or CAC into your card reader
 nds.piv_cac_setup.step_3: Add your PIV or CAC
 nds.piv_cac_setup.step_3_info: You’ll be asked to choose a certificate and enter your PIN after clicking the continue button.
+nds.totp_setup.new.code_label: Code
+nds.totp_setup.new.heading: Set up an authentication app
+nds.totp_setup.new.nickname_label: App nickname
+nds.totp_setup.new.remember_device_info: Select this to skip authentication on supported sites. Do not select this if you are on a public or shared device.
+nds.totp_setup.new.setup_code_label: Setup code
+nds.totp_setup.new.step_1: Enter a nickname
+nds.totp_setup.new.step_2: Open your preferred authentication app
+nds.totp_setup.new.step_3: Scan the QR code or enter the set up code manually in your authentication app
 notices.account_reactivation: Great! You have your personal key.
 notices.authenticated_successfully: Authenticated successfully.
 notices.backup_codes_configured: Backup codes were added to your account.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1630,6 +1630,14 @@ nds.piv_cac_setup.step_1: Ingrese un alias
 nds.piv_cac_setup.step_2: Inserte su tarjeta PIV o CAC en su lector de tarjetas
 nds.piv_cac_setup.step_3: Agregue su tarjeta PIV o CAC
 nds.piv_cac_setup.step_3_info: Se le pedirá que elija un certificado e ingrese su PIN después de hacer clic en el botón de continuar.
+nds.totp_setup.new.code_label: Código
+nds.totp_setup.new.heading: Configure una aplicación de autenticación
+nds.totp_setup.new.nickname_label: Sobrenombre de la aplicación
+nds.totp_setup.new.remember_device_info: Seleccione esto para omitir la autenticación en los sitios compatibles. No seleccione esto si se encuentra en un dispositivo público o compartido.
+nds.totp_setup.new.setup_code_label: Código de configuración
+nds.totp_setup.new.step_1: Ingrese un sobrenombre
+nds.totp_setup.new.step_2: Abra su aplicación de autenticación preferida
+nds.totp_setup.new.step_3: Escanee el código QR o ingrese el código de configuración manualmente en su aplicación de autenticación
 notices.account_reactivation: Qué bien. Tiene su clave personal.
 notices.authenticated_successfully: Logró autenticarse.
 notices.backup_codes_configured: Los códigos de recuperación se agregaron a su cuenta.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1619,6 +1619,14 @@ nds.piv_cac_setup.step_1: Saisissez un surnom
 nds.piv_cac_setup.step_2: Insérez votre PIV ou CAC dans votre lecteur de carte
 nds.piv_cac_setup.step_3: Ajoutez votre PIV ou CAC
 nds.piv_cac_setup.step_3_info: On vous demandera de choisir un certificat et de saisir votre PIN après avoir cliqué sur le bouton continuer.
+nds.totp_setup.new.code_label: Code
+nds.totp_setup.new.heading: Configurer une appli d’authentification
+nds.totp_setup.new.nickname_label: Surnom de l’appli
+nds.totp_setup.new.remember_device_info: Sélectionnez cette option pour ignorer l’authentification sur les sites pris en charge. Ne la sélectionnez pas si vous êtes sur un appareil public ou partagé.
+nds.totp_setup.new.setup_code_label: Code de configuration
+nds.totp_setup.new.step_1: Saisir un surnom
+nds.totp_setup.new.step_2: Ouvrir votre appli d’authentification préférée
+nds.totp_setup.new.step_3: Scanner le code QR ou saisir le code de configuration manuellement dans votre appli d’authentification
 notices.account_reactivation: Parfait ! Vous avez votre clé personnelle.
 notices.authenticated_successfully: Authentifié avec succès.
 notices.backup_codes_configured: Les codes de sauvegarde ont été ajoutés à votre compte.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1632,6 +1632,14 @@ nds.piv_cac_setup.step_1: 输入昵称
 nds.piv_cac_setup.step_2: 把 PIV 或 CAC 插入读卡器
 nds.piv_cac_setup.step_3: 添加 PIV 或 CAC
 nds.piv_cac_setup.step_3_info: 点击继续按钮后，系统会要求你选择一个证书并输入你的 PIN。
+nds.totp_setup.new.code_label: 代码
+nds.totp_setup.new.heading: 设置一个身份验证应用程序
+nds.totp_setup.new.nickname_label: 应用程序昵称
+nds.totp_setup.new.remember_device_info: 选择此项可在支持的网站上跳过身份验证。如果您使用的是公共或共享设备，请勿选择此项。
+nds.totp_setup.new.setup_code_label: 设置代码
+nds.totp_setup.new.step_1: 输入一个昵称
+nds.totp_setup.new.step_2: 打开您首选的身份验证应用程序
+nds.totp_setup.new.step_3: 扫描二维码或在身份验证应用程序中手动输入设置代码
 notices.account_reactivation: 好！你有个人密钥。
 notices.authenticated_successfully: 成功验证。
 notices.backup_codes_configured: 备用代码加到了你账户。

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -97,6 +97,7 @@ module I18n
         { key: 'in_person_proofing.process.passport.info' }, # Translations will be updated for In-Person Proofing Passport Epic, see LG-15972
         { key: 'in_person_proofing.info.choose_id_type', locales: %i[fr es zh] }, # Waiting on translations
         { key: 'links.contact', locales: %i[fr] }, # "Contact" is "Contact" in French
+        { key: 'nds.totp_setup.new.code_label', locales: %i[fr] }, # "Code" is "Code" in French
         { key: 'saml_idp.auth.error.title', locales: %i[es] }, # "Error" is "Error" in Spanish
         { key: 'simple_form.no', locales: %i[es] }, # "No" is "No" in Spanish
         { key: 'telephony.format_length.six', locales: %i[zh] }, # numeral is not translated

--- a/spec/views/users/totp_setup/new.html.erb_spec.rb
+++ b/spec/views/users/totp_setup/new.html.erb_spec.rb
@@ -2,53 +2,57 @@ require 'rails_helper'
 
 RSpec.describe 'users/totp_setup/new.html.erb' do
   let(:user) { create(:user, :fully_registered) }
+  let(:nds_layout) { false }
+  let(:in_account_creation_flow) { false }
+  let(:enabled_mfa_methods_count) { 0 }
+  let(:code) { 'D4C2L47CVZ3JJHD7' }
 
-  context 'user has sufficient factors enabled' do
-    before do
-      allow(view).to receive(:current_user).and_return(user)
-      allow(view).to receive(:user_session).and_return(signing_up: false)
-      allow(view).to receive(:in_multi_mfa_selection_flow?).and_return(false)
-      @code = 'D4C2L47CVZ3JJHD7'
-      @qrcode = 'qrcode.png'
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:user_session).and_return(signing_up: false)
+    allow(view).to receive(:in_multi_mfa_selection_flow?).and_return(false)
+    allow(view).to receive(:in_account_creation_flow?).and_return(in_account_creation_flow)
+    allow(view).to receive(:enabled_mfa_methods_count).and_return(enabled_mfa_methods_count)
 
-      @presenter = SetupPresenter.new(
-        current_user: user,
-        user_fully_authenticated: false,
-        user_opted_remember_device_cookie: true,
-        remember_device_default: true,
-      )
-    end
+    @code = code
+    @qrcode = 'qrcode.png'
+    @presenter = SetupPresenter.new(
+      current_user: user,
+      user_fully_authenticated: false,
+      user_opted_remember_device_cookie: true,
+      remember_device_default: true,
+    )
+  end
 
-    it 'renders the QR code' do
-      render
+  it 'sets a shared localized title regardless of layout' do
+    expect(view).to receive(:title=).with(t('titles.totp_setup.new'))
 
-      expect(rendered).to have_css('#qr-code', text: 'D4C2L47CVZ3JJHD7')
-    end
+    render
+  end
 
-    it 'renders the QR code image with useful alt text' do
-      render
+  context 'in the default (non-NDS) layout' do
+    let(:nds_layout) { false }
 
-      page = Capybara.string(rendered.html)
-      image_tag = page.find_css('img[src^="/images/qrcode.png"]').first
+    before { render }
+
+    it 'renders the QR code and its image with useful alt text' do
+      expect(rendered).to have_css('#qr-code', text: code)
+
+      image_tag = Capybara.string(rendered.html).find_css('img[src^="/images/qrcode.png"]').first
       expect(image_tag).to be
-      expect(image_tag['alt']).to eq(I18n.t('image_description.totp_qrcode'))
+      expect(image_tag['alt']).to eq(t('image_description.totp_qrcode'))
     end
 
     it 'renders a link to cancel and go back to the account page' do
-      render
-
       expect(rendered).to have_link(t('links.cancel'), href: account_path)
     end
 
     it 'has a button to copy the QR code' do
-      render
-
       expect(rendered).to have_button(t('components.clipboard_button.label'), type: 'button')
     end
 
-    it 'has labelled fields' do
-      render
-
+    it 'has labelled, aria-labelled fields' do
       expect(rendered).to have_selector(
         'h2#totp-step-1-label',
         text: t('forms.totp_setup.totp_step_1'),
@@ -57,36 +61,177 @@ RSpec.describe 'users/totp_setup/new.html.erb' do
         'h2#totp-step-4-label',
         text: t('forms.totp_setup.totp_step_4'),
       )
-    end
-
-    it 'has aria labels for TOTP' do
-      render
-
       expect(rendered).to have_selector('[aria-labelledby="totp-step-1-label"]')
       expect(rendered).to have_selector('[aria-labelledby="totp-step-4-label"]')
     end
+
+    it 'does not render the NDS form page card' do
+      expect(rendered).not_to have_selector('.auth--form-page')
+    end
+
+    it 'does not set the NDS header progress' do
+      expect(view.content_for(:nds_header_progress)).to be_blank
+    end
+
+    context 'user is setting up 2FA' do
+      let(:user) { create(:user) }
+
+      before do
+        allow(view).to receive(:user_session).and_return(signing_up: true)
+        render
+      end
+
+      it 'renders a link to choose a different option' do
+        expect(rendered).to have_link(
+          t('two_factor_authentication.choose_another_option'),
+          href: authentication_methods_setup_path,
+        )
+      end
+    end
   end
 
-  context 'user is setting up 2FA' do
-    it 'renders a link to choose a different option' do
-      user = create(:user)
-      allow(view).to receive(:current_user).and_return(user)
-      allow(view).to receive(:user_session).and_return(signing_up: true)
-      allow(view).to receive(:user_fully_authenticated?).and_return(false)
-      @code = 'D4C2L47CVZ3JJHD7'
-      @qrcode = 'qrcode.png'
-      @presenter = TwoFactorAuthCode::AuthenticatorDeliveryPresenter.new(
-        view: view,
-        data: { current_user: user },
-        service_provider: nil,
-      )
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
 
-      render
+    before { render }
 
-      expect(rendered).to have_link(
-        t('two_factor_authentication.choose_another_option'),
-        href: authentication_methods_setup_path,
+    it 'renders the NDS form page card with the heading' do
+      expect(rendered).to have_selector('.auth--form-page')
+      expect(rendered).to have_selector('h1', text: t('nds.totp_setup.new.heading'))
+    end
+
+    it 'renders the QR code, setup code readout, copy button, and manual-entry hint' do
+      expect(rendered).to have_css('#qr-code.field-readout__value', text: code)
+      expect(rendered).to have_css('img[src^="/images/qrcode.png"]')
+      expect(rendered).to have_content(t('nds.totp_setup.new.setup_code_label'))
+      expect(rendered).to have_button(t('components.clipboard_button.label'), type: 'button')
+      expect(rendered).to have_selector(
+        '#totp-manual-entry',
+        text: t('instructions.mfa.authenticator.manual_entry'),
       )
+    end
+
+    it 'renders the numbered steps as discrete flat cards' do
+      expect(rendered).to have_selector(
+        '.card.stack--gap-24 ol.usa-list[start="1"] li.text-body-emphasis#totp-step-1-label',
+        text: t('nds.totp_setup.new.step_1'),
+      )
+      expect(rendered).to have_selector(
+        '.card.stack--gap-24 ol.usa-list[start="2"] li.text-body-emphasis',
+        text: t('nds.totp_setup.new.step_2'),
+      )
+      expect(rendered).to have_selector(
+        '.card.stack--gap-24 ol.usa-list[start="3"] li.text-body-emphasis',
+        text: t('nds.totp_setup.new.step_3'),
+      )
+      expect(rendered).to have_selector(
+        '.card.stack--gap-24 ol.usa-list[start="4"] li.text-body-emphasis#totp-step-4-label',
+        text: t('forms.totp_setup.totp_step_4'),
+      )
+      expect(rendered).to have_selector('ol.usa-list--unstyled > li .card.stack--gap-24', count: 4)
+      expect(rendered).not_to have_selector('ol.usa-list--unstyled .card .card__inner')
+    end
+
+    it 'renders the remember-device checkbox as a plain NDS flat checkbox in a card' do
+      expect(rendered).to have_selector(
+        '.card .checkbox-group .checkbox input.checkbox__input[name="remember_device"]',
+        visible: :all,
+      )
+      expect(rendered).to have_selector(
+        '.checkbox label.checkbox__label .checkbox__label-text',
+        text: t('forms.messages.remember_device'),
+      )
+      expect(rendered).to have_selector(
+        '.checkbox__label-description',
+        text: strip_tags(t('nds.totp_setup.new.remember_device_info')),
+      )
+      expect(rendered).not_to have_selector('.checkbox__input--tile')
+      expect(rendered).not_to have_selector('.usa-checkbox__input--tile')
+      expect(rendered).not_to have_selector('.usa-checkbox__input--bordered')
+    end
+
+    it 'gates the submit button on form state' do
+      expect(rendered).to have_selector('form[data-nds-submit-gate]')
+    end
+
+    it 'renders the setup code as a static readout (not an input) with a bare copy button inside' do
+      expect(rendered).to have_selector('.field-readout .field-readout__value#qr-code', text: code)
+      expect(rendered).to have_selector(
+        '.field-readout .field-readout__label',
+        text: t('nds.totp_setup.new.setup_code_label'),
+      )
+      expect(rendered).not_to have_css('input#qr-code')
+      expect(rendered).to have_selector(
+        '.field-readout button.field-readout__action[aria-label="' +
+                t('components.clipboard_button.label') + '"]',
+      )
+      expect(rendered).not_to have_selector('.field-readout__action.usa-button')
+    end
+
+    it 'renders the code confirmation as a floating-label input labeled Code' do
+      expect(rendered).to have_selector(
+        'lg-one-time-code-input .usa-input-group--floating input.usa-input#code[name="code"]',
+      )
+      expect(rendered).to have_selector(
+        'label.usa-label[for="code"]',
+        text: t('nds.totp_setup.new.code_label'),
+      )
+      expect(rendered).not_to have_content('Example: 123456')
+    end
+
+    it 'renders the nickname field with a visible label' do
+      expect(rendered).to have_field(t('nds.totp_setup.new.nickname_label'))
+      expect(rendered).to have_css("input[name='name'][maxlength='20']")
+      expect(rendered).to have_selector('input#name[aria-labelledby="totp-step-1-label"]')
+    end
+
+    it 'submits with a continue button' do
+      expect(rendered).to have_button(t('forms.buttons.continue'))
+    end
+
+    context 'during sign-in (not account creation)' do
+      let(:in_account_creation_flow) { false }
+
+      it 'does not set the NDS header progress' do
+        expect(view.content_for(:nds_header_progress)).to be_blank
+      end
+    end
+
+    context 'during account creation with no methods yet' do
+      let(:in_account_creation_flow) { true }
+      let(:enabled_mfa_methods_count) { 0 }
+
+      it 'sets the security stepper on the first substep' do
+        expect(view.content_for(:nds_header_progress)).to be_present
+      end
+    end
+
+    context 'during account creation with a method already enabled' do
+      let(:in_account_creation_flow) { true }
+      let(:enabled_mfa_methods_count) { 1 }
+
+      it 'sets the security stepper' do
+        expect(view.content_for(:nds_header_progress)).to be_present
+      end
+    end
+
+    context 'user already has two-factor enabled' do
+      let(:user) { create(:user, :fully_registered) }
+
+      it 'renders a cancel link to the account page' do
+        expect(rendered).to have_link(t('links.cancel'), href: account_path)
+      end
+    end
+
+    context 'user is still setting up their first method' do
+      let(:user) { create(:user) }
+
+      it 'renders a link to choose another method' do
+        expect(rendered).to have_link(
+          t('nds.mfa.choose_another_method'),
+          href: authentication_methods_setup_path,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[lg-teams/ui-refresh#57 — Implement NDS account and authentication methods layouts](https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57)

## 🛠 Summary of changes

Adds the NDS (design-system refresh) treatment for the authentication app (TOTP) setup page (`/authenticator_setup` → `users/totp_setup#new`), behind `nds_layout?`. The legacy layout is preserved byte-for-byte in the `else` branch.

- Wrap the view in `if nds_layout? … else …(legacy verbatim)… end`; render under `NDS::FormPageComponent` (centered card) with the Security header stepper gated on `in_account_creation_flow?`.
- Four numbered step cards (nickname, open app, scan QR + setup code, enter code) using shipped NDS classes: `.card`/`.stack`, `usa-list` decimal markers, floating-label inputs, and a static `field-readout` for the copy-only setup code with an inline copy button.
- Remember-this-browser rendered as the NDS flat checkbox.
- Preserves the existing form contract (same action/params `name`, `code`, `remember_device`, hidden fields) and the TOTP JS packs, so registration behaves identically.
- Wires the page into the dev-only NDS page-state explorer (`Test::NDSPagesController` + `NDSPageCatalog`) with permutations for sign-in, first-MFA, and second-MFA account-creation states.
- New i18n keys in en/es/fr/zh (`nds.totp_setup.new.*`) with real translations.

## 🔗 Dependencies

Depends on the accompanying **identity-design-system** changes (new `field-readout` component + checkbox-flat/floating-label refinements) landing separately; this branch currently renders against the linked local IDS.

## 📜 Testing Plan

- [ ] Visit `/authenticator_setup` in the NDS bucket during account creation; confirm the stepper, four step cards, QR + setup code (copy works), and code entry render per Figma.
- [ ] Register an authenticator app end-to-end and confirm it succeeds (form contract unchanged).
- [ ] Confirm "Remember this browser" defaults unchecked and submits correctly.
- [ ] Confirm the legacy (non-NDS) layout is unchanged.
- [ ] Dev explorer: `/test/nds/totp-setup` renders all permutations.

## 👀 Screenshots

_NDS authentication app setup page (account creation)._