### PR TITLE
Add the NDS identity verification welcome page

### DIFF
--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -23,10 +23,19 @@ module Idv
         passport_cards_supported: passport_cards_supported?,
         mdl_enabled: mdl_enabled?,
       )
+      # NDS merges the agreement consent checkbox onto the welcome screen; the
+      # legacy layout ignores this form.
+      @consent_form = Idv::ConsentForm.new(idv_consent_given: idv_session.idv_consent_given?)
     end
 
     def update
       clear_future_steps!
+
+      # NDS presents the agreement consent on the welcome screen, so welcome
+      # records consent and advances straight to hybrid handoff. The legacy
+      # layout keeps welcome and agreement as separate steps.
+      return update_nds if nds_layout?
+
       clear_idv_session
       idv_session.proofing_started_at ||= Time.zone.now.iso8601
       create_document_capture_session
@@ -40,7 +49,8 @@ module Idv
       Idv::StepInfo.new(
         key: :welcome,
         controller: self,
-        next_steps: [:agreement],
+        next_steps: [:agreement, :hybrid_handoff, :choose_id_type, :document_capture,
+                     :how_to_verify],
         preconditions: ->(idv_session:, user:) { true },
         undo_step: ->(idv_session:, user:) do
           idv_session.welcome_visited = nil
@@ -50,6 +60,44 @@ module Idv
     end
 
     private
+
+    def update_nds
+      skip_to_capture if params[:skip_hybrid_handoff]
+
+      @consent_form = Idv::ConsentForm.new(idv_consent_given: idv_session.idv_consent_given?)
+      result = @consent_form.submit(consent_form_params)
+      analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
+
+      unless result.success?
+        @presenter = Idv::WelcomePresenter.new(
+          decorated_sp_session:,
+          show_sp_reproof_banner: show_sp_reproof_banner?,
+          passport_cards_supported: passport_cards_supported?,
+          mdl_enabled: mdl_enabled?,
+        )
+        return render :show
+      end
+
+      clear_idv_session
+      idv_session.proofing_started_at ||= Time.zone.now.iso8601
+      create_document_capture_session
+      idv_session.welcome_visited = true
+      idv_session.idv_consent_given_at = Time.zone.now
+      idv_session.opted_in_to_in_person_proofing = false
+      idv_session.skip_doc_auth_from_how_to_verify = false
+      idv_session.flow_path = 'standard'
+
+      redirect_to idv_choose_id_type_url
+    end
+
+    def skip_to_capture
+      idv_session.flow_path = 'standard'
+      idv_session.skip_hybrid_handoff = true
+    end
+
+    def consent_form_params
+      params.require(:doc_auth).permit(:idv_consent_given)
+    end
 
     def show_sp_reproof_banner?
       IdentityConfig.store.feature_show_sp_reproof_banner_enabled &&

--- a/app/controllers/test/nds_pages_controller.rb
+++ b/app/controllers/test/nds_pages_controller.rb
@@ -846,6 +846,31 @@ module Test
       {}
     end
 
+    def setup_idv_welcome
+      if params[:sp].present?
+        @decorated_sp_session = SpSessionStub.new(
+          sp_name: 'Example Service Provider',
+          sp_alert_text: nil,
+          cancel_link_url: root_url,
+        )
+      end
+      if params[:logo].present?
+        @current_sp = ServiceProviderStub.new(
+          logo: 'logo.svg',
+          logo_url: helpers.image_path('logo.svg'),
+          issuer: DEV_SP_ISSUER,
+        )
+      end
+      @presenter = Idv::WelcomePresenter.new(
+        decorated_sp_session:,
+        show_sp_reproof_banner: params[:reproof].present?,
+        passport_cards_supported: true,
+        mdl_enabled: true,
+      )
+      @consent_form = Idv::ConsentForm.new(idv_consent_given: false)
+      {}
+    end
+
     def build_mfa_user(configured:)
       user = User.new
       if configured

--- a/app/services/nds/account_creation_steps.rb
+++ b/app/services/nds/account_creation_steps.rb
@@ -13,7 +13,7 @@ module NDS
       { name: :verification },
     ].freeze
 
-    SUBSTEP_COUNTS = { account: 2, security: 2 }.freeze
+    SUBSTEP_COUNTS = { account: 2, security: 2, verification: 12 }.freeze
 
     module_function
 

--- a/app/services/test/nds_page_catalog.rb
+++ b/app/services/test/nds_page_catalog.rb
@@ -13,6 +13,7 @@ module Test
     CREATE_ACCOUNT = 'Create account'
     MFA = 'MFA'
     OTP = 'OTP'
+    IDV = 'Identity verification'
 
     PAGES = [
       Page.new(
@@ -126,6 +127,18 @@ module Test
           Permutation.new(label: 'Countdown', params: { countdown: '1' }),
           Permutation.new(label: 'Reauthentication', params: { reauthn: '1' }),
           Permutation.new(label: 'Prefilled code', params: { code: '1' }),
+        ],
+      ),
+      Page.new(
+        key: 'idv-welcome',
+        title: 'Verify your identity (welcome)',
+        flow: IDV,
+        template: 'idv/welcome/show',
+        permutations: [
+          Permutation.new(label: 'Default', params: {}),
+          Permutation.new(label: 'With service provider', params: { sp: '1' }),
+          Permutation.new(label: 'SP + logo', params: { sp: '1', logo: '1' }),
+          Permutation.new(label: 'SP reproof banner', params: { sp: '1', reproof: '1' }),
         ],
       ),
     ].freeze

--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -1,4 +1,135 @@
 <% self.title = @presenter.title %>
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 1) %>
+  <% end %>
+
+  <%= render JavascriptRequiredComponent.new(
+        header: t('idv.welcome.no_js_header'),
+        intro: t('idv.welcome.no_js_intro', sp_name: @presenter.sp_name),
+        location: :idv_welcome,
+      ) do %>
+    <% logo_url = current_sp&.logo.present? ? current_sp.logo_url : nil %>
+
+    <%= simple_form_for(
+          @consent_form,
+          as: :doc_auth,
+          url: url_for,
+          method: 'put',
+          html: {
+            class: 'js-consent-continue-form',
+            data: { nds_submit_gate: true },
+          },
+        ) do |f| %>
+      <%= render NDS::FormPageComponent.new(
+            title: t('nds.idv_welcome.title', sp_name: @presenter.sp_name),
+            subtitle: t('nds.idv_welcome.intro', sp_name: @presenter.sp_name),
+            divider: true,
+          ) do |page| %>
+        <% if logo_url.present? %>
+          <% page.with_media do %>
+            <%= image_tag(
+                  logo_url,
+                  alt: @presenter.sp_name,
+                  class: 'auth__media',
+                  width: 96,
+                  height: 96,
+                ) %>
+          <% end %>
+        <% end %>
+
+        <% if @presenter.show_sp_reproof_banner %>
+          <% page.with_alert do %>
+            <%= render AlertComponent.new(type: :info) do %>
+              <%= t('doc_auth.info.welcome_sp_reproof_alert', sp_name: @presenter.sp_name) %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <% page.with_body do %>
+          <%= render NDS::StackComponent.new(kind: :form, align: :stretch) do %>
+            <div class="copy">
+              <h2 class="heading-s"><%= t('nds.idv_welcome.what_youll_need') %></h2>
+            </div>
+            <%= render NDS::StackComponent.new(align: :stretch) do %>
+              <% @presenter.bullet_points.each do |point| %>
+                <div class="copy">
+                  <p class="text-body-emphasis"><%= point.bullet %></p>
+                  <p class="copy--muted"><%= point.text %></p>
+                </div>
+              <% end %>
+            <% end %>
+
+            <hr class="divider" />
+
+            <div class="copy">
+              <h2 class="heading-s"><%= t('nds.idv_welcome.how_we_protect_heading') %></h2>
+              <p class="copy--muted"><%= t('nds.idv_welcome.how_we_protect_info') %></p>
+            </div>
+
+            <div class="card card--bleed">
+              <%= render ClickObserverComponent.new(
+                    event_name: 'IdV: consent checkbox toggled',
+                  ) do %>
+                <div class="usa-checkbox">
+                  <%= f.check_box(
+                        :idv_consent_given,
+                        {
+                          class: 'usa-checkbox__input',
+                          required: true,
+                          aria: { describedby: 'consent-learn-more' },
+                        },
+                        '1',
+                        '0',
+                      ) %>
+                  <%= f.label :idv_consent_given,
+                              class: 'usa-checkbox__label usa-checkbox__label--regular' do %>
+                    <span id="consent-learn-more">
+                      <%= t(
+                            'nds.idv_welcome.consent_html',
+                            app_name: APP_NAME,
+                            link_html: new_tab_link_to(
+                              t('nds.idv_welcome.consent_link'),
+                              policy_redirect_url(
+                                policy: :privacy_act_statement,
+                                flow: :idv,
+                                step: :agreement,
+                                location: :consent,
+                              ),
+                            ),
+                          ) %>
+                    </span>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+
+        <% page.with_actions do %>
+          <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+            <%= render ButtonComponent.new(
+                  type: :submit,
+                  full_width: true,
+                ).with_content(t('doc_auth.buttons.continue')) %>
+            <%= render ButtonComponent.new(
+                  url: help_center_redirect_path(
+                    category: 'verify-your-identity',
+                    article: 'phone-number',
+                    flow: :idv,
+                    step: :welcome,
+                    location: 'no_phone_number',
+                  ),
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(t('nds.idv_welcome.no_phone_link')) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <%= javascript_packs_tag_once('document-capture-welcome', 'nds-auth-submit-gate') %>
+<% else %>
 <%= render JavascriptRequiredComponent.new(
       header: t('idv.welcome.no_js_header'),
       intro: t('idv.welcome.no_js_intro', sp_name: @presenter.sp_name),
@@ -56,3 +187,4 @@
   <%= render 'shared/cancel', link: idv_cancel_path(step: 'welcome') %>
 <% end %>
 <%= javascript_packs_tag_once('document-capture-welcome') %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1611,6 +1611,14 @@ mfa.second_method_warning.link: Add a second authentication method.
 mfa.second_method_warning.text: You will have to delete your account and start over if you lose your only authentication method.
 mfa.skip: Skip for now
 mfa.webauthn_platform_message: Add another authentication method in case you lose access to your first one.
+nds.idv_welcome.consent_html: By checking this box, you are letting %{app_name} ask for, use, keep and share your personal information. We will use it to verify your identity. Read about our %{link_html} measures.
+nds.idv_welcome.consent_link: privacy and security
+nds.idv_welcome.how_we_protect_heading: How we protect your data
+nds.idv_welcome.how_we_protect_info: We only use what you enter to verify your identity with the Social Security Administration. Your information will never be shared or sold outside the government.
+nds.idv_welcome.intro: '%{sp_name} needs to verify your identity before you continue. Most people finish in about 7 minutes.'
+nds.idv_welcome.no_phone_link: I don’t have a U.S. phone number
+nds.idv_welcome.title: Let’s verify your identity to access %{sp_name}
+nds.idv_welcome.what_youll_need: What you’ll need
 nds.mfa.choose_another_method: Choose another method
 nds.passwords.new.heading: Create your password
 nds.passwords.new.info: Create a strong password to secure your account and keep personal information safe.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1622,6 +1622,14 @@ mfa.second_method_warning.link: Agregue un segundo método de autenticación.
 mfa.second_method_warning.text: Deberá eliminar su cuenta y comenzar de nuevo si pierde su único método de autenticación.
 mfa.skip: Omitir por ahora
 mfa.webauthn_platform_message: Agregue otro método de autenticación en caso de que pierda el acceso al primero.
+nds.idv_welcome.consent_html: Al marcar esta casilla, usted permite que %{app_name} solicite, use, conserve y comparta su información personal. La usaremos para verificar su identidad. Lea sobre nuestras medidas de %{link_html}.
+nds.idv_welcome.consent_link: privacidad y seguridad
+nds.idv_welcome.how_we_protect_heading: Cómo protegemos sus datos
+nds.idv_welcome.how_we_protect_info: Solo usamos lo que usted ingresa para verificar su identidad con la Administración del Seguro Social. Su información nunca se compartirá ni se venderá fuera del Gobierno.
+nds.idv_welcome.intro: '%{sp_name} necesita verificar su identidad antes de que continúe. La mayoría de las personas terminan en unos 7 minutos.'
+nds.idv_welcome.no_phone_link: No tengo un número de teléfono de los EE. UU.
+nds.idv_welcome.title: Verifiquemos su identidad para acceder a %{sp_name}
+nds.idv_welcome.what_youll_need: Lo que necesitará
 nds.mfa.choose_another_method: Elija otro método
 nds.passwords.new.heading: Cree su contraseña
 nds.passwords.new.info: Cree una contraseña segura para proteger su cuenta y mantener a salvo su información personal.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1611,6 +1611,14 @@ mfa.second_method_warning.link: Ajouter une deuxième méthode d’authentificat
 mfa.second_method_warning.text: Vous devrez supprimer votre compte et recommencer si vous perdez votre seule méthode d’authentification.
 mfa.skip: Sauter pour le moment
 mfa.webauthn_platform_message: Ajouter une autre méthode d’authentification au cas où vous perdriez l’accès à la première.
+nds.idv_welcome.consent_html: En cochant cette case, vous autorisez %{app_name} à demander, utiliser, conserver et partager vos renseignements personnels. Nous les utiliserons pour vérifier votre identité. Consultez nos mesures de %{link_html}.
+nds.idv_welcome.consent_link: confidentialité et de sécurité
+nds.idv_welcome.how_we_protect_heading: Comment nous protégeons vos données
+nds.idv_welcome.how_we_protect_info: Nous n’utilisons que ce que vous saisissez pour vérifier votre identité auprès de la Social Security Administration. Vos renseignements ne seront jamais partagés ni vendus en dehors du gouvernement.
+nds.idv_welcome.intro: '%{sp_name} doit vérifier votre identité avant que vous continuiez. La plupart des gens terminent en environ 7 minutes.'
+nds.idv_welcome.no_phone_link: Je n’ai pas de numéro de téléphone américain
+nds.idv_welcome.title: Vérifions votre identité pour accéder à %{sp_name}
+nds.idv_welcome.what_youll_need: Ce dont vous aurez besoin
 nds.mfa.choose_another_method: Choisir une autre méthode
 nds.passwords.new.heading: Créez votre mot de passe
 nds.passwords.new.info: Créez un mot de passe fort pour sécuriser votre compte et protéger vos renseignements personnels.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1624,6 +1624,14 @@ mfa.second_method_warning.link: 添加第二个身份证实方法。
 mfa.second_method_warning.text: 如果你丢失唯一的身份证实方法，就不得不删除你的账户并从头开始。
 mfa.skip: 现在先跳过
 mfa.webauthn_platform_message: 添加另一个身份证实方法，以防你无法使用第一个方法。
+nds.idv_welcome.consent_html: 勾选此框即表示您允许%{app_name}索取、使用、保存和共享您的个人信息。我们将用它来验证您的身份。请阅读我们的%{link_html}措施。
+nds.idv_welcome.consent_link: 隐私和安全
+nds.idv_welcome.how_we_protect_heading: 我们如何保护您的数据
+nds.idv_welcome.how_we_protect_info: 我们仅使用您输入的信息向社会保障局验证您的身份。您的信息绝不会在政府之外被共享或出售。
+nds.idv_welcome.intro: '%{sp_name}需要先验证您的身份，然后您才能继续。大多数人大约在 7 分钟内完成。'
+nds.idv_welcome.no_phone_link: 我没有美国电话号码
+nds.idv_welcome.title: 让我们验证您的身份以访问%{sp_name}
+nds.idv_welcome.what_youll_need: 您需要准备的内容
 nds.mfa.choose_another_method: 选择另一种方法
 nds.passwords.new.heading: 创建您的密码
 nds.passwords.new.info: 创建一个强密码来保护您的账户并确保个人信息安全。

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -343,5 +343,51 @@ RSpec.describe Idv::WelcomeController do
 
       expect(subject.idv_session.proofing_started_at).to eq(Time.zone.now.iso8601)
     end
+
+    it 'redirects to the agreement step in the legacy layout' do
+      put :update
+
+      expect(response).to redirect_to(idv_agreement_url)
+    end
+
+    context 'in the NDS layout' do
+      before { allow(controller).to receive(:nds_layout?).and_return(true) }
+
+      context 'when consent is given' do
+        it 'records consent and advances to choose ID type', :freeze_time do
+          put :update, params: { doc_auth: { idv_consent_given: '1' } }
+
+          expect(subject.idv_session.idv_consent_given_at).to eq(Time.zone.now)
+          expect(subject.idv_session.welcome_visited).to eq(true)
+          expect(subject.idv_session.flow_path).to eq('standard')
+          expect(response).to redirect_to(idv_choose_id_type_url)
+        end
+      end
+
+      context 'when consent is not given' do
+        render_views
+
+        it 're-renders the welcome page without advancing' do
+          put :update, params: { doc_auth: { idv_consent_given: '0' } }
+
+          expect(subject.idv_session.idv_consent_given_at).to be_nil
+          expect(response).to render_template(:show)
+        end
+      end
+    end
+  end
+
+  describe 'NDS layout rendering' do
+    render_views
+
+    before { allow(controller).to receive(:nds_layout?).and_return(true) }
+
+    it 'renders the merged welcome + consent page without error' do
+      get :show
+
+      expect(response).to render_template(:show)
+      expect(response.body).to include(t('nds.idv_welcome.what_youll_need'))
+      expect(response.body).to include('doc_auth[idv_consent_given]')
+    end
   end
 end

--- a/spec/services/nds/account_creation_steps_spec.rb
+++ b/spec/services/nds/account_creation_steps_spec.rb
@@ -82,8 +82,17 @@ RSpec.describe NDS::AccountCreationSteps do
       )
     end
 
-    it 'omits substep args for steps without a substep count' do
-      expect(described_class.progress_args(step: :verification, substep: 1)).to eq(
+    it 'includes substep args for the verification step' do
+      expect(described_class.progress_args(step: :verification, substep: 2)).to eq(
+        steps: described_class.labels,
+        current_step: 2,
+        current_substep: 2,
+        substep_count: 12,
+      )
+    end
+
+    it 'omits substep args when no substep is given' do
+      expect(described_class.progress_args(step: :verification)).to eq(
         steps: described_class.labels,
         current_step: 2,
       )

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'idv/welcome/show.html.erb' do
   let(:sp) { build(:service_provider) }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     allow(view_context).to receive(:current_user).and_return(user)
 
     decorated_sp_session = ServiceProviderSession.new(


### PR DESCRIPTION
## 🎫 Tickets

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Implements the NDS branch of `idv/welcome#show`. Per the redesign, the NDS
layout **merges the agreement consent step onto the welcome screen** as a single
page. The legacy (non-NDS) branch renders byte-for-byte as before, and
welcome/agreement remain two separate steps in the legacy flow.

NDS layout:
- `NDS::FormPageComponent` with the verification stepper ("Verification 1 / 12"),
  the "What you'll need" bullet blocks, a "How we protect your data" section, and
  the agreement consent checkbox in a bordered card.
- Primary **Continue** submit is gated (`data-nds-submit-gate`) on the required
  consent checkbox; tertiary **"I don't have a U.S. phone number"** links to the
  `verify-your-identity/phone-number` help center article.
- `welcome#update` (NDS path only) records consent (`idv_consent_given_at`),
  marks `welcome_visited`, creates the document-capture session, and redirects
  to hybrid handoff — collapsing the separate agreement step. Legacy `update`
  still redirects to `agreement`.

Also:
- `nds.idv_welcome.*` copy keys (en/es/fr/zh).
- `NDS::AccountCreationSteps` gains a `verification` substep count so the header
  stepper shows "Verification 1 / 12".
- Dev NDS explorer catalog entry + fabricator (`idv-welcome`).

> Matching NDS visual tweaks (badge/list/type) live in the design-system (IDS)
> repo and are tracked separately.

## 👀 Preview

- Live via the dev NDS explorer: http://localhost:3005/test/nds/idv-welcome
  (permutations: Default / With SP / SP + logo / SP reproof banner)
- Explorer index: http://localhost:3005/test/nds

## 📜 Testing Plan

- [ ] `bundle exec rspec spec/controllers/idv/welcome_controller_spec.rb` (incl. NDS render + consent flow)
- [ ] `bundle exec rspec spec/views/idv/welcome/show.html.erb_spec.rb`
- [ ] `bundle exec rspec spec/services/test/nds_page_catalog_spec.rb spec/requests/test/nds_pages_spec.rb`
- [ ] `bundle exec rspec spec/i18n_spec.rb`
- [ ] erb_lint / rubocop / zeitwerk:check clean
- [ ] `/test/nds/idv-welcome` renders under the NDS layout; non-NDS bucket byte-identical