### PR TITLE
Overriding transitive dependency dom-purify per dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6956,9 +6956,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "serialize-javascript": ">=7.0.3",
     "styled-components": "6.4.1",
     "diff": "^8.0.3",
-    "undici": "6.28.0"
+    "undici": "6.28.0",
+    "dompurify": "3.4.13"
   }
 }


### PR DESCRIPTION
changelog: Internal, Override dom-purify, Overriding transitive dependency dom-purify per dependabot alerts

<!-- Uncomment and update the sections you need for your PR! -->

<!--
## 🎫 Ticket

Link to the relevant ticket:
[LG-XXXXX](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-XXXXX)
-->


## 🛠 Summary of changes
Updating dom-purify per [recommendation from Dependabot](https://github.com/18F/identity-idp/security/dependabot/286)


<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
