### PR TITLE
Add the NDS choose your ID type page

### DIFF
--- a/app/controllers/concerns/idv/choose_id_type_concern.rb
+++ b/app/controllers/concerns/idv/choose_id_type_concern.rb
@@ -50,7 +50,7 @@ module Idv
       end
     end
 
-    def locals_attrs(presenter:, form_submit_url: nil)
+    def locals_attrs(presenter:, form_submit_url: nil, show_verify_in_person: false)
       auto_check_value = case document_capture_session.document_type_requested
                         when Idp::Constants::DocumentTypes::MDL
                           :mobile_drivers_license
@@ -79,6 +79,7 @@ module Idv
         auto_check_value:,
         passport_cards_enabled: document_capture_session.passport_cards_supported?,
         mdl_enabled: mdl_enabled?,
+        show_verify_in_person:,
       }
     end
 

--- a/app/controllers/idv/choose_id_type_controller.rb
+++ b/app/controllers/idv/choose_id_type_controller.rb
@@ -16,12 +16,20 @@ module Idv
              locals: locals_attrs(
                presenter: Idv::ChooseIdTypePresenter.new,
                form_submit_url: idv_choose_id_type_path,
+               show_verify_in_person: in_person_opt_in_available?,
              ),
              layout: true
     end
 
     def update
       clear_future_steps!
+
+      if params[:verify_in_person].present? && in_person_opt_in_available?
+        idv_session.opted_in_to_in_person_proofing = true
+        idv_session.flow_path = 'standard'
+        idv_session.skip_doc_auth_from_how_to_verify = true
+        return redirect_to idv_document_capture_url(step: :choose_id_type)
+      end
 
       @choose_id_type_form = Idv::ChooseIdTypeForm.new(
         mdl_enabled: mdl_enabled?,
@@ -66,6 +74,11 @@ module Idv
     end
 
     private
+
+    def in_person_opt_in_available?
+      IdentityConfig.store.in_person_proofing_opt_in_enabled &&
+        Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
+    end
 
     def next_step
       idv_document_capture_url

--- a/app/controllers/test/nds_pages_controller.rb
+++ b/app/controllers/test/nds_pages_controller.rb
@@ -871,6 +871,18 @@ module Test
       {}
     end
 
+    def setup_choose_id_type
+      {
+        presenter: Idv::ChooseIdTypePresenter.new,
+        form_submit_url: '#',
+        disable_passports: params[:no_passport].present?,
+        auto_check_value: :state_id_card,
+        passport_cards_enabled: params[:passport_card].present?,
+        mdl_enabled: params[:mdl].present?,
+        show_verify_in_person: params[:ipp].present?,
+      }
+    end
+
     def build_mfa_user(configured:)
       user = User.new
       if configured

--- a/app/services/test/nds_page_catalog.rb
+++ b/app/services/test/nds_page_catalog.rb
@@ -141,6 +141,19 @@ module Test
           Permutation.new(label: 'SP reproof banner', params: { sp: '1', reproof: '1' }),
         ],
       ),
+      Page.new(
+        key: 'choose-id-type',
+        title: 'Choose your ID type',
+        flow: IDV,
+        template: 'idv/shared/choose_id_type',
+        permutations: [
+          Permutation.new(label: 'Default', params: {}),
+          Permutation.new(label: 'With passport card', params: { passport_card: '1' }),
+          Permutation.new(label: 'With mDL', params: { mdl: '1' }),
+          Permutation.new(label: 'Verify in person', params: { ipp: '1' }),
+          Permutation.new(label: 'Passports disabled', params: { no_passport: '1' }),
+        ],
+      ),
     ].freeze
 
     def self.pages

--- a/app/views/idv/shared/choose_id_type.html.erb
+++ b/app/views/idv/shared/choose_id_type.html.erb
@@ -1,5 +1,95 @@
 <% self.title = t('doc_auth.headings.choose_id_type') %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 2) %>
+  <% end %>
+
+  <% id_type_options = [
+       [t('nds.choose_id_type.option_drivers_license'), :state_id_card, false],
+       [t('nds.choose_id_type.option_passport'), :passport, disable_passports],
+       (if passport_cards_enabled
+          [t('nds.choose_id_type.option_passport_card'), :passport_card, disable_passports]
+        end),
+       (if mdl_enabled
+          [t('nds.choose_id_type.option_mdl'), :mobile_drivers_license, false]
+        end),
+     ].compact %>
+
+  <%= simple_form_for(
+        :doc_auth,
+        url: form_submit_url,
+        method: :put,
+        html: { data: { nds_submit_gate: true } },
+      ) do |f| %>
+    <%= render NDS::FormPageComponent.new(
+          title: t('nds.choose_id_type.title'),
+          subtitle: t('nds.choose_id_type.subtitle'),
+        ) do |page| %>
+      <% if presenter.hybrid_flow? %>
+        <% page.with_alert do %>
+          <%= render AlertComponent.new(type: :warning) do %>
+            <%= t(
+                  'doc_auth.hybrid_flow_warning.explanation_html',
+                  app_name: APP_NAME,
+                  service_provider_name: decorated_sp_session.sp_name,
+                ) %>
+          <% end %>
+        <% end %>
+      <% elsif disable_passports %>
+        <% page.with_alert do %>
+          <%= render AlertComponent.new(type: :error) do %>
+            <%= t('doc_auth.info.dos_passport_api_down_message') %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% page.with_body do %>
+        <fieldset class="usa-fieldset radio-group">
+          <legend class="usa-sr-only"><%= t('doc_auth.headings.choose_id_type') %></legend>
+          <% id_type_options.each do |label, value, disabled| %>
+            <div class="radio">
+              <%= f.radio_button(
+                    :choose_id_type_preference,
+                    value,
+                    class: 'radio__input usa-sr-only',
+                    checked: auto_check_value == value,
+                    disabled: disabled,
+                    required: true,
+                  ) %>
+              <%= f.label "choose_id_type_preference_#{value}", class: 'radio__label' do %>
+                <%= label %>
+              <% end %>
+            </div>
+          <% end %>
+        </fieldset>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+          <%= render ButtonComponent.new(
+                type: :submit,
+                full_width: true,
+              ).with_content(t('forms.buttons.continue')) %>
+          <% if local_assigns[:show_verify_in_person] %>
+            <div class="separator"><%= t('nds.choose_id_type.or') %></div>
+            <%= render ButtonComponent.new(
+                  type: :submit,
+                  name: 'verify_in_person',
+                  value: 'true',
+                  formnovalidate: true,
+                  variant: :secondary,
+                  full_width: true,
+                ).with_content(t('nds.choose_id_type.verify_in_person')) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('nds-auth-submit-gate', preload_links_header: false) %>
+<% else %>
+
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: presenter.step_indicator_steps,
@@ -78,3 +168,4 @@
 <% end %>
 
 <%= render 'idv/doc_auth/cancel', step: 'choose_id_type' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1611,6 +1611,14 @@ mfa.second_method_warning.link: Add a second authentication method.
 mfa.second_method_warning.text: You will have to delete your account and start over if you lose your only authentication method.
 mfa.skip: Skip for now
 mfa.webauthn_platform_message: Add another authentication method in case you lose access to your first one.
+nds.choose_id_type.option_drivers_license: U.S. driver’s license or state ID
+nds.choose_id_type.option_mdl: Mobile driver’s license
+nds.choose_id_type.option_passport: U.S. passport book
+nds.choose_id_type.option_passport_card: U.S. passport card
+nds.choose_id_type.or: or
+nds.choose_id_type.subtitle: Take a photo of your ID and a quick selfie to verify your identity online.
+nds.choose_id_type.title: Choose your ID type to verify
+nds.choose_id_type.verify_in_person: Verify in person
 nds.idv_welcome.consent_html: By checking this box, you are letting %{app_name} ask for, use, keep and share your personal information. We will use it to verify your identity. Read about our %{link_html} measures.
 nds.idv_welcome.consent_link: privacy and security
 nds.idv_welcome.how_we_protect_heading: How we protect your data

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1622,6 +1622,14 @@ mfa.second_method_warning.link: Agregue un segundo método de autenticación.
 mfa.second_method_warning.text: Deberá eliminar su cuenta y comenzar de nuevo si pierde su único método de autenticación.
 mfa.skip: Omitir por ahora
 mfa.webauthn_platform_message: Agregue otro método de autenticación en caso de que pierda el acceso al primero.
+nds.choose_id_type.option_drivers_license: Licencia de conducir o identificación estatal de los EE. UU.
+nds.choose_id_type.option_mdl: Licencia de conducir móvil
+nds.choose_id_type.option_passport: Libreta de pasaporte de los EE. UU.
+nds.choose_id_type.option_passport_card: Tarjeta de pasaporte de los EE. UU.
+nds.choose_id_type.or: o
+nds.choose_id_type.subtitle: Tome una foto de su identificación y una selfie rápida para verificar su identidad en línea.
+nds.choose_id_type.title: Elija el tipo de identificación para verificar
+nds.choose_id_type.verify_in_person: Verificar en persona
 nds.idv_welcome.consent_html: Al marcar esta casilla, usted permite que %{app_name} solicite, use, conserve y comparta su información personal. La usaremos para verificar su identidad. Lea sobre nuestras medidas de %{link_html}.
 nds.idv_welcome.consent_link: privacidad y seguridad
 nds.idv_welcome.how_we_protect_heading: Cómo protegemos sus datos

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1611,6 +1611,14 @@ mfa.second_method_warning.link: Ajouter une deuxième méthode d’authentificat
 mfa.second_method_warning.text: Vous devrez supprimer votre compte et recommencer si vous perdez votre seule méthode d’authentification.
 mfa.skip: Sauter pour le moment
 mfa.webauthn_platform_message: Ajouter une autre méthode d’authentification au cas où vous perdriez l’accès à la première.
+nds.choose_id_type.option_drivers_license: Permis de conduire ou pièce d’identité d’État des États-Unis
+nds.choose_id_type.option_mdl: Permis de conduire mobile
+nds.choose_id_type.option_passport: Passeport américain (livret)
+nds.choose_id_type.option_passport_card: Carte de passeport américaine
+nds.choose_id_type.or: ou
+nds.choose_id_type.subtitle: Prenez une photo de votre pièce d’identité et un égoportrait rapide pour vérifier votre identité en ligne.
+nds.choose_id_type.title: Choisissez le type de pièce d’identité à vérifier
+nds.choose_id_type.verify_in_person: Vérifier en personne
 nds.idv_welcome.consent_html: En cochant cette case, vous autorisez %{app_name} à demander, utiliser, conserver et partager vos renseignements personnels. Nous les utiliserons pour vérifier votre identité. Consultez nos mesures de %{link_html}.
 nds.idv_welcome.consent_link: confidentialité et de sécurité
 nds.idv_welcome.how_we_protect_heading: Comment nous protégeons vos données

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1624,6 +1624,14 @@ mfa.second_method_warning.link: 添加第二个身份证实方法。
 mfa.second_method_warning.text: 如果你丢失唯一的身份证实方法，就不得不删除你的账户并从头开始。
 mfa.skip: 现在先跳过
 mfa.webauthn_platform_message: 添加另一个身份证实方法，以防你无法使用第一个方法。
+nds.choose_id_type.option_drivers_license: 美国驾照或州身份证
+nds.choose_id_type.option_mdl: 移动驾照
+nds.choose_id_type.option_passport: 美国护照簿
+nds.choose_id_type.option_passport_card: 美国护照卡
+nds.choose_id_type.or: 或
+nds.choose_id_type.subtitle: 拍摄您的身份证件照片和一张快速自拍，即可在线验证您的身份。
+nds.choose_id_type.title: 选择要验证的身份证件类型
+nds.choose_id_type.verify_in_person: 亲自验证
 nds.idv_welcome.consent_html: 勾选此框即表示您允许%{app_name}索取、使用、保存和共享您的个人信息。我们将用它来验证您的身份。请阅读我们的%{link_html}措施。
 nds.idv_welcome.consent_link: 隐私和安全
 nds.idv_welcome.how_we_protect_heading: 我们如何保护您的数据

--- a/spec/controllers/idv/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/choose_id_type_controller_spec.rb
@@ -128,6 +128,35 @@ RSpec.describe Idv::ChooseIdTypeController do
         expect(response).to redirect_to(idv_document_capture_url)
       end
     end
+
+    context 'verify in person (NDS opt-in)' do
+      before do
+        allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled)
+          .and_return(true)
+        allow(Idv::InPersonConfig).to receive(:enabled_for_issuer?).and_return(true)
+      end
+
+      it 'opts into in-person proofing and redirects to document capture' do
+        put :update, params: { verify_in_person: 'true' }
+
+        expect(subject.idv_session.opted_in_to_in_person_proofing).to eq(true)
+        expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to eq(true)
+        expect(response).to redirect_to(idv_document_capture_url(step: :choose_id_type))
+      end
+    end
+  end
+
+  describe 'NDS layout rendering' do
+    render_views
+
+    before { allow(controller).to receive(:nds_layout?).and_return(true) }
+
+    it 'renders the NDS choose-id-type page without error' do
+      get :show
+
+      expect(response).to render_template('idv/shared/choose_id_type')
+      expect(response.body).to include(t('nds.choose_id_type.title'))
+    end
   end
 
   describe '#step_info' do


### PR DESCRIPTION
## 🎫 Tickets

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Implements the NDS branch of the shared `idv/shared/choose_id_type` view (used
by the `choose_id_type`, `hybrid_mobile/choose_id_type`, and
`in_person/choose_id_type` controllers). The legacy (non-NDS) branch renders
byte-for-byte as before.

NDS layout:
- `NDS::FormPageComponent` with the verification stepper ("Verification 2 / 12"),
  "Choose your ID type to verify" heading + subtitle.
- ID options rendered as a flat bordered **radio-group card** (shipped
  `.radio-group` / `.radio` / `.radio__label` family): U.S. driver's license or
  state ID, U.S. passport book, U.S. passport card, Mobile driver's license
  (options gated on `disable_passports` / `passport_cards_enabled` / `mdl_enabled`).
- Submit-gated **Continue** + an "or"-separated **Verify in person** secondary
  button.
- On the desktop `ChooseIdTypeController`, Verify in person opts into in-person
  proofing (`opted_in_to_in_person_proofing`, `skip_doc_auth_from_how_to_verify`)
  and advances to document capture. Shown only when in-person opt-in is enabled
  for the SP; the button/handler are scoped to the desktop controller (the
  `in_person`/`hybrid_mobile` variants share the view but not the opt-in path).

Also:
- `nds.choose_id_type.*` copy keys (en/es/fr/zh).
- `NDS::AccountCreationSteps` gains a `verification` substep count.
- Dev NDS explorer catalog entry + fabricator (`choose-id-type`).

> Matching NDS visual tweaks (badge/list/type/card) live in the design-system
> (IDS) repo and are tracked separately.

## 👀 Preview

- Live via the dev NDS explorer: http://localhost:3005/test/nds/choose-id-type
  (permutations: Default / With passport card / With mDL / Verify in person /
  Passports disabled)
- Explorer index: http://localhost:3005/test/nds

## 📜 Testing Plan

- [ ] `bundle exec rspec spec/controllers/idv/choose_id_type_controller_spec.rb` (incl. NDS render + verify-in-person opt-in)
- [ ] `bundle exec rspec spec/controllers/idv/in_person/choose_id_type_controller_spec.rb spec/controllers/idv/hybrid_mobile/choose_id_type_controller_spec.rb`
- [ ] `bundle exec rspec spec/services/test/nds_page_catalog_spec.rb spec/requests/test/nds_pages_spec.rb`
- [ ] `bundle exec rspec spec/i18n_spec.rb`
- [ ] erb_lint / rubocop / zeitwerk:check clean
- [ ] `/test/nds/choose-id-type` renders under the NDS layout; non-NDS bucket byte-identical