### PR TITLE
Add the NDS phone setup page

### DIFF
--- a/app/assets/images/nds/icons/chevron_down/16.svg
+++ b/app/assets/images/nds/icons/chevron_down/16.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="M8 9.79 3.77 5.55 2.63 6.68 8 12.05l5.37-5.37-1.14-1.13z" clip-rule="evenodd"/></svg>

--- a/app/assets/images/nds/icons/chevron_down/20.svg
+++ b/app/assets/images/nds/icons/chevron_down/20.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path fill="currentColor" fill-rule="evenodd" d="M10 12.23 4.71 6.94 3.29 8.35 10 15.06l6.71-6.71-1.42-1.41z" clip-rule="evenodd"/></svg>

--- a/app/assets/images/nds/icons/chevron_down/24.svg
+++ b/app/assets/images/nds/icons/chevron_down/24.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="M12 14.68 5.65 8.33l-1.7 1.7L12 18.07l8.05-8.04-1.7-1.7z" clip-rule="evenodd"/></svg>

--- a/app/controllers/users/phone_setup_controller.rb
+++ b/app/controllers/users/phone_setup_controller.rb
@@ -18,7 +18,10 @@ module Users
 
     after_action :add_recaptcha_resource_hints, if: :recaptcha_enabled?
 
-    helper_method :in_multi_mfa_selection_flow?
+    delegate :enabled_mfa_methods_count, to: :mfa_context
+
+    helper_method :in_multi_mfa_selection_flow?, :in_account_creation_flow?,
+                  :enabled_mfa_methods_count
 
     def index
       user_session[:phone_id] = nil

--- a/app/javascript/packages/input-validation/input-element.spec.ts
+++ b/app/javascript/packages/input-validation/input-element.spec.ts
@@ -1,5 +1,6 @@
 import {
   enhanceInputValidation,
+  enhanceNdsPhoneGroups,
   enhanceOverflowScrollFade,
   enhancePasswordToggles,
   enhancePhoneInputs,
@@ -714,5 +715,132 @@ describe('InputComponent validation', () => {
     confirmation.dispatchEvent(new InputEvent('input', { bubbles: true }));
     expect(button.disabled).to.equal(false);
     expect(confirmation.validity.valid).to.equal(true);
+  });
+});
+
+describe('NDS phone group', () => {
+  const messages = {
+    valueMissing: 'Phone number is required',
+    invalidUs: 'Enter a 10 digit phone number.',
+    invalidInternational: 'Enter a phone number with the correct number of digits.',
+  };
+
+  const renderPhoneGroup = ({ value = '', country = 'US' } = {}) => {
+    document.body.innerHTML = `
+      <form>
+        <div class="usa-phone-input-group" data-nds-phone
+             data-nds-phone-messages='${JSON.stringify(messages)}'>
+          <div class="usa-phone-input">
+            <details class="usa-phone-input__country">
+              <summary class="usa-phone-input__country-toggle">
+                <span class="usa-phone-input__country-code" data-nds-phone-dial>+1</span>
+              </summary>
+              <div class="popover-menu usa-phone-input__country-list">
+                <label class="usa-phone-input__country-option">
+                  <input type="radio" class="usa-phone-input__country-radio usa-sr-only"
+                         data-nds-phone-country data-dial="+1"
+                         name="new_phone_form[international_code]" value="US" checked>
+                  United States
+                </label>
+                <label class="usa-phone-input__country-option">
+                  <input type="radio" class="usa-phone-input__country-radio usa-sr-only"
+                         data-nds-phone-country data-dial="+44"
+                         name="new_phone_form[international_code]" value="GB">
+                  United Kingdom
+                </label>
+              </div>
+            </details>
+            <span class="usa-phone-input__field">
+              <input id="phone" type="tel" class="usa-phone-input__input" placeholder=" " required>
+              <label for="phone" class="usa-phone-input__label">Phone number</label>
+            </span>
+          </div>
+          <p class="usa-error-message" id="phone-error" data-nds-phone-error hidden></p>
+        </div>
+      </form>
+    `;
+
+    const input = document.querySelector<HTMLInputElement>('.usa-phone-input__input')!;
+    const details = document.querySelector<HTMLDetailsElement>('.usa-phone-input__country')!;
+    const dial = document.querySelector<HTMLElement>('[data-nds-phone-dial]')!;
+    const errorRegion = document.querySelector<HTMLElement>('[data-nds-phone-error]')!;
+    const radios = Array.from(
+      document.querySelectorAll<HTMLInputElement>('[data-nds-phone-country]'),
+    );
+    if (country !== 'US') {
+      radios.find((radio) => radio.value === country)!.checked = true;
+    }
+    input.value = value;
+    enhanceNdsPhoneGroups();
+
+    return { input, details, dial, errorRegion, radios };
+  };
+
+  const type = (input: HTMLInputElement, value: string) => {
+    input.focus();
+    for (const character of value) {
+      const start = input.selectionStart ?? input.value.length;
+      const end = input.selectionEnd ?? start;
+      input.setRangeText(character, start, end, 'end');
+      input.dispatchEvent(new InputEvent('input', { bubbles: true, data: character }));
+    }
+  };
+
+  it('formats the number as you type for the selected country', () => {
+    const { input } = renderPhoneGroup();
+    type(input, '2025550199');
+    expect(input.value).to.equal('(202) 555-0199');
+  });
+
+  it('reformats and updates the collapsed dial code when the country changes', () => {
+    const { input, dial, radios } = renderPhoneGroup({ value: '2025550199' });
+    expect(input.value).to.equal('(202) 555-0199');
+
+    const gb = radios.find((radio) => radio.value === 'GB')!;
+    gb.checked = true;
+    gb.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(dial.textContent).to.equal('+44');
+  });
+
+  it('closes the country disclosure after a selection', () => {
+    const { details, radios } = renderPhoneGroup();
+    details.open = true;
+
+    const gb = radios.find((radio) => radio.value === 'GB')!;
+    gb.checked = true;
+    gb.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(details.open).to.equal(false);
+  });
+
+  it('shows the required message on blur when empty', () => {
+    const { input, errorRegion } = renderPhoneGroup();
+    input.dispatchEvent(new FocusEvent('blur'));
+
+    expect(input.getAttribute('aria-invalid')).to.equal('true');
+    expect(errorRegion.hidden).to.equal(false);
+    expect(errorRegion.textContent).to.equal(messages.valueMissing);
+  });
+
+  it('shows the invalid-format message for an incomplete number on blur', () => {
+    const { input, errorRegion } = renderPhoneGroup();
+    type(input, '202');
+    input.dispatchEvent(new FocusEvent('blur'));
+
+    expect(input.validity.valid).to.equal(false);
+    expect(errorRegion.textContent).to.equal(messages.invalidUs);
+  });
+
+  it('clears the error once a valid number is entered', () => {
+    const { input, errorRegion } = renderPhoneGroup();
+    type(input, '202');
+    input.dispatchEvent(new FocusEvent('blur'));
+    expect(errorRegion.hidden).to.equal(false);
+
+    type(input, '5550199');
+
+    expect(input.validity.valid).to.equal(true);
+    expect(errorRegion.hidden).to.equal(true);
   });
 });

--- a/app/javascript/packages/input-validation/input-element.ts
+++ b/app/javascript/packages/input-validation/input-element.ts
@@ -1,4 +1,4 @@
-import { AsYouType } from 'libphonenumber-js';
+import { AsYouType, isValidNumber, isValidNumberForRegion } from 'libphonenumber-js';
 import type { CountryCode } from 'libphonenumber-js';
 import {
   bindFormSubmitters,
@@ -93,6 +93,148 @@ const bindPhoneInput = (phoneField: HTMLInputElement) => {
 
 export const enhancePhoneInputs = (root: ParentNode = document) => {
   root.querySelectorAll<HTMLInputElement>('[data-nds-phone-input]').forEach(bindPhoneInput);
+};
+
+const NDS_PHONE_GROUP_READY = 'ndsPhoneGroupReady';
+
+interface NdsPhoneMessages {
+  valueMissing?: string;
+  invalidUs?: string;
+  invalidInternational?: string;
+}
+
+const parsePhoneMessages = (group: HTMLElement): NdsPhoneMessages => {
+  try {
+    return JSON.parse(group.dataset.ndsPhoneMessages || '{}');
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * Enhances the `.usa-phone-input-group` (`.usa-phone-input` pill + `<details>`
+ * country picker) with as-you-type formatting and libphonenumber validation,
+ * rendering inline errors into the group's `[data-nds-phone-error]` region
+ * instead of the native validation bubble. Works with JavaScript disabled: the
+ * radio picker still submits and native `required` still applies.
+ */
+const bindNdsPhoneGroup = (group: HTMLElement) => {
+  if (group.dataset[NDS_PHONE_GROUP_READY] === 'true') {
+    return;
+  }
+
+  const field = group.querySelector<HTMLInputElement>('.usa-phone-input__input');
+  if (!field) {
+    return;
+  }
+
+  group.dataset[NDS_PHONE_GROUP_READY] = 'true';
+
+  const details = group.querySelector<HTMLDetailsElement>('.usa-phone-input__country');
+  const dial = group.querySelector<HTMLElement>('[data-nds-phone-dial]');
+  const radios = Array.from(group.querySelectorAll<HTMLInputElement>('[data-nds-phone-country]'));
+  const errorRegion = group.querySelector<HTMLElement>('[data-nds-phone-error]');
+  const messages = parsePhoneMessages(group);
+
+  const country = () =>
+    (radios.find((radio) => radio.checked)?.value || DEFAULT_COUNTRY) as CountryCode;
+
+  const renderError = (message: string) => {
+    field.setAttribute('aria-invalid', String(Boolean(message)));
+    if (!errorRegion) {
+      return;
+    }
+    errorRegion.textContent = message;
+    errorRegion.hidden = !message;
+  };
+
+  const invalidFormatMessage = () =>
+    (country() === 'US' ? messages.invalidUs : messages.invalidInternational) || '';
+
+  const syncCustomValidity = () => {
+    const value = field.value.trim();
+    if (!value) {
+      // Empty is governed by the native `required` constraint (valueMissing).
+      field.setCustomValidity('');
+      return;
+    }
+    const region = country();
+    const invalid = !isValidNumberForRegion(value, region) || !isValidNumber(value, region);
+    field.setCustomValidity(invalid ? invalidFormatMessage() : '');
+  };
+
+  const validate = () => {
+    syncCustomValidity();
+    if (field.validity.valid) {
+      renderError('');
+    } else if (field.validity.valueMissing) {
+      renderError(messages.valueMissing || field.validationMessage);
+    } else {
+      renderError(field.validationMessage);
+    }
+    return field.validity.valid;
+  };
+
+  field.addEventListener('input', () => {
+    formatPhoneInput(field, country());
+    syncCustomValidity();
+    if (field.validity.valid) {
+      renderError('');
+    }
+  });
+
+  field.addEventListener('blur', () => {
+    if (consumeIgnoreBlurValidation(field.form)) {
+      return;
+    }
+    validate();
+  });
+
+  field.addEventListener('invalid', (event) => {
+    event.preventDefault();
+    validate();
+    field.focus();
+  });
+
+  radios.forEach((radio) => {
+    radio.addEventListener('change', () => {
+      if (dial) {
+        dial.textContent = radio.dataset.dial || '';
+      }
+      if (details) {
+        details.open = false;
+      }
+      formatPhoneInput(field, country(), { preserveCaret: false });
+      syncCustomValidity();
+      if (field.validity.valid) {
+        renderError('');
+      }
+    });
+  });
+
+  if (details) {
+    document.addEventListener('click', (event) => {
+      if (details.open && !details.contains(event.target as Node)) {
+        details.open = false;
+      }
+    });
+    details.addEventListener('keydown', (event) => {
+      if ((event as KeyboardEvent).key === 'Escape') {
+        details.open = false;
+        details.querySelector<HTMLElement>('.usa-phone-input__country-toggle')?.focus();
+      }
+    });
+  }
+
+  if (field.value.trim()) {
+    formatPhoneInput(field, country(), { preserveCaret: false });
+  }
+};
+
+export const enhanceNdsPhoneGroups = (root: ParentNode = document) => {
+  root
+    .querySelectorAll<HTMLElement>('.usa-phone-input-group[data-nds-phone]')
+    .forEach(bindNdsPhoneGroup);
 };
 
 const syncPasswordToggle = (input: HTMLInputElement, button: HTMLButtonElement) => {
@@ -522,6 +664,7 @@ export const normalizeInputErrors = (root: ParentNode = document) => {
 };
 
 enhancePhoneInputs();
+enhanceNdsPhoneGroups();
 enhancePasswordToggles();
 enhanceOverflowScrollFade();
 normalizeInputErrors();

--- a/app/views/users/phone_setup/index.html.erb
+++ b/app/views/users/phone_setup/index.html.erb
@@ -1,5 +1,103 @@
 <% self.title = t('titles.add_info.phone') %>
 
+<% if nds_layout? %>
+  <% if in_account_creation_flow? %>
+    <% content_for(:nds_header_progress) do %>
+      <%= nds_account_creation_progress(
+            step: :security,
+            substep: enabled_mfa_methods_count >= 1 ? 2 : 1,
+          ) %>
+    <% end %>
+  <% end %>
+
+  <%= render NDS::FormPageComponent.new(
+        title: t('nds.phone_setup.heading'),
+        subtitle: t('nds.phone_setup.info'),
+      ) do |page| %>
+    <% page.with_alert do %>
+      <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice])) %>
+    <% end %>
+
+    <% page.with_body do %>
+      <%= simple_form_for(@new_phone_form, url: phone_setup_path) do |f| %>
+        <%= render NDS::StackComponent.new(kind: :form, align: :stretch) do %>
+          <%= render NDS::StackComponent.new(align: :stretch) do %>
+            <%= render 'users/shared/nds_phone_input', form: f %>
+
+            <%= render 'users/shared/nds_otp_delivery_preference_selection',
+                       form_obj: @new_phone_form %>
+
+            <% if TwoFactorAuthentication::PhonePolicy.new(current_user).enabled? %>
+              <%= render 'users/shared/otp_make_default_number',
+                         form_obj: @new_phone_form %>
+            <% end %>
+          <% end %>
+
+          <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+            <%= render CaptchaSubmitButtonComponent.new(
+                  form: f,
+                  action: PhoneRecaptchaForm::RECAPTCHA_ACTION,
+                ).with_content(t('forms.buttons.send_one_time_code')) %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% if !@webauthn_platform_configured %>
+        <%= render(AlertComponent.new(type: :info, class: 'margin-top-4')) do %>
+          <%= t(
+                'notices.phishing_warning_html',
+                common_scams_link_html:
+                new_tab_link_to(
+                  t('links.scams'),
+                  MarketingSite.help_center_article_url(
+                    category: 'fraud-concerns',
+                    article: 'common-scams',
+                  ),
+                ),
+                ft_unlock_setup_link_html: link_to(
+                  t('links.setup_ft_unlock'),
+                  webauthn_setup_url(platform: true),
+                ),
+              ) %>
+        <% end %>
+      <% end %>
+
+      <% if FeatureManagement.phone_recaptcha_enabled? %>
+        <p class="margin-top-4">
+          <%= t(
+                'two_factor_authentication.recaptcha.disclosure_statement_html',
+                app_name: APP_NAME,
+                google_policy_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_policy_link'), GooglePolicySite.privacy_url),
+                google_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.google_tos_link'), GooglePolicySite.terms_url),
+                login_tos_link_html: new_tab_link_to(t('two_factor_authentication.recaptcha.login_tos_link'), MarketingSite.rules_of_use_url),
+              ) %>
+        </p>
+      <% else %>
+        <%= link_to t('two_factor_authentication.mobile_terms_of_service'),
+                    MarketingSite.messaging_practices_url,
+                    class: 'display-block margin-top-4' %>
+      <% end %>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+        <% if MfaPolicy.new(current_user).two_factor_enabled? && !in_multi_mfa_selection_flow? %>
+          <%= render ButtonComponent.new(
+                url: account_path,
+                variant: :tertiary,
+                full_width: true,
+              ).with_content(t('links.cancel')) %>
+        <% else %>
+          <%= render ButtonComponent.new(
+                url: authentication_methods_setup_path,
+                variant: :tertiary,
+                full_width: true,
+              ).with_content(t('nds.mfa.choose_another_method')) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice])) %>
 
 <%= render PageHeadingComponent.new.with_content(t('headings.add_info.phone')) %>
@@ -74,3 +172,4 @@
 <% end %>
 
 <%= render 'shared/cancel_or_back_to_options' %>
+<% end %>

--- a/app/views/users/shared/_nds_otp_delivery_preference_selection.html.erb
+++ b/app/views/users/shared/_nds_otp_delivery_preference_selection.html.erb
@@ -1,0 +1,42 @@
+<% form_name = form_obj.class.name.underscore.to_s
+   form_name_label = form_name + '[otp_delivery_preference]'
+   form_name_tag_sms = form_name + '_otp_delivery_preference_sms'
+   form_name_tag_voice = form_name + '_otp_delivery_preference_voice' %>
+
+<div class="js-otp-delivery-preferences">
+  <fieldset class="margin-0 padding-0 border-0">
+    <legend class="usa-sr-only">
+      <%= t('two_factor_authentication.otp_delivery_preference.title') %>
+    </legend>
+    <div class="radio-group">
+      <div class="radio">
+        <%= radio_button_tag(
+              form_name_label,
+              :sms,
+              form_obj.delivery_preference_sms?,
+              disabled: OutageStatus.new.vendor_outage?(:sms),
+              class: 'js-otp-delivery-preference radio__input usa-sr-only',
+            ) %>
+        <label class="radio__label" for="<%= form_name_tag_sms %>">
+          <%= t('nds.phone_setup.delivery.sms') %>
+        </label>
+      </div>
+      <div class="radio">
+        <%= radio_button_tag(
+              form_name_label,
+              :voice,
+              form_obj.delivery_preference_voice?,
+              disabled: OutageStatus.new.vendor_outage?(:voice),
+              class: 'js-otp-delivery-preference radio__input usa-sr-only',
+            ) %>
+        <label class="radio__label" for="<%= form_name_tag_voice %>">
+          <%= t('nds.phone_setup.delivery.voice') %>
+        </label>
+      </div>
+    </div>
+    <p class="margin-top-1 margin-bottom-0" id="otp_delivery_preference_instruction">
+      <%= t('two_factor_authentication.otp_delivery_preference.instruction') %>
+    </p>
+  </fieldset>
+</div>
+<%= javascript_packs_tag_once('otp-delivery-preference') %>

--- a/app/views/users/shared/_nds_phone_input.html.erb
+++ b/app/views/users/shared/_nds_phone_input.html.erb
@@ -1,0 +1,74 @@
+<% component = PhoneInputComponent.new(form: form, confirmed_phone: false, required: true)
+   countries = component.international_phone_codes.map do |_label, code_key, opts|
+     {
+       iso: code_key,
+       name: opts.dig(:data, :country_name),
+       dial: "+#{opts.dig(:data, :country_code)}",
+     }
+   end
+   selected_iso = form.object.international_code.presence || 'US'
+   selected = countries.find { |c| c[:iso] == selected_iso } || countries.first
+   radio_name = "#{form.object_name}[international_code]"
+   phone_id = "#{form.object_name}_phone"
+   error_id = "#{phone_id}-error"
+   messages = {
+     valueMissing: t('errors.messages.phone_required'),
+     invalidUs: t('errors.messages.invalid_phone_number.us'),
+     invalidInternational: t('errors.messages.invalid_phone_number.international'),
+   } %>
+
+<div class="usa-phone-input-group"
+     data-nds-phone
+     data-nds-phone-messages="<%= messages.to_json %>">
+  <div class="usa-phone-input">
+    <details class="usa-phone-input__country">
+      <summary class="usa-phone-input__country-toggle"
+               aria-label="<%= t('components.phone_input.country_code_label') %>">
+        <span class="usa-phone-input__country-code" data-nds-phone-dial>
+          <%= selected[:dial] %>
+        </span>
+        <%= render NDS::IconComponent.new(
+              icon: :expand_more,
+              size: 20,
+              class: 'usa-phone-input__country-chevron',
+            ) %>
+      </summary>
+      <div class="popover-menu popover-menu--left usa-phone-input__country-list"
+           role="group"
+           aria-label="<%= t('components.phone_input.country_code_label') %>">
+        <% countries.each do |country| %>
+          <label class="popover-menu__item usa-phone-input__country-option">
+            <%= radio_button_tag(
+                  radio_name,
+                  country[:iso],
+                  country[:iso] == selected[:iso],
+                  class: 'usa-phone-input__country-radio usa-sr-only',
+                  data: { nds_phone_country: '', dial: country[:dial] },
+                  id: "#{form.object_name}_international_code_#{country[:iso].downcase}",
+                ) %>
+            <%= country[:name] %>
+            <span class="usa-phone-input__country-option-dial"><%= country[:dial] %></span>
+          </label>
+        <% end %>
+      </div>
+    </details>
+    <span class="usa-phone-input__field">
+      <%= form.telephone_field(
+            :phone,
+            id: phone_id,
+            class: 'usa-phone-input__input',
+            placeholder: ' ',
+            required: true,
+            autocomplete: 'tel',
+            aria: { describedby: error_id },
+          ) %>
+      <%= form.label(
+            :phone,
+            t('two_factor_authentication.phone_label'),
+            class: 'usa-phone-input__label',
+          ) %>
+    </span>
+  </div>
+  <p class="usa-error-message" id="<%= error_id %>" data-nds-phone-error aria-live="polite" hidden></p>
+</div>
+<%= javascript_packs_tag_once('input_component') %>

--- a/spec/views/phone_setup/index.html.erb_spec.rb
+++ b/spec/views/phone_setup/index.html.erb_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'users/phone_setup/index.html.erb' do
-  before do
-    user = build_stubbed(:user)
+  let(:user) { build_stubbed(:user) }
 
+  before do
     allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:nds_layout?).and_return(false)
 
     @new_phone_form = NewPhoneForm.new(user:)
 
@@ -76,6 +77,102 @@ RSpec.describe 'users/phone_setup/index.html.erb' do
 
     it 'renders alert banner' do
       expect(render).to have_selector('.usa-alert.usa-alert--error')
+    end
+  end
+
+  context 'nds bucket' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+      allow(view).to receive(:in_multi_mfa_selection_flow?).and_return(false)
+      allow(view).to receive(:enabled_mfa_methods_count).and_return(enabled_mfa_methods_count)
+      allow(view).to receive(:in_account_creation_flow?).and_return(in_account_creation_flow)
+      render
+    end
+
+    let(:enabled_mfa_methods_count) { 0 }
+    let(:in_account_creation_flow) { true }
+
+    it 'renders the FormPageComponent card with the NDS heading' do
+      expect(rendered).to have_css('.auth--form-page')
+      expect(rendered).to have_css('.auth--form-page h1', text: t('nds.phone_setup.heading'))
+    end
+
+    it 'renders the phone input and delivery preference radios' do
+      expect(rendered).to have_css('.usa-phone-input')
+      expect(rendered).to have_css(
+        'details.usa-phone-input__country .usa-phone-input__country-toggle',
+      )
+      expect(rendered).to have_css(
+        ".usa-phone-input__country-radio[name='new_phone_form[international_code]'][value='US']",
+        visible: :all,
+      )
+      expect(rendered).to have_css(
+        ".usa-phone-input input.usa-phone-input__input[type='tel'][name='new_phone_form[phone]']",
+      )
+      expect(rendered).to have_css('.radio-group')
+      expect(rendered).to have_css(
+        ".radio-group .radio__input[name='new_phone_form[otp_delivery_preference]'][value='sms']",
+        visible: :all,
+      )
+      expect(rendered).to have_css(
+        ".radio-group .radio__input[name='new_phone_form[otp_delivery_preference]'][value='voice']",
+        visible: :all,
+      )
+    end
+
+    it 'visually hides the delivery preference legend for screen readers' do
+      expect(rendered).to have_css(
+        'legend.usa-sr-only',
+        text: t('two_factor_authentication.otp_delivery_preference.title'),
+      )
+    end
+
+    it 'posts the form to phone_setup_path with the send code button' do
+      expect(rendered).to have_css("form[action='#{phone_setup_path}']")
+      expect(rendered).to have_button(t('forms.buttons.send_one_time_code'))
+    end
+
+    it 'renders a link to choose another method' do
+      expect(rendered).to have_link(
+        t('nds.mfa.choose_another_method'),
+        href: authentication_methods_setup_path,
+      )
+    end
+
+    context 'during account creation' do
+      let(:in_account_creation_flow) { true }
+
+      it 'sets the header progress to Security substep 1 / 2' do
+        rendered
+        progress = view.content_for(:nds_header_progress)
+        expect(progress).to have_css('nds-progress.progress')
+        expect(progress).to have_css(
+          '.progress__step[aria-current="step"] .progress__step-counter',
+          text: '1 / 2',
+        )
+      end
+
+      context 'with a method already configured' do
+        let(:enabled_mfa_methods_count) { 1 }
+
+        it 'sets the header progress to Security substep 2 / 2' do
+          rendered
+          progress = view.content_for(:nds_header_progress)
+          expect(progress).to have_css(
+            '.progress__step[aria-current="step"] .progress__step-counter',
+            text: '2 / 2',
+          )
+        end
+      end
+    end
+
+    context 'during sign-in (not account creation)' do
+      let(:in_account_creation_flow) { false }
+
+      it 'does not render the header progress stepper' do
+        rendered
+        expect(view.content_for(:nds_header_progress)).to be_blank
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/97
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Adds the NDS (redesigned) version of the phone setup page
(`users/phone_setup#index` — add a phone number as an MFA method / "Enter your
phone number"). The view is wrapped in `if nds_layout? … else …(legacy verbatim)… end`
so the legacy control bucket is byte-for-byte unchanged.

The NDS branch renders an `NDS::FormPageComponent` card with:

- A bespoke floating-label **phone number pill** (`.usa-phone-input`): a single
  bordered control grouping a `+1 ⌄` country-code `<details>` disclosure
  (design-system `.popover-menu` of radio options, so it submits without
  JavaScript) with a floating-label telephone field. This matches the Figma
  `PhoneNumberInput` component, not `NDS::InputComponent`.
- A **delivery-preference** bordered card (flat `.radio-group` / `.radio`) with
  "Text message" / "Phone call" radios and an inset divider rule.
- A full-width primary "Send one-time code" submit gated until the phone number
  is valid, and a tertiary full-width "Choose another method" / "Cancel" action
  mirroring the legacy logic.

The account-creation security stepper is shown only when
`in_account_creation_flow?`. Preserves the existing form contract (same action /
params, `international_code`, `phone`, `otp_delivery_preference`) and the phone
JS packs, so registration behaves identically.

Also:
- Adds client-side phone formatting + inline validation (an `enhancePhoneInputs`
  behavior in the `input-validation` package, with specs).
- Adds `expand_more`-aliased `chevron_down` NDS icon SVGs (16/20/24) for the
  country-code chevron via `NDS::IconComponent`.
- New `nds.phone_setup.*` i18n keys (en/es/fr/zh) matching the Figma copy;
  reuses the shared `nds.mfa.choose_another_method` key. Existing shared keys
  untouched.
- Wires the page into the dev-only NDS explorer catalog + fabricator.

## 👀 Preview

- Live via the dev NDS explorer: http://localhost:3002/test/nds/phone-setup
  (permutations: first MFA / second MFA configured / voice preferred /
  sign-in no-stepper / phone error)
- Explorer index: http://localhost:3002/test/nds
- The real page: `/phone_setup`

## 📜 Testing Plan

- [ ] `bundle exec rspec spec/views/phone_setup/index.html.erb_spec.rb`
- [ ] `bundle exec rspec spec/services/test/nds_page_catalog_spec.rb spec/requests/test/nds_pages_spec.rb`
- [ ] `bundle exec rspec spec/i18n_spec.rb`
- [ ] `yarn test app/javascript/packages/input-validation/input-element.spec.ts`
- [ ] erb_lint / rubocop / zeitwerk:check clean
- [ ] `/test/nds/phone-setup` renders under the NDS layout; non-NDS bucket unchanged