### PR TITLE
Add the NDS duplicate-profiles-detected page

### DIFF
--- a/app/views/duplicate_profiles_detected/show.html.erb
+++ b/app/views/duplicate_profiles_detected/show.html.erb
@@ -1,5 +1,200 @@
 <% self.title = @dupe_profiles_detected_presenter.heading %>
 
+<% if nds_layout? %>
+  <%= render NDS::FormPageComponent.new(
+        title: @dupe_profiles_detected_presenter.heading,
+        subtitle: t(
+          'nds.duplicate_profiles_detected.intro_html',
+          app_name: APP_NAME,
+          sp_name: decorated_sp_session.sp_name,
+          link_html: new_tab_link_to(
+            t('nds.duplicate_profiles_detected.learn_more_link'),
+            MarketingSite.help_center_article_url(
+              category: 'manage-your-account',
+              article: 'resolve-duplicate-accounts',
+            ),
+          ),
+        ),
+        class_name: 'duplicate-profiles',
+      ) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--warning">
+        <%= render NDS::IconComponent.new(icon: :warning, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <%= render NDS::StackComponent.new(kind: :form, align: :stretch) do %>
+        <hr class="divider" />
+
+        <p class="duplicate-profiles__instructions">
+          <%= t('nds.duplicate_profiles_detected.instructions') %>
+        </p>
+
+        <ol class="process-list">
+          <li class="process-list__item">
+            <span class="process-list__marker" aria-hidden="true"></span>
+            <div class="process-list__body">
+              <h2 class="process-list__heading">
+                <%= t('nds.duplicate_profiles_detected.step_1.heading') %>
+              </h2>
+              <p><%= t('nds.duplicate_profiles_detected.step_1.body') %></p>
+              <p>
+                <%= t(
+                      'nds.duplicate_profiles_detected.step_1.connected_html',
+                      link_html: link_to(
+                        t('nds.duplicate_profiles_detected.step_1.account_link'),
+                        account_path,
+                      ),
+                    ) %>
+              </p>
+            </div>
+          </li>
+          <li class="process-list__item">
+            <span class="process-list__marker" aria-hidden="true"></span>
+            <div class="process-list__body">
+              <h2 class="process-list__heading">
+                <%= t('nds.duplicate_profiles_detected.step_2.heading') %>
+              </h2>
+              <p>
+                <%= t(
+                      'nds.duplicate_profiles_detected.step_2.body_html',
+                      login_link_html: new_tab_link_to(
+                        'https://secure.login.gov',
+                        'https://secure.login.gov',
+                      ),
+                      delete_link_html: new_tab_link_to(
+                        t('nds.duplicate_profiles_detected.step_2.delete_link'),
+                        MarketingSite.help_center_article_url(
+                          category: 'manage-your-account',
+                          article: 'delete-your-account',
+                        ),
+                      ),
+                    ) %>
+              </p>
+            </div>
+          </li>
+          <li class="process-list__item">
+            <span class="process-list__marker" aria-hidden="true"></span>
+            <div class="process-list__body">
+              <h2 class="process-list__heading">
+                <%= t(
+                      'nds.duplicate_profiles_detected.step_3.heading',
+                      sp_name: decorated_sp_session.sp_name,
+                    ) %>
+              </h2>
+              <p>
+                <%= t(
+                      'nds.duplicate_profiles_detected.step_3.body',
+                      sp_name: decorated_sp_session.sp_name,
+                      app_name: APP_NAME,
+                    ) %>
+              </p>
+            </div>
+          </li>
+        </ol>
+
+        <div class="duplicate-profiles__accounts">
+          <% @dupe_profiles_detected_presenter.associated_profiles.each_with_index do |dupe_profile, index| %>
+            <% if index.positive? %>
+              <hr class="duplicate-profiles__account-divider" />
+            <% end %>
+            <div class="duplicate-profiles__account">
+              <% if dupe_profile[:current_account] %>
+                <span class="badge badge--success">
+                  <%= t('nds.duplicate_profiles_detected.signed_in') %>
+                </span>
+              <% else %>
+                <span class="badge badge--warning">
+                  <%= t('nds.duplicate_profiles_detected.duplicate') %>
+                </span>
+              <% end %>
+
+              <div class="duplicate-profiles__details">
+                <p class="duplicate-profiles__email">
+                  <% if dupe_profile[:current_account] %>
+                    <%= dupe_profile[:email] %>
+                  <% else %>
+                    <%= dupe_profile[:masked_email] %>
+                  <% end %>
+                </p>
+                <div class="duplicate-profiles__meta">
+                  <p>
+                    <%= t(
+                          'nds.duplicate_profiles_detected.created_at_html',
+                          timestamp_html: render(TimeComponent.new(time: dupe_profile[:created_at])),
+                        ) %>
+                  </p>
+                  <% if dupe_profile[:current_account] %>
+                    <p>
+                      <%= t(
+                            'nds.duplicate_profiles_detected.connected_agencies',
+                            count: dupe_profile[:connected_accts],
+                          ) %>
+                    </p>
+                  <% elsif dupe_profile[:last_sign_in] %>
+                    <p>
+                      <%= t(
+                            'nds.duplicate_profiles_detected.last_sign_in_html',
+                            timestamp_html: render(TimeComponent.new(time: dupe_profile[:last_sign_in])),
+                          ) %>
+                    </p>
+                  <% else %>
+                    <p>
+                      <%= t(
+                            'nds.duplicate_profiles_detected.never_signed_in',
+                            sp_name: decorated_sp_session.sp_name,
+                          ) %>
+                    </p>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          <% end %>
+
+          <hr class="duplicate-profiles__account-divider" />
+          <%= render ButtonComponent.new(
+                url: duplicate_profiles_please_call_path(source: 'dont_recognize'),
+                method: :get,
+                variant: :tertiary,
+                full_width: true,
+              ).with_content(t('nds.duplicate_profiles_detected.dont_recognize_account')) %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+        <%= render ButtonComponent.new(
+              url: MarketingSite.help_center_article_url(
+                category: 'manage-your-account',
+                article: 'resolve-duplicate-accounts',
+              ),
+              full_width: true,
+              target: '_blank',
+              rel: 'noopener noreferrer',
+              class: 'duplicate-profiles__get-help',
+            ) do %>
+          <span><%= t('nds.duplicate_profiles_detected.get_help') %></span>
+          <%= render NDS::IconComponent.new(icon: :launch, size: 20) %>
+          <span class="usa-sr-only"><%= t('links.new_tab') %></span>
+        <% end %>
+        <%= render ButtonComponent.new(
+              url: logout_path,
+              method: :delete,
+              variant: :secondary,
+              full_width: true,
+            ).with_content(t('nds.duplicate_profiles_detected.sign_out')) %>
+        <%= render ButtonComponent.new(
+              url: duplicate_profiles_please_call_path(source: 'cant_access'),
+              method: :get,
+              variant: :tertiary,
+              full_width: true,
+            ).with_content(t('nds.duplicate_profiles_detected.cant_access')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render StatusPageComponent.new(status: :warning) do |c| %>
   <% c.with_header { @dupe_profiles_detected_presenter.heading } %>
 
@@ -98,4 +293,5 @@
           unstyled: true,
         ).with_content(t('duplicate_profiles_detected.cant_access')) %>
   </div>
+<% end %>
 <% end %>

--- a/spec/views/duplicate_profiles_detected/show.html.erb_spec.rb
+++ b/spec/views/duplicate_profiles_detected/show.html.erb_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+RSpec.describe 'duplicate_profiles_detected/show.html.erb' do
+  let(:sp_name) { 'Veterans Affairs' }
+  let(:decorated_sp_session) { double('DecoratedSpSession', sp_name:) }
+  let(:associated_profiles) do
+    [
+      {
+        email: 'john@example.com',
+        masked_email: 'j****n@example.com',
+        last_sign_in: nil,
+        created_at: Time.zone.local(2025, 4, 15, 20, 18),
+        connected_accts: 5,
+        current_account: true,
+      },
+      {
+        email: 'jane.doe@example.com',
+        masked_email: 'j******e@example.com',
+        last_sign_in: Time.zone.local(2026, 9, 2, 12, 0),
+        created_at: Time.zone.local(2025, 4, 15, 20, 18),
+        connected_accts: 5,
+        current_account: false,
+      },
+    ]
+  end
+  let(:presenter) do
+    instance_double(
+      DuplicateProfilesDetectedPresenter,
+      heading: t('duplicate_profiles_detected.heading'),
+      associated_profiles:,
+    )
+  end
+
+  before do
+    allow(view).to receive(:duplicate_profiles_please_call_path) do |arg = nil, source: nil|
+      duplicate_profiles_please_call_path(source: source || arg)
+    end
+    allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
+    allow(view).to receive(:nds_layout?).and_return(false)
+    @dupe_profiles_detected_presenter = presenter
+  end
+
+  it 'sets the page title to the heading' do
+    expect(view).to receive(:title=).with(t('duplicate_profiles_detected.heading'))
+
+    render
+  end
+
+  it 'renders the legacy status page in the default layout' do
+    render
+
+    expect(rendered).to have_selector('.usa-process-list')
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the heading and intro' do
+      render
+
+      expect(rendered).to have_selector('section.auth.auth--form-page.duplicate-profiles')
+      expect(rendered).to have_selector(
+        '.auth--form-page h1',
+        text: t('duplicate_profiles_detected.heading'),
+      )
+      expect(rendered).to have_selector(
+        '.auth__intro-description',
+        text: sp_name,
+      )
+    end
+
+    it 'renders the warning status icon' do
+      render
+
+      expect(rendered).to have_selector('.nds-status-icon.nds-status-icon--warning svg.usa-icon')
+    end
+
+    it 'renders the three-step process list' do
+      render
+
+      expect(rendered).to have_selector('ol.process-list .process-list__item', count: 3)
+      expect(rendered).to have_selector(
+        '.process-list__heading',
+        text: t('nds.duplicate_profiles_detected.step_1.heading'),
+      )
+      expect(rendered).to have_link(
+        t('nds.duplicate_profiles_detected.step_1.account_link'),
+        href: account_path,
+      )
+    end
+
+    it 'renders a card per associated profile with status badges' do
+      render
+
+      expect(rendered).to have_selector('.duplicate-profiles__account', count: 2)
+      expect(rendered).to have_selector(
+        '.badge--success',
+        text: t('nds.duplicate_profiles_detected.signed_in'),
+      )
+      expect(rendered).to have_selector(
+        '.badge--warning',
+        text: t('nds.duplicate_profiles_detected.duplicate'),
+      )
+      expect(rendered).to have_content('john@example.com')
+      expect(rendered).to have_content('j******e@example.com')
+    end
+
+    it 'renders the get-help, sign-out, and support actions' do
+      render
+
+      expect(rendered).to have_link(
+        t('nds.duplicate_profiles_detected.get_help'),
+        href: MarketingSite.help_center_article_url(
+          category: 'manage-your-account',
+          article: 'resolve-duplicate-accounts',
+        ),
+      )
+      expect(rendered).to have_button(t('nds.duplicate_profiles_detected.sign_out'))
+      expect(rendered).to have_link(
+        t('nds.duplicate_profiles_detected.dont_recognize_account'),
+        href: duplicate_profiles_please_call_path(source: 'dont_recognize'),
+      )
+      expect(rendered).to have_link(
+        t('nds.duplicate_profiles_detected.cant_access'),
+        href: duplicate_profiles_please_call_path(source: 'cant_access'),
+      )
+    end
+
+    it 'shows the never-signed-in copy for a duplicate that never signed in' do
+      associated_profiles[1][:last_sign_in] = nil
+
+      render
+
+      expect(rendered).to have_content(
+        t('nds.duplicate_profiles_detected.never_signed_in', sp_name:),
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- [NDS: duplicate profiles detected page (#110)](https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/110)
- [Implement NDS personal key, process list, and duplicate profiles overlays (#55)](https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/55)
- [NDS auth-flow refresh umbrella (#57)](https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57)

## 🛠 Summary of changes

Renders an NDS variant of `duplicate_profiles_detected#show` behind the `nds_layout?` A/B bucket. The legacy (control) branch is **byte-identical** — the new markup lives entirely in the `if nds_layout?` branch.

The NDS branch uses `NDS::FormPageComponent` with:
- an `.nds-status-icon--warning` header status circle (warning triangle glyph),
- a numbered `.process-list` of the three resolution steps,
- a **single outer card** listing each associated profile, separated by internal dividers, with `.badge--success` ("Signed in") / `.badge--warning` ("Duplicate") status badges and the "I don't recognize an account above" action in the card footer,
- get-help (external) / sign-out / "I can't access an account" actions.

Also adds the `warning/24.svg` (triangle) and `launch/20.svg` NDS glyphs and drops the `warning → error` icon alias so `icon: :warning` resolves to its own glyph.

### Cross-repo dependencies

- **Depends on / blocked-by** the IDS `_status-icon.scss` MR (adds `.nds-status-icon` + the `--warning` modifier, owned separately). The header status circle will not render until that IDS MR merges to IDS main.
- Accompanied by an IDS MR for `_duplicate-profiles.scss` (`__instructions` / `__accounts` (the card) / `__account` / `__account-divider` / `__email` / `__meta` / `__get-help`, composing the `.process-list` and `.badge` overlays).

> Note: because the shared locale files and the dev NDS explorer catalog/controller are frozen (`--skip-worktree`) during the parallel NDS effort, this PR is page-only. Its i18n keys and explorer wiring land via the consolidation PR, so server-side i18n/catalog CI is expected to fail until then.

## 👀 Preview

Dev NDS explorer: `/test/nds/duplicate-profiles-detected` — permutations **Default** and **Duplicate never signed in**.

## 📜 Testing Plan

- [ ] `spec/views/duplicate_profiles_detected/show.html.erb_spec.rb`
- [ ] `spec/i18n_spec.rb`
- [ ] `spec/services/test/nds_page_catalog_spec.rb`
- [ ] `spec/requests/test/nds_pages_spec.rb`
- [ ] `erb_lint` the view; `rubocop` changed `.rb`; `rake zeitwerk:check`
- [ ] Confirm the legacy (control bucket) render is unchanged