### PR TITLE
Add the NDS identity-verification unavailable page

### DIFF
--- a/app/views/idv/unavailable/show.html.erb
+++ b/app/views/idv/unavailable/show.html.erb
@@ -1,5 +1,50 @@
 <% self.title = t('idv.titles.unavailable') %>
 
+<% if nds_layout? %>
+  <%= render NDS::FormPageComponent.new(
+        title: t('idv.titles.unavailable'),
+      ) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--error">
+        <%= render NDS::IconComponent.new(icon: :error, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <hr class="divider" />
+
+      <p>
+        <% if decorated_sp_session.sp_name.present? %>
+          <%= t('idv.unavailable.idv_explanation.with_sp_html', sp: decorated_sp_session.sp_name) %>
+        <% else %>
+          <%= t('idv.unavailable.idv_explanation.without_sp') %>
+        <% end %>
+      </p>
+
+      <p>
+        <%= t('idv.unavailable.technical_difficulties') %>
+      </p>
+
+      <p>
+        <%= t(
+              'idv.unavailable.next_steps_html',
+              app_name: APP_NAME,
+              status_page_link_html: new_tab_link_to(
+                t('idv.unavailable.status_page_link'),
+                StatusPage.base_url,
+              ),
+            ) %>
+      </p>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render ButtonComponent.new(
+            url: return_to_sp_failure_to_proof_path(step: :unavailable, location: :unavailable),
+            full_width: true,
+          ).with_content(t('idv.unavailable.exit_button', app_name: APP_NAME)) %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render StatusPageComponent.new(status: :error) do |c| %>
 
   <% c.with_header { t('idv.titles.unavailable') } %>
@@ -33,4 +78,5 @@
        wide: true,
      ).with_content(t('idv.unavailable.exit_button', app_name: APP_NAME)) %>
 
+<% end %>
 <% end %>

--- a/spec/views/idv/unavailable/show.html.erb_spec.rb
+++ b/spec/views/idv/unavailable/show.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'idv/unavailable/show.html.erb' do
   subject(:rendered) { render }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     allow(view).to receive(:decorated_sp_session).and_return(
       instance_double(ServiceProviderSession, sp_name: sp_name),
     )
@@ -47,6 +48,83 @@ RSpec.describe 'idv/unavailable/show.html.erb' do
     let(:sp_name) { 'Department of Ice Cream' }
     it 'renders the explanation with the sp name' do
       expect(rendered).to include(sp_name)
+    end
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    render
+
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the unavailable heading' do
+      render
+
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector('.auth--form-page h1', text: t('idv.titles.unavailable'))
+    end
+
+    it 'renders the error status-icon badge above the heading' do
+      render
+
+      expect(rendered).to have_selector('.auth__header--with-media .nds-status-icon--error')
+      expect(rendered).to have_selector('.nds-status-icon--error .usa-icon')
+    end
+
+    it 'renders a divider under the heading' do
+      render
+
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+    end
+
+    it 'renders the technical-difficulties and next-steps body copy' do
+      render
+
+      expect(rendered).to have_selector(
+        '.auth__form-page-body',
+        text: t('idv.unavailable.technical_difficulties'),
+      )
+      expect(rendered).to have_selector(
+        '.auth__form-page-body a[target=_blank]',
+        text: t('idv.unavailable.status_page_link'),
+      )
+    end
+
+    it 'renders the exit action button to the failure-to-proof path' do
+      render
+
+      expect(rendered).to have_selector('.auth__actions')
+      expect(rendered).to have_link(
+        t('idv.unavailable.exit_button', app_name: APP_NAME),
+        href: return_to_sp_failure_to_proof_path(step: 'unavailable', location: 'unavailable'),
+      )
+    end
+
+    it 'renders the without-sp explanation by default' do
+      render
+
+      expect(rendered).to have_content(t('idv.unavailable.idv_explanation.without_sp'))
+    end
+
+    it 'does not render any l13n markers' do
+      render
+
+      expect(rendered).not_to include('%{')
+    end
+
+    context 'with sp' do
+      let(:sp_name) { 'Department of Ice Cream' }
+
+      it 'renders the explanation with the sp name' do
+        render
+
+        expect(rendered).to include(sp_name)
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/111
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Renders `idv/unavailable#show` under the NDS design system behind the `nds_layout?` bucket:

- New NDS branch built with `NDS::FormPageComponent`: an error status badge (`.nds-status-icon--error`) above the heading, a divider placed manually under the heading (matching Figma), the existing explanation / technical-difficulties / next-steps copy, and a primary full-width exit action.
- The legacy `StatusPageComponent` branch is preserved **byte-for-byte** in the `else` branch.
- Reuses the existing `idv.unavailable.*` i18n copy verbatim — **no new locale keys**.
- Adds the app-side `error/24.svg` glyph consumed by `NDS::IconComponent(icon: :error)`.
- Wires the page into the dev NDS explorer catalog (working-tree-only, per the shared-file freeze model).

**Dependency:** the header status circle styling comes from the separate IDS `_status-icon.scss` MR (`.nds-status-icon` + `--error`). The badge will not be styled until that IDS MR merges to IDS main; the glyph and markup ship here.

## 👀 Preview

Dev NDS explorer: `/test/nds/idv-unavailable`

- Default
- With service provider (`?sp=1`)

## 📜 Testing Plan

- `spec/views/idv/unavailable/show.html.erb_spec.rb`
- `spec/i18n_spec.rb`
- `spec/services/test/nds_page_catalog_spec.rb`
- `spec/requests/test/nds_pages_spec.rb`
- `erb_lint` the view
- `rake zeitwerk:check`