### PR TITLE
Add the NDS delete-backup-codes page

### DIFF
--- a/app/views/users/backup_code_setup/confirm_delete.html.erb
+++ b/app/views/users/backup_code_setup/confirm_delete.html.erb
@@ -1,5 +1,36 @@
 <% self.title = t('forms.backup_code.confirm_delete') %>
 
+<% if nds_layout? %>
+  <%= render NDS::FormPageComponent.new(title: t('forms.backup_code.confirm_delete')) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--warning">
+        <%= render NDS::IconComponent.new(icon: :warning, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <%= tag.hr(class: 'divider') %>
+      <div class="copy copy--muted">
+        <p><%= t('forms.backup_code.caution_delete') %></p>
+      </div>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+        <%= render ButtonComponent.new(
+              url: backup_code_delete_path,
+              method: :delete,
+              full_width: true,
+            ).with_content(t('account.index.backup_code_confirm_delete')) %>
+        <%= render ButtonComponent.new(
+              url: account_path,
+              variant: :tertiary,
+              full_width: true,
+            ).with_content(t('links.cancel')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-4') %>
 
 <%= render PageHeadingComponent.new.with_content(t('forms.backup_code.confirm_delete')) %>
@@ -15,3 +46,4 @@
 
 <%= link_to t('links.cancel'), account_path,
             class: 'usa-button usa-button--big usa-button--wide usa-button--outline' %>
+<% end %>

--- a/spec/views/users/backup_code_setup/confirm_delete.html.erb_spec.rb
+++ b/spec/views/users/backup_code_setup/confirm_delete.html.erb_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe 'users/backup_code_setup/confirm_delete.html.erb' do
+  before do
+    allow(view).to receive(:nds_layout?).and_return(false)
+  end
+
+  it 'has a localized title' do
+    expect(view).to receive(:title=).with(t('forms.backup_code.confirm_delete'))
+
+    render
+  end
+
+  context 'in the default layout' do
+    it 'renders the legacy heading and caution copy' do
+      render
+
+      expect(rendered).to have_css('h1', text: t('forms.backup_code.confirm_delete'))
+      expect(rendered).to have_content(t('forms.backup_code.caution_delete'))
+    end
+
+    it 'submits the delete form and links to cancel' do
+      render
+
+      expect(rendered).to have_css(
+        "form[action='#{backup_code_delete_path}'] [name=_method][value=delete]",
+        visible: :all,
+      )
+      expect(rendered).to have_button(t('account.index.backup_code_confirm_delete'))
+      expect(rendered).to have_link(t('links.cancel'), href: account_path)
+    end
+
+    it 'does not render the NDS form-page card' do
+      render
+
+      expect(rendered).to_not have_selector('.auth--form-page')
+    end
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the confirm-delete heading' do
+      render
+
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector(
+        '.auth--form-page h1',
+        text: t('forms.backup_code.confirm_delete'),
+      )
+    end
+
+    it 'renders the warning status icon' do
+      render
+
+      expect(rendered).to have_selector('.nds-status-icon.nds-status-icon--warning .usa-icon')
+    end
+
+    it 'renders the caution copy and a divider' do
+      render
+
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+      expect(rendered).to have_content(t('forms.backup_code.caution_delete'))
+    end
+
+    it 'renders the delete submit button posting to the backup code delete path' do
+      render
+
+      expect(rendered).to have_css(
+        "form[action='#{backup_code_delete_path}'] [name=_method][value=delete]",
+        visible: :all,
+      )
+      expect(rendered).to have_button(t('account.index.backup_code_confirm_delete'))
+    end
+
+    it 'renders the cancel button linking to the account path' do
+      render
+
+      expect(rendered).to have_link(t('links.cancel'), href: account_path)
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/112
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Render an NDS variant of `users/backup_code_setup#confirm_delete` when `nds_layout?` is true; the default (legacy) branch is byte-identical to before.

- Uses `NDS::FormPageComponent` for the centered form-page card: a warning `.nds-status-icon` badge, a divider, muted caution copy, a primary "Yes, delete codes" submit button posting `DELETE` to `backup_code_delete_path`, and a tertiary Cancel button to the account page.
- Reuses the existing plural `forms.backup_code.confirm_delete` / `forms.backup_code.caution_delete` keys plus `account.index.backup_code_confirm_delete` and `links.cancel` — **zero new locale keys**.

### ⚠️ Dependency

This page renders `.nds-status-icon--warning` (styled by the IDS status-icon work) and `NDS::IconComponent.new(icon: :warning)`, which depends on the shared NDS icon scaffolding — the `warning/24.svg` glyph and the removal of the `warning: :error` alias in `app/components/nds/icon_component.rb` — landing via the consolidation PR. The badge/glyph will not render until the IDS status-icon styles and the consolidation PR land.

## 👀 Preview

Dev NDS explorer: `/test/nds/backup-code-delete`

## 📜 Testing Plan

- `bundle exec rspec spec/views/users/backup_code_setup/confirm_delete.html.erb_spec.rb`
- `bundle exec rspec spec/i18n_spec.rb`
- `bundle exec rspec spec/services/test/nds_page_catalog_spec.rb`
- `bundle exec rspec spec/requests/test/nds_pages_spec.rb`
- `bundle exec erb_lint app/views/users/backup_code_setup/confirm_delete.html.erb`
- `bundle exec rubocop` on changed Ruby
- `bundle exec rake zeitwerk:check`
- `make optimize_svg`