### PR TITLE
Add the NDS service-provider inactive page

### DIFF
--- a/app/views/users/service_provider_inactive/index.html.erb
+++ b/app/views/users/service_provider_inactive/index.html.erb
@@ -1,5 +1,35 @@
 <% self.title = t('service_providers.errors.inactive.heading', sp_name: @sp_name, app_name: APP_NAME) %>
 
+<% if nds_layout? %>
+  <%= render NDS::FormPageComponent.new(
+        title: t('service_providers.errors.inactive.heading', sp_name: @sp_name, app_name: APP_NAME),
+      ) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--error">
+        <%= render NDS::IconComponent.new(icon: :error, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <hr class="divider" />
+
+      <p>
+        <%= t('service_providers.errors.inactive.instructions', sp_name: @sp_name, app_name: APP_NAME) %>
+      </p>
+
+      <p>
+        <%= t('service_providers.errors.inactive.instructions2') %>
+      </p>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render ButtonComponent.new(
+            url: root_path,
+            full_width: true,
+          ).with_content(t('service_providers.errors.inactive.button_text', app_name: APP_NAME)) %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render StatusPageComponent.new(status: :error) do |c| %>
   <% c.with_header { t('service_providers.errors.inactive.heading', sp_name: @sp_name, app_name: APP_NAME) } %>
 
@@ -13,4 +43,5 @@
 
   <% c.with_action_button(url: root_path)
        .with_content(t('service_providers.errors.inactive.button_text', app_name: APP_NAME)) %>
+<% end %>
 <% end %>

--- a/spec/views/users/service_provider_inactive/index.html.erb_spec.rb
+++ b/spec/views/users/service_provider_inactive/index.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'users/service_provider_inactive/index.html.erb' do
   subject(:rendered) { render }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     assign(:sp_name, sp_name)
   end
 
@@ -14,5 +15,63 @@ RSpec.describe 'users/service_provider_inactive/index.html.erb' do
       'h1',
       text: t('service_providers.errors.inactive.heading', sp_name:, app_name: APP_NAME),
     )
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the inactive heading' do
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector(
+        '.auth--form-page h1',
+        text: t('service_providers.errors.inactive.heading', sp_name:, app_name: APP_NAME),
+      )
+    end
+
+    it 'renders the error status-icon badge above the heading' do
+      expect(rendered).to have_selector('.auth__header--with-media .nds-status-icon--error')
+      expect(rendered).to have_selector('.nds-status-icon--error .usa-icon')
+    end
+
+    it 'renders a divider under the heading' do
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+    end
+
+    it 'renders the instructions body copy' do
+      expect(rendered).to have_selector(
+        '.auth__form-page-body',
+        text: t('service_providers.errors.inactive.instructions', sp_name:, app_name: APP_NAME),
+      )
+      expect(rendered).to have_selector(
+        '.auth__form-page-body',
+        text: t('service_providers.errors.inactive.instructions2'),
+      )
+    end
+
+    it 'renders the return action button to the root path' do
+      expect(rendered).to have_selector('.auth__actions')
+      expect(rendered).to have_link(
+        t('service_providers.errors.inactive.button_text', app_name: APP_NAME),
+        href: root_path,
+      )
+    end
+
+    it 'does not render any l13n markers' do
+      expect(rendered).not_to include('%{')
+    end
+
+    context 'with a named service provider' do
+      let(:sp_name) { 'Department of Ice Cream' }
+
+      it 'renders the heading with the sp name' do
+        expect(rendered).to have_selector('.auth--form-page h1', text: sp_name)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/113
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Renders `users/service_provider_inactive#index` under the NDS design system behind the `nds_layout?` bucket, styled identically to the NDS idv-unavailable error page (#13479):

- NDS branch built with `NDS::FormPageComponent`: the shared error status badge (`.nds-status-icon--error`) above the heading, a divider under the heading, the existing instructions copy, and a primary return-to-account action.
- The legacy `StatusPageComponent` branch is preserved **byte-for-byte** in the `else` branch.
- Reuses the existing `service_providers.errors.inactive.*` i18n copy verbatim — **no new locale keys**.
- Wires the page into the dev NDS explorer catalog (working-tree-only, per the shared-file freeze model).

**Dependencies:** badge styling comes from the IDS `_status-icon.scss` change (`.nds-status-icon` + `--error`) and the `error/24.svg` glyph ships via the shared NDS icon scaffolding consolidation, not this PR.

## 👀 Preview

Dev NDS explorer: `/test/nds/sp-inactive`

- Generic service provider
- Named service provider (`?sp=1`)

## 📜 Testing Plan

- `spec/views/users/service_provider_inactive/index.html.erb_spec.rb`
- `spec/i18n_spec.rb`
- `spec/services/test/nds_page_catalog_spec.rb`
- `spec/requests/test/nds_pages_spec.rb`
- `erb_lint` the view
- `rake zeitwerk:check`