### PR TITLE
Add the NDS banned-user page

### DIFF
--- a/app/views/banned_user/show.html.erb
+++ b/app/views/banned_user/show.html.erb
@@ -1,7 +1,25 @@
 <% self.title = t('banned_user.title') %>
 
+<% if nds_layout? %>
+  <%= render NDS::FormPageComponent.new(title: t('banned_user.title')) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--error">
+        <%= render NDS::IconComponent.new(icon: :error, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <hr class="divider" />
+
+      <p>
+        <%= t('banned_user.details') %>
+      </p>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render AlertIconComponent.new(icon_name: :error, class: 'display-block margin-bottom-4') %>
 <%= render PageHeadingComponent.new.with_content(t('banned_user.title')) %>
 <p>
   <%= t('banned_user.details') %>
 </p>
+<% end %>

--- a/spec/views/banned_user/show.html.erb_spec.rb
+++ b/spec/views/banned_user/show.html.erb_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'banned_user/show.html.erb' do
+  subject(:rendered) { render }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(false)
+  end
+
+  it 'sets a title' do
+    expect(view).to receive(:title=).with(t('banned_user.title'))
+    render
+  end
+
+  it 'renders the heading and details' do
+    expect(rendered).to have_selector('h1', text: t('banned_user.title'))
+    expect(rendered).to have_content(t('banned_user.details'))
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the heading' do
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector('.auth--form-page h1', text: t('banned_user.title'))
+    end
+
+    it 'renders the error status-icon badge above the heading' do
+      expect(rendered).to have_selector('.auth__header--with-media .nds-status-icon--error')
+      expect(rendered).to have_selector('.nds-status-icon--error .usa-icon')
+    end
+
+    it 'renders a divider under the heading' do
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+    end
+
+    it 'renders the details body copy' do
+      expect(rendered).to have_selector('.auth__form-page-body', text: t('banned_user.details'))
+    end
+
+    it 'does not render any l13n markers' do
+      expect(rendered).not_to include('%{')
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/114
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Renders `banned_user#show` (`/restricted`) under the NDS design system behind the `nds_layout?` bucket, using the same status-icon error page pattern as #13479 / #13481:

- `NDS::FormPageComponent` with the shared `.nds-status-icon--error` badge above the heading, a divider under the heading, and the existing details copy.
- Legacy branch preserved **byte-for-byte**; existing `banned_user.*` copy reused verbatim — **no new locale keys**.
- Explorer catalog wiring lands via the shared-file consolidation (freeze model).

**Dependencies:** badge styling from the IDS `_status-icon.scss` change; `error/24.svg` glyph ships via the shared NDS icon scaffolding consolidation.

## 👀 Preview

Dev NDS explorer: `/test/nds/banned-user`

## 📜 Testing Plan

- `spec/views/banned_user/show.html.erb_spec.rb`
- `spec/i18n_spec.rb`, `spec/services/test/nds_page_catalog_spec.rb`, `spec/requests/test/nds_pages_spec.rb`
- `erb_lint` the view