### PR TITLE
Add the NDS device-profiling-failed page

### DIFF
--- a/app/views/device_profiling_failed/show.html.erb
+++ b/app/views/device_profiling_failed/show.html.erb
@@ -1,5 +1,27 @@
 <% self.title = t('profiling_failed.title') %>
 
+<% if nds_layout? %>
+  <%= render NDS::FormPageComponent.new(title: t('profiling_failed.title')) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--error">
+        <%= render NDS::IconComponent.new(icon: :error, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <hr class="divider" />
+
+      <p>
+        <%= t('profiling_failed.details_html') %>
+      </p>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render ButtonComponent.new(url: root_url)
+            .with_content(t('links.exit_login', app_name: APP_NAME)) %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render AlertIconComponent.new(icon_name: :error, class: 'display-block margin-bottom-4') %>
 <%= render PageHeadingComponent.new.with_content(t('profiling_failed.title')) %>
 <p>
@@ -11,3 +33,4 @@
       class: 'usa-button usa-button--big usa-button--wide',
     ) { t('links.exit_login', app_name: APP_NAME) } %>
 
+<% end %>

--- a/spec/views/device_profiling_failed/show.html.erb_spec.rb
+++ b/spec/views/device_profiling_failed/show.html.erb_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'device_profiling_failed/show.html.erb' do
+  subject(:rendered) { render }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(false)
+  end
+
+  it 'sets a title' do
+    expect(view).to receive(:title=).with(t('profiling_failed.title'))
+    render
+  end
+
+  it 'renders the heading and exit link' do
+    expect(rendered).to have_selector('h1', text: t('profiling_failed.title'))
+    expect(rendered).to have_link(t('links.exit_login', app_name: APP_NAME), href: root_url)
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the heading' do
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector('.auth--form-page h1', text: t('profiling_failed.title'))
+    end
+
+    it 'renders the error status-icon badge above the heading' do
+      expect(rendered).to have_selector('.auth__header--with-media .nds-status-icon--error')
+      expect(rendered).to have_selector('.nds-status-icon--error .usa-icon')
+    end
+
+    it 'renders a divider under the heading' do
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+    end
+
+    it 'renders the details body copy' do
+      expect(rendered).to have_selector('.auth__form-page-body p')
+    end
+
+    it 'renders the exit action to the root url' do
+      expect(rendered).to have_selector('.auth__actions')
+      expect(rendered).to have_link(t('links.exit_login', app_name: APP_NAME), href: root_url)
+    end
+
+    it 'does not render any l13n markers' do
+      expect(rendered).not_to include('%{')
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/115
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Renders `device_profiling_failed#show` under the NDS design system behind the `nds_layout?` bucket, using the status-icon error page pattern from #13479 / #13481:

- `NDS::FormPageComponent` with the shared `.nds-status-icon--error` badge above the heading, a divider under the heading, the existing details copy, and a primary exit action.
- Legacy branch preserved **byte-for-byte**; existing `profiling_failed.*` copy reused verbatim — **no new locale keys**.
- Explorer catalog wiring lands via the shared-file consolidation (freeze model).

**Dependencies:** badge styling from the IDS `_status-icon.scss` change; `error/24.svg` glyph ships via the shared NDS icon scaffolding consolidation.

## 👀 Preview

Dev NDS explorer: `/test/nds/device-profiling-failed`

## 📜 Testing Plan

- `spec/views/device_profiling_failed/show.html.erb_spec.rb`
- `spec/i18n_spec.rb`, `spec/services/test/nds_page_catalog_spec.rb`, `spec/requests/test/nds_pages_spec.rb`
- `erb_lint` the view