### PR TITLE
Add the NDS sign-in security check failed page

### DIFF
--- a/app/views/sign_in_security_check_failed/show.html.erb
+++ b/app/views/sign_in_security_check_failed/show.html.erb
@@ -1,5 +1,51 @@
 <% self.title = t('security_check_failed.title') %>
 
+<% if nds_layout? %>
+  <%= render NDS::FormPageComponent.new(title: t('security_check_failed.title')) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--warning">
+        <%= render NDS::IconComponent.new(icon: :warning, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <hr class="divider" />
+
+      <p>
+        <%= t('security_check_failed.details') %>
+        <%= new_tab_link_to(
+              t('security_check_failed.learn_more', app_name: APP_NAME),
+              help_center_redirect_path(
+                category: 'trouble-signing-in',
+                article: 'security-check-failed',
+              ),
+            ) %>
+      </p>
+
+      <ul class="usa-list">
+        <li><%= t('security_check_failed.info_p1', app_name: APP_NAME) %></li>
+        <li><%= t('security_check_failed.info_p2_html', piv_cac_url: login_piv_cac_url) %></li>
+        <li><%= t('security_check_failed.info_p3') %></li>
+      </ul>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render ButtonComponent.new(
+            url: contact_redirect_url,
+            target: '_blank',
+            rel: 'noopener',
+            variant: :tertiary,
+          ) do %>
+        <%= t('security_check_failed.contact', app_name: APP_NAME) %>
+        <span class="usa-sr-only"><%= t('links.new_tab') %></span>
+      <% end %>
+      <%= render ButtonComponent.new(
+            url: root_url,
+            variant: :tertiary,
+          ).with_content(t('forms.buttons.back')) %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render StatusPageComponent.new(status: :warning) do |c| %>
   <% c.with_header { t('security_check_failed.title') } %>
   <p>
@@ -30,4 +76,5 @@
 
 <%= render PageFooterComponent.new do %>
   <%= link_to t('forms.buttons.back'), root_url %>
+<% end %>
 <% end %>

--- a/spec/views/sign_in_security_check_failed/show.html.erb_spec.rb
+++ b/spec/views/sign_in_security_check_failed/show.html.erb_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'sign_in_security_check_failed/show.html.erb' do
+  subject(:rendered) { render }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(false)
+  end
+
+  it 'sets a title' do
+    expect(view).to receive(:title=).with(t('security_check_failed.title'))
+    render
+  end
+
+  it 'renders the heading' do
+    expect(rendered).to have_selector('h1', text: t('security_check_failed.title'))
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the heading' do
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector(
+        '.auth--form-page h1',
+        text: t('security_check_failed.title'),
+      )
+    end
+
+    it 'renders the warning status-icon badge above the heading' do
+      expect(rendered).to have_selector('.auth__header--with-media .nds-status-icon--warning')
+      expect(rendered).to have_selector('.nds-status-icon--warning .usa-icon')
+    end
+
+    it 'renders a divider under the heading' do
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+    end
+
+    it 'renders the details, learn-more link, and info list' do
+      expect(rendered).to have_selector(
+        '.auth__form-page-body',
+        text: t('security_check_failed.details'),
+      )
+      expect(rendered).to have_selector(
+        '.auth__form-page-body a[target=_blank]',
+        text: t('security_check_failed.learn_more', app_name: APP_NAME),
+      )
+      expect(rendered).to have_selector('.auth__form-page-body ul.usa-list li', count: 3)
+    end
+
+    it 'renders the contact and back actions' do
+      expect(rendered).to have_selector(
+        '.auth__actions a[target=_blank][href="' + contact_redirect_url + '"]',
+        text: t('security_check_failed.contact', app_name: APP_NAME),
+      )
+      expect(rendered).to have_link(t('forms.buttons.back'), href: root_url)
+    end
+
+    it 'does not render any l13n markers' do
+      expect(rendered).not_to include('%{')
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/116
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Renders `sign_in_security_check_failed#show` under the NDS design system behind the `nds_layout?` bucket, using the status-icon page pattern from #13479 / #13481 with the **warning** variant (mirrors the legacy `StatusPageComponent(status: :warning)`):

- `NDS::FormPageComponent` with the shared `.nds-status-icon--warning` badge above the heading, a divider under the heading, the existing details/learn-more/info-list copy, and tertiary contact-support (new tab) + back actions in place of the legacy troubleshooting options and footer link.
- Legacy branch preserved **byte-for-byte**; existing `security_check_failed.*` copy reused verbatim — **no new locale keys**.
- Explorer catalog wiring lands via the shared-file consolidation (freeze model).

**Dependencies:** badge styling from the IDS `_status-icon.scss` change; `warning/24.svg` glyph + alias removal ship via the shared NDS icon scaffolding consolidation.

## 👀 Preview

Dev NDS explorer: `/test/nds/security-check-failed`

## 📜 Testing Plan

- `spec/views/sign_in_security_check_failed/show.html.erb_spec.rb`
- `spec/i18n_spec.rb`, `spec/services/test/nds_page_catalog_spec.rb`, `spec/requests/test/nds_pages_spec.rb`
- `erb_lint` the view