### PR TITLE
Add the NDS proofing-agent expired page

### DIFF
--- a/app/views/idv/proofing_agent_expired/show.html.erb
+++ b/app/views/idv/proofing_agent_expired/show.html.erb
@@ -1,5 +1,42 @@
 <% self.title = t('idv.proofing_agent_expired.heading') %>
 
+<% if nds_layout? %>
+  <%= simple_form_for(
+        '',
+        url: idv_proofing_agent_expired_path,
+        method: :post,
+        html: { data: { nds_submit_gate: true } },
+      ) do |f| %>
+    <%= render NDS::FormPageComponent.new(title: t('idv.proofing_agent_expired.heading')) do |page| %>
+      <% page.with_media do %>
+        <span class="nds-status-icon nds-status-icon--warning">
+          <%= render NDS::IconComponent.new(icon: :warning, size: 24) %>
+        </span>
+      <% end %>
+
+      <% page.with_body do %>
+        <hr class="divider" />
+
+        <p>
+          <%= t('idv.proofing_agent_expired.body') %>
+        </p>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render ButtonComponent.new(
+              type: :submit,
+              full_width: true,
+            ).with_content(t('idv.proofing_agent_expired.continue')) %>
+        <%= render ButtonComponent.new(
+              url: account_path,
+              variant: :tertiary,
+              full_width: true,
+            ).with_content(cancel_link_text) %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <%= javascript_packs_tag_once('nds-auth-submit-gate', preload_links_header: false) %>
+<% else %>
 <div class="proofing-agent-expired-page">
   <%= render AlertIconComponent.new(icon_name: :warning, class: 'display-block margin-bottom-4') %>
 
@@ -30,3 +67,4 @@
 
   <%= render 'shared/cancel', link: account_path %>
 </div>
+<% end %>

--- a/spec/views/idv/proofing_agent_expired/show.html.erb_spec.rb
+++ b/spec/views/idv/proofing_agent_expired/show.html.erb_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/proofing_agent_expired/show.html.erb' do
+  subject(:rendered) { render }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:user_signing_up?).and_return(false)
+  end
+
+  it 'sets a title' do
+    expect(view).to receive(:title=).with(t('idv.proofing_agent_expired.heading'))
+    render
+  end
+
+  it 'renders the heading and continue button' do
+    expect(rendered).to have_selector('h1', text: t('idv.proofing_agent_expired.heading'))
+    expect(rendered).to have_button(t('idv.proofing_agent_expired.continue'))
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the heading' do
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector(
+        '.auth--form-page h1',
+        text: t('idv.proofing_agent_expired.heading'),
+      )
+    end
+
+    it 'renders the warning status-icon badge above the heading' do
+      expect(rendered).to have_selector('.auth__header--with-media .nds-status-icon--warning')
+      expect(rendered).to have_selector('.nds-status-icon--warning .usa-icon')
+    end
+
+    it 'renders a divider under the heading' do
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+    end
+
+    it 'renders the body copy' do
+      expect(rendered).to have_selector(
+        '.auth__form-page-body',
+        text: t('idv.proofing_agent_expired.body'),
+      )
+    end
+
+    it 'renders the continue form posting to the expired path with a cancel link' do
+      expect(rendered).to have_css("form[action='#{idv_proofing_agent_expired_path}']")
+      expect(rendered).to have_selector(
+        '.auth__actions button[type=submit]',
+        text: t('idv.proofing_agent_expired.continue'),
+      )
+      expect(rendered).to have_link(t('links.cancel'), href: account_path)
+    end
+
+    it 'does not render any l13n markers' do
+      expect(rendered).not_to include('%{')
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/117
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Renders `idv/proofing_agent_expired#show` under the NDS design system behind the `nds_layout?` bucket, using the status-icon page pattern from #13479 / #13481 with the **warning** variant (mirrors the legacy `AlertIconComponent(icon_name: :warning)`):

- `NDS::FormPageComponent` wrapped in the existing continue form (`data-nds-submit-gate`), with the shared `.nds-status-icon--warning` badge above the heading, a divider under the heading, the existing body copy, a primary continue submit, and a tertiary cancel action.
- Legacy branch preserved **byte-for-byte**; existing `idv.proofing_agent_expired.*` copy reused verbatim — **no new locale keys**.
- Explorer catalog wiring lands via the shared-file consolidation (freeze model).

**Dependencies:** badge styling from the IDS `_status-icon.scss` change; `warning/24.svg` glyph + alias removal ship via the shared NDS icon scaffolding consolidation.

## 👀 Preview

Dev NDS explorer: `/test/nds/proofing-agent-expired`

## 📜 Testing Plan

- `spec/views/idv/proofing_agent_expired/show.html.erb_spec.rb`
- `spec/i18n_spec.rb`, `spec/services/test/nds_page_catalog_spec.rb`, `spec/requests/test/nds_pages_spec.rb`
- `erb_lint` the view