### PR TITLE
Add the NDS mail-only warning page

### DIFF
--- a/app/views/idv/mail_only_warning/show.html.erb
+++ b/app/views/idv/mail_only_warning/show.html.erb
@@ -1,5 +1,51 @@
 <% self.title = t('vendor_outage.alerts.pinpoint.idv.header') %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 1) %>
+  <% end %>
+
+  <%= render NDS::FormPageComponent.new(
+        title: t('vendor_outage.alerts.pinpoint.idv.header'),
+      ) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--warning">
+        <%= render NDS::IconComponent.new(icon: :warning, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <hr class="divider" />
+
+      <p>
+        <%= t('vendor_outage.alerts.pinpoint.idv.message_html', sp_name_html: content_tag(:strong, current_sp&.friendly_name || APP_NAME)) %>
+      </p>
+      <p>
+        <%= t('vendor_outage.alerts.pinpoint.idv.status_page_html', link_html: new_tab_link_to(t('vendor_outage.alerts.pinpoint.idv.status_page_link'), StatusPage.base_url)) %>
+      </p>
+      <p><%= t('vendor_outage.alerts.pinpoint.idv.options_prompt') %></p>
+      <ul class="usa-list">
+        <% t('vendor_outage.alerts.pinpoint.idv.options_html', app_name: APP_NAME).each do |option| %>
+          <li>
+            <%= option %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render ButtonComponent.new(
+            url: idv_url,
+            full_width: true,
+          ).with_content(t('doc_auth.buttons.continue')) %>
+      <%= render ButtonComponent.new(
+            url: exit_url,
+            variant: :secondary,
+            full_width: true,
+          ).with_content(t('links.exit_login', app_name: APP_NAME)) %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render StepIndicatorComponent.new(
       steps: step_indicator_steps,
       current_step: :getting_started,
@@ -36,4 +82,5 @@
        outline: true,
        class: 'usa-button',
      ).with_content(t('links.exit_login', app_name: APP_NAME)) %>
+<% end %>
 <% end %>

--- a/spec/views/idv/mail_only_warning/show.html.erb_spec.rb
+++ b/spec/views/idv/mail_only_warning/show.html.erb_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'idv/mail_only_warning/show.html.erb' do
+  subject(:rendered) { render }
+
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     allow(view).to receive(:step_indicator_steps).and_return([])
     allow(view).to receive(:current_sp).and_return(nil)
 
@@ -9,8 +12,64 @@ RSpec.describe 'idv/mail_only_warning/show.html.erb' do
   end
 
   it 'lists options with correct interpolation' do
-    render
-
     expect(rendered).to include(APP_NAME)
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+    end
+
+    it 'renders the form-page card with the outage heading' do
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector(
+        '.auth--form-page h1',
+        text: t('vendor_outage.alerts.pinpoint.idv.header'),
+      )
+    end
+
+    it 'sets the verification header progress' do
+      render
+
+      progress = view.content_for(:nds_header_progress)
+      expect(progress).to have_css('nds-progress .progress__step[aria-current="step"]')
+    end
+
+    it 'renders the warning status-icon badge above the heading' do
+      expect(rendered).to have_selector('.auth__header--with-media .nds-status-icon--warning')
+      expect(rendered).to have_selector('.nds-status-icon--warning .usa-icon')
+    end
+
+    it 'renders a divider under the heading' do
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+    end
+
+    it 'renders the message, status link, and options list' do
+      expect(rendered).to have_selector('.auth__form-page-body strong', text: APP_NAME)
+      expect(rendered).to have_selector(
+        '.auth__form-page-body a[target=_blank]',
+        text: t('vendor_outage.alerts.pinpoint.idv.status_page_link'),
+      )
+      expect(rendered).to have_selector(
+        '.auth__form-page-body ul.usa-list li',
+        count: t('vendor_outage.alerts.pinpoint.idv.options_html', app_name: APP_NAME).length,
+      )
+    end
+
+    it 'renders the continue and exit actions' do
+      expect(rendered).to have_link(t('doc_auth.buttons.continue'), href: idv_url)
+      expect(rendered).to have_link(
+        t('links.exit_login', app_name: APP_NAME),
+        href: '/exit_url',
+      )
+    end
+
+    it 'does not render any l13n markers' do
+      expect(rendered).not_to include('%{')
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/118
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Renders `idv/mail_only_warning#show` under the NDS design system behind the `nds_layout?` bucket, using the status-icon page pattern from #13479 / #13481 with the **warning** variant (mirrors the legacy `StatusPageComponent(status: :warning)`):

- Verification header progress (`nds_account_creation_progress(step: :verification, substep: 1)`, replacing the legacy step indicator) and an `NDS::FormPageComponent` with the shared `.nds-status-icon--warning` badge above the heading, a divider under the heading, the existing outage message / status-page link / options list, and primary continue + secondary exit actions.
- Legacy branch preserved **byte-for-byte**; existing `vendor_outage.alerts.pinpoint.idv.*` copy reused verbatim — **no new locale keys**.
- Explorer catalog wiring lands via the shared-file consolidation (freeze model).

**Dependencies:** badge styling from the IDS `_status-icon.scss` change; `warning/24.svg` glyph + alias removal ship via the shared NDS icon scaffolding consolidation.

## 👀 Preview

Dev NDS explorer: `/test/nds/mail-only-warning` (and `?sp=1`)

## 📜 Testing Plan

- `spec/views/idv/mail_only_warning/show.html.erb_spec.rb`
- `spec/i18n_spec.rb`, `spec/services/test/nds_page_catalog_spec.rb`, `spec/requests/test/nds_pages_spec.rb`
- `erb_lint` the view