### PR TITLE
Add the NDS verify-info and address session warning pages

### DIFF
--- a/app/views/idv/session_errors/address_warning.html.erb
+++ b/app/views/idv/session_errors/address_warning.html.erb
@@ -1,5 +1,37 @@
 <% self.title = t('titles.failure.information_not_verified') %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 2) %>
+  <% end %>
+
+  <%= render NDS::FormPageComponent.new(title: t('idv.warning.address.heading')) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--warning">
+        <%= render NDS::IconComponent.new(icon: :warning, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <hr class="divider" />
+
+      <p><%= t('idv.failure.address.warning') %></p>
+      <p><%= t('idv.failure.attempts_html', count: @remaining_submit_attempts) %></p>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render ButtonComponent.new(
+            url: @address_path,
+            full_width: true,
+          ).with_content(t('idv.forgot_password.try_again')) %>
+      <%= render ButtonComponent.new(
+            url: idv_cancel_path(step: :invalid_session),
+            variant: :tertiary,
+            full_width: true,
+          ).with_content(t('links.cancel')) %>
+    <% end %>
+  <% end %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: @step_indicator_steps,
@@ -23,4 +55,5 @@
 
 <%= render PageFooterComponent.new do %>
   <%= link_to t('links.cancel'), idv_cancel_path(step: :invalid_session) %>
+<% end %>
 <% end %>

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -1,5 +1,37 @@
 <% self.title = t('titles.failure.information_not_verified') %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 2) %>
+  <% end %>
+
+  <%= render NDS::FormPageComponent.new(title: t('idv.warning.sessions.heading')) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--warning">
+        <%= render NDS::IconComponent.new(icon: :warning, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <hr class="divider" />
+
+      <p><%= t('idv.failure.sessions.warning') %></p>
+      <p><%= t('idv.failure.attempts_html', count: @remaining_submit_attempts) %></p>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render ButtonComponent.new(
+            url: @try_again_path,
+            full_width: true,
+          ).with_content(t('idv.forgot_password.try_again')) %>
+      <%= render ButtonComponent.new(
+            url: idv_cancel_path(step: :invalid_session),
+            variant: :tertiary,
+            full_width: true,
+          ).with_content(t('links.cancel')) %>
+    <% end %>
+  <% end %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: @step_indicator_steps,
@@ -23,4 +55,5 @@
 
 <%= render PageFooterComponent.new do %>
   <%= link_to t('links.cancel'), idv_cancel_path(step: :invalid_session) %>
+<% end %>
 <% end %>

--- a/spec/views/idv/session_errors/address_warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/address_warning.html.erb_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe 'idv/session_errors/address_warning.html.erb' do
   let(:address_path) { '/example/path' }
   let(:remaining_submit_attempts) { 5 }
   let(:user_session) { {} }
+  let(:nds_layout) { false }
 
   before do
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
     allow(view).to receive(:user_session).and_return(user_session)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
 
     assign(:remaining_submit_attempts, remaining_submit_attempts)
     assign(:address_path, address_path)
@@ -52,6 +54,51 @@ RSpec.describe 'idv/session_errors/address_warning.html.erb' do
         t('links.cancel'),
         href: idv_cancel_path(step: :invalid_session),
       )
+    end
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the form-page card with the warning heading' do
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector(
+        '.auth--form-page h1',
+        text: t('idv.warning.address.heading'),
+      )
+    end
+
+    it 'sets the verification header progress' do
+      progress = view.content_for(:nds_header_progress)
+      expect(progress).to have_css('nds-progress .progress__step[aria-current="step"]')
+    end
+
+    it 'renders the warning status-icon badge and divider' do
+      expect(rendered).to have_selector('.auth__header--with-media .nds-status-icon--warning')
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+    end
+
+    it 'shows remaining attempts in the body' do
+      expect(rendered).to have_selector(
+        '.auth__form-page-body',
+        text: strip_tags(t('idv.failure.attempts_html', count: remaining_submit_attempts)),
+      )
+    end
+
+    it 'shows the try-again and cancel actions' do
+      expect(rendered).to have_link(t('idv.failure.button.warning'), href: address_path)
+      expect(rendered).to have_link(
+        t('links.cancel'),
+        href: idv_cancel_path(step: :invalid_session),
+      )
+    end
+
+    it 'does not render any l13n markers' do
+      expect(rendered).not_to include('%{')
     end
   end
 end

--- a/spec/views/idv/session_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/warning.html.erb_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe 'idv/session_errors/warning.html.erb' do
   let(:try_again_path) { '/example/path' }
   let(:remaining_submit_attempts) { 5 }
   let(:user_session) { {} }
+  let(:nds_layout) { false }
 
   before do
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
     allow(view).to receive(:user_session).and_return(user_session)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
 
     assign(:remaining_submit_attempts, remaining_submit_attempts)
     assign(:try_again_path, try_again_path)
@@ -52,6 +54,51 @@ RSpec.describe 'idv/session_errors/warning.html.erb' do
         t('links.cancel'),
         href: idv_cancel_path(step: :invalid_session),
       )
+    end
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    expect(rendered).to_not have_selector('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the form-page card with the warning heading' do
+      expect(rendered).to have_selector('section.auth.auth--form-page')
+      expect(rendered).to have_selector(
+        '.auth--form-page h1',
+        text: t('idv.warning.sessions.heading'),
+      )
+    end
+
+    it 'sets the verification header progress' do
+      progress = view.content_for(:nds_header_progress)
+      expect(progress).to have_css('nds-progress .progress__step[aria-current="step"]')
+    end
+
+    it 'renders the warning status-icon badge and divider' do
+      expect(rendered).to have_selector('.auth__header--with-media .nds-status-icon--warning')
+      expect(rendered).to have_selector('.auth__form-page-body hr.divider')
+    end
+
+    it 'shows remaining attempts in the body' do
+      expect(rendered).to have_selector(
+        '.auth__form-page-body',
+        text: strip_tags(t('idv.failure.attempts_html', count: remaining_submit_attempts)),
+      )
+    end
+
+    it 'shows the try-again and cancel actions' do
+      expect(rendered).to have_link(t('idv.failure.button.warning'), href: try_again_path)
+      expect(rendered).to have_link(
+        t('links.cancel'),
+        href: idv_cancel_path(step: :invalid_session),
+      )
+    end
+
+    it 'does not render any l13n markers' do
+      expect(rendered).not_to include('%{')
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/119
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Renders `idv/session_errors#warning` and `#address_warning` under the NDS design system behind the `nds_layout?` bucket, using the status-icon page pattern from #13479 / #13481 with the **warning** variant (mirrors the legacy `StatusPageComponent(status: :warning)`):

- Verification header progress (`substep: 2`, replacing the legacy step indicator) and an `NDS::FormPageComponent` with the shared `.nds-status-icon--warning` badge above the heading, a divider under the heading, the existing warning + attempts-remaining copy, and primary try-again + tertiary cancel actions.
- Legacy branches preserved **byte-for-byte**; existing `idv.warning.*` / `idv.failure.*` copy reused verbatim — **no new locale keys**.
- Explorer catalog wiring lands via the shared-file consolidation (freeze model).

**Dependencies:** badge styling from the IDS `_status-icon.scss` change; `warning/24.svg` glyph + alias removal ship via the shared NDS icon scaffolding consolidation.

## 👀 Preview

Dev NDS explorer: `/test/nds/session-error-warning`, `/test/nds/session-error-address-warning` (each with `?attempts=1`)

## 📜 Testing Plan

- `spec/views/idv/session_errors/warning.html.erb_spec.rb`, `spec/views/idv/session_errors/address_warning.html.erb_spec.rb`
- `spec/i18n_spec.rb`, `spec/services/test/nds_page_catalog_spec.rb`, `spec/requests/test/nds_pages_spec.rb`
- `erb_lint` the views