### PR TITLE
Add the NDS idv/shared/error partial

### DIFF
--- a/app/components/nds/troubleshooting_options_component.html.erb
+++ b/app/components/nds/troubleshooting_options_component.html.erb
@@ -1,0 +1,11 @@
+<%= render NDS::StackComponent.new(kind: :actions, align: :stretch, class: 'nds-troubleshooting-options') do %>
+  <%= content_tag(heading_level, heading, class: 'heading-s text-center') %>
+  <% options.each do |option| %>
+    <%= render button_for(option) do %>
+      <%= option.text %>
+      <% if option.new_tab %>
+        <span class="usa-sr-only"><%= t('links.new_tab') %></span>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/nds/troubleshooting_options_component.html.erb
+++ b/app/components/nds/troubleshooting_options_component.html.erb
@@ -1,5 +1,5 @@
 <%= render NDS::StackComponent.new(kind: :actions, align: :stretch, class: 'nds-troubleshooting-options margin-top-4') do %>
-  <%= content_tag(heading_level, heading, class: 'heading-s text-center') %>
+  <%= content_tag(heading_level, heading, class: 'heading-s text-center') if heading.present? %>
   <% options.each do |option| %>
     <%= render button_for(option) do %>
       <%= option.text %>

--- a/app/components/nds/troubleshooting_options_component.html.erb
+++ b/app/components/nds/troubleshooting_options_component.html.erb
@@ -1,4 +1,4 @@
-<%= render NDS::StackComponent.new(kind: :actions, align: :stretch, class: 'nds-troubleshooting-options') do %>
+<%= render NDS::StackComponent.new(kind: :actions, align: :stretch, class: 'nds-troubleshooting-options margin-top-4') do %>
   <%= content_tag(heading_level, heading, class: 'heading-s text-center') %>
   <% options.each do |option| %>
     <%= render button_for(option) do %>

--- a/app/components/nds/troubleshooting_options_component.rb
+++ b/app/components/nds/troubleshooting_options_component.rb
@@ -4,10 +4,10 @@ module NDS
   # Net-new NDS troubleshooting options (nds bucket only): the auth-flow
   # replacement for TroubleshootingOptionsComponent. Renders a heading over a
   # stack of tertiary ButtonComponents (Figma "links" in auth flows are
-  # tertiary buttons), with new-tab options opened in a new window and
-  # announced to screen readers.
+  # tertiary buttons; an option may set variant: to promote itself), with
+  # new-tab options opened in a new window and announced to screen readers.
   class TroubleshootingOptionsComponent < BaseComponent
-    Option = Struct.new(:text, :url, :new_tab, :method, keyword_init: true)
+    Option = Struct.new(:text, :url, :new_tab, :method, :variant, keyword_init: true)
 
     attr_reader :heading, :options, :heading_level
 
@@ -25,7 +25,7 @@ module NDS
       ButtonComponent.new(
         url: option.url,
         method: option.method,
-        variant: :tertiary,
+        variant: option.variant || :tertiary,
         full_width: true,
         **(option.new_tab ? { target: '_blank', rel: 'noopener' } : {}),
       )

--- a/app/components/nds/troubleshooting_options_component.rb
+++ b/app/components/nds/troubleshooting_options_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module NDS
+  # Net-new NDS troubleshooting options (nds bucket only): the auth-flow
+  # replacement for TroubleshootingOptionsComponent. Renders a heading over a
+  # stack of tertiary ButtonComponents (Figma "links" in auth flows are
+  # tertiary buttons), with new-tab options opened in a new window and
+  # announced to screen readers.
+  class TroubleshootingOptionsComponent < BaseComponent
+    Option = Struct.new(:text, :url, :new_tab, :method, keyword_init: true)
+
+    attr_reader :heading, :options, :heading_level
+
+    def initialize(heading:, options:, heading_level: :h2)
+      @heading = heading
+      @options = options.map { |option| Option.new(**option.to_h.slice(*Option.members)) }
+      @heading_level = heading_level
+    end
+
+    def render?
+      options.present?
+    end
+
+    def button_for(option)
+      ButtonComponent.new(
+        url: option.url,
+        method: option.method,
+        variant: :tertiary,
+        full_width: true,
+        **(option.new_tab ? { target: '_blank', rel: 'noopener' } : {}),
+      )
+    end
+  end
+end

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -26,6 +26,63 @@ locals:
 
 <% self.title = local_assigns.fetch(:title, heading) %>
 
+<% if nds_layout? %>
+  <% if local_assigns[:current_step] and defined?(step_indicator_steps) %>
+    <% content_for(:nds_header_progress) do %>
+      <%= nds_account_creation_progress(
+            step: :verification,
+            substep: step_indicator_steps.index { |s| s[:name] == local_assigns[:current_step] }.to_i + 1,
+          ) %>
+    <% end %>
+  <% end %>
+
+  <%= render NDS::FormPageComponent.new(title: heading) do |page| %>
+    <% page.with_media do %>
+      <span class="nds-status-icon nds-status-icon--<%= icon_name %>">
+        <%= render NDS::IconComponent.new(icon: icon_name, size: 24) %>
+      </span>
+    <% end %>
+
+    <% page.with_body do %>
+      <hr class="divider" />
+
+      <%= yield %>
+
+      <% if local_assigns[:secondary_action] && local_assigns[:secondary_action_heading] %>
+        <h2 class="heading-s"><%= local_assigns[:secondary_action_heading] %></h2>
+      <% end %>
+      <% if local_assigns[:secondary_action] && local_assigns[:secondary_action_text] %>
+        <p><%= local_assigns[:secondary_action_text] %></p>
+      <% end %>
+    <% end %>
+
+    <% if local_assigns[:action] || local_assigns.fetch(:options, []).present? %>
+      <% page.with_actions do %>
+        <% if local_assigns[:action] %>
+          <%= render ButtonComponent.new(
+                url: action[:url],
+                method: action[:method],
+                full_width: true,
+              ).with_content(action[:text]) %>
+
+          <% if local_assigns[:secondary_action] %>
+            <%= render ButtonComponent.new(
+                  url: secondary_action[:url],
+                  method: secondary_action[:method],
+                  variant: :secondary,
+                  full_width: true,
+                ).with_content(secondary_action[:text]) %>
+          <% end %>
+        <% end %>
+
+        <%= render NDS::TroubleshootingOptionsComponent.new(
+              heading: troubleshooting_heading,
+              options: local_assigns.fetch(:options, []),
+            ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
 <% if local_assigns[:current_step] and defined?(step_indicator_steps) %>
   <% content_for(:pre_flash_content) do %>
     <%= render StepIndicatorComponent.new(
@@ -81,3 +138,4 @@ locals:
       options: local_assigns.fetch(:options, []),
       class: 'margin-top-5',
     ) %>
+<% end %>

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -45,7 +45,7 @@ locals:
 
     <% body = capture { yield } %>
     <% page.with_body do %>
-      <% if body.present? %>
+      <% if strip_tags(body).present? %>
         <hr class="divider" />
       <% end %>
 

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -65,6 +65,7 @@ locals:
           <%= render ButtonComponent.new(
                 url: action[:url],
                 method: action[:method],
+                variant: action.fetch(:variant, :primary),
                 full_width: true,
               ).with_content(action[:text]) %>
 

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -59,7 +59,7 @@ locals:
       <% end %>
     <% end %>
 
-    <% if local_assigns[:action] || local_assigns.fetch(:options, []).present? %>
+    <% if local_assigns[:action] || local_assigns[:secondary_action] || local_assigns.fetch(:options, []).present? %>
       <% page.with_actions do %>
         <% if local_assigns[:action] %>
           <%= render ButtonComponent.new(
@@ -67,16 +67,18 @@ locals:
                 method: action[:method],
                 variant: action.fetch(:variant, :primary),
                 full_width: true,
+                **(action[:new_tab] ? { target: '_blank', rel: 'noopener' } : {}),
               ).with_content(action[:text]) %>
+        <% end %>
 
-          <% if local_assigns[:secondary_action] %>
-            <%= render ButtonComponent.new(
-                  url: secondary_action[:url],
-                  method: secondary_action[:method],
-                  variant: :secondary,
-                  full_width: true,
-                ).with_content(secondary_action[:text]) %>
-          <% end %>
+        <% if local_assigns[:secondary_action] %>
+          <%= render ButtonComponent.new(
+                url: secondary_action[:url],
+                method: secondary_action[:method],
+                variant: :secondary,
+                full_width: true,
+                **(secondary_action[:new_tab] ? { target: '_blank', rel: 'noopener' } : {}),
+              ).with_content(secondary_action[:text]) %>
         <% end %>
 
         <%= render NDS::TroubleshootingOptionsComponent.new(

--- a/app/views/idv/shared/_error.html.erb
+++ b/app/views/idv/shared/_error.html.erb
@@ -43,10 +43,13 @@ locals:
       </span>
     <% end %>
 
+    <% body = capture { yield } %>
     <% page.with_body do %>
-      <hr class="divider" />
+      <% if body.present? %>
+        <hr class="divider" />
+      <% end %>
 
-      <%= yield %>
+      <%= body %>
 
       <% if local_assigns[:secondary_action] && local_assigns[:secondary_action_heading] %>
         <h2 class="heading-s"><%= local_assigns[:secondary_action_heading] %></h2>

--- a/spec/views/idv/not_verified/show.html.erb_spec.rb
+++ b/spec/views/idv/not_verified/show.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'idv/not_verified/show.html.erb' do
   let(:sp_name) { nil }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     allow(view).to receive(:decorated_sp_session).and_return(
       instance_double(ServiceProviderSession, sp_name: sp_name),
     )

--- a/spec/views/idv/phone_errors/_warning.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/_warning.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'idv/phone_errors/_warning.html.erb' do
   let(:assigns) { {} }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
 

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
   end
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
     assign(:gpo_letter_available, gpo_letter_available)

--- a/spec/views/idv/phone_errors/jobfail.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/jobfail.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'idv/phone_errors/jobfail.html.erb' do
   let(:gpo_letter_available) { false }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
     assign(:gpo_letter_available, gpo_letter_available)

--- a/spec/views/idv/phone_errors/timeout.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/timeout.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'idv/phone_errors/timeout.html.erb' do
   let(:gpo_letter_available) { false }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
     assign(:gpo_letter_available, gpo_letter_available)

--- a/spec/views/idv/phone_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/warning.html.erb_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'idv/phone_errors/warning.html.erb' do
   let(:formatted_phone) { '+1 360-234-5678' }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
     assign(:gpo_letter_available, gpo_letter_available)

--- a/spec/views/idv/please_call/show.html.erb_spec.rb
+++ b/spec/views/idv/please_call/show.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'idv/please_call/show.html.erb' do
   let(:in_person_proofing_enabled) { false }
   let(:in_person) { false }
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     @call_by_date = Date.new(2023, 10, 13)
     @in_person = in_person
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled)

--- a/spec/views/idv/session_errors/exception.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/exception.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'idv/session_errors/exception.html.erb' do
   let(:try_again_path) { '/example/path' }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     decorated_sp_session = instance_double(
       ServiceProviderSession,
       sp_name: sp_name,

--- a/spec/views/idv/session_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/failure.html.erb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'idv/session_errors/failure.html.erb' do
   end
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     allow(IdentityConfig.store).to receive(:idv_attempt_window_in_hours).and_return(timeout_hours)
 
     @expires_at = Time.zone.now + timeout_hours.hours

--- a/spec/views/idv/session_errors/rate_limited.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/rate_limited.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'idv/session_errors/rate_limited.html.erb' do
   let(:sp_issuer) { nil }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     decorated_sp_session = instance_double(
       ServiceProviderSession,
       sp_name: sp_name,

--- a/spec/views/idv/session_errors/state_id_warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/state_id_warning.html.erb_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'idv/session_errors/state_id_warning.html.erb' do
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     assign(:try_again_path, '/try_again')
 
     render

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -217,8 +217,16 @@ RSpec.describe 'idv/shared/_error.html.erb' do
       expect(rendered).not_to have_css('.auth__form-page-body hr.divider')
     end
 
+    context 'with whitespace-only body content' do
+      before { render('idv/shared/error', **params) { '<p> </p>'.html_safe } }
+
+      it 'omits the divider' do
+        expect(rendered).not_to have_css('.auth__form-page-body hr.divider')
+      end
+    end
+
     context 'with body content' do
-      before { render 'idv/shared/error', **params do 'Body copy' end }
+      before { render('idv/shared/error', **params) { 'Body copy' } }
 
       it 'renders a divider under the heading' do
         expect(rendered).to have_css('.auth__form-page-body hr.divider')
@@ -324,6 +332,17 @@ RSpec.describe 'idv/shared/_error.html.erb' do
 
         it 'does not render troubleshooting options' do
           expect(rendered).not_to have_css('.nds-troubleshooting-options')
+        end
+      end
+
+      context 'with a promoted option' do
+        let(:options) { [{ text: 'Status', url: '#status', variant: :secondary }] }
+
+        it 'renders it with the requested variant' do
+          expect(rendered).to have_css(
+            '.nds-troubleshooting-options a.usa-button--secondary',
+            text: 'Status',
+          )
         end
       end
 

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -209,9 +209,20 @@ RSpec.describe 'idv/shared/_error.html.erb' do
   context 'in the NDS layout' do
     let(:nds_layout) { true }
 
-    it 'renders the form-page card with the heading and a divider under it' do
+    it 'renders the form-page card with the heading' do
       expect(rendered).to have_css('section.auth.auth--form-page h1', text: heading)
-      expect(rendered).to have_css('.auth__form-page-body hr.divider')
+    end
+
+    it 'omits the divider when there is no body content' do
+      expect(rendered).not_to have_css('.auth__form-page-body hr.divider')
+    end
+
+    context 'with body content' do
+      before { render 'idv/shared/error', **params do 'Body copy' end }
+
+      it 'renders a divider under the heading' do
+        expect(rendered).to have_css('.auth__form-page-body hr.divider')
+      end
     end
 
     describe 'type' do

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -311,6 +311,18 @@ RSpec.describe 'idv/shared/_error.html.erb' do
     describe 'secondary action' do
       let(:action) { { text: 'Primary Action', url: '#primary' } }
 
+      context 'without a primary action' do
+        let(:action) { nil }
+        let(:secondary_action) { { text: 'Only Action', url: '#only', new_tab: true } }
+
+        it 'still renders the secondary button in a new tab' do
+          expect(rendered).to have_css(
+            "a.usa-button--secondary[target=_blank][href='#only']",
+            text: 'Only Action',
+          )
+        end
+      end
+
       context 'without secondary action' do
         it 'does not render a secondary button' do
           expect(rendered).not_to have_css('.usa-button--secondary')

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -20,9 +20,12 @@ RSpec.describe 'idv/shared/_error.html.erb' do
     }
   end
 
+  let(:nds_layout) { false }
+
   before do
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
 
     if step_indicator_steps
       allow(view).to receive(:step_indicator_steps).and_return(step_indicator_steps)
@@ -121,7 +124,7 @@ RSpec.describe 'idv/shared/_error.html.erb' do
       let(:options) { [] }
 
       it 'does not render troubleshooting options' do
-        expect(rendered).not_to have_css('.troubleshooting-options')
+        expect(rendered).not_to have_css('.nds-troubleshooting-options')
       end
     end
 
@@ -194,6 +197,158 @@ RSpec.describe 'idv/shared/_error.html.erb' do
             '.step-indicator__step--current .step-indicator__step-title',
             text: t('step_indicator.flows.idv.verify_phone'),
           )
+        end
+      end
+    end
+  end
+
+  it 'does not render the NDS form-page card in the default layout' do
+    expect(rendered).not_to have_css('.auth--form-page')
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the form-page card with the heading and a divider under it' do
+      expect(rendered).to have_css('section.auth.auth--form-page h1', text: heading)
+      expect(rendered).to have_css('.auth__form-page-body hr.divider')
+    end
+
+    describe 'type' do
+      context 'absent' do
+        let(:params) { { heading: heading } }
+
+        it 'renders the error status-icon badge' do
+          expect(rendered).to have_css(
+            '.auth__header--with-media .nds-status-icon--error .usa-icon',
+          )
+        end
+      end
+
+      context 'warning' do
+        let(:type) { :warning }
+
+        it 'renders the warning status-icon badge' do
+          expect(rendered).to have_css('.nds-status-icon--warning .usa-icon')
+        end
+
+        it 'shows the default troubleshooting heading' do
+          expect(rendered).to have_css(
+            '.auth__actions h2',
+            text: t('components.troubleshooting_options.default_heading'),
+          )
+        end
+      end
+
+      context 'error' do
+        let(:type) { :error }
+
+        it 'shows the need-assistance troubleshooting heading' do
+          expect(rendered).to have_css(
+            '.auth__actions h2',
+            text: t('idv.troubleshooting.headings.need_assistance'),
+          )
+        end
+      end
+    end
+
+    describe 'action' do
+      context 'without action' do
+        it 'does not render a primary button' do
+          expect(rendered).not_to have_css('.auth__actions .usa-button:not(.usa-button--tertiary)')
+        end
+      end
+
+      context 'with action' do
+        let(:action) { { text: 'Primary Action', url: '#primary' } }
+
+        it 'renders the primary action in the actions stack' do
+          expect(rendered).to have_css('.auth__actions a.usa-button', text: 'Primary Action')
+          expect(rendered).to have_link('Primary Action', href: '#primary')
+        end
+      end
+
+      context 'with form action' do
+        let(:action) { { text: 'Delete', url: '#delete', method: :delete } }
+
+        it 'renders a form-submitting button' do
+          expect(rendered).to have_button('Delete')
+          expect(rendered).to have_css(
+            'form[action="#delete"] input[name="_method"][value="delete"]',
+            visible: :all,
+          )
+        end
+      end
+    end
+
+    describe 'secondary action' do
+      let(:action) { { text: 'Primary Action', url: '#primary' } }
+
+      context 'without secondary action' do
+        it 'does not render a secondary button' do
+          expect(rendered).not_to have_css('.usa-button--secondary')
+        end
+      end
+
+      context 'with secondary action' do
+        let(:secondary_action) { { text: 'Secondary Action', url: '#secondary' } }
+        let(:params) do
+          super().merge(
+            secondary_action_heading: 'Other ways',
+            secondary_action_text: 'You can also do this.',
+          )
+        end
+
+        it 'renders the secondary button with its heading and text in the body' do
+          expect(rendered).to have_css('a.usa-button--secondary', text: 'Secondary Action')
+          expect(rendered).to have_css('.auth__form-page-body h2', text: 'Other ways')
+          expect(rendered).to have_css('.auth__form-page-body p', text: 'You can also do this.')
+        end
+      end
+    end
+
+    describe 'options' do
+      context 'no options' do
+        let(:options) { [] }
+
+        it 'does not render troubleshooting options' do
+          expect(rendered).not_to have_css('.nds-troubleshooting-options')
+        end
+      end
+
+      context 'with options' do
+        let(:options) { [{ text: 'Example', url: '#example', new_tab: true }] }
+
+        it 'renders each option as a tertiary new-tab button' do
+          expect(rendered).to have_css(
+            '.nds-troubleshooting-options a.usa-button--tertiary[target=_blank][href="#example"]',
+            text: 'Example',
+          )
+          expect(rendered).to have_css(
+            '.nds-troubleshooting-options .usa-sr-only',
+            text: t('links.new_tab'),
+          )
+        end
+      end
+    end
+
+    describe 'current_step' do
+      it 'does not render header progress by default' do
+        expect(view.content_for(:nds_header_progress)).to be_nil
+      end
+
+      context 'current_step provided with steps available' do
+        let(:current_step) { :verify_info }
+        let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
+
+        it 'renders the verification header progress at the matching substep' do
+          progress = view.content_for(:nds_header_progress)
+          expect(progress).to have_css('nds-progress .progress__step[aria-current="step"]')
+          expect(progress).to have_css('.progress__step-counter', text: '3 / 12')
+        end
+
+        it 'does not render the legacy step indicator' do
+          expect(view.content_for(:pre_flash_content)).to be_nil
         end
       end
     end

--- a/spec/views/idv/shared/_error.html.erb_spec.rb
+++ b/spec/views/idv/shared/_error.html.erb_spec.rb
@@ -287,6 +287,14 @@ RSpec.describe 'idv/shared/_error.html.erb' do
         end
       end
 
+      context 'with a destructive variant' do
+        let(:action) { { text: 'Cancel', url: '#cancel', variant: :destructive } }
+
+        it 'renders the primary action with the requested variant' do
+          expect(rendered).to have_css('.auth__actions a.usa-button--danger', text: 'Cancel')
+        end
+      end
+
       context 'with form action' do
         let(:action) { { text: 'Delete', url: '#delete', method: :delete } }
 

--- a/spec/views/idv/socure/errors/show.html.erb_spec.rb
+++ b/spec/views/idv/socure/errors/show.html.erb_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'idv/socure/errors/show.html.erb' do
   include Devise::Test::ControllerHelpers
 
+  before do
+    allow(view).to receive(:nds_layout?).and_return(false)
+  end
+
   let(:remaining_submit_attempts) { 5 }
   let(:in_person_url) { nil }
   let(:passport_requested) { false }

--- a/spec/views/users/please_call/show.html.erb_spec.rb
+++ b/spec/views/users/please_call/show.html.erb_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'users/please_call/show.html.erb' do
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     render
   end
 

--- a/spec/views/vendor_outage/show.html.erb_spec.rb
+++ b/spec/views/vendor_outage/show.html.erb_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'vendor_outage/show.html.erb' do
   subject(:rendered) { render }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(false)
     @show_gpo_option = show_gpo_option
   end
 


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/120
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts the shared `idv/shared/_error` partial — which backs ~18 IdV / dead-end pages (session errors, please-call, not-verified, vendor outage, socure errors, phone errors, etc.) — to the NDS status-icon page pattern from #13479 behind the `nds_layout?` bucket, so every consumer flips with **no per-page view change**:

- `NDS::FormPageComponent` with the shared `.nds-status-icon--{error|warning}` badge driven by the partial's existing `type:` local, a divider under the heading, the yielded body, and primary/secondary `ButtonComponent` actions (`method:` honored).
- New `NDS::TroubleshootingOptionsComponent`: the existing troubleshooting heading over a stack of tertiary buttons (new-tab options get `target=_blank` + sr-only text) — the NDS replacement for `TroubleshootingOptionsComponent`.
- `current_step` maps onto the NDS verification header progress instead of the legacy step indicator.
- Every existing local (`title`, `type`, `action`, `secondary_action(_heading/_text)`, `troubleshooting_heading`, `options`, `current_step`) is preserved; legacy `else` branch **byte-for-byte**; **no new locale keys**.
- Consumer view specs gain a one-line `nds_layout?` stub so they keep exercising the legacy branch.

Per-page body content (links/buttons inside each consumer's `yield`) is restyled in follow-up page-only PRs. Explorer catalog wiring (incl. partial-aware NDS detection) lands via the shared-file consolidation.

**Dependencies:** IDS `_status-icon.scss`; `error/warning` glyphs via the shared icon scaffolding consolidation.

## 👀 Preview

Dev NDS explorer, e.g. `/test/nds/session-error-failure`, `/test/nds/session-error-exception`, `/test/nds/socure-errors?code=timeout`, `/test/nds/idv-not-verified`

## 📜 Testing Plan

- `spec/views/idv/shared/_error.html.erb_spec.rb` (NDS context: type, action/method, secondary, options, current_step)
- All consumer view specs under `spec/views/idv/{session_errors,not_verified,please_call,phone_errors,socure,by_mail}`, `spec/views/users/please_call`, `spec/views/vendor_outage`
- `spec/i18n_spec.rb`, `spec/services/test/nds_page_catalog_spec.rb`, `spec/requests/test/nds_pages_spec.rb`
- `erb_lint`, `rubocop`