### PR TITLE
Add the NDS verify-info failure page body

### DIFF
--- a/app/views/idv/session_errors/failure.html.erb
+++ b/app/views/idv/session_errors/failure.html.erb
@@ -1,3 +1,34 @@
+<% if nds_layout? %>
+  <%= render(
+        'idv/shared/error',
+        title: t('titles.failure.information_not_verified'),
+        heading: t('idv.failure.sessions.heading'),
+        action: {
+          text: @sp_name ?
+            t('idv.failure.exit.with_sp', app_name: APP_NAME, sp_name: @sp_name) :
+            t('nds.errors.return_home'),
+          url: return_to_sp_failure_to_proof_path(step: 'verify_id', location: 'failure'),
+        },
+        options: [
+          {
+            url: contact_redirect_url,
+            text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+            new_tab: true,
+          },
+        ],
+      ) do %>
+    <p>
+      <%= t(
+            'idv.failure.sessions.fail_html',
+            timeout: distance_of_time_in_words(
+              Time.zone.now,
+              [@expires_at, Time.zone.now].compact.max,
+              except: :seconds,
+            ),
+          ) %>
+    </p>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       title: t('titles.failure.information_not_verified'),
@@ -34,3 +65,4 @@
         </strong>
       </p>
     <% end %>
+<% end %>

--- a/spec/views/idv/session_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/failure.html.erb_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 RSpec.describe 'idv/session_errors/failure.html.erb' do
   let(:sp_name) { nil }
   let(:timeout_hours) { 6 }
+  let(:nds_layout) { false }
 
   around do |ex|
     freeze_time { ex.run }
   end
 
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     allow(IdentityConfig.store).to receive(:idv_attempt_window_in_hours).and_return(timeout_hours)
 
     @expires_at = Time.zone.now + timeout_hours.hours
@@ -55,6 +56,48 @@ RSpec.describe 'idv/session_errors/failure.html.erb' do
         ),
         href: return_to_sp_failure_to_proof_path(step: 'verify_id', location: 'failure'),
       )
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the exit link as the primary action in the actions stack' do
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button:not(.usa-button--tertiary)',
+        text: t('nds.errors.return_home'),
+      )
+      expect(rendered).not_to have_css('.auth__form-page-body strong a')
+    end
+
+    it 'keeps the try-again message in the body' do
+      expect(rendered).to have_css(
+        '.auth__form-page-body',
+        text: strip_tags(
+          t(
+            'idv.failure.sessions.fail_html',
+            timeout: distance_of_time_in_words(timeout_hours.hours),
+          ),
+        ),
+      )
+    end
+
+    it 'renders the contact-support troubleshooting option as a tertiary new-tab button' do
+      expect(rendered).to have_css(
+        '.nds-troubleshooting-options a.usa-button--tertiary[target=_blank]',
+        text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+      )
+    end
+
+    context 'with an associated service provider' do
+      let(:sp_name) { 'Example SP' }
+
+      it 'uses the SP exit copy for the primary action' do
+        expect(rendered).to have_css(
+          '.auth__actions a.usa-button',
+          text: t('idv.failure.exit.with_sp', sp_name: sp_name, app_name: 'Login.gov'),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/121
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles the body of `idv/session_errors#failure` for the NDS bucket:

- The bold exit link moves out of the body and becomes the partial's primary action button — **"Return home"** (new `nds.errors.return_home` key, via consolidation) or the existing return-to-SP copy — rendered above the tertiary Contact Support troubleshooting option.
- Body keeps only the try-again-in-N-hours message. Legacy branch preserved **byte-for-byte**.

## 👀 Preview

Dev NDS explorer: `/test/nds/session-error-failure` (and `?sp=1`)

## 📜 Testing Plan

- `spec/views/idv/session_errors/failure.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`