### PR TITLE
Add the NDS document-capture rate-limited page body

### DIFF
--- a/app/views/idv/session_errors/rate_limited.html.erb
+++ b/app/views/idv/session_errors/rate_limited.html.erb
@@ -1,3 +1,36 @@
+<% if nds_layout? %>
+  <%= render(
+        'idv/shared/error',
+        heading: t('doc_auth.errors.rate_limited_heading'),
+        action: {
+          text: decorated_sp_session.sp_name.present? ?
+            t('idv.failure.exit.with_sp', app_name: APP_NAME, sp_name: decorated_sp_session.sp_name) :
+            t('nds.errors.return_home'),
+          url: return_to_sp_failure_to_proof_path(
+            step: 'verify_id',
+            location: request.params[:action],
+          ),
+        },
+        options: [
+          {
+            url: contact_redirect_url,
+            text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+            new_tab: true,
+          },
+        ],
+      ) do %>
+    <p>
+      <%= t(
+            'doc_auth.errors.rate_limited_text_html',
+            timeout: distance_of_time_in_words(
+              Time.zone.now,
+              [@expires_at, Time.zone.now].compact.max,
+              except: :seconds,
+            ),
+          ) %>
+    </p>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       heading: t('doc_auth.errors.rate_limited_heading'),
@@ -47,3 +80,4 @@
         </strong>
       </p>
     <% end %>
+<% end %>

--- a/spec/views/idv/session_errors/rate_limited.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/rate_limited.html.erb_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe 'idv/session_errors/rate_limited.html.erb' do
   let(:sp_name) { nil }
   let(:sp_issuer) { nil }
+  let(:nds_layout) { false }
 
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     decorated_sp_session = instance_double(
       ServiceProviderSession,
       sp_name: sp_name,
@@ -54,6 +55,33 @@ RSpec.describe 'idv/session_errors/rate_limited.html.erb' do
   context 'with liveness feature enabled' do
     it 'renders expected heading' do
       expect(rendered).to have_text(t('doc_auth.errors.rate_limited_heading'))
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the return-home exit as the primary action above troubleshooting' do
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button:not(.usa-button--tertiary)',
+        text: t('nds.errors.return_home'),
+      )
+      expect(rendered).not_to have_css('.auth__form-page-body strong a')
+      expect(rendered).to have_css(
+        '.nds-troubleshooting-options a.usa-button--tertiary[target=_blank]',
+        text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+      )
+    end
+
+    context 'with an SP' do
+      let(:sp_name) { 'Example SP' }
+
+      it 'uses the return-to-SP copy for the primary action' do
+        expect(rendered).to have_css(
+          '.auth__actions a.usa-button',
+          text: t('idv.failure.exit.with_sp', app_name: APP_NAME, sp_name: sp_name),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/122
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles the body of `idv/session_errors#rate_limited` for the NDS bucket:

- The bold exit link moves out of the body and becomes the partial's primary action button — **"Return home"** (`nds.errors.return_home`, via consolidation) or the existing return-to-SP copy — above the tertiary Contact Support troubleshooting option.
- Body keeps only the try-again-in-N-hours message. Legacy branch preserved **byte-for-byte**.

## 👀 Preview

Dev NDS explorer: `/test/nds/session-error-rate-limited` (and `?sp=1`)

## 📜 Testing Plan

- `spec/views/idv/session_errors/rate_limited.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`