### PR TITLE
Add the NDS information-not-verified page body

### DIFF
--- a/app/views/idv/not_verified/show.html.erb
+++ b/app/views/idv/not_verified/show.html.erb
@@ -1,3 +1,27 @@
+<% if nds_layout? %>
+  <% help_url = if decorated_sp_session.sp_name.present?
+                  return_to_sp_failure_to_proof_path(step: 'verify_info', location: request.params[:action])
+                else
+                  account_path
+                end %>
+  <%= render(
+        'idv/shared/error',
+        title: t('titles.failure.information_not_verified'),
+        heading: t('idv.failure.verify.heading'),
+        action: { text: t('idv.failure.verify.exit', app_name: APP_NAME), url: :return_to_sp_failure_to_proof, method: :get },
+        secondary_action: {
+          text: strip_tags(
+            t('idv.failure.verify.fail_link_html', sp_name: decorated_sp_session.sp_name.presence || APP_NAME),
+          ),
+          url: help_url,
+        },
+      ) do %>
+    <p>
+      <%= t('idv.failure.verify.fail_link_html', sp_name: decorated_sp_session.sp_name.presence || APP_NAME) %>
+      <%= t('idv.failure.verify.fail_text') %>
+    </p>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       title: t('titles.failure.information_not_verified'),
@@ -21,4 +45,5 @@
       <% end %>
       <%= t('idv.failure.verify.fail_text') %>
     </p>
+<% end %>
 <% end %>

--- a/spec/views/idv/not_verified/show.html.erb_spec.rb
+++ b/spec/views/idv/not_verified/show.html.erb_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'idv/not_verified/show.html.erb' do
   let(:sp_name) { nil }
+  let(:nds_layout) { false }
 
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     allow(view).to receive(:decorated_sp_session).and_return(
       instance_double(ServiceProviderSession, sp_name: sp_name),
     )
@@ -48,6 +49,44 @@ RSpec.describe 'idv/not_verified/show.html.erb' do
         t('idv.failure.verify.exit', app_name: APP_NAME),
         href: return_to_sp_failure_to_proof_path,
       )
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the exit primary action and a get-help secondary action to the account page' do
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button:not(.usa-button--secondary)',
+        text: t('idv.failure.verify.exit', app_name: APP_NAME),
+      )
+      expect(rendered).to have_css(
+        ".auth__actions a.usa-button--secondary[href='#{account_path}']",
+        text: strip_tags(t('idv.failure.verify.fail_link_html', sp_name: APP_NAME)),
+      )
+    end
+
+    it 'keeps the help sentence in the body without an inline link' do
+      expect(rendered).to have_css(
+        '.auth__form-page-body p',
+        text: t('idv.failure.verify.fail_text'),
+      )
+      expect(rendered).not_to have_css('.auth__form-page-body a')
+    end
+
+    context 'with an sp' do
+      let(:sp_name) { 'Department of Departments' }
+
+      it 'points the get-help action at the SP failure-to-proof redirect' do
+        expect(rendered).to have_css(
+          '.auth__actions a.usa-button--secondary',
+          text: strip_tags(t('idv.failure.verify.fail_link_html', sp_name: sp_name)),
+        )
+        expect(rendered).to have_link(
+          strip_tags(t('idv.failure.verify.fail_link_html', sp_name: sp_name)),
+          href: return_to_sp_failure_to_proof_path(step: 'verify_info', location: 'show'),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/123
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57
- Follow-up UX concern: #13491

## 🛠 Summary of changes

Restyles the body of `idv/not_verified#show` for the NDS bucket:

- "Exit Login.gov" stays the primary action; the inline "Get help at {SP}" link becomes a **secondary action button** pointing at the same destinations as legacy (`/account` without an SP, the SP failure-to-proof redirect with one).
- Body keeps the sentence as plain copy. Legacy branch preserved **byte-for-byte**; existing copy reused — **no new locale keys**.

## 👀 Preview

Dev NDS explorer: `/test/nds/idv-not-verified` (and `?sp=1`)

## 📜 Testing Plan

- `spec/views/idv/not_verified/show.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`