### PR TITLE
Add the NDS vendor outage page body

### DIFF
--- a/app/views/vendor_outage/show.html.erb
+++ b/app/views/vendor_outage/show.html.erb
@@ -1,3 +1,38 @@
+<% if nds_layout? %>
+  <%= render(
+        'idv/shared/error',
+        heading: t('vendor_outage.working'),
+        options: [
+          @show_gpo_option && {
+            text: t('idv.troubleshooting.options.verify_by_mail'),
+            url: idv_request_letter_path,
+          },
+          {
+            text: t('vendor_outage.get_updates_on_status_page'),
+            url: StatusPage.base_url,
+            new_tab: true,
+            variant: :secondary,
+          },
+          {
+            text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+            url: contact_redirect_url,
+            new_tab: true,
+          },
+        ].select(&:present?),
+      ) do %>
+    <p><%= @specific_message %></p>
+  <% end %>
+
+  <% if go_back_path %>
+    <%= render NDS::StackComponent.new(kind: :actions, align: :stretch, class: 'margin-top-4') do %>
+      <%= render ButtonComponent.new(
+            url: go_back_path,
+            variant: :tertiary,
+            full_width: true,
+          ).with_content(t('forms.buttons.back')) %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       heading: t('vendor_outage.working'),
@@ -22,3 +57,4 @@
 <% end %>
 
 <%= render('idv/shared/back') %>
+<% end %>

--- a/spec/views/vendor_outage/show.html.erb_spec.rb
+++ b/spec/views/vendor_outage/show.html.erb_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 RSpec.describe 'vendor_outage/show.html.erb' do
   let(:show_gpo_option) { false }
+  let(:nds_layout) { false }
 
   subject(:rendered) { render }
 
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     @show_gpo_option = show_gpo_option
   end
 
@@ -19,6 +20,58 @@ RSpec.describe 'vendor_outage/show.html.erb' do
 
     it 'renders gpo option' do
       expect(rendered).to have_link(t('idv.troubleshooting.options.verify_by_mail'))
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the status page as a secondary option and support as tertiary' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('vendor_outage.working'))
+      expect(rendered).to have_css(
+        '.nds-troubleshooting-options a.usa-button--secondary[target=_blank]',
+        text: t('vendor_outage.get_updates_on_status_page'),
+      )
+      expect(rendered).to have_css(
+        '.nds-troubleshooting-options a.usa-button--tertiary[target=_blank]',
+        text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+      )
+    end
+
+    it 'omits the divider when there is no outage message' do
+      expect(rendered).not_to have_css('hr.divider')
+    end
+
+    context 'with an outage message' do
+      before { @specific_message = 'Outage details' }
+
+      it 'renders the message and a divider' do
+        expect(rendered).to have_css('.auth__form-page-body p', text: 'Outage details')
+        expect(rendered).to have_css('hr.divider')
+      end
+    end
+
+    it 'does not render a back link without a referer' do
+      expect(rendered).not_to have_link(t('forms.buttons.back'))
+    end
+
+    context 'with a go-back path' do
+      before { allow(view).to receive(:go_back_path).and_return('/verify') }
+
+      it 'renders a tertiary back button' do
+        expect(rendered).to have_link(t('forms.buttons.back'), href: '/verify')
+      end
+    end
+
+    context 'gpo option shown' do
+      let(:show_gpo_option) { true }
+
+      it 'renders the verify-by-mail option as a tertiary button' do
+        expect(rendered).to have_css(
+          '.nds-troubleshooting-options a.usa-button--tertiary',
+          text: t('idv.troubleshooting.options.verify_by_mail'),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/124
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles `vendor_outage#show` for the NDS bucket:

- "Get updates on our status page" is promoted to a **secondary** button, kept in place under the troubleshooting heading; verify-by-mail (when shown) and Contact Support stay tertiary.
- The referer-based back link (`idv/shared/back`) renders as a tertiary Back button below the card.
- Divider only renders when there is an outage message (partial behavior). Legacy branch preserved **byte-for-byte**; **no new locale keys**.

## 👀 Preview

Dev NDS explorer: `/test/nds/vendor-outage` (and `?gpo=1`)

## 📜 Testing Plan

- `spec/views/vendor_outage/show.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`