### PR TITLE
Add the NDS suspended-account please-call page body

### DIFF
--- a/app/views/users/please_call/show.html.erb
+++ b/app/views/users/please_call/show.html.erb
@@ -1,3 +1,34 @@
+<% if nds_layout? %>
+  <%= render(
+        'idv/shared/error',
+        heading: t('users.suspended_sign_in_account.heading'),
+      ) do %>
+    <p>
+      <%= t('users.suspended_sign_in_account.contact_details', contact_number: '%{number}')
+            .split('%{number}', -1)
+            .map { |part| ERB::Util.html_escape(part) }
+            .join(
+              link_to(
+                IdentityConfig.store.idv_contact_phone_number,
+                "tel:#{IdentityConfig.store.idv_contact_phone_number.gsub(/\D/, '')}",
+                class: 'link text-no-wrap',
+              ),
+            )
+            .html_safe %>
+    </p>
+    <p>
+      <%= t('users.suspended_sign_in_account.error_details', error_code: '%{code}')
+            .split('%{code}', -1)
+            .map { |part| ERB::Util.html_escape(part) }
+            .join(
+              content_tag(:span, class: 'field-readout field-readout--inline') do
+                content_tag(:span, IdentityConfig.store.account_suspended_support_code, class: 'field-readout__value')
+              end,
+            )
+            .html_safe %>
+    </p>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       heading: t('users.suspended_sign_in_account.heading'),
@@ -8,4 +39,5 @@
     <p>
       <%= t('users.suspended_sign_in_account.error_details', error_code: IdentityConfig.store.account_suspended_support_code) %>
     </p>
+<% end %>
 <% end %>

--- a/spec/views/users/please_call/show.html.erb_spec.rb
+++ b/spec/views/users/please_call/show.html.erb_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'users/please_call/show.html.erb' do
+  let(:nds_layout) { false }
+
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     render
   end
 
@@ -26,5 +28,41 @@ RSpec.describe 'users/please_call/show.html.erb' do
         ),
       ),
     )
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the contact details in the card body' do
+      expect(rendered).to have_css(
+        '.auth__form-page-body p',
+        text: strip_tags(
+          t(
+            'users.suspended_sign_in_account.contact_details',
+            contact_number: IdentityConfig.store.idv_contact_phone_number,
+          ),
+        ),
+      )
+    end
+
+    it 'links the contact number as a non-wrapping tel: link' do
+      number = IdentityConfig.store.idv_contact_phone_number
+      expect(rendered).to have_css(
+        "a.text-no-wrap[href='tel:#{number.gsub(/\D/, '')}']",
+        text: number,
+      )
+    end
+
+    it 'renders the support code as an inline field readout within the sentence' do
+      expect(rendered).to have_css(
+        '.auth__form-page-body p',
+        text: strip_tags(t('users.suspended_sign_in_account.error_details', error_code: 'EFGHI')),
+      )
+      expect(rendered).to have_css(
+        'p .field-readout.field-readout--inline .field-readout__value',
+        text: 'EFGHI',
+      )
+      expect(rendered).not_to have_css('lg-clipboard-button')
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/125
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles `users/please_call#show` for the NDS bucket:

- Contact number becomes a non-wrapping `tel:` link.
- Support code renders as an inline `field-readout--inline` pill inside the existing sentence (no copy button).
- Legacy branch preserved **byte-for-byte**; existing copy reused — **no new locale keys**.

**Dependencies:** IDS `field-readout--inline` variant (on the consolidated IDS branch).

## 👀 Preview

Dev NDS explorer: `/test/nds/please-call`

## 📜 Testing Plan

- `spec/views/users/please_call/show.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`