### PR TITLE
Add the NDS fraud-review please-call page body

### DIFF
--- a/app/views/idv/please_call/show.html.erb
+++ b/app/views/idv/please_call/show.html.erb
@@ -1,3 +1,33 @@
+<% if nds_layout? %>
+  <% if @in_person == false or @in_person.nil? %>
+    <% content_for(:nds_header_progress) do %>
+      <%= nds_account_creation_progress(step: :verification, substep: 10) %>
+    <% end %>
+  <% end %>
+
+  <%= render(
+        'idv/shared/error',
+        title: t('titles.failure.information_not_verified'),
+        heading: t('idv.failure.setup.heading'),
+      ) do %>
+    <p>
+      <%= t('idv.failure.setup.fail_date_html', date_html: I18n.l(@call_by_date, format: I18n.t('time.formats.event_date'))) %>
+    </p>
+    <p>
+      <%= t(
+            'idv.failure.setup.fail_html',
+            contact_number: link_to(
+              IdentityConfig.store.idv_contact_phone_number,
+              "tel:#{IdentityConfig.store.idv_contact_phone_number.gsub(/\D/, '')}",
+              class: 'link text-no-wrap',
+            ),
+            support_code: content_tag(:span, class: 'field-readout field-readout--inline') do
+              content_tag(:span, IdentityConfig.store.lexisnexis_threatmetrix_support_code, class: 'field-readout__value')
+            end,
+          ) %>
+    </p>
+  <% end %>
+<% else %>
 <% if @in_person == false or @in_person.nil? %>
   <% content_for(:pre_flash_content) do %>
       <%= render StepIndicatorComponent.new(
@@ -20,4 +50,5 @@
     <p>
       <%= t('idv.failure.setup.fail_html', support_code: IdentityConfig.store.lexisnexis_threatmetrix_support_code, contact_number: IdentityConfig.store.idv_contact_phone_number) %>
     </p>
+<% end %>
 <% end %>

--- a/spec/views/idv/please_call/show.html.erb_spec.rb
+++ b/spec/views/idv/please_call/show.html.erb_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe 'idv/please_call/show.html.erb' do
   let(:in_person_proofing_enabled) { false }
   let(:in_person) { false }
+  let(:nds_layout) { false }
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     @call_by_date = Date.new(2023, 10, 13)
     @in_person = in_person
     allow(IdentityConfig.store).to receive(:in_person_proofing_enabled)
@@ -40,6 +41,32 @@ RSpec.describe 'idv/please_call/show.html.erb' do
         '.step-indicator__step--current',
         text: t('step_indicator.flows.idv.secure_account'),
       )
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the verification header progress instead of the step indicator' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+      expect(view.content_for(:pre_flash_content)).to be_nil
+    end
+
+    it 'renders the call-by date and the contact sentence with a tel: link and inline code' do
+      expect(rendered).to have_css('.auth__form-page-body strong', text: 'October 13, 2023')
+      expect(rendered).to have_css("a.text-no-wrap[href='tel:8445555555']", text: '(844) 555-5555')
+      expect(rendered).to have_css('p .field-readout--inline .field-readout__value', text: 'ABCD')
+    end
+
+    context 'in person' do
+      let(:in_person_proofing_enabled) { true }
+      let(:in_person) { true }
+
+      it 'does not render header progress' do
+        expect(view.content_for(:nds_header_progress)).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/126
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles `idv/please_call#show` for the NDS bucket:

- Verification header progress (substep 5) replaces the legacy step indicator (omitted for in-person, as legacy).
- Contact number becomes a non-wrapping `tel:` link; support code renders as an inline `field-readout--inline` pill inside the existing sentence.
- Legacy branch preserved **byte-for-byte**; existing copy reused — **no new locale keys**.

**Dependencies:** IDS `field-readout--inline` variant (consolidated IDS branch).

## 👀 Preview

Dev NDS explorer: `/test/nds/idv-please-call` (and `?ipp=1`)

## 📜 Testing Plan

- `spec/views/idv/please_call/show.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`