### PR TITLE
Add the NDS state-ID warning page body

### DIFF
--- a/app/views/idv/session_errors/state_id_warning.html.erb
+++ b/app/views/idv/session_errors/state_id_warning.html.erb
@@ -16,11 +16,13 @@
 
   <p><%= t('idv.warning.state_id.explanation') %></p>
 
-  <p class="margin-bottom-0"><%= t('idv.warning.state_id.next_steps.preamble') %></p>
-  <ul>
-    <% t('idv.warning.state_id.next_steps.items_html', app_name: APP_NAME).each do |item| %>
-      <li><%= item %></li>
-    <% end %>
-  </ul>
+  <% unless nds_layout? %>
+    <p class="margin-bottom-0"><%= t('idv.warning.state_id.next_steps.preamble') %></p>
+    <ul>
+      <% t('idv.warning.state_id.next_steps.items_html', app_name: APP_NAME).each do |item| %>
+        <li><%= item %></li>
+      <% end %>
+    </ul>
+  <% end %>
 <% end %>
 

--- a/spec/views/idv/session_errors/state_id_warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/state_id_warning.html.erb_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'idv/session_errors/state_id_warning.html.erb' do
+  let(:nds_layout) { false }
+
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     assign(:try_again_path, '/try_again')
 
     render
@@ -33,5 +35,26 @@ RSpec.describe 'idv/session_errors/state_id_warning.html.erb' do
       t('idv.warning.state_id.cancel_button', app_name: APP_NAME),
       href: return_to_sp_failure_to_proof_url(step: 'verify_info', location: 'state_id_warning'),
     )
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'shows the explanation and both actions without the next-steps list' do
+      expect(rendered).to have_css(
+        '.auth__form-page-body p',
+        text: t('idv.warning.state_id.explanation'),
+      )
+      expect(rendered).not_to have_text(strip_tags(t('idv.warning.state_id.next_steps.preamble')))
+      expect(rendered).not_to have_css('.auth__form-page-body ul')
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button:not(.usa-button--secondary)',
+        text: t('idv.warning.state_id.try_again_button'),
+      )
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button--secondary',
+        text: t('idv.warning.state_id.cancel_button', app_name: APP_NAME),
+      )
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/127
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles `idv/session_errors#state_id_warning` for the NDS bucket:

- Drops the "You can:" preamble + bullet list in the NDS bucket — the Try again (primary) and Exit Login.gov (secondary) buttons already carry those options.
- Legacy rendered output unchanged; existing copy reused — **no new locale keys**.

## 👀 Preview

Dev NDS explorer: `/test/nds/session-error-state-id-warning`

## 📜 Testing Plan

- `spec/views/idv/session_errors/state_id_warning.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`