### PR TITLE
Add the NDS Socure document-capture error pages

### DIFF
--- a/app/presenters/socure_error_presenter.rb
+++ b/app/presenters/socure_error_presenter.rb
@@ -6,7 +6,7 @@ class SocureErrorPresenter
   include ActionView::Helpers::TranslationHelper
   include LinkHelper
 
-  attr_reader :url_options, :passport_requested
+  attr_reader :url_options, :passport_requested, :remaining_attempts
 
   def initialize(error_code:, remaining_attempts:, sp_name:, issuer:, passport_requested:,
                  flow_path:)
@@ -77,7 +77,7 @@ class SocureErrorPresenter
 
   private
 
-  attr_reader :error_code, :remaining_attempts, :sp_name, :issuer, :flow_path
+  attr_reader :error_code, :sp_name, :issuer, :flow_path
 
   SOCURE_ERROR_MAP = {
     'I848' => 'unreadable_id',

--- a/app/views/idv/hybrid_mobile/socure/errors/show.html.erb
+++ b/app/views/idv/hybrid_mobile/socure/errors/show.html.erb
@@ -1,3 +1,6 @@
+<% if nds_layout? %>
+  <%= render 'idv/socure/nds_errors', presenter: @presenter %>
+<% else %>
 <%= render(
       'idv/shared/error',
       type: :warning,
@@ -14,4 +17,5 @@
 %>
   <p><%= @presenter.body_text %></p>
   <p><%= @presenter.rate_limit_text %></p>
+<% end %>
 <% end %>

--- a/app/views/idv/socure/_nds_errors.html.erb
+++ b/app/views/idv/socure/_nds_errors.html.erb
@@ -1,0 +1,76 @@
+<%#
+NDS-bucket body for the Socure document-capture error pages (standard and
+hybrid). Renders the SocureErrorPresenter as a single card: attempts copy,
+try-again / use-another-ID actions, the in-person CTA, then the remaining
+troubleshooting options as links.
+locals:
+* presenter: SocureErrorPresenter
+%>
+<% self.title = presenter.heading %>
+<% content_for(:nds_header_progress) do %>
+  <%= nds_account_creation_progress(step: :verification, substep: 2) %>
+<% end %>
+
+<% another_id_option, *help_options = presenter.options %>
+
+<%= render NDS::FormPageComponent.new(title: presenter.heading) do |page| %>
+  <% page.with_media do %>
+    <span class="nds-status-icon nds-status-icon--warning">
+      <%= render NDS::IconComponent.new(icon: :warning, size: 24) %>
+    </span>
+  <% end %>
+
+  <% if presenter.rate_limit_text.present? %>
+    <% page.with_body do %>
+      <hr class="divider" />
+      <p><%= t('nds.socure_errors.rate_limit_html', count: presenter.remaining_attempts) %></p>
+    <% end %>
+  <% end %>
+
+  <% page.with_actions do %>
+    <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+      <%= render ButtonComponent.new(
+            url: presenter.action[:url],
+            full_width: true,
+          ).with_content(presenter.action[:text]) %>
+      <% if another_id_option %>
+        <%= render ButtonComponent.new(
+              url: another_id_option[:url],
+              variant: :secondary,
+              full_width: true,
+            ).with_content(another_id_option[:text]) %>
+      <% end %>
+    <% end %>
+
+    <% if presenter.secondary_action %>
+      <%= render NDS::StackComponent.new(kind: :actions, align: :stretch, class: 'margin-top-4') do %>
+        <h2 class="heading-s text-center"><%= t('nds.socure_errors.in_person_heading') %></h2>
+        <p class="text-center margin-0"><%= presenter.secondary_action_text %></p>
+        <%= render ButtonComponent.new(
+              url: presenter.secondary_action[:url],
+              variant: :secondary,
+              full_width: true,
+            ).with_content(presenter.secondary_action[:text]) %>
+      <% end %>
+    <% end %>
+
+    <% if help_options.present? %>
+      <%= render NDS::StackComponent.new(kind: :links, align: :center, class: 'margin-top-4') do %>
+        <h2 class="heading-s text-center"><%= presenter.troubleshooting_heading %></h2>
+        <% help_options.each do |option| %>
+          <% external_redirect = option[:isExternal] && option[:url].include?('return_to_sp') %>
+          <%= link_to(
+                option[:url],
+                class: 'link',
+                **(option[:isExternal] && !external_redirect ? { target: '_blank', rel: 'noopener' } : {}),
+              ) do %>
+            <%= option[:text] %>
+            <% if external_redirect %>
+              <%= render NDS::IconComponent.new(icon: :launch, size: 20, class: 'margin-left-05 text-middle') %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/idv/socure/errors/show.html.erb
+++ b/app/views/idv/socure/errors/show.html.erb
@@ -1,3 +1,6 @@
+<% if nds_layout? %>
+  <%= render 'idv/socure/nds_errors', presenter: @presenter %>
+<% else %>
 <%= render(
       'idv/shared/error',
       type: :warning,
@@ -14,4 +17,5 @@
 %>
   <p><%= @presenter.body_text %></p>
   <p><%= @presenter.rate_limit_text %></p>
+<% end %>
 <% end %>

--- a/spec/views/idv/socure/errors/show.html.erb_spec.rb
+++ b/spec/views/idv/socure/errors/show.html.erb_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe 'idv/socure/errors/show.html.erb' do
   include Devise::Test::ControllerHelpers
 
+  let(:nds_layout) { false }
+
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
   end
 
   let(:remaining_submit_attempts) { 5 }
@@ -224,6 +226,68 @@ RSpec.describe 'idv/socure/errors/show.html.erb' do
       expect(rendered).to have_link(
         t('idv.failure.button.warning'),
         href: idv_socure_document_capture_path,
+      )
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+    let(:error_code) { :network }
+
+    before do
+      allow(IdentityConfig.store).to receive(:in_person_proofing_enabled).and_return(true)
+      assign(:presenter, presenter)
+      render
+    end
+
+    it 'renders the warning card with attempts copy and no try-again-later text' do
+      expect(rendered).to have_css('.auth--form-page h1', text: presenter.heading)
+      expect(rendered).to have_css('.nds-status-icon--warning')
+      expect(rendered).to have_css(
+        '.auth__form-page-body p',
+        text: strip_tags(t('nds.socure_errors.rate_limit_html', count: remaining_submit_attempts)),
+      )
+      expect(rendered).not_to have_text(t('idv.errors.try_again_later'))
+    end
+
+    it 'renders try-again primary and use-another-ID secondary actions' do
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button:not(.usa-button--secondary)',
+        text: t('idv.failure.button.warning'),
+      )
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button--secondary',
+        text: t('idv.troubleshooting.options.use_another_id_type'),
+      )
+    end
+
+    it 'renders the in-person CTA with its heading and copy' do
+      expect(rendered).to have_css('h2', text: t('nds.socure_errors.in_person_heading'))
+      expect(rendered).to have_text(t('in_person_proofing.body.cta.prompt_detail'))
+      expect(rendered).to have_css(
+        'a.usa-button--secondary',
+        text: t('in_person_proofing.body.cta.button'),
+      )
+    end
+
+    it 'renders the remaining troubleshooting options as links' do
+      expect(rendered).to have_css('h2', text: t('components.troubleshooting_options.ipp_heading'))
+      expect(rendered).to have_css(
+        'a.link[target=_blank]',
+        text: t('idv.troubleshooting.options.doc_capture_tips'),
+      )
+      expect(rendered).to have_css(
+        'a.link[target=_blank]',
+        text: t('idv.troubleshooting.options.supported_documents'),
+      )
+      expect(rendered).to have_css(
+        'a.link:not([target]) svg.usa-icon',
+      )
+    end
+
+    it 'sets the verification header progress' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
       )
     end
   end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/128
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Stacked on #13488. Converts `idv/socure/errors#show` and `idv/hybrid_mobile/socure/errors#show` to the NDS bucket via a shared `idv/socure/_nds_errors` partial driven by `SocureErrorPresenter`:

- Warning status badge + heading; body = attempts-remaining copy only ("Try again later" dropped).
- Actions: **Try again** (primary), **Use another type of ID** (secondary); then the in-person CTA ("Or, try verifying your ID in person" + copy + secondary button); then "Additional troubleshooting options" as links — help-center links open in a new tab, the return-to-SP redirect gets an explicit launch icon.
- Verification header progress replaces the step indicator. Legacy branches **byte-for-byte**.
- New keys (via consolidation): `nds.socure_errors.in_person_heading`, `nds.socure_errors.rate_limit_html` (comma after "Then"). Exposes `remaining_attempts` on the presenter.

## 👀 Preview

Dev NDS explorer: `/test/nds/socure-errors` (`?code=timeout|unaccepted_id_type|selfie_fail`), `/test/nds/hybrid-socure-errors`

## 📜 Testing Plan

- `spec/views/idv/socure/errors/show.html.erb_spec.rb`, `spec/presenters/socure_error_presenter_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`