### PR TITLE
Add the NDS verify-by-mail code rate-limited page body

### DIFF
--- a/app/views/idv/by_mail/enter_code_rate_limited/index.html.erb
+++ b/app/views/idv/by_mail/enter_code_rate_limited/index.html.erb
@@ -1,3 +1,37 @@
+<% if nds_layout? %>
+  <%= render(
+        'idv/shared/error',
+        title: t('idv.gpo.title'),
+        heading: t('idv.failure.gpo.rate_limited.heading'),
+        action: {
+          text: decorated_sp_session.sp_name.present? ?
+            t('idv.failure.exit.with_sp', app_name: APP_NAME, sp_name: decorated_sp_session.sp_name) :
+            t('nds.errors.return_home'),
+          url: return_to_sp_failure_to_proof_path(
+            step: 'verify_address',
+            location: request.params[:action],
+          ),
+        },
+        options: [
+          {
+            url: contact_redirect_url,
+            text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+            new_tab: true,
+          },
+        ],
+      ) do %>
+    <p>
+      <%= t(
+            'errors.enter_code.rate_limited_html',
+            timeout: distance_of_time_in_words(
+              Time.zone.now,
+              [@expires_at, Time.zone.now].compact.max,
+              except: :seconds,
+            ),
+          ) %>
+    </p>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       title: t('idv.gpo.title'),
@@ -49,3 +83,4 @@
         </strong>
       </p>
     <% end %>
+<% end %>

--- a/spec/views/idv/by_mail/enter_code_rate_limited/index.html.erb_spec.rb
+++ b/spec/views/idv/by_mail/enter_code_rate_limited/index.html.erb_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/by_mail/enter_code_rate_limited/index.html.erb' do
+  let(:sp_name) { nil }
+  let(:nds_layout) { false }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(view).to receive(:decorated_sp_session).and_return(
+      instance_double(ServiceProviderSession, sp_name: sp_name),
+    )
+    @expires_at = 6.hours.from_now
+
+    render
+  end
+
+  it 'renders the heading and legacy exit link' do
+    expect(rendered).to have_css('h1', text: t('idv.failure.gpo.rate_limited.heading'))
+    expect(rendered).to have_link(
+      t('idv.failure.exit.without_sp', app_name: APP_NAME),
+      href: return_to_sp_failure_to_proof_path(step: 'verify_address', location: 'index'),
+    )
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the return-home exit as the primary action above troubleshooting' do
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button:not(.usa-button--tertiary)',
+        text: t('nds.errors.return_home'),
+      )
+      expect(rendered).not_to have_css('.auth__form-page-body strong a')
+      expect(rendered).to have_css(
+        '.nds-troubleshooting-options a.usa-button--tertiary[target=_blank]',
+        text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+      )
+    end
+
+    context 'with an SP' do
+      let(:sp_name) { 'Example SP' }
+
+      it 'uses the return-to-SP copy for the primary action' do
+        expect(rendered).to have_css(
+          '.auth__actions a.usa-button',
+          text: t('idv.failure.exit.with_sp', app_name: APP_NAME, sp_name: sp_name),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/129
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles `idv/by_mail/enter_code_rate_limited#index` for the NDS bucket:

- The bold exit link moves out of the body and becomes the partial's primary action button — **"Return home"** (`nds.errors.return_home`, via consolidation) or the existing return-to-SP copy — above the tertiary Contact Support option.
- Body keeps only the try-again-in-N-hours message. Legacy branch preserved **byte-for-byte**; **no new locale keys**.
- Adds a view spec (none existed).

## 👀 Preview

Dev NDS explorer: `/test/nds/enter-code-rate-limited` (and `?sp=1`)

## 📜 Testing Plan

- `spec/views/idv/by_mail/enter_code_rate_limited/index.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`