### PR TITLE
Add the NDS confirm-start-over pages

### DIFF
--- a/app/views/idv/confirm_start_over/before_letter.html.erb
+++ b/app/views/idv/confirm_start_over/before_letter.html.erb
@@ -1,3 +1,24 @@
+<% if nds_layout? %>
+  <%= render(
+        'idv/shared/error',
+        type: :warning,
+        heading: t('idv.cancel.headings.prompt.start_over'),
+        current_step: @step_indicator_step,
+        action: {
+          text: t('nds.errors.cancel_verification'),
+          url: idv_session_path(step: :request_letter),
+          method: :delete,
+          variant: :destructive,
+        },
+        secondary_action: {
+          text: t('forms.buttons.back'),
+          url: go_back_path || idv_request_letter_path,
+        },
+      ) do %>
+    <p><%= t('idv.cancel.description.gpo.start_over_new_address') %></p>
+    <p><%= t('idv.cancel.description.gpo.continue') %></p>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       type: :warning,
@@ -21,3 +42,4 @@
   </div>
 <% end %>
 <%= render('idv/shared/back', step: 'request_letter', fallback_path: idv_request_letter_path) %>
+<% end %>

--- a/app/views/idv/confirm_start_over/index.html.erb
+++ b/app/views/idv/confirm_start_over/index.html.erb
@@ -1,3 +1,27 @@
+<% if nds_layout? %>
+  <%= render(
+        'idv/shared/error',
+        type: :warning,
+        heading: t('idv.cancel.headings.prompt.standard'),
+        current_step: @step_indicator_step,
+        action: {
+          text: t('nds.errors.cancel_verification'),
+          url: idv_session_path(step: :gpo_verify),
+          method: :delete,
+          variant: :destructive,
+        },
+        secondary_action: {
+          text: t('forms.buttons.back'),
+          url: go_back_path || idv_verify_by_mail_enter_code_path,
+        },
+      ) do %>
+    <p><%= t('idv.cancel.description.gpo.start_over') %></p>
+    <ul class="usa-list text-left">
+      <li><%= t('idv.cancel.description.gpo.warnings').first %></li>
+      <li><%= t('nds.errors.start_over_warning') %></li>
+    </ul>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       type: :warning,
@@ -25,3 +49,4 @@
   </div>
 <% end %>
 <%= render('idv/shared/back', step: 'gpo_verify', fallback_path: idv_verify_by_mail_enter_code_path) %>
+<% end %>

--- a/spec/views/idv/confirm_start_over/before_letter.html.erb_spec.rb
+++ b/spec/views/idv/confirm_start_over/before_letter.html.erb_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/confirm_start_over/before_letter.html.erb' do
+  let(:nds_layout) { false }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(view).to receive(:go_back_path).and_return(nil)
+    @step_indicator_step = :verify_address
+
+    render
+  end
+
+  it 'renders the heading and legacy continue button' do
+    expect(rendered).to have_css('h1', text: t('idv.cancel.headings.prompt.start_over'))
+    expect(rendered).to have_button(t('idv.buttons.continue_plain'))
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders a destructive cancel-verification action posting a delete' do
+      expect(rendered).to have_css(
+        '.auth__actions button.usa-button--danger[type=submit]',
+        text: t('nds.errors.cancel_verification'),
+      )
+      form_selector = "form[action='#{idv_session_path(step: :request_letter)}']"
+      expect(rendered).to have_css(
+        "#{form_selector} input[name=_method][value=delete]",
+        visible: :all,
+      )
+      expect(rendered).not_to have_button(t('idv.buttons.continue_plain'))
+    end
+
+    it 'renders a secondary back action to the fallback path without the legacy back link' do
+      expect(rendered).to have_css(
+        ".auth__actions a.usa-button--secondary[href='#{idv_request_letter_path}']",
+        text: t('forms.buttons.back'),
+      )
+      expect(rendered).not_to have_css('.border-top')
+    end
+
+    context 'with a go-back path' do
+      before do
+        allow(view).to receive(:go_back_path).and_return('/previous')
+        render
+      end
+
+      it 'uses the referer for the back action' do
+        expect(rendered).to have_link(t('forms.buttons.back'), href: '/previous')
+      end
+    end
+  end
+end

--- a/spec/views/idv/confirm_start_over/index.html.erb_spec.rb
+++ b/spec/views/idv/confirm_start_over/index.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/confirm_start_over/index.html.erb' do
+  let(:nds_layout) { false }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(view).to receive(:go_back_path).and_return(nil)
+    @step_indicator_step = :verify_address
+
+    render
+  end
+
+  it 'renders the heading and legacy continue button' do
+    expect(rendered).to have_css('h1', text: t('idv.cancel.headings.prompt.standard'))
+    expect(rendered).to have_button(t('idv.buttons.continue_plain'))
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders a destructive cancel-verification action posting a delete' do
+      expect(rendered).to have_css(
+        '.auth__actions button.usa-button--danger[type=submit]',
+        text: t('nds.errors.cancel_verification'),
+      )
+      expect(rendered).to have_css(
+        "form[action='#{idv_session_path(step: :gpo_verify)}'] input[name=_method][value=delete]",
+        visible: :all,
+      )
+      expect(rendered).not_to have_button(t('idv.buttons.continue_plain'))
+    end
+
+    it 'renders left-aligned warning bullets with the reworded start-over copy' do
+      expect(rendered).to have_css('ul.usa-list.text-left li', count: 2)
+      expect(rendered).to have_css('li', text: t('nds.errors.start_over_warning'))
+    end
+
+    it 'renders a secondary back action to the fallback path without the legacy back link' do
+      expect(rendered).to have_css(
+        ".auth__actions a.usa-button--secondary[href='#{idv_verify_by_mail_enter_code_path}']",
+        text: t('forms.buttons.back'),
+      )
+      expect(rendered).not_to have_css('.border-top')
+    end
+
+    context 'with a go-back path' do
+      before do
+        allow(view).to receive(:go_back_path).and_return('/previous')
+        render
+      end
+
+      it 'uses the referer for the back action' do
+        expect(rendered).to have_link(t('forms.buttons.back'), href: '/previous')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/130
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/confirm_start_over#index` and `#before_letter` for the NDS bucket:

- The ambiguous embedded **Continue** button becomes a **destructive "Cancel verification"** primary action (same DELETE form), with a **secondary Back** button directly below (referer or step fallback); the bottom divider + "‹ Back" link are gone.
- Index warning bullets are left-aligned; the second bullet reads "You will need to verify your identity from the beginning".
- Legacy branches preserved **byte-for-byte**. New keys via consolidation: `nds.errors.cancel_verification`, `nds.errors.start_over_warning`.

## 👀 Preview

Dev NDS explorer: `/test/nds/confirm-start-over`, `/test/nds/confirm-start-over-before-letter`

## 📜 Testing Plan

- `spec/views/idv/confirm_start_over/{index,before_letter}.html.erb_spec.rb` (new)
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`