### PR TITLE
Add the NDS duplicate-profiles please-call page body

### DIFF
--- a/app/views/users/duplicate_profiles_please_call/show.html.erb
+++ b/app/views/users/duplicate_profiles_please_call/show.html.erb
@@ -1,3 +1,19 @@
+<% if nds_layout? %>
+  <% contact_number = IdentityConfig.store.idv_contact_phone_number %>
+  <%= render(
+        'idv/shared/error',
+        heading: t('users.duplicate_profiles_please_call.heading'),
+      ) do %>
+    <%= t(
+          'nds.duplicate_profiles_please_call.error_details_html',
+          contact_number: link_to(contact_number, "tel:#{contact_number.gsub(/\D/, '')}", class: 'link text-no-wrap'),
+          error_code: content_tag(:span, class: 'field-readout field-readout--inline') do
+            content_tag(:span, 'LG33', class: 'field-readout__value')
+          end,
+          help_url: MarketingSite.help_url,
+        ) %>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       heading: t('users.duplicate_profiles_please_call.heading'),
@@ -6,4 +22,5 @@
       <%= t('users.duplicate_profiles_please_call.error_details_html', contact_number: IdentityConfig.store.idv_contact_phone_number, help_url: MarketingSite.help_url) %>
       <%# TODO Change help_url to be more specific %>
     </p>
+<% end %>
 <% end %>

--- a/spec/views/users/duplicate_profiles_please_call/show.html.erb_spec.rb
+++ b/spec/views/users/duplicate_profiles_please_call/show.html.erb_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'users/duplicate_profiles_please_call/show.html.erb' do
+  let(:nds_layout) { false }
+  let(:contact_number) { IdentityConfig.store.idv_contact_phone_number }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    render
+  end
+
+  it 'renders the heading and error details' do
+    expect(rendered).to have_css('h1', text: t('users.duplicate_profiles_please_call.heading'))
+    expect(rendered).to have_css('strong', text: 'LG33')
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'links the contact number as a non-wrapping tel: link' do
+      expect(rendered).to have_css(
+        "a.text-no-wrap[href='tel:#{contact_number.gsub(/\D/, '')}']",
+        text: contact_number,
+      )
+    end
+
+    it 'renders the error code as an inline field readout' do
+      expect(rendered).to have_css('p .field-readout--inline .field-readout__value', text: 'LG33')
+    end
+
+    it 'keeps the help link' do
+      expect(rendered).to have_link(href: MarketingSite.help_url)
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/131
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles `users/duplicate_profiles_please_call#show` for the NDS bucket:

- Contact number becomes a non-wrapping `tel:` link; the LG33 error code renders as an inline `field-readout--inline` pill.
- Legacy branch preserved **byte-for-byte**. New key via consolidation: `nds.duplicate_profiles_please_call.error_details_html` (existing copy with `%{error_code}` interpolated instead of the hardcoded code).
- Adds a view spec (none existed).

**Dependencies:** IDS `field-readout--inline` variant (consolidated IDS branch).

## 👀 Preview

Dev NDS explorer: `/test/nds/duplicate-profiles-please-call`

## 📜 Testing Plan

- `spec/views/users/duplicate_profiles_please_call/show.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`