### PR TITLE
Add the NDS phone verification warning page body

### DIFF
--- a/app/views/idv/phone_errors/warning.html.erb
+++ b/app/views/idv/phone_errors/warning.html.erb
@@ -1,3 +1,59 @@
+<% if nds_layout? %>
+  <%= render(
+        'idv/shared/error',
+        type: :warning,
+        title: t('titles.failure.phone_verification'),
+        heading: t('idv.failure.phone.warning.heading'),
+        current_step: :verify_phone,
+        action: {
+          text: t('idv.failure.phone.warning.try_again_button'),
+          url: idv_phone_path,
+        },
+        secondary_action: {
+          text: t('links.go_back'),
+          url: idv_cancel_path(step: 'phone'),
+        },
+      ) do %>
+    <% if @phone %>
+      <p>
+        <%= t('idv.failure.phone.warning.you_entered_html', formatted_phone: @formatted_phone) %>
+      </p>
+    <% end %>
+
+    <p>
+      <%= t('idv.failure.phone.warning.next_steps_html') %>
+      <%= new_tab_link_to(
+            t('idv.failure.phone.warning.learn_more_link'),
+            help_center_redirect_path(
+              category: 'verify-your-identity',
+              article: 'phone-number',
+              flow: :idv,
+              step: :phone,
+              location: 'learn_more',
+            ),
+          ) %>
+    </p>
+
+    <p>
+      <%= t('idv.failure.warning.attempts_html', count: @remaining_submit_attempts) %>
+    </p>
+  <% end %>
+
+  <% if @gpo_letter_available %>
+    <%= render NDS::StackComponent.new(kind: :actions, align: :stretch, class: 'margin-top-4') do %>
+      <h2 class="heading-s text-center"><%= t('idv.failure.phone.warning.gpo.heading') %></h2>
+      <p class="text-center margin-0">
+        <%= t('idv.failure.phone.warning.gpo.explanation') %>
+        <%= t('idv.failure.phone.warning.gpo.how_long_it_takes_html') %>
+      </p>
+      <%= render ButtonComponent.new(
+            url: idv_request_letter_path,
+            variant: :secondary,
+            full_width: true,
+          ).with_content(t('idv.failure.phone.warning.gpo.button')) %>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       type: :warning,
@@ -59,3 +115,4 @@
       <% end %>
 <% end %>
 <%= render('idv/doc_auth/cancel', step: 'phone') %>
+<% end %>

--- a/spec/views/idv/phone_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/warning.html.erb_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe 'idv/phone_errors/warning.html.erb' do
   let(:phone) { '+13602345678' }
   let(:country_code) { 'US' }
   let(:formatted_phone) { '+1 360-234-5678' }
+  let(:nds_layout) { false }
 
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
     assign(:gpo_letter_available, gpo_letter_available)
@@ -113,6 +114,47 @@ RSpec.describe 'idv/phone_errors/warning.html.erb' do
           t('idv.failure.phone.warning.you_entered_html', formatted_phone: formatted_phone),
         ),
       )
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders try-another-number primary and go-back secondary actions' do
+      expect(rendered).to have_css(
+        ".auth__actions a.usa-button:not(.usa-button--secondary)[href='#{idv_phone_path}']",
+        text: t('idv.failure.phone.warning.try_again_button'),
+      )
+      expect(rendered).to have_css(
+        ".auth__actions a.usa-button--secondary[href='#{idv_cancel_path(step: 'phone')}']",
+        text: t('links.go_back'),
+      )
+      expect(rendered).not_to have_link(t('links.cancel'))
+    end
+
+    it 'keeps the entered number, next steps and attempts in the body' do
+      expect(rendered).to have_css('.auth__form-page-body strong', text: formatted_phone)
+      expect(rendered).to have_css(
+        '.auth__form-page-body a[target=_blank]',
+        text: t('idv.failure.phone.warning.learn_more_link'),
+      )
+    end
+
+    it 'does not render the verify-by-mail block when unavailable' do
+      expect(rendered).not_to have_css('h2', text: t('idv.failure.phone.warning.gpo.heading'))
+    end
+
+    context 'with gpo letter available' do
+      let(:gpo_letter_available) { true }
+
+      it 'renders the verify-by-mail heading, copy and secondary button' do
+        expect(rendered).to have_css('h2', text: t('idv.failure.phone.warning.gpo.heading'))
+        expect(rendered).to have_text(t('idv.failure.phone.warning.gpo.explanation'))
+        expect(rendered).to have_css(
+          "a.usa-button--secondary[href='#{idv_request_letter_path}']",
+          text: t('idv.failure.phone.warning.gpo.button'),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/132
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles `idv/phone_errors#warning` for the NDS bucket:

- **Try another number** becomes the primary action; the legacy cancel footer becomes a **secondary "Go back"** button directly below (`links.go_back`).
- When a letter is available, the verify-by-mail section renders under the card as heading + copy + secondary **Verify by mail** button (no `<hr>`).
- Body keeps the entered number, next steps / learn-more link, and attempts copy. Legacy branch preserved **byte-for-byte**; **no new locale keys**.

## 👀 Preview

Dev NDS explorer: `/test/nds/phone-error-warning` (and `?gpo=1`)

## 📜 Testing Plan

- `spec/views/idv/phone_errors/warning.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`