### PR TITLE
Add the NDS phone verification failure page body

### DIFF
--- a/app/views/idv/phone_errors/failure.html.erb
+++ b/app/views/idv/phone_errors/failure.html.erb
@@ -1,3 +1,54 @@
+<% if nds_layout? %>
+  <%= render(
+        'idv/shared/error',
+        title: t('titles.failure.phone_verification'),
+        heading: t('idv.failure.phone.rate_limited.heading'),
+        current_step: :verify_phone,
+        action: @gpo_letter_available && {
+          text: t('idv.failure.phone.rate_limited.gpo.button'),
+          url: idv_request_letter_path,
+        },
+        secondary_action: {
+          text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+          url: contact_redirect_url,
+          new_tab: true,
+        },
+        options: [
+          {
+            text: t('links.cancel'),
+            url: idv_cancel_path(step: :phone_error),
+          },
+        ],
+        troubleshooting_heading: '',
+      ) do %>
+    <p>
+      <%= t('idv.failure.phone.rate_limited.body') %>
+    </p>
+    <% if @gpo_letter_available %>
+      <p>
+        <%= t(
+              'idv.failure.phone.rate_limited.option_try_again_later_html',
+              time_left: distance_of_time_in_words(
+                Time.zone.now,
+                [@expires_at, Time.zone.now].compact.max,
+                except: :seconds,
+              ),
+            ) %>
+      </p>
+    <% else %>
+      <p>
+        <%= t(
+              'idv.failure.phone.rate_limited.option_try_again_later_no_gpo_html',
+              time_left: distance_of_time_in_words(
+                Time.zone.now,
+                [@expires_at, Time.zone.now].compact.max,
+                except: :seconds,
+              ),
+            ) %>
+      </p>
+    <% end %>
+  <% end %>
+<% else %>
 <%= render(
       'idv/shared/error',
       title: t('titles.failure.phone_verification'),
@@ -55,3 +106,4 @@
     <%= render PageFooterComponent.new do %>
       <%= link_to(t('links.cancel'), idv_cancel_path(step: :phone_error)) %>
     <% end %>
+<% end %>

--- a/spec/views/idv/phone_errors/failure.html.erb_spec.rb
+++ b/spec/views/idv/phone_errors/failure.html.erb_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
   let(:sp_name) { 'Example SP' }
   let(:timeout_hours) { 6 }
   let(:gpo_letter_available) { true }
+  let(:nds_layout) { false }
 
   around do |ex|
     freeze_time { ex.run }
   end
 
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     decorated_sp_session = instance_double(ServiceProviderSession, sp_name: sp_name)
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
     assign(:gpo_letter_available, gpo_letter_available)
@@ -84,6 +85,48 @@ RSpec.describe 'idv/phone_errors/failure.html.erb' do
         '.usa-button',
         text: t('idv.failure.phone.rate_limited.gpo.button'),
       )
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders verify-by-mail primary, contact secondary, and cancel tertiary actions' do
+      expect(rendered).to have_css(
+        ".auth__actions a.usa-button:not(.usa-button--secondary):not(.usa-button--tertiary)" \
+        "[href='#{idv_request_letter_path}']",
+        text: t('idv.failure.phone.rate_limited.gpo.button'),
+      )
+      expect(rendered).to have_css(
+        '.auth__actions a.usa-button--secondary[target=_blank]',
+        text: t('idv.troubleshooting.options.contact_support', app_name: APP_NAME),
+      )
+      expect(rendered).to have_css(
+        ".auth__actions a.usa-button--tertiary[href='#{idv_cancel_path(step: :phone_error)}']",
+        text: t('links.cancel'),
+      )
+      expect(rendered).not_to have_css('.nds-troubleshooting-options h2')
+    end
+
+    it 'does not render the legacy options list' do
+      expect(rendered).not_to have_text(t('idv.failure.phone.rate_limited.options_header'))
+      expect(rendered).not_to have_css('.auth__form-page-body ul')
+    end
+
+    context 'without gpo letter available' do
+      let(:gpo_letter_available) { false }
+
+      it 'omits the verify-by-mail action and shows the no-gpo try-again copy' do
+        expect(rendered).not_to have_link(t('idv.failure.phone.rate_limited.gpo.button'))
+        expect(rendered).to have_text(
+          strip_tags(
+            t(
+              'idv.failure.phone.rate_limited.option_try_again_later_no_gpo_html',
+              time_left: distance_of_time_in_words(timeout_hours.hours),
+            ),
+          ),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/133
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Restyles `idv/phone_errors#failure` for the NDS bucket:

- **Verify by mail** (when a letter is available) is the primary action; **Contact Login.gov Support** is a secondary new-tab button; the legacy cancel footer becomes a tertiary **Cancel** beneath it.
- The "You can:" options list is dropped; body keeps the rate-limit explanation and try-again-later copy.
- Legacy branch preserved **byte-for-byte**; **no new locale keys**.

## 👀 Preview

Dev NDS explorer: `/test/nds/phone-error-failure` (and `?gpo=1`)

## 📜 Testing Plan

- `spec/views/idv/phone_errors/failure.html.erb_spec.rb`
- `spec/views/idv/shared/_error.html.erb_spec.rb`, `spec/i18n_spec.rb`, catalog/explorer specs
- `erb_lint`, `rubocop`