### PR TITLE
Collect the phone number before document capture in the NDS IdV flow

### DIFF
--- a/app/controllers/idv/choose_id_type_controller.rb
+++ b/app/controllers/idv/choose_id_type_controller.rb
@@ -28,7 +28,7 @@ module Idv
         idv_session.opted_in_to_in_person_proofing = true
         idv_session.flow_path = 'standard'
         idv_session.skip_doc_auth_from_how_to_verify = true
-        return redirect_to idv_document_capture_url(step: :choose_id_type)
+        return redirect_to idv_document_capture_url(step: in_person_entry_step)
       end
 
       @choose_id_type_form = Idv::ChooseIdTypeForm.new(
@@ -80,8 +80,22 @@ module Idv
         Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
     end
 
+    # In the NDS phone-first flow, hybrid handoff (phone or continue on this
+    # computer) follows choosing an ID type, unless handoff is skipped on mobile.
     def next_step
-      idv_document_capture_url
+      if idv_session.phone_first_flow? && !idv_session.skip_hybrid_handoff?
+        idv_hybrid_handoff_url
+      else
+        idv_document_capture_url
+      end
+    end
+
+    # Document capture's direct-IPP entry re-derives skip_doc_auth_from_how_to_verify
+    # from the step param, so anything other than how_to_verify lands the user on
+    # photo capture instead of the in-person location picker. The NDS flow has no
+    # how-to-verify page; verify-in-person from choose_id_type is that entry point.
+    def in_person_entry_step
+      idv_session.phone_first_flow? ? :how_to_verify : :choose_id_type
     end
 
     def analytics_arguments

--- a/app/controllers/idv/document_capture_controller.rb
+++ b/app/controllers/idv/document_capture_controller.rb
@@ -142,6 +142,7 @@ module Idv
       return false unless IdentityConfig.store.in_person_proofing_opt_in_enabled &&
                           Idv::InPersonConfig.enabled_for_issuer?(decorated_sp_session.sp_issuer)
       @previous_step_url = step_is_handoff? ? idv_hybrid_handoff_path : nil
+      @how_to_verify_url = idv_choose_id_type_url if phone_first_in_person_entry?
       idv_session.flow_path = 'standard'
       idv_session.skip_doc_auth_from_handoff = step_is_handoff?
       idv_session.skip_doc_auth_from_how_to_verify = params[:step] == 'how_to_verify'
@@ -151,6 +152,10 @@ module Idv
 
     def step_is_handoff?
       params[:step] == 'hybrid_handoff'
+    end
+
+    def phone_first_in_person_entry?
+      idv_session.phone_first_flow? && params[:step] == 'how_to_verify'
     end
 
     def set_usps_form_presenter

--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -182,7 +182,9 @@ module Idv
 
     def bypass_send_link_steps
       idv_session.flow_path = 'standard'
-      redirect_to idv_choose_id_type_url
+      # In the phone-first flow choose_id_type precedes this step, so continue
+      # straight to document capture instead of looping back to it.
+      redirect_to idv_session.phone_first_flow? ? idv_document_capture_url : idv_choose_id_type_url
 
       analytics.idv_doc_auth_hybrid_handoff_submitted(
         **analytics_arguments.merge(

--- a/app/controllers/idv/welcome_controller.rb
+++ b/app/controllers/idv/welcome_controller.rb
@@ -62,8 +62,6 @@ module Idv
     private
 
     def update_nds
-      skip_to_capture if params[:skip_hybrid_handoff]
-
       @consent_form = Idv::ConsentForm.new(idv_consent_given: idv_session.idv_consent_given?)
       result = @consent_form.submit(consent_form_params)
       analytics.idv_doc_auth_welcome_submitted(**analytics_arguments)
@@ -86,6 +84,8 @@ module Idv
       idv_session.opted_in_to_in_person_proofing = false
       idv_session.skip_doc_auth_from_how_to_verify = false
       idv_session.flow_path = 'standard'
+      idv_session.phone_first_flow = true
+      skip_to_capture if params[:skip_hybrid_handoff]
 
       redirect_to idv_choose_id_type_url
     end

--- a/app/policies/idv/flow_policy.rb
+++ b/app/policies/idv/flow_policy.rb
@@ -41,6 +41,58 @@ module Idv
         personal_key: Idv::PersonalKeyController.step_info,
       }.freeze
 
+    # Rebuilds a step with a different next_steps list and/or an additional
+    # precondition (ANDed with the original); controller, action and undo are
+    # carried over.
+    def self.rewire(step, next_steps: step.next_steps, also_require: nil, undo_step: step.undo_step)
+      preconditions = if also_require
+                        ->(idv_session:, user:) do
+                          step.preconditions.call(idv_session:, user:) &&
+                            also_require.call(idv_session:, user:)
+                        end
+                      else
+                        step.preconditions
+                      end
+      Idv::StepInfo.new(
+        key: step.key,
+        controller: "#{step.controller.delete_prefix('/')}_controller".camelize.constantize,
+        action: step.action,
+        next_steps:,
+        preconditions:,
+        undo_step:,
+      )
+    end
+    private_class_method :rewire
+
+    # NDS bucket ("phone first"): hybrid handoff — enter a phone number to get a
+    # link, or continue on this computer — comes right after choosing an ID type
+    # and before document capture, so a user without a usable phone finds out
+    # before investing in the rest of the flow. Only the ordering around
+    # choose_id_type differs: handoff now requires a chosen ID type and is skipped
+    # on mobile, and it loses choose_id_type as a successor since it precedes it.
+    PHONE_FIRST_HANDOFF = lambda do |idv_session:, user:|
+      !idv_session.skip_hybrid_handoff? &&
+        Idv::DocumentCaptureController.ensure_choose_id_type_completed(idv_session:, user:)
+    end.freeze
+    private_constant :PHONE_FIRST_HANDOFF
+
+    PHONE_FIRST_STEPS = STEPS.merge(
+      choose_id_type: rewire(
+        STEPS[:choose_id_type],
+        next_steps: [:hybrid_handoff, :document_capture],
+      ),
+      hybrid_handoff: rewire(
+        STEPS[:hybrid_handoff],
+        next_steps: STEPS[:hybrid_handoff].next_steps - [:choose_id_type],
+        also_require: PHONE_FIRST_HANDOFF,
+        undo_step: ->(idv_session:, user:) do
+          idv_session.flow_path = 'standard'
+          idv_session.phone_for_mobile_flow = nil
+          idv_session.source_check_vendor = nil
+        end,
+      ),
+    ).freeze
+
     def initialize(idv_session:, user:)
       @idv_session = idv_session
       @user = user
@@ -79,7 +131,7 @@ module Idv
     end
 
     def steps
-      STEPS
+      idv_session.phone_first_flow? ? PHONE_FIRST_STEPS : STEPS
     end
 
     def step_allowed?(key:)

--- a/app/services/idv/session.rb
+++ b/app/services/idv/session.rb
@@ -32,6 +32,7 @@ module Idv
   # @attr personal_key [String, nil]
   # @attr personal_key_acknowledged [Boolean, nil]
   # @attr phone_confirmation_manually_reviewed [Boolean, nil]
+  # @attr phone_first_flow [Boolean, nil] NDS: hybrid handoff (phone) precedes document capture
   # @attr phone_for_mobile_flow [String, nil]
   # @attr previous_phone_step_params [Array]
   # @attr previous_ssn [String, nil]
@@ -90,6 +91,7 @@ module Idv
       personal_key
       phone_confirmation_manually_reviewed
       personal_key_acknowledged
+      phone_first_flow
       phone_for_mobile_flow
       phone_precheck_successful
       phone_precheck_vendor
@@ -412,6 +414,10 @@ module Idv
       session[:address_verification_mechanism] = nil
       session[:vendor_phone_confirmation] = nil
       session[:user_phone_confirmation] = nil
+    end
+
+    def phone_first_flow?
+      !!session[:phone_first_flow]
     end
 
     def skip_hybrid_handoff?

--- a/app/views/idv/shared/_document_capture.html.erb
+++ b/app/views/idv/shared/_document_capture.html.erb
@@ -44,7 +44,7 @@
       skip_doc_auth_from_how_to_verify:,
       skip_doc_auth_from_handoff:,
       skip_doc_auth_from_socure:,
-      how_to_verify_url: idv_how_to_verify_url,
+      how_to_verify_url: @how_to_verify_url || idv_how_to_verify_url,
       socure_errors_timeout_url:,
       previous_step_url: @previous_step_url,
       locations_url: idv_in_person_usps_locations_url,

--- a/app/views/users/shared/_nds_phone_input.html.erb
+++ b/app/views/users/shared/_nds_phone_input.html.erb
@@ -6,9 +6,15 @@
        dial: "+#{opts.dig(:data, :country_code)}",
      }
    end
+   pinned_isos = %w[US CA]
+   pinned, others = countries.partition { |c| pinned_isos.include?(c[:iso]) }
+   countries = pinned.sort_by { |c| pinned_isos.index(c[:iso]) } + others
    selected_iso = form.object.international_code.presence || 'US'
    selected = countries.find { |c| c[:iso] == selected_iso } || countries.first
    radio_name = "#{form.object_name}[international_code]"
+   # The dial code is shown by the country toggle, so present the number itself
+   # in national format rather than the form's "+1 …" international string.
+   national_phone = form.object.phone.present? ? Phonelib.parse(form.object.phone, selected[:iso]).national : nil
    phone_id = "#{form.object_name}_phone"
    error_id = "#{phone_id}-error"
    messages = {
@@ -36,7 +42,10 @@
       <div class="popover-menu popover-menu--left usa-phone-input__country-list"
            role="group"
            aria-label="<%= t('components.phone_input.country_code_label') %>">
-        <% countries.each do |country| %>
+        <% countries.each_with_index do |country, index| %>
+          <% if index == pinned.length && pinned.any? %>
+            <hr class="usa-phone-input__country-rule" />
+          <% end %>
           <label class="popover-menu__item usa-phone-input__country-option">
             <%= radio_button_tag(
                   radio_name,
@@ -46,8 +55,15 @@
                   data: { nds_phone_country: '', dial: country[:dial] },
                   id: "#{form.object_name}_international_code_#{country[:iso].downcase}",
                 ) %>
-            <%= country[:name] %>
-            <span class="usa-phone-input__country-option-dial"><%= country[:dial] %></span>
+            <span class="usa-phone-input__country-option-label">
+              <%= country[:name] %>
+              <span class="usa-phone-input__country-option-dial">(<%= country[:dial] %>)</span>
+            </span>
+            <%= render NDS::IconComponent.new(
+                  icon: :checkmark,
+                  size: 16,
+                  class: 'usa-phone-input__country-option-check',
+                ) %>
           </label>
         <% end %>
       </div>
@@ -55,6 +71,7 @@
     <span class="usa-phone-input__field">
       <%= form.telephone_field(
             :phone,
+            value: national_phone,
             id: phone_id,
             class: 'usa-phone-input__input',
             placeholder: ' ',

--- a/spec/controllers/idv/choose_id_type_controller_spec.rb
+++ b/spec/controllers/idv/choose_id_type_controller_spec.rb
@@ -111,6 +111,38 @@ RSpec.describe Idv::ChooseIdTypeController do
       end
     end
 
+    context 'in the phone-first (NDS) flow' do
+      before { subject.idv_session.phone_first_flow = true }
+
+      it 'redirects to hybrid handoff instead of document capture' do
+        put :update, params: params
+
+        expect(response).to redirect_to(idv_hybrid_handoff_url)
+      end
+
+      it 'redirects to document capture when handoff is skipped on mobile' do
+        subject.idv_session.skip_hybrid_handoff = true
+        put :update, params: params
+
+        expect(response).to redirect_to(idv_document_capture_url)
+      end
+
+      context 'when the user chooses to verify in person' do
+        before do
+          allow(IdentityConfig.store).to receive(:in_person_proofing_opt_in_enabled)
+            .and_return(true)
+          allow(Idv::InPersonConfig).to receive(:enabled_for_issuer?).and_return(true)
+        end
+
+        it 'enters document capture as the in-person location picker' do
+          put :update, params: { verify_in_person: 'true' }
+
+          expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to be true
+          expect(response).to redirect_to(idv_document_capture_url(step: :how_to_verify))
+        end
+      end
+    end
+
     context 'user selects passport' do
       let(:chosen_id_type) { 'passport' }
 

--- a/spec/controllers/idv/document_capture_controller_spec.rb
+++ b/spec/controllers/idv/document_capture_controller_spec.rb
@@ -483,6 +483,24 @@ RSpec.describe Idv::DocumentCaptureController do
         expect(response).to render_template :show
         expect(subject.idv_session.skip_doc_auth_from_handoff).to eq(true)
       end
+
+      it 'sends the in-person picker back to how to verify in the legacy flow' do
+        get :show, params: { step: 'how_to_verify' }
+
+        expect(response).to render_template :show
+        expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to eq(true)
+        expect(assigns(:how_to_verify_url)).to be_nil
+      end
+
+      it 'sends the in-person picker back to choose ID type in the phone-first flow' do
+        subject.idv_session.phone_first_flow = true
+
+        get :show, params: { step: 'how_to_verify' }
+
+        expect(response).to render_template :show
+        expect(subject.idv_session.skip_doc_auth_from_how_to_verify).to eq(true)
+        expect(assigns(:how_to_verify_url)).to eq(idv_choose_id_type_url)
+      end
     end
 
     context 'ipp disabled for sp' do

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -392,6 +392,19 @@ RSpec.describe Idv::HybridHandoffController do
       end
     end
 
+    context 'phone-first (NDS) flow' do
+      before do
+        subject.idv_session.phone_first_flow = true
+        stub_up_to(:choose_id_type, idv_session: subject.idv_session)
+      end
+
+      it 'continues on this computer straight to document capture' do
+        put :update, params: { type: 'desktop' }
+
+        expect(response).to redirect_to(idv_document_capture_url)
+      end
+    end
+
     context 'desktop flow' do
       let(:analytics_args) do
         {

--- a/spec/controllers/idv/welcome_controller_spec.rb
+++ b/spec/controllers/idv/welcome_controller_spec.rb
@@ -360,6 +360,14 @@ RSpec.describe Idv::WelcomeController do
           expect(subject.idv_session.idv_consent_given_at).to eq(Time.zone.now)
           expect(subject.idv_session.welcome_visited).to eq(true)
           expect(subject.idv_session.flow_path).to eq('standard')
+          expect(subject.idv_session.phone_first_flow).to eq(true)
+          expect(response).to redirect_to(idv_choose_id_type_url)
+        end
+
+        it 'keeps skip_hybrid_handoff set when the device can capture on its own' do
+          put :update, params: { doc_auth: { idv_consent_given: '1' }, skip_hybrid_handoff: 'true' }
+
+          expect(subject.idv_session.skip_hybrid_handoff).to eq(true)
           expect(response).to redirect_to(idv_choose_id_type_url)
         end
       end

--- a/spec/policies/idv/flow_policy_spec.rb
+++ b/spec/policies/idv/flow_policy_spec.rb
@@ -376,4 +376,97 @@ RSpec.describe 'Idv::FlowPolicy' do
       end
     end
   end
+
+  describe 'legacy step graph' do
+    # The phone-first (NDS) flow lives in a separate steps table; the legacy
+    # graph must stay exactly as it was.
+    let(:legacy_next_steps) do
+      {
+        root: %i[welcome request_letter],
+        welcome: %i[agreement hybrid_handoff choose_id_type document_capture how_to_verify],
+        agreement: %i[hybrid_handoff choose_id_type document_capture how_to_verify],
+        how_to_verify: %i[choose_id_type document_capture],
+        hybrid_handoff: %i[choose_id_type link_sent document_capture socure_document_capture
+                           clear1_session],
+        choose_id_type: %i[document_capture],
+        link_sent: %i[ssn],
+        document_capture: %i[ssn ipp_state_id ipp_choose_id_type],
+        clear1_session: %i[enter_password],
+        socure_document_capture: %i[ssn ipp_ssn],
+        socure_errors: %i[final],
+        ipp_choose_id_type: %i[ipp_state_id ipp_passport],
+        ipp_passport: %i[ipp_address],
+        ipp_state_id: %i[ipp_address ipp_ssn],
+        ipp_address: %i[ipp_ssn],
+        ssn: %i[verify_info],
+        ipp_ssn: %i[ipp_verify_info],
+        verify_info: %i[phone request_letter],
+        ipp_verify_info: %i[phone],
+        address: %i[verify_info],
+        phone: %i[otp_verification],
+        phone_errors: %i[final],
+        otp_verification: %i[enter_password],
+        request_letter: %i[enter_password],
+        enter_password: %i[personal_key],
+        personal_key: %i[final],
+      }
+    end
+
+    it 'is unchanged by the phone-first fork' do
+      expect(Idv::FlowPolicy::STEPS.transform_values(&:next_steps)).to eq(legacy_next_steps)
+    end
+  end
+
+  describe 'phone-first (NDS) flow' do
+    before do
+      allow(IdentityConfig.store).to receive(:doc_auth_desktop_test_mode).and_return(false)
+      idv_session.phone_first_flow = true
+      stub_up_to(:agreement, idv_session: idv_session)
+      idv_session.skip_doc_auth_from_how_to_verify = false
+      idv_session.flow_path = 'standard'
+    end
+
+    it 'does not allow hybrid handoff until an ID type is chosen' do
+      expect(subject.controller_allowed?(controller: Idv::ChooseIdTypeController)).to be true
+      expect(subject.controller_allowed?(controller: Idv::HybridHandoffController)).to be false
+      expect(subject.info_for_latest_step.key).to eq(:choose_id_type)
+    end
+
+    it 'does not loop hybrid handoff back to choose_id_type' do
+      expect(Idv::FlowPolicy::PHONE_FIRST_STEPS[:hybrid_handoff].next_steps)
+        .not_to include(:choose_id_type)
+    end
+
+    context 'after an ID type is chosen' do
+      before { stub_step(key: :choose_id_type, idv_session: idv_session) }
+
+      it 'routes to hybrid handoff' do
+        expect(subject.controller_allowed?(controller: Idv::HybridHandoffController)).to be true
+        expect(subject.info_for_latest_step.key).to eq(:hybrid_handoff)
+      end
+
+      it 'clears the handoff phone but keeps the standard flow path when undoing' do
+        idv_session.phone_for_mobile_flow = '+1 202-555-1212'
+        subject.undo_future_steps_from_controller!(controller: Idv::ChooseIdTypeController)
+        expect(idv_session.phone_for_mobile_flow).to be_nil
+        expect(idv_session.flow_path).to eq('standard')
+        expect(subject.controller_allowed?(controller: Idv::ChooseIdTypeController)).to be true
+      end
+
+      context 'on mobile (handoff skipped)' do
+        before { idv_session.skip_hybrid_handoff = true }
+
+        it 'skips handoff and goes to document capture' do
+          expect(subject.controller_allowed?(controller: Idv::HybridHandoffController)).to be false
+          expect(subject.info_for_latest_step.key).to eq(:document_capture)
+        end
+      end
+    end
+
+    it 'leaves the rest of the graph identical to legacy' do
+      (Idv::FlowPolicy::STEPS.keys - %i[choose_id_type hybrid_handoff]).each do |key|
+        expect(Idv::FlowPolicy::PHONE_FIRST_STEPS[key]).to equal(Idv::FlowPolicy::STEPS[key])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/134
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Builds on the shared `users/shared/_nds_phone_input` pill (#13477, merged). **Not page-only** — this is a flow change gated to the NDS bucket.

In the NDS bucket, users who finish identity verification and only then discover they have no usable US phone number have wasted the whole flow. This reorders the NDS flow so hybrid handoff (phone number for a link, or continue on this computer) comes right after choosing an ID type, before document capture. Everything after document capture is unchanged.

- `choose_id_type` → `hybrid_handoff` (or straight to document capture when handoff is skipped on mobile). Hybrid handoff requires a chosen ID type, drops choose_id_type as a successor, keeps `flow_path` on undo, and "Continue on this computer" goes straight to document capture. The later `phone` step still runs address-phone proofing unchanged.
- `Idv::FlowPolicy::PHONE_FIRST_STEPS`, selected by a new `idv_session.phone_first_flow` flag set in `welcome#update_nds`. **Legacy `STEPS`, controllers and behavior are unchanged** — the policy spec pins the legacy graph.
- NDS "Verify in person" on choose_id_type enters document capture with `step=how_to_verify` so the in-person location picker opens instead of photo capture.
- Shared phone pill: US + Canada pinned above a rule, then alphabetical; `Name (+N)` left-aligned with a checkmark on the selection; national-format prefill.
- No new locale keys or analytics events.

**IDS dependencies** (consolidated `nds-additional-tweaks`): `phoneInput` behavior, country-panel overflow fix, option/rule styling. `checkmark/16.svg` glyph via icon-scaffolding consolidation.

## 👀 Preview

Live: `/verify/welcome?ui_test_bucket=nds` → consent → choose ID → hybrid handoff; "Verify in person" → location picker.

## 📜 Testing Plan

- `spec/policies/idv/flow_policy_spec.rb` (legacy graph pinned + phone-first graph)
- `spec/controllers/idv/{choose_id_type,hybrid_handoff,welcome}_controller_spec.rb`
- `spec/i18n_spec.rb`, catalog/explorer specs, `erb_lint`, `rubocop`, `rake zeitwerk:check`