### PR TITLE
Replace the NDS welcome no-phone help link with Cancel

### DIFF
--- a/app/views/idv/welcome/show.html.erb
+++ b/app/views/idv/welcome/show.html.erb
@@ -113,16 +113,10 @@
                   full_width: true,
                 ).with_content(t('doc_auth.buttons.continue')) %>
             <%= render ButtonComponent.new(
-                  url: help_center_redirect_path(
-                    category: 'verify-your-identity',
-                    article: 'phone-number',
-                    flow: :idv,
-                    step: :welcome,
-                    location: 'no_phone_number',
-                  ),
+                  url: idv_cancel_path(step: 'welcome'),
                   variant: :tertiary,
                   full_width: true,
-                ).with_content(t('nds.idv_welcome.no_phone_link')) %>
+                ).with_content(t('links.cancel')) %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1658,7 +1658,6 @@ nds.idv_welcome.consent_link: privacy and security
 nds.idv_welcome.how_we_protect_heading: How we protect your data
 nds.idv_welcome.how_we_protect_info: We only use what you enter to verify your identity with the Social Security Administration. Your information will never be shared or sold outside the government.
 nds.idv_welcome.intro: '%{sp_name} needs to verify your identity before you continue. Most people finish in about 7 minutes.'
-nds.idv_welcome.no_phone_link: I don’t have a U.S. phone number
 nds.idv_welcome.title: Let’s verify your identity to access %{sp_name}
 nds.idv_welcome.what_youll_need: What you’ll need
 nds.link_sent.heading: Continue on your phone

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1669,7 +1669,6 @@ nds.idv_welcome.consent_link: privacidad y seguridad
 nds.idv_welcome.how_we_protect_heading: Cómo protegemos sus datos
 nds.idv_welcome.how_we_protect_info: Solo usamos lo que usted ingresa para verificar su identidad con la Administración del Seguro Social. Su información nunca se compartirá ni se venderá fuera del Gobierno.
 nds.idv_welcome.intro: '%{sp_name} necesita verificar su identidad antes de que continúe. La mayoría de las personas terminan en unos 7 minutos.'
-nds.idv_welcome.no_phone_link: No tengo un número de teléfono de los EE. UU.
 nds.idv_welcome.title: Verifiquemos su identidad para acceder a %{sp_name}
 nds.idv_welcome.what_youll_need: Lo que necesitará
 nds.link_sent.heading: Continúe en su teléfono

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1658,7 +1658,6 @@ nds.idv_welcome.consent_link: confidentialité et de sécurité
 nds.idv_welcome.how_we_protect_heading: Comment nous protégeons vos données
 nds.idv_welcome.how_we_protect_info: Nous n’utilisons que ce que vous saisissez pour vérifier votre identité auprès de la Social Security Administration. Vos renseignements ne seront jamais partagés ni vendus en dehors du gouvernement.
 nds.idv_welcome.intro: '%{sp_name} doit vérifier votre identité avant que vous continuiez. La plupart des gens terminent en environ 7 minutes.'
-nds.idv_welcome.no_phone_link: Je n’ai pas de numéro de téléphone américain
 nds.idv_welcome.title: Vérifions votre identité pour accéder à %{sp_name}
 nds.idv_welcome.what_youll_need: Ce dont vous aurez besoin
 nds.link_sent.heading: Continuez sur votre téléphone

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1671,7 +1671,6 @@ nds.idv_welcome.consent_link: 隐私和安全
 nds.idv_welcome.how_we_protect_heading: 我们如何保护您的数据
 nds.idv_welcome.how_we_protect_info: 我们仅使用您输入的信息向社会保障局验证您的身份。您的信息绝不会在政府之外被共享或出售。
 nds.idv_welcome.intro: '%{sp_name}需要先验证您的身份，然后您才能继续。大多数人大约在 7 分钟内完成。'
-nds.idv_welcome.no_phone_link: 我没有美国电话号码
 nds.idv_welcome.title: 让我们验证您的身份以访问%{sp_name}
 nds.idv_welcome.what_youll_need: 您需要准备的内容
 nds.link_sent.heading: 在您的手机上继续

--- a/spec/views/idv/welcome/show.html.erb_spec.rb
+++ b/spec/views/idv/welcome/show.html.erb_spec.rb
@@ -7,10 +7,13 @@ RSpec.describe 'idv/welcome/show.html.erb' do
   let(:sp_session) { {} }
   let(:view_context) { ActionController::Base.new.view_context }
   let(:sp) { build(:service_provider) }
+  let(:nds_layout) { false }
 
   before do
-    allow(view).to receive(:nds_layout?).and_return(false)
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(view).to receive(:current_sp).and_return(nil)
     allow(view_context).to receive(:current_user).and_return(user)
+    assign(:consent_form, Idv::ConsentForm.new(idv_consent_given: false))
 
     decorated_sp_session = ServiceProviderSession.new(
       sp: sp,
@@ -76,6 +79,18 @@ RSpec.describe 'idv/welcome/show.html.erb' do
           location: 'intro_paragraph',
         ),
       )
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders a tertiary cancel action instead of the no-phone help link' do
+      expect(rendered).to have_css(
+        ".auth__actions a.usa-button--tertiary[href='#{idv_cancel_path(step: 'welcome')}']",
+        text: t('links.cancel'),
+      )
+      expect(rendered).not_to have_link(href: /help_center.*phone-number/)
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/135
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Stacked on #13503 (phone-first flow). With the phone number now collected right after choosing an ID type, and mobile driver's licenses soon not requiring a phone at all, the NDS welcome page's tertiary "I don't have a U.S. phone number" help link no longer fits.

- Renders a tertiary **Cancel** (`idv_cancel_path(step: 'welcome')`) in its place. Legacy branch unchanged.
- Retires `nds.idv_welcome.no_phone_link` (locale removal lands via the shared-file consolidation).

## 👀 Preview

`/verify/welcome?ui_test_bucket=nds` or explorer `/test/nds/idv-welcome`

## 📜 Testing Plan

- `spec/views/idv/welcome/show.html.erb_spec.rb`, `spec/controllers/idv/welcome_controller_spec.rb`
- `spec/i18n_spec.rb`, `erb_lint`, `rubocop`