### PR TITLE
Add the NDS hybrid handoff page

### DIFF
--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -1,5 +1,57 @@
 <% self.title = @presenter.header_text %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 4) %>
+  <% end %>
+
+  <%= simple_form_for(
+        idv_phone_form,
+        as: :doc_auth,
+        url: url_for(type: :mobile, combined: true),
+        method: 'PUT',
+        html: {
+          id: 'form-to-submit-photos-through-mobile',
+          aria: { label: t('forms.buttons.send_link') },
+          data: { nds_submit_gate: true },
+        },
+      ) do |f| %>
+    <%= render NDS::FormPageComponent.new(
+          title: t('nds.hybrid_handoff.heading'),
+          subtitle: t('nds.hybrid_handoff.subtitle'),
+        ) do |page| %>
+      <% page.with_body do %>
+        <%= render 'users/shared/nds_phone_input', form: f %>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+          <%= render ButtonComponent.new(
+                type: :submit,
+                full_width: true,
+              ).with_content(t('forms.buttons.send_link')) %>
+          <% if @upload_enabled %>
+            <div class="separator"><%= t('nds.choose_id_type.or') %></div>
+            <%= render ButtonComponent.new(
+                  type: :submit,
+                  formaction: url_for(type: :desktop),
+                  formnovalidate: true,
+                  variant: :secondary,
+                  full_width: true,
+                ).with_content(t('doc_auth.headings.upload_from_computer')) %>
+          <% end %>
+          <%= render ButtonComponent.new(
+                url: idv_cancel_path(step: 'hybrid_handoff'),
+                variant: :tertiary,
+                full_width: true,
+              ).with_content(t('links.cancel')) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('nds-auth-submit-gate', preload_links_header: false) %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
@@ -174,3 +226,4 @@
   </div>
 <% end %>
 <%= render 'idv/doc_auth/cancel', step: 'hybrid_handoff' %>
+<% end %>

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
   let(:clear1_enabled) { false }
+  let(:nds_layout) { false }
   before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     allow(view).to receive(:current_user).and_return(@user)
     @idv_form = Idv::PhoneForm.new(user: build_stubbed(:user), previous_params: nil)
     @idv_how_to_verify_form = Idv::HowToVerifyForm.new
@@ -93,6 +95,52 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
         expect(rendered).to_not have_link(
           t('in_person_proofing.headings.prepare'),
           href: idv_document_capture_path(step: :hybrid_handoff),
+        )
+      end
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    before { @selfie_required = false }
+
+    it 'renders the phone card with send-link primary and cancel tertiary actions' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('nds.hybrid_handoff.heading'))
+      expect(rendered).to have_css(
+        '.auth__intro-description',
+        text: t('nds.hybrid_handoff.subtitle'),
+      )
+      expect(rendered).to have_css('.usa-phone-input')
+      expect(rendered).to have_css(
+        '.auth__actions button[type=submit]:not(.usa-button--secondary)',
+        text: t('forms.buttons.send_link'),
+      )
+      expect(rendered).to have_link(
+        t('links.cancel'),
+        href: idv_cancel_path(step: 'hybrid_handoff'),
+      )
+    end
+
+    it 'sets the verification header progress' do
+      rendered
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+
+    it 'does not offer in-person verification or desktop upload by default' do
+      expect(rendered).not_to have_content(t('doc_auth.headings.upload_from_computer'))
+      expect(rendered).not_to have_field('idv_how_to_verify_form[selection]', type: :hidden)
+    end
+
+    context 'with desktop upload enabled' do
+      before { @upload_enabled = true }
+
+      it 'offers continue-on-this-computer as a secondary submit' do
+        expect(rendered).to have_css(
+          '.auth__actions button.usa-button--secondary[formnovalidate]',
+          text: t('doc_auth.headings.upload_from_computer'),
         )
       end
     end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/136
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/hybrid_handoff#show` for the NDS bucket to the Figma "Enter your phone number" card:

- Verification header progress (4/12), the shared NDS phone pill, **Send link** primary, **Continue on this computer** as a secondary submit when desktop upload is enabled, tertiary Cancel.
- The in-person section is dropped — choose-ID-type already offers it in the NDS flow.
- Legacy branch preserved **byte-for-byte**. New keys via consolidation: `nds.hybrid_handoff.heading`, `nds.hybrid_handoff.subtitle`.

## 👀 Preview

Explorer `/test/nds/hybrid-handoff` (`?upload=1`); live `/verify/welcome?ui_test_bucket=nds` → choose ID → handoff.

## 📜 Testing Plan

- `spec/views/idv/hybrid_handoff/show.html.erb_spec.rb`, `spec/controllers/idv/hybrid_handoff_controller_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`