### PR TITLE
Add the NDS link-sent page

### DIFF
--- a/app/views/idv/link_sent/show.html.erb
+++ b/app/views/idv/link_sent/show.html.erb
@@ -1,3 +1,32 @@
+<% if nds_layout? %>
+  <% self.title = t('nds.link_sent.heading') %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 4) %>
+  <% end %>
+
+  <%= render NDS::CardComponent.new(class: 'card--elevated card--centered') do %>
+    <%= render NDS::StackComponent.new(align: :center, gap: 24) do %>
+      <h1 class="heading-s"><%= t('nds.link_sent.heading') %></h1>
+      <%= image_tag('nds/illustrations/devices.svg', alt: '', width: 87, height: 65) %>
+      <%= render NDS::StackComponent.new(align: :center, gap: 16, class: 'copy copy--muted text-center') do %>
+        <p class="margin-0"><%= t('nds.link_sent.instructions') %></p>
+        <p class="margin-0"><%= t('nds.link_sent.keep_open') %></p>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= button_to(
+        idv_link_sent_url,
+        method: :put,
+        class: 'usa-button usa-button--tertiary usa-button--full-width margin-top-4',
+        form_class: 'link-sent-continue-button-form',
+      ) { t('forms.buttons.continue') } %>
+
+  <% if FeatureManagement.doc_capture_polling_enabled? %>
+    <%= content_tag 'script', '', data: { status_endpoint: idv_link_sent_poll_url } %>
+    <%= javascript_packs_tag_once 'doc-capture-polling' %>
+  <% end %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
@@ -52,3 +81,4 @@
         class: 'link-sent-back-link',
       ) %>
 </div>
+<% end %>

--- a/spec/views/idv/link_sent/show.html.erb_spec.rb
+++ b/spec/views/idv/link_sent/show.html.erb_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/link_sent/show.html.erb' do
+  let(:nds_layout) { false }
+  let(:polling) { true }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(FeatureManagement).to receive(:doc_capture_polling_enabled?).and_return(polling)
+    render template: 'idv/link_sent/show', locals: { phone: '(202) 555-1212' }
+  end
+
+  it 'renders the legacy heading and continue form' do
+    expect(rendered).to have_css('h1', text: t('doc_auth.headings.text_message'))
+    expect(rendered).to have_button(t('forms.buttons.continue'))
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the connected-phone card with instructions' do
+      expect(rendered).to have_css('.card.card--elevated h1', text: t('nds.link_sent.heading'))
+      expect(rendered).to have_css("img[src*='devices'][width='87'][height='65']")
+      expect(rendered).to have_text(t('nds.link_sent.instructions'))
+      expect(rendered).to have_text(t('nds.link_sent.keep_open'))
+      expect(rendered).not_to have_text(t('doc_auth.info.you_entered'))
+    end
+
+    it 'sets the verification header progress' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+
+    it 'keeps the continue form and polling hook' do
+      expect(rendered).to have_css(
+        "form.link-sent-continue-button-form[action='#{idv_link_sent_url}']",
+      )
+      expect(rendered).to have_css(
+        "script[data-status-endpoint='#{idv_link_sent_poll_url}']",
+        visible: :all,
+      )
+    end
+
+    context 'without polling' do
+      let(:polling) { false }
+
+      it 'omits the polling hook' do
+        expect(rendered).not_to have_css('script[data-status-endpoint]', visible: :all)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/137
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/link_sent#show` for the NDS bucket to the Figma "Your phone is connected" card (title per design review: **Continue on your phone**):

- Verification header progress (4/12); elevated, centered card with the devices illustration and the follow-instructions / keep-this-window-open copy.
- Tertiary Continue kept as the no-JS fallback; the document-capture polling hook is unchanged, so the desktop still auto-advances when the phone finishes.
- Legacy branch preserved **byte-for-byte**. New keys via consolidation: `nds.link_sent.{heading,instructions,keep_open}`; `nds/illustrations/devices.svg` (87×65) ships via the shared asset consolidation.

## 👀 Preview

Explorer `/test/nds/link-sent`.

## 📜 Testing Plan

- `spec/views/idv/link_sent/show.html.erb_spec.rb` (new), `spec/controllers/idv/link_sent_controller_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`