### PR TITLE
Add the NDS capture-complete page

### DIFF
--- a/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
+++ b/app/views/idv/hybrid_mobile/capture_complete/show.html.erb
@@ -1,3 +1,14 @@
+<% if nds_layout? %>
+  <% self.title = t('titles.doc_auth.switch_back') %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 4) %>
+  <% end %>
+
+  <%= render NDS::FormPageComponent.new(
+        title: t('titles.doc_auth.switch_back'),
+        subtitle: t('nds.capture_complete.info'),
+      ) %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
@@ -14,3 +25,4 @@
 <% self.title = t('titles.doc_auth.switch_back') %>
 
 <%= render PageHeadingComponent.new.with_content(t('doc_auth.instructions.switch_back')) %>
+<% end %>

--- a/spec/views/idv/hybrid_mobile/capture_complete/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_mobile/capture_complete/show.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/hybrid_mobile/capture_complete/show.html.erb' do
+  let(:nds_layout) { false }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    render
+  end
+
+  it 'renders the legacy switch-back heading and illustration' do
+    expect(rendered).to have_css('h1', text: t('doc_auth.instructions.switch_back'))
+    expect(rendered).to have_css("img[src*='switch-back-to-computer']")
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the heading and success copy without the legacy illustration' do
+      expect(rendered).to have_css(
+        '.auth--form-page h1',
+        text: t('titles.doc_auth.switch_back'),
+      )
+      expect(rendered).to have_css('.auth__intro-description', text: t('nds.capture_complete.info'))
+      expect(rendered).not_to have_css('img')
+    end
+
+    it 'sets the verification header progress' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/138
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/hybrid_mobile/capture_complete#show` (the mobile dead-end after hybrid capture) for the NDS bucket to the Figma "Switch back to your computer" screen:

- Verification header progress (4/12); heading (existing `titles.doc_auth.switch_back`) plus success copy; legacy illustration dropped.
- Legacy branch preserved **byte-for-byte**. New key via consolidation: `nds.capture_complete.info`.

## 👀 Preview

Explorer `/test/nds/capture-complete`.

## 📜 Testing Plan

- `spec/views/idv/hybrid_mobile/capture_complete/show.html.erb_spec.rb` (new)
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`