### PR TITLE
Add the NDS Social Security number page

### DIFF
--- a/app/components/nds/input_component.html.erb
+++ b/app/components/nds/input_component.html.erb
@@ -40,11 +40,11 @@
       <% if @floating_label %>
         <span class="usa-input__floating-label" aria-hidden="true"><%= floating_label_text %></span>
       <% end %>
-      <% if password? %>
+      <% if password? || ssn? %>
         <button
           type="button"
           class="usa-input__toggle"
-          data-nds-password-toggle
+          <%= ssn? ? 'data-nds-ssn-toggle' : 'data-nds-password-toggle' %>
           data-label-show="<%= password_toggle_label %>"
           data-label-hide="<%= password_toggle_hide_label %>"
           aria-controls="<%= input_id %>"

--- a/app/components/nds/input_component.rb
+++ b/app/components/nds/input_component.rb
@@ -72,6 +72,20 @@ module NDS
       type == :password
     end
 
+    # SSN: a display-only masked control plus a hidden input that carries the
+    # submitted digits; the IDS inputSsn behavior keeps them in sync.
+    def ssn?
+      type == :ssn
+    end
+
+    def ssn_display_value
+      digits = form.object&.public_send(attribute).to_s.gsub(/\D/, '')
+      return '' if digits.empty?
+
+      masked = ('•' * (digits.length - 1)) + digits[-1]
+      [masked[0, 3], masked[3, 2], masked[5, 4]].compact.reject(&:empty?).join('-')
+    end
+
     def validation_error_messages
       {
         valueMissing: value_missing_error_message,
@@ -85,6 +99,7 @@ module NDS
       classes = ['usa-input']
       classes << 'usa-input--phone' if country_selector
       classes << 'usa-input--password' if password?
+      classes << 'usa-input--ssn' if ssn?
       classes << field_class if field_class.present?
       classes.join(' ')
     end
@@ -97,6 +112,7 @@ module NDS
       classes = ['usa-input__control']
       classes << 'usa-input__control--phone' if country_selector
       classes << 'usa-input__control--password' if password?
+      classes << 'usa-input__control--ssn' if ssn?
       classes << 'usa-input__control--floating' if @floating_label
       classes.concat(Array(@input_options[:class]))
       classes.join(' ')
@@ -173,12 +189,38 @@ module NDS
         opts[:pattern] ||= EMAIL_PATTERN
         form.email_field(attribute, **opts)
       when :password then form.password_field(attribute, **opts)
+      when :ssn      then render_ssn_input(opts)
       when :tel      then form.telephone_field(attribute, **opts)
       else                form.text_field(attribute, **opts)
       end
     end
 
     private
+
+    # The visible control keeps the field name so a no-JS submit still works;
+    # the behavior moves the name onto the hidden input once it mounts.
+    def render_ssn_input(opts)
+      opts = opts.merge(
+        value: ssn_display_value,
+        inputmode: 'numeric',
+        autocomplete: 'off',
+        pattern: nil,
+        maxlength: 11,
+        data: (opts[:data] || {}).merge(nds_ssn_incomplete: error_messages[:customError]),
+      )
+      safe_join(
+        [
+          form.text_field(attribute, **opts),
+          form.hidden_field(
+            attribute,
+            id: "#{input_id}_value",
+            name: nil,
+            value: form.object&.public_send(attribute).to_s.gsub(/\D/, ''),
+            data: { nds_ssn_value: true },
+          ),
+        ],
+      )
+    end
 
     def country_option_data(data, dial_code)
       supports_sms = data['supports_sms']

--- a/app/javascript/packs/nds-input-ssn.ts
+++ b/app/javascript/packs/nds-input-ssn.ts
@@ -1,0 +1,12 @@
+import * as designSystem from '@18f/identity-design-system';
+
+interface NDSBehavior {
+  on(root?: ParentNode): void;
+  off(): void;
+}
+
+// `inputSsn` ships in the design system's next release; until the published
+// typings include it, read it off the module without a static member check.
+const { inputSsn } = designSystem as unknown as { inputSsn: NDSBehavior };
+
+inputSsn.on(document.body);

--- a/app/views/idv/shared/ssn.html.erb
+++ b/app/views/idv/shared/ssn.html.erb
@@ -1,3 +1,80 @@
+<% if nds_layout? %>
+  <% self.title = t('titles.doc_auth.ssn') %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 5) %>
+  <% end %>
+
+  <% if FeatureManagement.proofing_device_profiling_collecting_enabled? %>
+    <%= render partial: 'shared/threat_metrix_profiling',
+               locals: {
+                 threatmetrix_session_id:,
+                 threatmetrix_javascript_urls:,
+                 threatmetrix_iframe_url:,
+               } %>
+  <% end %>
+
+  <%= simple_form_for(
+        @ssn_presenter.ssn_form,
+        url: url_for,
+        method: :put,
+        html: { data: { nds_submit_gate: true } },
+      ) do |f| %>
+    <%= render NDS::FormPageComponent.new(
+          title: @ssn_presenter.updating_ssn? ? t('doc_auth.headings.ssn_update') : t('doc_auth.headings.ssn'),
+          subtitle: t('nds.ssn.info', app_name: APP_NAME),
+        ) do |page| %>
+      <% if IdentityConfig.store.proofer_mock_fallback %>
+        <% page.with_alert do %>
+          <%= render AlertComponent.new(type: :info) do %>
+            <%= t('doc_auth.instructions.test_ssn') %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% page.with_body do %>
+        <%= render NDS::StackComponent.new(kind: :form, align: :stretch) do %>
+          <%= render NDS::InputComponent.new(
+                form: f,
+                attribute: :ssn,
+                type: :ssn,
+                label: t('idv.form.ssn_label'),
+                required: true,
+                password_toggle_label: t('forms.ssn.show'),
+                error_messages: { customError: t('idv.errors.pattern_mismatch.ssn') },
+              ) %>
+
+          <div class="copy text-center">
+            <h2 class="heading-s"><%= t('doc_auth.headings.no_ssn') %></h2>
+            <p class="copy--muted margin-0"><%= t('doc_auth.info.no_ssn') %></p>
+          </div>
+        <% end %>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+          <%= render ButtonComponent.new(type: :submit, full_width: true) do %>
+            <%= @ssn_presenter.updating_ssn? ? t('forms.buttons.submit.update') : t('forms.buttons.continue') %>
+          <% end %>
+          <% if @ssn_presenter.updating_ssn? %>
+            <%= render ButtonComponent.new(
+                  url: go_back_path || idv_verify_info_path,
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(t('forms.buttons.back')) %>
+          <% else %>
+            <%= render ButtonComponent.new(
+                  url: idv_cancel_url(step: 'ssn_offramp'),
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(@ssn_presenter.exit_text) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('nds-input-ssn', 'nds-auth-submit-gate', preload_links_header: false) %>
+<% else %>
 <%#
 Renders a page asking the user to enter their SSN or update their SSN if they had previously entered it.
 This template is used from both the remote and in person (IPP) SsnControllers.
@@ -75,4 +152,5 @@ locals:
   <%= render 'idv/shared/back', fallback_path: idv_verify_info_path %>
 <% else %>
   <%= render 'idv/doc_auth/cancel', step: 'ssn' %>
+<% end %>
 <% end %>

--- a/spec/components/nds/input_component_spec.rb
+++ b/spec/components/nds/input_component_spec.rb
@@ -192,4 +192,35 @@ RSpec.describe NDS::InputComponent, type: :component do
       )
     end
   end
+
+  context 'ssn contract' do
+    let(:options) do
+      { type: :ssn, attribute: :ssn, label: 'SSN', error_messages: { customError: 'Nine digits' } }
+    end
+
+    it 'emits a display control, a hidden value input and the reveal toggle' do
+      expect(rendered).to have_css('.usa-input.usa-input--ssn')
+      expect(rendered).to have_css(
+        'input[type=text].usa-input__control--ssn[name="preview[ssn]"]' \
+        '[inputmode=numeric][data-nds-ssn-incomplete="Nine digits"]',
+      )
+      expect(rendered).to have_css(
+        'input[type=hidden][data-nds-ssn-value]:not([name])',
+        visible: :all,
+      )
+      expect(rendered).to have_css('button.usa-input__toggle[data-nds-ssn-toggle]')
+    end
+
+    context 'with an existing value' do
+      let(:form) do
+        object = Struct.new(:ssn).new('900-12-3456')
+        ActionView::Helpers::FormBuilder.new(:preview, object, view_context, {})
+      end
+
+      it 'masks all but the last digit in the display and keeps the digits in the hidden input' do
+        expect(rendered).to have_css('.usa-input__control--ssn[value="•••-••-•••6"]')
+        expect(rendered).to have_css('input[data-nds-ssn-value][value="900123456"]', visible: :all)
+      end
+    end
+  end
 end

--- a/spec/views/idv/shared/ssn.html.erb_spec.rb
+++ b/spec/views/idv/shared/ssn.html.erb_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe 'idv/shared/ssn.html.erb' do
   end
 
   let(:sp_name) { 'SP' }
+  let(:nds_layout) { false }
 
   before :each do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     allow(view).to receive(:url_for).and_return('https://example.com/')
 
     allow(IdentityConfig.store).to receive(:proofing_device_profiling)
@@ -131,5 +133,68 @@ RSpec.describe 'idv/shared/ssn.html.erb' do
   def expect_session_id_input_not_rendered
     expect(rendered)
       .not_to have_css('input[name="doc_auth[threatmetrix_session_id]"]', visible: false)
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+    let(:updating_ssn) { false }
+
+    before do
+      assign(
+        :ssn_presenter,
+        Idv::SsnPresenter.new(
+          sp_name: sp_name,
+          ssn_form: Idv::SsnFormatForm.new(updating_ssn ? '900-12-3456' : nil),
+          step_indicator_steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
+        ),
+      )
+      render template: 'idv/shared/ssn', locals: {
+        threatmetrix_session_id: nil, threatmetrix_javascript_urls: [], threatmetrix_iframe_url: nil
+      }
+    end
+
+    it 'renders the SSN card with a password-style masked input and continue' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('doc_auth.headings.ssn'))
+      expect(rendered).to have_css(
+        '.auth__intro-description',
+        text: t('nds.ssn.info', app_name: APP_NAME),
+      )
+      expect(rendered).to have_css('.usa-input--ssn .usa-input__control--ssn[name="doc_auth[ssn]"]')
+      expect(rendered).to have_css(
+        '.usa-input--ssn input[type=hidden][data-nds-ssn-value]',
+        visible: :all,
+      )
+      expect(rendered).to have_css('button.usa-input__toggle[data-nds-ssn-toggle]')
+      expect(rendered).to have_css(
+        '.auth__actions button[type=submit]',
+        text: t('forms.buttons.continue'),
+      )
+    end
+
+    it 'keeps the no-SSN copy and the exit off-ramp as a tertiary action' do
+      expect(rendered).to have_css('h2', text: t('doc_auth.headings.no_ssn'))
+      expect(rendered).to have_text(t('doc_auth.info.no_ssn'))
+      expect(rendered).to have_css(
+        ".auth__actions a.usa-button--tertiary[href='#{idv_cancel_url(step: 'ssn_offramp')}']",
+      )
+    end
+
+    it 'sets the verification header progress' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+
+    context 'when updating the SSN' do
+      let(:updating_ssn) { true }
+
+      it 'uses the update heading, prefilled value, update submit and a back action' do
+        expect(rendered).to have_css('h1', text: t('doc_auth.headings.ssn_update'))
+        expect(rendered).to have_css('.usa-input__control--ssn[value="•••-••-•••6"]')
+        expect(rendered).to have_css('input[data-nds-ssn-value][value="900123456"]', visible: :all)
+        expect(rendered).to have_css('button[type=submit]', text: t('forms.buttons.submit.update'))
+        expect(rendered).to have_link(t('forms.buttons.back'), href: idv_verify_info_path)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/139
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/shared/ssn` — rendered by both the remote and in-person SSN steps — for the NDS bucket to the Figma "Enter your Social Security number" card:

- Verification header progress (5/12), heading + info copy, **Continue**; the "Don't have a Social Security number?" copy is kept in-card with the exit off-ramp as a tertiary action (Back when updating an SSN).
- New `type: :ssn` on `NDS::InputComponent`: a display-only control that groups digits as `123-45-6789` (dash appears as each group fills), shows only the most recently typed digit and masks it after a 5s pause (`•••-••-••••`), with an eye toggle to reveal the full number. The real digits live in a hidden input the form submits; without JS the visible field submits plain text. Mounted by the new `nds-input-ssn` pack.
- Legacy branch preserved **byte-for-byte**. New key via consolidation: `nds.ssn.info`.

**IDS dependencies** (consolidated `nds-additional-tweaks`): `inputSsn` behavior + `.usa-input--ssn` styles + docs, and typings for the net-new NDS behaviors.

## 👀 Preview

Explorer `/test/nds/idv-ssn` (`?update=1`, `?sp=1`).

## 📜 Testing Plan

- `spec/views/idv/shared/ssn.html.erb_spec.rb`, `spec/components/nds/input_component_spec.rb`
- `spec/controllers/idv/ssn_controller_spec.rb`, `spec/controllers/idv/in_person/ssn_controller_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`, `tsc`