### PR TITLE
Add the NDS residential address page

### DIFF
--- a/app/views/idv/address/new.html.erb
+++ b/app/views/idv/address/new.html.erb
@@ -1,3 +1,115 @@
+<% if nds_layout? %>
+  <% self.title = t('titles.doc_auth.address') %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 6) %>
+  <% end %>
+
+  <%= simple_form_for(
+        @address_form,
+        url: idv_address_path,
+        html: { data: { nds_submit_gate: true } },
+      ) do |f| %>
+    <%= render NDS::FormPageComponent.new(
+          title: @presenter.address_heading,
+          subtitle: @presenter.address_info,
+        ) do |page| %>
+      <% page.with_alert do %>
+        <%= render AlertComponent.new(
+              type: :info,
+              id: 'puerto-rico-extra-text',
+              class: @presenter.hint_class,
+            ) do
+              t('doc_auth.info.address_guidance_puerto_rico_html')
+            end %>
+      <% end %>
+
+      <% page.with_body do %>
+        <%= render NDS::StackComponent.new(align: :stretch) do %>
+          <%= render NDS::InputComponent.new(
+                form: f,
+                attribute: :address1,
+                id: 'address1',
+                label: t('idv.form.address1'),
+                required: true,
+                maxlength: 255,
+                autocomplete: 'address-line1',
+              ) %>
+          <%= render NDS::InputComponent.new(
+                form: f,
+                attribute: :address2,
+                label: t('idv.form.address2'),
+                maxlength: 255,
+                autocomplete: 'address-line2',
+              ) %>
+          <%= render NDS::InputComponent.new(
+                form: f,
+                attribute: :city,
+                label: t('idv.form.city'),
+                required: true,
+                maxlength: 255,
+                autocomplete: 'address-level2',
+              ) %>
+          <div class="usa-form-group margin-0">
+            <%= f.label :state, t('idv.form.state'), class: 'usa-sr-only' %>
+            <%= f.select(
+                  :state,
+                  us_states_territories,
+                  { include_blank: t('idv.form.state') },
+                  class: 'usa-select',
+                  required: true,
+                  autocomplete: 'address-level1',
+                ) %>
+          </div>
+          <%= render NDS::InputComponent.new(
+                form: f,
+                attribute: :zipcode,
+                type: :tel,
+                label: t('idv.form.zipcode'),
+                required: true,
+                pattern: '(\d{5}([\-]\d{4})?)',
+                class: 'zipcode',
+                autocomplete: 'postal-code',
+                error_messages: { patternMismatch: t('idv.errors.pattern_mismatch.zipcode') },
+              ) %>
+          <p class="puerto-rico-extras display-none copy--muted margin-0">
+            <%= @presenter.address_line1_hint %>, <%= @presenter.address_line2_hint %>,
+            <%= @presenter.city_hint %>, <%= @presenter.zipcode_hint %>
+          </p>
+        <% end %>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+          <%= render ButtonComponent.new(
+                type: :submit,
+                full_width: true,
+              ).with_content(@presenter.update_or_continue_button) %>
+          <% if @presenter.address_update_request %>
+            <%= render ButtonComponent.new(
+                  url: go_back_path || idv_verify_info_path,
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(t('forms.buttons.back')) %>
+          <% elsif @presenter.gpo_request_letter_visited %>
+            <%= render ButtonComponent.new(
+                  url: go_back_path || idv_request_letter_path,
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(t('forms.buttons.back')) %>
+          <% else %>
+            <%= render ButtonComponent.new(
+                  url: idv_cancel_path(step: 'verify'),
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(t('links.cancel')) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('formatted-fields', 'state-guidance', 'nds-auth-submit-gate', preload_links_header: false) %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: step_indicator_steps,
@@ -93,3 +205,4 @@
 
 <%= javascript_packs_tag_once('formatted-fields') %>
 <%= javascript_packs_tag_once('state-guidance') %>
+<% end %>

--- a/spec/views/idv/address/new.html.erb_spec.rb
+++ b/spec/views/idv/address/new.html.erb_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe 'idv/address/new' do
   let(:gpo_request_letter_visited) { nil }
   let(:address_update_request) { nil }
   let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
+  let(:nds_layout) { false }
 
   shared_examples 'valid address page and form' do
     before do
+      allow(view).to receive(:nds_layout?).and_return(nds_layout)
       allow(view).to receive(:current_user).and_return(user)
       allow(view).to receive(:step_indicator_steps).and_return(step_indicator_steps)
       assign(
@@ -131,5 +133,72 @@ RSpec.describe 'idv/address/new' do
     let(:address_update_request) { true }
 
     it_behaves_like 'valid address page and form'
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    before do
+      allow(view).to receive(:nds_layout?).and_return(true)
+      allow(view).to receive(:current_user).and_return(user)
+      allow(view).to receive(:go_back_path).and_return(nil)
+      assign(
+        :presenter, Idv::AddressPresenter.new(
+          gpo_request_letter_visited: gpo_request_letter_visited,
+          address_update_request: address_update_request,
+        )
+      )
+      assign(:address_form, Idv::AddressForm.new({}))
+      render
+    end
+
+    it 'renders the address card with NDS inputs, a state select and continue' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('doc_auth.headings.address'))
+      expect(rendered).to have_css('.auth__intro-description', text: t('doc_auth.info.address'))
+      %w[address1 address2 city zipcode].each do |field|
+        expect(rendered).to have_css(".usa-input__control[name='idv_form[#{field}]']")
+      end
+      expect(rendered).to have_css(
+        "select.usa-select[name='idv_form[state]'] option[value='']",
+        text: t('idv.form.state'),
+      )
+      expect(rendered).to have_css(
+        '.auth__actions button[type=submit]',
+        text: t('forms.buttons.continue'),
+      )
+      expect(rendered).to have_link(t('links.cancel'), href: idv_cancel_path(step: 'verify'))
+    end
+
+    it 'keeps the hidden Puerto Rico guidance for the state-guidance script' do
+      expect(rendered).to have_css(
+        '#puerto-rico-extra-text.puerto-rico-extras.display-none',
+        visible: :all,
+      )
+    end
+
+    it 'sets the verification header progress' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+
+    context 'when updating the address' do
+      let(:address_update_request) { true }
+
+      it 'uses the update heading and submit with a back action' do
+        expect(rendered).to have_css('h1', text: t('doc_auth.headings.address_update'))
+        expect(rendered).to have_css('button[type=submit]', text: t('forms.buttons.submit.update'))
+        expect(rendered).to have_link(t('forms.buttons.back'), href: idv_verify_info_path)
+      end
+    end
+
+    context 'when requesting a letter' do
+      let(:gpo_request_letter_visited) { true }
+
+      it 'uses the mailing address copy with a back action to the letter page' do
+        expect(rendered).to have_css('h1', text: t('doc_auth.headings.mailing_address'))
+        expect(rendered).to have_link(t('forms.buttons.back'), href: idv_request_letter_path)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/140
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/address#new` for the NDS bucket to the Figma "Enter your residential address" card:

- Verification header progress (6/12), heading + info copy (mailing-address / update variants preserved via the presenter).
- NDS floating-label inputs for Address line 1/2, City, ZIP (tel keypad, pattern-validated) and a `.usa-select` State picker; **Continue** primary; tertiary **Cancel**, or **Back** when updating / requesting a letter.
- Puerto Rico guidance alert and example hints remain hidden and toggled by the existing `state-guidance` pack; `formatted-fields` still formats the ZIP.
- Legacy branch preserved **byte-for-byte**; **no new locale keys**.

## 👀 Preview

Explorer `/test/nds/idv-address` (`?update=1`, `?gpo=1`).

## 📜 Testing Plan

- `spec/views/idv/address/new.html.erb_spec.rb`, `spec/controllers/idv/address_controller_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`