### PR TITLE
Add the NDS verify-your-information page

### DIFF
--- a/app/javascript/packs/nds-masked-text.ts
+++ b/app/javascript/packs/nds-masked-text.ts
@@ -1,0 +1,19 @@
+document.querySelectorAll<HTMLElement>('[data-nds-masked]').forEach((wrapper) => {
+  const toggle = wrapper.querySelector<HTMLButtonElement>('[data-nds-masked-toggle]');
+  if (!toggle) {
+    return;
+  }
+  toggle.addEventListener('click', () => {
+    const revealed = toggle.getAttribute('aria-pressed') !== 'true';
+    toggle.setAttribute('aria-pressed', String(revealed));
+    wrapper.querySelectorAll<HTMLElement>('.masked-text__text').forEach((el) => {
+      el.classList.toggle('display-none', (el.dataset.masked === 'true') === revealed);
+    });
+    wrapper
+      .querySelector<HTMLElement>('.nds-masked__icon-show')
+      ?.toggleAttribute('hidden', revealed);
+    wrapper
+      .querySelector<HTMLElement>('.nds-masked__icon-hide')
+      ?.toggleAttribute('hidden', !revealed);
+  });
+});

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -1,3 +1,117 @@
+<% if nds_layout? %>
+  <% self.title = t('titles.idv.verify_info') %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 7) %>
+  <% end %>
+
+  <div id="form-steps-wait-alert"></div>
+
+  <%= render NDS::FormPageComponent.new(
+        title: t('headings.verify'),
+        subtitle: t('idv.messages.verify_info'),
+      ) do |page| %>
+    <% if @had_barcode_read_failure %>
+      <% page.with_alert do %>
+        <%= render AlertComponent.new(type: :warning) do %>
+          <%= t(
+                'doc_auth.headings.capture_scan_warning_html',
+                link_html: link_to(
+                  t('doc_auth.headings.capture_scan_warning_link'),
+                  idv_hybrid_handoff_url(redo: true),
+                  'aria-label': t('doc_auth.headings.capture_scan_warning_link'),
+                ),
+              ) %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% page.with_body do %>
+      <%= render NDS::CardComponent.new(class: 'card--elevated card--spacious text-left') do %>
+        <dl class="nds-summary">
+          <div class="nds-summary__row">
+            <dt class="nds-summary__label"><%= t('idv.form.first_name') %></dt>
+            <dd class="nds-summary__value"><%= @pii[:first_name] %></dd>
+          </div>
+          <div class="nds-summary__row">
+            <dt class="nds-summary__label"><%= t('idv.form.last_name') %></dt>
+            <dd class="nds-summary__value"><%= @pii[:last_name] %></dd>
+          </div>
+          <div class="nds-summary__row">
+            <dt class="nds-summary__label"><%= t('idv.form.dob') %></dt>
+            <dd class="nds-summary__value">
+              <%= I18n.l(Date.parse(@pii[:dob]), format: I18n.t('time.formats.event_date')) %>
+            </dd>
+          </div>
+          <div class="nds-summary__row">
+            <dt class="nds-summary__label"><%= t('idv.form.id_number') %></dt>
+            <dd class="nds-summary__value"><%= @pii[:state_id_number] || @pii[:document_number] %></dd>
+          </div>
+          <div class="nds-summary__row">
+            <div class="nds-summary__cell">
+              <dt class="nds-summary__label"><%= t('nds.verify_info.address') %></dt>
+              <dd class="nds-summary__value">
+                <%= @pii[:address1] %><br>
+                <% if @pii[:address2].present? %><%= @pii[:address2] %><br><% end %>
+                <%= @pii[:city] %>, <%= @pii[:state] %> <%= @pii[:zipcode] %>
+              </dd>
+            </div>
+            <%= render ButtonComponent.new(
+                  url: idv_address_url,
+                  variant: :tertiary,
+                  size: :sm,
+                  'aria-label': t('idv.buttons.change_address_label'),
+                ).with_content(t('forms.buttons.edit')) %>
+          </div>
+          <div class="nds-summary__row">
+            <div class="nds-summary__cell">
+              <dt class="nds-summary__label"><%= t('idv.form.ssn') %></dt>
+              <dd class="nds-summary__value">
+                <span class="nds-masked" data-nds-masked>
+                  <span class="masked-text__text" data-masked="true">
+                    <span class="usa-sr-only"><%= t('idv.accessible_labels.masked_ssn', first_number: @ssn[0], last_number: @ssn[-1]) %></span>
+                    <span aria-hidden="true" class="text-no-wrap"><%= "•••-••-#{@ssn.to_s.delete('-')[-4..]}" %></span>
+                  </span>
+                  <span class="masked-text__text display-none text-no-wrap" data-masked="false"><%= SsnFormatter.format(@ssn) %></span>
+                  <button type="button" class="nds-masked__toggle" data-nds-masked-toggle aria-pressed="false" aria-label="<%= t('forms.ssn.show') %>">
+                    <%= render NDS::IconComponent.new(icon: :visibility_off, size: 16, class: 'nds-masked__icon-show') %>
+                    <%= render NDS::IconComponent.new(icon: :visibility, size: 16, class: 'nds-masked__icon-hide', hidden: true) %>
+                  </button>
+                </span>
+              </dd>
+            </div>
+            <%= render ButtonComponent.new(
+                  url: idv_ssn_url,
+                  variant: :tertiary,
+                  size: :sm,
+                  'aria-label': t('idv.buttons.change_ssn_label'),
+                ).with_content(t('forms.buttons.edit')) %>
+          </div>
+        </dl>
+      <% end %>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render SpinnerButtonComponent.new(
+            url: idv_verify_info_path,
+            full_width: true,
+            action_message: t('idv.messages.verifying'),
+            method: :put,
+            form: {
+              class: 'button_to',
+              data: {
+                form_steps_wait: '',
+                error_message: t('idv.failure.exceptions.internal_error'),
+                alert_target: '#form-steps-wait-alert',
+                wait_step_path: idv_verify_info_path,
+                poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
+              },
+            },
+          ).with_content(t('forms.buttons.continue')) %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('form-steps-wait', 'nds-masked-text', preload_links_header: false) %>
+<% else %>
 <%#
 locals:
   @step_indicator_steps - the correct Idv::Flows variable for this flow
@@ -142,3 +256,4 @@ locals:
 
 <% javascript_packs_tag_once 'form-steps-wait' %>
 <%= render 'idv/doc_auth/cancel', step: 'verify' %>
+<% end %>

--- a/spec/views/idv/verify_info/show.html.erb_spec.rb
+++ b/spec/views/idv/verify_info/show.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/verify_info/show.html.erb' do
+  include Devise::Test::ControllerHelpers
+
+  let(:nds_layout) { false }
+  let(:pii) { Idp::Constants::MOCK_IDV_APPLICANT.dup }
+  let(:ssn) { '900-12-1234' }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(view).to receive(:user_signing_up?).and_return(false)
+    @pii = pii
+    @ssn = ssn
+    @step_indicator_steps = Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS
+    @had_barcode_read_failure = false
+    render
+  end
+
+  it 'renders the legacy heading and submit' do
+    expect(rendered).to have_css('h1', text: t('headings.verify'))
+    expect(rendered).to have_button(t('forms.buttons.submit.default'))
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the review card with labeled rows and edit actions' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('headings.verify'))
+      expect(rendered).to have_css('.card--elevated .nds-summary__row', count: 6)
+      expect(rendered).to have_css('.nds-summary__label', text: t('nds.verify_info.address'))
+      expect(rendered).to have_link(t('forms.buttons.edit'), href: idv_address_url)
+      expect(rendered).to have_link(t('forms.buttons.edit'), href: idv_ssn_url)
+    end
+
+    it 'masks the SSN to the last four digits with a reveal toggle' do
+      expect(rendered).to have_css('[data-nds-masked] [data-masked="true"]', text: '•••-••-1234')
+      expect(rendered).to have_css(
+        '[data-nds-masked] [data-masked="false"]', text: ssn,
+                                                   visible: :all
+      )
+      expect(rendered).to have_css('button[data-nds-masked-toggle][aria-pressed="false"]')
+    end
+
+    it 'keeps the form-steps-wait continue button' do
+      expect(rendered).to have_css(
+        'form[data-form-steps-wait] button',
+        text: t('forms.buttons.continue'),
+      )
+    end
+
+    it 'sets the verification header progress' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/141
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/verify_info#show` for the NDS bucket to the Figma review card:

- Verification header progress (7/12), heading + info copy; an elevated card of labeled rows — first/last name, date of birth, ID number, address (multi-line), SSN — with tertiary **Edit** actions for address and SSN.
- SSN masked to its last four (`•••-••-1234`) with an eye toggle (new `nds-masked-text` pack; SR text preserved).
- Full-width **Continue** keeps the `form-steps-wait` polling submit; barcode-read warning preserved as the card alert.
- Legacy branch preserved **byte-for-byte**. New key via consolidation: `nds.verify_info.address`; `visibility`/`visibility_off` glyphs via icon consolidation.

**IDS dependencies** (consolidated `nds-additional-tweaks`): `.nds-summary` review-row list + `.nds-masked` toggle styles.

## 👀 Preview

Explorer `/test/nds/idv-verify-info` (`?barcode=1`).

## 📜 Testing Plan

- `spec/views/idv/verify_info/show.html.erb_spec.rb` (new), `spec/controllers/idv/verify_info_controller_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`, `tsc`