### PR TITLE
Add the NDS re-enter password page

### DIFF
--- a/app/views/idv/enter_password/new.html.erb
+++ b/app/views/idv/enter_password/new.html.erb
@@ -1,5 +1,64 @@
 <% self.title = @title %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 10) %>
+  <% end %>
+
+  <% content_for(:skip_layout_flash, 'true') %>
+  <% content_for(:form_page_flash, 'true') %>
+
+  <% if flash[:success].present? %>
+    <%= render NDS::ToastComponent.new(message: flash[:success]) %>
+  <% end %>
+
+  <%= simple_form_for(
+        current_user,
+        url: idv_enter_password_path,
+        method: :put,
+        html: { data: { nds_submit_gate: true } },
+      ) do |f| %>
+    <%= render NDS::FormPageComponent.new(
+          title: @heading,
+          subtitle: t('nds.enter_password.info'),
+        ) do |page| %>
+      <% if @verify_by_mail %>
+        <% page.with_alert do %>
+          <%= render AlertComponent.new(type: :warning, id: 'by-mail-password-warning') do
+                t('idv.messages.enter_password.by_mail_password_reminder_html')
+              end %>
+        <% end %>
+      <% end %>
+
+      <% page.with_body do %>
+        <%= render NDS::InputComponent.new(
+              form: f,
+              attribute: :password,
+              type: :password,
+              label: t('idv.form.password'),
+              required: true,
+              autocomplete: 'current-password',
+            ) %>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+          <%= render ButtonComponent.new(
+                type: :submit,
+                full_width: true,
+              ).with_content(t('forms.buttons.continue')) %>
+          <%= render ButtonComponent.new(
+                url: idv_forgot_password_url,
+                variant: :tertiary,
+                full_width: true,
+              ).with_content(t('idv.forgot_password.link_text')) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('nds-auth-submit-gate', preload_links_header: false) %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: step_indicator_steps,
@@ -50,3 +109,4 @@
 <% end %>
 
 <%= render 'idv/doc_auth/cancel', step: 'review' %>
+<% end %>

--- a/spec/views/idv/enter_password/new.html.erb_spec.rb
+++ b/spec/views/idv/enter_password/new.html.erb_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'idv/enter_password/new.html.erb' do
   include XPathHelper
 
+  let(:nds_layout) { false }
+
+  before { allow(view).to receive(:nds_layout?).and_return(nds_layout) }
+
   context 'user has completed all steps' do
     let(:dob) { '1972-03-29' }
 
@@ -56,6 +60,63 @@ RSpec.describe 'idv/enter_password/new.html.erb' do
         expect(rendered).to have_content(
           t('idv.titles.session.enter_password_letter', app_name: APP_NAME),
         )
+      end
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+    let(:verify_by_mail) { false }
+
+    before do
+      user = build_stubbed(:user, :fully_registered)
+      allow(view).to receive(:current_user).and_return(user)
+      @title = t('titles.idv.enter_password')
+      @heading = t('idv.titles.session.enter_password', app_name: APP_NAME)
+      @verify_by_mail = verify_by_mail
+      render
+    end
+
+    it 'renders the password card with continue and a forgot-password action' do
+      expect(rendered).to have_css('.auth--form-page h1', text: @heading)
+      expect(rendered).to have_css('.auth__intro-description', text: t('nds.enter_password.info'))
+      expect(rendered).to have_css('.usa-input__control--password[name="user[password]"]')
+      expect(rendered).to have_css(
+        '.auth__actions button[type=submit]',
+        text: t('forms.buttons.continue'),
+      )
+      expect(rendered).to have_link(
+        t('idv.forgot_password.link_text'),
+        href: idv_forgot_password_url,
+      )
+      expect(rendered).not_to have_css('#by-mail-password-warning')
+    end
+
+    it 'sets the verification header progress' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+
+    context 'with a phone-verified flash' do
+      before do
+        flash[:success] = t('idv.messages.enter_password.phone_verified')
+        render
+      end
+
+      it 'renders it as a toast' do
+        expect(rendered).to have_css(
+          'lg-toast.toast',
+          text: t('idv.messages.enter_password.phone_verified'),
+        )
+      end
+    end
+
+    context 'when verifying by mail' do
+      let(:verify_by_mail) { true }
+
+      it 'shows the remember-your-password warning' do
+        expect(rendered).to have_css('#by-mail-password-warning')
       end
     end
   end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/142
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/enter_password#new` for the NDS bucket to the Figma "Re-enter your Login.gov password" card:

- Verification header progress (10/12), existing heading + new info copy, NDS password input with eye toggle, **Continue**, tertiary **Forgot password?**.
- The phone-verified flash renders as an `NDS::ToastComponent`; the verify-by-mail password reminder renders as the card alert.
- Legacy branch preserved **byte-for-byte**. New key via consolidation: `nds.enter_password.info`.

## 👀 Preview

Explorer `/test/nds/idv-enter-password` (`?toast=1`, `?gpo=1`).

## 📜 Testing Plan

- `spec/views/idv/enter_password/new.html.erb_spec.rb`, `spec/controllers/idv/enter_password_controller_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`