### PR TITLE
Add the NDS identity-verification phone page

### DIFF
--- a/app/javascript/packages/input-validation/input-element.spec.ts
+++ b/app/javascript/packages/input-validation/input-element.spec.ts
@@ -723,13 +723,21 @@ describe('NDS phone group', () => {
     valueMissing: 'Phone number is required',
     invalidUs: 'Enter a 10 digit phone number.',
     invalidInternational: 'Enter a phone number with the correct number of digits.',
+    failedNumber: 'We couldn’t match you to this number.',
   };
 
-  const renderPhoneGroup = ({ value = '', country = 'US' } = {}) => {
+  const renderPhoneGroup = ({
+    value = '',
+    country = 'US',
+    failedNumbers = [] as string[],
+  } = {}) => {
+    const failedAttribute = failedNumbers.length
+      ? `data-nds-phone-failed-numbers='${JSON.stringify(failedNumbers)}'`
+      : '';
     document.body.innerHTML = `
       <form>
         <div class="usa-phone-input-group" data-nds-phone
-             data-nds-phone-messages='${JSON.stringify(messages)}'>
+             data-nds-phone-messages='${JSON.stringify(messages)}' ${failedAttribute}>
           <div class="usa-phone-input">
             <details class="usa-phone-input__country">
               <summary class="usa-phone-input__country-toggle">
@@ -842,5 +850,36 @@ describe('NDS phone group', () => {
 
     expect(input.validity.valid).to.equal(true);
     expect(errorRegion.hidden).to.equal(true);
+  });
+
+  it('blocks resubmitting a number that already failed verification', () => {
+    const { input, errorRegion } = renderPhoneGroup({ failedNumbers: ['+12025550199'] });
+    type(input, '2025550199');
+
+    expect(input.validity.valid).to.equal(false);
+    expect(input.validationMessage).to.equal(messages.failedNumber);
+
+    input.dispatchEvent(new FocusEvent('blur'));
+    expect(errorRegion.hidden).to.equal(false);
+    expect(errorRegion.textContent).to.equal(messages.failedNumber);
+  });
+
+  it('accepts a different valid number when others have failed', () => {
+    const { input } = renderPhoneGroup({ failedNumbers: ['+12025550199'] });
+    type(input, '2025550198');
+
+    expect(input.validity.valid).to.equal(true);
+  });
+
+  it('matches failed numbers against the selected country', () => {
+    const { input, radios } = renderPhoneGroup({ failedNumbers: ['+442071234567'] });
+    type(input, '02071234567');
+    expect(input.validity.valid).to.equal(false);
+
+    const gb = radios.find((radio) => radio.value === 'GB')!;
+    gb.checked = true;
+    gb.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(input.validationMessage).to.equal(messages.failedNumber);
   });
 });

--- a/app/javascript/packages/input-validation/input-element.ts
+++ b/app/javascript/packages/input-validation/input-element.ts
@@ -1,4 +1,9 @@
-import { AsYouType, isValidNumber, isValidNumberForRegion } from 'libphonenumber-js';
+import {
+  AsYouType,
+  isValidNumber,
+  isValidNumberForRegion,
+  parsePhoneNumberFromString,
+} from 'libphonenumber-js';
 import type { CountryCode } from 'libphonenumber-js';
 import {
   bindFormSubmitters,
@@ -101,6 +106,7 @@ interface NdsPhoneMessages {
   valueMissing?: string;
   invalidUs?: string;
   invalidInternational?: string;
+  failedNumber?: string;
 }
 
 const parsePhoneMessages = (group: HTMLElement): NdsPhoneMessages => {
@@ -108,6 +114,16 @@ const parsePhoneMessages = (group: HTMLElement): NdsPhoneMessages => {
     return JSON.parse(group.dataset.ndsPhoneMessages || '{}');
   } catch {
     return {};
+  }
+};
+
+/** E.164 numbers that already failed verification and must not be resubmitted. */
+const parseFailedNumbers = (group: HTMLElement): string[] => {
+  try {
+    const parsed = JSON.parse(group.dataset.ndsPhoneFailedNumbers || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
   }
 };
 
@@ -135,6 +151,7 @@ const bindNdsPhoneGroup = (group: HTMLElement) => {
   const radios = Array.from(group.querySelectorAll<HTMLInputElement>('[data-nds-phone-country]'));
   const errorRegion = group.querySelector<HTMLElement>('[data-nds-phone-error]');
   const messages = parsePhoneMessages(group);
+  const failedNumbers = parseFailedNumbers(group);
 
   const country = () =>
     (radios.find((radio) => radio.checked)?.value || DEFAULT_COUNTRY) as CountryCode;
@@ -160,7 +177,13 @@ const bindNdsPhoneGroup = (group: HTMLElement) => {
     }
     const region = country();
     const invalid = !isValidNumberForRegion(value, region) || !isValidNumber(value, region);
-    field.setCustomValidity(invalid ? invalidFormatMessage() : '');
+    if (invalid) {
+      field.setCustomValidity(invalidFormatMessage());
+      return;
+    }
+    const e164 = parsePhoneNumberFromString(value, region)?.number;
+    const failed = Boolean(e164 && failedNumbers.includes(e164));
+    field.setCustomValidity(failed ? messages.failedNumber || invalidFormatMessage() : '');
   };
 
   const validate = () => {

--- a/app/javascript/packages/input-validation/nds-phone-group.ts
+++ b/app/javascript/packages/input-validation/nds-phone-group.ts
@@ -1,0 +1,24 @@
+import { parsePhoneNumberFromString } from 'libphonenumber-js';
+import type { CountryCode } from 'libphonenumber-js';
+
+const DEFAULT_COUNTRY: CountryCode = 'US';
+
+export const NDS_PHONE_GROUP_SELECTOR = '.usa-phone-input-group[data-nds-phone]';
+
+/** Selected ISO country of an NDS phone group (`.usa-phone-input-group[data-nds-phone]`). */
+export const getNdsPhoneGroupCountry = (group: HTMLElement): CountryCode =>
+  (group.querySelector<HTMLInputElement>('[data-nds-phone-country]:checked')?.value ||
+    DEFAULT_COUNTRY) as CountryCode;
+
+/**
+ * E.164 form of the number typed into an NDS phone group, or `undefined` when
+ * the current value can't be parsed for the selected country.
+ */
+export const getNdsPhoneGroupE164 = (group: HTMLElement): string | undefined => {
+  const field = group.querySelector<HTMLInputElement>('.usa-phone-input__input');
+  const value = field?.value.trim();
+  if (!value) {
+    return undefined;
+  }
+  return parsePhoneNumberFromString(value, getNdsPhoneGroupCountry(group))?.number;
+};

--- a/app/javascript/packs/nds-idv-phone-alert.ts
+++ b/app/javascript/packs/nds-idv-phone-alert.ts
@@ -1,0 +1,29 @@
+import {
+  NDS_PHONE_GROUP_SELECTOR,
+  getNdsPhoneGroupE164,
+} from '@18f/identity-input-validation/nds-phone-group';
+
+// Shows the "we couldn't match you to this number" warning on the NDS IdV
+// phone page only while the typed number is one that already failed
+// verification (mirrors idv-phone-alert.ts for the legacy lg-phone-input).
+export function initialize(root: ParentNode = document) {
+  const alertElement = root.querySelector<HTMLElement>('#phone-already-submitted-alert');
+  const group = root.querySelector<HTMLElement>(NDS_PHONE_GROUP_SELECTOR);
+  if (!alertElement || !group) {
+    return;
+  }
+
+  const failedPhoneNumbers: string[] = JSON.parse(alertElement.dataset.failedPhoneNumbers || '[]');
+
+  const sync = () => {
+    const number = getNdsPhoneGroupE164(group);
+    alertElement.hidden = !number || !failedPhoneNumbers.includes(number);
+  };
+
+  group.addEventListener('input', sync);
+  group.addEventListener('change', sync);
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  initialize();
+}

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -1,3 +1,107 @@
+<% if nds_layout? %>
+  <% self.title = t('titles.idv.phone') %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 8) %>
+  <% end %>
+
+  <div id="form-steps-wait-alert"></div>
+
+  <%= simple_form_for(
+        @idv_form,
+        url: idv_phone_path,
+        method: :put,
+        html: {
+          data: {
+            form_steps_wait: '',
+            error_message: t('idv.failure.exceptions.internal_error'),
+            alert_target: '#form-steps-wait-alert',
+            wait_step_path: idv_phone_path,
+            poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
+            nds_submit_gate: true,
+          },
+        },
+      ) do |f| %>
+    <%= render NDS::FormPageComponent.new(
+          title: t('titles.idv.phone'),
+          subtitle: t('nds.idv_phone.info'),
+        ) do |page| %>
+      <% page.with_alert do %>
+        <%= render(VendorOutageAlertComponent.new(vendors: [:sms, :voice], context: :idv)) %>
+        <%= tag.div(
+              id: 'phone-already-submitted-alert',
+              data: { failed_phone_numbers: @idv_form.failed_phone_numbers },
+              hidden: true,
+            ) do %>
+          <%= render AlertComponent.new(type: :warning) do %>
+            <%= t('idv.messages.phone.failed_number.alert_text') %>
+            <% if gpo_letter_available %>
+              <%= t(
+                    'idv.messages.phone.failed_number.gpo_alert_html',
+                    link_html: link_to(
+                      t('idv.messages.phone.failed_number.gpo_verify_link'),
+                      idv_request_letter_path,
+                    ),
+                  ) %>
+            <% else %>
+              <%= t('idv.messages.phone.failed_number.try_again_html') %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% page.with_body do %>
+        <%= render NDS::StackComponent.new(kind: :form, align: :stretch) do %>
+          <%= render 'users/shared/nds_phone_input', form: f %>
+
+          <fieldset class="usa-fieldset radio-group">
+            <legend class="usa-sr-only">
+              <%= t('two_factor_authentication.otp_delivery_preference.title') %>
+            </legend>
+            <div class="radio">
+              <%= f.radio_button(
+                    :otp_delivery_preference,
+                    :sms,
+                    checked: @idv_form.otp_delivery_preference != 'voice' && !OutageStatus.new.vendor_outage?(:sms),
+                    disabled: OutageStatus.new.vendor_outage?(:sms),
+                    class: 'radio__input usa-sr-only',
+                  ) %>
+              <%= f.label :otp_delivery_preference_sms, t('nds.phone_setup.delivery.sms'), class: 'radio__label' %>
+            </div>
+            <div class="radio">
+              <%= f.radio_button(
+                    :otp_delivery_preference,
+                    :voice,
+                    checked: @idv_form.otp_delivery_preference == 'voice',
+                    disabled: OutageStatus.new.vendor_outage?(:voice),
+                    class: 'radio__input usa-sr-only',
+                  ) %>
+              <%= f.label :otp_delivery_preference_voice, t('nds.phone_setup.delivery.voice'), class: 'radio__label' %>
+            </div>
+          </fieldset>
+        <% end %>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+          <%= render SpinnerButtonComponent.new(
+                action_message: t('idv.messages.verifying'),
+                type: :submit,
+                full_width: true,
+              ).with_content(t('forms.buttons.send_one_time_code')) %>
+          <% if gpo_letter_available %>
+            <%= render ButtonComponent.new(
+                  url: idv_request_letter_path,
+                  variant: :tertiary,
+                  full_width: true,
+                ).with_content(t('idv.troubleshooting.options.verify_by_mail')) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('form-steps-wait', 'nds-auth-submit-gate', 'nds-idv-phone-alert', preload_links_header: false) %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: step_indicator_steps,
@@ -134,3 +238,4 @@
 <%= render 'idv/doc_auth/cancel', step: 'phone' %>
 
 <% javascript_packs_tag_once 'form-steps-wait', 'idv-phone-alert' %>
+<% end %>

--- a/app/views/idv/phone/new.html.erb
+++ b/app/views/idv/phone/new.html.erb
@@ -51,7 +51,9 @@
 
       <% page.with_body do %>
         <%= render NDS::StackComponent.new(kind: :form, align: :stretch) do %>
-          <%= render 'users/shared/nds_phone_input', form: f %>
+          <%= render 'users/shared/nds_phone_input',
+                     form: f,
+                     failed_phone_numbers: @idv_form.failed_phone_numbers %>
 
           <fieldset class="usa-fieldset radio-group">
             <legend class="usa-sr-only">

--- a/app/views/users/shared/_nds_phone_input.html.erb
+++ b/app/views/users/shared/_nds_phone_input.html.erb
@@ -17,15 +17,17 @@
    national_phone = form.object.phone.present? ? Phonelib.parse(form.object.phone, selected[:iso]).national : nil
    phone_id = "#{form.object_name}_phone"
    error_id = "#{phone_id}-error"
+   failed_phone_numbers = local_assigns.fetch(:failed_phone_numbers, [])
    messages = {
      valueMissing: t('errors.messages.phone_required'),
      invalidUs: t('errors.messages.invalid_phone_number.us'),
      invalidInternational: t('errors.messages.invalid_phone_number.international'),
-   } %>
+   }
+   messages[:failedNumber] = t('idv.messages.phone.failed_number.alert_text') if failed_phone_numbers.present?
+   group_data = { nds_phone: '', nds_phone_messages: messages.to_json }
+   group_data[:nds_phone_failed_numbers] = failed_phone_numbers.to_json if failed_phone_numbers.present? %>
 
-<div class="usa-phone-input-group"
-     data-nds-phone
-     data-nds-phone-messages="<%= messages.to_json %>">
+<%= tag.div(class: 'usa-phone-input-group', data: group_data) do %>
   <div class="usa-phone-input">
     <details class="usa-phone-input__country">
       <summary class="usa-phone-input__country-toggle"
@@ -87,5 +89,5 @@
     </span>
   </div>
   <p class="usa-error-message" id="<%= error_id %>" data-nds-phone-error aria-live="polite" hidden></p>
-</div>
+<% end %>
 <%= javascript_packs_tag_once('input_component') %>

--- a/spec/javascript/packs/nds-idv-phone-alert-spec.ts
+++ b/spec/javascript/packs/nds-idv-phone-alert-spec.ts
@@ -1,0 +1,79 @@
+import { initialize } from '../../../app/javascript/packs/nds-idv-phone-alert';
+
+describe('nds-idv-phone-alert', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  const buildPage = (failedPhoneNumbers: string[] = ['+12025551234']) => {
+    document.body.innerHTML = `
+      <div
+        id="phone-already-submitted-alert"
+        data-failed-phone-numbers='${JSON.stringify(failedPhoneNumbers)}'
+        hidden
+      ></div>
+      <div class="usa-phone-input-group" data-nds-phone>
+        <input type="radio" name="country" value="US" data-nds-phone-country checked />
+        <input type="radio" name="country" value="GB" data-nds-phone-country />
+        <input type="tel" class="usa-phone-input__input" />
+      </div>
+    `;
+    return {
+      alert: document.querySelector<HTMLElement>('#phone-already-submitted-alert')!,
+      phone: document.querySelector<HTMLInputElement>('.usa-phone-input__input')!,
+      gb: document.querySelector<HTMLInputElement>('input[value=GB]')!,
+    };
+  };
+
+  const type = (phone: HTMLInputElement, value: string) => {
+    phone.value = value;
+    phone.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+
+  it('stays hidden until a failed number is entered', () => {
+    const { alert, phone } = buildPage();
+
+    initialize();
+    expect(alert.hidden).to.be.true();
+
+    type(phone, '(202) 555-9999');
+    expect(alert.hidden).to.be.true();
+  });
+
+  it('shows the alert when the typed number matches a failed number', () => {
+    const { alert, phone } = buildPage();
+
+    initialize();
+    type(phone, '(202) 555-1234');
+
+    expect(alert.hidden).to.be.false();
+  });
+
+  it('re-hides the alert when the number changes away from a failed number', () => {
+    const { alert, phone } = buildPage();
+
+    initialize();
+    type(phone, '2025551234');
+    type(phone, '2025551235');
+
+    expect(alert.hidden).to.be.true();
+  });
+
+  it('accounts for the selected country when matching', () => {
+    const { alert, phone, gb } = buildPage(['+442071234567']);
+
+    initialize();
+    type(phone, '020 7123 4567');
+    expect(alert.hidden).to.be.true();
+
+    gb.checked = true;
+    gb.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(alert.hidden).to.be.false();
+  });
+
+  it('is a no-op without the alert or phone group', () => {
+    document.body.innerHTML = '<div class="usa-phone-input-group" data-nds-phone></div>';
+
+    expect(() => initialize()).not.to.throw();
+  });
+});

--- a/spec/views/idv/phone/new.html.erb_spec.rb
+++ b/spec/views/idv/phone/new.html.erb_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe 'idv/phone/new.html.erb' do
   let(:gpo_letter_available) { false }
   let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
+  let(:nds_layout) { false }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     allow(view).to receive(:user_signing_up?).and_return(false)
     allow(view).to receive(:user_fully_authenticated?).and_return(true)
     allow(view).to receive(:gpo_letter_available).and_return(gpo_letter_available)
@@ -29,6 +31,56 @@ RSpec.describe 'idv/phone/new.html.erb' do
     it 'renders troubleshooting options' do
       expect(rendered).to have_link(t('idv.troubleshooting.options.learn_more_verify_by_phone'))
       expect(rendered).not_to have_link(t('idv.troubleshooting.options.verify_by_mail'))
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the phone card with the pill, delivery radios and send-code submit' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('titles.idv.phone'))
+      expect(rendered).to have_css('.auth__intro-description', text: t('nds.idv_phone.info'))
+      expect(rendered).to have_css('.usa-phone-input input[name="idv_phone_form[phone]"]')
+      expect(rendered).to have_css(
+        'input.radio__input[name="idv_phone_form[otp_delivery_preference]"]',
+        count: 2, visible: :all,
+      )
+      expect(rendered).to have_css(
+        '.auth__actions button[type=submit]',
+        text: t('forms.buttons.send_one_time_code'),
+      )
+      expect(rendered).to have_css('form[data-form-steps-wait]')
+    end
+
+    it 'does not offer verify by mail without a letter' do
+      expect(rendered).not_to have_link(t('idv.troubleshooting.options.verify_by_mail'))
+    end
+
+    it 'renders the failed-number alert hidden, wired for the toggle script' do
+      expect(rendered).to have_css(
+        '#phone-already-submitted-alert[hidden][data-failed-phone-numbers="[]"] .usa-alert',
+        text: t('idv.messages.phone.failed_number.alert_text'),
+        visible: :all,
+      )
+      expect(rendered).not_to have_css('#phone-already-submitted-alert')
+    end
+
+    context 'gpo letter available' do
+      let(:gpo_letter_available) { true }
+
+      it 'offers verify by mail as a tertiary action' do
+        expect(rendered).to have_css(
+          '.auth__actions a.usa-button--tertiary',
+          text: t('idv.troubleshooting.options.verify_by_mail'),
+        )
+      end
+    end
+
+    it 'sets the verification header progress' do
+      rendered
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
     end
   end
 end

--- a/spec/views/idv/phone/new.html.erb_spec.rb
+++ b/spec/views/idv/phone/new.html.erb_spec.rb
@@ -65,6 +65,30 @@ RSpec.describe 'idv/phone/new.html.erb' do
       expect(rendered).not_to have_css('#phone-already-submitted-alert')
     end
 
+    it 'does not mark any numbers as failed on the phone group by default' do
+      expect(rendered).to have_css('.usa-phone-input-group[data-nds-phone]')
+      expect(rendered).not_to have_css('.usa-phone-input-group[data-nds-phone-failed-numbers]')
+    end
+
+    context 'with previously failed numbers' do
+      before do
+        @idv_form = Idv::PhoneForm.new(
+          user: build_stubbed(:user),
+          previous_params: nil,
+          failed_phone_numbers: ['+12025550199'],
+        )
+      end
+
+      it 'hands the failed numbers to the phone group so they cannot be resubmitted' do
+        expect(rendered).to have_css(
+          '.usa-phone-input-group[data-nds-phone-failed-numbers=\'["+12025550199"]\']',
+        )
+        group = Nokogiri::HTML(rendered).at_css('.usa-phone-input-group')
+        messages = JSON.parse(group['data-nds-phone-messages'])
+        expect(messages['failedNumber']).to eq(t('idv.messages.phone.failed_number.alert_text'))
+      end
+    end
+
     context 'gpo letter available' do
       let(:gpo_letter_available) { true }
 


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/143
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/phone#new` for the NDS bucket to the Figma "Verify your phone number" card:

- Verification header progress (8/12), heading + new info copy, the shared NDS phone pill, **Text message / Phone call** radios, **Send code** primary (spinner, `form-steps-wait` polling preserved), tertiary **Verify your address by mail instead** when a letter is available.
- Vendor-outage and already-submitted-number alerts render in the card alert slot.
- Legacy branch preserved **byte-for-byte**. New key via consolidation: `nds.idv_phone.info`.

## 👀 Preview

Explorer `/test/nds/idv-phone` (`?gpo=1`).

## 📜 Testing Plan

- `spec/views/idv/phone/new.html.erb_spec.rb`, `spec/controllers/idv/phone_controller_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`