### PR TITLE
Add the NDS request-letter page

### DIFF
--- a/app/views/idv/by_mail/request_letter/index.html.erb
+++ b/app/views/idv/by_mail/request_letter/index.html.erb
@@ -1,5 +1,61 @@
 <% self.title = t('titles.idv.get_letter') %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 8) %>
+  <% end %>
+
+  <%= render NDS::FormPageComponent.new(
+        title: t('nds.request_letter.heading'),
+        subtitle: t('nds.request_letter.info'),
+      ) do |page| %>
+    <% page.with_body do %>
+      <%= render NDS::CardComponent.new(class: 'card--elevated card--spacious text-left') do %>
+        <dl class="nds-summary">
+          <div class="nds-summary__row">
+            <div class="nds-summary__cell">
+              <dt class="nds-summary__label"><%= t('nds.verify_info.address') %></dt>
+              <dd class="nds-summary__value">
+                <%= @applicant[:address1] %><br>
+                <% if @applicant[:address2].present? %><%= @applicant[:address2] %><br><% end %>
+                <%= @applicant[:city] %>, <%= @applicant[:state] %> <%= @applicant[:zipcode] %>
+              </dd>
+            </div>
+            <%= render ButtonComponent.new(
+                  url: idv_address_url,
+                  variant: :tertiary,
+                  size: :sm,
+                  'aria-label': t('idv.buttons.change_address_label'),
+                ).with_content(t('forms.buttons.edit')) %>
+          </div>
+        </dl>
+      <% end %>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+        <%= render ButtonComponent.new(
+              url: idv_request_letter_path,
+              method: :put,
+              full_width: true,
+            ).with_content(t('idv.buttons.mail.send')) %>
+        <% if FeatureManagement.idv_by_mail_only? %>
+          <%= render ButtonComponent.new(
+                url: idv_cancel_path(step: 'gpo'),
+                variant: :tertiary,
+                full_width: true,
+              ).with_content(t('links.cancel')) %>
+        <% else %>
+          <%= render ButtonComponent.new(
+                url: go_back_path || idv_phone_path,
+                variant: :tertiary,
+                full_width: true,
+              ).with_content(t('forms.buttons.back')) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: step_indicator_steps,
@@ -63,4 +119,5 @@
   <%= render 'idv/doc_auth/cancel', step: 'gpo' %>
 <% else %>
   <%= render 'idv/shared/back', fallback_path: idv_phone_path %>
+<% end %>
 <% end %>

--- a/spec/views/idv/by_mail/request_letter/index.html.erb_spec.rb
+++ b/spec/views/idv/by_mail/request_letter/index.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'idv/by_mail/request_letter/index.html.erb' do
   let(:go_back_path) { nil }
   let(:step_indicator_steps) { Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS }
   let(:idv_by_mail_only) { false }
+  let(:nds_layout) { false }
 
   let(:address1) { 'applicant address 1' }
   let(:address2) { nil }
@@ -13,6 +14,7 @@ RSpec.describe 'idv/by_mail/request_letter/index.html.erb' do
   let(:zipcode) { 'applicant zipcode' }
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     allow(view).to receive(:current_user).and_return(user)
     allow(view).to receive(:go_back_path).and_return(go_back_path)
     allow(view).to receive(:step_indicator_steps).and_return(step_indicator_steps)
@@ -65,6 +67,30 @@ RSpec.describe 'idv/by_mail/request_letter/index.html.erb' do
 
     it 'returns a cancel link' do
       expect(rendered).to have_link(t('links.cancel'), href: idv_cancel_path(step: 'gpo'))
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the verify-by-mail card with the address summary and request action' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('nds.request_letter.heading'))
+      expect(rendered).to have_css('.auth__intro-description', text: t('nds.request_letter.info'))
+      expect(rendered).to have_css('.card--elevated .nds-summary__value', text: address1)
+      expect(rendered).to have_link(t('forms.buttons.edit'), href: idv_address_url)
+      expect(rendered).to have_css(
+        "form[action='#{idv_request_letter_path}'] button",
+        text: t('idv.buttons.mail.send'),
+      )
+      expect(rendered).to have_link(t('forms.buttons.back'), href: idv_phone_path)
+    end
+
+    context 'when idv is by mail only' do
+      let(:idv_by_mail_only) { true }
+
+      it 'offers cancel instead of back' do
+        expect(rendered).to have_link(t('links.cancel'), href: idv_cancel_path(step: 'gpo'))
+      end
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/145
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/by_mail/request_letter#index` for the NDS bucket to the Figma "Verify by mail instead" card:

- Verification header progress (8/12), heading + info copy; an elevated address summary card (`.nds-summary`) with a tertiary **Edit** action.
- **Request a letter** primary (PUT); tertiary **Back** (or **Cancel** when IdV is mail-only).
- Legacy branch preserved **byte-for-byte**. New keys via consolidation: `nds.request_letter.heading`, `nds.request_letter.info`.

## 👀 Preview

Explorer `/test/nds/idv-request-letter`.

## 📜 Testing Plan

- `spec/views/idv/by_mail/request_letter/index.html.erb_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`