### PR TITLE
Add the NDS personal key page

### DIFF
--- a/app/views/idv/personal_key/show.html.erb
+++ b/app/views/idv/personal_key/show.html.erb
@@ -1,3 +1,92 @@
+<% if nds_layout? %>
+  <% self.title = t('titles.idv.personal_key') %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 11) %>
+  <% end %>
+
+  <% content_for(:skip_layout_flash, 'true') %>
+  <% content_for(:form_page_flash, 'true') %>
+  <% if flash[:success].present? %>
+    <%= render NDS::ToastComponent.new(message: flash[:success]) %>
+  <% end %>
+
+  <%= simple_form_for('', url: idv_personal_key_path, html: { data: { nds_submit_gate: true } }) do |f| %>
+    <%= render NDS::FormPageComponent.new(
+          title: t('forms.personal_key_partial.header'),
+          subtitle: t('nds.personal_key.info'),
+        ) do |page| %>
+      <% page.with_body do %>
+        <%= render NDS::StackComponent.new(align: :stretch, gap: 16) do %>
+          <%= render NDS::CardComponent.new do %>
+            <%= render NDS::StackComponent.new(align: :stretch, gap: 24) do %>
+              <p class="copy--muted margin-0 text-center">
+                <%= t(
+                      'nds.personal_key.generated_on',
+                      date: I18n.l(@personal_key_generated_at || Time.zone.today, format: I18n.t('time.formats.event_date')),
+                    ) %>
+              </p>
+              <p class="heading-s margin-0 padding-y-2 text-center" aria-label="<%= t('forms.personal_key.confirmation_label') %>">
+                <%= @code.split('-').join(' - ') %>
+              </p>
+              <hr class="divider" />
+              <div class="display-flex">
+                <lg-clipboard-button class="flex-1 display-flex" clipboard-text="<%= @code %>" tooltip-text="<%= t('components.clipboard_button.tooltip') %>">
+                  <%= render ButtonComponent.new(type: :button, variant: :tertiary, size: :sm, class: 'flex-1') do %>
+                    <%= render NDS::IconComponent.new(icon: :copy, size: 20) %>
+                    <%= t('components.clipboard_button.label') %>
+                  <% end %>
+                </lg-clipboard-button>
+                <%= render ClickObserverComponent.new(event_name: 'IdV: download personal key', class: 'flex-1 display-flex') do %>
+                  <%= render ButtonComponent.new(
+                        url: "data:text/plain;charset=utf-8,#{ERB::Util.url_encode(@code)}",
+                        download: 'personal_key.txt',
+                        variant: :tertiary,
+                        size: :sm,
+                        class: 'flex-1',
+                      ) do %>
+                    <%= render NDS::IconComponent.new(icon: :download, size: 20) %>
+                    <%= t('components.download_button.label') %>
+                  <% end %>
+                <% end %>
+                <lg-print-button class="flex-1 display-flex">
+                  <%= render ButtonComponent.new(type: :button, variant: :tertiary, size: :sm, class: 'flex-1') do %>
+                    <%= render NDS::IconComponent.new(icon: :print, size: 20) %>
+                    <%= t('components.print_button.label') %>
+                  <% end %>
+                </lg-print-button>
+              </div>
+            <% end %>
+          <% end %>
+
+          <%= render NDS::CardComponent.new do %>
+            <%= render ClickObserverComponent.new(event_name: 'IdV: personal key acknowledgment toggled') do %>
+              <div class="checkbox-group">
+                <div class="checkbox">
+                  <%= f.check_box(
+                        :acknowledgment,
+                        { class: 'checkbox__input', required: true, autocomplete: 'off' },
+                        '1',
+                        '0',
+                      ) %>
+                  <%= f.label :acknowledgment, class: 'checkbox__label' do %>
+                    <span class="checkbox__label-text"><%= t('nds.personal_key.acknowledgment') %></span>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render ButtonComponent.new(type: :submit, full_width: true)
+              .with_content(t('forms.buttons.continue')) %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('clipboard_button_component', 'print_button_component', 'nds-auth-submit-gate', preload_links_header: false) %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: step_indicator_steps,
@@ -14,3 +103,4 @@
            personal_key_generated_at: @personal_key_generated_at,
            update_path: idv_personal_key_path
 %>
+<% end %>

--- a/spec/views/idv/personal_key/show.html.erb_spec.rb
+++ b/spec/views/idv/personal_key/show.html.erb_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/personal_key/show.html.erb' do
+  let(:nds_layout) { false }
+  let(:code) { '0193-0039-4739-9920' }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(view).to receive(:step_indicator_steps)
+      .and_return(Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS)
+    allow(view).to receive(:step_indicator_step).and_return(:secure_account)
+    @code = code
+    @personal_key_generated_at = Time.zone.today
+    render
+  end
+
+  it 'renders the legacy heading and acknowledgment' do
+    expect(rendered).to have_css('h1', text: t('forms.personal_key_partial.header'))
+    expect(rendered).to have_text(t('forms.personal_key.required_checkbox'))
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the key card with date, key, and copy/download/print actions' do
+      expect(rendered).to have_css(
+        '.auth--form-page h1',
+        text: t('forms.personal_key_partial.header'),
+      )
+      expect(rendered).to have_css('.auth__intro-description', text: t('nds.personal_key.info'))
+      expect(rendered).to have_text(
+        t(
+          'nds.personal_key.generated_on',
+          date: I18n.l(Time.zone.today, format: I18n.t('time.formats.event_date')),
+        ),
+      )
+      expect(rendered).to have_css('.card p', text: '0193 - 0039 - 4739 - 9920')
+      expect(rendered).to have_css(
+        "lg-clipboard-button[clipboard-text='#{code}'] button",
+        text: t('components.clipboard_button.label'),
+      )
+      expect(rendered).to have_css(
+        "a[download='personal_key.txt']",
+        text: t('components.download_button.label'),
+      )
+      expect(rendered).to have_css(
+        'lg-print-button button',
+        text: t('components.print_button.label'),
+      )
+    end
+
+    it 'gates continue on the safe-place acknowledgment' do
+      expect(rendered).to have_css(
+        'input.checkbox__input[name="acknowledgment"][required]',
+        visible: :all,
+      )
+      expect(rendered).to have_css(
+        '.checkbox__label-text',
+        text: t('nds.personal_key.acknowledgment'),
+      )
+      expect(rendered).to have_css(
+        'form[data-nds-submit-gate] .auth__actions button[type=submit]',
+        text: t('forms.buttons.continue'),
+      )
+    end
+
+    it 'sets the verification header progress' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/146
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `idv/personal_key#show` for the NDS bucket to the Figma "Save your personal key" card:

- Verification header progress (11/12), heading + new info copy; the secured-information flash renders as an NDS toast.
- Key card: centered "Generated on <date>", the key with spaced separators, a rule, and equal-width tertiary **Copy / Download / Print** actions with icons (reusing `lg-clipboard-button` / `lg-print-button`).
- Acknowledgment checkbox card ("I've saved my personal key in a safe place") gating **Continue**.
- Legacy branch preserved **byte-for-byte**. New keys via consolidation: `nds.personal_key.{info,generated_on,acknowledgment}`; `copy/20`, `download/20`, `print/20` glyphs via icon consolidation.

## 👀 Preview

Explorer `/test/nds/idv-personal-key` (`?toast=1`).

## 📜 Testing Plan

- `spec/views/idv/personal_key/show.html.erb_spec.rb` (new), `spec/controllers/idv/personal_key_controller_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`