### PR TITLE
Add the NDS sign-up completions (consent) page

### DIFF
--- a/app/javascript/packs/nds-masked-text.ts
+++ b/app/javascript/packs/nds-masked-text.ts
@@ -1,0 +1,19 @@
+document.querySelectorAll<HTMLElement>('[data-nds-masked]').forEach((wrapper) => {
+  const toggle = wrapper.querySelector<HTMLButtonElement>('[data-nds-masked-toggle]');
+  if (!toggle) {
+    return;
+  }
+  toggle.addEventListener('click', () => {
+    const revealed = toggle.getAttribute('aria-pressed') !== 'true';
+    toggle.setAttribute('aria-pressed', String(revealed));
+    wrapper.querySelectorAll<HTMLElement>('.masked-text__text').forEach((el) => {
+      el.classList.toggle('display-none', (el.dataset.masked === 'true') === revealed);
+    });
+    wrapper
+      .querySelector<HTMLElement>('.nds-masked__icon-show')
+      ?.toggleAttribute('hidden', revealed);
+    wrapper
+      .querySelector<HTMLElement>('.nds-masked__icon-hide')
+      ?.toggleAttribute('hidden', !revealed);
+  });
+});

--- a/app/views/idv/verify_info/show.html.erb
+++ b/app/views/idv/verify_info/show.html.erb
@@ -1,3 +1,117 @@
+<% if nds_layout? %>
+  <% self.title = t('titles.idv.verify_info') %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 7) %>
+  <% end %>
+
+  <div id="form-steps-wait-alert"></div>
+
+  <%= render NDS::FormPageComponent.new(
+        title: t('headings.verify'),
+        subtitle: t('idv.messages.verify_info'),
+      ) do |page| %>
+    <% if @had_barcode_read_failure %>
+      <% page.with_alert do %>
+        <%= render AlertComponent.new(type: :warning) do %>
+          <%= t(
+                'doc_auth.headings.capture_scan_warning_html',
+                link_html: link_to(
+                  t('doc_auth.headings.capture_scan_warning_link'),
+                  idv_hybrid_handoff_url(redo: true),
+                  'aria-label': t('doc_auth.headings.capture_scan_warning_link'),
+                ),
+              ) %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% page.with_body do %>
+      <%= render NDS::CardComponent.new(class: 'card--elevated card--spacious text-left') do %>
+        <dl class="nds-summary">
+          <div class="nds-summary__row">
+            <dt class="nds-summary__label"><%= t('idv.form.first_name') %></dt>
+            <dd class="nds-summary__value"><%= @pii[:first_name] %></dd>
+          </div>
+          <div class="nds-summary__row">
+            <dt class="nds-summary__label"><%= t('idv.form.last_name') %></dt>
+            <dd class="nds-summary__value"><%= @pii[:last_name] %></dd>
+          </div>
+          <div class="nds-summary__row">
+            <dt class="nds-summary__label"><%= t('idv.form.dob') %></dt>
+            <dd class="nds-summary__value">
+              <%= I18n.l(Date.parse(@pii[:dob]), format: I18n.t('time.formats.event_date')) %>
+            </dd>
+          </div>
+          <div class="nds-summary__row">
+            <dt class="nds-summary__label"><%= t('idv.form.id_number') %></dt>
+            <dd class="nds-summary__value"><%= @pii[:state_id_number] || @pii[:document_number] %></dd>
+          </div>
+          <div class="nds-summary__row">
+            <div class="nds-summary__cell">
+              <dt class="nds-summary__label"><%= t('nds.verify_info.address') %></dt>
+              <dd class="nds-summary__value">
+                <%= @pii[:address1] %><br>
+                <% if @pii[:address2].present? %><%= @pii[:address2] %><br><% end %>
+                <%= @pii[:city] %>, <%= @pii[:state] %> <%= @pii[:zipcode] %>
+              </dd>
+            </div>
+            <%= render ButtonComponent.new(
+                  url: idv_address_url,
+                  variant: :tertiary,
+                  size: :sm,
+                  'aria-label': t('idv.buttons.change_address_label'),
+                ).with_content(t('forms.buttons.edit')) %>
+          </div>
+          <div class="nds-summary__row">
+            <div class="nds-summary__cell">
+              <dt class="nds-summary__label"><%= t('idv.form.ssn') %></dt>
+              <dd class="nds-summary__value">
+                <span class="nds-masked" data-nds-masked>
+                  <span class="masked-text__text" data-masked="true">
+                    <span class="usa-sr-only"><%= t('idv.accessible_labels.masked_ssn', first_number: @ssn[0], last_number: @ssn[-1]) %></span>
+                    <span aria-hidden="true" class="text-no-wrap"><%= "•••-••-#{@ssn.to_s.delete('-')[-4..]}" %></span>
+                  </span>
+                  <span class="masked-text__text display-none text-no-wrap" data-masked="false"><%= SsnFormatter.format(@ssn) %></span>
+                  <button type="button" class="nds-masked__toggle" data-nds-masked-toggle aria-pressed="false" aria-label="<%= t('forms.ssn.show') %>">
+                    <%= render NDS::IconComponent.new(icon: :visibility_off, size: 16, class: 'nds-masked__icon-show') %>
+                    <%= render NDS::IconComponent.new(icon: :visibility, size: 16, class: 'nds-masked__icon-hide', hidden: true) %>
+                  </button>
+                </span>
+              </dd>
+            </div>
+            <%= render ButtonComponent.new(
+                  url: idv_ssn_url,
+                  variant: :tertiary,
+                  size: :sm,
+                  'aria-label': t('idv.buttons.change_ssn_label'),
+                ).with_content(t('forms.buttons.edit')) %>
+          </div>
+        </dl>
+      <% end %>
+    <% end %>
+
+    <% page.with_actions do %>
+      <%= render SpinnerButtonComponent.new(
+            url: idv_verify_info_path,
+            full_width: true,
+            action_message: t('idv.messages.verifying'),
+            method: :put,
+            form: {
+              class: 'button_to',
+              data: {
+                form_steps_wait: '',
+                error_message: t('idv.failure.exceptions.internal_error'),
+                alert_target: '#form-steps-wait-alert',
+                wait_step_path: idv_verify_info_path,
+                poll_interval_ms: IdentityConfig.store.poll_rate_for_verify_in_seconds * 1000,
+              },
+            },
+          ).with_content(t('forms.buttons.continue')) %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('form-steps-wait', 'nds-masked-text', preload_links_header: false) %>
+<% else %>
 <%#
 locals:
   @step_indicator_steps - the correct Idv::Flows variable for this flow
@@ -142,3 +256,4 @@ locals:
 
 <% javascript_packs_tag_once 'form-steps-wait' %>
 <%= render 'idv/doc_auth/cancel', step: 'verify' %>
+<% end %>

--- a/app/views/sign_up/completions/show.html.erb
+++ b/app/views/sign_up/completions/show.html.erb
@@ -1,5 +1,103 @@
 <% self.title = @presenter.heading %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 12) %>
+  <% end %>
+
+  <%= simple_form_for(:idv_form, url: sign_up_completed_path, html: { data: { nds_submit_gate: true } }) do |f| %>
+    <%= render NDS::FormPageComponent.new(
+          title: @presenter.idv_requested? ? t('nds.completions.heading_idv') : @presenter.heading,
+          subtitle: @presenter.idv_requested? ?
+            t('nds.completions.intro_html', sp_html: content_tag(:strong, @presenter.sp_name)) :
+            @presenter.intro,
+        ) do |page| %>
+      <% if current_sp&.logo.present? %>
+        <% page.with_media do %>
+          <%= image_tag(current_sp.logo_url, alt: @presenter.sp_name, class: 'auth__media', width: 96, height: 96) %>
+        <% end %>
+      <% end %>
+
+      <% if !@multiple_factors_enabled %>
+        <% page.with_alert do %>
+          <%= render(AlertComponent.new(type: :warning)) do %>
+            <%= link_to(t('mfa.second_method_warning.link'), authentication_methods_setup_path) %>
+            <%= t('mfa.second_method_warning.text') %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% page.with_body do %>
+        <%= render NDS::StackComponent.new(align: :stretch, gap: 24) do %>
+          <%= render NDS::CardComponent.new(class: 'card--elevated text-left') do %>
+            <%= render NDS::StackComponent.new(align: :stretch, gap: 24) do %>
+              <dl class="nds-summary">
+                <% @presenter.pii.each do |attribute_key, attribute_value| %>
+                  <% next if attribute_value.blank? %>
+                  <div class="nds-summary__row">
+                    <div class="nds-summary__cell">
+                      <dt class="nds-summary__label"><%= t("help_text.requested_attributes.#{attribute_key}") %></dt>
+                      <dd class="nds-summary__value">
+                        <% if attribute_value.is_a? Array %>
+                          <%= safe_join(attribute_value, tag.br) %>
+                        <% elsif attribute_key == :social_security_number %>
+                          <span class="nds-masked" data-nds-masked>
+                            <span class="masked-text__text" data-masked="true">
+                              <span class="usa-sr-only"><%= t('idv.accessible_labels.masked_ssn', first_number: attribute_value[0], last_number: attribute_value[-1]) %></span>
+                              <span aria-hidden="true" class="text-no-wrap"><%= "•••-••-#{attribute_value.to_s.delete('-')[-4..]}" %></span>
+                            </span>
+                            <span class="masked-text__text display-none text-no-wrap" data-masked="false"><%= attribute_value %></span>
+                            <button type="button" class="nds-masked__toggle" data-nds-masked-toggle aria-pressed="false" aria-label="<%= t('forms.ssn.show') %>">
+                              <%= render NDS::IconComponent.new(icon: :visibility_off, size: 16, class: 'nds-masked__icon-show') %>
+                              <%= render NDS::IconComponent.new(icon: :visibility, size: 16, class: 'nds-masked__icon-hide', hidden: true) %>
+                            </button>
+                          </span>
+                        <% elsif attribute_key == :verified_at %>
+                          <%= render TimeComponent.new(time: attribute_value) %>
+                        <% else %>
+                          <%= attribute_value.to_s %>
+                        <% end %>
+                      </dd>
+                    </div>
+                    <% if attribute_key == :email %>
+                      <%= render ButtonComponent.new(
+                            url: sign_up_select_email_path,
+                            variant: :tertiary,
+                            size: :sm,
+                          ).with_content(t('help_text.requested_attributes.change_email_link')) %>
+                    <% end %>
+                  </div>
+                <% end %>
+              </dl>
+
+              <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+                <%= render ButtonComponent.new(type: :submit, full_width: true)
+                      .with_content(t('forms.buttons.continue')) %>
+                <%= render ButtonComponent.new(
+                      url: sign_up_completed_cancel_path,
+                      variant: :secondary,
+                      full_width: true,
+                    ).with_content(t('links.cancel')) %>
+              <% end %>
+            <% end %>
+          <% end %>
+
+          <p class="copy--muted text-center margin-0">
+            <%= t(
+                  'sign_up.information_sharing_html',
+                  app_name: APP_NAME,
+                  link_html: new_tab_link_to(t('notices.privacy.privacy_act_statement'), MarketingSite.privacy_act_statement_url),
+                ) %>
+          </p>
+
+          <%= image_tag('nds/illustrations/nist.png', alt: t('nds.completions.nist_alt'), class: 'width-full height-auto') %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('nds-masked-text', 'nds-auth-submit-gate', preload_links_header: false) %>
+<% else %>
 <div class="text-center">
   <%= image_tag(
         asset_url('user-signup.svg'),
@@ -86,4 +184,5 @@
 
 <%= render PageFooterComponent.new do %>
   <%= link_to t('links.cancel'), sign_up_completed_cancel_path %>
+<% end %>
 <% end %>

--- a/spec/views/idv/verify_info/show.html.erb_spec.rb
+++ b/spec/views/idv/verify_info/show.html.erb_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/verify_info/show.html.erb' do
+  include Devise::Test::ControllerHelpers
+
+  let(:nds_layout) { false }
+  let(:pii) { Idp::Constants::MOCK_IDV_APPLICANT.dup }
+  let(:ssn) { '900-12-1234' }
+
+  before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(view).to receive(:user_signing_up?).and_return(false)
+    @pii = pii
+    @ssn = ssn
+    @step_indicator_steps = Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS
+    @had_barcode_read_failure = false
+    render
+  end
+
+  it 'renders the legacy heading and submit' do
+    expect(rendered).to have_css('h1', text: t('headings.verify'))
+    expect(rendered).to have_button(t('forms.buttons.submit.default'))
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    it 'renders the review card with labeled rows and edit actions' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('headings.verify'))
+      expect(rendered).to have_css('.card--elevated .nds-summary__row', count: 6)
+      expect(rendered).to have_css('.nds-summary__label', text: t('nds.verify_info.address'))
+      expect(rendered).to have_link(t('forms.buttons.edit'), href: idv_address_url)
+      expect(rendered).to have_link(t('forms.buttons.edit'), href: idv_ssn_url)
+    end
+
+    it 'masks the SSN to the last four digits with a reveal toggle' do
+      expect(rendered).to have_css('[data-nds-masked] [data-masked="true"]', text: '•••-••-1234')
+      expect(rendered).to have_css(
+        '[data-nds-masked] [data-masked="false"]', text: ssn,
+                                                   visible: :all
+      )
+      expect(rendered).to have_css('button[data-nds-masked-toggle][aria-pressed="false"]')
+    end
+
+    it 'keeps the form-steps-wait continue button' do
+      expect(rendered).to have_css(
+        'form[data-form-steps-wait] button',
+        text: t('forms.buttons.continue'),
+      )
+    end
+
+    it 'sets the verification header progress' do
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+  end
+end

--- a/spec/views/sign_up/completions/show.html.erb_spec.rb
+++ b/spec/views/sign_up/completions/show.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
   let(:requested_attributes) { [:email] }
   let(:idv_requested) { false }
   let(:completion_context) { :new_sp }
+  let(:nds_layout) { false }
 
   let(:view_context) { ActionController::Base.new.view_context }
   let(:decorated_sp_session) do
@@ -34,6 +35,8 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
   end
 
   before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
+    allow(view).to receive(:current_sp).and_return(service_provider)
     @user = user
     @presenter = presenter
     allow(view).to receive(:decorated_sp_session).and_return(decorated_sp_session)
@@ -158,6 +161,37 @@ RSpec.describe 'sign_up/completions/show.html.erb' do
         render
         expect(rendered).not_to have_content(t('mfa.second_method_warning.text'))
       end
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+    let(:idv_requested) { true }
+    let(:requested_attributes) { %i[email given_name family_name address social_security_number] }
+    let(:decrypted_pii) { Pii::Attributes.new_from_hash(Idp::Constants::MOCK_IDV_APPLICANT_WITH_SSN) }
+
+    before { render }
+
+    it 'renders the identity-verified card with summary rows, actions and NIST seal' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('nds.completions.heading_idv'))
+      expect(rendered).to have_css(
+        '.auth__intro-description strong',
+        text: service_provider.friendly_name,
+      )
+      expect(rendered).to have_css(
+        '.card--elevated .nds-summary__label',
+        text: t('help_text.requested_attributes.full_name'),
+      )
+      expect(rendered).to have_css(
+        '.card--elevated [data-nds-masked] [data-masked="true"]',
+        text: /•••-••-\d{4}/,
+      )
+      expect(rendered).to have_css(
+        '.card--elevated button[type=submit]',
+        text: t('forms.buttons.continue'),
+      )
+      expect(rendered).to have_link(t('links.cancel'), href: sign_up_completed_cancel_path)
+      expect(rendered).to have_css("img[src*='nist'][alt='#{t('nds.completions.nist_alt')}']")
     end
   end
 end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/147
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/102
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Converts `sign_up/completions#show` for the NDS bucket to the Figma "Identity verified" screen:

- Verification header progress (12/12), SP logo as media, heading + consent copy (bold SP name); auth-only completions keep the presenter's existing heading/intro.
- Elevated `.nds-summary` card of the requested attributes (masked SSN with reveal toggle, tertiary **Change** for email) with **Continue** and secondary **Cancel** inside the card; single-MFA warning as the card alert.
- Information-sharing notice, then the NIST seal image at form width (descriptive alt text).
- Legacy branch preserved **byte-for-byte**. New keys via consolidation: `nds.completions.{heading_idv,intro_html,nist_alt}`; `nds/illustrations/nist.png` via asset consolidation.

## 👀 Preview

Explorer `/test/nds/completions` (`?auth=1`, `?single=1`).

## 📜 Testing Plan

- `spec/views/sign_up/completions/show.html.erb_spec.rb`
- catalog/explorer specs, `spec/i18n_spec.rb`, `erb_lint`, `rubocop`