### PR TITLE
Add the NDS U.S.-phone-required dead end

### DIFF
--- a/app/controllers/idv/hybrid_handoff_controller.rb
+++ b/app/controllers/idv/hybrid_handoff_controller.rb
@@ -101,6 +101,7 @@ module Idv
     end
 
     def handle_phone_submission
+      return redirect_to idv_phone_required_url if non_us_phone_in_phone_first_flow?
       return rate_limited_failure if rate_limiter.limited?
       rate_limiter.increment!
       idv_session.phone_for_mobile_flow = formatted_destination_phone
@@ -263,6 +264,16 @@ module Idv
       form_response_params = { success: false, errors: { message: message } }
       form_response_params[:extra] = extra unless extra.nil?
       FormResponse.new(**form_response_params)
+    end
+
+    # The phone-first flow collects the country explicitly; identity
+    # verification currently needs a U.S. number, so stop before sending a link.
+    def non_us_phone_in_phone_first_flow?
+      return false unless idv_session.phone_first_flow?
+
+      country = params.dig(:doc_auth, :international_code).presence ||
+                Phonelib.parse(params.dig(:doc_auth, :phone)).country
+      country.present? && country != 'US'
     end
 
     def formatted_destination_phone

--- a/app/controllers/idv/phone_required_controller.rb
+++ b/app/controllers/idv/phone_required_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Idv
+  # NDS dead end: identity verification currently needs a U.S. phone number,
+  # so a user who enters a non-U.S. number on hybrid handoff lands here before
+  # investing in document capture.
+  class PhoneRequiredController < ApplicationController
+    include Idv::AvailabilityConcern
+
+    before_action :confirm_two_factor_authenticated
+
+    def show
+      analytics.idv_phone_required_visited
+    end
+  end
+end

--- a/app/services/analytics_events.rb
+++ b/app/services/analytics_events.rb
@@ -5345,6 +5345,11 @@ module AnalyticsEvents
     )
   end
 
+  # The user reached the NDS dead end because identity verification requires a U.S. phone number
+  def idv_phone_required_visited(**extra)
+    track_event(:idv_phone_required_visited, **extra)
+  end
+
   # @param [Hash,nil] proofing_components User's current proofing components
   # @option proofing_components [String,nil] 'document_check' Vendor that verified the user's ID
   # @option proofing_components [String,nil] 'document_type_received' Type of ID detected by vendor

--- a/app/views/idv/hybrid_handoff/show.html.erb
+++ b/app/views/idv/hybrid_handoff/show.html.erb
@@ -1,5 +1,57 @@
 <% self.title = @presenter.header_text %>
 
+<% if nds_layout? %>
+  <% content_for(:nds_header_progress) do %>
+    <%= nds_account_creation_progress(step: :verification, substep: 4) %>
+  <% end %>
+
+  <%= simple_form_for(
+        idv_phone_form,
+        as: :doc_auth,
+        url: url_for(type: :mobile, combined: true),
+        method: 'PUT',
+        html: {
+          id: 'form-to-submit-photos-through-mobile',
+          aria: { label: t('forms.buttons.send_link') },
+          data: { nds_submit_gate: true },
+        },
+      ) do |f| %>
+    <%= render NDS::FormPageComponent.new(
+          title: t('nds.hybrid_handoff.heading'),
+          subtitle: t('nds.hybrid_handoff.subtitle'),
+        ) do |page| %>
+      <% page.with_body do %>
+        <%= render 'users/shared/nds_phone_input', form: f %>
+      <% end %>
+
+      <% page.with_actions do %>
+        <%= render NDS::StackComponent.new(kind: :actions, align: :stretch) do %>
+          <%= render ButtonComponent.new(
+                type: :submit,
+                full_width: true,
+              ).with_content(t('forms.buttons.send_link')) %>
+          <% if @upload_enabled %>
+            <div class="separator"><%= t('nds.choose_id_type.or') %></div>
+            <%= render ButtonComponent.new(
+                  type: :submit,
+                  formaction: url_for(type: :desktop),
+                  formnovalidate: true,
+                  variant: :secondary,
+                  full_width: true,
+                ).with_content(t('doc_auth.headings.upload_from_computer')) %>
+          <% end %>
+          <%= render ButtonComponent.new(
+                url: idv_cancel_path(step: 'hybrid_handoff'),
+                variant: :tertiary,
+                full_width: true,
+              ).with_content(t('links.cancel')) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= javascript_packs_tag_once('nds-auth-submit-gate', preload_links_header: false) %>
+<% else %>
 <% content_for(:pre_flash_content) do %>
   <%= render StepIndicatorComponent.new(
         steps: Idv::StepIndicatorConcern::STEP_INDICATOR_STEPS,
@@ -174,3 +226,4 @@
   </div>
 <% end %>
 <%= render 'idv/doc_auth/cancel', step: 'hybrid_handoff' %>
+<% end %>

--- a/app/views/idv/phone_required/show.html.erb
+++ b/app/views/idv/phone_required/show.html.erb
@@ -1,0 +1,15 @@
+<%# NDS-only dead end (reached only from the phone-first flow). %>
+<% self.title = t('nds.phone_required.heading') %>
+
+<%= render NDS::FormPageComponent.new(title: t('nds.phone_required.heading')) do |page| %>
+  <% page.with_media do %>
+    <span class="nds-status-icon nds-status-icon--error">
+      <%= render NDS::IconComponent.new(icon: :error, size: 24) %>
+    </span>
+  <% end %>
+
+  <% page.with_body do %>
+    <hr class="divider" />
+    <p><%= t('nds.phone_required.info') %></p>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -435,6 +435,7 @@ Rails.application.routes.draw do
       get '/hybrid_mobile/choose_id_type' => 'hybrid_mobile/choose_id_type#show'
       put '/hybrid_mobile/choose_id_type' => 'hybrid_mobile/choose_id_type#update'
       get '/hybrid_handoff' => 'hybrid_handoff#show'
+      get '/phone_required' => 'phone_required#show'
       put '/hybrid_handoff' => 'hybrid_handoff#update'
       get '/choose_id_type' => 'choose_id_type#show'
       put '/choose_id_type' => 'choose_id_type#update'

--- a/spec/controllers/idv/hybrid_handoff_controller_spec.rb
+++ b/spec/controllers/idv/hybrid_handoff_controller_spec.rb
@@ -403,6 +403,17 @@ RSpec.describe Idv::HybridHandoffController do
 
         expect(response).to redirect_to(idv_document_capture_url)
       end
+
+      it 'sends users with a non-U.S. number to the phone-required dead end' do
+        expect(Telephony).not_to receive(:send_doc_auth_link)
+
+        put :update,
+            params: { type: 'mobile',
+                      doc_auth: { phone: '20 7946 0958', international_code: 'GB' } }
+
+        expect(response).to redirect_to(idv_phone_required_url)
+        expect(subject.idv_session.phone_for_mobile_flow).to be_nil
+      end
     end
 
     context 'desktop flow' do

--- a/spec/controllers/idv/phone_required_controller_spec.rb
+++ b/spec/controllers/idv/phone_required_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Idv::PhoneRequiredController do
+  let(:user) { create(:user, :fully_registered) }
+
+  before do
+    stub_sign_in(user)
+    stub_analytics
+  end
+
+  describe '#show' do
+    it 'renders and logs the visit' do
+      get :show
+
+      expect(response).to render_template(:show)
+      expect(@analytics).to have_logged_event(:idv_phone_required_visited)
+    end
+  end
+end

--- a/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
+++ b/spec/views/idv/hybrid_handoff/show.html.erb_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
   let(:clear1_enabled) { false }
+  let(:nds_layout) { false }
   before do
+    allow(view).to receive(:nds_layout?).and_return(nds_layout)
     allow(view).to receive(:current_user).and_return(@user)
     @idv_form = Idv::PhoneForm.new(user: build_stubbed(:user), previous_params: nil)
     @idv_how_to_verify_form = Idv::HowToVerifyForm.new
@@ -93,6 +95,52 @@ RSpec.describe 'idv/hybrid_handoff/show.html.erb' do
         expect(rendered).to_not have_link(
           t('in_person_proofing.headings.prepare'),
           href: idv_document_capture_path(step: :hybrid_handoff),
+        )
+      end
+    end
+  end
+
+  context 'in the NDS layout' do
+    let(:nds_layout) { true }
+
+    before { @selfie_required = false }
+
+    it 'renders the phone card with send-link primary and cancel tertiary actions' do
+      expect(rendered).to have_css('.auth--form-page h1', text: t('nds.hybrid_handoff.heading'))
+      expect(rendered).to have_css(
+        '.auth__intro-description',
+        text: t('nds.hybrid_handoff.subtitle'),
+      )
+      expect(rendered).to have_css('.usa-phone-input')
+      expect(rendered).to have_css(
+        '.auth__actions button[type=submit]:not(.usa-button--secondary)',
+        text: t('forms.buttons.send_link'),
+      )
+      expect(rendered).to have_link(
+        t('links.cancel'),
+        href: idv_cancel_path(step: 'hybrid_handoff'),
+      )
+    end
+
+    it 'sets the verification header progress' do
+      rendered
+      expect(view.content_for(:nds_header_progress)).to have_css(
+        'nds-progress .progress__step[aria-current="step"]',
+      )
+    end
+
+    it 'does not offer in-person verification or desktop upload by default' do
+      expect(rendered).not_to have_content(t('doc_auth.headings.upload_from_computer'))
+      expect(rendered).not_to have_field('idv_how_to_verify_form[selection]', type: :hidden)
+    end
+
+    context 'with desktop upload enabled' do
+      before { @upload_enabled = true }
+
+      it 'offers continue-on-this-computer as a secondary submit' do
+        expect(rendered).to have_css(
+          '.auth__actions button.usa-button--secondary[formnovalidate]',
+          text: t('doc_auth.headings.upload_from_computer'),
         )
       end
     end

--- a/spec/views/idv/phone_required/show.html.erb_spec.rb
+++ b/spec/views/idv/phone_required/show.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'idv/phone_required/show.html.erb' do
+  before do
+    allow(view).to receive(:nds_layout?).and_return(true)
+    render
+  end
+
+  it 'renders the error card with the phone-required copy and no actions' do
+    expect(rendered).to have_css('.nds-status-icon--error')
+    expect(rendered).to have_css('.auth--form-page h1', text: t('nds.phone_required.heading'))
+    expect(rendered).to have_css('.auth__form-page-body hr.divider')
+    expect(rendered).to have_text(t('nds.phone_required.info'))
+    expect(rendered).not_to have_css('.auth__actions')
+  end
+end


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/148
- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Depends on #13505 / #13503 (phone-first flow). Adds the Figma "A U.S. phone number is required" dead end:

- New `Idv::PhoneRequiredController` at `/verify/phone_required`, NDS-only status-icon error card (heading, divider, copy, no actions).
- Hybrid handoff, in the phone-first flow only, redirects there when the submitted country is not US — before any link is sent or the number stored. Legacy handoff unchanged.
- New keys via consolidation: `nds.phone_required.{heading,info}`; new analytics event `idv_phone_required_visited`.

## 👀 Preview

Explorer `/test/nds/idv-phone-required`; live: NDS welcome → choose ID → handoff, pick a non-US country.

## 📜 Testing Plan

- `spec/controllers/idv/phone_required_controller_spec.rb`, `spec/views/idv/phone_required/show.html.erb_spec.rb` (new)
- `spec/controllers/idv/hybrid_handoff_controller_spec.rb`, `spec/policies/idv/flow_policy_spec.rb`
- catalog/explorer specs, analytics lint, `erb_lint`, `rubocop`, `zeitwerk:check`