### PR TITLE
LG-17574: Create Device Profiling Error (LG22) Account Clearance Email Notification

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -587,6 +587,12 @@ class UserMailer < ActionMailer::Base
     end
   end
 
+  def device_profiling_error_cleared
+    with_user_locale(user) do
+      mail(to: email_address.email, subject: t('user_mailer.account_reinstated.subject'))
+    end
+  end
+
   private
 
   attr_reader :user, :email_address

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -589,7 +589,10 @@ class UserMailer < ActionMailer::Base
 
   def device_profiling_error_cleared
     with_user_locale(user) do
-      mail(to: email_address.email, subject: t('user_mailer.account_reinstated.subject'))
+      mail(
+        to: email_address.email,
+        subject: t('user_mailer.device_profiling_error_cleared.subject'),
+      )
     end
   end
 

--- a/app/views/user_mailer/device_profiling_error_cleared.html.erb
+++ b/app/views/user_mailer/device_profiling_error_cleared.html.erb
@@ -1,0 +1,7 @@
+<p class="lead">
+  <%= t('user_mailer.device_profiling_error.header') %>
+</p>
+
+<p>
+  <%= t('user_mailer.device_profiling_error.info') %>
+</p>

--- a/app/views/user_mailer/device_profiling_error_cleared.html.erb
+++ b/app/views/user_mailer/device_profiling_error_cleared.html.erb
@@ -1,7 +1,7 @@
 <p class="lead">
-  <%= t('user_mailer.device_profiling_error.header') %>
+  <%= t('user_mailer.device_profiling_error_cleared.header') %>
 </p>
 
 <p>
-  <%= t('user_mailer.device_profiling_error.info') %>
+  <%= t('user_mailer.device_profiling_error_cleared.info') %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2041,6 +2041,9 @@ user_mailer.agent_proofing_succeeded.footer_html: If you did not attempt to veri
 user_mailer.agent_proofing_succeeded.header: You have successfully completed identity verification
 user_mailer.agent_proofing_succeeded.subject: 'Action Required: Confirm Your Verified Account'
 user_mailer.contact_link_text: contact us
+user_mailer.device_profiling_error.header: You can sign back in with your account
+user_mailer.device_profiling_error.info: The error on your account (LG22) has been resolved. You can now sign into the agency website with your account.
+user_mailer.device_profiling_error.subject: You can sign back in with your account
 user_mailer.dupe_profile.created.description: Someone has verified another %{app_name} account using your personal information. For your safety, we have restricted access on all accounts with matching information and access to %{sp_or_app_name}.
 user_mailer.dupe_profile.created.description2_html: If this was you verifying another account, delete the duplicate account by following the %{steps_link_html}. If this wasn’t you contact the %{help_center_link_html}.
 user_mailer.dupe_profile.created.heading: Your personal information was verified on another %{app_name} account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2041,9 +2041,9 @@ user_mailer.agent_proofing_succeeded.footer_html: If you did not attempt to veri
 user_mailer.agent_proofing_succeeded.header: You have successfully completed identity verification
 user_mailer.agent_proofing_succeeded.subject: 'Action Required: Confirm Your Verified Account'
 user_mailer.contact_link_text: contact us
-user_mailer.device_profiling_error.header: You can sign back in with your account
-user_mailer.device_profiling_error.info: The error on your account (LG22) has been resolved. You can now sign into the agency website with your account.
-user_mailer.device_profiling_error.subject: You can sign back in with your account
+user_mailer.device_profiling_error_cleared.header: You can sign back in with your account
+user_mailer.device_profiling_error_cleared.info: The error on your account (LG22) has been resolved. You can now sign into the agency website with your account.
+user_mailer.device_profiling_error_cleared.subject: You can sign back in with your account
 user_mailer.dupe_profile.created.description: Someone has verified another %{app_name} account using your personal information. For your safety, we have restricted access on all accounts with matching information and access to %{sp_or_app_name}.
 user_mailer.dupe_profile.created.description2_html: If this was you verifying another account, delete the duplicate account by following the %{steps_link_html}. If this wasn’t you contact the %{help_center_link_html}.
 user_mailer.dupe_profile.created.heading: Your personal information was verified on another %{app_name} account

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2053,6 +2053,9 @@ user_mailer.agent_proofing_succeeded.footer_html: Si usted no intentó verificar
 user_mailer.agent_proofing_succeeded.header: Ha completado con éxito su verificación de identidad
 user_mailer.agent_proofing_succeeded.subject: 'Acción requerida: Confirme su cuenta verificada'
 user_mailer.contact_link_text: contáctenos
+user_mailer.device_profiling_error.header: Puede volver a iniciar sesión con su cuenta
+user_mailer.device_profiling_error.info: El error en su cuenta (LG22) se ha solucionado. Ahora puede iniciar sesión en el sitio web de la agencia con su cuenta.
+user_mailer.device_profiling_error.subject: Puede volver a iniciar sesión con su cuenta
 user_mailer.dupe_profile.created.description: Alguien verificó otra cuenta de %{app_name} usando la información personal de usted. Por su seguridad, hemos restringido su acceso a todas las cuentas con información que coincide y a %{sp_or_app_name}.
 user_mailer.dupe_profile.created.description2_html: Si fue usted quien verificó otra cuenta, elimine la cuenta duplicada siguiendo %{steps_link_html}. Si no fue usted, contacte con %{help_center_link_html}.
 user_mailer.dupe_profile.created.heading: Su información personal fue verificada en otra cuenta de %{app_name}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2053,9 +2053,9 @@ user_mailer.agent_proofing_succeeded.footer_html: Si usted no intentó verificar
 user_mailer.agent_proofing_succeeded.header: Ha completado con éxito su verificación de identidad
 user_mailer.agent_proofing_succeeded.subject: 'Acción requerida: Confirme su cuenta verificada'
 user_mailer.contact_link_text: contáctenos
-user_mailer.device_profiling_error.header: Puede volver a iniciar sesión con su cuenta
-user_mailer.device_profiling_error.info: El error en su cuenta (LG22) se ha solucionado. Ahora puede iniciar sesión en el sitio web de la agencia con su cuenta.
-user_mailer.device_profiling_error.subject: Puede volver a iniciar sesión con su cuenta
+user_mailer.device_profiling_error_cleared.header: Puede volver a iniciar sesión con su cuenta
+user_mailer.device_profiling_error_cleared.info: El error en su cuenta (LG22) se ha solucionado. Ahora puede iniciar sesión en el sitio web de la agencia con su cuenta.
+user_mailer.device_profiling_error_cleared.subject: Puede volver a iniciar sesión con su cuenta
 user_mailer.dupe_profile.created.description: Alguien verificó otra cuenta de %{app_name} usando la información personal de usted. Por su seguridad, hemos restringido su acceso a todas las cuentas con información que coincide y a %{sp_or_app_name}.
 user_mailer.dupe_profile.created.description2_html: Si fue usted quien verificó otra cuenta, elimine la cuenta duplicada siguiendo %{steps_link_html}. Si no fue usted, contacte con %{help_center_link_html}.
 user_mailer.dupe_profile.created.heading: Su información personal fue verificada en otra cuenta de %{app_name}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2042,6 +2042,9 @@ user_mailer.agent_proofing_succeeded.footer_html: 'Si vous n’avez pas tenté d
 user_mailer.agent_proofing_succeeded.header: Vous avez completé la vérification de votre identité avec succès.
 user_mailer.agent_proofing_succeeded.subject: 'Action requise : Confirmez votre compte vérifié'
 user_mailer.contact_link_text: nous contacter
+user_mailer.device_profiling_error.header: Vous pouvez vous reconnecter à votre compte
+user_mailer.device_profiling_error.info: L’erreur concernant votre compte (LG22) a été résolue. Vous pouvez désormais vous connecter au site web de l’agence avec votre compte.
+user_mailer.device_profiling_error.subject: Vous pouvez vous reconnecter à votre compte
 user_mailer.dupe_profile.created.description: Quelqu’un a utilisé vos renseignements personnels pour confirmer un autre compte %{app_name}. Pour votre sécurité, nous avons restreint votre accès sur tous les comptes comportant des informations identiques et ayant accès à %{sp_or_app_name}.
 user_mailer.dupe_profile.created.description2_html: Si c’est vous qui avez confirmé un autre compte, veuillez supprimer le compte en double en suivant %{steps_link_html}. Si vous n’avez pas effectué cette action, veuillez prendre contact avec le %{help_center_link_html}.
 user_mailer.dupe_profile.created.heading: Vos renseignements personnels ont été confirmés pour un autre compte %{app_name}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2042,9 +2042,9 @@ user_mailer.agent_proofing_succeeded.footer_html: 'Si vous n’avez pas tenté d
 user_mailer.agent_proofing_succeeded.header: Vous avez completé la vérification de votre identité avec succès.
 user_mailer.agent_proofing_succeeded.subject: 'Action requise : Confirmez votre compte vérifié'
 user_mailer.contact_link_text: nous contacter
-user_mailer.device_profiling_error.header: Vous pouvez vous reconnecter à votre compte
-user_mailer.device_profiling_error.info: L’erreur concernant votre compte (LG22) a été résolue. Vous pouvez désormais vous connecter au site web de l’agence avec votre compte.
-user_mailer.device_profiling_error.subject: Vous pouvez vous reconnecter à votre compte
+user_mailer.device_profiling_error_cleared.header: Vous pouvez vous reconnecter à votre compte
+user_mailer.device_profiling_error_cleared.info: L’erreur concernant votre compte (LG22) a été résolue. Vous pouvez désormais vous connecter au site web de l’agence avec votre compte.
+user_mailer.device_profiling_error_cleared.subject: Vous pouvez vous reconnecter à votre compte
 user_mailer.dupe_profile.created.description: Quelqu’un a utilisé vos renseignements personnels pour confirmer un autre compte %{app_name}. Pour votre sécurité, nous avons restreint votre accès sur tous les comptes comportant des informations identiques et ayant accès à %{sp_or_app_name}.
 user_mailer.dupe_profile.created.description2_html: Si c’est vous qui avez confirmé un autre compte, veuillez supprimer le compte en double en suivant %{steps_link_html}. Si vous n’avez pas effectué cette action, veuillez prendre contact avec le %{help_center_link_html}.
 user_mailer.dupe_profile.created.heading: Vos renseignements personnels ont été confirmés pour un autre compte %{app_name}

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -2054,6 +2054,9 @@ user_mailer.agent_proofing_succeeded.footer_html: 如果您并未亲自尝试进
 user_mailer.agent_proofing_succeeded.header: 您已成功完成身份验证
 user_mailer.agent_proofing_succeeded.subject: 需采取行动：确认您的已验证账户
 user_mailer.contact_link_text: 联系我们
+user_mailer.device_profiling_error.header: 您可以使用 帐户重新登录。
+user_mailer.device_profiling_error.info: 您的账户（LG22）错误已解决。您现在可以使用 账户登录机构网站。
+user_mailer.device_profiling_error.subject: 您可以使用 帐户重新登录。
 user_mailer.dupe_profile.created.description: 有人使用你的个人信息验证了另一个 %{app_name} 账户。 为了你的安全，我们已限制了具有同样信息的所有账户的访问权以及对 %{sp_or_app_name} 的访问权.
 user_mailer.dupe_profile.created.description2_html: 如果另一个账户是你本人验证的，请按照这里列出的 %{steps_link_html}。如果不是你本人，请联系 %{help_center_link_html}.
 user_mailer.dupe_profile.created.heading: 你的个人信息在另一个 %{app_name} 账户上得到了验证

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -2054,9 +2054,9 @@ user_mailer.agent_proofing_succeeded.footer_html: 如果您并未亲自尝试进
 user_mailer.agent_proofing_succeeded.header: 您已成功完成身份验证
 user_mailer.agent_proofing_succeeded.subject: 需采取行动：确认您的已验证账户
 user_mailer.contact_link_text: 联系我们
-user_mailer.device_profiling_error.header: 您可以使用 帐户重新登录。
-user_mailer.device_profiling_error.info: 您的账户（LG22）错误已解决。您现在可以使用 账户登录机构网站。
-user_mailer.device_profiling_error.subject: 您可以使用 帐户重新登录。
+user_mailer.device_profiling_error_cleared.header: 您可以使用 帐户重新登录。
+user_mailer.device_profiling_error_cleared.info: 您的账户（LG22）错误已解决。您现在可以使用您的账户登录机构网站。
+user_mailer.device_profiling_error_cleared.subject: 您可以使用 帐户重新登录。
 user_mailer.dupe_profile.created.description: 有人使用你的个人信息验证了另一个 %{app_name} 账户。 为了你的安全，我们已限制了具有同样信息的所有账户的访问权以及对 %{sp_or_app_name} 的访问权.
 user_mailer.dupe_profile.created.description2_html: 如果另一个账户是你本人验证的，请按照这里列出的 %{steps_link_html}。如果不是你本人，请联系 %{help_center_link_html}.
 user_mailer.dupe_profile.created.heading: 你的个人信息在另一个 %{app_name} 账户上得到了验证

--- a/lib/action_account.rb
+++ b/lib/action_account.rb
@@ -84,7 +84,8 @@ class ActionAccount
         closed_inconclusive_duplicate:
           'User has been notified that the fraud investigation is inconclusive',
         deactivated_duplicate: "User's profile has been deactivated and the user has been notified",
-        device_profiling_approved: 'Device profiling result has been updated to pass',
+        device_profiling_approved:
+          'Device profiling result has been updated to pass and the user has been emailed',
         device_profiling_already_passed: 'Device profiling result already passed',
         device_profiling_no_results_found: 'No device profiling results found for this user',
         error_activating: "There was an error activating the user's profile. Please try again.",
@@ -152,6 +153,7 @@ class ActionAccount
             log_texts << log_text[:device_profiling_already_passed]
           else
             result.update!(review_status: 'pass', notes: 'Manually overridden')
+            user.send_email_to_all_addresses(:device_profiling_error_cleared)
             log_texts << log_text[:device_profiling_approved]
           end
         else

--- a/spec/lib/action_account_spec.rb
+++ b/spec/lib/action_account_spec.rb
@@ -484,13 +484,57 @@ RSpec.describe ActionAccount do
         expect(result.table).to match_array(
           [
             ['uuid', 'status', 'reason'],
-            [user.uuid, 'Device profiling result has been updated to pass', nil],
+            [user.uuid,
+             'Device profiling result has been updated to pass and the user has been emailed', nil],
             [user2.uuid, 'No device profiling results found for this user', nil],
           ],
         )
 
         expect(result.subtask).to eq('clear-device-profiling-failure-user')
         expect(result.uuids).to match_array([user.uuid, user2.uuid])
+      end
+
+      it 'updates the device profiling result to pass' do
+        result
+        expect(device_profiling_result.reload.review_status).to eq('pass')
+      end
+
+      it 'sends the device profiling error cleared email to the user' do
+        expect { result }.to(
+          change { ActionMailer::Base.deliveries.count }.by(user.email_addresses.count),
+        )
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.subject).to eq(t('user_mailer.device_profiling_error_cleared.subject'))
+      end
+
+      context 'when the device profiling result already passed' do
+        let!(:device_profiling_result) do
+          create(
+            :device_profiling_result,
+            user:,
+            review_status: 'pass',
+            profiling_type: DeviceProfilingResult::PROFILING_TYPES[:account_creation],
+          )
+        end
+
+        it 'does not send an email' do
+          expect { result }.to_not(change { ActionMailer::Base.deliveries.count })
+        end
+
+        it 'reports that the result already passed' do
+          expect(result.table).to include(
+            [user.uuid, 'Device profiling result already passed', nil],
+          )
+        end
+      end
+
+      context 'when no device profiling results are found' do
+        let!(:device_profiling_result) { nil }
+
+        it 'does not send an email' do
+          expect { result }.to_not(change { ActionMailer::Base.deliveries.count })
+        end
       end
     end
   end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -395,6 +395,13 @@ class UserMailerPreview < ActionMailer::Preview
       )
   end
 
+  def device_profiling_error_cleared
+    UserMailer.with(
+      user: user,
+      email_address: email_address_record,
+    ).device_profiling_error_cleared
+  end
+
   private
 
   def user

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1876,4 +1876,13 @@ RSpec.describe UserMailer, type: :mailer do
       end
     end
   end
+
+  describe '#account_reinstated' do
+    let(:mail) do
+      UserMailer.with(user: user, email_address: email_address).device_profiling_error_cleared
+    end
+
+    it_behaves_like 'a system email'
+    it_behaves_like 'an email that respects user email locale preference'
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1877,12 +1877,25 @@ RSpec.describe UserMailer, type: :mailer do
     end
   end
 
-  describe '#account_reinstated' do
+  describe '#device_profiling_error_cleared' do
     let(:mail) do
       UserMailer.with(user: user, email_address: email_address).device_profiling_error_cleared
     end
 
     it_behaves_like 'a system email'
     it_behaves_like 'an email that respects user email locale preference'
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq(t('user_mailer.device_profiling_error_cleared.subject'))
+    end
+
+    it 'renders the body' do
+      expect(mail.html_part.body).to have_content(
+        t('user_mailer.device_profiling_error_cleared.header'),
+      )
+      expect(mail.html_part.body).to have_content(
+        t('user_mailer.device_profiling_error_cleared.info'),
+      )
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket
[LG-17574: Create Device Profiling Error (LG22) Account Clearance Email Notification](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17574)

## 🛠 Summary of changes

This pull requests adds functionality to send a email when LG22 has been resolved from a user's account

## 📜 Testing Plan

**User Mailer Preview**
- With application running, go to http://localhost:3000/rails/mailers
- Under "User Mailer", look for `device_profiling_error_cleared`
- Observe email preview

**Email send**
Note: testing this ticket requires developer intervention

With an account with two or more confirmed emails and rejected account_creation device-profiling result
- Find the uuid of the test account. You can do this by running `user = User.find_by(email: "test@example.com")`
- Set the account-creation device profiling review status result to `'reject'`
- run `bundle exec ./bin/action-account clear-device-profiling-failure <UUID> --reason LG-22`
- Email should be sent to all addresses on the account

## 👀 Screenshots

| English | Header | Header | Header |
|--------|--------|--------|--------|
| <img width="687" height="734" alt="Create Device Profiling Error (LG22) Account Clearance Email in English" src="https://github.com/user-attachments/assets/58adfeb1-0e19-4dfd-bd39-cf722885356f" /> | <img width="781" height="763" alt="Create Device Profiling Error (LG22) Account Clearance Email in Spanish" src="https://github.com/user-attachments/assets/69531930-a22d-4e5f-bcf8-c92fb7ed9c29" /> | <img width="746" height="800" alt="Create Device Profiling Error (LG22) Account Clearance Email in French" src="https://github.com/user-attachments/assets/148d0d7e-3abf-45da-a697-994afcc5eaa5" /> | <img width="746" height="801" alt="Create Device Profiling Error (LG22) Account Clearance Email in Chinese" src="https://github.com/user-attachments/assets/da0893bb-d496-4846-8a35-d854fe24ecbf" /> |



