### PR TITLE
De-flake the NDS look-and-feel experiment feature spec

### DIFF
--- a/spec/features/nds_look_and_feel_spec.rb
+++ b/spec/features/nds_look_and_feel_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.feature 'NDS look and feel experiment' do
   before do
+    # The experiment UUID cookie is permanent and short-circuits generation, so a
+    # cookie left over from an earlier example in this shard would mask the
+    # stubbed UUID. Start every scenario from an empty jar.
+    Capybara.reset_sessions!
     allow(IdentityConfig.store).to receive(:nds_look_and_feel_percent).and_return(50)
     reload_ab_tests
     allow(SecureRandom).to receive(:uuid).and_return('experiment-uuid')


### PR DESCRIPTION
## 🎫 Tickets

- https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/34

## 🛠 Summary of changes

`spec/features/nds_look_and_feel_spec.rb:21` fails intermittently in CI shard 18/22 (seen on #13519, #13508, #13516, …): it stubs `SecureRandom.uuid` and asserts the `nds_experiment_uuid` cookie equals the stub, but that cookie is permanent and `ApplicationController#nds_experiment_uuid` short-circuits on an existing value — so a cookie left by an earlier example in the shard wins and the spec sees a real UUID.

Fix: `Capybara.reset_sessions!` in `before` so each scenario starts with an empty cookie jar. Spec-only.

## 📜 Testing Plan

- `spec/features/nds_look_and_feel_spec.rb`