### PR TITLE
LG-17899: add user_email_confirmed to proofing agent search user

### DIFF
--- a/app/controllers/api/proofing_agent/proofing_agent_controller.rb
+++ b/app/controllers/api/proofing_agent/proofing_agent_controller.rb
@@ -26,6 +26,7 @@ module Api
           ssn_profile_found: ssn_active_profiles.any?,
           profiles: active_profiles_info,
           email_account_awaiting_binding: !!user&.proofing_agent_user_awaiting_binding?,
+          user_email_confirmed: email_confirmed?,
         }
 
         analytics.idv_proofing_agent_account_check_requested(

--- a/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
+++ b/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
@@ -289,12 +289,15 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               expect(body['ssn_profile_found']).to eq(false)
               expect(body['profiles']).to eq([])
               expect(body['email_account_awaiting_binding']).to eq(false)
+              expect(body['user_email_confirmed']).to eq(false)
               expect(@analytics).to have_logged_event(
                 :idv_proofing_agent_account_check_requested,
                 response_body: a_hash_including(
                   email_account_found: false,
                   ssn_profile_found: false,
                   profiles: [],
+                  user_email_confirmed: false,
+                  email_account_awaiting_binding: false,
                 ),
                 proofing_agent: proofing_agent_analytics_hash,
                 issuer:,
@@ -316,6 +319,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               expect(body['email_account_found']).to eq(false)
               expect(body['ssn_profile_found']).to eq(true)
               expect(body['email_account_awaiting_binding']).to eq(false)
+              expect(body['user_email_confirmed']).to eq(false)
               expect(body['profiles'].length).to eq(1)
               expect(body['profiles']).to include(
                 a_hash_including(
@@ -329,6 +333,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
                 response_body: a_hash_including(
                   email_account_found: false,
                   email_account_awaiting_binding: false,
+                  user_email_confirmed: false,
                   ssn_profile_found: true,
                   profiles: include(
                     a_hash_including(
@@ -360,10 +365,39 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['ssn_profile_found']).to eq(false)
             expect(body['profiles'].length).to eq(0)
             expect(body['email_account_awaiting_binding']).to eq(false)
+            expect(body['user_email_confirmed']).to eq(true)
             expect(@analytics).to have_logged_event(
               :idv_proofing_agent_account_check_requested,
               response_body: a_hash_including(
                 email_account_found: true,
+                user_email_confirmed: true,
+                email_account_awaiting_binding: false,
+                ssn_profile_found: false,
+                profiles: [],
+              ),
+              proofing_agent: proofing_agent_analytics_hash,
+              issuer:,
+            )
+          end
+        end
+
+        context 'when a user has not confirmed their email address' do
+          before do
+            user.email_addresses.update(confirmed_at: nil)
+          end
+          it 'returns correct profiles and found attributes' do
+            user.update!(confirmed_at: nil)
+            action
+            body = JSON.parse(response.body)
+            expect(body['email_account_found']).to eq(true)
+            expect(body['ssn_profile_found']).to eq(false)
+            expect(body['email_account_awaiting_binding']).to eq(false)
+            expect(body['user_email_confirmed']).to eq(false)
+            expect(@analytics).to have_logged_event(
+              :idv_proofing_agent_account_check_requested,
+              response_body: a_hash_including(
+                email_account_found: true,
+                user_email_confirmed: false,
                 email_account_awaiting_binding: false,
                 ssn_profile_found: false,
                 profiles: [],
@@ -423,6 +457,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(true)
             expect(body['email_account_awaiting_binding']).to eq(false)
+            expect(body['user_email_confirmed']).to eq(true)
             expect(body['profiles'].length).to eq(3)
             expect(body['profiles']).to include(
               a_hash_including(
@@ -446,6 +481,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               response_body: a_hash_including(
                 email_account_found: true,
                 email_account_awaiting_binding: false,
+                user_email_confirmed: true,
                 ssn_profile_found: true,
                 profiles: include(
                   a_hash_including(
@@ -513,6 +549,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(true)
             expect(body['email_account_awaiting_binding']).to eq(false)
+            expect(body['user_email_confirmed']).to eq(true)
             expect(body['profiles'].length).to eq(2)
             expect(body['profiles']).to include(
               a_hash_including(
@@ -532,6 +569,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
                 email_account_found: true,
                 ssn_profile_found: true,
                 email_account_awaiting_binding: false,
+                user_email_confirmed: true,
                 profiles: include(
                   a_hash_including(
                     email_match: true,
@@ -589,6 +627,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(true)
             expect(body['email_account_awaiting_binding']).to eq(true)
+            expect(body['user_email_confirmed']).to eq(true)
             expect(body['profiles'].length).to eq(1)
             expect(body['profiles']).to include(
               a_hash_including(
@@ -603,6 +642,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
                 email_account_found: true,
                 email_account_awaiting_binding: true,
                 ssn_profile_found: true,
+                user_email_confirmed: true,
                 profiles: include(
                   a_hash_including(
                     email_match: true,


### PR DESCRIPTION
## 🎫 Ticket
[LG-17899](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17899)

## 🛠 Summary of changes
Add user_email_confirmed to the search user result for proofing agent

## 📜 Testing Plan
1. Register an account and do not confirm
2. Search for account email using proofing agent endpoint and verify response body includes:
user_email_confirmed: false
3.  Confirm email to complete registration
4. Search for account email using proofing agent endpoint and verify response body includes:
user_email_confirmed: true

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17899]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17899