### PR TITLE
LG-17899: rename user search result attribute to account_email_confirmed

### DIFF
--- a/app/controllers/api/proofing_agent/proofing_agent_controller.rb
+++ b/app/controllers/api/proofing_agent/proofing_agent_controller.rb
@@ -26,7 +26,7 @@ module Api
           ssn_profile_found: ssn_active_profiles.any?,
           profiles: active_profiles_info,
           email_account_awaiting_binding: !!user&.proofing_agent_user_awaiting_binding?,
-          user_email_confirmed: email_confirmed?,
+          account_email_confirmed: email_confirmed?,
         }
 
         analytics.idv_proofing_agent_account_check_requested(

--- a/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
+++ b/spec/controllers/api/proofing_agent/proofing_agent_controller_spec.rb
@@ -289,14 +289,14 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               expect(body['ssn_profile_found']).to eq(false)
               expect(body['profiles']).to eq([])
               expect(body['email_account_awaiting_binding']).to eq(false)
-              expect(body['user_email_confirmed']).to eq(false)
+              expect(body['account_email_confirmed']).to eq(false)
               expect(@analytics).to have_logged_event(
                 :idv_proofing_agent_account_check_requested,
                 response_body: a_hash_including(
                   email_account_found: false,
                   ssn_profile_found: false,
                   profiles: [],
-                  user_email_confirmed: false,
+                  account_email_confirmed: false,
                   email_account_awaiting_binding: false,
                 ),
                 proofing_agent: proofing_agent_analytics_hash,
@@ -319,7 +319,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               expect(body['email_account_found']).to eq(false)
               expect(body['ssn_profile_found']).to eq(true)
               expect(body['email_account_awaiting_binding']).to eq(false)
-              expect(body['user_email_confirmed']).to eq(false)
+              expect(body['account_email_confirmed']).to eq(false)
               expect(body['profiles'].length).to eq(1)
               expect(body['profiles']).to include(
                 a_hash_including(
@@ -333,7 +333,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
                 response_body: a_hash_including(
                   email_account_found: false,
                   email_account_awaiting_binding: false,
-                  user_email_confirmed: false,
+                  account_email_confirmed: false,
                   ssn_profile_found: true,
                   profiles: include(
                     a_hash_including(
@@ -365,12 +365,12 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['ssn_profile_found']).to eq(false)
             expect(body['profiles'].length).to eq(0)
             expect(body['email_account_awaiting_binding']).to eq(false)
-            expect(body['user_email_confirmed']).to eq(true)
+            expect(body['account_email_confirmed']).to eq(true)
             expect(@analytics).to have_logged_event(
               :idv_proofing_agent_account_check_requested,
               response_body: a_hash_including(
                 email_account_found: true,
-                user_email_confirmed: true,
+                account_email_confirmed: true,
                 email_account_awaiting_binding: false,
                 ssn_profile_found: false,
                 profiles: [],
@@ -392,12 +392,12 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(false)
             expect(body['email_account_awaiting_binding']).to eq(false)
-            expect(body['user_email_confirmed']).to eq(false)
+            expect(body['account_email_confirmed']).to eq(false)
             expect(@analytics).to have_logged_event(
               :idv_proofing_agent_account_check_requested,
               response_body: a_hash_including(
                 email_account_found: true,
-                user_email_confirmed: false,
+                account_email_confirmed: false,
                 email_account_awaiting_binding: false,
                 ssn_profile_found: false,
                 profiles: [],
@@ -457,7 +457,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(true)
             expect(body['email_account_awaiting_binding']).to eq(false)
-            expect(body['user_email_confirmed']).to eq(true)
+            expect(body['account_email_confirmed']).to eq(true)
             expect(body['profiles'].length).to eq(3)
             expect(body['profiles']).to include(
               a_hash_including(
@@ -481,7 +481,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
               response_body: a_hash_including(
                 email_account_found: true,
                 email_account_awaiting_binding: false,
-                user_email_confirmed: true,
+                account_email_confirmed: true,
                 ssn_profile_found: true,
                 profiles: include(
                   a_hash_including(
@@ -549,7 +549,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(true)
             expect(body['email_account_awaiting_binding']).to eq(false)
-            expect(body['user_email_confirmed']).to eq(true)
+            expect(body['account_email_confirmed']).to eq(true)
             expect(body['profiles'].length).to eq(2)
             expect(body['profiles']).to include(
               a_hash_including(
@@ -569,7 +569,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
                 email_account_found: true,
                 ssn_profile_found: true,
                 email_account_awaiting_binding: false,
-                user_email_confirmed: true,
+                account_email_confirmed: true,
                 profiles: include(
                   a_hash_including(
                     email_match: true,
@@ -627,7 +627,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
             expect(body['email_account_found']).to eq(true)
             expect(body['ssn_profile_found']).to eq(true)
             expect(body['email_account_awaiting_binding']).to eq(true)
-            expect(body['user_email_confirmed']).to eq(true)
+            expect(body['account_email_confirmed']).to eq(true)
             expect(body['profiles'].length).to eq(1)
             expect(body['profiles']).to include(
               a_hash_including(
@@ -642,7 +642,7 @@ RSpec.describe Api::ProofingAgent::ProofingAgentController do
                 email_account_found: true,
                 email_account_awaiting_binding: true,
                 ssn_profile_found: true,
-                user_email_confirmed: true,
+                account_email_confirmed: true,
                 profiles: include(
                   a_hash_including(
                     email_match: true,


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

## 🎫 Ticket
[LG-17899](https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17899)

## 🛠 Summary of changes
Rename attribute from user_email_confirmed to account_email_confirmed for consistency.

<!--
## 📜 Testing Plan
1. Register an account and do not confirm
2. Search for account email using proofing agent endpoint and verify response body includes:
account_email_confirmed: false
3.  Confirm email to complete registration
4. Search for account email using proofing agent endpoint and verify response body includes:
account_email_confirmed: true
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->


[LG-17899]: https://gsa-standard.atlassian-us-gov-mod.net/browse/LG-17899