### PR TITLE
Fix NDS warning-page stepper substeps and mail-only list alignment

### DIFF
--- a/app/views/idv/mail_only_warning/show.html.erb
+++ b/app/views/idv/mail_only_warning/show.html.erb
@@ -24,7 +24,7 @@
         <%= t('vendor_outage.alerts.pinpoint.idv.status_page_html', link_html: new_tab_link_to(t('vendor_outage.alerts.pinpoint.idv.status_page_link'), StatusPage.base_url)) %>
       </p>
       <p><%= t('vendor_outage.alerts.pinpoint.idv.options_prompt') %></p>
-      <ul class="usa-list">
+      <ul class="usa-list text-left">
         <% t('vendor_outage.alerts.pinpoint.idv.options_html', app_name: APP_NAME).each do |option| %>
           <li>
             <%= option %>

--- a/app/views/idv/session_errors/address_warning.html.erb
+++ b/app/views/idv/session_errors/address_warning.html.erb
@@ -2,7 +2,7 @@
 
 <% if nds_layout? %>
   <% content_for(:nds_header_progress) do %>
-    <%= nds_account_creation_progress(step: :verification, substep: 2) %>
+    <%= nds_account_creation_progress(step: :verification, substep: 6) %>
   <% end %>
 
   <%= render NDS::FormPageComponent.new(title: t('idv.warning.address.heading')) do |page| %>

--- a/app/views/idv/session_errors/warning.html.erb
+++ b/app/views/idv/session_errors/warning.html.erb
@@ -2,7 +2,7 @@
 
 <% if nds_layout? %>
   <% content_for(:nds_header_progress) do %>
-    <%= nds_account_creation_progress(step: :verification, substep: 2) %>
+    <%= nds_account_creation_progress(step: :verification, substep: 7) %>
   <% end %>
 
   <%= render NDS::FormPageComponent.new(title: t('idv.warning.sessions.heading')) do |page| %>

--- a/spec/views/idv/mail_only_warning/show.html.erb_spec.rb
+++ b/spec/views/idv/mail_only_warning/show.html.erb_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'idv/mail_only_warning/show.html.erb' do
         text: t('vendor_outage.alerts.pinpoint.idv.status_page_link'),
       )
       expect(rendered).to have_selector(
-        '.auth__form-page-body ul.usa-list li',
+        '.auth__form-page-body ul.usa-list.text-left li',
         count: t('vendor_outage.alerts.pinpoint.idv.options_html', app_name: APP_NAME).length,
       )
     end

--- a/spec/views/idv/session_errors/address_warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/address_warning.html.erb_spec.rb
@@ -72,9 +72,12 @@ RSpec.describe 'idv/session_errors/address_warning.html.erb' do
       )
     end
 
-    it 'sets the verification header progress' do
+    it 'sets the verification header progress to the address substep' do
       progress = view.content_for(:nds_header_progress)
-      expect(progress).to have_css('nds-progress .progress__step[aria-current="step"]')
+      expect(progress).to have_css(
+        'nds-progress .progress__step[aria-current="step"] .progress__step-counter',
+        text: '6 / 12',
+      )
     end
 
     it 'renders the warning status-icon badge and divider' do

--- a/spec/views/idv/session_errors/warning.html.erb_spec.rb
+++ b/spec/views/idv/session_errors/warning.html.erb_spec.rb
@@ -72,9 +72,12 @@ RSpec.describe 'idv/session_errors/warning.html.erb' do
       )
     end
 
-    it 'sets the verification header progress' do
+    it 'sets the verification header progress to the verify-info substep' do
       progress = view.content_for(:nds_header_progress)
-      expect(progress).to have_css('nds-progress .progress__step[aria-current="step"]')
+      expect(progress).to have_css(
+        'nds-progress .progress__step[aria-current="step"] .progress__step-counter',
+        text: '7 / 12',
+      )
     end
 
     it 'renders the warning status-icon badge and divider' do


### PR DESCRIPTION
## 🎫 Tickets

https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/118
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/119
https://gitlab.login.gov/lg-teams/ui-refresh/-/work_items/57

## 🛠 Summary of changes

Review follow-ups from #13486 and #13487 (both already merged), NDS bucket only —
legacy branches untouched.

- **Stepper substeps** (#13487): `idv/session_error/warning` now renders
  `substep: 7` (verify-info — where the page is reached from and where "Try again"
  returns) instead of `2`, and `address_warning` renders `substep: 6` (address).
  Previously the stepper dropped back to the choose-ID slot on error and jumped
  forward again on retry.
- **Pinned specs** (#13487): both view specs now assert the rendered counter
  (`7 / 12`, `6 / 12`) rather than just the presence of an active step, so the
  substeps can't silently drift.
- **Options list alignment** (#13486): `mail_only_warning` adds `text-left` to its
  `ul.usa-list` so bullets line up. `.auth__form-page-body` is `text-align: center`
  and the NDS `.usa-list` overlay is `list-style-position: inside`; this uses the
  shipped utility rather than new CSS and sets the precedent for bare lists in an
  NDS form-page body.

## 👀 Preview

- `/test/nds/session-errors-warning` — stepper reads Verification 7 / 12
- `/test/nds/session-errors-address-warning` — stepper reads Verification 6 / 12
- `/test/nds/mail-only-warning` — options bullets left-aligned

## 📜 Testing Plan

- [ ] `bundle exec rspec spec/views/idv/session_error/warning.html.erb_spec.rb spec/views/idv/session_error/address_warning.html.erb_spec.rb spec/views/idv/mail_only_warning/show.html.erb_spec.rb`
- [ ] erb_lint / rubocop clean
- [ ] Legacy (`ui_test_bucket=legacy`) renders of all three pages unchanged