### PR TITLE
Joan 115: Use field review_status to determine PhoneFinder pass/fail for analytics/logging

### DIFF
--- a/app/services/proofing/lexis_nexis/ddp/parsed_response.rb
+++ b/app/services/proofing/lexis_nexis/ddp/parsed_response.rb
@@ -6,8 +6,9 @@ module Proofing
       class ParsedResponse
         attr_reader :response
 
-        def initialize(response)
+        def initialize(response, review_status: nil)
           @response = response
+          @review_status = review_status
         end
 
         def verification_errors
@@ -59,7 +60,8 @@ module Proofing
         end
 
         def verification_error_parser
-          @verification_error_parser ||= VerificationErrorParser.new(response_body)
+          @verification_error_parser ||=
+            VerificationErrorParser.new(response_body, review_status: @review_status)
         end
       end
     end

--- a/app/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer.rb
@@ -12,13 +12,14 @@ module Proofing
 
           def build_result_from_response(verification_response)
             response_body = verification_response.response_body
+            vendor_raw_response = raw_response(response_body)
             review_status = response_body['review_status']
 
             validate_review_status!(review_status)
 
             parsed_response =
               Proofing::LexisNexis::Ddp::ParsedResponse.new(
-                raw_response(response_body),
+                vendor_raw_response,
                 review_status: review_status,
               )
 

--- a/app/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer.rb
+++ b/app/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer.rb
@@ -12,11 +12,15 @@ module Proofing
 
           def build_result_from_response(verification_response)
             response_body = verification_response.response_body
-            parsed_response =
-              Proofing::LexisNexis::Ddp::ParsedResponse.new(raw_response(response_body))
             review_status = response_body['review_status']
 
             validate_review_status!(review_status)
+
+            parsed_response =
+              Proofing::LexisNexis::Ddp::ParsedResponse.new(
+                raw_response(response_body),
+                review_status: review_status,
+              )
 
             AddressResult.new(
               success: review_status == 'pass',

--- a/app/services/proofing/lexis_nexis/verification_error_parser.rb
+++ b/app/services/proofing/lexis_nexis/verification_error_parser.rb
@@ -5,8 +5,9 @@ module Proofing
     class VerificationErrorParser
       attr_reader :body
 
-      def initialize(response_body)
+      def initialize(response_body, review_status: nil)
         @body = response_body
+        @review_status = review_status
         @product_error_messages = parse_product_error_messages
         @base_error_message = parse_base_error_message
       end
@@ -21,7 +22,7 @@ module Proofing
 
       private
 
-      attr_reader :base_error_message, :product_error_messages
+      attr_reader :base_error_message, :product_error_messages, :review_status
 
       def parse_base_error_message
         return "Invalid status in response body: '#{verification_status}'" if !valid_status?
@@ -61,7 +62,22 @@ module Proofing
         return true if product['ProductStatus'] != 'pass'
         return true if product['ProductType'] == 'InstantVerify'
         return true if product['Items']&.flat_map(&:keys)&.include?('ItemReason')
+        return true if product['ProductType'] == 'PhoneFinder' && phone_finder_not_passed?
         return false
+      end
+
+      def phone_finder_not_passed?
+        return review_status != 'pass' unless review_status.nil?
+
+        products = body['Products']
+        return false unless products.is_a?(Array)
+
+        products.any? do |product|
+          next false unless product.is_a?(Hash)
+
+          product['ProductType'].to_s.start_with?('PhoneFinder') &&
+            product['ProductStatus'] != 'pass'
+        end
       end
     end
   end

--- a/spec/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer_spec.rb
+++ b/spec/services/proofing/lexis_nexis/ddp/proofers/phone_finder_proofer_spec.rb
@@ -196,6 +196,15 @@ RSpec.describe Proofing::LexisNexis::Ddp::Proofers::PhoneFinderProofer do
 
             expect(result.result[:review_status]).to eq('reject')
           end
+
+          it 'logs the PhoneFinder detail product (with Items) alongside the decision' do
+            result = proofer.proof(proofing_applicant)
+            phone_finder_detail = result.errors[:PhoneFinder].first
+
+            expect(phone_finder_detail).to be_a(Hash)
+            expect(phone_finder_detail['Items']).to be_present
+            expect(phone_finder_detail['ParameterDetails']).to be_nil
+          end
         end
 
         context 'when the failure is "could not be verified to name" with additional errors' do

--- a/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
+++ b/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
@@ -100,4 +100,3 @@ RSpec.describe Proofing::LexisNexis::VerificationErrorParser do
     end
   end
 end
-

--- a/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
+++ b/spec/services/proofing/lexis_nexis/verification_error_parser_spec.rb
@@ -38,4 +38,66 @@ RSpec.describe Proofing::LexisNexis::VerificationErrorParser do
       expect(errors[:'Executed Fake Product']).to be_a Hash
     end
   end
+
+  describe 'PhoneFinder detail logging' do
+    subject(:errors) do
+      described_class.new(response_body, review_status:).parsed_errors
+    end
+
+    let(:review_status) { nil }
+    let(:transaction_status) { 'passed' }
+    let(:checks_status) { 'pass' }
+    let(:response_body) do
+      {
+        'Status' => { 'TransactionStatus' => transaction_status },
+        'Products' => [
+          {
+            'ExecutedStepName' => 'PhoneFinder',
+            'ProductType' => 'PhoneFinder',
+            'ProductStatus' => 'pass',
+            'ParameterDetails' => [{ 'Name' => 'Phone', 'Value' => '5551234567' }],
+            'Items' => [{ 'ItemName' => 'VOIPPhone', 'ItemStatus' => 'pass' }],
+          },
+          {
+            'ExecutedStepName' => 'PhoneFinder Checks',
+            'ProductType' => 'PhoneFinder_Decision',
+            'ProductStatus' => checks_status,
+          },
+        ],
+      }
+    end
+
+    shared_examples 'logs the PhoneFinder detail with Items but no PII' do
+      it 'logs the PhoneFinder detail product with its Items and strips ParameterDetails' do
+        expect(errors[:PhoneFinder]['Items']).to be_present
+        expect(errors[:PhoneFinder]).not_to have_key('ParameterDetails')
+      end
+    end
+
+    context 'when the raw PhoneFinder Checks decision fails' do
+      let(:transaction_status) { 'failed' }
+      let(:checks_status) { 'fail' }
+
+      it_behaves_like 'logs the PhoneFinder detail with Items but no PII'
+    end
+
+    context 'when the raw response passes but the DDP review_status does not' do
+      %w[review reject].each do |status|
+        context "with review_status '#{status}'" do
+          let(:review_status) { status }
+
+          it_behaves_like 'logs the PhoneFinder detail with Items but no PII'
+        end
+      end
+    end
+
+    context 'when both the raw response and review_status pass' do
+      let(:review_status) { 'pass' }
+
+      it 'does not log the clean passing PhoneFinder detail product' do
+        expect(errors[:PhoneFinder]).to be_nil
+      end
+    end
+  end
 end
+


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->


## 🎫 Ticket

Adds additional logging to complement the following [PR](https://github.com/18F/identity-idp/pull/13416).

[115](https://gitlab.login.gov/lg-teams/joan/joan/-/work_items/115#note_336934)


<!--
## 🛠 Summary of changes

Write a brief description of what you changed.
-->

<!--
## 📜 Testing Plan

Provide a checklist of steps to confirm the changes.

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
-->

<!--
## 👀 Screenshots

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
