### PR TITLE
Joan-131: Implement AAMVA get-to-yes for Socure KYC

### DIFF
--- a/app/services/proofing/socure/id_plus/proofers/kyc_proofer.rb
+++ b/app/services/proofing/socure/id_plus/proofers/kyc_proofer.rb
@@ -29,6 +29,10 @@ module Proofing
               exception: nil,
               vendor_name: VENDOR_NAME,
               verified_attributes: response.verified_attributes,
+              failed_result_can_pass_with_additional_verification:
+                response.failed_result_can_pass_with_additional_verification?,
+              attributes_requiring_additional_verification:
+                response.attributes_requiring_additional_verification,
               transaction_id: response.reference_id,
               vendor_id: response.vendor_id,
               source_attribution: response.source_attribution,

--- a/app/services/proofing/socure/id_plus/responses/kyc_response.rb
+++ b/app/services/proofing/socure/id_plus/responses/kyc_response.rb
@@ -22,8 +22,25 @@ module Proofing
             ssn
           ].to_set.freeze
 
+          # Failed attributes we report by name so AAMVA coverage can rescue the result.
+          # Anything else is reported as :unknown, which never appears in aamva_verified_attributes.
+          REPORTABLE_FAILED_ATTRIBUTES = %i[address dob ssn].to_set.freeze
+
           def all_required_attributes_verified?
             (REQUIRED_ATTRIBUTES - verified_attributes).empty?
+          end
+
+          def attributes_requiring_additional_verification
+            (REQUIRED_ATTRIBUTES - verified_attributes)
+              .map { |attribute| reportable_failed_attribute(attribute) }
+              .uniq.sort
+          end
+
+          def failed_result_can_pass_with_additional_verification?
+            return false if successful?
+            return false if has_autofail_reason_codes?
+
+            attributes_requiring_additional_verification.any?
           end
 
           def reason_codes
@@ -69,6 +86,10 @@ module Proofing
           private
 
           attr_reader :http_response
+
+          def reportable_failed_attribute(attribute)
+            REPORTABLE_FAILED_ATTRIBUTES.include?(attribute) ? attribute : :unknown
+          end
 
           def kyc(*fields)
             kyc_object = http_response.body['kyc']

--- a/spec/services/proofing/resolution/result_adjudicator_spec.rb
+++ b/spec/services/proofing/resolution/result_adjudicator_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
       end
     end
 
-    context 'InstantVerify fails on address verification' do
+    context 'resolution fails on address verification' do
       let(:resolution_success) { false }
       let(:can_pass_with_additional_verification) { true }
       let(:attributes_requiring_additional_verification) { [:address] }
@@ -121,7 +121,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
         context 'the address has not been edited' do
           let(:address_edited) { false }
 
-          it 'lets the verified AAMVA address override the InstantVerify failure' do
+          it 'lets the verified AAMVA address override the resolution failure' do
             result = subject.adjudicated_result
 
             expect(result.success?).to eq(true)
@@ -140,7 +140,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
         context 'the address has been edited' do
           let(:address_edited) { true }
 
-          it 'does not let the verified AAMVA address override the InstantVerify failure' do
+          it 'does not let the verified AAMVA address override the resolution failure' do
             result = subject.adjudicated_result
 
             expect(result.success?).to eq(false)
@@ -164,7 +164,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
               )
             end
 
-            it 'allows those attributes to cover the InstantVerify failure' do
+            it 'allows those attributes to cover the resolution failure' do
               result = subject.adjudicated_result
 
               expect(result.success?).to eq(true)
@@ -190,7 +190,7 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
           )
         end
 
-        it 'does not let AAMVA override the InstantVerify failure' do
+        it 'does not let AAMVA override the resolution failure' do
           result = subject.adjudicated_result
 
           expect(result.success?).to eq(false)
@@ -264,6 +264,31 @@ RSpec.describe Proofing::Resolution::ResultAdjudicator do
             expect(result.success?).to eq(false)
             expect(result.extra[:context][:resolution_adjudication_reason])
               .to eq(:fail_resolution_without_state_id_coverage)
+          end
+        end
+
+        context 'when socure_kyc proofed the resolution result' do
+          let(:proofing_vendor) { :socure_kyc }
+          let(:get_to_yes_enabled_vendors) { ['socure_kyc'] }
+
+          it 'lets AAMVA cover the failure' do
+            result = subject.adjudicated_result
+
+            expect(result.success?).to eq(true)
+            expect(result.extra[:context][:resolution_adjudication_reason])
+              .to eq(:state_id_covers_failed_resolution)
+          end
+
+          context 'when the failed attributes include an unknown attribute' do
+            let(:attributes_requiring_additional_verification) { [:address, :unknown] }
+
+            it 'does not let AAMVA cover the failure' do
+              result = subject.adjudicated_result
+
+              expect(result.success?).to eq(false)
+              expect(result.extra[:context][:resolution_adjudication_reason])
+                .to eq(:fail_resolution_without_state_id_coverage)
+            end
           end
         end
       end

--- a/spec/services/proofing/socure/id_plus/proofers/kyc_proofer_spec.rb
+++ b/spec/services/proofing/socure/id_plus/proofers/kyc_proofer_spec.rb
@@ -134,6 +134,40 @@ RSpec.describe Proofing::Socure::IdPlus::Proofers::KycProofer do
           ].to_set,
         )
       end
+
+      it 'cannot pass with additional verification' do
+        expect(result.failed_result_can_pass_with_additional_verification).to eql(false)
+        expect(result.attributes_requiring_additional_verification).to eql([])
+      end
+    end
+  end
+
+  context 'when resolution fails on attributes AAMVA could cover' do
+    let(:field_validation_overrides) { { 'streetAddress' => 0.01 } }
+
+    it 'can pass with additional verification' do
+      expect(result.success).to eql(false)
+      expect(result.failed_result_can_pass_with_additional_verification).to eql(true)
+      expect(result.attributes_requiring_additional_verification).to eql([:address])
+    end
+  end
+
+  context 'when resolution fails on a name' do
+    let(:field_validation_overrides) { { 'firstName' => 0.01 } }
+
+    it 'reports the failure as unknown, which blocks a rescue downstream' do
+      expect(result.success).to eql(false)
+      expect(result.attributes_requiring_additional_verification).to eql([:unknown])
+    end
+  end
+
+  context 'when an autofail reason code is present alongside a failed attribute' do
+    let(:reason_codes) { ['R995'] }
+    let(:field_validation_overrides) { { 'streetAddress' => 0.01 } }
+
+    it 'cannot pass with additional verification' do
+      expect(result.success).to eql(false)
+      expect(result.failed_result_can_pass_with_additional_verification).to eql(false)
     end
   end
 

--- a/spec/services/proofing/socure/id_plus/responses/kyc_response_spec.rb
+++ b/spec/services/proofing/socure/id_plus/responses/kyc_response_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Proofing::Socure::IdPlus::Responses::KycResponse do
     ]
   end
 
+  let(:field_validation_overrides) { {} }
+
   let(:response_body) do
     {
       'referenceId' => 'a1234b56-e789-0123-4fga-56b7c890d123',
@@ -24,7 +26,7 @@ RSpec.describe Proofing::Socure::IdPlus::Responses::KycResponse do
           'mobileNumber' => 0.99,
           'dob' => 0.99,
           'ssn' => 0.99,
-        },
+        }.merge(field_validation_overrides),
       },
     }
   end
@@ -130,6 +132,121 @@ RSpec.describe Proofing::Socure::IdPlus::Responses::KycResponse do
         expect do
           subject.field_validations
         end.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  # The base fixture fails city, state, and zip, so address is the only unverified
+  # required attribute unless a context overrides more fields.
+  describe '#attributes_requiring_additional_verification' do
+    it 'reports the unverified address' do
+      expect(subject.attributes_requiring_additional_verification).to eq([:address])
+    end
+
+    context 'when every required attribute is verified' do
+      let(:field_validation_overrides) { { 'city' => 0.99, 'state' => 0.99, 'zip' => 0.99 } }
+
+      it 'reports nothing' do
+        expect(subject.attributes_requiring_additional_verification).to eq([])
+      end
+    end
+
+    context 'when dob is not verified' do
+      let(:field_validation_overrides) { { 'dob' => 0.01 } }
+
+      it 'reports address and dob' do
+        expect(subject.attributes_requiring_additional_verification).to eq([:address, :dob])
+      end
+    end
+
+    context 'when ssn is not verified' do
+      let(:field_validation_overrides) { { 'ssn' => 0.01 } }
+
+      it 'reports address and ssn' do
+        expect(subject.attributes_requiring_additional_verification).to eq([:address, :ssn])
+      end
+    end
+
+    context 'when a name is not verified' do
+      let(:field_validation_overrides) do
+        { 'city' => 0.99, 'state' => 0.99, 'zip' => 0.99, 'firstName' => 0.01 }
+      end
+
+      it 'reports the name as unknown, since AAMVA coverage cannot be claimed for it' do
+        expect(subject.attributes_requiring_additional_verification).to eq([:unknown])
+      end
+    end
+
+    context 'when both names are not verified' do
+      let(:field_validation_overrides) do
+        {
+          'city' => 0.99,
+          'state' => 0.99,
+          'zip' => 0.99,
+          'firstName' => 0.01,
+          'surName' => 0.01,
+        }
+      end
+
+      it 'reports a single unknown entry' do
+        expect(subject.attributes_requiring_additional_verification).to eq([:unknown])
+      end
+    end
+
+    context 'when a reportable attribute and a name are both unverified' do
+      let(:field_validation_overrides) { { 'firstName' => 0.01 } }
+
+      it 'reports the attribute alongside unknown' do
+        expect(subject.attributes_requiring_additional_verification)
+          .to eq([:address, :unknown])
+      end
+    end
+
+    context 'when only phone is not verified' do
+      let(:field_validation_overrides) do
+        { 'city' => 0.99, 'state' => 0.99, 'zip' => 0.99, 'mobileNumber' => 0.01 }
+      end
+
+      it 'reports nothing, since phone is not a required attribute' do
+        expect(subject.attributes_requiring_additional_verification).to eq([])
+      end
+    end
+  end
+
+  describe '#failed_result_can_pass_with_additional_verification?' do
+    before do
+      allow(IdentityConfig.store).to receive(:idv_socure_kyc_auto_failure_reason_codes)
+        .and_return(['R995'])
+    end
+
+    it 'is true when the result failed on a reportable attribute' do
+      expect(subject.failed_result_can_pass_with_additional_verification?).to eq(true)
+    end
+
+    context 'when the result was successful' do
+      let(:field_validation_overrides) { { 'city' => 0.99, 'state' => 0.99, 'zip' => 0.99 } }
+
+      it 'is false' do
+        expect(subject.failed_result_can_pass_with_additional_verification?).to eq(false)
+      end
+    end
+
+    context 'when the result has an autofail reason code' do
+      let(:response_reason_codes) { ['R995'] }
+
+      it 'is false, since the failure is not about attributes' do
+        expect(subject.failed_result_can_pass_with_additional_verification?).to eq(false)
+      end
+    end
+
+    context 'when the only unverified attribute is a name' do
+      let(:field_validation_overrides) do
+        { 'city' => 0.99, 'state' => 0.99, 'zip' => 0.99, 'firstName' => 0.01 }
+      end
+
+      it 'is true, and the reported unknown attribute prevents the rescue downstream' do
+        expect(subject.failed_result_can_pass_with_additional_verification?).to eq(true)
+        expect(subject.attributes_requiring_additional_verification).to eq([:unknown])
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

[Joan-131](https://gitlab.login.gov/lg-teams/joan/joan/-/work_items/131)

## 🛠 Summary of changes

Populates `attributes_requiring_additional_verification` and `failed_result_can_pass_with_additional_verification` in the Socure KYC resolution result, so AAMVA-verified attributes can cover a failed Socure resolution. This is the "get to yes" behavior already supported for LexisNexis Instant Verify and Instant Verify DDP.

Socure did not populate these fields, so get-to-yes never applied to Socure users regardless of the feature flag. Joan-125 measured the opportunity at roughly 36,454 rescued users over 30 days, or about 21.8% of Socure resolution failures.

- Failed attributes are derived in `KycResponse` from Socure's five required attributes (`first_name`, `last_name`, `address`, `dob`, `ssn`) minus `verified_attributes`. Socure reports what passed, unlike LexisNexis which reports what failed.
- `REPORTABLE_FAILED_ATTRIBUTES` is an allowlist of `address`, `dob`, and `ssn`. Anything else, including names today and any new Socure field later, is reported as `:unknown`. That value never appears in `aamva_verified_attributes`, so it blocks a rescue. This matches the sentinel LexisNexis already uses for unmapped checks.
- `failed_result_can_pass_with_additional_verification?` mirrors the LexisNexis guards: false when the result succeeded, false when an autofail reason code is present, otherwise true when any attribute failed.
- No change to `ResultAdjudicator`. It already gates on the per-vendor flag added in Joan-117.

Deploys disabled, since `socure_kyc` is not in `idv_aamva_get_to_yes_enabled_vendors`. Enabling it in production is a separate config-only change.

Also renames a few spec descriptions from "InstantVerify" to "resolution" in `result_adjudicator_spec.rb`, since that context is vendor-agnostic.

## 📜 Testing Plan

- [x] `bundle exec rspec spec/services/proofing/socure/id_plus/responses/kyc_response_spec.rb spec/services/proofing/socure/id_plus/proofers/kyc_proofer_spec.rb spec/services/proofing/resolution/result_adjudicator_spec.rb` passes (82 examples)
- [x] `CAPYBARA_WAIT_TIME_SECONDS=5 bundle exec rspec spec/features/idv/doc_auth/verify_info_step_spec.rb:90` passes the Socure KYC contexts (4 examples)
- [x] With `socure_kyc` absent from `idv_aamva_get_to_yes_enabled_vendors`, a Socure resolution failure still fails and logs `fail_resolution_without_state_id_coverage`
- [x] With `socure_kyc` added to the flag, a Socure failure on address only, where AAMVA verified the address, passes and logs `state_id_covers_failed_resolution`
- [x] With `socure_kyc` added to the flag, a Socure failure on a name reports `unknown` and still fails
