### PR TITLE
Add logging to seeder

### DIFF
--- a/app/services/seed_runner.rb
+++ b/app/services/seed_runner.rb
@@ -8,11 +8,11 @@ class SeedRunner
     @failed_seeders = []
   end
 
-  def run(name)
+  def run(seeder, name: seeder.class.name)
     logger.info("[db:seed] Starting #{name}")
-    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    yield
-    duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+    started_at = Time.zone.now
+    yield seeder
+    duration = Time.zone.now - started_at
     logger.info("[db:seed] #{name} succeeded (#{duration.round(2)}s)")
   rescue StandardError => e
     logger.error("[db:seed] #{name} failed: #{e.class}: #{e.message}")

--- a/app/services/seed_runner.rb
+++ b/app/services/seed_runner.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Wraps individual db/seeds.rb seeder calls with logging so failures are visible
+# without halting the rest of the seeding process.
+class SeedRunner
+  def initialize(logger: Rails.logger)
+    @logger = logger
+    @failed_seeders = []
+  end
+
+  def run(name)
+    logger.info("[db:seed] Starting #{name}")
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+    logger.info("[db:seed] #{name} succeeded (#{duration.round(2)}s)")
+  rescue StandardError => e
+    logger.error("[db:seed] #{name} failed: #{e.class}: #{e.message}")
+    failed_seeders << name
+  end
+
+  # Logs a final summary and raises if any seeder failed.
+  def finish!
+    if failed_seeders.any?
+      logger.error("[db:seed] Seeding completed with failures: #{failed_seeders.join(', ')}")
+      raise "db:seed failed for: #{failed_seeders.join(', ')}"
+    else
+      logger.info('[db:seed] Seeding completed: all seeders succeeded')
+    end
+  end
+
+  private
+
+  attr_reader :logger, :failed_seeders
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+seed_runner = SeedRunner.new
+
 # add config/service_providers.yml
 if ENV['KUBERNETES_REVIEW_APP'] == 'true' && ENV['DASHBOARD_URL'].present?
   dashboard_url = ENV['DASHBOARD_URL']
@@ -7,23 +9,31 @@ if ENV['KUBERNETES_REVIEW_APP'] == 'true' && ENV['DASHBOARD_URL'].present?
   # This should never be invoked in production.
   # If we change how production is deployed, we should revisit the above conditionals to ensure
   # production never runs this.
-  ServiceProviderSeeder.new.run_review_app(dashboard_url: dashboard_url)
-  ReviewAppUserSeeder.new.run
+  seed_runner.run('ServiceProviderSeeder#run_review_app') do
+    ServiceProviderSeeder.new.run_review_app(dashboard_url: dashboard_url)
+  end
+  seed_runner.run('ReviewAppUserSeeder') { ReviewAppUserSeeder.new.run }
 else
-  ServiceProviderSeeder.new.run
+  seed_runner.run('ServiceProviderSeeder') { ServiceProviderSeeder.new.run }
 end
 
 # add config/agencies.yml
-AgencySeeder.new.run
+seed_runner.run('AgencySeeder') { AgencySeeder.new.run }
 
 # add partnerships / agreements data, note that the order matters!
 if IdentityConfig.store.seed_agreements_data
   Rails.logger.info('=== Seeding agreements data ===')
 
-  Agreements::PartnerAccountStatusSeeder.new.run
-  Agreements::PartnerAccountSeeder.new.run
-  Agreements::IaaGtcSeeder.new.run
-  Agreements::IntegrationStatusSeeder.new.run
-  Agreements::IntegrationSeeder.new.run
-  Agreements::IaaOrderSeeder.new.run
+  seed_runner.run('Agreements::PartnerAccountStatusSeeder') do
+    Agreements::PartnerAccountStatusSeeder.new.run
+  end
+  seed_runner.run('Agreements::PartnerAccountSeeder') { Agreements::PartnerAccountSeeder.new.run }
+  seed_runner.run('Agreements::IaaGtcSeeder') { Agreements::IaaGtcSeeder.new.run }
+  seed_runner.run('Agreements::IntegrationStatusSeeder') do
+    Agreements::IntegrationStatusSeeder.new.run
+  end
+  seed_runner.run('Agreements::IntegrationSeeder') { Agreements::IntegrationSeeder.new.run }
+  seed_runner.run('Agreements::IaaOrderSeeder') { Agreements::IaaOrderSeeder.new.run }
 end
+
+seed_runner.finish!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,31 +9,28 @@ if ENV['KUBERNETES_REVIEW_APP'] == 'true' && ENV['DASHBOARD_URL'].present?
   # This should never be invoked in production.
   # If we change how production is deployed, we should revisit the above conditionals to ensure
   # production never runs this.
-  seed_runner.run('ServiceProviderSeeder#run_review_app') do
-    ServiceProviderSeeder.new.run_review_app(dashboard_url: dashboard_url)
-  end
-  seed_runner.run('ReviewAppUserSeeder') { ReviewAppUserSeeder.new.run }
+  seed_runner.run(
+    ServiceProviderSeeder.new,
+    name: 'ServiceProviderSeeder#run_review_app',
+  ) { |seeder| seeder.run_review_app(dashboard_url: dashboard_url) }
+  seed_runner.run(ReviewAppUserSeeder.new, &:run)
 else
-  seed_runner.run('ServiceProviderSeeder') { ServiceProviderSeeder.new.run }
+  seed_runner.run(ServiceProviderSeeder.new, &:run)
 end
 
 # add config/agencies.yml
-seed_runner.run('AgencySeeder') { AgencySeeder.new.run }
+seed_runner.run(AgencySeeder.new, &:run)
 
 # add partnerships / agreements data, note that the order matters!
 if IdentityConfig.store.seed_agreements_data
   Rails.logger.info('=== Seeding agreements data ===')
 
-  seed_runner.run('Agreements::PartnerAccountStatusSeeder') do
-    Agreements::PartnerAccountStatusSeeder.new.run
-  end
-  seed_runner.run('Agreements::PartnerAccountSeeder') { Agreements::PartnerAccountSeeder.new.run }
-  seed_runner.run('Agreements::IaaGtcSeeder') { Agreements::IaaGtcSeeder.new.run }
-  seed_runner.run('Agreements::IntegrationStatusSeeder') do
-    Agreements::IntegrationStatusSeeder.new.run
-  end
-  seed_runner.run('Agreements::IntegrationSeeder') { Agreements::IntegrationSeeder.new.run }
-  seed_runner.run('Agreements::IaaOrderSeeder') { Agreements::IaaOrderSeeder.new.run }
+  seed_runner.run(Agreements::PartnerAccountStatusSeeder.new, &:run)
+  seed_runner.run(Agreements::PartnerAccountSeeder.new, &:run)
+  seed_runner.run(Agreements::IaaGtcSeeder.new, &:run)
+  seed_runner.run(Agreements::IntegrationStatusSeeder.new, &:run)
+  seed_runner.run(Agreements::IntegrationSeeder.new, &:run)
+  seed_runner.run(Agreements::IaaOrderSeeder.new, &:run)
 end
 
 seed_runner.finish!

--- a/spec/services/seed_runner_spec.rb
+++ b/spec/services/seed_runner_spec.rb
@@ -4,28 +4,39 @@ RSpec.describe SeedRunner do
   subject(:seed_runner) { SeedRunner.new(logger: logger) }
   let(:logger) { instance_double(Logger, info: nil, error: nil) }
 
-  describe '#run' do
-    it 'logs a start and success message when the block succeeds' do
-      seed_runner.run('SomeSeeder') { 'noop' }
+  before do
+    stub_const('FakeSeeder', Class.new { def run; end })
+    stub_const('AnotherFakeSeeder', Class.new { def run; end })
+  end
 
-      expect(logger).to have_received(:info).with('[db:seed] Starting SomeSeeder')
-      expect(logger).to have_received(:info).with(/\[db:seed\] SomeSeeder succeeded \(\d+\.\d+s\)/)
+  describe '#run' do
+    it 'logs a start and success message using the seeder class name by default' do
+      seed_runner.run(FakeSeeder.new, &:run)
+
+      expect(logger).to have_received(:info).with('[db:seed] Starting FakeSeeder')
+      expect(logger).to have_received(:info).with(/\[db:seed\] FakeSeeder succeeded \(\d+\.\d+s\)/)
+    end
+
+    it 'uses the given name instead of the seeder class name when provided' do
+      seed_runner.run(FakeSeeder.new, name: 'FakeSeeder#special') { |seeder| seeder.run }
+
+      expect(logger).to have_received(:info).with('[db:seed] Starting FakeSeeder#special')
     end
 
     it 'logs a failure message and does not raise when the block raises' do
       expect do
-        seed_runner.run('SomeSeeder') { raise ArgumentError, 'bad config' }
+        seed_runner.run(FakeSeeder.new) { raise ArgumentError, 'bad config' }
       end.to_not raise_error
 
       expect(logger).to have_received(:error).with(
-        '[db:seed] SomeSeeder failed: ArgumentError: bad config',
+        '[db:seed] FakeSeeder failed: ArgumentError: bad config',
       )
     end
 
     it 'runs subsequent seeders after a prior one fails' do
-      seed_runner.run('FailingSeeder') { raise 'boom' }
+      seed_runner.run(FakeSeeder.new) { raise 'boom' }
       ran = false
-      seed_runner.run('NextSeeder') { ran = true }
+      seed_runner.run(AnotherFakeSeeder.new) { ran = true }
 
       expect(ran).to eq(true)
     end
@@ -34,7 +45,7 @@ RSpec.describe SeedRunner do
   describe '#finish!' do
     context 'when no seeders failed' do
       it 'logs a success summary and does not raise' do
-        seed_runner.run('SomeSeeder') { 'noop' }
+        seed_runner.run(FakeSeeder.new, &:run)
 
         expect { seed_runner.finish! }.to_not raise_error
         expect(logger).to have_received(:info).with(
@@ -45,20 +56,20 @@ RSpec.describe SeedRunner do
 
     context 'when one or more seeders failed' do
       it 'logs a failure summary and raises' do
-        seed_runner.run('FailingSeeder') { raise 'boom' }
+        seed_runner.run(FakeSeeder.new) { raise 'boom' }
 
-        expect { seed_runner.finish! }.to raise_error('db:seed failed for: FailingSeeder')
+        expect { seed_runner.finish! }.to raise_error('db:seed failed for: FakeSeeder')
         expect(logger).to have_received(:error).with(
-          '[db:seed] Seeding completed with failures: FailingSeeder',
+          '[db:seed] Seeding completed with failures: FakeSeeder',
         )
       end
 
       it 'includes every failed seeder by name' do
-        seed_runner.run('FirstFailure') { raise 'boom' }
-        seed_runner.run('SecondFailure') { raise 'boom' }
+        seed_runner.run(FakeSeeder.new) { raise 'boom' }
+        seed_runner.run(AnotherFakeSeeder.new) { raise 'boom' }
 
         expect { seed_runner.finish! }.to raise_error(
-          'db:seed failed for: FirstFailure, SecondFailure',
+          'db:seed failed for: FakeSeeder, AnotherFakeSeeder',
         )
       end
     end

--- a/spec/services/seed_runner_spec.rb
+++ b/spec/services/seed_runner_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe SeedRunner do
+  subject(:seed_runner) { SeedRunner.new(logger: logger) }
+  let(:logger) { instance_double(Logger, info: nil, error: nil) }
+
+  describe '#run' do
+    it 'logs a start and success message when the block succeeds' do
+      seed_runner.run('SomeSeeder') { 'noop' }
+
+      expect(logger).to have_received(:info).with('[db:seed] Starting SomeSeeder')
+      expect(logger).to have_received(:info).with(/\[db:seed\] SomeSeeder succeeded \(\d+\.\d+s\)/)
+    end
+
+    it 'logs a failure message and does not raise when the block raises' do
+      expect do
+        seed_runner.run('SomeSeeder') { raise ArgumentError, 'bad config' }
+      end.to_not raise_error
+
+      expect(logger).to have_received(:error).with(
+        '[db:seed] SomeSeeder failed: ArgumentError: bad config',
+      )
+    end
+
+    it 'runs subsequent seeders after a prior one fails' do
+      seed_runner.run('FailingSeeder') { raise 'boom' }
+      ran = false
+      seed_runner.run('NextSeeder') { ran = true }
+
+      expect(ran).to eq(true)
+    end
+  end
+
+  describe '#finish!' do
+    context 'when no seeders failed' do
+      it 'logs a success summary and does not raise' do
+        seed_runner.run('SomeSeeder') { 'noop' }
+
+        expect { seed_runner.finish! }.to_not raise_error
+        expect(logger).to have_received(:info).with(
+          '[db:seed] Seeding completed: all seeders succeeded',
+        )
+      end
+    end
+
+    context 'when one or more seeders failed' do
+      it 'logs a failure summary and raises' do
+        seed_runner.run('FailingSeeder') { raise 'boom' }
+
+        expect { seed_runner.finish! }.to raise_error('db:seed failed for: FailingSeeder')
+        expect(logger).to have_received(:error).with(
+          '[db:seed] Seeding completed with failures: FailingSeeder',
+        )
+      end
+
+      it 'includes every failed seeder by name' do
+        seed_runner.run('FirstFailure') { raise 'boom' }
+        seed_runner.run('SecondFailure') { raise 'boom' }
+
+        expect { seed_runner.finish! }.to raise_error(
+          'db:seed failed for: FirstFailure, SecondFailure',
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

[Team FIE Daily 81](https://gitlab.login.gov/lg-teams/FIE/team-fie-daily/-/work_items/81)

## 🛠 Summary of changes

`db/seeds.rb` failures were hard to diagnose since seeders didn't log their progress, and the process would halt on the first failure. This adds a `SeedRunner` service that wraps every seeder call in `db/seeds.rb` to log when each seeder starts, succeeds (with duration), or fails. Seeders now continue running even after a failure so we get a complete picture of the run; if any seeder failed, a summary is logged and the process still raises/exits non-zero at the end so `db:seed` failures remain visible to deploy tooling.

## 📜 Testing Plan

- [ ] Run `bundle exec rspec spec/services/seed_runner_spec.rb` and confirm all specs pass
- [ ] Run `bundle exec rails db:seed` locally and confirm `[db:seed]` start/success log lines appear for each seeder, ending with a success summary