### PR TITLE
GL reporting 716 phonefinder alternate result update

### DIFF
--- a/lib/reporting/api_transaction_count_report.rb
+++ b/lib/reporting/api_transaction_count_report.rb
@@ -364,8 +364,8 @@ module Reporting
     def socure_phonerisk_query
       <<~QUERY
         fields @timestamp, @message
-        | filter (name IN ["idv_socure_shadow_mode_phonerisk_result"])
-        OR (name = 'IdV: phone confirmation vendor' AND properties.event_properties.vendor.vendor_name = "socure_phonerisk")
+        |filter name = 'IdV: phone confirmation vendor' 
+        AND (properties.event_properties.vendor.vendor_name = "socure_phonerisk" OR properties.event_properties.alternate_result.vendor.vendor_name = "socure_phonerisk")
         | display id
         | limit 10000
       QUERY
@@ -375,7 +375,9 @@ module Reporting
       <<~QUERY
         fields @timestamp, @message, id
         | filter name = 'IdV: phone confirmation vendor'
-        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder" or properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder_ddp"
+        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder" or 
+        properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder_ddp" or 
+        properties.event_properties.alternate_result.vendor.vendor_name = "lexisnexis:phone_finder_ddp"
         | display id
         | limit 10000
       QUERY

--- a/lib/reporting/api_transaction_count_report.rb
+++ b/lib/reporting/api_transaction_count_report.rb
@@ -375,9 +375,7 @@ module Reporting
       <<~QUERY
         fields @timestamp, @message, id
         | filter name = 'IdV: phone confirmation vendor'
-        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder" or 
-        properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder_ddp" or 
-        properties.event_properties.alternate_result.vendor.vendor_name = "lexisnexis:phone_finder_ddp"
+        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder" or properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder_ddp" 
         | display id
         | limit 10000
       QUERY

--- a/lib/reporting/api_transaction_count_report.rb
+++ b/lib/reporting/api_transaction_count_report.rb
@@ -365,7 +365,7 @@ module Reporting
       <<~QUERY
         fields @timestamp, @message
         |filter name = 'IdV: phone confirmation vendor' 
-        AND (properties.event_properties.vendor.vendor_name = "socure_phonerisk" OR properties.event_properties.alternate_result.vendor.vendor_name = "socure_phonerisk")
+        | filter properties.event_properties.vendor.vendor_name = "socure_phonerisk" OR properties.event_properties.alternate_result.vendor.vendor_name = "socure_phonerisk"
         | display id
         | limit 10000
       QUERY
@@ -375,7 +375,7 @@ module Reporting
       <<~QUERY
         fields @timestamp, @message, id
         | filter name = 'IdV: phone confirmation vendor'
-        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder" or properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder_ddp" 
+        | filter properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder" or properties.event_properties.vendor.vendor_name = "lexisnexis:phone_finder_ddp"  or  properties.event_properties.alternate_result.vendor.vendor_name = "lexisnexis:phone_finder_ddp"
         | display id
         | limit 10000
       QUERY


### PR DESCRIPTION



## 🎫 Ticket

Link to the relevant ticket:
[GL-716: API Transaction Count Report: LN phone finder and Socure Prod Risk Count Discrepancies
](https://gitlab.login.gov/lg-teams/Team-Data/reporting/-/work_items/716)



## 🛠 Summary of changes

Added `properties.event_properties.alternate_result.vendor.vendor_name` into both the phone finder queries within the API transaction count report file to capture missing API calls.

The `IdV: phone confirmation vendor` event log is used to track phone verification lookups made to external vendors (LexisNexis Phone Finder and Socure Phone Risk). A discrepancy was discovered between vendor-reported usage counts and internal event log counts.

**The Core Issue: One Event, Two Lookups**
Around late May 2026, a dual-vendor phone check was introduced. Under this feature:

- A single IdV: phone confirmation vendor log event can now represent two separate API calls — one to each vendor (LexisNexis and Socure).
- When two lookups occur, the event contains both:
   1. `properties.event_properties.vendor.vendor_name` → the second (final) vendor result (e.g., socure_phonerisk)
   2. `properties.event_properties.alternate_result.vendor.vendor_name` → the first vendor result (e.g., lexisnexis:phone_finder_ddp)

If alternate_result is absent, the event represents a single vendor lookup. If alternate_result is present, the event represents two separate vendor API calls (one to each vendor).


## 📜 Testing Plan

Tested local updated version on prod data and validated against CW dashboard for 8/30/2026-8/31/2026 to validate counts match


